### PR TITLE
feat: add Login Rule CRD for k8s operator

### DIFF
--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -78,7 +78,7 @@ manifests: crdgen controller-gen ## Generate WebhookConfiguration, ClusterRole a
 		-I=$(PROTOBUF_MOD_PATH) \
 		--plugin=./crdgen/protoc-gen-crd \
 		--crd_out=:./config/crd/bases \
-		../../api/proto/teleport/legacy/types/types.proto
+		teleport/legacy/types/types.proto
 
 # Some comments have `{{xyz}}` which triggers the golang templating engine when installing the chart.
 # We don't want that, so we escape them.

--- a/integrations/operator/crdgen/Makefile
+++ b/integrations/operator/crdgen/Makefile
@@ -1,18 +1,26 @@
 build:
 	go build -o protoc-gen-crd
 
+PROTOS = \
+	teleport/loginrule/v1/loginrule.proto \
+	teleport/legacy/types/types.proto
+
 .PHONY: test
 test: build
 # The wrappers.proto file needed for this generator exist only inside the go mod cache,
 # so we retrieve the file path for the cached proto files with go mod tools.
 	$(eval PROTOBUF_MOD_PATH := $(shell go mod download --json github.com/gogo/protobuf | awk -F: '/"Dir"/ { print $$2 }' | tr -d ' ",'))
 	$(eval CRD_OUT_PATH := $(shell mktemp -d))
-	protoc \
-		-I=testdata/protofiles \
-		-I=$(PROTOBUF_MOD_PATH) \
-		--plugin=./protoc-gen-crd \
-		--crd_out=$(CRD_OUT_PATH) \
-		teleport/legacy/types/types.proto
+
+	for proto in $(PROTOS); do \
+		protoc \
+			-I=testdata/protofiles \
+			-I=$(PROTOBUF_MOD_PATH) \
+			--plugin=./protoc-gen-crd \
+			--crd_out=$(CRD_OUT_PATH) \
+			"$${proto}"; \
+	done
+
 	diff testdata/golden/ $(CRD_OUT_PATH);\
 	EXIT_CODE=$$?;\
 	rm -rf $(CRD_OUT_PATH) $(CUSTOM_IMPORTS_TMP_DIR);\
@@ -30,12 +38,16 @@ update-protos:
 update-snapshot: build
 	$(eval PROTOBUF_MOD_PATH := $(shell go mod download --json github.com/gogo/protobuf | awk -F: '/"Dir"/ { print $$2 }' | tr -d ' ",'))
 	$(eval CRD_OUT_PATH := $(shell mktemp -d))
-	protoc \
-		-I=testdata/protofiles \
-		-I=$(PROTOBUF_MOD_PATH) \
-		--plugin=./protoc-gen-crd \
-		--crd_out=$(CRD_OUT_PATH) \
-		teleport/legacy/types/types.proto
+
+	for proto in $(PROTOS); do \
+		protoc \
+			-I=testdata/protofiles \
+			-I=$(PROTOBUF_MOD_PATH) \
+			--plugin=./protoc-gen-crd \
+			--crd_out=$(CRD_OUT_PATH) \
+			"$${proto}"; \
+	done
+
 	rm -rf testdata/golden
 	cp -r $(CRD_OUT_PATH) testdata/golden
 	rm -rf $(CRD_OUT_PATH)

--- a/integrations/operator/crdgen/schemagen.go
+++ b/integrations/operator/crdgen/schemagen.go
@@ -36,7 +36,7 @@ const k8sKindPrefix = "Teleport"
 
 // Add names to this array when adding support to new Teleport resources that could conflict with Kubernetes
 var kubernetesReservedNames = []string{"role"}
-var regexpResourceName = regexp.MustCompile(`^([A-Za-z]+)(V[0-9]+)$`)
+var regexpResourceName = regexp.MustCompile(`^([A-Za-z]+)(V[0-9]+)?$`)
 
 // SchemaGenerator generates the OpenAPI v3 schema from a proto file.
 type SchemaGenerator struct {
@@ -87,33 +87,75 @@ func NewSchema() *Schema {
 	}}
 }
 
