### PR TITLE
Plugins service no longer accepts getBackend().

### DIFF
--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -35,8 +35,6 @@ type PluginsService struct {
 }
 
 // NewPluginsService constructs a new PluginsService
-// todo(mdwn): make the argument here just a backend.Backend once the
-// reference to getBackend() has been removed in e.
 func NewPluginsService(backend backend.Backend) *PluginsService {
 	return &PluginsService{backend: backend}
 }

--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gravitational/trace"
 
@@ -38,15 +37,8 @@ type PluginsService struct {
 // NewPluginsService constructs a new PluginsService
 // todo(mdwn): make the argument here just a backend.Backend once the
 // reference to getBackend() has been removed in e.
-func NewPluginsService(input any) *PluginsService {
-	switch value := input.(type) {
-	case func() backend.Backend:
-		return &PluginsService{backend: value()}
-	case backend.Backend:
-		return &PluginsService{backend: value}
-	}
-
-	panic(fmt.Sprintf("Unrecognized plugins service backend type: %T", input))
+func NewPluginsService(backend backend.Backend) *PluginsService {
+	return &PluginsService{backend: backend}
 }
 
 // CreatePlugin implements services.Plugins

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -29,7 +29,6 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
@@ -44,7 +43,7 @@ func TestPluginsCRUD(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { mem.Close() })
 
-	service := NewPluginsService(func() backend.Backend { return mem })
+	service := NewPluginsService(mem)
 
 	// Define two plugins
 	plugin1 := types.NewPluginV1(types.Metadata{Name: "p1"}, types.PluginSpecV1{


### PR DESCRIPTION
Now that enterprise has been fixed so that it provides the backend directly to the plugins service, it's no longer necessary for the plugins service to accept the `getBackend()` function.

Note: this bumps `e` so that it points to the e ref that doesn't supply a `getBackend` function to the plugins service.