### PR TITLE
Spell fix API comments

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -111,7 +111,7 @@ message Rotation {
     (gogoproto.jsontag) = "last_rotated,omitempty"
   ];
   // Schedule is a rotation schedule - used in
-  // automatic mode to switch beetween phases.
+  // automatic mode to switch between phases.
   RotationSchedule Schedule = 8 [
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "schedule,omitempty"
@@ -141,7 +141,7 @@ message RotationSchedule {
   ];
 }
 
-// ResorceHeader is a shared resource header
+// ResourceHeader is a shared resource header
 // used in cases when only type and name is known
 message ResourceHeader {
   // Kind is a resource kind
@@ -602,7 +602,7 @@ message InstanceSpecV1 {
 // synchronization as well as recordkeeping. For example, an auth server intending to trigger an upgrade
 // for a given instance can check its control log for 'upgrade-attempt' entries. If no such entry exists,
 // it can attempt to write an 'upgrade-attempt' entry of its own. If that entry successfully writes without
-// hiting a CompareFailed, the auth server knows that no other auth servers will make concurrent upgrade
+// hitting a CompareFailed, the auth server knows that no other auth servers will make concurrent upgrade
 // attempts while that entry persists.
 //
 // NOTE: Due to resource size and backend throughput limitations, care should be taken to minimize the
@@ -1146,7 +1146,7 @@ message ProvisionTokenSpecV2GitHub {
   // when trying to create rules around which workflows should be allowed to
   // authenticate against a cluster.
   message Rule {
-    // Sub also known as Subject is a string that roughly uniquely indentifies
+    // Sub also known as Subject is a string that roughly uniquely identifies
     // the workload. The format of this varies depending on the type of
     // github action run.
     string Sub = 1 [(gogoproto.jsontag) = "sub,omitempty"];
@@ -1754,7 +1754,7 @@ message Namespace {
   ];
 }
 
-// NamespaceSpec is a namespace specificateion
+// NamespaceSpec is a namespace specification
 message NamespaceSpec {}
 
 message UserTokenV3 {
@@ -1982,7 +1982,7 @@ message AccessRequestSpecV3 {
   string RequestReason = 6 [(gogoproto.jsontag) = "request_reason,omitempty"];
 
   // ResolveReason is an optional message explaining the reason for the resolution
-  // of the request (approval, denail, etc...).
+  // of the request (approval, denial, etc...).
   string ResolveReason = 7 [(gogoproto.jsontag) = "resolve_reason,omitempty"];
 
   // ResolveAnnotations is a set of arbitrary values received from plugins or other
@@ -2160,7 +2160,7 @@ message PluginDataFilter {
   string Plugin = 3 [(gogoproto.jsontag) = "plugin,omitempty"];
 }
 
-// PluginDataUpdateParams encodes paramers for updating a PluginData field.
+// PluginDataUpdateParams encodes parameters for updating a PluginData field.
 message PluginDataUpdateParams {
   // Kind is the kind of resource that the target plugin data
   // is associated with.
@@ -2279,7 +2279,7 @@ message RoleOptions {
   // concurrent sessions per connection.
   int64 MaxSessions = 10 [(gogoproto.jsontag) = "max_sessions,omitempty"];
 
-  // RequestAccess defines the access request stategy (optional|note|always)
+  // RequestAccess defines the access request strategy (optional|note|always)
   // where optional is the default.
   string RequestAccess = 11 [
     (gogoproto.jsontag) = "request_access,omitempty",
@@ -2412,7 +2412,7 @@ message CertExtension {
   CertExtensionMode Mode = 2 [(gogoproto.jsontag) = "mode"];
   // Name specifies the key to be used in the cert extension.
   string Name = 3 [(gogoproto.jsontag) = "name"];
-  // Value specifies the valueg to be used in the cert extension.
+  // Value specifies the value to be used in the cert extension.
   string Value = 4 [(gogoproto.jsontag) = "value"];
 }
 
@@ -2480,7 +2480,7 @@ message RoleConditions {
 
   // DatabaseNames is a list of database names this role is allowed to connect to.
   repeated string DatabaseNames = 12 [(gogoproto.jsontag) = "db_names,omitempty"];
-  // DatabaseUsers is a list of databaes users this role is allowed to connect as.
+  // DatabaseUsers is a list of databases users this role is allowed to connect as.
   repeated string DatabaseUsers = 13 [(gogoproto.jsontag) = "db_users,omitempty"];
 
   // Impersonate specifies what users and roles this role is allowed to impersonate
@@ -3040,7 +3040,7 @@ message TunnelConnectionSpecV2 {
 
 // SemaphoreFilter encodes semaphore filtering params.
 // A semaphore filter matches a semaphore if all nonzero fields
-// match the corresponding semaphore fileds (e.g. a filter which
+// match the corresponding semaphore fields (e.g. a filter which
 // specifies only `kind=foo` would match all semaphores of
 // kind `foo`).
 message SemaphoreFilter {
@@ -3065,7 +3065,7 @@ message AcquireSemaphoreRequest {
     (gogoproto.nullable) = false,
     (gogoproto.jsontag) = "expires"
   ];
-  // Holder identifies the entitiy holding the lease.
+  // Holder identifies the entity holding the lease.
   string Holder = 5 [(gogoproto.jsontag) = "holder"];
 }
 
@@ -3665,14 +3665,14 @@ message OIDCAuthRequest {
   bool CheckUser = 3 [(gogoproto.jsontag) = "check_user"];
 
   // StateToken is generated by service and is used to validate
-  // reuqest coming from
+  // request coming from
   string StateToken = 4 [(gogoproto.jsontag) = "state_token"];
 
   // CSRFToken is associated with user web session token
   string CSRFToken = 5 [(gogoproto.jsontag) = "csrf_token"];
 
   // RedirectURL will be used to route the user back to a
-  // Teleport Proxy after the oidc login attempt in the brower.
+  // Teleport Proxy after the oidc login attempt in the browser.
   string RedirectURL = 6 [(gogoproto.jsontag) = "redirect_url"];
 
   // PublicKey is an optional public key, users want these
@@ -4292,7 +4292,7 @@ message LockTarget {
   string Device = 8 [(gogoproto.jsontag) = "device,omitempty"];
 }
 
-// AddressCondition represents a set of addresses. Presently the addresses are specfied
+// AddressCondition represents a set of addresses. Presently the addresses are specified
 // exclusively in terms of IPv4/IPv6 ranges.
 message AddressCondition {
   // CIDR is IPv4 or IPv6 address. Valid value are either CIDR ranges (e.g. "10.0.1.0/24",
@@ -4742,7 +4742,7 @@ message ConnectionDiagnosticSpecV1 {
   // Success describes whether the connection was a success or a failure.
   bool Success = 1 [(gogoproto.jsontag) = "success"];
   // Message may contain some user friendly message to let the user know whether it was
-  // successfull or a failure.
+  // successful or a failure.
   string Message = 2 [(gogoproto.jsontag) = "message"];
   // Traces contain a list of checkpoints defined by
   repeated ConnectionDiagnosticTrace Traces = 3 [(gogoproto.jsontag) = "traces"];

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -870,7 +870,7 @@ type Rotation struct {
 	// LastRotated specifies the last time of the completed rotation.
 	LastRotated time.Time `protobuf:"bytes,7,opt,name=LastRotated,proto3,stdtime" json:"last_rotated,omitempty"`
 	// Schedule is a rotation schedule - used in
-	// automatic mode to switch beetween phases.
+	// automatic mode to switch between phases.
 	Schedule             RotationSchedule `protobuf:"bytes,8,opt,name=Schedule,proto3" json:"schedule,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
 	XXX_unrecognized     []byte           `json:"-"`
@@ -956,7 +956,7 @@ func (m *RotationSchedule) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_RotationSchedule proto.InternalMessageInfo
 
-// ResorceHeader is a shared resource header
+// ResourceHeader is a shared resource header
 // used in cases when only type and name is known
 type ResourceHeader struct {
 	// Kind is a resource kind
@@ -2102,7 +2102,7 @@ var xxx_messageInfo_InstanceSpecV1 proto.InternalMessageInfo
 // synchronization as well as recordkeeping. For example, an auth server intending to trigger an upgrade
 // for a given instance can check its control log for 'upgrade-attempt' entries. If no such entry exists,
 // it can attempt to write an 'upgrade-attempt' entry of its own. If that entry successfully writes without
-// hiting a CompareFailed, the auth server knows that no other auth servers will make concurrent upgrade
+// hitting a CompareFailed, the auth server knows that no other auth servers will make concurrent upgrade
 // attempts while that entry persists.
 //
 // NOTE: Due to resource size and backend throughput limitations, care should be taken to minimize the
@@ -3519,7 +3519,7 @@ var xxx_messageInfo_ProvisionTokenSpecV2GitHub proto.InternalMessageInfo
 // when trying to create rules around which workflows should be allowed to
 // authenticate against a cluster.
 type ProvisionTokenSpecV2GitHub_Rule struct {
-	// Sub also known as Subject is a string that roughly uniquely indentifies
+	// Sub also known as Subject is a string that roughly uniquely identifies
 	// the workload. The format of this varies depending on the type of
 	// github action run.
 	Sub string `protobuf:"bytes,1,opt,name=Sub,proto3" json:"sub,omitempty"`
@@ -5001,7 +5001,7 @@ func (m *Namespace) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_Namespace proto.InternalMessageInfo
 
-// NamespaceSpec is a namespace specificateion
+// NamespaceSpec is a namespace specification
 type NamespaceSpec struct {
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -5534,7 +5534,7 @@ type AccessRequestSpecV3 struct {
 	// RequestReason is an optional message explaining the reason for the request.
 	RequestReason string `protobuf:"bytes,6,opt,name=RequestReason,proto3" json:"request_reason,omitempty"`
 	// ResolveReason is an optional message explaining the reason for the resolution
-	// of the request (approval, denail, etc...).
+	// of the request (approval, denial, etc...).
 	ResolveReason string `protobuf:"bytes,7,opt,name=ResolveReason,proto3" json:"resolve_reason,omitempty"`
 	// ResolveAnnotations is a set of arbitrary values received from plugins or other
 	// resolving parties during approval/denial.  Importantly, these annotations are
@@ -5989,7 +5989,7 @@ func (m *PluginDataFilter) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_PluginDataFilter proto.InternalMessageInfo
 
-// PluginDataUpdateParams encodes paramers for updating a PluginData field.
+// PluginDataUpdateParams encodes parameters for updating a PluginData field.
 type PluginDataUpdateParams struct {
 	// Kind is the kind of resource that the target plugin data
 	// is associated with.
@@ -6166,7 +6166,7 @@ type RoleOptions struct {
 	// MaxSessions defines the maximum number of
 	// concurrent sessions per connection.
 	MaxSessions int64 `protobuf:"varint,10,opt,name=MaxSessions,proto3" json:"max_sessions,omitempty"`
-	// RequestAccess defines the access request stategy (optional|note|always)
+	// RequestAccess defines the access request strategy (optional|note|always)
 	// where optional is the default.
 	RequestAccess RequestStrategy `protobuf:"bytes,11,opt,name=RequestAccess,proto3,casttype=RequestStrategy" json:"request_access,omitempty"`
 	// RequestPrompt is an optional message which tells users what they aught to
@@ -6306,7 +6306,7 @@ type CertExtension struct {
 	Mode CertExtensionMode `protobuf:"varint,2,opt,name=Mode,proto3,enum=types.CertExtensionMode" json:"mode"`
 	// Name specifies the key to be used in the cert extension.
 	Name string `protobuf:"bytes,3,opt,name=Name,proto3" json:"name"`
-	// Value specifies the valueg to be used in the cert extension.
+	// Value specifies the value to be used in the cert extension.
 	Value                string   `protobuf:"bytes,4,opt,name=Value,proto3" json:"value"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -6376,7 +6376,7 @@ type RoleConditions struct {
 	DatabaseLabels Labels `protobuf:"bytes,11,opt,name=DatabaseLabels,proto3,customtype=Labels" json:"db_labels,omitempty"`
 	// DatabaseNames is a list of database names this role is allowed to connect to.
 	DatabaseNames []string `protobuf:"bytes,12,rep,name=DatabaseNames,proto3" json:"db_names,omitempty"`
-	// DatabaseUsers is a list of databaes users this role is allowed to connect as.
+	// DatabaseUsers is a list of databases users this role is allowed to connect as.
 	DatabaseUsers []string `protobuf:"bytes,13,rep,name=DatabaseUsers,proto3" json:"db_users,omitempty"`
 	// Impersonate specifies what users and roles this role is allowed to impersonate
 	// by issuing certificates or other possible means.
@@ -7839,7 +7839,7 @@ var xxx_messageInfo_TunnelConnectionSpecV2 proto.InternalMessageInfo
 
 // SemaphoreFilter encodes semaphore filtering params.
 // A semaphore filter matches a semaphore if all nonzero fields
-// match the corresponding semaphore fileds (e.g. a filter which
+// match the corresponding semaphore fields (e.g. a filter which
 // specifies only `kind=foo` would match all semaphores of
 // kind `foo`).
 type SemaphoreFilter struct {
@@ -7896,7 +7896,7 @@ type AcquireSemaphoreRequest struct {
 	MaxLeases int64 `protobuf:"varint,3,opt,name=MaxLeases,proto3" json:"max_resources"`
 	// Expires is the time at which this lease expires.
 	Expires time.Time `protobuf:"bytes,4,opt,name=Expires,proto3,stdtime" json:"expires"`
-	// Holder identifies the entitiy holding the lease.
+	// Holder identifies the entity holding the lease.
 	Holder               string   `protobuf:"bytes,5,opt,name=Holder,proto3" json:"holder"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -9689,12 +9689,12 @@ type OIDCAuthRequest struct {
 	// CheckUser tells validator if it should expect and check user
 	CheckUser bool `protobuf:"varint,3,opt,name=CheckUser,proto3" json:"check_user"`
 	// StateToken is generated by service and is used to validate
-	// reuqest coming from
+	// request coming from
 	StateToken string `protobuf:"bytes,4,opt,name=StateToken,proto3" json:"state_token"`
 	// CSRFToken is associated with user web session token
 	CSRFToken string `protobuf:"bytes,5,opt,name=CSRFToken,proto3" json:"csrf_token"`
 	// RedirectURL will be used to route the user back to a
-	// Teleport Proxy after the oidc login attempt in the brower.
+	// Teleport Proxy after the oidc login attempt in the browser.
 	RedirectURL string `protobuf:"bytes,6,opt,name=RedirectURL,proto3" json:"redirect_url"`
 	// PublicKey is an optional public key, users want these
 	// keys to be signed by auth servers user CA in case
@@ -10996,7 +10996,7 @@ func (m *LockTarget) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_LockTarget proto.InternalMessageInfo
 
-// AddressCondition represents a set of addresses. Presently the addresses are specfied
+// AddressCondition represents a set of addresses. Presently the addresses are specified
 // exclusively in terms of IPv4/IPv6 ranges.
 type AddressCondition struct {
 	// CIDR is IPv4 or IPv6 address. Valid value are either CIDR ranges (e.g. "10.0.1.0/24",
@@ -12214,7 +12214,7 @@ type ConnectionDiagnosticSpecV1 struct {
 	// Success describes whether the connection was a success or a failure.
 	Success bool `protobuf:"varint,1,opt,name=Success,proto3" json:"success"`
 	// Message may contain some user friendly message to let the user know whether it was
-	// successfull or a failure.
+	// successful or a failure.
 	Message string `protobuf:"bytes,2,opt,name=Message,proto3" json:"message"`
 	// Traces contain a list of checkpoints defined by
 	Traces               []*ConnectionDiagnosticTrace `protobuf:"bytes,3,rep,name=Traces,proto3" json:"traces"`


### PR DESCRIPTION
These are reused elsewhere which leads to spelling errors in our docs.