### PR TITLE
[v12] Handle getBackend() or backend argument for plugins.

### DIFF
--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gravitational/trace"
 
@@ -35,8 +36,18 @@ type PluginsService struct {
 	backend backend.Backend
 }
 
-func NewPluginsService(backend backend.Backend) *PluginsService {
-	return &PluginsService{backend: backend}
+// NewPluginsService constructs a new PluginsService
+// todo(mdwn): make the argument here just a backend.Backend once the
+// reference to getBackend() has been removed in e.
+func NewPluginsService(input any) *PluginsService {
+	switch value := input.(type) {
+	case func() backend.Backend:
+		return &PluginsService{backend: value()}
+	case backend.Backend:
+		return &PluginsService{backend: value}
+	}
+
+	panic(fmt.Sprintf("Unrecognized plugins service backend type: %T", input))
 }
 
 // CreatePlugin implements services.Plugins


### PR DESCRIPTION
Backporting https://github.com/gravitational/teleport/pull/23042 to branch/v12.