### PR TITLE
[v12] Backport IP pinning for Kube and DB access

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -385,6 +385,14 @@ const (
 	// allowed GCP service accounts.
 	TraitGCPServiceAccounts = "gcp_service_accounts"
 )
+const (
+	// ProxyHelloSignature is a string which Teleport proxy will send
+	// right after the initial SSH "handshake/version" message if it detects
+	// talking to a Teleport server.
+	//
+	// This is also leveraged by tsh to propagate its tracing span ID.
+	ProxyHelloSignature = "Teleport-Proxy"
+)
 
 const (
 	// TimeoutGetClusterAlerts is the timeout for grabbing cluster alerts from tctl and tsh

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -29,6 +29,7 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 )
@@ -149,7 +150,7 @@ func NewClientConn(ctx context.Context, conn net.Conn, addr string, config *ssh.
 	if len(hp.TracingContext) > 0 {
 		payloadJSON, err := json.Marshal(hp)
 		if err == nil {
-			payload := fmt.Sprintf("%s%s\x00", sshutils.ProxyHelloSignature, payloadJSON)
+			payload := fmt.Sprintf("%s%s\x00", constants.ProxyHelloSignature, payloadJSON)
 			if _, err := conn.Write([]byte(payload)); err != nil {
 				log.WithError(err).Warnf("Failed to pass along tracing context to proxy %v", addr)
 			}

--- a/api/utils/sshutils/conn.go
+++ b/api/utils/sshutils/conn.go
@@ -77,6 +77,7 @@ func ConnectProxyTransport(sconn ssh.Conn, req *DialReq, exclusive bool) (conn *
 	if exclusive {
 		return NewExclusiveChConn(sconn, channel), false, nil
 	}
+
 	return NewChConn(sconn, channel), false, nil
 }
 
@@ -92,6 +93,17 @@ type DialReq struct {
 
 	// ConnType is the type of connection requested, either node or application.
 	ConnType types.TunnelType `json:"conn_type"`
+
+	// TeleportVersion shows what teleport version is the node that we're trying to dial
+	TeleportVersion string `json:"teleport_version,omitempty"`
+
+	// ClientSrcAddr is the original observed client address, it is used to propagate
+	// correct client IP through indirect connections inside teleport
+	ClientSrcAddr string `json:"client_src_addr,omitempty"`
+
+	// ClientDstAddr is the original client's destination address, it is used to propagate
+	// correct client point of contact through indirect connections inside teleport
+	ClientDstAddr string `json:"client_dst_addr,omitempty"`
 }
 
 // CheckAndSetDefaults verifies all the values are valid.

--- a/api/utils/sshutils/ssh.go
+++ b/api/utils/sshutils/ssh.go
@@ -32,15 +32,6 @@ import (
 	"github.com/gravitational/teleport/api/defaults"
 )
 
-const (
-	// ProxyHelloSignature is a string which Teleport proxy will send
-	// right after the initial SSH "handshake/version" message if it detects
-	// talking to a Teleport server.
-	//
-	// This is also leveraged by tsh to propagate its tracing span ID.
-	ProxyHelloSignature = "Teleport-Proxy"
-)
-
 // HandshakePayload structure is sent as a JSON blob by the teleport
 // proxy to every SSH server who identifies itself as Teleport server
 //

--- a/integration/helpers/discard.go
+++ b/integration/helpers/discard.go
@@ -18,7 +18,7 @@ package helpers
 
 import (
 	"context"
-	"fmt"
+	"net"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/crypto/ssh"
@@ -33,13 +33,13 @@ type DiscardServer struct {
 	sshServer *sshutils.Server
 }
 
-func NewDiscardServer(host string, port int, hostSigner ssh.Signer) (*DiscardServer, error) {
+func NewDiscardServer(hostSigner ssh.Signer, listener net.Listener) (*DiscardServer, error) {
 	ds := &DiscardServer{}
 
 	// create underlying ssh server
 	sshServer, err := sshutils.NewServer(
 		"integration-discard-server",
-		utils.NetAddr{AddrNetwork: "tcp", Addr: fmt.Sprintf("%v:%v", host, port)},
+		utils.NetAddr{AddrNetwork: "tcp", Addr: listener.Addr().String()},
 		ds,
 		[]ssh.Signer{hostSigner},
 		sshutils.AuthMethods{
@@ -48,6 +48,10 @@ func NewDiscardServer(host string, port int, hostSigner ssh.Signer) (*DiscardSer
 		sshutils.SetInsecureSkipHostValidation(),
 	)
 	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := sshServer.SetListener(listener); err != nil {
 		return nil, trace.Wrap(err)
 	}
 	ds.sshServer = sshServer

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -48,6 +48,7 @@ import (
 	"github.com/gravitational/teleport/lib/client/identityfile"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/teleagent"
@@ -309,6 +310,21 @@ func WaitForDatabaseServers(t *testing.T, authServer *auth.Server, dbs []service
 			require.Fail(t, "database servers not registered after 10s")
 		}
 	}
+}
+
+// CreatePROXYEnabledListener creates net.Listener that can handle receiving signed PROXY headers
+func CreatePROXYEnabledListener(ctx context.Context, t *testing.T, address string, caGetter multiplexer.CertAuthorityGetter, clusterName string) (net.Listener, error) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", address)
+	require.NoError(t, err)
+
+	return multiplexer.NewPROXYEnabledListener(multiplexer.Config{
+		Listener:            listener,
+		Context:             ctx,
+		CertAuthorityGetter: caGetter,
+		LocalClusterName:    clusterName,
+	})
 }
 
 // MakeTestServers starts an Auth and a Proxy Service.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4194,8 +4194,11 @@ func testProxyHostKeyCheck(t *testing.T, suite *integrationTestSuite) {
 			instance := suite.NewTeleportWithConfig(makeConfig())
 			defer instance.StopAll()
 
+			caGetter := func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
+				return instance.Process.GetAuthServer().Cache.GetCertAuthority(ctx, id, loadKeys)
+			}
 			proxyEnabledListener, err := helpers.CreatePROXYEnabledListener(context.Background(), t, net.JoinHostPort(Host, strconv.Itoa(nodePort)),
-				instance.Process.GetAuthServer().Cache, instance.Secrets.SiteName)
+				caGetter, instance.Secrets.SiteName)
 			require.NoError(t, err)
 
 			sshNode, err := helpers.NewDiscardServer(hostSigner, proxyEnabledListener)

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -1273,6 +1273,10 @@ func testEscapeSequenceNoTrigger(t *testing.T, terminal *Terminal, sess <-chan e
 
 // testIPPropagation makes sure that we can correctly propagate initial client IP observed by proxy.
 func testIPPropagation(t *testing.T, suite *integrationTestSuite) {
+	// We're temporarily disable this one, because we have catch 22 with minimal supported version -
+	// version in which we backport this feature is less than minimal supported version 12.2 which will
+	// be released once this feature has landed. Will be reenabled after 12.2 is released.
+	t.Skip("Temporary disabled")
 	tr := utils.NewTracer(utils.ThisFunction()).Start()
 	defer tr.Stop()
 

--- a/integration/kube/fixtures.go
+++ b/integration/kube/fixtures.go
@@ -38,6 +38,7 @@ const TestImpersonationGroup = "teleport-ci-test-group"
 type ProxyConfig struct {
 	T                   *helpers.TeleInstance
 	Username            string
+	PinnedIP            string
 	KubeUsers           []string
 	KubeGroups          []string
 	Impersonation       *rest.ImpersonationConfig
@@ -96,6 +97,7 @@ func ProxyClient(cfg ProxyConfig) (*kubernetes.Clientset, *rest.Config, error) {
 		KubernetesUsers:  cfg.KubeUsers,
 		KubernetesGroups: cfg.KubeGroups,
 		RouteToCluster:   cfg.RouteToCluster,
+		PinnedIP:         cfg.PinnedIP,
 	}
 	subj, err := id.Subject()
 	if err != nil {

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -317,6 +317,9 @@ func TestALPNSNIProxyKube(t *testing.T) {
 				},
 			},
 		},
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
 	}
 	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
 	require.NoError(t, err)
@@ -335,6 +338,7 @@ func TestALPNSNIProxyKube(t *testing.T) {
 	k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
 		T:                   suite.root,
 		Username:            kubeRoleSpec.Allow.Logins[0],
+		PinnedIP:            "127.0.0.1",
 		KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
 		KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
 		CustomTLSServerName: localK8SNI,
@@ -375,6 +379,9 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 				},
 			},
 		},
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
 	}
 	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
 	require.NoError(t, err)
@@ -402,6 +409,7 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 	k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
 		T:                   suite.root,
 		Username:            kubeRoleSpec.Allow.Logins[0],
+		PinnedIP:            "127.0.0.1",
 		KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
 		KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
 		CustomTLSServerName: localK8SNI,
@@ -413,6 +421,131 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 	resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(resp.Items), "pods item length mismatch")
+}
+
+func TestKubeIPPinning(t *testing.T) {
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	const (
+		kubeCluster = "kube.teleport.cluster.local"
+		k8User      = "alice@example.com"
+		k8RoleName  = "kubemaster"
+	)
+
+	kubeAPIMockSvrRoot := startKubeAPIMock(t)
+	kubeAPIMockSvrLeaf := startKubeAPIMock(t)
+	kubeConfigPathRoot := mustCreateKubeConfigFile(t, k8ClientConfig(kubeAPIMockSvrRoot.URL, kubeCluster))
+	kubeConfigPathLeaf := mustCreateKubeConfigFile(t, k8ClientConfig(kubeAPIMockSvrLeaf.URL, kubeCluster))
+
+	username := helpers.MustGetCurrentUser(t).Username
+	kubeRoleSpec := types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			Logins:           []string{username, username + "2", username + "3"},
+			KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			KubeGroups:       []string{kube.TestImpersonationGroup},
+			KubeUsers:        []string{k8User},
+			KubernetesResources: []types.KubernetesResource{
+				{
+					Kind: types.KindKubePod, Name: types.Wildcard, Namespace: types.Wildcard,
+				},
+			},
+		},
+		Options: types.RoleOptions{
+			PinSourceIP: true,
+		},
+	}
+	kubeRole, err := types.NewRole(k8RoleName, kubeRoleSpec)
+	require.NoError(t, err)
+
+	suite := newSuite(t,
+		withRootClusterConfig(rootClusterStandardConfig(t), func(config *service.Config) {
+			config.Proxy.Kube.Enabled = true
+			config.Version = defaults.TeleportConfigVersionV3
+
+			config.Kube.Enabled = true
+			config.Kube.KubeconfigPath = kubeConfigPathRoot
+			config.Kube.ListenAddr = utils.MustParseAddr(
+				helpers.NewListener(t, service.ListenerKube, &config.FileDescriptors))
+		}),
+		withLeafClusterConfig(leafClusterStandardConfig(t), func(config *service.Config) {
+			config.Version = defaults.TeleportConfigVersionV3
+			config.Proxy.Kube.Enabled = true
+
+			config.Kube.Enabled = true
+			config.Kube.KubeconfigPath = kubeConfigPathLeaf
+			config.Kube.ListenAddr = utils.MustParseAddr(
+				helpers.NewListener(t, service.ListenerKube, &config.FileDescriptors))
+		}),
+		withRootClusterRoles(kubeRole),
+		withLeafClusterRoles(kubeRole),
+		withRootAndLeafTrustedClusterReset(),
+		withTrustedCluster(),
+	)
+
+	testCases := []struct {
+		desc           string
+		pinnedIP       string
+		routeToCluster string
+		wantClientErr  string
+	}{
+		{
+			desc:           "root cluster missing pinned IP",
+			routeToCluster: suite.root.Secrets.SiteName,
+			wantClientErr:  "pinned IP is required for the user, but is not present on identity",
+		},
+		{
+			desc:           "root cluster wrong pinned IP",
+			pinnedIP:       "127.0.0.2",
+			routeToCluster: suite.root.Secrets.SiteName,
+			wantClientErr:  "pinned IP doesn't match observed client IP",
+		},
+		{
+			desc:           "root cluster pinned IP",
+			pinnedIP:       "127.0.0.1",
+			routeToCluster: suite.root.Secrets.SiteName,
+		},
+		{
+			desc:           "leaf cluster missing pinned IP",
+			routeToCluster: suite.leaf.Secrets.SiteName,
+			wantClientErr:  "pinned IP is required for the user, but is not present on identity",
+		},
+		{
+			desc:           "leaf cluster wrong pinned IP",
+			pinnedIP:       "127.0.0.2",
+			routeToCluster: suite.leaf.Secrets.SiteName,
+			wantClientErr:  "pinned IP doesn't match observed client IP",
+		},
+		{
+			desc:           "leaf cluster pinned IP",
+			pinnedIP:       "127.0.0.1",
+			routeToCluster: suite.leaf.Secrets.SiteName,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			k8Client, _, err := kube.ProxyClient(kube.ProxyConfig{
+				T:                   suite.root,
+				Username:            kubeRoleSpec.Allow.Logins[0],
+				PinnedIP:            tc.pinnedIP,
+				KubeUsers:           kubeRoleSpec.Allow.KubeGroups,
+				KubeGroups:          kubeRoleSpec.Allow.KubeUsers,
+				CustomTLSServerName: kubeCluster,
+				TargetAddress:       suite.root.Config.Proxy.WebAddr,
+				RouteToCluster:      tc.routeToCluster,
+			})
+			require.NoError(t, err)
+
+			resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+			if tc.wantClientErr != "" {
+				require.ErrorContains(t, err, tc.wantClientErr)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, 1, len(resp.Items), "pods item length mismatch")
+		})
+	}
 }
 
 // TestALPNSNIProxyDatabaseAccess test DB connection forwarded through local SNI ALPN proxy where

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1392,6 +1392,8 @@ type DatabaseTestCertRequest struct {
 	Username string
 	// RouteToDatabase contains database routing information.
 	RouteToDatabase tlsca.RouteToDatabase
+	// PinnedIP is an IP new certificate should be pinned to.
+	PinnedIP string
 }
 
 // GenerateDatabaseTestCert generates a database access certificate for the
