### PR TITLE
Fix styled-components CSS prop in Storybook

### DIFF
--- a/web/.storybook/main.js
+++ b/web/.storybook/main.js
@@ -79,6 +79,9 @@ module.exports = {
             onlyCompileBundledFiles: true,
             configFile: tsconfigPath,
             transpileOnly: configType === 'DEVELOPMENT',
+            compilerOptions: {
+              jsx: 'preserve',
+            },
           },
         },
       ],


### PR DESCRIPTION
The changes for Vite made the JSX get parsed at the TypeScript transform level instead of preserving it for babel to transform.

This fixes that by setting `jsx: preserve` for Storybook's Webpack config, so babel continues to parse styled-component's `css` prop

Before:
<img width="1666" alt="image" src="https://user-images.githubusercontent.com/7922109/226907737-341a33cd-660c-4abe-af9a-8413cf6486ff.png">

After:
<img width="1666" alt="image" src="https://user-images.githubusercontent.com/7922109/226907608-bdc56373-c4b5-4e5f-89e7-8e67a21a71d9.png">
