### PR TITLE
Fix flaky test `TestHeadlessAuthenticationWatcher`

### DIFF
--- a/api/types/headlessauthn.go
+++ b/api/types/headlessauthn.go
@@ -17,8 +17,25 @@ limitations under the License.
 package types
 
 import (
+	"time"
+
 	"github.com/gravitational/trace"
 )
+
+// NewHeadlessAuthenticationStub creates a new headless authentication stub, which is
+// a headless authentication resource with limited data. This stub is used to initiate
+// headless login.
+func NewHeadlessAuthenticationStub(name string, expires time.Time) (*HeadlessAuthentication, error) {
+	ha := &HeadlessAuthentication{
+		ResourceHeader: ResourceHeader{
+			Metadata: Metadata{
+				Name:    name,
+				Expires: &expires,
+			},
+		},
+	}
+	return ha, ha.CheckAndSetDefaults()
+}
 
 // CheckAndSetDefaults does basic validation and default setting.
 func (h *HeadlessAuthentication) CheckAndSetDefaults() error {

--- a/api/types/headlessauthn.go
+++ b/api/types/headlessauthn.go
@@ -22,9 +22,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
-// NewHeadlessAuthenticationStub creates a new headless authentication stub, which is
-// a headless authentication resource with limited data. This stub is used to initiate
-// headless login.
+// NewHeadlessAuthenticationStub creates a new a headless authentication resource with limited data.
+// The stub is used to initiate headless login.
 func NewHeadlessAuthenticationStub(name string, expires time.Time) (*HeadlessAuthentication, error) {
 	ha := &HeadlessAuthentication{
 		ResourceHeader: ResourceHeader{

--- a/lib/services/local/headlessauthn.go
+++ b/lib/services/local/headlessauthn.go
@@ -31,17 +31,12 @@ import (
 
 // CreateHeadlessAuthenticationStub creates a headless authentication stub in the backend.
 func (s *IdentityService) CreateHeadlessAuthenticationStub(ctx context.Context, name string) (*types.HeadlessAuthentication, error) {
-	expires := s.Clock().Now().Add(defaults.CallbackTimeout)
-	headlessAuthn := &types.HeadlessAuthentication{
-		ResourceHeader: types.ResourceHeader{
-			Metadata: types.Metadata{
-				Name:    name,
-				Expires: &expires,
-			},
-		},
+	headlessAuthn, err := types.NewHeadlessAuthenticationStub(name, s.Clock().Now().Add(defaults.CallbackTimeout))
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
-	item, err := marshalHeadlessAuthenticationToItem(headlessAuthn)
+	item, err := MarshalHeadlessAuthenticationToItem(headlessAuthn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -60,12 +55,12 @@ func (s *IdentityService) CompareAndSwapHeadlessAuthentication(ctx context.Conte
 		return nil, trace.Wrap(err)
 	}
 
-	oldItem, err := marshalHeadlessAuthenticationToItem(old)
+	oldItem, err := MarshalHeadlessAuthenticationToItem(old)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	newItem, err := marshalHeadlessAuthenticationToItem(new)
+	newItem, err := MarshalHeadlessAuthenticationToItem(new)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -120,7 +115,7 @@ func (s *IdentityService) DeleteHeadlessAuthentication(ctx context.Context, name
 	return trace.Wrap(err)
 }
 
-func marshalHeadlessAuthenticationToItem(headlessAuthn *types.HeadlessAuthentication) (*backend.Item, error) {
+func MarshalHeadlessAuthenticationToItem(headlessAuthn *types.HeadlessAuthentication) (*backend.Item, error) {
 	if err := headlessAuthn.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/headlessauthn_watcher.go
+++ b/lib/services/local/headlessauthn_watcher.go
@@ -224,6 +224,24 @@ func (h *HeadlessAuthenticationWatcher) CheckWaiter(name string) bool {
 	return false
 }
 
+// CheckWaiterStale checks if the active waiter with the given
+// headless authentication ID is marked as stale. Used in tests.
+func (h *HeadlessAuthenticationWatcher) CheckWaiterStale(name string) (bool, error) {
+	h.mux.Lock()
+	defer h.mux.Unlock()
+	for i := range h.waiters {
+		if h.waiters[i].name == name {
+			select {
+			case <-h.waiters[i].stale:
+				return true, nil
+			default:
+				return false, nil
+			}
+		}
+	}
+	return false, trace.NotFound("no waiter found with ID %v", name)
+}
+
 // Wait watches for the headless authentication with the given id to be added/updated
 // in the backend, and waits for the given condition to be met, to result in an error,
 // or for the given context to close.


### PR DESCRIPTION
This PR fixes a race condition that could cause a deadlock. ~1/1000 repro chance locally.

I also reworked the tests to avoid adding new test-only methods (`CheckWaiter`) and re-initialize test environment for each test to allow `t.Parallel()`.