### PR TITLE
Fix ProvisionToken incompatibility with BootstrapResources

### DIFF
--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -28,33 +28,38 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 )
 
 func TestUserResource(t *testing.T) {
 	t.Parallel()
-
-	tt := setupServicesContext(context.Background(), t)
-	runUserResourceTest(t, tt, false)
+	ctx := context.Background()
+	tt := setupServicesContext(ctx, t)
+	runUserResourceTest(ctx, t, tt, false)
 }
 
 func TestUserResourceWithSecrets(t *testing.T) {
 	t.Parallel()
-
-	tt := setupServicesContext(context.Background(), t)
-	runUserResourceTest(t, tt, true)
+	ctx := context.Background()
+	tt := setupServicesContext(ctx, t)
+	runUserResourceTest(ctx, t, tt, true)
 }
 
-func runUserResourceTest(t *testing.T, tt *servicesContext, withSecrets bool) {
+func runUserResourceTest(
+	ctx context.Context,
+	t *testing.T,
+	tt *servicesContext,
+	withSecrets bool,
+) {
 	expiry := tt.bk.Clock().Now().Add(time.Minute)
 
 	alice := newUserTestCase(t, "alice", nil, withSecrets, expiry)
 	bob := newUserTestCase(t, "bob", nil, withSecrets, expiry)
 
 	// Check basic dynamic item creation
-	runCreationChecks(t, tt, alice, bob)
+	err := CreateResources(ctx, tt.bk, alice, bob)
+	require.NoError(t, err)
 
 	// Check that dynamically created item is compatible with service
 	s := NewIdentityService(tt.bk)
@@ -84,18 +89,19 @@ func runUserResourceTest(t *testing.T, tt *servicesContext, withSecrets bool) {
 
 func TestCertAuthorityResource(t *testing.T) {
 	t.Parallel()
-
-	tt := setupServicesContext(context.Background(), t)
+	ctx := context.Background()
+	tt := setupServicesContext(ctx, t)
 
 	userCA := suite.NewTestCA(types.UserCA, "example.com")
 	hostCA := suite.NewTestCA(types.HostCA, "example.com")
 
 	// Check basic dynamic item creation
-	runCreationChecks(t, tt, userCA, hostCA)
+	err := CreateResources(ctx, tt.bk, userCA, hostCA)
+	require.NoError(t, err)
 
 	// Check that dynamically created item is compatible with service
 	s := NewCAService(tt.bk)
-	err := s.CompareAndSwapCertAuthority(userCA, userCA)
+	err = s.CompareAndSwapCertAuthority(userCA, userCA)
 	require.NoError(t, err)
 }
 
@@ -124,7 +130,8 @@ func TestTrustedClusterResource(t *testing.T) {
 	require.NoError(t, err)
 
 	// Check basic dynamic item creation
-	runCreationChecks(t, tt, foo, bar)
+	err = CreateResources(ctx, tt.bk, foo, bar)
+	require.NoError(t, err)
 
 	s := NewPresenceService(tt.bk)
 	_, err = s.GetTrustedCluster(ctx, "foo")
@@ -163,10 +170,11 @@ func TestGithubConnectorResource(t *testing.T) {
 	}
 
 	// Check basic dynamic item creation
-	runCreationChecks(t, tt, connector)
+	err := CreateResources(ctx, tt.bk, connector)
+	require.NoError(t, err)
 
 	s := NewIdentityService(tt.bk)
-	_, err := s.GetGithubConnector(ctx, "github", true)
+	_, err = s.GetGithubConnector(ctx, "github", true)
 	require.NoError(t, err)
 }
 
@@ -203,16 +211,6 @@ func newUserTestCase(t *testing.T, name string, roles []string, withSecrets bool
 	return &user
 }
 
-func dumpResources(t *testing.T, tt *servicesContext) []types.Resource {
-	startKey := []byte("/")
-	endKey := backend.RangeEnd(startKey)
-	result, err := tt.bk.GetRange(context.TODO(), startKey, endKey, 0)
-	require.NoError(t, err)
-	resources, err := itemsToResources(result.Items...)
-	require.NoError(t, err)
-	return resources
-}
-
 func runCreationChecks(t *testing.T, tt *servicesContext, resources ...types.Resource) {
 	for _, rsc := range resources {
 		switch r := rsc.(type) {
@@ -223,14 +221,4 @@ func runCreationChecks(t *testing.T, tt *servicesContext, resources ...types.Res
 	}
 	err := CreateResources(context.TODO(), tt.bk, resources...)
 	require.NoError(t, err)
-	dump := dumpResources(t, tt)
-Outer:
-	for _, exp := range resources {
-		for _, got := range dump {
-			if got.GetKind() == exp.GetKind() && got.GetName() == exp.GetName() && got.Expiry() == exp.Expiry() {
-				continue Outer
-			}
-		}
-		t.Errorf("Missing expected resource kind=%s,name=%s,expiry=%v", exp.GetKind(), exp.GetName(), exp.Expiry().String())
-	}
 }

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -19,10 +19,10 @@ package local
 import (
 	"context"
 	"encoding/base32"
-	"github.com/google/go-cmp/cmp"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -33,7 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/suite"
 )
 
-func TestCreateResources_ProvisionToken(t *testing.T) {
+func TestCreateResourcesProvisionToken(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	tt := setupServicesContext(ctx, t)

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -208,7 +208,7 @@ func dumpResources(t *testing.T, tt *servicesContext) []types.Resource {
 	endKey := backend.RangeEnd(startKey)
 	result, err := tt.bk.GetRange(context.TODO(), startKey, endKey, 0)
 	require.NoError(t, err)
-	resources, err := ItemsToResources(result.Items...)
+	resources, err := itemsToResources(result.Items...)
 	require.NoError(t, err)
 	return resources
 }

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -19,6 +19,7 @@ package local
 import (
 	"context"
 	"encoding/base32"
+	"github.com/google/go-cmp/cmp"
 	"testing"
 	"time"
 
@@ -31,6 +32,25 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/suite"
 )
+
+func TestCreateResources_ProvisionToken(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tt := setupServicesContext(ctx, t)
+
+	token, err := types.NewProvisionToken(
+		"foo",
+		types.SystemRoles{types.RoleNode},
+		time.Time{},
+	)
+	require.NoError(t, err)
+	require.NoError(t, CreateResources(ctx, tt.bk, token))
+
+	s := NewProvisioningService(tt.bk)
+	fetchedToken, err := s.GetToken(ctx, "foo")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(token, fetchedToken))
+}
 
 func TestUserResource(t *testing.T) {
 	t.Parallel()

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -210,15 +210,3 @@ func newUserTestCase(t *testing.T, name string, roles []string, withSecrets bool
 	}
 	return &user
 }
-
-func runCreationChecks(t *testing.T, tt *servicesContext, resources ...types.Resource) {
-	for _, rsc := range resources {
-		switch r := rsc.(type) {
-		case types.User:
-			t.Logf("Creating User: %+v", r)
-		default:
-		}
-	}
-	err := CreateResources(context.TODO(), tt.bk, resources...)
-	require.NoError(t, err)
-}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -396,6 +396,10 @@ func GetResourceMarshalerKinds() []string {
 }
 
 // RegisterResourceMarshaler registers a marshaler for resources of a specific kind.
+// WARNING!!
+// Registering a resource Marshaler requires lib/services/local.CreateResources
+// supports the resource kind or the standard backup/restore procedure of using
+// `tctl get all` and then BootstrapResources in Teleport will fail.
 func RegisterResourceMarshaler(kind string, marshaler ResourceMarshaler) {
 	marshalerMutex.Lock()
 	defer marshalerMutex.Unlock()


### PR DESCRIPTION
In addition to adding support for ProvisionToken, I've also completed the following actions:

- Unexported methods that were only used internally to the package to reduce the API surface 
- Refactored the tests for this code. The existing tests checked that the resources had been created twice, once by checking the raw backend items and once by calling the service `Get` method. The code for checking the raw backend items was supported by a large amount of boiler-plated helpers, so I've removed this and we now rely on the heavier Get based check which tests more of the stack.

It's probably worth reviewing each commit individually if the overall diff is confusing.

Closes https://github.com/gravitational/teleport/issues/23422