-func (generator *SchemaGenerator) addResource(file *File, name string, overrideVersion ...string) error {
+type resourceSchemaConfig struct {
+	versionOverride  string
+	customSpecFields []string
+}
+
+type resourceSchemaOption func(*resourceSchemaConfig)
+
+func withVersionOverride(version string) resourceSchemaOption {
+	return func(cfg *resourceSchemaConfig) {
+		cfg.versionOverride = version
+	}
+}
+
+func withCustomSpecFields(customSpecFields []string) resourceSchemaOption {
+	return func(cfg *resourceSchemaConfig) {
+		cfg.customSpecFields = customSpecFields
+	}
+}
+
+func (generator *SchemaGenerator) addResource(file *File, name string, opts ...resourceSchemaOption) error {
+	var cfg resourceSchemaConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	rootMsg, ok := file.messageByName[name]
 	if !ok {
 		return trace.NotFound("resource %q is not found", name)
 	}
 
-	specField, ok := rootMsg.GetField("Spec")
-	if !ok {
-		return trace.NotFound("message %q does not have Spec field", name)
+	var schema *Schema
+	if len(cfg.customSpecFields) > 0 {
+		schema = NewSchema()
+		for _, fieldName := range cfg.customSpecFields {
+			field, ok := rootMsg.GetField(fieldName)
+			if !ok {
+				return trace.NotFound("field %q not found", fieldName)
+			}
+			var err error
+			schema.Properties[fieldName], err = generator.prop(field)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	} else {
+		specField, ok := rootMsg.GetField("Spec")
+		if !ok {
+			return trace.NotFound("message %q does not have Spec field", name)
+		}
+
+		specMsg := specField.TypeMessage()
+		if specMsg == nil {
+			return trace.NotFound("message %q Spec type is not a message", name)
+		}
+
+		var err error
+		schema, err = generator.traverseInner(specMsg)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
-	specMsg := specField.TypeMessage()
-	if specMsg == nil {
-		return trace.NotFound("message %q Spec type is not a message", name)
-	}
-
-	schema, err := generator.traverseInner(specMsg)
-	if err != nil {
-		return trace.Wrap(err)
-	}
 	schema = schema.DeepCopy()
 	resourceKind, resourceVersion, err := parseKindAndVersion(rootMsg)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if len(overrideVersion) > 0 {
-		resourceVersion = overrideVersion[0]
+	if cfg.versionOverride != "" {
+		resourceVersion = cfg.versionOverride
 	}
 	schema.Description = fmt.Sprintf("%s resource definition %s from Teleport", resourceKind, resourceVersion)
 
@@ -168,40 +210,52 @@ func (generator *SchemaGenerator) traverseInner(message *Message) (*Schema, erro
 			continue
 		}
 
-		prop := apiextv1.JSONSchemaProps{Description: field.LeadingComments()}
-
-		if field.IsRepeated() {
-			prop.Type = "array"
-			prop.Items = &apiextv1.JSONSchemaPropsOrArray{
-				Schema: &apiextv1.JSONSchemaProps{},
-			}
-			generator.singularProp(field, prop.Items.Schema)
-		} else {
-			generator.singularProp(field, &prop)
+		var err error
+		schema.Properties[jsonName], err = generator.prop(field)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
-
-		if field.IsNullable() && (prop.Type == "array" || prop.Type == "object") {
-			prop.Nullable = true
-		}
-
-		// Labels are relying on `utils.Strings`, which can either marshall as an array of strings or a single string
-		// This does not pass Schema validation from the apiserver, to workaround we don't specify type for those fields
-		// and ask Kubernetes to preserve unknown fields.
-		if field.CustomType() == "Labels" {
-			prop.Type = "object"
-			preserveUnknownFields := true
-			prop.AdditionalProperties = &apiextv1.JSONSchemaPropsOrBool{
-				Schema: &apiextv1.JSONSchemaProps{
-					XPreserveUnknownFields: &preserveUnknownFields,
-				},
-			}
-		}
-
-		schema.Properties[jsonName] = prop
 	}
 	schema.built = true
 
 	return schema, nil
+}
+
+func (generator *SchemaGenerator) prop(field *Field) (apiextv1.JSONSchemaProps, error) {
+	prop := apiextv1.JSONSchemaProps{Description: field.LeadingComments()}
+
+	if field.IsRepeated() && !field.IsMap() {
+		prop.Type = "array"
+		prop.Items = &apiextv1.JSONSchemaPropsOrArray{
+			Schema: &apiextv1.JSONSchemaProps{},
+		}
+		if err := generator.singularProp(field, prop.Items.Schema); err != nil {
+			return prop, trace.Wrap(err)
+		}
+	} else {
+		if err := generator.singularProp(field, &prop); err != nil {
+			return prop, trace.Wrap(err)
+		}
+	}
+
+	if field.IsNullable() && (prop.Type == "array" || prop.Type == "object") {
+		prop.Nullable = true
+	}
+
+	// Labels are relying on `utils.Strings`, which can either marshall as an array of strings or a single string
+	// This does not pass Schema validation from the apiserver, to workaround we don't specify type for those fields
+	// and ask Kubernetes to preserve unknown fields.
+	if field.CustomType() == "Labels" {
+		prop.Type = "object"
+		preserveUnknownFields := true
+		prop.AdditionalProperties = &apiextv1.JSONSchemaPropsOrBool{
+			Schema: &apiextv1.JSONSchemaProps{
+				XPreserveUnknownFields: &preserveUnknownFields,
+			},
+		}
+	}
+
+	return prop, nil
 }
 
 func (generator *SchemaGenerator) singularProp(field *Field, prop *apiextv1.JSONSchemaProps) error {
@@ -238,6 +292,14 @@ func (generator *SchemaGenerator) singularProp(field *Field, prop *apiextv1.JSON
 	case field.TypeName() == ".types.CertExtensionType" || field.TypeName() == ".types.CertExtensionMode":
 		prop.Type = "integer"
 		prop.Format = "int32"
+	case strings.HasSuffix(field.TypeName(), ".v1.LoginRule.TraitsMapEntry"):
+		prop.Type = "object"
+		prop.AdditionalProperties = &apiextv1.JSONSchemaPropsOrBool{
+			Schema: &apiextv1.JSONSchemaProps{
+				Type:  "array",
+				Items: &apiextv1.JSONSchemaPropsOrArray{Schema: &apiextv1.JSONSchemaProps{Type: "string"}},
+			},
+		}
 	case field.IsMessage():
 		inner := field.TypeMessage()
 		if inner == nil {
@@ -253,8 +315,6 @@ func (generator *SchemaGenerator) singularProp(field *Field, prop *apiextv1.JSON
 		return trace.Errorf("unsupported casttype %s.%s", field.Message().Name(), field.Name())
 	case field.CustomType() != "":
 		return trace.Errorf("unsupported customtype %s.%s", field.Message().Name(), field.Name())
-	case field.IsMap():
-		return trace.Errorf("maps are not supported %s.%s", field.Message().Name(), field.Name())
 	default:
 		return trace.Errorf("unsupported %s.%s", field.Message().Name(), field.Name())
 	}
@@ -301,8 +361,7 @@ func (root RootSchema) CustomResourceDefinition() apiextv1.CustomResourceDefinit
 	// Some types are special and require manual overrides, like metav1.Time.
 	crdtools.AddKnownTypes(parser)
 
-	// hack, we should be able to retrieve the path instead
-	pkgs, err := loader.LoadRoots("../../...")
+	pkgs, err := loader.LoadRoots("github.com/gravitational/teleport/integrations/operator/apis/...")
 	if err != nil {
 		fmt.Printf("parser error: %s", err)
 	}

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_loginrules.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_loginrules.yaml
@@ -1,0 +1,70 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: teleportloginrules.resources.teleport.dev
+spec:
+  group: resources.teleport.dev
+  names:
+    kind: TeleportLoginRule
+    listKind: TeleportLoginRuleList
+    plural: teleportloginrules
+    shortNames:
+    - loginrule
+    - loginrules
+    singular: teleportloginrule
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: LoginRule is the Schema for the loginrules API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: LoginRule resource definition v1 from Teleport
+            properties:
+              priority:
+                description: Priority is the priority of the login rule relative to
+                  other login rules in the same cluster. Login rules with a lower
+                  numbered priority will be evaluated first.
+                format: int32
+                type: integer
+              traits_expression:
+                description: TraitsExpression is a predicate expression which should
+                  return the desired traits for the user upon login.
+                type: string
+              traits_map:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: TraitsMap is a map of trait keys to lists of predicate
+                  expressions which should evaluate to the desired values for that
+                  trait.
+                nullable: true
+                type: object
+            type: object
+          status: {}
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/integrations/operator/crdgen/tree.go
+++ b/integrations/operator/crdgen/tree.go
@@ -206,6 +206,9 @@ func (field Field) JSONName() string {
 	if res := gogoproto.GetJsonTag(field.desc); res != nil {
 		return strings.Split(*res, ",")[0]
 	}
+	if field.desc.JsonName != nil {
+		return *field.desc.JsonName
+	}
 	return ""
 }
 


### PR DESCRIPTION
This PR adds a k8s Custom Resource Definition for Login Rules, which will be used in a [following PR](https://github.com/gravitational/teleport/pull/23416) to enable configuration of Teleport Login Rules via kubectl.

This CRD, similar to the currently existing CRDs, is generated from the protobuf spec. The difference is that login rules are defined in their own package, do not use gogo syntax in the proto file, and the login rule type does not contain an explicit "spec" field. Some workarounds in `crdgen/main.go` and `crdgen/schemagen.go` cover over these differences to make login rules appear like any other resource.