@@ -1413,6 +1415,8 @@ func (a *Server) GenerateDatabaseTestCert(req DatabaseTestCertRequest) ([]byte, 
 	certs, err := a.generateUserCert(certRequest{
 		user:      user,
 		publicKey: req.PublicKey,
+		loginIP:   req.PinnedIP,
+		pinIP:     req.PinnedIP != "",
 		checker:   checker,
 		ttl:       time.Hour,
 		traits: map[string][]string{

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -367,8 +367,12 @@ func (a *authorizer) authorizeRemoteUser(ctx context.Context, u RemoteUser) (*Co
 		RouteToDatabase:   u.Identity.RouteToDatabase,
 		MFAVerified:       u.Identity.MFAVerified,
 		LoginIP:           u.Identity.LoginIP,
+		PinnedIP:          u.Identity.PinnedIP,
 		PrivateKeyPolicy:  u.Identity.PrivateKeyPolicy,
 		UserType:          u.Identity.UserType,
+	}
+	if checker.PinSourceIP() && identity.PinnedIP == "" {
+		return nil, trace.AccessDenied("pinned IP is required for the user, but is not present on identity")
 	}
 
 	return &Context{

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -365,6 +365,9 @@ type Config struct {
 	// MockSSOLogin is used in tests for mocking the SSO login response.
 	MockSSOLogin SSOLoginFunc
 
+	// MockConnectToProxy is used in tests to override connection to proxy
+	MockConnectToProxy ConnectToProxyFunc
+
 	// HomePath is where tsh stores profiles
 	HomePath string
 
@@ -2679,10 +2682,17 @@ func formatConnectToProxyErr(err error) error {
 	return err
 }
 
+// ConnectToProxyFunc is used in tests to override connection to proxy function.
+type ConnectToProxyFunc func(ctx context.Context) (*ProxyClient, error)
+
 // ConnectToProxy will dial to the proxy server and return a ProxyClient when
 // successful. If the passed in context is canceled, this function will return
 // a trace.ConnectionProblem right away.
 func (tc *TeleportClient) ConnectToProxy(ctx context.Context) (*ProxyClient, error) {
+	if tc.Config.MockConnectToProxy != nil {
+		return tc.Config.MockConnectToProxy(ctx)
+	}
+
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ConnectToProxy",

--- a/lib/jwt/jwt.go
+++ b/lib/jwt/jwt.go
@@ -226,8 +226,8 @@ type PROXYSignParams struct {
 
 const expirationPROXY = time.Second * 60
 
-// SignPROXY will create short lived signed JWT that is used in signed PROXY header
-func (k *Key) SignPROXY(p PROXYSignParams) (string, error) {
+// SignPROXYJwt will create short lived signed JWT that is used in signed PROXY header
+func (k *Key) SignPROXYJWT(p PROXYSignParams) (string, error) {
 	claims := Claims{
 		Claims: jwt.Claims{
 			Subject:   p.SourceAddress,

--- a/lib/jwt/jwt_test.go
+++ b/lib/jwt/jwt_test.go
@@ -191,7 +191,7 @@ func TestKey_SignAndVerifyPROXY(t *testing.T) {
 	destination := "4.3.2.1:666:"
 
 	// Sign a token with the new key.
-	token, err := key.SignPROXY(PROXYSignParams{
+	token, err := key.SignPROXYJWT(PROXYSignParams{
 		ClusterName:        clusterName,
 		SourceAddress:      source,
 		DestinationAddress: destination,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -78,6 +78,7 @@ import (
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv"
@@ -153,6 +154,8 @@ type ForwarderConfig struct {
 	CheckImpersonationPermissions ImpersonationPermissionsChecker
 	// PublicAddr is the address that can be used to reach the kube cluster
 	PublicAddr string
+	// PROXYSigner is used to sign PROXY headers for securely propagating client IP address
+	PROXYSigner multiplexer.PROXYHeaderSigner
 	// log is the logger function
 	log logrus.FieldLogger
 }
@@ -182,6 +185,9 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 	}
 	if f.HostID == "" {
 		return trace.BadParameter("missing parameter ServerID")
+	}
+	if f.KubeServiceType != KubeService && f.PROXYSigner == nil {
+		return trace.BadParameter("missing parameter PROXYSigner")
 	}
 	if f.Namespace == "" {
 		f.Namespace = apidefaults.Namespace
@@ -702,6 +708,10 @@ func (f *Forwarder) setupContext(authCtx authz.Context, req *http.Request, isRem
 	// the correct behavior when forwarding the request to the Kubernetes API.
 	kubeUsers, kubeGroups = fillDefaultKubePrincipalDetails(kubeUsers, kubeGroups, authCtx.User.GetName())
 
+	clientSrc, clientDst := utils.ClientAddrFromContext(req.Context())
+
+	forwarderType := f.cfg.KubeServiceType
+
 	// Get a dialer for either a k8s endpoint in current cluster or a tunneled
 	// endpoint for a leaf teleport cluster.
 	var dialFn dialFunc
@@ -720,11 +730,12 @@ func (f *Forwarder) setupContext(authCtx authz.Context, req *http.Request, isRem
 
 		dialFn = func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
 			return targetCluster.DialTCP(reversetunnel.DialParams{
-				From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
-				To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: endpoint.addr},
-				ConnType: types.KubeTunnel,
-				ServerID: endpoint.serverID,
-				ProxyIDs: endpoint.proxyIDs,
+				From:                  &utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
+				To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: endpoint.addr},
+				ConnType:              types.KubeTunnel,
+				ServerID:              endpoint.serverID,
+				ProxyIDs:              endpoint.proxyIDs,
+				OriginalClientDstAddr: clientDst,
 			})
 		}
 		isRemoteClosed = targetCluster.IsClosed
@@ -739,19 +750,45 @@ func (f *Forwarder) setupContext(authCtx authz.Context, req *http.Request, isRem
 		}
 
 		dialFn = func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
+
+			// Make sure we will only send signed PROXY headers to teleport kube service node, not real kube cluster
+			if forwarderType != ProxyService && endpoint.serverID == "" {
+				clientDst = nil
+			}
 			return localCluster.DialTCP(reversetunnel.DialParams{
-				From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
-				To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: endpoint.addr},
-				ConnType: types.KubeTunnel,
-				ServerID: endpoint.serverID,
-				ProxyIDs: endpoint.proxyIDs,
+				From:                  &utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
+				To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: endpoint.addr},
+				ConnType:              types.KubeTunnel,
+				ServerID:              endpoint.serverID,
+				ProxyIDs:              endpoint.proxyIDs,
+				OriginalClientDstAddr: clientDst,
 			})
 		}
 		isRemoteClosed = localCluster.IsClosed
 	} else {
 		// Don't have a reverse tunnel server, so we can only dial directly.
 		dialFn = func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
-			return new(net.Dialer).DialContext(ctx, network, endpoint.addr)
+			conn, err := new(net.Dialer).DialContext(ctx, network, endpoint.addr)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			// Make sure we will only send signed PROXY headers to teleport kube service node, not real kube cluster
+			if forwarderType != ProxyService && endpoint.serverID == "" {
+				clientDst = nil
+			}
+			// Teleport proxy will send signed PROXY headers to the kube service
+			if f.cfg.PROXYSigner != nil && clientSrc != nil && clientDst != nil {
+				signedHeader, err := f.cfg.PROXYSigner.SignPROXYHeader(clientSrc, clientDst)
+				if err != nil {
+					return nil, trace.Wrap(err, "could not create signed PROXY header")
+				}
+				if _, err := conn.Write(signedHeader); err != nil {
+					return nil, trace.Wrap(err, "could not write signed PROXY header into connection")
+				}
+			}
+
+			return conn, nil
 		}
 		isRemoteClosed = func() bool { return false }
 	}
@@ -946,6 +983,11 @@ func getPodResourceFromRequest(requestURI string) *types.KubernetesResource {
 }
 
 func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
+	// TODO(anton): Move this into authorizer.Authorize when we can enable it for all protocols
+	if err := auth.CheckIPPinning(ctx, actx.Identity.GetIdentity(), actx.Checker.PinSourceIP()); err != nil {
+		return trace.Wrap(err)
+	}
+
 	if actx.teleportCluster.isRemote {
 		// Authorization for a remote kube cluster will happen on the remote
 		// end (by their proxy), after that cluster has remapped used roles.

--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -39,12 +39,11 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/loglimit"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -55,9 +54,8 @@ var (
 )
 
 // CertAuthorityGetter allows to get cluster's host CA for verification of signed PROXY headers.
-type CertAuthorityGetter interface {
-	GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool, opts ...services.MarshalOption) (types.CertAuthority, error)
-}
+// We define our own version to not create dependency on the 'services' package, which causes circular references
+type CertAuthorityGetter = func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
 
 // Config is a multiplexer config
 type Config struct {
@@ -472,7 +470,7 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 				continue
 			}
 
-			if m.CertAuthorityGetter != nil && newProxyLine.isSigned() && !newProxyLine.IsVerified {
+			if m.CertAuthorityGetter != nil && newProxyLine.IsSigned() && !newProxyLine.IsVerified {
 				return nil, trace.BadParameter("could not verify proxy line signature")
 			}
 
@@ -551,10 +549,10 @@ func (p Protocol) String() string {
 
 var (
 	proxyPrefix      = []byte{'P', 'R', 'O', 'X', 'Y'}
-	proxyV2Prefix    = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+	ProxyV2Prefix    = []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
 	sshPrefix        = []byte{'S', 'S', 'H'}
 	tlsPrefix        = []byte{0x16}
-	proxyHelloPrefix = []byte(sshutils.ProxyHelloSignature)
+	proxyHelloPrefix = []byte(constants.ProxyHelloSignature)
 )
 
 // This section defines Postgres wire protocol messages detected by Teleport:
@@ -614,15 +612,15 @@ func detectProto(r *bufio.Reader) (Protocol, error) {
 	switch {
 	case bytes.HasPrefix(in, proxyPrefix):
 		return ProtoProxy, nil
-	case bytes.HasPrefix(in, proxyV2Prefix[:8]):
+	case bytes.HasPrefix(in, ProxyV2Prefix[:8]):
 		// if the first 8 bytes matches the first 8 bytes of the proxy
 		// protocol v2 magic bytes, read more of the connection so we can
 		// ensure all magic bytes match
-		in, err = r.Peek(len(proxyV2Prefix))
+		in, err = r.Peek(len(ProxyV2Prefix))
 		if err != nil {
 			return ProtoUnknown, trace.Wrap(err, failedToPeekConnectionError)
 		}
-		if bytes.HasPrefix(in, proxyV2Prefix) {
+		if bytes.HasPrefix(in, ProxyV2Prefix) {
 			return ProtoProxyV2, nil
 		}
 	case bytes.HasPrefix(in, proxyHelloPrefix[:8]):

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -1234,3 +1234,59 @@ func Test_GetTcpAddr(t *testing.T) {
 		require.Equal(t, tt.expected, result.String())
 	}
 }
+
+func TestIsDifferentTCPVersion(t *testing.T) {
+	testCases := []struct {
+		addr1    string
+		addr2    string
+		expected bool
+	}{
+		{
+			addr1:    "8.8.8.8:42",
+			addr2:    "8.8.8.8:42",
+			expected: false,
+		},
+		{
+			addr1:    "[2601:602:8700:4470:a3:813c:1d8c:30b9]:42",
+			addr2:    "[2607:f8b0:4005:80a::200e]:42",
+			expected: false,
+		},
+		{
+			addr1:    "127.0.0.1:42",
+			addr2:    "[::1]:42",
+			expected: true,
+		},
+		{
+			addr1:    "[::1]:42",
+			addr2:    "127.0.0.1:42",
+			expected: true,
+		},
+		{
+			addr1:    "::ffff:39.156.68.48:42",
+			addr2:    "39.156.68.48:42",
+			expected: true,
+		},
+		{
+			addr1:    "[2607:f8b0:4005:80a::200e]:42",
+			addr2:    "1.1.1.1:42",
+			expected: true,
+		},
+		{
+			addr1:    "127.0.0.1:42",
+			addr2:    "[2607:f8b0:4005:80a::200e]:42",
+			expected: true,
+		},
+		{
+			addr1:    "::ffff:39.156.68.48:42",
+			addr2:    "[2607:f8b0:4005:80a::200e]:42",
+			expected: false,
+		},
+	}
+
+	for _, tt := range testCases {
+		addr1 := getTCPAddr(utils.MustParseAddr(tt.addr1))
+		addr2 := getTCPAddr(utils.MustParseAddr(tt.addr2))
+		require.Equal(t, tt.expected, isDifferentTCPVersion(addr1, addr2),
+			fmt.Sprintf("Unexpected result for %q, %q", tt.addr1, tt.addr2))
+	}
+}

--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -23,7 +23,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -44,7 +43,6 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
-	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -704,73 +702,6 @@ func TestMux(t *testing.T) {
 		require.Equal(t, "db listener", string(dbBytes))
 	})
 
-	t.Run("SSHProxyHelloSignature", func(t *testing.T) {
-		// Ensures SSH connections fronted with the ProxyHelloSignature are
-		// detected as SSH connections.
-		t.Parallel()
-		listener, err := net.Listen("tcp", "127.0.0.1:0")
-		require.NoError(t, err)
-
-		mux, err := New(Config{
-			Listener:                    listener,
-			EnableExternalProxyProtocol: true,
-		})
-		require.NoError(t, err)
-		go mux.Serve()
-		defer mux.Close()
-
-		// Record the remote addr from the point of view of the ssh handler
-		// so we can confirm that the header is parsed properly.
-		calledWithRemoteAddr := ""
-		sshHandler := sshutils.NewChanHandlerFunc(func(_ context.Context, c *sshutils.ConnectionContext, nch ssh.NewChannel) {
-			calledWithRemoteAddr = c.ServerConn.RemoteAddr().String()
-			err := nch.Reject(ssh.Prohibited, "nothing to see here")
-			require.NoError(t, err)
-		})
-
-		srv, err := sshutils.NewServer(
-			"test",
-			utils.NetAddr{AddrNetwork: "tcp", Addr: "localhost:0"},
-			sshHandler,
-			[]ssh.Signer{signer},
-			sshutils.AuthMethods{Password: pass("abc123")},
-		)
-		require.NoError(t, err)
-		go srv.Serve(mux.SSH())
-		defer srv.Close()
-
-		// Manually create client conn so we can inject the ProxyHelloSignature
-		conn, err := net.DialTimeout("tcp", listener.Addr().String(), time.Second)
-		remoteAddr := "6.6.6.6:1337"
-		require.NoError(t, err)
-		hp := &apisshutils.HandshakePayload{
-			ClientAddr: remoteAddr,
-		}
-		payloadJSON, err := json.Marshal(hp)
-		require.NoError(t, err)
-		payload := fmt.Sprintf("%s%s\x00", apisshutils.ProxyHelloSignature, payloadJSON)
-		_, err = conn.Write([]byte(payload))
-		require.NoError(t, err)
-		c, chans, reqs, err := ssh.NewClientConn(conn, listener.Addr().String(), &ssh.ClientConfig{
-			Auth:            []ssh.AuthMethod{ssh.Password("abc123")},
-			Timeout:         time.Second,
-			HostKeyCallback: ssh.FixedHostKey(signer.PublicKey()),
-		})
-		require.NoError(t, err)
-		clt := ssh.NewClient(c, chans, reqs)
-		defer clt.Close()
-
-		// call new session to initiate opening new channel
-		_, err = clt.NewSession()
-		require.EqualError(t, err, "ssh: rejected: administratively prohibited (nothing to see here)")
-		// make sure the channel handler was called OK
-		require.Equal(t, remoteAddr, calledWithRemoteAddr)
-
-		// Close mux, new requests should fail
-		mux.Close()
-		mux.Wait()
-	})
-
 	// Ensures that we can correctly send and verify signed PROXY header
 	t.Run("signed PROXYv2 headers", func(t *testing.T) {
 		t.Parallel()
@@ -833,7 +764,7 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := GetSignedPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -854,7 +785,7 @@ func TestMux(t *testing.T) {
 
 			defer conn.Close()
 
-			signedHeader, err := GetSignedPROXYHeader(&addrV6, &addrV6, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(&addrV6, &addrV6, clusterName, tlsProxyCert, jwtSigner)
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -871,7 +802,7 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := GetSignedPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -889,9 +820,9 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := GetSignedPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
 			require.NoError(t, err)
-			signedHeader2, err := GetSignedPROXYHeader(&addr2, &addr1, clusterName+"wrong", tlsProxyCert, jwtSigner)
+			signedHeader2, err := signPROXYHeader(&addr2, &addr1, clusterName+"wrong", tlsProxyCert, jwtSigner)
 			require.NoError(t, err)
 
 			_, err = conn.Write(signedHeader)
@@ -909,7 +840,7 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := GetSignedPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
 			require.NoError(t, err)
 
 			pl := ProxyLine{
@@ -937,7 +868,7 @@ func TestMux(t *testing.T) {
 			require.NoError(t, err)
 			defer conn.Close()
 
-			signedHeader, err := GetSignedPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+			signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
 			require.NoError(t, err)
 
 			pl := ProxyLine{
@@ -986,7 +917,7 @@ func TestMux(t *testing.T) {
 		})
 	})
 	// Ensures that we can correctly send and verify signed PROXY header
-	t.Run("is ignored if signed PROXY header can't be verified (wrong cluster)", func(t *testing.T) {
+	t.Run("signed PROXY header is ignored if signed by wrong cluster", func(t *testing.T) {
 		t.Parallel()
 
 		const clusterName = "teleport-test"
@@ -1028,7 +959,7 @@ func TestMux(t *testing.T) {
 		sAddr := net.TCPAddr{IP: net.ParseIP(ip), Port: 444}
 		dAddr := net.TCPAddr{IP: net.ParseIP(ip), Port: 555}
 
-		signedHeader, err := GetSignedPROXYHeader(&sAddr, &dAddr, clusterName, tlsProxyCert, jwtSigner)
+		signedHeader, err := signPROXYHeader(&sAddr, &dAddr, clusterName, tlsProxyCert, jwtSigner)
 		require.NoError(t, err)
 
 		_, err = conn.Write(signedHeader)
@@ -1143,7 +1074,7 @@ func TestIsHTTP(t *testing.T) {
 	}
 }
 
-func getTestCertCAsGetterAndSigner(t testing.TB, clusterName string) ([]byte, CertAuthorityGetter, PROXYSigner) {
+func getTestCertCAsGetterAndSigner(t testing.TB, clusterName string) ([]byte, CertAuthorityGetter, JWTPROXYSigner) {
 	t.Helper()
 	caPriv, caCert, err := tlsca.GenerateSelfSignedCA(pkix.Name{
 		CommonName: clusterName, Organization: []string{clusterName}}, []string{clusterName}, time.Hour)
@@ -1220,7 +1151,7 @@ func BenchmarkMux_ProxyV2Signature(b *testing.B) {
 
 	b.Run("simulation of signing and verifying PROXY header", func(b *testing.B) {
 		for n := 0; n < b.N; n++ {
-			token, err := jwtSigner.SignPROXY(jwt.PROXYSignParams{
+			token, err := jwtSigner.SignPROXYJWT(jwt.PROXYSignParams{
 				ClusterName:        clusterName,
 				SourceAddress:      sAddr.String(),
 				DestinationAddress: dAddr.String(),
@@ -1271,4 +1202,43 @@ func BenchmarkMux_ProxyV2Signature(b *testing.B) {
 				"IP addresses in PROXY header don't match JWT")
 		}
 	})
+}
+
+func Test_GetTcpAddr(t *testing.T) {
+	testCases := []struct {
+		input    net.Addr
+		expected string
+	}{
+		{
+			input: &utils.NetAddr{
+				Addr:        "127.0.0.1:24998",
+				AddrNetwork: "tcp",
+				Path:        "",
+			},
+			expected: "127.0.0.1:24998",
+		},
+		{
+			input:    nil,
+			expected: ":0",
+		},
+		{
+			input: &net.TCPAddr{
+				IP:   net.ParseIP("8.8.8.8"),
+				Port: 25000,
+			},
+			expected: "8.8.8.8:25000",
+		},
+		{
+			input: &net.TCPAddr{
+				IP:   net.ParseIP("::1"),
+				Port: 25000,
+			},
+			expected: "[::1]:25000",
+		},
+	}
+
+	for _, tt := range testCases {
+		result := getTCPAddr(tt.input)
+		require.Equal(t, tt.expected, result.String())
+	}
 }

--- a/lib/multiplexer/proxyline.go
+++ b/lib/multiplexer/proxyline.go
@@ -40,7 +40,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/jwt"
-	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -116,7 +115,7 @@ func (p *ProxyLine) String() string {
 func (p *ProxyLine) Bytes() ([]byte, error) {
 	b := &bytes.Buffer{}
 	header := proxyV2Header{VersionCommand: (Version2 << 4) | ProxyCommand}
-	copy(header.Signature[:], proxyV2Prefix)
+	copy(header.Signature[:], ProxyV2Prefix)
 	var addr interface{}
 	if p.Source.Port < 0 || p.Destination.Port < 0 ||
 		p.Source.Port > math.MaxUint16 || p.Destination.Port > math.MaxUint16 {
@@ -278,7 +277,7 @@ func ReadProxyLineV2(reader *bufio.Reader) (*ProxyLine, error) {
 	if err := binary.Read(reader, binary.BigEndian, &header); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	if !bytes.Equal(header.Signature[:], proxyV2Prefix) {
+	if !bytes.Equal(header.Signature[:], ProxyV2Prefix) {
 		return nil, trace.BadParameter("unrecognized signature %s", hex.EncodeToString(header.Signature[:]))
 	}
 	cmd, ver := header.VersionCommand&0xF, header.VersionCommand>>4
@@ -427,9 +426,9 @@ func (p *ProxyLine) AddSignature(signature, signingCert []byte) error {
 	return nil
 }
 
-// isSigned returns true if proxy line's TLV contains signature.
+// IsSigned returns true if proxy line's TLV contains signature.
 // Does not take into account if signature is valid or not, just the presence of it.
-func (p *ProxyLine) isSigned() bool {
+func (p *ProxyLine) IsSigned() bool {
 	token, proxyCert, _ := p.getSignatureAndSigningCert()
 	return len(token) > 0 || proxyCert != nil
 }
@@ -489,14 +488,14 @@ func (p *ProxyLine) VerifySignature(ctx context.Context, caGetter CertAuthorityG
 			identity.TeleportCluster, localClusterName)
 	}
 
-	hostCA, err := caGetter.GetCertAuthority(ctx, types.CertAuthID{
+	hostCA, err := caGetter(ctx, types.CertAuthID{
 		Type:       types.HostCA,
 		DomainName: localClusterName,
 	}, false)
 	if err != nil {
 		return trace.Wrap(ErrNoHostCA, "CA cluster name: %s", localClusterName)
 	}
-	hostCACerts := services.GetTLSCerts(hostCA)
+	hostCACerts := getTLSCerts(hostCA)
 
 	roots := x509.NewCertPool()
 	for _, cert := range hostCACerts {
@@ -539,6 +538,15 @@ func (p *ProxyLine) VerifySignature(ctx context.Context, caGetter CertAuthorityG
 
 	p.IsVerified = true
 	return nil
+}
+
+func getTLSCerts(ca types.CertAuthority) [][]byte {
+	pairs := ca.GetTrustedTLSKeyPairs()
+	out := make([][]byte, len(pairs))
+	for i, pair := range pairs {
+		out[i] = append([]byte{}, pair.Cert...)
+	}
+	return out
 }
 
 func checkForSystemRole(identity *tlsca.Identity, roleToFind types.SystemRole) bool {

--- a/lib/multiplexer/proxyline_test.go
+++ b/lib/multiplexer/proxyline_test.go
@@ -63,7 +63,7 @@ func TestReadProxyLine(t *testing.T) {
 		require.ErrorIs(t, err, io.EOF)
 	})
 	t.Run("malformed line", func(t *testing.T) {
-		_, err := ReadProxyLine(bufio.NewReader(bytes.NewReader([]byte("JIBBERISH\r\n"))))
+		_, err := ReadProxyLine(bufio.NewReader(bytes.NewReader([]byte("GIBBERISH\r\n"))))
 		require.ErrorIs(t, err, trace.BadParameter("malformed PROXY line protocol string"))
 	})
 	t.Run("successfully read proxy v1 line", func(t *testing.T) {
@@ -423,21 +423,21 @@ func TestProxyLine_VerifySignature(t *testing.T) {
 	sAddr := net.TCPAddr{IP: net.ParseIP(ip), Port: 444}
 	dAddr := net.TCPAddr{IP: net.ParseIP(ip), Port: 555}
 
-	signature, err := jwtSigner.SignPROXY(jwt.PROXYSignParams{
+	signature, err := jwtSigner.SignPROXYJWT(jwt.PROXYSignParams{
 		ClusterName:        clusterName,
 		SourceAddress:      sAddr.String(),
 		DestinationAddress: dAddr.String(),
 	})
 	require.NoError(t, err)
 
-	wrongClusterSignature, err := jwtSigner.SignPROXY(jwt.PROXYSignParams{
+	wrongClusterSignature, err := jwtSigner.SignPROXYJWT(jwt.PROXYSignParams{
 		ClusterName:        "wrong-cluster",
 		SourceAddress:      sAddr.String(),
 		DestinationAddress: dAddr.String(),
 	})
 	require.NoError(t, err)
 
-	wrongSourceSignature, err := jwtSigner.SignPROXY(jwt.PROXYSignParams{
+	wrongSourceSignature, err := jwtSigner.SignPROXYJWT(jwt.PROXYSignParams{
 		ClusterName:        clusterName,
 		SourceAddress:      "4.3.2.1:1234",
 		DestinationAddress: dAddr.String(),

--- a/lib/multiplexer/wrapper_test.go
+++ b/lib/multiplexer/wrapper_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package multiplexer
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPROXYEnabledListener_Accept(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	clusterName := "teleport-test"
+	tlsProxyCert, casGetter, jwtSigner := getTestCertCAsGetterAndSigner(t, clusterName)
+	_, _ = tlsProxyCert, jwtSigner
+	proxyListener, err := NewPROXYEnabledListener(Config{
+		Listener:                    listener,
+		Context:                     ctx,
+		EnableExternalProxyProtocol: true,
+		ID:                          "test",
+		CertAuthorityGetter:         casGetter,
+		LocalClusterName:            clusterName,
+	})
+	require.NoError(t, err, "Could not create new PROXY enabled listener")
+
+	addr1 := net.TCPAddr{IP: net.ParseIP("1.2.3.4"), Port: 444}
+	addr2 := net.TCPAddr{IP: net.ParseIP("5.4.3.2"), Port: 555}
+
+	signedHeader, err := signPROXYHeader(&addr1, &addr2, clusterName, tlsProxyCert, jwtSigner)
+	require.NoError(t, err)
+
+	testCases := []struct {
+		name               string
+		proxyLine          []byte
+		expectedRemoteAddr string
+		expectedLocalAddr  string
+	}{
+		{
+			name:               "PROXY v1 header",
+			proxyLine:          []byte(sampleProxyV1Line),
+			expectedLocalAddr:  "127.0.0.2:42",
+			expectedRemoteAddr: "127.0.0.1:12345",
+		},
+		{
+			name:               "unsigned PROXY v2 header",
+			proxyLine:          sampleProxyV2Line,
+			expectedLocalAddr:  "127.0.0.2:42",
+			expectedRemoteAddr: "127.0.0.1:12345",
+		},
+		{
+			name:               "signed PROXY v2 header",
+			proxyLine:          signedHeader,
+			expectedLocalAddr:  addr2.String(),
+			expectedRemoteAddr: addr1.String(),
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			connChan := make(chan net.Conn)
+			errChan := make(chan error)
+			go func() {
+				conn, err := proxyListener.Accept()
+				if err != nil {
+					errChan <- err
+					return
+				}
+				connChan <- conn
+			}()
+			conn, err := net.Dial("tcp", proxyListener.Addr().String())
+			require.NoError(t, err)
+			defer conn.Close()
+
+			_, err = conn.Write(tt.proxyLine)
+			require.NoError(t, err)
+
+			testData := append(sshPrefix, []byte("this is test data")...)
+			_, err = conn.Write(testData) // Force PROXY listener to pass connection since it detected a real protocol (SSH)
+			require.NoError(t, err)
+
+			select {
+			case conn := <-connChan:
+				require.Equal(t, tt.expectedRemoteAddr, conn.RemoteAddr().String())
+				require.Equal(t, tt.expectedLocalAddr, conn.LocalAddr().String())
+			case err := <-errChan:
+				require.NoError(t, err, "Received error while trying to accept connection")
+			case <-time.After(time.Millisecond * 500):
+				require.Fail(t, "Time out while accepting connection")
+			}
+		})
+	}
+}

--- a/lib/proxy/router_test.go
+++ b/lib/proxy/router_test.go
@@ -313,7 +313,7 @@ func (r testRemoteSite) Dial(reversetunnel.DialParams) (net.Conn, error) {
 	return r.conn, r.err
 }
 
-func (r testRemoteSite) DialAuthServer() (net.Conn, error) {
+func (r testRemoteSite) DialAuthServer(reversetunnel.DialParams) (net.Conn, error) {
 	return r.conn, r.err
 }
 
@@ -405,7 +405,7 @@ func TestRouter_DialHost(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			conn, err := tt.router.DialHost(ctx, &utils.NetAddr{}, "host", "0", "test", nil, nil)
+			conn, _, err := tt.router.DialHost(ctx, &utils.NetAddr{}, &utils.NetAddr{}, "host", "0", "test", nil, nil)
 			tt.assertion(t, conn, err)
 		})
 	}
@@ -502,7 +502,7 @@ func TestRouter_DialSite(t *testing.T) {
 				tracer:      tracing.NoopTracer(cluster),
 			}
 
-			conn, err := router.DialSite(ctx, tt.cluster)
+			conn, err := router.DialSite(ctx, tt.cluster, nil, nil)
 			tt.assertion(t, conn, err)
 		})
 	}

--- a/lib/reversetunnel/agent.go
+++ b/lib/reversetunnel/agent.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
 	"github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -115,6 +116,8 @@ type agentConfig struct {
 	// localAuthAddresses is a list of auth servers to use when dialing back to
 	// the local cluster.
 	localAuthAddresses []string
+	// PROXYSigner is used to sign PROXY headers for securely propagating client IP address
+	proxySigner multiplexer.PROXYHeaderSigner
 }
 
 // checkAndSetDefaults ensures an agentConfig contains required parameters.
@@ -186,6 +189,8 @@ type agent struct {
 	// drainWG tracks transports and other concurrent operations required
 	// to drain a connection are finished.
 	drainWG sync.WaitGroup
+	// PROXYSigner is used to sign PROXY headers for securely propagating client IP address
+	proxySigner multiplexer.PROXYHeaderSigner
 }
 
 // newAgent intializes a reverse tunnel agent.
@@ -202,6 +207,7 @@ func newAgent(config agentConfig) (*agent, error) {
 		drainCancel:    noop,
 		unclaim:        noop,
 		doneConnecting: make(chan struct{}),
+		proxySigner:    config.proxySigner,
 	}, nil
 }
 

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -67,6 +67,12 @@ type DialParams struct {
 	// FromPeerProxy indicates that the dial request is being tunneled from
 	// a peer proxy.
 	FromPeerProxy bool
+
+	// TeleportVersion shows version of the target node, if we know that it's teleport node.
+	TeleportVersion string
+
+	// OriginalClientDstAddr is used in PROXY headers to show where client originally contacted Teleport infrastructure
+	OriginalClientDstAddr net.Addr
 }
 
 func (params DialParams) String() string {
@@ -77,21 +83,27 @@ func (params DialParams) String() string {
 	return fmt.Sprintf("from: %q to: %q", params.From, to)
 }
 
+func stringOrEmpty(addr net.Addr) string {
+	if addr == nil {
+		return ""
+	}
+	return addr.String()
+}
+
 // RemoteSite represents remote teleport site that can be accessed via
 // teleport tunnel or directly by proxy
 //
 // There are two implementations of this interface: local and remote sites.
 type RemoteSite interface {
 	// DialAuthServer returns a net.Conn to the Auth Server of a site.
-	DialAuthServer() (net.Conn, error)
+	DialAuthServer(DialParams) (conn net.Conn, err error)
 	// Dial dials any address within the site network, in terminating
 	// mode it uses local instance of forwarding server to terminate
-	// and record the connection
-	Dial(DialParams) (net.Conn, error)
-	// DialTCP dials any address within the site network,
-	// ignores recording mode and always uses TCP dial, used
-	// in components that need direct dialer.
-	DialTCP(DialParams) (net.Conn, error)
+	// and record the connection.
+	Dial(DialParams) (conn net.Conn, err error)
+	// DialTCP dials any address within the site network and
+	// ignores recording mode, used in components that need direct dialer.
+	DialTCP(DialParams) (conn net.Conn, err error)
 	// GetLastConnected returns last time the remote site was seen connected
 	GetLastConnected() time.Time
 	// GetName returns site name (identified by authority domain's name)

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -35,6 +35,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/proxy/peer"
 	"github.com/gravitational/teleport/lib/reversetunnel/track"
@@ -217,7 +218,7 @@ func (s *localSite) GetLastConnected() time.Time {
 	return s.clock.Now()
 }
 
-func (s *localSite) DialAuthServer() (net.Conn, error) {
+func (s *localSite) DialAuthServer(params DialParams) (net.Conn, error) {
 	if len(s.authServers) == 0 {
 		return nil, trace.ConnectionProblem(nil, "no auth servers available")
 	}
@@ -226,6 +227,10 @@ func (s *localSite) DialAuthServer() (net.Conn, error) {
 	conn, err := net.DialTimeout("tcp", addr, apidefaults.DefaultIOTimeout)
 	if err != nil {
 		return nil, trace.ConnectionProblem(err, "unable to connect to auth server")
+	}
+
+	if err := s.maybeSendSignedPROXYHeader(params, conn, false, false); err != nil {
+		return nil, trace.ConnectionProblem(err, "unable to send signed PROXY header to auth server")
 	}
 
 	return conn, nil
@@ -247,15 +252,44 @@ func (s *localSite) Dial(params DialParams) (net.Conn, error) {
 	return s.DialTCP(params)
 }
 
+func shouldSendSignedPROXYHeader(signer multiplexer.PROXYHeaderSigner, version string, useTunnel, checkVersion bool, srcAddr, dstAddr net.Addr) bool {
+	return !(signer == nil ||
+		useTunnel ||
+		(checkVersion && utils.CheckVersion(version, utils.MinIPPropagationVersion) != nil) ||
+		srcAddr == nil ||
+		dstAddr == nil)
+}
+
+func (s *localSite) maybeSendSignedPROXYHeader(params DialParams, conn net.Conn, useTunnel, checkVersion bool) error {
+	if !shouldSendSignedPROXYHeader(s.srv.proxySigner, params.TeleportVersion, useTunnel, checkVersion, params.From, params.OriginalClientDstAddr) {
+		return nil
+	}
+
+	header, err := s.srv.proxySigner.SignPROXYHeader(params.From, params.OriginalClientDstAddr)
+	if err != nil {
+		return trace.Wrap(err, "could not create signed PROXY header")
+	}
+
+	_, err = conn.Write(header)
+	if err != nil {
+		return trace.Wrap(err, "could not write signed PROXY header into connection")
+	}
+	return nil
+}
+
 // TODO(awly): unit test this
 func (s *localSite) DialTCP(params DialParams) (net.Conn, error) {
 	s.log.Debugf("Dialing %v.", params)
 
-	conn, _, err := s.getConn(params)
+	conn, useTunnel, err := s.getConn(params)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	s.log.Debugf("Succeeded dialing %v.", params)
+
+	if err := s.maybeSendSignedPROXYHeader(params, conn, useTunnel, true); err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	return conn, nil
 }
@@ -317,6 +351,10 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 		return nil, trace.NewAggregate(trace.Wrap(err), userAgent.Close())
 	}
 
+	if err := s.maybeSendSignedPROXYHeader(params, targetConn, useTunnel, true); err != nil {
+		return nil, trace.NewAggregate(trace.Wrap(err), userAgent.Close())
+	}
+
 	// Get a host certificate for the forwarding node from the cache.
 	hostCertificate, err := s.certificateCache.getHostCertificate(context.TODO(), params.Address, params.Principals)
 	if err != nil {
@@ -350,14 +388,14 @@ func (s *localSite) dialWithAgent(params DialParams) (net.Conn, error) {
 	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.NewAggregate(trace.Wrap(err), userAgent.Close())
 	}
 	go remoteServer.Serve()
 
 	// Return a connection to the forwarding server.
 	conn, err := remoteServer.Dial()
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.NewAggregate(trace.Wrap(err), userAgent.Close())
 	}
 
 	return conn, nil
@@ -370,7 +408,7 @@ func (s *localSite) dialTunnel(dreq *sshutils.DialReq) (net.Conn, error) {
 		return nil, trace.NotFound("no tunnel connection found: %v", err)
 	}
 
-	s.log.Debugf("Tunnel dialing to %v.", dreq.ServerID)
+	s.log.Debugf("Tunnel dialing to %v, client source %v", dreq.ServerID, dreq.ClientSrcAddr)
 
 	conn, err := s.chanTransportConn(rconn, dreq)
 	if err != nil {
@@ -415,7 +453,7 @@ func (s *localSite) skipDirectDial(params DialParams) (bool, error) {
 	}
 
 	// This node can only be reached over a tunnel, don't attempt to dial
-	// remotely.
+	// directly.
 	if params.To == nil || params.To.String() == "" || params.To.String() == LocalNode {
 		return true, nil
 	}
@@ -442,8 +480,11 @@ with the cluster.`
 
 func (s *localSite) getConn(params DialParams) (conn net.Conn, useTunnel bool, err error) {
 	dreq := &sshutils.DialReq{
-		ServerID: params.ServerID,
-		ConnType: params.ConnType,
+		ServerID:        params.ServerID,
+		ConnType:        params.ConnType,
+		ClientSrcAddr:   stringOrEmpty(params.From),
+		ClientDstAddr:   stringOrEmpty(params.OriginalClientDstAddr),
+		TeleportVersion: params.TeleportVersion,
 	}
 	if params.To != nil {
 		dreq.Address = params.To.String()

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -287,7 +287,8 @@ func (s *localSite) DialTCP(params DialParams) (net.Conn, error) {
 	}
 	s.log.Debugf("Succeeded dialing %v.", params)
 
-	if err := s.maybeSendSignedPROXYHeader(params, conn, useTunnel, true); err != nil {
+	isKubeOrDB := params.ConnType == types.KubeTunnel || params.ConnType == types.DatabaseTunnel
+	if err := s.maybeSendSignedPROXYHeader(params, conn, useTunnel, !isKubeOrDB); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/reversetunnel/peer.go
+++ b/lib/reversetunnel/peer.go
@@ -127,7 +127,7 @@ func (p *clusterPeers) GetLastConnected() time.Time {
 	return peer.GetLastConnected()
 }
 
-func (p *clusterPeers) DialAuthServer() (net.Conn, error) {
+func (p *clusterPeers) DialAuthServer(DialParams) (net.Conn, error) {
 	return nil, trace.ConnectionProblem(nil, "unable to dial to auth server, this proxy has not been discovered yet, try again later")
 }
 

--- a/lib/reversetunnel/rc_manager.go
+++ b/lib/reversetunnel/rc_manager.go
@@ -30,6 +30,7 @@ import (
 	apitypes "github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -82,6 +83,8 @@ type RemoteClusterTunnelManagerConfig struct {
 	// LocalAuthAddresses is a list of auth servers to use when dialing back to
 	// the local cluster.
 	LocalAuthAddresses []string
+	// PROXYSigner is used to sign PROXY headers for securely propagating client IP address
+	PROXYSigner multiplexer.PROXYHeaderSigner
 }
 
 func (c *RemoteClusterTunnelManagerConfig) CheckAndSetDefaults() error {
@@ -234,6 +237,7 @@ func realNewAgentPool(ctx context.Context, cfg RemoteClusterTunnelManagerConfig,
 		Cluster:         cluster,
 		Resolver:        StaticResolver(addr, apitypes.ProxyListenerMode_Separate),
 		IsRemoteCluster: true,
+		PROXYSigner:     cfg.PROXYSigner,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "failed creating reverse tunnel pool for remote cluster %q at address %q: %v", cluster, addr, err)

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -42,6 +42,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/proxy/peer"
 	"github.com/gravitational/teleport/lib/services"
@@ -115,6 +116,9 @@ type server struct {
 	// offlineThreshold is how long to wait for a keep alive message before
 	// marking a reverse tunnel connection as invalid.
 	offlineThreshold time.Duration
+
+	// proxySigner is used to sign PROXY headers to securely propagate client IP information
+	proxySigner multiplexer.PROXYHeaderSigner
 }
 
 // Config is a reverse tunnel server configuration
@@ -209,8 +213,12 @@ type Config struct {
 	// LocalAuthAddresses is a list of auth servers to use when dialing back to
 	// the local cluster.
 	LocalAuthAddresses []string
+
 	// IngressReporter reports new and active connections.
 	IngressReporter *ingress.Reporter
+
+	// PROXYSigner is used to sign PROXY headers to securely propagate client IP information.
+	PROXYSigner multiplexer.PROXYHeaderSigner
 }
 
 // CheckAndSetDefaults checks parameters and sets default values
@@ -319,6 +327,7 @@ func NewServer(cfg Config) (Server, error) {
 		clusterPeers:     make(map[string]*clusterPeers),
 		log:              cfg.Log,
 		offlineThreshold: offlineThreshold,
+		proxySigner:      cfg.PROXYSigner,
 	}
 
 	localSite, err := newLocalSite(srv, cfg.ClusterName, cfg.LocalAuthAddresses)
@@ -679,6 +688,7 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 		component:        teleport.ComponentReverseTunnelServer,
 		localClusterName: s.ClusterName,
 		emitter:          s.Emitter,
+		proxySigner:      s.proxySigner,
 	}
 	go t.start()
 }

--- a/lib/reversetunnel/srv_test.go
+++ b/lib/reversetunnel/srv_test.go
@@ -18,6 +18,7 @@ package reversetunnel
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net"
 	"testing"
@@ -30,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/services"
@@ -229,5 +231,33 @@ func TestCreateRemoteAccessPoint(t *testing.T) {
 			_, err := createRemoteAccessPoint(srv, clt, tt.version, "test")
 			tt.assertion(t, err)
 		})
+	}
+}
+
+func Test_ParseDialReq(t *testing.T) {
+	testCases := []sshutils.DialReq{
+		{
+			Address:       "TargetAddress",
+			ServerID:      "ServerID123",
+			ConnType:      types.NodeTunnel,
+			ClientSrcAddr: "192.168.1.13:444",
+			ClientDstAddr: "192.168.1.14:444",
+		},
+		{
+			Address:       "TargetAddress",
+			ServerID:      "ServerID123",
+			ConnType:      types.NodeTunnel,
+			ClientSrcAddr: "[::1]:444",
+			ClientDstAddr: "[::1]:555",
+		},
+	}
+
+	for _, test := range testCases {
+		payload, err := json.Marshal(test)
+		require.NoError(t, err)
+		require.NotEmpty(t, payload)
+
+		parsed := parseDialReq(payload)
+		require.Equal(t, &test, parsed)
 	}
 }

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -325,7 +325,8 @@ func (p *transport) start() {
 		clientDst = dst
 	}
 	var signedHeader []byte
-	if shouldSendSignedPROXYHeader(p.proxySigner, dreq.TeleportVersion, useTunnel, dreq.Address != RemoteAuthServer, clientSrc, clientDst) {
+	isKubeOrAuth := dreq.ConnType == types.KubeTunnel || dreq.Address == RemoteAuthServer
+	if shouldSendSignedPROXYHeader(p.proxySigner, dreq.TeleportVersion, useTunnel, !isKubeOrAuth, clientSrc, clientDst) {
 		signedHeader, err = p.proxySigner.SignPROXYHeader(clientSrc, clientDst)
 		if err != nil {
 			errorMessage := fmt.Sprintf("connection rejected - could not create signed PROXY header: %v", err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3928,6 +3928,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				KubeServiceType:               kubeServiceType,
 				LockWatcher:                   lockWatcher,
 				CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
+				PROXYSigner:                   proxySigner,
 			},
 			TLS:             tlsConfig,
 			LimiterConfig:   cfg.Proxy.Limiter,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -90,7 +90,6 @@ import (
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/inventory"
 	"github.com/gravitational/teleport/lib/joinserver"
-	"github.com/gravitational/teleport/lib/jwt"
 	kubegprc "github.com/gravitational/teleport/lib/kube/grpc"
 	kubeproxy "github.com/gravitational/teleport/lib/kube/proxy"
 	"github.com/gravitational/teleport/lib/labels"
@@ -1688,7 +1687,7 @@ func (process *TeleportProcess) initAuthService() error {
 	// clean up unused descriptors passed for proxy, but not used by it
 	warnOnErr(process.closeImportedDescriptors(teleport.ComponentAuth), log)
 	if cfg.Auth.EnableProxyProtocol {
-		log.Infof("Starting Auth service with PROXY protocol support.")
+		log.Infof("Starting Auth service with external PROXY protocol support.")
 	}
 
 	// use multiplexer to leverage support for proxy protocol.
@@ -2386,9 +2385,20 @@ func (process *TeleportProcess) initSSH() error {
 			utils.Consolef(cfg.Console, log, teleport.ComponentNode, "Service %s:%s is starting on %v.",
 				teleport.Version, teleport.Gitref, cfg.SSH.Addr.Addr)
 
+			sshListener, err := multiplexer.NewPROXYEnabledListener(multiplexer.Config{
+				Listener:                    listener,
+				Context:                     process.ExitContext(),
+				EnableExternalProxyProtocol: false,
+				ID:                          teleport.Component(teleport.ComponentNode, fmt.Sprintf("%d", time.Now().Unix())),
+				CertAuthorityGetter:         conn.Client,
+				LocalClusterName:            clusterName.GetClusterName(),
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
 			// Start the SSH server. This kicks off updating labels, starting the
 			// heartbeat, and accepting connections.
-			go s.Serve(limiter.WrapListener(listener))
+			go s.Serve(limiter.WrapListener(sshListener))
 		} else {
 			// Start the SSH server. This kicks off updating labels and starting the
 			// heartbeat.
@@ -2981,8 +2991,9 @@ func (process *TeleportProcess) initProxy() error {
 }
 
 type proxyListeners struct {
-	mux *multiplexer.Mux
-	tls *multiplexer.WebListener
+	mux    *multiplexer.Mux
+	sshMux *multiplexer.Mux
+	tls    *multiplexer.WebListener
 	// ssh receives SSH traffic that is multiplexed on the Proxy SSH Port. When TLS routing
 	// is enabled only traffic with the TLS ALPN protocol common.ProtocolProxySSH is received.
 	ssh net.Listener
@@ -2994,7 +3005,7 @@ type proxyListeners struct {
 	kube          net.Listener
 	db            dbListeners
 	alpn          net.Listener
-	proxy         net.Listener
+	proxyPeer     net.Listener
 	// grpcPublic receives gRPC traffic that has the TLS ALPN protocol common.ProtocolProxyGRPCInsecure. This
 	// listener is only enabled when TLS routing is enabled and does not enforce mTLS authentication since
 	// it's used to handle cluster join requests.
@@ -3020,6 +3031,9 @@ func (l *proxyListeners) Close() {
 	if l.sshGRPC != nil {
 		l.sshGRPC.Close()
 	}
+	if l.sshMux != nil {
+		l.sshMux.Close()
+	}
 	if l.web != nil {
 		l.web.Close()
 	}
@@ -3033,8 +3047,8 @@ func (l *proxyListeners) Close() {
 	if l.alpn != nil {
 		l.alpn.Close()
 	}
-	if l.proxy != nil {
-		l.proxy.Close()
+	if l.proxyPeer != nil {
+		l.proxyPeer.Close()
 	}
 	if l.grpcPublic != nil {
 		l.grpcPublic.Close()
@@ -3084,7 +3098,7 @@ func (l *dbListeners) Close() {
 }
 
 // setupProxyListeners sets up web proxy listeners based on the configuration
-func (process *TeleportProcess) setupProxyListeners(networkingConfig types.ClusterNetworkingConfig) (*proxyListeners, error) {
+func (process *TeleportProcess) setupProxyListeners(networkingConfig types.ClusterNetworkingConfig, accessPoint auth.ProxyAccessPoint, clusterName string) (*proxyListeners, error) {
 	cfg := process.Config
 	process.log.Debugf("Setup Proxy: Web Proxy Address: %v, Reverse Tunnel Proxy Address: %v", cfg.Proxy.WebAddr.Addr, cfg.Proxy.ReverseTunnelListenAddr.Addr)
 	var err error
@@ -3100,11 +3114,14 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			Listener:                    l,
 			EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 			ID:                          teleport.Component(teleport.ComponentProxy, "ssh"),
+			CertAuthorityGetter:         accessPoint,
+			LocalClusterName:            clusterName,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 
+		listeners.sshMux = mux
 		listeners.ssh = mux.SSH()
 		listeners.sshGRPC = mux.TLS()
 		go func() {
@@ -3175,7 +3192,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			return nil, trace.Wrap(err)
 		}
 
-		listeners.proxy = listener
+		listeners.proxyPeer = listener
 	}
 
 	switch {
@@ -3192,6 +3209,8 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 			Listener:                    listener,
 			ID:                          teleport.Component(teleport.ComponentProxy, "tunnel", "web", process.id),
+			CertAuthorityGetter:         accessPoint,
+			LocalClusterName:            clusterName,
 		})
 		if err != nil {
 			listener.Close()
@@ -3220,6 +3239,8 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 			Listener:                    listener,
 			ID:                          teleport.Component(teleport.ComponentProxy, "web", process.id),
+			CertAuthorityGetter:         accessPoint,
+			LocalClusterName:            clusterName,
 		})
 		if err != nil {
 			listener.Close()
@@ -3271,6 +3292,8 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 					EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 					Listener:                    listener,
 					ID:                          teleport.Component(teleport.ComponentProxy, "web", process.id),
+					CertAuthorityGetter:         accessPoint,
+					LocalClusterName:            clusterName,
 				})
 				if err != nil {
 					listener.Close()
@@ -3345,6 +3368,8 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	cfg := process.Config
 	var tlsConfigWeb *tls.Config
 
+	clusterName := conn.ServerIdentity.ClusterName
+
 	proxyLimiter, err := limiter.NewLimiter(cfg.Proxy.Limiter)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3371,7 +3396,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		return trace.Wrap(err)
 	}
 
-	listeners, err := process.setupProxyListeners(clusterNetworkConfig)
+	listeners, err := process.setupProxyListeners(clusterNetworkConfig, accessPoint, clusterName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -3386,8 +3411,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	log := process.log.WithFields(logrus.Fields{
 		trace.Component: teleport.Component(teleport.ComponentReverseTunnelServer, process.id),
 	})
-
-	clusterName := conn.ServerIdentity.ClusterName
 
 	// asyncEmitter makes sure that sessions do not block
 	// in case if connections are slow
@@ -3464,6 +3487,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	proxySigner, err := process.getPROXYSigner(conn.ServerIdentity)
+	if err != nil {
+		return trace.Wrap(err)
+	}
 
 	// register SSH reverse tunnel server that accepts connections
 	// from remote teleport nodes
@@ -3471,7 +3498,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	var peerClient *peer.Client
 
 	if !process.Config.Proxy.DisableReverseTunnel {
-		if listeners.proxy != nil {
+		if listeners.proxyPeer != nil {
 			peerClient, err = peer.NewClient(peer.ClientConfig{
 				Context:     process.ExitContext(),
 				ID:          process.Config.HostUUID,
@@ -3517,6 +3544,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				CircuitBreakerConfig:          process.Config.CircuitBreakerConfig,
 				LocalAuthAddresses:            utils.NetAddrsToStrings(process.Config.AuthServerAddresses()),
 				IngressReporter:               ingressReporter,
+				PROXYSigner:                   proxySigner,
 			})
 		if err != nil {
 			return trace.Wrap(err)
@@ -3646,6 +3674,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			TraceClient:      traceClt,
 			Router:           proxyRouter,
 			SessionControl:   sessionController,
+			PROXYSigner:      proxySigner,
 		}
 		webHandler, err := web.NewHandler(webConfig)
 		if err != nil {
@@ -3679,6 +3708,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
 				ConnState:         ingress.HTTPConnStateReporter(ingress.Web, ingressReporter),
+				ConnContext: func(ctx context.Context, c net.Conn) context.Context {
+					return utils.ClientAddrContext(ctx, c.RemoteAddr(), c.LocalAddr())
+				},
 			},
 			Handler: webHandler,
 			Log:     log,
@@ -3720,7 +3752,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	var peerAddrString string
 	var proxyServer *peer.Server
-	if !process.Config.Proxy.DisableReverseTunnel && listeners.proxy != nil {
+	if !process.Config.Proxy.DisableReverseTunnel && listeners.proxyPeer != nil {
 		peerAddr, err := process.Config.Proxy.publicPeerAddr()
 		if err != nil {
 			return trace.Wrap(err)
@@ -3728,7 +3760,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		peerAddrString = peerAddr.String()
 		proxyServer, err = peer.NewServer(peer.ServerConfig{
 			AccessCache:   accessPoint,
-			Listener:      listeners.proxy,
+			Listener:      listeners.proxyPeer,
 			TLSConfig:     serverTLSConfig,
 			ClusterDialer: clusterdial.NewClusterDialer(tsrv),
 			Log:           log,
@@ -3744,7 +3776,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				return nil
 			}
 
-			log.Infof("Peer proxy service is starting on %s", listeners.proxy.Addr().String())
+			log.Infof("Peer proxy service is starting on %s", listeners.proxyPeer.Addr().String())
 			err := proxyServer.Serve()
 			if err != nil {
 				return trace.Wrap(err)
@@ -3783,6 +3815,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		regular.SetTracerProvider(process.TracingProvider),
 		regular.SetSessionController(sessionController),
 		regular.SetIngressReporter(ingress.SSH, ingressReporter),
+		regular.SetPROXYSigner(proxySigner),
 	)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3840,6 +3873,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		FIPS:                process.Config.FIPS,
 		Log:                 rcWatchLog,
 		LocalAuthAddresses:  utils.NetAddrsToStrings(process.Config.AuthServerAddresses()),
+		PROXYSigner:         proxySigner,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -4061,16 +4095,13 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 	var alpnServer *alpnproxy.Proxy
 	if !cfg.Proxy.DisableTLS && !cfg.Proxy.DisableALPNSNIListener && listeners.web != nil {
-		jwtSigner, err := process.getJWTSigner(conn.ServerIdentity)
-		if err != nil {
-			return trace.Wrap(err)
-		}
 		authDialerService := alpnproxyauth.NewAuthProxyDialerService(
 			tsrv,
 			clusterName,
 			utils.NetAddrsToStrings(process.Config.AuthServerAddresses()),
-			jwtSigner,
-			conn.ServerIdentity.XCert.Raw)
+			proxySigner,
+			process.log,
+			process.TracingProvider.Tracer(teleport.ComponentProxy))
 
 		alpnRouter.Add(alpnproxy.HandlerDecs{
 			MatchFunc:           alpnproxy.MatchByALPNPrefix(string(alpncommon.ProtocolAuth)),
@@ -4187,7 +4218,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	return nil
 }
 
-func (process *TeleportProcess) getJWTSigner(ident *auth.Identity) (*jwt.Key, error) {
+func (process *TeleportProcess) getPROXYSigner(ident *auth.Identity) (multiplexer.PROXYHeaderSigner, error) {
 	signer, err := utils.ParsePrivateKeyPEM(ident.KeyBytes)
 	if err != nil {
 		return nil, trace.Wrap(err, "could not parse identity's private key")
@@ -4198,7 +4229,11 @@ func (process *TeleportProcess) getJWTSigner(ident *auth.Identity) (*jwt.Key, er
 		return nil, trace.Wrap(err, "could not create JWT signer")
 	}
 
-	return jwtSigner, nil
+	proxySigner, err := multiplexer.NewPROXYSigner(ident.XCert, jwtSigner)
+	if err != nil {
+		return nil, trace.Wrap(err, "could not create PROXY signer")
+	}
+	return proxySigner, nil
 }
 
 func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListeners, tlsConfigWeb *tls.Config, cfg *Config, webConfig web.Config, log *logrus.Entry) (*web.Server, error) {

--- a/lib/srv/alpnproxy/auth/auth_proxy.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy.go
@@ -18,11 +18,15 @@ package alpnproxyauth
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"strings"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/gravitational/teleport/api/defaults"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -38,13 +42,14 @@ type sitesGetter interface {
 }
 
 // NewAuthProxyDialerService create new instance of AuthProxyDialerService.
-func NewAuthProxyDialerService(reverseTunnelServer sitesGetter, localClusterName string, authServers []string, jwtSigner multiplexer.PROXYSigner, signingCert []byte) *AuthProxyDialerService {
+func NewAuthProxyDialerService(reverseTunnelServer sitesGetter, localClusterName string, authServers []string, proxySigner multiplexer.PROXYHeaderSigner, log logrus.FieldLogger, tracer oteltrace.Tracer) *AuthProxyDialerService {
 	return &AuthProxyDialerService{
 		reverseTunnelServer: reverseTunnelServer,
 		localClusterName:    localClusterName,
 		authServers:         authServers,
-		jwtSigner:           jwtSigner,
-		signingCert:         signingCert,
+		proxySigner:         proxySigner,
+		log:                 log,
+		tracer:              tracer,
 	}
 }
 
@@ -54,8 +59,9 @@ type AuthProxyDialerService struct {
 	reverseTunnelServer sitesGetter
 	localClusterName    string
 	authServers         []string
-	jwtSigner           multiplexer.PROXYSigner
-	signingCert         []byte // DER-encoded TLS certificate
+	proxySigner         multiplexer.PROXYHeaderSigner
+	log                 logrus.FieldLogger
+	tracer              oteltrace.Tracer
 }
 
 func (s *AuthProxyDialerService) HandleConnection(ctx context.Context, conn net.Conn, connInfo alpnproxy.ConnectionInfo) error {
@@ -64,24 +70,12 @@ func (s *AuthProxyDialerService) HandleConnection(ctx context.Context, conn net.
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	authConn, err := s.dialAuthServer(ctx, clusterName)
+
+	authConn, err := s.dialAuthServer(ctx, clusterName, conn.RemoteAddr(), conn.LocalAddr())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	defer authConn.Close()
-
-	// We'll write signed PROXY header to the outgoing connection to securely
-	// propagate observed client ip to the auth server.
-	if s.jwtSigner != nil && s.signingCert != nil {
-		b, err := multiplexer.GetSignedPROXYHeader(conn.RemoteAddr(), conn.LocalAddr(), s.localClusterName, s.signingCert, s.jwtSigner)
-		if err != nil {
-			return trace.Wrap(err, "could not create signed PROXY header")
-		}
-		_, err = authConn.Write(b)
-		if err != nil {
-			return trace.Wrap(err, "could not write PROXY line to remote connection")
-		}
-	}
 
 	if err := s.proxyConn(ctx, conn, authConn); err != nil {
 		return trace.Wrap(err)
@@ -105,17 +99,26 @@ func getClusterName(info alpnproxy.ConnectionInfo) (string, error) {
 	return cn, nil
 }
 
-func (s *AuthProxyDialerService) dialAuthServer(ctx context.Context, clusterNameFromSNI string) (net.Conn, error) {
+func (s *AuthProxyDialerService) dialAuthServer(ctx context.Context, clusterNameFromSNI string, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error) {
 	if clusterNameFromSNI == s.localClusterName {
-		return s.dialLocalAuthServer(ctx)
+		return s.dialLocalAuthServer(ctx, clientSrcAddr, clientDstAddr)
 	}
 	if s.reverseTunnelServer != nil {
-		return s.dialRemoteAuthServer(ctx, clusterNameFromSNI)
+		return s.dialRemoteAuthServer(ctx, clusterNameFromSNI, clientSrcAddr, clientDstAddr)
 	}
 	return nil, trace.NotFound("auth server for %q cluster name not found", clusterNameFromSNI)
 }
 
-func (s *AuthProxyDialerService) dialLocalAuthServer(ctx context.Context) (net.Conn, error) {
+func (s *AuthProxyDialerService) dialLocalAuthServer(ctx context.Context, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error) {
+	ctx, span := s.tracer.Start(ctx, "authProxyDialerService/dialLocalAuthServer",
+		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+		oteltrace.WithAttributes(
+			attribute.String("src_addr", fmt.Sprintf("%v", clientSrcAddr)),
+			attribute.String("dst_addr", fmt.Sprintf("%v", clientDstAddr)),
+			attribute.String("cluster_name", s.localClusterName),
+		))
+	defer span.End()
+
 	if len(s.authServers) == 0 {
 		return nil, trace.NotFound("empty auth servers list")
 	}
@@ -128,20 +131,45 @@ func (s *AuthProxyDialerService) dialLocalAuthServer(ctx context.Context) (net.C
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	span.AddEvent("dialed remote server")
+
+	// We'll write signed PROXY header to the outgoing connection to securely
+	// propagate observed client ip to the auth server.
+	if s.proxySigner != nil && clientSrcAddr != nil && clientDstAddr != nil {
+		b, err := s.proxySigner.SignPROXYHeader(clientSrcAddr, clientDstAddr)
+		if err != nil {
+			return nil, trace.Wrap(err, "could not create signed PROXY header")
+		}
+
+		_, err = conn.Write(b)
+		if err != nil {
+			return nil, trace.Wrap(err, "could not write PROXY line to remote connection")
+		}
+		span.AddEvent("wrote signed PROXY header")
+	}
 
 	return conn, nil
 }
 
-func (s *AuthProxyDialerService) dialRemoteAuthServer(ctx context.Context, clusterName string) (net.Conn, error) {
+func (s *AuthProxyDialerService) dialRemoteAuthServer(ctx context.Context, clusterName string, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error) {
+	_, span := s.tracer.Start(ctx, "authProxyDialerService/dialRemoteAuthServer",
+		oteltrace.WithSpanKind(oteltrace.SpanKindServer),
+		oteltrace.WithAttributes(
+			attribute.String("src_addr", fmt.Sprintf("%v", clientSrcAddr)),
+			attribute.String("dst_addr", fmt.Sprintf("%v", clientDstAddr)),
+			attribute.String("cluster_name", clusterName),
+		))
+	defer span.End()
+
 	sites, err := s.reverseTunnelServer.GetSites()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	for _, s := range sites {
-		if s.GetName() != clusterName {
+	for _, site := range sites {
+		if site.GetName() != clusterName {
 			continue
 		}
-		conn, err := s.DialAuthServer()
+		conn, err := site.DialAuthServer(reversetunnel.DialParams{From: clientSrcAddr, OriginalClientDstAddr: clientDstAddr})
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/alpnproxy/auth/auth_proxy_test.go
+++ b/lib/srv/alpnproxy/auth/auth_proxy_test.go
@@ -24,11 +24,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/observability/tracing"
 )
 
 func TestDialLocalAuthServerNoServers(t *testing.T) {
-	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", nil /* authServers */, nil, nil)
-	_, err := s.dialLocalAuthServer(context.Background())
+	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", nil /* authServers */, nil, nil, tracing.NoopTracer("test"))
+	_, err := s.dialLocalAuthServer(context.Background(), nil, nil)
 	require.Error(t, err, "dialLocalAuthServer expected to fail")
 	require.Equal(t, "empty auth servers list", err.Error())
 }
@@ -36,10 +38,10 @@ func TestDialLocalAuthServerNoServers(t *testing.T) {
 func TestDialLocalAuthServerNoAvailableServers(t *testing.T) {
 	// The 203.0.113.0/24 range is part of block TEST-NET-3 as defined in RFC-5735 (https://www.rfc-editor.org/rfc/rfc5735).
 	// IPs in this range do not appear on the public internet.
-	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", []string{"203.0.113.1:3025"}, nil, nil)
+	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", []string{"203.0.113.1:3025"}, nil, nil, tracing.NoopTracer("test"))
 	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 	t.Cleanup(cancel)
-	_, err := s.dialLocalAuthServer(ctx)
+	_, err := s.dialLocalAuthServer(ctx, nil, nil)
 	require.Error(t, err, "dialLocalAuthServer expected to fail")
 	var netErr *net.OpError
 	require.ErrorAs(t, err, &netErr)
@@ -60,11 +62,11 @@ func TestDialLocalAuthServerAvailableServers(t *testing.T) {
 		// IPs in this range do not appear on the public internet.
 		authServers = append(authServers, fmt.Sprintf("203.0.113.%d:3025", i+1))
 	}
-	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", authServers, nil, nil)
+	s := NewAuthProxyDialerService(nil /* reverseTunnelServer */, "clustername", authServers, nil, nil, tracing.NoopTracer("test"))
 	require.Eventually(t, func() bool {
 		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 		t.Cleanup(cancel)
-		conn, err := s.dialLocalAuthServer(ctx)
+		conn, err := s.dialLocalAuthServer(ctx, nil, nil)
 		if err != nil {
 			return false
 		}

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -375,6 +375,7 @@ func (p *Proxy) handleConn(ctx context.Context, clientConn net.Conn, defaultOver
 		SNI:  hello.ServerName,
 		ALPN: hello.SupportedProtos,
 	}
+	ctx = utils.ClientAddrContext(ctx, clientConn.RemoteAddr(), clientConn.LocalAddr())
 
 	if handlerDesc.ForwardTLS {
 		return trace.Wrap(handlerDesc.handle(ctx, conn, connInfo))

--- a/lib/srv/db/common/interfaces.go
+++ b/lib/srv/db/common/interfaces.go
@@ -49,7 +49,7 @@ type Service interface {
 	// Authorize authorizes the provided client TLS connection.
 	Authorize(ctx context.Context, tlsConn utils.TLSConn, params ConnectParams) (*ProxyContext, error)
 	// Connect is used to connect to remote database server over reverse tunnel.
-	Connect(ctx context.Context, proxyCtx *ProxyContext) (net.Conn, error)
+	Connect(ctx context.Context, proxyCtx *ProxyContext, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error)
 	// Proxy starts proxying between client and service connections.
 	Proxy(ctx context.Context, proxyCtx *ProxyContext, clientConn, serviceConn net.Conn) error
 }

--- a/lib/srv/db/common/test.go
+++ b/lib/srv/db/common/test.go
@@ -159,6 +159,8 @@ type TestClientConfig struct {
 	Cluster string
 	// Username is the Teleport user name.
 	Username string
+	// PinnedIP is an IP client's certificate should be pinned to.
+	PinnedIP string
 	// RouteToDatabase contains database routing information.
 	RouteToDatabase tlsca.RouteToDatabase
 }
@@ -176,6 +178,7 @@ func MakeTestClientTLSCert(config TestClientConfig) (*tls.Certificate, error) {
 		Cluster:         config.Cluster,
 		Username:        config.Username,
 		RouteToDatabase: config.RouteToDatabase,
+		PinnedIP:        config.PinnedIP,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/srv/db/mysql/proxy.go
+++ b/lib/srv/db/mysql/proxy.go
@@ -117,7 +117,7 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 		return trace.Wrap(err)
 	}
 
-	serviceConn, err := p.Service.Connect(ctx, proxyCtx)
+	serviceConn, err := p.Service.Connect(ctx, proxyCtx, clientConn.RemoteAddr(), clientConn.LocalAddr())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/postgres/proxy.go
+++ b/lib/srv/db/postgres/proxy.go
@@ -99,7 +99,7 @@ func (p *Proxy) handleConnection(ctx context.Context, clientConn utils.TLSConn, 
 		defer p.IngressReporter.AuthenticatedConnectionClosed(ingress.Postgres, clientConn)
 	}
 
-	serviceConn, err := p.Service.Connect(ctx, proxyCtx)
+	serviceConn, err := p.Service.Connect(ctx, proxyCtx, clientConn.RemoteAddr(), clientConn.LocalAddr())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -496,6 +496,12 @@ func (s *ProxyServer) Authorize(ctx context.Context, tlsConn utils.TLSConn, para
 		return nil, trace.Wrap(err)
 	}
 	identity := authContext.Identity.GetIdentity()
+
+	// TODO(anton): Move this into authorizer.Authorize when we can enable it for all protocols
+	if err := auth.CheckIPPinning(ctx, identity, authContext.Checker.PinSourceIP()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	if params.User != "" {
 		identity.RouteToDatabase.Username = params.User
 	}

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -343,7 +343,7 @@ func (s *ProxyServer) handleConnection(conn net.Conn) error {
 	case defaults.ProtocolSQLServer:
 		return s.SQLServerProxy().HandleConnection(s.closeCtx, proxyCtx, tlsConn)
 	}
-	serviceConn, err := s.Connect(s.closeCtx, proxyCtx)
+	serviceConn, err := s.Connect(s.closeCtx, proxyCtx, conn.RemoteAddr(), conn.LocalAddr())
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -425,7 +425,7 @@ func (s *ProxyServer) SQLServerProxy() *sqlserver.Proxy {
 // decoded from the client certificate by auth.Middleware.
 //
 // Implements common.Service.
-func (s *ProxyServer) Connect(ctx context.Context, proxyCtx *common.ProxyContext) (net.Conn, error) {
+func (s *ProxyServer) Connect(ctx context.Context, proxyCtx *common.ProxyContext, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error) {
 	// There may be multiple database servers proxying the same database. If
 	// we get a connection problem error trying to dial one of them, likely
 	// the database server is down so try the next one.
@@ -435,12 +435,14 @@ func (s *ProxyServer) Connect(ctx context.Context, proxyCtx *common.ProxyContext
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
+
 		serviceConn, err := proxyCtx.Cluster.Dial(reversetunnel.DialParams{
-			From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: "@db-proxy"},
-			To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
-			ServerID: fmt.Sprintf("%v.%v", server.GetHostID(), proxyCtx.Cluster.GetName()),
-			ConnType: types.DatabaseTunnel,
-			ProxyIDs: server.GetProxyIDs(),
+			From:                  clientSrcAddr,
+			To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
+			OriginalClientDstAddr: clientDstAddr,
+			ServerID:              fmt.Sprintf("%v.%v", server.GetHostID(), proxyCtx.Cluster.GetName()),
+			ConnType:              types.DatabaseTunnel,
+			ProxyIDs:              server.GetProxyIDs(),
 		})
 		if err != nil {
 			// If an agent is down, we'll retry on the next one (if available).

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -996,6 +996,12 @@ func (s *Server) authorize(ctx context.Context) (*common.Session, error) {
 	}
 	identity := authContext.Identity.GetIdentity()
 	s.log.Debugf("Client identity: %#v.", identity)
+
+	// TODO(anton): Move this into authorizer.Authorize when we can enable it for all protocols
+	if err := auth.CheckIPPinning(ctx, identity, authContext.Checker.PinSourceIP()); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Fetch the requested database server.
 	var database types.Database
 	registeredDatabases := s.getProxiedDatabases()

--- a/lib/srv/db/sqlserver/proxy.go
+++ b/lib/srv/db/sqlserver/proxy.go
@@ -47,7 +47,7 @@ func (p *Proxy) HandleConnection(ctx context.Context, proxyCtx *common.ProxyCont
 		return trace.Wrap(err)
 	}
 
-	serviceConn, err := p.Service.Connect(ctx, proxyCtx)
+	serviceConn, err := p.Service.Connect(ctx, proxyCtx, conn.RemoteAddr(), conn.LocalAddr())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -39,14 +39,21 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// PROXYHeaderSigner allows to sign PROXY headers for securely propagating original client IP information
+type PROXYHeaderSigner interface {
+	SignPROXYHeader(source, destination net.Addr) ([]byte, error)
+}
+
 // proxySubsys implements an SSH subsystem for proxying listening sockets from
 // remote hosts to a proxy client (AKA port mapping)
 type proxySubsys struct {
 	proxySubsysRequest
-	router *proxy.Router
-	ctx    *srv.ServerContext
-	log    *logrus.Entry
-	closeC chan error
+	router       *proxy.Router
+	ctx          *srv.ServerContext
+	log          *logrus.Entry
+	closeC       chan error
+	proxySigner  PROXYHeaderSigner
+	localCluster string
 }
 
 // parseProxySubsys looks at the requested subsystem name and returns a fully configured
@@ -175,8 +182,10 @@ func newProxySubsys(ctx *srv.ServerContext, srv *Server, req proxySubsysRequest)
 			trace.Component:       teleport.ComponentSubsystemProxy,
 			trace.ComponentFields: map[string]string{},
 		}),
-		closeC: make(chan error),
-		router: srv.router,
+		closeC:       make(chan error),
+		router:       srv.router,
+		proxySigner:  srv.proxySigner,
+		localCluster: ctx.ClusterName,
 	}, nil
 }
 
@@ -192,8 +201,9 @@ func (t *proxySubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.C
 	t.log = logrus.WithFields(logrus.Fields{
 		trace.Component: teleport.ComponentSubsystemProxy,
 		trace.ComponentFields: map[string]string{
-			"src": sconn.RemoteAddr().String(),
-			"dst": sconn.LocalAddr().String(),
+			"src":       sconn.RemoteAddr().String(),
+			"dst":       sconn.LocalAddr().String(),
+			"subsystem": t.String(),
 		},
 	})
 	t.log.Debugf("Starting subsystem")
@@ -212,19 +222,19 @@ func (t *proxySubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.C
 
 	// connect to a site's auth server
 	if t.host == "" {
-		return t.proxyToSite(ctx, ch, t.clusterName)
+		return t.proxyToSite(ctx, ch, t.clusterName, clientAddr, sconn.LocalAddr())
 	}
 
 	// connect to a server
-	return t.proxyToHost(ctx, ch, clientAddr)
+	return t.proxyToHost(ctx, ch, clientAddr, sconn.LocalAddr())
 }
 
 // proxyToSite establishes a proxy connection from the connected SSH client to the
 // auth server of the requested remote site
-func (t *proxySubsys) proxyToSite(ctx context.Context, ch ssh.Channel, clusterName string) error {
-	t.log.Debugf("Connecting to site: %v", clusterName)
+func (t *proxySubsys) proxyToSite(ctx context.Context, ch ssh.Channel, clusterName string, clientSrcAddr, clientDstAddr net.Addr) error {
+	t.log.Debugf("Connecting from cluster %q to site: %q", t.localCluster, clusterName)
 
-	conn, err := t.router.DialSite(ctx, clusterName)
+	conn, err := t.router.DialSite(ctx, clusterName, clientSrcAddr, clientDstAddr)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -238,18 +248,17 @@ func (t *proxySubsys) proxyToSite(ctx context.Context, ch ssh.Channel, clusterNa
 
 // proxyToHost establishes a proxy connection from the connected SSH client to the
 // requested remote node (t.host:t.port) via the given site
-func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, remoteAddr net.Addr) error {
+func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrcAddr, clientDstAddr net.Addr) error {
 	t.log.Debugf("proxy connecting to host=%v port=%v, exact port=%v", t.host, t.port, t.SpecifiedPort())
 
-	conn, err := t.router.DialHost(ctx, remoteAddr, t.host, t.port, t.clusterName, t.ctx.Identity.AccessChecker, t.ctx.StartAgentChannel)
+	conn, teleportVersion, err := t.router.DialHost(ctx, clientSrcAddr, clientDstAddr, t.host, t.port, t.clusterName, t.ctx.Identity.AccessChecker, t.ctx.StartAgentChannel)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// this custom SSH handshake allows SSH proxy to relay the client's IP
-	// address to the SSH server
-	t.doHandshake(ctx, remoteAddr, ch, conn)
-
+	if teleportVersion != "" && utils.CheckVersion(teleportVersion, utils.MinIPPropagationVersion) != nil {
+		t.doHandshake(ctx, clientSrcAddr, ch, conn)
+	}
 	go func() {
 		t.close(utils.ProxyConn(ctx, ch, conn))
 	}()
@@ -264,8 +273,11 @@ func (t *proxySubsys) Wait() error {
 	return <-t.closeC
 }
 
-// doHandshake allows a proxy server to send additional information (client IP)
-// to an SSH server before establishing a bridge
+// doHandshake allows a proxy server to send additional information (client IP and tracing context)
+// to an SSH server before establishing a bridge.
+// NOTE: Used for compatibility with versions <12.1, before IP propagation through signed PROXY headers was added.
+// DELETE IN 14.0
+// DEPRECATED
 func (t *proxySubsys) doHandshake(ctx context.Context, clientAddr net.Addr, clientConn io.ReadWriter, serverConn io.ReadWriter) {
 	// on behalf of a client ask the server for its version:
 	buff := make([]byte, sshutils.MaxVersionStringBytes)

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -228,6 +228,9 @@ type Server struct {
 	ingressReporter *ingress.Reporter
 	// ingressService the service name passed to the ingress reporter.
 	ingressService string
+
+	// proxySigner is used to generate signed PROXYv2 header so we can securely propagate client IP
+	proxySigner PROXYHeaderSigner
 }
 
 // TargetMetadata returns metadata about the server.
@@ -678,6 +681,14 @@ func SetTracerProvider(provider oteltrace.TracerProvider) ServerOption {
 func SetSessionController(controller *srv.SessionController) ServerOption {
 	return func(s *Server) error {
 		s.sessionController = controller
+		return nil
+	}
+}
+
+// SetPROXYSigner sets the PROXY headers signer
+func SetPROXYSigner(proxySigner PROXYHeaderSigner) ServerOption {
+	return func(s *Server) error {
+		s.proxySigner = proxySigner
 		return nil
 	}
 }

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -17,17 +17,28 @@ limitations under the License.
 package sshutils
 
 import (
+	"bytes"
 	"context"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"net"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/observability/tracing"
+	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
@@ -250,6 +261,119 @@ func TestHostSignerFIPS(t *testing.T) {
 		)
 		tt.assert(t, err)
 	}
+}
+
+// TestConnectionWrapper_Read makes sure connectionWrapper can correctly process ProxyHelloSignature and PROXY protocol
+// on the wire.
+func TestConnectionWrapper_Read(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		sendData []byte
+	}{
+		{
+			desc:     "Plain connection without any special headers",
+			sendData: nil,
+		},
+		{
+			desc:     "Sending ProxyHelloSignature",
+			sendData: getProxyHelloSignaturePayload(t),
+		},
+		{
+			desc:     "Sending PROXY header",
+			sendData: getPROXYProtocolPayload(),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			t.Cleanup(func() { listener.Close() })
+
+			go startSSHServer(t, listener)
+
+			conn, err := net.Dial("tcp", listener.Addr().String())
+			require.NoError(t, err)
+
+			_, err = conn.Write(tc.sendData)
+			require.NoError(t, err)
+
+			sconn, nc, r, err := ssh.NewClientConn(conn, "", &ssh.ClientConfig{
+				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+				Timeout:         time.Second,
+			})
+			require.NoError(t, err)
+			require.Equal(t, "SSH-2.0-Go", string(sconn.ServerVersion()))
+
+			client := ssh.NewClient(sconn, nc, r)
+			require.NoError(t, err)
+
+			// Make sure SSH connection works correctly
+			ok, response, err := client.SendRequest("echo", true, []byte("beep"))
+			require.NoError(t, err)
+			require.True(t, ok)
+			require.Equal(t, "beep", string(response))
+		})
+	}
+}
+
+func getPROXYProtocolPayload() []byte {
+	proxyV2Prefix := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
+	// source=127.0.0.1:12345 destination=127.0.0.2:42
+	sampleIPv4Addresses := []byte{0x7F, 0x00, 0x00, 0x01, 0x7F, 0x00, 0x00, 0x02, 0x30, 0x39, 0x00, 0x2A}
+	// {0x21, 0x11, 0x00, 0x0C} - 4 bits version, 4 bits command, 4 bits address family, 4 bits protocol, 16 bits length
+	sampleProxyV2Line := bytes.Join([][]byte{proxyV2Prefix, {0x21, 0x11, 0x00, 0x0C}, sampleIPv4Addresses}, nil)
+
+	return sampleProxyV2Line
+}
+
+func getProxyHelloSignaturePayload(t *testing.T) []byte {
+	t.Helper()
+
+	hp := &apisshutils.HandshakePayload{
+		ClientAddr:     "127.0.0.1:12345",
+		TracingContext: tracing.PropagationContextFromContext(context.Background()),
+	}
+	payloadJSON, err := json.Marshal(hp)
+	require.NoError(t, err)
+
+	return []byte(fmt.Sprintf("%s%s\x00", constants.ProxyHelloSignature, payloadJSON))
+}
+
+func startSSHServer(t *testing.T, listener net.Listener) {
+	nConn, err := listener.Accept()
+	assert.NoError(t, err)
+
+	t.Cleanup(func() { nConn.Close() })
+
+	wConn := wrapConnection(nConn, nil, "", clockwork.NewRealClock(), logrus.New())
+
+	block, _ := pem.Decode(fixtures.LocalhostKey)
+	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	assert.NoError(t, err)
+
+	signer, err := ssh.NewSignerFromKey(pkey)
+	assert.NoError(t, err)
+
+	config := &ssh.ServerConfig{NoClientAuth: true}
+	config.AddHostKey(signer)
+
+	conn, _, reqs, err := ssh.NewServerConn(wConn, config)
+	assert.NoError(t, err)
+	if err != nil {
+		return
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	go func() {
+		for newReq := range reqs {
+			if newReq.Type == "echo" {
+				newReq.Reply(true, newReq.Payload)
+			}
+			err := newReq.Reply(false, nil)
+			assert.NoError(t, err)
+		}
+	}()
 }
 
 func pass(need string) PasswordFunc {

--- a/lib/utils/ver.go
+++ b/lib/utils/ver.go
@@ -21,6 +21,8 @@ import (
 	"github.com/gravitational/trace"
 )
 
+var MinIPPropagationVersion = semver.New(VersionBeforeAlpha("12.2.0")).String()
+
 // CheckVersion compares a version with a minimum version supported.
 func CheckVersion(currentVersion, minVersion string) error {
 	currentSemver, minSemver, err := versionStringToSemver(currentVersion, minVersion)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -75,6 +75,7 @@ import (
 	"github.com/gravitational/teleport/lib/jwt"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -237,6 +238,9 @@ type Config struct {
 	// SessionControl is used to determine if users are
 	// allowed to spawn new sessions
 	SessionControl *srv.SessionController
+
+	// PROXYSigner is used to sign PROXY header and securely propagate client IP information
+	PROXYSigner multiplexer.PROXYHeaderSigner
 
 	// TracerProvider generates tracers to create spans with
 	TracerProvider oteltrace.TracerProvider
@@ -2462,6 +2466,7 @@ func (h *Handler) siteNodeConnect(
 		Router:             h.cfg.Router,
 		TracerProvider:     h.cfg.TracerProvider,
 		ParticipantMode:    req.ParticipantMode,
+		PROXYSigner:        h.cfg.PROXYSigner,
 	}
 
 	term, err := NewTerminal(ctx, terminalConfig)
@@ -3207,7 +3212,7 @@ type ContextHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Pa
 type ClusterHandler func(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnel.RemoteSite) (interface{}, error)
 
 // WithClusterAuth wraps a ClusterHandler to ensure that a request is authenticated to this proxy
-// (the same as WithAuth), as well as to grab the RemoteSite (which can represent this local cluster
+// (the same as WithAuth), as well as to grab the remoteSite (which can represent this local cluster
 // or a remote trusted cluster) as specified by the ":site" url parameter.
 func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 	return httplib.MakeHandler(func(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
@@ -3222,7 +3227,7 @@ func (h *Handler) WithClusterAuth(fn ClusterHandler) httprouter.Handle {
 
 // authenticateRequestWithCluster ensures that a request is authenticated
 // to this proxy, returning the *SessionContext (same as AuthenticateRequest),
-// and also grabs the RemoteSite (which can represent this local cluster or a
+// and also grabs the remoteSite (which can represent this local cluster or a
 // remote trusted cluster) as specified by the ":site" url parameter.
 func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.Request, p httprouter.Params) (*SessionContext, reversetunnel.RemoteSite, error) {
 	sctx, err := h.AuthenticateRequest(w, r, true)
@@ -3239,7 +3244,7 @@ func (h *Handler) authenticateRequestWithCluster(w http.ResponseWriter, r *http.
 	return sctx, site, nil
 }
 
-// getSiteByParams gets the RemoteSite (which can represent this local cluster or a
+// getSiteByParams gets the remoteSite (which can represent this local cluster or a
 // remote trusted cluster) as specified by the ":site" url parameter.
 func (h *Handler) getSiteByParams(sctx *SessionContext, p httprouter.Params) (reversetunnel.RemoteSite, error) {
 	clusterName := p.ByName("site")

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7876,6 +7876,11 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		component = teleport.ComponentKube
 	}
 
+	proxySigner := &mockPROXYSigner{}
+	if cfg.serviceType == kubeproxy.KubeService {
+		proxySigner = nil
+	}
+
 	kubeServer, err := kubeproxy.NewTLSServer(kubeproxy.TLSServerConfig{
 		ForwarderConfig: kubeproxy.ForwarderConfig{
 			Namespace:         apidefaults.Namespace,
@@ -7893,6 +7898,7 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 			Component:         component,
 			LockWatcher:       proxyLockWatcher,
 			ReverseTunnelSrv:  cfg.revTunnel,
+			PROXYSigner:       proxySigner,
 			// skip Impersonation validation
 			CheckImpersonationPermissions: func(ctx context.Context, clusterName string, sarClient authztypes.SelfSubjectAccessReviewInterface) error {
 				return nil
@@ -8200,6 +8206,14 @@ func TestForwardingTraces(t *testing.T) {
 			tt.assertion(t, clt.spans, err, recorder.Code)
 		})
 	}
+}
+
+type mockPROXYSigner struct {
+}
+
+func (m *mockPROXYSigner) SignPROXYHeader(source, destination net.Addr) ([]byte, error) {
+	return nil, nil
+
 }
 
 type mockTraceClient struct {

--- a/lib/web/app/match_test.go
+++ b/lib/web/app/match_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package app
 
 import (
+	"context"
 	"errors"
 	"net"
 	"testing"
@@ -29,12 +30,12 @@ import (
 )
 
 func TestMatchAll(t *testing.T) {
-	falseMatcher := func(_ types.AppServer) bool { return false }
-	trueMatcher := func(_ types.AppServer) bool { return true }
+	falseMatcher := func(_ context.Context, _ types.AppServer) bool { return false }
+	trueMatcher := func(_ context.Context, _ types.AppServer) bool { return true }
 
-	require.True(t, MatchAll(trueMatcher, trueMatcher, trueMatcher)(nil))
-	require.False(t, MatchAll(trueMatcher, trueMatcher, falseMatcher)(nil))
-	require.False(t, MatchAll(falseMatcher, falseMatcher, falseMatcher)(nil))
+	require.True(t, MatchAll(trueMatcher, trueMatcher, trueMatcher)(nil, nil))
+	require.False(t, MatchAll(trueMatcher, trueMatcher, falseMatcher)(nil, nil))
+	require.False(t, MatchAll(falseMatcher, falseMatcher, falseMatcher)(nil, nil))
 }
 
 func TestMatchHealthy(t *testing.T) {
@@ -72,7 +73,7 @@ func TestMatchHealthy(t *testing.T) {
 
 			appServer, err := types.NewAppServerV3FromApp(app, "localhost", "123")
 			require.NoError(t, err)
-			require.Equal(t, test.match, match(appServer))
+			require.Equal(t, test.match, match(context.Background(), appServer))
 		})
 	}
 }

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -237,7 +237,7 @@ func (t *transport) DialContext(ctx context.Context, _, _ string) (net.Conn, err
 		}
 
 		var dialErr error
-		conn, dialErr = dialAppServer(t.c.proxyClient, t.c.identity.RouteToApp.ClusterName, appServer)
+		conn, dialErr = dialAppServer(ctx, t.c.proxyClient, t.c.identity.RouteToApp.ClusterName, appServer)
 		if dialErr != nil {
 			if isReverseTunnelDownError(dialErr) {
 				t.c.log.Warnf("Failed to connect to application server %q: %v.", serverID, dialErr)
@@ -278,24 +278,28 @@ func (t *transport) DialWebsocket(network, address string) (net.Conn, error) {
 
 // dialAppServer dial and connect to the application service over the reverse
 // tunnel subsystem.
-func dialAppServer(proxyClient reversetunnel.Tunnel, clusterName string, server types.AppServer) (net.Conn, error) {
+func dialAppServer(ctx context.Context, proxyClient reversetunnel.Tunnel, clusterName string, server types.AppServer) (net.Conn, error) {
 	clusterClient, err := proxyClient.GetSite(clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	conn, err := clusterClient.Dial(reversetunnel.DialParams{
-		From:     &utils.NetAddr{AddrNetwork: "tcp", Addr: "@web-proxy"},
-		To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
-		ServerID: fmt.Sprintf("%v.%v", server.GetHostID(), clusterName),
-		ConnType: types.AppTunnel,
-		ProxyIDs: server.GetProxyIDs(),
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
+	var from net.Addr
+	from = &utils.NetAddr{AddrNetwork: "tcp", Addr: "@web-proxy"}
+	clientSrcAddr, originalDst := utils.ClientAddrFromContext(ctx)
+	if clientSrcAddr != nil {
+		from = clientSrcAddr
 	}
 
-	return conn, nil
+	conn, err := clusterClient.Dial(reversetunnel.DialParams{
+		From:                  from,
+		To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalNode},
+		OriginalClientDstAddr: originalDst,
+		ServerID:              fmt.Sprintf("%v.%v", server.GetHostID(), clusterName),
+		ConnType:              types.AppTunnel,
+		ProxyIDs:              server.GetProxyIDs(),
+	})
+	return conn, trace.Wrap(err)
 }
 
 // configureTLS creates and configures a *tls.Config that will be used for

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -292,7 +292,12 @@ func newRemoteClient(ctx context.Context, sctx *SessionContext, site reversetunn
 // clusterDialer returns DialContext function using cluster's dial function
 func clusterDialer(remoteCluster reversetunnel.RemoteSite) apiclient.ContextDialer {
 	return apiclient.ContextDialerFunc(func(in context.Context, network, _ string) (net.Conn, error) {
-		return remoteCluster.DialAuthServer()
+		dialParams := reversetunnel.DialParams{}
+		clientSrcAddr, clientDstAddr := utils.ClientAddrFromContext(in)
+		dialParams.From = clientSrcAddr
+		dialParams.OriginalClientDstAddr = clientDstAddr
+
+		return remoteCluster.DialAuthServer(dialParams)
 	})
 }
 


### PR DESCRIPTION
This PR backports enabling of IP pinning for Kube and DB access, specifically it backports #21080 #22572 #22310 #22716 and #23386 

Part of #22061