### PR TITLE
Refactor `tbot start --data-dir` to support memory backed storage

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -300,6 +301,45 @@ func isJoinMethodDefault(joinMethod string) bool {
 	return joinMethod == "" || joinMethod == DefaultJoinMethod
 }
 
+func storageConfigFromCLIConf(dataDir string) (*StorageConfig, error) {
+	uri, err := url.Parse(dataDir)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing --data-dir")
+	}
+	switch uri.Scheme {
+	case "", "file":
+		if uri.Host != "" {
+			return nil, trace.BadParameter(
+				"file-backed data storage must be on the local host",
+			)
+		}
+		// TODO(strideynet): eventually we can allow for URI query parameters
+		// to be used to configure symlinks/acl protection.
+		return &StorageConfig{
+			DestinationMixin: DestinationMixin{
+				Directory: &DestinationDirectory{
+					Path: uri.Path,
+				},
+			},
+		}, nil
+	case "memory":
+		if uri.Host != "" || uri.Path != "" {
+			return nil, trace.BadParameter(
+				"memory-backed data storage should not have host or path specified",
+			)
+		}
+		return &StorageConfig{
+			DestinationMixin: DestinationMixin{
+				Memory: &DestinationMemory{},
+			},
+		}, nil
+	default:
+		return nil, trace.BadParameter(
+			"unrecognized data storage scheme",
+		)
+	}
+}
+
 // FromCLIConf loads bot config from CLI parameters, potentially loading and
 // merging a configuration file if specified. CheckAndSetDefaults() will
 // be called. Note that CLI flags, if specified, will override file values.
@@ -350,16 +390,15 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 	if cf.DataDir != "" {
 		if config.Storage != nil {
 			if _, err := config.Storage.GetDestination(); err != nil {
-				log.Warnf("CLI parameters are overriding storage location from %s", cf.ConfigPath)
+				log.Warnf(
+					"CLI parameters are overriding storage location from %s",
+					cf.ConfigPath,
+				)
 			}
 		}
-
-		config.Storage = &StorageConfig{
-			DestinationMixin: DestinationMixin{
-				Directory: &DestinationDirectory{
-					Path: cf.DataDir,
-				},
-			},
+		config.Storage, err = storageConfigFromCLIConf(cf.DataDir)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 	}
 

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -162,3 +162,93 @@ destinations:
       - ssh_client:
           proxy_port: 1234
 `
+
+func TestStorageConfigFromCLIConf(t *testing.T) {
+	tests := []struct {
+		in      string
+		want    *StorageConfig
+		wantErr bool
+	}{
+		{
+			in: "/absolute/dir",
+			want: &StorageConfig{
+				DestinationMixin: DestinationMixin{
+					Directory: &DestinationDirectory{
+						Path: "/absolute/dir",
+					},
+				},
+			},
+		},
+		{
+			in: "relative/dir",
+			want: &StorageConfig{
+				DestinationMixin: DestinationMixin{
+					Directory: &DestinationDirectory{
+						Path: "relative/dir",
+					},
+				},
+			},
+		},
+		{
+			in: "./relative/dir",
+			want: &StorageConfig{
+				DestinationMixin: DestinationMixin{
+					Directory: &DestinationDirectory{
+						Path: "./relative/dir",
+					},
+				},
+			},
+		},
+		{
+			in: "file:///absolute/dir",
+			want: &StorageConfig{
+				DestinationMixin: DestinationMixin{
+					Directory: &DestinationDirectory{
+						Path: "/absolute/dir",
+					},
+				},
+			},
+		},
+		{
+			in: "file:/absolute/dir",
+			want: &StorageConfig{
+				DestinationMixin: DestinationMixin{
+					Directory: &DestinationDirectory{
+						Path: "/absolute/dir",
+					},
+				},
+			},
+		},
+		{
+			in:      "file://host/absolute/dir",
+			wantErr: true,
+		},
+		{
+			in: "memory://",
+			want: &StorageConfig{
+				DestinationMixin: DestinationMixin{
+					Memory: &DestinationMemory{},
+				},
+			},
+		},
+		{
+			in:      "memory://foo/bar",
+			wantErr: true,
+		},
+		{
+			in:      "foobar://",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			got, err := storageConfigFromCLIConf(tt.in)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -51,12 +51,19 @@ func main() {
 	}
 }
 
+const appHelp = `Teleport Machine ID
+
+Machine ID issues and renews short-lived certificates so your machines can 
+access Teleport protected resources in the same way your engineers do!
+
+Find out more at https://goteleport.com/docs/machine-id/introduction/`
+
 func Run(args []string, stdout io.Writer) error {
 	var cf config.CLIConf
 	utils.InitLogger(utils.LoggingForDaemon, logrus.InfoLevel)
 
-	app := utils.InitCLIParser("tbot", "tbot: Teleport Machine ID").Interspersed(false)
-	app.Flag("debug", "Verbose logging to stdout").Short('d').BoolVar(&cf.Debug)
+	app := utils.InitCLIParser("tbot", appHelp).Interspersed(false)
+	app.Flag("debug", "Verbose logging to stdout.").Short('d').BoolVar(&cf.Debug)
 	app.Flag("config", "Path to a configuration file.").Short('c').StringVar(&cf.ConfigPath)
 	app.HelpFlag.Short('h')
 
@@ -65,7 +72,7 @@ func Run(args []string, stdout io.Writer) error {
 		strings.Join(config.SupportedJoinMethods, ", "),
 	)
 
-	versionCmd := app.Command("version", "Print the version of your tbot binary")
+	versionCmd := app.Command("version", "Print the version of your tbot binary.")
 
 	startCmd := app.Command("start", "Starts the renewal bot, writing certificates to the data dir at a set interval.")
 	startCmd.Flag("auth-server", "Address of the Teleport Auth Server or Proxy Server.").Short('a').Envar(authServerEnvVar).StringVar(&cf.AuthServer)
@@ -99,7 +106,7 @@ func Run(args []string, stdout io.Writer) error {
 
 	watchCmd := app.Command("watch", "Watch a destination directory for changes.").Hidden()
 
-	dbCmd := app.Command("db", "Execute database commands through tsh")
+	dbCmd := app.Command("db", "Execute database commands through tsh.")
 	dbCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.Proxy)
 	dbCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
 	dbCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)
@@ -108,7 +115,7 @@ func Run(args []string, stdout io.Writer) error {
 		"Arguments to `tsh db ...`; prefix with `-- ` to ensure flags are passed correctly.",
 	))
 
-	proxyCmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode")
+	proxyCmd := app.Command("proxy", "Start a local TLS proxy via tsh to connect to Teleport in single-port mode.")
 	proxyCmd.Flag("proxy", "The Teleport proxy server to use, in host:port form.").Required().StringVar(&cf.Proxy)
 	proxyCmd.Flag("destination-dir", "The destination directory with which to authenticate tsh").StringVar(&cf.DestinationDir)
 	proxyCmd.Flag("cluster", "The cluster name. Extracted from the certificate if unset.").StringVar(&cf.Cluster)


### PR DESCRIPTION
Useful for ephemeral environments where writing data to disk that will not be read represents a security concern.

Adopts a backwards compatible URI for this value, which we can re-use in future when we add support for backends like Kubernetes or Etcd.

Closes https://github.com/gravitational/teleport/issues/20095