### PR TITLE
[v11] Bump cloud version to 12.1.2

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1291,7 +1291,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "12.1.1",
+      "version": "12.1.2",
       "major_version": "12",
       "sla": {
         "monthly_percentage": "99.5%",


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/23378

See: https://github.com/gravitational/cloud/issues/3838