### PR TITLE
Fix incorrect report of active sessions

### DIFF
--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -580,7 +580,7 @@ func (s *session) launch() error {
 	}()
 
 	if err = s.tracker.UpdateState(s.forwarder.ctx, types.SessionState_SessionStateRunning); err != nil {
-		s.log.Warn("Failed to set tracker state to running")
+		s.log.WithError(err).Warn("Failed to set tracker state to running")
 	}
 
 	var executor remotecommand.Executor

--- a/lib/services/local/sessiontracker_test.go
+++ b/lib/services/local/sessiontracker_test.go
@@ -114,7 +114,6 @@ func TestSessionTrackerStorage(t *testing.T) {
 	require.Error(t, err)
 	require.True(t, trace.IsNotFound(err))
 	require.Nil(t, tracker)
-
 }
 
 func TestSessionTrackerImplicitExpiry(t *testing.T) {
@@ -234,6 +233,17 @@ func TestSessionTrackerTermination(t *testing.T) {
 		}},
 	}))
 
+	// Try to change the state to running, this should fail because the tracker
+	// is now in a terminal state
+	err = srv.UpdateSessionTracker(ctx, &proto.UpdateSessionTrackerRequest{
+		SessionID: id,
+		Update: &proto.UpdateSessionTrackerRequest_UpdateState{UpdateState: &proto.SessionTrackerUpdateState{
+			State: types.SessionState_SessionStateRunning,
+		}},
+	})
+	require.Error(t, err)
+	require.True(t, trace.IsBadParameter(err))
+
 	// Validate that the tracker still exists
 	sessions, err = srv.GetActiveSessionTrackers(ctx)
 	require.NoError(t, err)
@@ -247,5 +257,4 @@ func TestSessionTrackerTermination(t *testing.T) {
 	sessions, err = srv.GetActiveSessionTrackers(ctx)
 	require.NoError(t, err)
 	require.Empty(t, sessions)
-
 }


### PR DESCRIPTION
The session tracker didn't validate the current state of the tracked session and allowed out-of-order events to replace the session state if the session was already marked as terminated.

This resulted in the session being marked as active but the expiry TTL was equal to the same as a terminated session which eventually resulted in the session being active for days due to the improper deletion propagation that DynamoDB has.

This PR checks the state and if the session is already marked as closed, it denies any update.