### PR TITLE
Docs: Standardize prerequisite partial use.

### DIFF
--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -17,11 +17,10 @@ usernameless authentication for Teleport.
   As an alternative, you can use a Mac with biometrics / Touch ID or device that
   supports Windows Hello (Windows 10 19H1 or later).
 - A web browser with WebAuthn support. To see if your browser supports
-  WebAuthn, check the [WebAuthn Compatibility](
-  https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) page.
+  WebAuthn, check the [WebAuthn
+  Compatibility](https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) page.
 - A signed and notarized version of `tsh` is required for Touch ID. This precludes
   versions installed from Homebrew. [Download the macOS tsh installer](../../installation.mdx#macos).
-
 - (!docs/pages/includes/tctl.mdx!)
 
 A Teleport cluster capable of WebAuthn is automatically capable of passwordless.

--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -9,16 +9,20 @@ usernameless authentication for Teleport.
 
 ## Prerequisites
 
-- A Teleport cluster with WebAuthn configured.
-  See the [Second Factor: WebAuthn](./webauthn.mdx) guide.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+- Teleport must be configured for WebAuthn. See the [Second Factor:
+  WebAuthn](./webauthn.mdx) guide.
 - A hardware device with support for WebAuthn and resident keys.
   As an alternative, you can use a Mac with biometrics / Touch ID or device that
   supports Windows Hello (Windows 10 19H1 or later).
 - A web browser with WebAuthn support. To see if your browser supports
   WebAuthn, check the [WebAuthn Compatibility](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) page.
-- A signed and notarized `tsh` for Touch ID.
-  [Download the macOS tsh installer](../../installation.mdx#macos).
+- A signed and notarized version of `tsh` is required for Touch ID. This precludes
+  versions installed from Homebrew. [Download the macOS tsh installer](../../installation.mdx#macos).
+
+(!docs/pages/includes/tctl.mdx!)
 
 A Teleport cluster capable of WebAuthn is automatically capable of passwordless.
 

--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -22,7 +22,7 @@ usernameless authentication for Teleport.
 - A signed and notarized version of `tsh` is required for Touch ID. This precludes
   versions installed from Homebrew. [Download the macOS tsh installer](../../installation.mdx#macos).
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 A Teleport cluster capable of WebAuthn is automatically capable of passwordless.
 

--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -15,7 +15,10 @@ Here are the steps we'll walkthrough:
 ## Prerequisites
 
 - Install [Go](https://golang.org/doc/install) (=teleport.golang=)+ and Go development environment.
-- Set up Teleport through one of our [getting started guides](../try-out-teleport/introduction.mdx). You can also begin a [free trial](https://goteleport.com/signup/) of Teleport Cloud.
+
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Create a user
 

--- a/docs/pages/api/getting-started.mdx
+++ b/docs/pages/api/getting-started.mdx
@@ -18,7 +18,7 @@ Here are the steps we'll walkthrough:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Create a user
 

--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -19,10 +19,9 @@ This guide will explain how to:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
-
+- (!docs/pages/includes/tctl.mdx!)
 - A host running the `teleport` daemon with the Application Service enabled.
-  Follow the [Getting Started](../getting-started.mdx) or   [Connecting
+  Follow the [Getting Started](../getting-started.mdx) or [Connecting
   Apps](../guides/connecting-apps.mdx) guides to get it running.
 - IAM permissions in the AWS account you want to connect.
 - AWS EC2 or other instance where you can assign a IAM Security Role for the

--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -17,9 +17,12 @@ This guide will explain how to:
 
 ## Prerequisites
 
-- A running Teleport cluster, either self hosted or in Teleport Cloud.
-- A host running the `teleport` daemon with the Teleport Application Service
-  enabled. Follow the [Getting Started](../getting-started.mdx) or [Connecting
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
+- A host running the `teleport` daemon with the Application Service enabled.
+  Follow the [Getting Started](../getting-started.mdx) or   [Connecting
   Apps](../guides/connecting-apps.mdx) guides to get it running.
 - IAM permissions in the AWS account you want to connect.
 - AWS EC2 or other instance where you can assign a IAM Security Role for the

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -13,32 +13,32 @@ Use [TCP application access](./tcp.mdx) for non-HTTP APIs (like gRPC).
 
 ## Prerequisites
 
-You will need a running Teleport cluster, either self hosted or in Teleport Cloud.
-We'll assume that you followed the [Getting Started](../getting-started.mdx)
-guide or the general [App Access Usage](./connecting-apps.mdx) guide to connect the web application providing an API to Teleport.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-For simplicity's sake, we'll use Grafana running in a
-[Docker container](https://grafana.com/docs/grafana/latest/installation/docker/)
-and execute API queries against it. You can launch Grafana too with a single Docker
-command:
+- (!docs/pages/includes/tctl.mdx!)
 
-```code
-$ docker run -d -p 3000:3000 grafana/grafana
-```
+- For simplicity's sake, we'll use Grafana running in a
+  [Docker container](https://grafana.com/docs/grafana/latest/installation/docker/)
+  and execute API queries against it. You can launch Grafana too with a single Docker
+  command:
 
-Connect Grafana to your Teleport cluster by adding the following section in
-the Teleport App Service YAML configuration file:
+  ```code
+  $ docker run -d -p 3000:3000 grafana/grafana
+  ```
 
-```yaml
-app_service:
-  enabled: yes
-  apps:
-  - name: "grafana"
-    description: "Test Grafana server"
-    uri: "http://localhost:3000"
-    labels:
-      "env": "dev"
-```
+  Connect Grafana to your Teleport cluster by adding the following section in
+  the Teleport App Service YAML configuration file:
+
+  ```yaml
+  app_service:
+    enabled: yes
+    apps:
+    - name: "grafana"
+      description: "Test Grafana server"
+      uri: "http://localhost:3000"
+      labels:
+        "env": "dev"
+  ```
 
 ## Accessing the API
 

--- a/docs/pages/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/application-access/jwt/elasticsearch.mdx
@@ -14,7 +14,7 @@ with Teleport.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - Running [Application Service](../guides/connecting-apps.mdx).
 - Elasticsearch cluster version >= `8.2.0`.

--- a/docs/pages/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/application-access/jwt/elasticsearch.mdx
@@ -12,7 +12,10 @@ with Teleport.
 
 ## Prerequisites
 
-- Teleport cluster version >= `9.3` with running Auth/Proxy Services or Teleport Cloud account.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
+
 - Running [Application Service](../guides/connecting-apps.mdx).
 - Elasticsearch cluster version >= `8.2.0`.
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
@@ -48,9 +48,7 @@ This guide is intended for self-hosted Teleport Enterprise users.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-- The `tctl` administration tool
-
-  (!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - A Google Cloud account.
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
@@ -8,6 +8,18 @@ This guide will show you how to set up your Teleport Cluster to use the Google
 Cloud Key Management Service (KMS) to store and handle the CA private key
 material used to sign all certificates issued by your Teleport cluster.
 
+<Details
+  title="Version warning"
+  opened={true}
+  scope={["enterprise"]}
+  scopeOnly={true}
+  min="11.1.0"
+>
+
+The features documented on this page are available in Teleport `11.1.0` and higher.
+
+</Details>
+
 Teleport generates private key material for its internal Certificate Authorities
 (CAs) during the first Auth Server's initial startup.
 These CAs are used to sign all certificates issued to clients and hosts in the
@@ -34,7 +46,7 @@ This guide is intended for self-hosted Teleport Enterprise users.
 
 ## Prerequisites
 
-- Teleport version 11.1.0 or newer Enterprise (self-hosted).
+(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
 - The `tctl` administration tool
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
@@ -16,11 +16,8 @@ This guide is intended for Teleport Enterprise users.
 ## Prerequisites
 
 - Teleport v(=teleport.version=) Enterprise (self-hosted).
-
 - (!docs/pages/includes/tctl.mdx!)
-
 - An HSM reachable from your Teleport auth server.
-
 - The PKCS#11 module for your HSM.
 
 <Admonition type="warning" scope={["cloud", "oss"]} opened={true} scopeOnly={true} title="Compatibility Warning">

--- a/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
@@ -17,7 +17,7 @@ This guide is intended for Teleport Enterprise users.
 
 - Teleport v(=teleport.version=) Enterprise (self-hosted).
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - An HSM reachable from your Teleport auth server.
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
@@ -17,9 +17,7 @@ This guide is intended for Teleport Enterprise users.
 
 - Teleport v(=teleport.version=) Enterprise (self-hosted).
 
-- The `tctl` administration tool version >= (=teleport.version=).
-
-  (!docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/tctl.mdx!)
 
 - An HSM reachable from your Teleport auth server.
 

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -13,7 +13,6 @@ work with Teleport.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - The Teleport Database Service configured to access a database. See one of our
   [guides](../database-access/guides.mdx) for how to set up the Teleport
   Database Service for your database.

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -10,56 +10,9 @@ work with Teleport.
 
 ### Prerequisites
 
-Ensure that your environment includes the following:
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-<Tabs>
-<TabItem scope={["oss"]} label="Open Source">
-
-- A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](/docs/getting-started) guides.
-
-- The `tsh` client tool version >= (=teleport.version=).
-
-  ```code
-  $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](/docs/installation.mdx) for details.
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster. For details on how to set this up, see our Enterprise
-  [Getting Started](/docs/enterprise/getting-started) guide.
-
-- The `tsh` client tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Teleport Cloud">
-
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
-
-- The `tsh` client tool version >= (=cloud.version=). To download these tools,
-  visit the [Downloads](../choose-an-edition/teleport-cloud/downloads.mdx) page.
-
-  ```code
-  $ tsh version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
-  ```
-
-</TabItem>
-</Tabs>
+- (!docs/pages/includes/tctl.mdx!)
 
 - The Teleport Database Service configured to access a database. See one of our
   [guides](../database-access/guides.mdx) for how to set up the Teleport

--- a/docs/pages/database-access/guides/redshift-serverless.mdx
+++ b/docs/pages/database-access/guides/redshift-serverless.mdx
@@ -17,15 +17,15 @@ This guide will help you to:
 
 ## Prerequisites
 
-- A pre-existing Teleport `(=teleport.version=)` cluster. If you don't already
-  have Teleport running, see [How to Choose a Teleport Edition](../../choose-an-edition/introduction.mdx)
-  to learn more about your options, and how to set up Teleport.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - AWS account with a Redshift Serverless configuration and permissions to create
   and attach IAM policies.
 - Command-line client `psql` installed and added to your system's `PATH` environment variable.
 - A host where you will run the Teleport Database Service. This guide assumes an
   EC2 instance, and provides a corresponding example of access control.
-- (!docs/pages/includes/tctl.mdx!)
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create an IAM policy for Teleport
 

--- a/docs/pages/database-access/guides/redshift-serverless.mdx
+++ b/docs/pages/database-access/guides/redshift-serverless.mdx
@@ -24,8 +24,7 @@ This guide will help you to:
 - Command-line client `psql` installed and added to your system's `PATH` environment variable.
 - A host where you will run the Teleport Database Service. This guide assumes an
   EC2 instance, and provides a corresponding example of access control.
-
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create an IAM policy for Teleport
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -6,11 +6,12 @@ description: Install and configure an HA Teleport cluster using an AWS EKS clust
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and AWS products (DynamoDB and S3).
 
-<ScopedBlock scope="cloud">
-
-(!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
-
-</ScopedBlock>
+<Admonition type="tip" title="Have an existing Teleport cluster?">
+If you are already running Teleport on another platform, you can use your
+existing Teleport deployment to access your Kubernetes cluster. [Follow our
+guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
+cluster to Teleport.
+</Admonition>
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -11,6 +11,15 @@ This setup can be useful when you already have an existing Teleport cluster and 
 like to start running it in Kubernetes, or when migrating your setup from a legacy
 version of the Helm charts.
 
+<Admonition type="tip" title="Have an existing Teleport cluster?">
+If you are already running Teleport on another platform, you can use your
+existing Teleport deployment to access your Kubernetes cluster. [Follow our
+guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
+cluster to Teleport.
+</Admonition>
+
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 <Admonition type="warning">
 Those instructions are both for v12 Teleport and the v12 `teleport-cluster` chart.
 If you are running an older Teleport version, use the version selector at the top

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -7,26 +7,24 @@ In this guide, we'll explain how to set up a Teleport cluster in Kubernetes
 with a custom [`teleport.yaml`](../../reference/config.mdx) config file
 using Teleport Helm charts.
 
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
 This setup can be useful when you already have an existing Teleport cluster and would
 like to start running it in Kubernetes, or when migrating your setup from a legacy
 version of the Helm charts.
 
-<Admonition type="tip" title="Have an existing Teleport cluster?">
 If you are already running Teleport on another platform, you can use your
 existing Teleport deployment to access your Kubernetes cluster. [Follow our
 guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
 cluster to Teleport.
-</Admonition>
 
-(!docs/pages/includes/cloud/call-to-action.mdx!)
+## Prerequisites
 
 <Admonition type="warning">
 Those instructions are both for v12 Teleport and the v12 `teleport-cluster` chart.
 If you are running an older Teleport version, use the version selector at the top
 of this page to choose the correct version.
 </Admonition>
-
-## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -3,23 +3,15 @@ title: Get started with Teleport on DigitalOcean Kubernetes
 description: How to get started with Teleport on DigitalOcean Kubernetes
 ---
 
-<ScopedBlock title="Teleport Cloud customers" scope={["cloud"]}>
-
-This guide shows you how to deploy the Teleport Auth Service and Proxy Service
-on a DigitalOcean Kubernetes cluster. These services are fully managed in
-Teleport Cloud.
-
-Instead, Teleport Cloud users should consult the following guide, which shows
-you how to connect a Teleport Kubernetes Service instance to an existing Teleport
-cluster:
-
-- [Connect a Kubernetes Cluster to
-  Teleport](../../kubernetes-access/getting-started.mdx):
-
-</ScopedBlock>
-
 This guide will show you how to get started with Teleport on DigitalOcean
 Kubernetes.
+
+<Admonition type="tip" title="Have an existing Teleport cluster?">
+If you are already running Teleport on another platform, you can use your
+existing Teleport deployment to access your Kubernetes cluster. [Follow our
+guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
+cluster to Teleport.
+</Admonition>
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
@@ -41,7 +33,7 @@ While the Kubernetes cluster is being provisioned, follow the "Getting Started" 
   ![Set up DigitalOcean Kubernetes client](../../../img/helm/digitalocean/setup-k8s.png)
 </Figure>
 
-## Step 2/4. Install Teleport 
+## Step 2/4. Install Teleport
 
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -6,12 +6,10 @@ description: How to get started with Teleport on DigitalOcean Kubernetes
 This guide will show you how to get started with Teleport on DigitalOcean
 Kubernetes.
 
-<Admonition type="tip" title="Have an existing Teleport cluster?">
 If you are already running Teleport on another platform, you can use your
 existing Teleport deployment to access your Kubernetes cluster. [Follow our
 guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
 cluster to Teleport.
-</Admonition>
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -6,12 +6,10 @@ description: Install and configure an HA Teleport cluster using a Google Cloud G
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and Google Cloud Platform products (Firestore and Google Cloud Storage).
 
-<Admonition type="tip" title="Have an existing Teleport cluster?">
 If you are already running Teleport on another platform, you can use your
 existing Teleport deployment to access your Kubernetes cluster. [Follow our
 guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
 cluster to Teleport.
-</Admonition>
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -6,11 +6,12 @@ description: Install and configure an HA Teleport cluster using a Google Cloud G
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and Google Cloud Platform products (Firestore and Google Cloud Storage).
 
-<ScopedBlock scope="cloud">
-
-(!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
-
-</ScopedBlock>
+<Admonition type="tip" title="Have an existing Teleport cluster?">
+If you are already running Teleport on another platform, you can use your
+existing Teleport deployment to access your Kubernetes cluster. [Follow our
+guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
+cluster to Teleport.
+</Admonition>
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -15,12 +15,10 @@ Teleport can provide secure, unified access to your Kubernetes clusters. This gu
 
 While completing this guide, you will deploy one Teleport pod each for the Auth Service and Proxy Service in your Kubernetes cluster, and a load balancer that allows outside traffic to your Teleport cluster. Users can then access your Kubernetes cluster via the Teleport cluster running within it.
 
-<Admonition type="tip" title="Have an existing Teleport cluster?">
 If you are already running Teleport on another platform, you can use your
 existing Teleport deployment to access your Kubernetes cluster. [Follow our
 guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
 cluster to Teleport.
-</Admonition>
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -3,13 +3,6 @@ title: Getting Started - Kubernetes with SSO
 description: Getting started with Teleport. Let's deploy Teleport in a Kubernetes with SSO and Audit logs
 ---
 
-<ScopedBlock title="Teleport Cloud customers" scope={["cloud"]}>
-This guide shows you how to deploy the Teleport Auth Service and Proxy Service on a Kubernetes cluster. These services are fully managed in Teleport Cloud.
-
-Instead, Teleport Cloud users should consult the following guide, which shows you how to connect a Teleport Kubernetes Service instance to an existing Teleport cluster:
-
-</ScopedBlock>
-
 Teleport can provide secure, unified access to your Kubernetes clusters. This guide will show you how to:
 
 <ScopedBlock scope={["enterprise"]}>
@@ -23,7 +16,10 @@ Teleport can provide secure, unified access to your Kubernetes clusters. This gu
 While completing this guide, you will deploy one Teleport pod each for the Auth Service and Proxy Service in your Kubernetes cluster, and a load balancer that allows outside traffic to your Teleport cluster. Users can then access your Kubernetes cluster via the Teleport cluster running within it.
 
 <Admonition type="tip" title="Have an existing Teleport cluster?">
-If you are already running Teleport on another platform, you can use your existing Teleport deployment to access your Kubernetes cluster. [Follow our guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes cluster to Teleport.
+If you are already running Teleport on another platform, you can use your
+existing Teleport deployment to access your Kubernetes cluster. [Follow our
+guide](../../kubernetes-access/getting-started.mdx) to connect your Kubernetes
+cluster to Teleport.
 </Admonition>
 
 (!docs/pages/includes/cloud/call-to-action.mdx!)

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -39,7 +39,7 @@ This guide requires you to have:
 
   You can reuse an existing server running any other Teleport instance.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Create a restrictive service account
 

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -33,21 +33,13 @@ This guide requires you to have:
 
 - Access to a Domain Controller
 
-- An existing Teleport cluster with one of the following versions:
-
-  **Open Source or Enterprise:** version 8.0 or newer
-
-  **Teleport Cloud:** version 9.0 or newer
-
-  See [Teleport Getting Started](../try-out-teleport/introduction.mdx) if you're new to Teleport.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - A Linux server to run the Teleport Desktop Service on.
 
   You can reuse an existing server running any other Teleport instance.
 
-- The `tctl` administration tool version >= (=teleport.version=)
-
-  (!docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Create a restrictive service account
 

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -30,7 +30,6 @@ This guide requires you to have:
 - An Active Directory domain, configured for LDAPS (Teleport requires an
   encrypted LDAP connection). Typically this means installing
   [AD CS](https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/)
-
 - Access to a Domain Controller
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,13 +1,13 @@
-{/* 
+{/*
 TODO: Since we can't control the directory level of the page that uses this
-partial, and it is currently not possible to include absolute paths to MDX 
+partial, and it is currently not possible to include absolute paths to MDX
 files in partials, this partial uses relative URL paths instead.
 */}
 <Tabs>
 <TabItem scope={["oss"]} label="Open Source">
 
 - A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](/docs/getting-started) guides. 
+  [Getting Started](/docs/getting-started) guides.
 
 - The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
 

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,31 +1,31 @@
-- Make sure you can connect to Teleport. Log in to your cluster using `tsh`, then use `tctl`
-  remotely:
+Make sure you can connect to Teleport. Log in to your cluster using `tsh`, then use `tctl`
+remotely:
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
+<ScopedBlock scope={["oss", "enterprise"]}>
 
-  ```code
-  $ tsh login --proxy=teleport.example.com --user=email@example.com
-  $ tctl status
-  # Cluster  teleport.example.com
-  # Version  (=teleport.version=)
-  # CA pin   (=presets.ca_pin=)
-  ```
+```code
+$ tsh login --proxy=teleport.example.com --user=email@example.com
+$ tctl status
+# Cluster  teleport.example.com
+# Version  (=teleport.version=)
+# CA pin   (=presets.ca_pin=)
+```
 
-  You can run subsequent `tctl` commands in this guide on your local machine.
+You can run subsequent `tctl` commands in this guide on your local machine.
 
-  For full privileges, you can also run `tctl` commands on your Auth Service host.
+For full privileges, you can also run `tctl` commands on your Auth Service host.
 
-  </ScopedBlock>
-  <ScopedBlock scope="cloud">
+</ScopedBlock>
+<ScopedBlock scope="cloud">
 
-  ```code
-  $ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
-  $ tctl status
-  # Cluster  myinstance.teleport.sh
-  # Version  (=cloud.version=)
-  # CA pin   sha256:sha-hash-here
-  ```
+```code
+$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
+$ tctl status
+# Cluster  myinstance.teleport.sh
+# Version  (=cloud.version=)
+# CA pin   sha256:sha-hash-here
+```
 
-  You must run subsequent `tctl` commands in this guide on your local machine.
+You must run subsequent `tctl` commands in this guide on your local machine.
 
-  </ScopedBlock>
+</ScopedBlock>

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,34 +1,31 @@
-<ScopedBlock scope={["oss", "enterprise"]}>
+- Make sure you can connect to Teleport. Log in to your cluster using `tsh`, then use `tctl`
+  remotely:
 
-To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
-remotely:
+  <ScopedBlock scope={["oss", "enterprise"]}>
 
-```code
-$ tsh login --proxy=teleport.example.com --user=email@example.com
-$ tctl status
-# Cluster  teleport.example.com
-# Version  (=teleport.version=)
-# CA pin   (=presets.ca_pin=)
-```
+  ```code
+  $ tsh login --proxy=teleport.example.com --user=email@example.com
+  $ tctl status
+  # Cluster  teleport.example.com
+  # Version  (=teleport.version=)
+  # CA pin   (=presets.ca_pin=)
+  ```
 
-You can run subsequent `tctl` commands in this guide on your local machine.
+  You can run subsequent `tctl` commands in this guide on your local machine.
 
-For full privileges, you can also run `tctl` commands on your Auth Service host.
+  For full privileges, you can also run `tctl` commands on your Auth Service host.
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+  </ScopedBlock>
+  <ScopedBlock scope="cloud">
 
-To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
-remotely:
+  ```code
+  $ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
+  $ tctl status
+  # Cluster  myinstance.teleport.sh
+  # Version  (=cloud.version=)
+  # CA pin   sha256:sha-hash-here
+  ```
 
-```code
-$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
-$ tctl status
-# Cluster  myinstance.teleport.sh
-# Version  (=cloud.version=)
-# CA pin   sha256:sha-hash-here
-```
+  You must run subsequent `tctl` commands in this guide on your local machine.
 
-You must run subsequent `tctl` commands in this guide on your local machine.
-
-</ScopedBlock>
+  </ScopedBlock>

--- a/docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx
+++ b/docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx
@@ -1,8 +1,13 @@
-This guide shows you how to install the `teleport-cluster` Helm chart, which is intended to help you get started with Teleport by deploying the Auth Service and 
-Proxy Service in a Kubernetes cluster so you can access that cluster via the Kubernetes Service.
+This guide shows you how to install the `teleport-cluster` Helm chart, which is
+intended to help you get started with Teleport by deploying the Auth Service and
+Proxy Service in a Kubernetes cluster so you can access that cluster via the
+Kubernetes Service.
 
-Since the Auth and Proxy Services are fully managed in Teleport Cloud, you should install our `teleport-kube-agent` chart, which is intended for deployments where the Auth Service and Proxy Service run outside your Kubernetes cluster.
+Since the Auth and Proxy Services are fully managed in Teleport Cloud, you should
+install our `teleport-kube-agent` chart, which is intended for deployments where
+the Auth Service and Proxy Service run outside your Kubernetes cluster.
 
-You can use the `teleport-kube-agent` chart to enable the Application Service and Database Service in addition to the Kubernetes Service.
+You can use the `teleport-kube-agent` chart to enable the Application Service
+and Database Service in addition to the Kubernetes Service.
 
 For more information, see our [Helm chart reference](../../../reference/helm-reference/teleport-kube-agent.mdx).

--- a/docs/pages/machine-id/guides/ansible.mdx
+++ b/docs/pages/machine-id/guides/ansible.mdx
@@ -10,38 +10,24 @@ with a configuration file that is automatically managed by Machine ID.
 
 You will need the following tools to use Teleport with Ansible.
 
-- The Teleport Auth Service and Proxy Service version >= 9.0.0, deployed on
-  your own infrastructure or managed via Teleport Cloud.
-- The `tsh` client tool version >= (=teleport.version=).
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - `ssh` OpenSSH tool
 - `ansible` >= (=ansible.min_version=)
-- Optional tool `jq` to process `JSON` output
+- Optional: [`jq`](https://stedolan.github.io/jq/) to process `JSON` output
 
-<Admonition type="note" title="Machine ID and TLS Routing">
-TLS Routing support will be added to Machine ID in [Teleport
-9.3](https://goteleport.com/docs/preview/upcoming-releases/#teleport-93). Until
-that time, the Teleport Proxy Server will need to be configured with a
-dedicated SSH listener.
-
-```yaml
-version: v1
-proxy_service:
-  enabled: "yes"
-  listen_addr: "0.0.0.0:3023"
-  ...
-```
-</Admonition>
-
-In addition, if you already have not done so, follow the
+- If you already have not done so, follow the
 [Machine ID Getting Started Guide](../getting-started.mdx) to create a bot
 user and start Machine ID.
 
-If you followed the above guide, you are interested in the
-`--destination-dir=/opt/machine-id` flag, which defines the directory where
-SSH certificates and OpenSSH configuration used by Ansible will be written.
+- If you followed the above guide, note the `--destination-dir=/opt/machine-id`
+flag, which defines the directory where SSH certificates and OpenSSH configuration
+used by Ansible will be written.
 
-In particular, you will be using the `/opt/machine-id/ssh_config` file in your
+  In particular, you will be using the `/opt/machine-id/ssh_config` file in your
 Ansible configuration to define how Ansible should connect to Teleport Nodes.
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Configure Ansible
 

--- a/docs/pages/machine-id/guides/ansible.mdx
+++ b/docs/pages/machine-id/guides/ansible.mdx
@@ -13,19 +13,21 @@ You will need the following tools to use Teleport with Ansible.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - `ssh` OpenSSH tool
+
 - `ansible` >= (=ansible.min_version=)
+
 - Optional: [`jq`](https://stedolan.github.io/jq/) to process `JSON` output
 
 - If you already have not done so, follow the
-[Machine ID Getting Started Guide](../getting-started.mdx) to create a bot
-user and start Machine ID.
+  [Machine ID Getting Started Guide](../getting-started.mdx) to create a bot
+  user and start Machine ID.
 
 - If you followed the above guide, note the `--destination-dir=/opt/machine-id`
-flag, which defines the directory where SSH certificates and OpenSSH configuration
-used by Ansible will be written.
+  flag, which defines the directory where SSH certificates and OpenSSH configuration
+  used by Ansible will be written.
 
   In particular, you will be using the `/opt/machine-id/ssh_config` file in your
-Ansible configuration to define how Ansible should connect to Teleport Nodes.
+  Ansible configuration to define how Ansible should connect to Teleport Nodes.
 
 - (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/machine-id/guides/ansible.mdx
+++ b/docs/pages/machine-id/guides/ansible.mdx
@@ -27,7 +27,7 @@ used by Ansible will be written.
   In particular, you will be using the `/opt/machine-id/ssh_config` file in your
 Ansible configuration to define how Ansible should connect to Teleport Nodes.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Configure Ansible
 

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -15,19 +15,16 @@ controls that Teleport provides for human users.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - If you have not already connected your application to Teleport, follow
-the [Application Access Getting Started Guide](../../application-access/getting-started.mdx).
-
+  the [Application Access Getting Started Guide](../../application-access/getting-started.mdx).
 - If you're not already familiar with Machine ID, follow the
-[Getting Started Guide](../getting-started.mdx) to familiarize yourself with
-Machine ID. You'll also need `tctl` access to initially configure the bot.
-
+  [Getting Started Guide](../getting-started.mdx) to familiarize yourself with
+  Machine ID. You'll also need `tctl` access to initially configure the bot.
 - (!docs/pages/includes/tctl.mdx!)
-
 - Ensure the `tbot` binary is installed on your Machine ID client system.
-The client system is any system from which you want to access your Teleport
-cluster and the resources it protects from an automated service. Refer to our
-[Installation guide](../../installation.mdx) for instructions on installing
-Teleport, which includes the necessary `tbot` binary.
+  The client system is any system from which you want to access your Teleport
+  cluster and the resources it protects from an automated service. Refer to our
+  [Installation guide](../../installation.mdx) for instructions on installing
+  Teleport, which includes the necessary `tbot` binary.
 
 ## Step 1/3. Create a Machine ID bot and assign permissions
 

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -12,23 +12,18 @@ controls that Teleport provides for human users.
 
 ## Prerequisites
 
-<ScopedBlock scope={["cloud"]}>
-You will need Teleport Cloud 10.1.0 or later.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
-You will need a running Teleport cluster version 10.1.0 or later.
-</ScopedBlock>
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-If you have not already connected your application to Teleport, follow
+- If you have not already connected your application to Teleport, follow
 the [Application Access Getting Started Guide](../../application-access/getting-started.mdx).
 
-If you're not already familiar with Machine ID, follow the
+- If you're not already familiar with Machine ID, follow the
 [Getting Started Guide](../getting-started.mdx) to familiarize yourself with
 Machine ID. You'll also need `tctl` access to initially configure the bot.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-Lastly, ensure the `tbot` binary is installed on your Machine ID client system.
+- Ensure the `tbot` binary is installed on your Machine ID client system.
 The client system is any system from which you want to access your Teleport
 cluster and the resources it protects from an automated service. Refer to our
 [Installation guide](../../installation.mdx) for instructions on installing

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -11,32 +11,26 @@ that can be rotated, audited, and managed with the same access controls that
 Teleport provides for human users.
 
 <Figure align="left" bordered caption="Machine ID and Database Access Deployment">
-  ![Machine ID and Database Access Deployment](../../../img/machine-id/machine-id-database-access.svg)
+![Machine ID and Database Access Deployment](../../../img/machine-id/machine-id-database-access.svg)
 </Figure>
 
 ## Prerequisites
 
-<ScopedBlock scope={["cloud"]}>
-You will need Teleport Cloud 9.3.0 or later.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
-You will need to be running the Teleport Proxy and Auth Services, version 9.3.0 or
-later.
-</ScopedBlock>
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-If you have not already put your database behind the Teleport Database Service,
+- If you have not already put your database behind the Teleport Database Service,
 follow the [database access getting started guide](../../database-access/getting-started.mdx).
 The Teleport Database Service supports databases like PostgreSQL, MongoDB,
 Redis, and much more. See our [database access
 guides](../../database-access/guides.mdx) for a complete list.
 
-If you have not already set up Machine ID, follow the [Machine ID getting
+- If you have not already set up Machine ID, follow the [Machine ID getting
 started guide](../getting-started.mdx) to familiarize yourself with Machine ID.
 You'll need `tctl` access to initially configure the bot.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-Lastly, ensure both the `tbot` and `tsh` executables are available on your
+- Ensure both the `tbot` and `tsh` executables are available on your
 application host. See [Installation](../../installation.mdx) for details.
 
 ## Step 1/3. Create a Machine ID bot and assign permissions

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -19,19 +19,16 @@ Teleport provides for human users.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - If you have not already put your database behind the Teleport Database Service,
-follow the [database access getting started guide](../../database-access/getting-started.mdx).
-The Teleport Database Service supports databases like PostgreSQL, MongoDB,
-Redis, and much more. See our [database access
-guides](../../database-access/guides.mdx) for a complete list.
-
+  follow the [database access getting started guide](../../database-access/getting-started.mdx).
+  The Teleport Database Service supports databases like PostgreSQL, MongoDB,
+  Redis, and much more. See our [database access
+  guides](../../database-access/guides.mdx) for a complete list.
 - If you have not already set up Machine ID, follow the [Machine ID getting
-started guide](../getting-started.mdx) to familiarize yourself with Machine ID.
-You'll need `tctl` access to initially configure the bot.
-
+  started guide](../getting-started.mdx) to familiarize yourself with Machine ID.
+  You'll need `tctl` access to initially configure the bot.
 - (!docs/pages/includes/tctl.mdx!)
-
 - Ensure both the `tbot` and `tsh` executables are available on your
-application host. See [Installation](../../installation.mdx) for details.
+  application host. See [Installation](../../installation.mdx) for details.
 
 ## Step 1/3. Create a Machine ID bot and assign permissions
 

--- a/docs/pages/machine-id/guides/jenkins.mdx
+++ b/docs/pages/machine-id/guides/jenkins.mdx
@@ -13,26 +13,10 @@ utilize Machine ID with minimal changes.
 
 You will need the following tools to use Teleport with Jenkins.
 
-- The Teleport Auth Service and Proxy Service version >= 9.0.0, deployed on
-  your own infrastructure or managed via Teleport Cloud.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - `ssh` OpenSSH tool
 - Jenkins
-- The `tctl` admin tool version >= (=teleport.version=)
-
-<Admonition type="note" title="Machine ID and TLS Routing">
-TLS Routing support will be added to Machine ID in [Teleport
-9.3](https://goteleport.com/docs/preview/upcoming-releases/#teleport-93). Until
-that time, the Teleport Proxy Server will need to be configured with a
-dedicated SSH listener.
-
-```yaml
-version: v1
-proxy_service:
-  enabled: "yes"
-  listen_addr: "0.0.0.0:3023"
-  ...
-```
-</Admonition>
 
 - (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/machine-id/guides/kubernetes.mdx
+++ b/docs/pages/machine-id/guides/kubernetes.mdx
@@ -12,31 +12,26 @@ controls that Teleport provides for human users.
 
 ## Prerequisites
 
-<ScopedBlock scope={["cloud"]}>
-You will need Teleport Cloud 10.1.0 or later.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
-You will need a running Teleport cluster version 10.1.0 or later.
-</ScopedBlock>
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-If you have not already connected your Kubernetes cluster to Teleport, follow
+- If you have not already connected your Kubernetes cluster to Teleport, follow
 the [Kubernetes Access Getting Started Guide](../../kubernetes-access/getting-started.mdx).
 
 (!docs/pages/includes/machine-id/kubernetes-machineidnote.mdx!)
 
-If you're not already familiar with Machine ID, follow the
-[Getting Started Guide](../getting-started.mdx) to familiarize yourself with
-Machine ID. You'll also need `tctl` access to initially configure the bot.
+- If you're not already familiar with Machine ID, follow the
+  [Getting Started Guide](../getting-started.mdx) to familiarize yourself with
+  Machine ID. You'll also need `tctl` access to initially configure the bot.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-Next, ensure the `tbot` binary is installed on your Machine ID client system.
+- Ensure the `tbot` binary is installed on your Machine ID client system.
 The client system is any system from which you want to access your Teleport
 cluster and the resources it protects from an automated service. Refer to our
 [Installation guide](../../installation.mdx) for instructions on installing
 Teleport, which includes the necessary `tbot` binary.
 
-Finally, to interact with the connected Kubernetes cluster, your client system
+- Finally, to interact with the connected Kubernetes cluster, your client system
 will need to have `kubectl` installed. See the
 [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/) for
 installation instructions.

--- a/docs/pages/machine-id/guides/kubernetes.mdx
+++ b/docs/pages/machine-id/guides/kubernetes.mdx
@@ -15,22 +15,19 @@ controls that Teleport provides for human users.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - If you have not already connected your Kubernetes cluster to Teleport, follow
-the [Kubernetes Access Getting Started Guide](../../kubernetes-access/getting-started.mdx).
+  the [Kubernetes Access Getting Started Guide](../../kubernetes-access/getting-started.mdx).
 
 (!docs/pages/includes/machine-id/kubernetes-machineidnote.mdx!)
 
 - If you're not already familiar with Machine ID, follow the
   [Getting Started Guide](../getting-started.mdx) to familiarize yourself with
   Machine ID. You'll also need `tctl` access to initially configure the bot.
-
 - (!docs/pages/includes/tctl.mdx!)
-
 - Ensure the `tbot` binary is installed on your Machine ID client system.
-The client system is any system from which you want to access your Teleport
-cluster and the resources it protects from an automated service. Refer to our
-[Installation guide](../../installation.mdx) for instructions on installing
-Teleport, which includes the necessary `tbot` binary.
-
+  The client system is any system from which you want to access your Teleport
+  cluster and the resources it protects from an automated service. Refer to our
+  [Installation guide](../../installation.mdx) for instructions on installing
+  Teleport, which includes the necessary `tbot` binary.
 - Finally, to interact with the connected Kubernetes cluster, your client system
 will need to have `kubectl` installed. See the
 [Kubernetes documentation](https://kubernetes.io/docs/tasks/tools/) for
@@ -42,6 +39,7 @@ In this example, you'll create a bot named "example" and assign it a role
 granting access to a Kubernetes cluster named "example".
 
 First, create a file named `role.yaml` with the following content:
+
 ```yaml
 kind: role
 metadata:

--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -9,25 +9,22 @@ credentials from the Teleport Auth Service. This enables fine-grained
 role-based access controls and audit.
 
 Machine ID supports the following Teleport features:
- - [Server Access](./getting-started.mdx)
- - [Database Access](./guides/databases.mdx)
- - [Kubernetes Access](./guides/kubernetes.mdx) (*in Teleport v10.1*)
- - [Application Access](./guides/applications.mdx) (*in Teleport v10.1*)
-   - Note: [AWS Console](../application-access/cloud-apis/aws-console.mdx) and API access is currently unsupported.
- - [Teleport API Access](../api/introduction.mdx)
+
+- [Server Access](./getting-started.mdx)
+- [Database Access](./guides/databases.mdx)
+- [Kubernetes Access](./guides/kubernetes.mdx) (*in Teleport v10.1*)
+- [Application Access](./guides/applications.mdx) (*in Teleport v10.1*)
+  - Note: [AWS Console](../application-access/cloud-apis/aws-console.mdx) and API access is currently unsupported.
+- [Teleport API Access](../api/introduction.mdx)
 
 These features are supported in Teleport Enterprise and Teleport Cloud.
 
 The following features are **not** yet supported by Machine ID:
- - [Desktop Access](../desktop-access/introduction.mdx)
- - [User Impersonation](../access-controls/guides/impersonation.mdx): Machine 
-   ID uses Role Impersonation which cannot be combined with User Impersonation
- - Multifactor authentication like [WebAuthn](../access-controls/guides/webauthn.mdx) and [Passwordless](../access-controls/guides/passwordless.mdx)
- - [AWS Console Access](../application-access/cloud-apis/aws-console.mdx)
-
-{
-/*
-TODO(russjones): Once we have a demo video for Machine ID, include it here.
+- [Desktop Access](../desktop-access/introduction.mdx)
+- [User Impersonation](../access-controls/guides/impersonation.mdx): Machine
+  ID uses Role Impersonation which cannot be combined with User Impersonation
+- Multifactor authentication like [WebAuthn](../access-controls/guides/webauthn.mdx) and [Passwordless](../access-controls/guides/passwordless.mdx)
+- [AWS Console Access](../application-access/cloud-apis/aws-console.mdx)
 
 ## Demo
 
@@ -52,8 +49,6 @@ Let's create a bot and use the machine identity to connect to a server.
 
   Your browser does not support the video tag.
 </video>
-*/
-}
 
 ## Getting started
 

--- a/docs/pages/machine-id/introduction.mdx
+++ b/docs/pages/machine-id/introduction.mdx
@@ -14,7 +14,7 @@ Machine ID supports the following Teleport features:
 - [Database Access](./guides/databases.mdx)
 - [Kubernetes Access](./guides/kubernetes.mdx) (*in Teleport v10.1*)
 - [Application Access](./guides/applications.mdx) (*in Teleport v10.1*)
-  - Note: [AWS Console](../application-access/cloud-apis/aws-console.mdx) and API access is currently unsupported.
+  - Note: [AWS Console](../application-access/cloud-apis/aws-console.mdx) and API access are currently unsupported.
 - [Teleport API Access](../api/introduction.mdx)
 
 These features are supported in Teleport Enterprise and Teleport Cloud.

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -46,48 +46,7 @@ more in the following guide:
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
-
-- A running Teleport cluster. For details on how to set this up, see [Getting
-  Started on a Linux Server](../../try-out-teleport/linux-server.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-- An AWS EC2 instance to act as a Teleport Node, with the Teleport binary
-  installed. The Node should not have an existing data dir (`/var/lib/teleport` by default).
-  Remove the data directory if this instance has previously joined a Teleport cluster.
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster. For details on setting this up, see our
-  [Enterprise getting started guide](../../choose-an-edition/teleport-enterprise/getting-started.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-- An AWS EC2 instance to act as a Teleport Node, with the Teleport binary
-    installed. The Node should not have an existing data dir
-    (`/var/lib/teleport` by default). Remove the data directory if this
-    instance has previously joined a Teleport cluster.
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -49,6 +49,9 @@ more in the following guide:
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
+- An AWS EC2 instance to act as a Teleport Node, with the Teleport binary
+  installed. The Node should not have an existing data dir (`/var/lib/teleport` by default).
+  Remove the data directory if this instance has previously joined a Teleport cluster.
 
 ## Step 1/4. Set up AWS IAM credentials
 

--- a/docs/pages/management/guides/ssh-key-extensions.mdx
+++ b/docs/pages/management/guides/ssh-key-extensions.mdx
@@ -7,7 +7,8 @@ Teleport supports exporting user SSH certificates with configurable key extensio
 
 ## Prerequisites
 
-- The Teleport Auth Service and Proxy Service v(=teleport.version=), either self hosted or deployed on Teleport Cloud.
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - The GitHub SSO authentication connector. For more information, see [GitHub SSO](../../access-controls/sso/github-sso.mdx).
 - Access to GitHub Enterprise and permissions to modify GitHub's SSH Certificate Authorities.
 

--- a/docs/pages/management/operations/tls-routing.mdx
+++ b/docs/pages/management/operations/tls-routing.mdx
@@ -13,22 +13,6 @@ description: How to upgrade an existing Teleport cluster to single-port TLS rout
   TLS routing is available starting from Teleport `8.0`.
 </Details>
 
-<Notice type="tip" label="Teleport Cloud Users">
-
-Teleport Cloud manages the Proxy Service's networking configuration for you.
-
-To see which ports and networking settings the Proxy Service is configured to
-use in your Teleport Cloud tenant, run the following command, replacing
-`mytenant.teleport.sh` with your tenant address:
-
-```code
-$ curl https://mytenant.teleport.sh/webapi/ping | jq '.proxy'
-```
-
-</Notice>
-
-(!docs/pages/includes/cloud/call-to-action.mdx!)
-
 Teleport supports TLS routing. In this mode, all client connections are wrapped
 in TLS and multiplexed on one Teleport proxy port.
 
@@ -45,6 +29,22 @@ is served on a separate port:
 Existing clusters upgraded to `8.0` will not utilize TLS routing by default and
 keep working in backwards-compatibility mode. Follow this guide to migrate your
 Teleport installation to TLS routing.
+
+<Notice type="tip">
+
+Teleport Cloud manages the Proxy Service's networking configuration for you.
+Get started with a [free trial](https://goteleport.com/signup?source=docs) of
+Teleport Cloud.
+
+To see which ports and networking settings the Proxy Service is configured to
+use in your Teleport Cloud tenant, run the following command, replacing
+`mytenant.teleport.sh` with your tenant address:
+
+```code
+$ curl https://mytenant.teleport.sh/webapi/ping | jq '.proxy'
+```
+
+</Notice>
 
 ## Requirements
 

--- a/docs/pages/management/operations/tls-routing.mdx
+++ b/docs/pages/management/operations/tls-routing.mdx
@@ -13,7 +13,7 @@ description: How to upgrade an existing Teleport cluster to single-port TLS rout
   TLS routing is available starting from Teleport `8.0`.
 </Details>
 
-<Admonition scope={["cloud"]} type="tip" scopeOnly>
+<Notice type="tip" label="Teleport Cloud Users">
 
 Teleport Cloud manages the Proxy Service's networking configuration for you.
 
@@ -25,11 +25,12 @@ use in your Teleport Cloud tenant, run the following command, replacing
 $ curl https://mytenant.teleport.sh/webapi/ping | jq '.proxy'
 ```
 
-</Admonition>
+</Notice>
 
-Starting from version `8.0` Teleport supports TLS routing. In this mode, all
-client connections are wrapped in TLS and multiplexed on one Teleport proxy
-port.
+(!docs/pages/includes/cloud/call-to-action.mdx!)
+
+Teleport supports TLS routing. In this mode, all client connections are wrapped
+in TLS and multiplexed on one Teleport proxy port.
 
 TLS routing has multiple benefits compared to the deployment where each protocol
 is served on a separate port:

--- a/docs/pages/server-access/guides/ansible.mdx
+++ b/docs/pages/server-access/guides/ansible.mdx
@@ -17,7 +17,7 @@ and run a sample ansible playbook.
 - `ansible` >= (=ansible.min_version=)
 - Optional tool `jq` to process `JSON` output.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Login and configure SSH
 

--- a/docs/pages/server-access/guides/ansible.mdx
+++ b/docs/pages/server-access/guides/ansible.mdx
@@ -16,7 +16,6 @@ and run a sample ansible playbook.
 - `ssh` openssh tool
 - `ansible` >= (=ansible.min_version=)
 - Optional tool `jq` to process `JSON` output.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Login and configure SSH

--- a/docs/pages/server-access/guides/ansible.mdx
+++ b/docs/pages/server-access/guides/ansible.mdx
@@ -11,11 +11,13 @@ and run a sample ansible playbook.
 
 ## Prerequisites
 
-- Installed [Teleport Enterprise](../../choose-an-edition/teleport-enterprise/introduction.mdx) or [Teleport Cloud](../../choose-an-edition/teleport-cloud/introduction.mdx) >= (=teleport.version=)
-- `tsh` client tool  >= (=teleport.version=)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
+
 - `ssh` openssh tool
 - `ansible` >= (=ansible.min_version=)
 - Optional tool `jq` to process `JSON` output.
+
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Login and configure SSH
 

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -36,7 +36,9 @@ The Teleport Proxy Service should be available to clients and set up with TLS.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- A host where you will run an OpenSSH server.
+
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Configure Teleport
 

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -37,7 +37,6 @@ The Teleport Proxy Service should be available to clients and set up with TLS.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - A host where you will run an OpenSSH server.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Configure Teleport

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -34,43 +34,9 @@ The Teleport Proxy Service should be available to clients and set up with TLS.
 
 ## Prerequisites
 
-<Tabs>
-<TabItem scope={["oss"]} label="Self-Hosted">
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A running Teleport cluster. For details on how to set this up, see [Getting
-  Started on a Linux Server](../../try-out-teleport/linux-server.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-  See [Installation](../../installation.mdx) for details.
-
-- A host where you will run an OpenSSH server.
-
-</TabItem>
-<TabItem
-  scope={["enterprise"]} label="Enterprise">
-
-- A running Teleport cluster. For details on setting this up, see our
-  [Enterprise getting started guide](../../choose-an-edition/teleport-enterprise/getting-started.mdx).
-
-- The `tctl` admin tool version >= (=teleport.version=), which you can download
-  by visiting the
-  [customer portal](https://dashboard.gravitational.com/web/login).
-
-  ```code
-  $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
-  ```
-
-- A host where you will run an OpenSSH server.
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Configure Teleport
 


### PR DESCRIPTION
I went through the list of pages in #21541 and updated them to use our `prereqs-tabs` and `tctl` partials wherever appropriate. Along the way, I caught some other edits/updates needed in these pages, which I've reflected in my commit messages.

I'm leaving it to @ptgott to say if this PR closes the issue linked above, or if additional work should still be done on the partial files themselves.

P.S. Not backporting to 10 as some of the updates remove version warnings pertaining to minor versions of Teleport v10.