### PR TITLE
[v12] Add `srv.ConnectionMonitor` to unify connection monitoring logic

### DIFF
--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/db"
 )
 
@@ -134,6 +135,18 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 
 	proxyGetter := reversetunnel.NewConnectedProxyGetter()
 
+	connMonitor, err := srv.NewConnectionMonitor(srv.ConnectionMonitorConfig{
+		AccessPoint: accessPoint,
+		LockWatcher: lockWatcher,
+		Clock:       process.Config.Clock,
+		ServerID:    process.Config.HostUUID,
+		Emitter:     asyncEmitter,
+		Logger:      process.log,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Create and start the database service.
 	dbService, err := db.New(process.ExitContext(), db.Config{
 		Clock:       process.Clock,
@@ -156,7 +169,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		AWSMatchers:          process.Config.Databases.AWSMatchers,
 		AzureMatchers:        process.Config.Databases.AzureMatchers,
 		OnHeartbeat:          process.onHeartbeat(teleport.ComponentDatabase),
-		LockWatcher:          lockWatcher,
+		ConnectionMonitor:    connMonitor,
 		ConnectedProxyGetter: proxyGetter,
 	})
 	if err != nil {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3930,19 +3930,29 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
+
+		connMonitor, err := srv.NewConnectionMonitor(srv.ConnectionMonitorConfig{
+			AccessPoint: accessPoint,
+			LockWatcher: lockWatcher,
+			Clock:       process.Config.Clock,
+			ServerID:    process.Config.HostUUID,
+			Emitter:     asyncEmitter,
+			Logger:      process.log,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
 		dbProxyServer, err := db.NewProxyServer(process.ExitContext(),
 			db.ProxyServerConfig{
-				AuthClient:      conn.Client,
-				AccessPoint:     accessPoint,
-				Authorizer:      authorizer,
-				Tunnel:          tsrv,
-				TLSConfig:       tlsConfig,
-				Limiter:         connLimiter,
-				Emitter:         asyncEmitter,
-				Clock:           process.Clock,
-				ServerID:        cfg.HostUUID,
-				LockWatcher:     lockWatcher,
-				IngressReporter: ingressReporter,
+				AuthClient:        conn.Client,
+				AccessPoint:       accessPoint,
+				Authorizer:        authorizer,
+				Tunnel:            tsrv,
+				TLSConfig:         tlsConfig,
+				Limiter:           connLimiter,
+				IngressReporter:   ingressReporter,
+				ConnectionMonitor: connMonitor,
 			})
 		if err != nil {
 			return trace.Wrap(err)
@@ -4667,6 +4677,19 @@ func (process *TeleportProcess) initApps() {
 
 		proxyGetter := reversetunnel.NewConnectedProxyGetter()
 
+		connMonitor, err := srv.NewConnectionMonitor(srv.ConnectionMonitorConfig{
+			AccessPoint:         accessPoint,
+			LockWatcher:         lockWatcher,
+			Clock:               process.Config.Clock,
+			ServerID:            process.Config.HostUUID,
+			Emitter:             asyncEmitter,
+			Logger:              process.log,
+			MonitorCloseChannel: process.Config.Apps.MonitorCloseChannel,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
 		appServer, err := app.New(process.ExitContext(), &app.Config{
 			Clock:                process.Config.Clock,
 			DataDir:              process.Config.DataDir,
@@ -4683,9 +4706,8 @@ func (process *TeleportProcess) initApps() {
 			ResourceMatchers:     process.Config.Apps.ResourceMatchers,
 			OnHeartbeat:          process.onHeartbeat(teleport.ComponentApp),
 			ConnectedProxyGetter: proxyGetter,
-			LockWatcher:          lockWatcher,
 			Emitter:              asyncEmitter,
-			MonitorCloseChannel:  process.Config.Apps.MonitorCloseChannel,
+			ConnectionMonitor:    connMonitor,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -61,6 +61,12 @@ const (
 	connContextKey appServerContextKey = "teleport-connContextKey"
 )
 
+// ConnMonitor monitors authorized connnections and terminates them when
+// session controls dictate so.
+type ConnMonitor interface {
+	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error)
+}
+
 // Config is the configuration for an application server.
 type Config struct {
 	// Clock is used to control time.
@@ -116,15 +122,12 @@ type Config struct {
 	// ConnectedProxyGetter gets the proxies teleport is connected to.
 	ConnectedProxyGetter *reversetunnel.ConnectedProxyGetter
 
-	// LockWatcher is the lock watcher for app access targets.
-	LockWatcher *services.LockWatcher
-
 	// Emitter is an event emitter.
 	Emitter events.Emitter
 
-	// MonitorCloseChannel will be signaled when the monitor closes a connection.
-	// Used only for testing. Optional.
-	MonitorCloseChannel chan struct{}
+	// ConnectionMonitor monitors connections and terminates any if
+	// any session controls prevent them.
+	ConnectionMonitor ConnMonitor
 }
 
 // CheckAndSetDefaults makes sure the configuration has the minimum required
@@ -692,25 +695,15 @@ func (s *Server) HandleConnection(conn net.Conn) {
 }
 
 func (s *Server) handleConnection(conn net.Conn) (func(), error) {
-	// Make sure everything here is wrapped in the tracking read connection for monitoring.
-	ctx, cancel := context.WithCancel(s.closeContext)
-	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
-		Conn:    conn,
-		Clock:   s.c.Clock,
-		Context: ctx,
-		Cancel:  cancel,
-	})
+	// Proxy sends a X.509 client certificate to pass identity information,
+	// extract it and run authorization checks on it.
+	tlsConn, user, app, err := s.getConnectionInfo(s.closeContext, conn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	// Proxy sends a X.509 client certificate to pass identity information,
-	// extract it and run authorization checks on it.
-	tlsConn, user, app, err := s.getConnectionInfo(ctx, tc)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	authCtx, _, err := s.authorizeContext(authz.ContextWithUser(ctx, user))
+	ctx := authz.ContextWithUser(s.closeContext, user)
+	authCtx, _, err := s.authorizeContext(ctx)
 
 	// The behavior here is a little hard to track. To be clear here, if authorization fails
 	// the following will occur:
@@ -725,7 +718,8 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 			return nil, trace.Wrap(err)
 		}
 	} else {
-		err = s.monitorConn(ctx, tc, authCtx)
+		// Monitor the connection an update the context.
+		ctx, err = s.c.ConnectionMonitor.MonitorConn(ctx, authCtx, conn)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -743,48 +737,9 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 	}, s.handleHTTPApp(ctx, tlsConn)
 }
 
-// monitorConn takes a TrackingReadConn and starts a connection monitor. The tracking connection will be
-// auto-terminated if disconnect_expired_cert or idle timeout is configured.
-func (s *Server) monitorConn(ctx context.Context, tc *srv.TrackingReadConn, authCtx *authz.Context) error {
-	authPref, err := s.c.AuthClient.GetAuthPreference(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	netConfig, err := s.c.AuthClient.GetClusterNetworkingConfig(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	identity := authCtx.Identity.GetIdentity()
-	checker := authCtx.Checker
-
-	idleTimeout := checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
-
-	// Start monitoring client connection. When client connection is closed the monitor goroutine exits.
-	err = srv.StartMonitor(srv.MonitorConfig{
-		LockWatcher:           s.c.LockWatcher,
-		LockTargets:           authCtx.LockTargets(),
-		DisconnectExpiredCert: srv.GetDisconnectExpiredCertFromIdentity(checker, authPref, &identity),
-		ClientIdleTimeout:     idleTimeout,
-		Conn:                  tc,
-		Tracker:               tc,
-		Context:               ctx,
-		Clock:                 s.c.Clock,
-		ServerID:              s.c.HostID,
-		TeleportUser:          identity.Username,
-		Emitter:               s.c.Emitter,
-		Entry:                 s.log,
-		MonitorCloseChannel:   s.c.MonitorCloseChannel,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
 // handleTCPApp handles connection for a TCP application.
 func (s *Server) handleTCPApp(ctx context.Context, conn net.Conn, identity *tlsca.Identity, app types.Application) error {
-	err := s.tcpServer.handleConnection(s.closeContext, conn, identity, app)
+	err := s.tcpServer.handleConnection(ctx, conn, identity, app)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -794,7 +749,7 @@ func (s *Server) handleTCPApp(ctx context.Context, conn net.Conn, identity *tlsc
 // handleHTTPApp handles connection for an HTTP application.
 func (s *Server) handleHTTPApp(ctx context.Context, conn net.Conn) error {
 	// Wrap a TLS authorizing conn in a single-use listener.
-	listener := newListener(s.closeContext, conn)
+	listener := newListener(ctx, conn)
 
 	// Serve will return as soon as tlsConn is running in its own goroutine
 	err := s.httpServer.Serve(listener)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -127,6 +127,13 @@ type suiteConfig struct {
 	RoleAppLabels types.Labels
 }
 
+type fakeConnMonitor struct {
+}
+
+func (f fakeConnMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error) {
+	return ctx, nil
+}
+
 func SetUpSuite(t *testing.T) *Suite {
 	return SetUpSuiteWithConfig(t, suiteConfig{})
 }
@@ -310,24 +317,24 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 	discard := events.NewDiscardEmitter()
 
 	s.appServer, err = New(s.closeContext, &Config{
-		Clock:            s.clock,
-		DataDir:          s.dataDir,
-		AccessPoint:      s.authClient,
-		AuthClient:       s.authClient,
-		TLSConfig:        tlsConfig,
-		CipherSuites:     utils.DefaultCipherSuites(),
-		HostID:           s.hostUUID,
-		Hostname:         "test",
-		Authorizer:       authorizer,
-		GetRotation:      testRotationGetter,
-		Apps:             apps,
-		OnHeartbeat:      func(err error) {},
-		Cloud:            &testCloud{},
-		ResourceMatchers: config.ResourceMatchers,
-		OnReconcile:      config.OnReconcile,
-		LockWatcher:      lockWatcher,
-		Emitter:          discard,
-		CloudLabels:      config.CloudImporter,
+		Clock:             s.clock,
+		DataDir:           s.dataDir,
+		AccessPoint:       s.authClient,
+		AuthClient:        s.authClient,
+		TLSConfig:         tlsConfig,
+		CipherSuites:      utils.DefaultCipherSuites(),
+		HostID:            s.hostUUID,
+		Hostname:          "test",
+		Authorizer:        authorizer,
+		GetRotation:       testRotationGetter,
+		Apps:              apps,
+		OnHeartbeat:       func(err error) {},
+		Cloud:             &testCloud{},
+		ResourceMatchers:  config.ResourceMatchers,
+		OnReconcile:       config.OnReconcile,
+		Emitter:           discard,
+		CloudLabels:       config.CloudImporter,
+		ConnectionMonitor: fakeConnMonitor{},
 	})
 	require.NoError(t, err)
 

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/authz"
 	dtauthz "github.com/gravitational/teleport/lib/devicetrust/authz"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -51,6 +52,8 @@ type Session struct {
 	Log logrus.FieldLogger
 	// LockTargets is a list of lock targets applicable to this session.
 	LockTargets []types.LockTarget
+	// AuthContext is the identity context of the user.
+	AuthContext *authz.Context
 }
 
 // String returns string representation of the session parameters.

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -21,7 +21,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"io"
 	"math/rand"
 	"net"
 	"sort"
@@ -30,7 +29,6 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
@@ -38,7 +36,6 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/events"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -46,8 +43,6 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/reversetunnel"
-	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/dbutils"
 	"github.com/gravitational/teleport/lib/srv/db/mysql"
@@ -72,6 +67,12 @@ type ProxyServer struct {
 	log logrus.FieldLogger
 }
 
+// ConnMonitor monitors authorized connnections and terminates them when
+// session controls dictate so.
+type ConnMonitor interface {
+	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error)
+}
+
 // ProxyServerConfig is the proxy configuration.
 type ProxyServerConfig struct {
 	// AuthClient is the authenticated client to the auth server.
@@ -86,16 +87,11 @@ type ProxyServerConfig struct {
 	TLSConfig *tls.Config
 	// Limiter is the connection/rate limiter.
 	Limiter *limiter.Limiter
-	// Emitter is used to emit audit events.
-	Emitter events.Emitter
-	// Clock to override clock in tests.
-	Clock clockwork.Clock
-	// ServerID is the ID of the audit log server.
-	ServerID string
-	// LockWatcher is a lock watcher.
-	LockWatcher *services.LockWatcher
 	// IngressReporter reports new and active connections.
 	IngressReporter *ingress.Reporter
+	// ConnectionMonitor monitors and closes connections if session controls
+	// prevent the connections.
+	ConnectionMonitor ConnMonitor
 }
 
 // ShuffleFunc defines a function that shuffles a list of database servers.
@@ -156,14 +152,8 @@ func (c *ProxyServerConfig) CheckAndSetDefaults() error {
 	if c.TLSConfig == nil {
 		return trace.BadParameter("missing TLSConfig")
 	}
-	if c.Clock == nil {
-		c.Clock = clockwork.NewRealClock()
-	}
-	if c.ServerID == "" {
-		return trace.BadParameter("missing ServerID")
-	}
-	if c.LockWatcher == nil {
-		return trace.BadParameter("missing LockWatcher")
+	if c.ConnectionMonitor == nil {
+		return trace.BadParameter("missing ConnectionMonitor")
 	}
 	if c.Limiter == nil {
 		// Empty config means no connection limit.
@@ -477,118 +467,16 @@ func isReverseTunnelDownError(err error) bool {
 //
 // Implements common.Service.
 func (s *ProxyServer) Proxy(ctx context.Context, proxyCtx *common.ProxyContext, clientConn, serviceConn net.Conn) error {
-	// Wrap a client connection into monitor that auto-terminates
+	// Wrap a client connection with a monitor that auto-terminates
 	// idle connection and connection with expired cert.
-	tc, err := monitorConn(ctx, monitorConnConfig{
-		conn:         clientConn,
-		lockWatcher:  s.cfg.LockWatcher,
-		lockTargets:  proxyCtx.AuthContext.LockTargets(),
-		identity:     proxyCtx.AuthContext.Identity.GetIdentity(),
-		checker:      proxyCtx.AuthContext.Checker,
-		clock:        s.cfg.Clock,
-		serverID:     s.cfg.ServerID,
-		authClient:   s.cfg.AuthClient,
-		teleportUser: proxyCtx.AuthContext.Identity.GetIdentity().Username,
-		emitter:      s.cfg.Emitter,
-		log:          s.log,
-		ctx:          s.closeCtx,
-	})
+	ctx, err := s.cfg.ConnectionMonitor.MonitorConn(ctx, proxyCtx.AuthContext, clientConn)
 	if err != nil {
 		clientConn.Close()
 		serviceConn.Close()
 		return trace.Wrap(err)
 	}
-	errCh := make(chan error, 2)
-	go func() {
-		defer s.log.Debug("Stop proxying from client to service.")
-		defer serviceConn.Close()
-		defer tc.Close()
-		_, err := io.Copy(serviceConn, tc)
-		errCh <- err
-	}()
-	go func() {
-		defer s.log.Debug("Stop proxying from service to client.")
-		defer serviceConn.Close()
-		defer tc.Close()
-		_, err := io.Copy(tc, serviceConn)
-		errCh <- err
-	}()
-	var errs []error
-	for i := 0; i < 2; i++ {
-		select {
-		case err := <-errCh:
-			if err != nil && !utils.IsOKNetworkError(err) {
-				s.log.WithError(err).Warn("Connection problem.")
-				errs = append(errs, err)
-			}
-		case <-ctx.Done():
-			return trace.ConnectionProblem(nil, "context is closing")
-		}
-	}
-	return trace.NewAggregate(errs...)
-}
 
-// monitorConnConfig is a monitorConn configuration.
-type monitorConnConfig struct {
-	conn         net.Conn
-	lockWatcher  *services.LockWatcher
-	lockTargets  []types.LockTarget
-	checker      services.AccessChecker
-	identity     tlsca.Identity
-	clock        clockwork.Clock
-	serverID     string
-	authClient   *auth.Client
-	teleportUser string
-	emitter      events.Emitter
-	log          logrus.FieldLogger
-	ctx          context.Context
-}
-
-// monitorConn wraps a client connection with TrackingReadConn, starts a connection monitor and
-// returns a tracking connection that will be auto-terminated in case disconnect_expired_cert or idle timeout is
-// configured, and unmodified client connection otherwise.
-func monitorConn(ctx context.Context, cfg monitorConnConfig) (net.Conn, error) {
-	authPref, err := cfg.authClient.GetAuthPreference(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	netConfig, err := cfg.authClient.GetClusterNetworkingConfig(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	idleTimeout := cfg.checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
-	ctx, cancel := context.WithCancel(ctx)
-	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
-		Conn:    cfg.conn,
-		Clock:   cfg.clock,
-		Context: ctx,
-		Cancel:  cancel,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Start monitoring client connection. When client connection is closed the monitor goroutine exits.
-	err = srv.StartMonitor(srv.MonitorConfig{
-		LockWatcher:           cfg.lockWatcher,
-		LockTargets:           cfg.lockTargets,
-		DisconnectExpiredCert: srv.GetDisconnectExpiredCertFromIdentity(cfg.checker, authPref, &cfg.identity),
-		ClientIdleTimeout:     idleTimeout,
-		Conn:                  cfg.conn,
-		Tracker:               tc,
-		Context:               cfg.ctx,
-		Clock:                 cfg.clock,
-		ServerID:              cfg.serverID,
-		TeleportUser:          cfg.teleportUser,
-		Emitter:               cfg.emitter,
-		Entry:                 cfg.log,
-	})
-	if err != nil {
-		tc.Close()
-		return nil, trace.Wrap(err)
-	}
-	return tc, nil
+	return trace.Wrap(utils.ProxyConn(ctx, clientConn, serviceConn))
 }
 
 // Authorize authorizes the provided client TLS connection.

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -118,8 +118,6 @@ type Config struct {
 	Auth common.Auth
 	// CADownloader automatically downloads root certs for cloud hosted databases.
 	CADownloader CADownloader
-	// LockWatcher is a lock watcher.
-	LockWatcher *services.LockWatcher
 	// CloudClients creates cloud API clients.
 	CloudClients clients.Clients
 	// CloudMeta fetches cloud metadata for cloud hosted databases.
@@ -130,6 +128,10 @@ type Config struct {
 	ConnectedProxyGetter *reversetunnel.ConnectedProxyGetter
 	// CloudUsers manage users for cloud hosted databases.
 	CloudUsers *users.Users
+	// ConnectionMonitor monitors and closes connections if session controls
+	// prevent the connections.
+	ConnectionMonitor ConnMonitor
+
 	// discoveryResourceChecker performs some pre-checks when creating databases
 	// discovered by the discovery service.
 	discoveryResourceChecker discoveryResourceChecker
@@ -189,8 +191,8 @@ func (c *Config) CheckAndSetDefaults(ctx context.Context) (err error) {
 	if c.CADownloader == nil {
 		c.CADownloader = NewRealDownloader()
 	}
-	if c.LockWatcher == nil {
-		return trace.BadParameter("missing LockWatcher")
+	if c.ConnectionMonitor == nil {
+		return trace.BadParameter("missing ConnectionMonitor")
 	}
 	if c.CloudClients == nil {
 		c.CloudClients = clients.NewClients()
@@ -895,20 +897,7 @@ func (s *Server) handleConnection(ctx context.Context, clientConn net.Conn) erro
 
 	// Wrap a client connection into monitor that auto-terminates
 	// idle connection and connection with expired cert.
-	clientConn, err = monitorConn(ctx, monitorConnConfig{
-		conn:         clientConn,
-		lockWatcher:  s.cfg.LockWatcher,
-		lockTargets:  sessionCtx.LockTargets,
-		identity:     sessionCtx.Identity,
-		checker:      sessionCtx.Checker,
-		clock:        s.cfg.Clock,
-		serverID:     s.cfg.HostID,
-		authClient:   s.cfg.AuthClient,
-		teleportUser: sessionCtx.Identity.Username,
-		emitter:      s.cfg.Emitter,
-		log:          s.log,
-		ctx:          s.closeContext,
-	})
+	ctx, err = s.cfg.ConnectionMonitor.MonitorConn(ctx, sessionCtx.AuthContext, clientConn)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -1031,6 +1020,7 @@ func (s *Server) authorize(ctx context.Context) (*common.Session, error) {
 		Identity:          identity,
 		DatabaseUser:      identity.RouteToDatabase.Username,
 		DatabaseName:      identity.RouteToDatabase.Database,
+		AuthContext:       authContext,
 		Checker:           authContext.Checker,
 		StartupParameters: make(map[string]string),
 		Log: s.log.WithFields(logrus.Fields{

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -55,6 +56,120 @@ type TrackingConn interface {
 	RemoteAddr() net.Addr
 	// Close closes the connection
 	Close() error
+}
+
+// ConnectionMonitorConfig contains dependencies required by
+// the ConnectionMonitor.
+type ConnectionMonitorConfig struct {
+	// AccessPoint is used to retrieve cluster configuration.
+	AccessPoint AccessPoint
+	// LockWatcher ensures lock information is up to date.
+	LockWatcher *services.LockWatcher
+	// Clock is a clock, realtime or fixed in tests.
+	Clock clockwork.Clock
+	// ServerID is the host UUID of the server receiving connections.
+	ServerID string
+	// Emitter allows events to be emitted.
+	Emitter apievents.Emitter
+	// Logger is a logging entry.
+	Logger log.FieldLogger
+	// MonitorCloseChannel will be signaled when the monitor closes a connection.
+	// Used only for testing. Optional.
+	MonitorCloseChannel chan struct{}
+}
+
+// CheckAndSetDefaults checks values and sets defaults
+func (c *ConnectionMonitorConfig) CheckAndSetDefaults() error {
+	if c.AccessPoint == nil {
+		return trace.BadParameter("missing parameter AccessPoint")
+	}
+	if c.LockWatcher == nil {
+		return trace.BadParameter("missing parameter LockWatcher")
+	}
+	if c.Logger == nil {
+		return trace.BadParameter("missing parameter Logger")
+	}
+	if c.Emitter == nil {
+		return trace.BadParameter("missing parameter Emitter")
+	}
+	if c.ServerID == "" {
+		return trace.BadParameter("missing parameter ServerID")
+	}
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+// ConnectionMonitor monitors the activity of connections and disconnects
+// them if the certificate expires, if a new lock is placed
+// that applies to the connection, or after periods of inactivity
+type ConnectionMonitor struct {
+	cfg ConnectionMonitorConfig
+}
+
+// NewConnectionMonitor returns a ConnectionMonitor that can be used to monitor
+// connection activity and terminate connections based on various cluster conditions.
+func NewConnectionMonitor(cfg ConnectionMonitorConfig) (*ConnectionMonitor, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &ConnectionMonitor{cfg: cfg}, nil
+}
+
+// MonitorConn ensures that the provided [net.Conn] is allowed per cluster configuration
+// and security controls. If at any point during the lifetime of the connection the
+// cluster controls dictate that the connection is not permitted it will be closed and the
+// returned [context.Context] will be canceled.
+func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error) {
+	authPref, err := c.cfg.AccessPoint.GetAuthPreference(ctx)
+	if err != nil {
+		return ctx, trace.Wrap(err)
+	}
+	netConfig, err := c.cfg.AccessPoint.GetClusterNetworkingConfig(ctx)
+	if err != nil {
+		return ctx, trace.Wrap(err)
+	}
+
+	identity := authzCtx.Identity.GetIdentity()
+	checker := authzCtx.Checker
+
+	idleTimeout := checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
+
+	monitorCtx, cancel := context.WithCancel(ctx)
+	tconn, err := NewTrackingReadConn(TrackingReadConnConfig{
+		Conn:    conn,
+		Clock:   c.cfg.Clock,
+		Context: monitorCtx,
+		Cancel:  cancel,
+	})
+	if err != nil {
+		return ctx, trace.Wrap(err)
+	}
+
+	// Start monitoring client connection. When client connection is closed the monitor goroutine exits.
+	if err := StartMonitor(MonitorConfig{
+		LockWatcher:           c.cfg.LockWatcher,
+		LockTargets:           authzCtx.LockTargets(),
+		LockingMode:           authzCtx.Checker.LockingMode(authPref.GetLockingMode()),
+		DisconnectExpiredCert: GetDisconnectExpiredCertFromIdentity(checker, authPref, &identity),
+		ClientIdleTimeout:     idleTimeout,
+		Conn:                  tconn,
+		Tracker:               tconn,
+		Context:               ctx,
+		Clock:                 c.cfg.Clock,
+		ServerID:              c.cfg.ServerID,
+		TeleportUser:          identity.Username,
+		Emitter:               c.cfg.Emitter,
+		Entry:                 c.cfg.Logger,
+		IdleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
+		MonitorCloseChannel:   c.cfg.MonitorCloseChannel,
+	}); err != nil {
+		return ctx, trace.Wrap(err)
+	}
+
+	return monitorCtx, nil
 }
 
 // MonitorConfig is a wiretap configuration

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -31,13 +31,14 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 func newTestMonitor(ctx context.Context, t *testing.T, asrv *auth.TestAuthServer, mut ...func(*MonitorConfig)) (*mockTrackingConn, *eventstest.ChannelEmitter, MonitorConfig) {
-	conn := &mockTrackingConn{make(chan struct{})}
+	conn := &mockTrackingConn{closedC: make(chan struct{})}
 	emitter := eventstest.NewChannelEmitter(1)
 	cfg := MonitorConfig{
 		Context:     ctx,
@@ -55,6 +56,91 @@ func newTestMonitor(ctx context.Context, t *testing.T, asrv *auth.TestAuthServer
 	}
 	require.NoError(t, StartMonitor(cfg))
 	return conn, emitter, cfg
+}
+
+func TestConnectionMonitorLockInForce(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	asrv, err := auth.NewTestAuthServer(auth.TestAuthServerConfig{
+		Dir:   t.TempDir(),
+		Clock: clockwork.NewFakeClock(),
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, asrv.Close()) })
+
+	// Create a connection monitor that points to our test
+	// Auth server.
+	emitter := eventstest.NewChannelEmitter(1)
+	monitor, err := NewConnectionMonitor(ConnectionMonitorConfig{
+		AccessPoint: asrv.AuthServer,
+		Emitter:     emitter,
+		Clock:       asrv.Clock(),
+		Logger:      logrus.StandardLogger(),
+		LockWatcher: asrv.LockWatcher,
+		ServerID:    "test",
+	})
+	require.NoError(t, err)
+
+	lock, err := types.NewLock("test-lock", types.LockSpecV2{Target: types.LockTarget{User: "test-user"}})
+	require.NoError(t, err)
+
+	identity := &authz.LocalUser{
+		Username: "test-user",
+		Identity: tlsca.Identity{
+			Username: "test-user",
+		},
+	}
+
+	authzCtx := &authz.Context{
+		Checker:          mockChecker{},
+		Identity:         identity,
+		UnmappedIdentity: identity,
+	}
+
+	t.Run("lock created after connection has been established", func(t *testing.T) {
+		// Create a fake connection and monitor it.
+		conn := &mockTrackingConn{closedC: make(chan struct{})}
+		monitorCtx, err := monitor.MonitorConn(ctx, authzCtx, conn)
+		require.NoError(t, err)
+		require.Nil(t, monitorCtx.Err())
+
+		// Create a lock targeting the user that was connected above.
+		require.NoError(t, asrv.AuthServer.UpsertLock(ctx, lock))
+
+		// Assert that the connection was terminated.
+		select {
+		case <-conn.closedC:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for connection close.")
+		}
+
+		// Assert that the context was canceled.
+		require.Error(t, monitorCtx.Err())
+
+		// Validate that the disconnect event was logged.
+		require.Equal(t, services.LockInForceAccessDenied(lock).Error(), (<-emitter.C()).(*apievents.ClientDisconnect).Reason)
+	})
+
+	t.Run("connection terminated if lock already exists", func(t *testing.T) {
+		// Create another connection for the locked user and validate
+		// that it is terminated right away.
+		conn := &mockTrackingConn{closedC: make(chan struct{})}
+		monitorCtx, err := monitor.MonitorConn(ctx, authzCtx, conn)
+		require.NoError(t, err)
+
+		// Assert that the context was canceled and that the connection was terminated.
+		require.Error(t, monitorCtx.Err())
+		select {
+		case <-conn.closedC:
+		case <-time.After(2 * time.Second):
+			t.Fatal("Timeout waiting for connection close.")
+		}
+
+		// Validate that the disconnect event was logged.
+		require.Equal(t, services.LockInForceAccessDenied(lock).Error(), (<-emitter.C()).(*apievents.ClientDisconnect).Reason)
+	})
 }
 
 func TestMonitorLockInForce(t *testing.T) {
@@ -147,6 +233,7 @@ func TestMonitorStaleLocks(t *testing.T) {
 }
 
 type mockTrackingConn struct {
+	net.Conn
 	closedC chan struct{}
 }
 
@@ -221,8 +308,16 @@ type mockChecker struct {
 	services.AccessChecker
 }
 
-func (m *mockChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
+func (m mockChecker) AdjustDisconnectExpiredCert(disconnect bool) bool {
 	return disconnect
+}
+
+func (m mockChecker) AdjustClientIdleTimeout(ttl time.Duration) time.Duration {
+	return ttl
+}
+
+func (m mockChecker) LockingMode(defaultMode constants.LockingMode) constants.LockingMode {
+	return defaultMode
 }
 
 type mockAuthPreference struct {
@@ -240,7 +335,7 @@ func TestGetDisconnectExpiredCertFromIdentity(t *testing.T) {
 	now := clock.Now()
 	inAnHour := clock.Now().Add(time.Hour)
 	var unset time.Time
-	checker := &mockChecker{}
+	checker := mockChecker{}
 	authPref := &mockAuthPreference{}
 
 	for _, test := range []struct {


### PR DESCRIPTION
Backport #23343 to branch/v12