### PR TITLE
[v12] support postgres cancel request

### DIFF
--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -508,7 +508,15 @@ func TestALPNSNIProxyDatabaseAccess(t *testing.T) {
 	})
 
 	t.Run("postgres", func(t *testing.T) {
-		lp := mustStartALPNLocalProxy(t, pack.Root.Cluster.SSHProxy, alpncommon.ProtocolPostgres)
+		lp := mustStartALPNLocalProxyWithConfig(t, alpnproxy.LocalProxyConfig{
+			RemoteProxyAddr:    pack.Root.Cluster.SSHProxy,
+			Protocols:          []alpncommon.Protocol{alpncommon.ProtocolPostgres},
+			InsecureSkipVerify: true,
+			// Since this a non-tunnel local proxy, we should check certs are needed
+			// for postgres.
+			// (this is how a local proxy would actually be configured for postgres).
+			CheckCertsNeeded: true,
+		})
 		t.Run("connect to main cluster via proxy", func(t *testing.T) {
 			client, err := postgres.MakeTestClient(context.Background(), common.TestClientConfig{
 				AuthClient: pack.Root.Cluster.GetSiteAPI(pack.Root.Cluster.Secrets.SiteName),
@@ -546,7 +554,15 @@ func TestALPNSNIProxyDatabaseAccess(t *testing.T) {
 			mustClosePostgresClient(t, client)
 		})
 		t.Run("connect to main cluster via proxy with ping protocol", func(t *testing.T) {
-			pingProxy := mustStartALPNLocalProxy(t, pack.Root.Cluster.SSHProxy, alpncommon.ProtocolWithPing(alpncommon.ProtocolPostgres))
+			pingProxy := mustStartALPNLocalProxyWithConfig(t, alpnproxy.LocalProxyConfig{
+				RemoteProxyAddr:    pack.Root.Cluster.SSHProxy,
+				Protocols:          []alpncommon.Protocol{alpncommon.ProtocolWithPing(alpncommon.ProtocolPostgres)},
+				InsecureSkipVerify: true,
+				// Since this a non-tunnel local proxy, we should check certs are needed
+				// for postgres.
+				// (this is how a local proxy would actually be configured for postgres).
+				CheckCertsNeeded: true,
+			})
 			client, err := postgres.MakeTestClient(context.Background(), common.TestClientConfig{
 				AuthClient: pack.Root.Cluster.GetSiteAPI(pack.Root.Cluster.Secrets.SiteName),
 				AuthServer: pack.Root.Cluster.Process.GetAuthServer(),

--- a/lib/srv/alpnproxy/helpers_test.go
+++ b/lib/srv/alpnproxy/helpers_test.go
@@ -32,7 +32,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgproto3/v2"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -214,13 +213,6 @@ func mustGenCertSignedWithCA(t *testing.T, ca *tlsca.CertAuthority, opts ...sign
 	require.NoError(t, err)
 	cert.Leaf = leaf
 	return cert
-}
-
-func mustSendPostgresMsg(t *testing.T, conn net.Conn, msg pgproto3.FrontendMessage) {
-	payload := msg.Encode(nil)
-	nWritten, err := conn.Write(payload)
-	require.NoError(t, err)
-	require.Equal(t, len(payload), nWritten, "failed to fully write payload")
 }
 
 func mustReadFromConnection(t *testing.T, conn net.Conn, want string) {

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -17,9 +17,11 @@ limitations under the License.
 package alpnproxy
 
 import (
+	"bytes"
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -27,8 +29,10 @@ import (
 	"sync"
 
 	"github.com/gravitational/trace"
+	"github.com/jackc/pgproto3/v2"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	commonApp "github.com/gravitational/teleport/lib/srv/app/common"
@@ -47,7 +51,7 @@ type LocalProxy struct {
 
 // LocalProxyConfig is configuration for LocalProxy.
 type LocalProxyConfig struct {
-	// RemoteProxyAddr is the downstream destination address of remote ALPN proxy service.
+	// RemoteProxyAddr is the upstream destination address of remote ALPN proxy service.
 	RemoteProxyAddr string
 	// Protocol set for the upstream TLS connection.
 	Protocols []common.Protocol
@@ -73,6 +77,14 @@ type LocalProxyConfig struct {
 	Clock clockwork.Clock
 	// Log is the Logger.
 	Log logrus.FieldLogger
+	// CheckCertsNeeded determines if the local proxy will check if it should
+	// load certs for dialing upstream. Defaults to false, in which case
+	// the local proxy will always use whatever certs it has to dial upstream.
+	// For example postgres cancel requests are not sent with TLS even if the
+	// postgres client was configured to use client certs, so a local proxy
+	// needs to always have certs loaded for postgres in case they are needed,
+	// but only use those certs as needed.
+	CheckCertsNeeded bool
 	// verifyUpstreamConnection is a callback function to verify upstream connection state.
 	verifyUpstreamConnection func(tls.ConnectionState) error
 }
@@ -115,6 +127,12 @@ func (cfg *LocalProxyConfig) CheckAndSetDefaults() error {
 	}
 	if cfg.Log == nil {
 		cfg.Log = logrus.WithField(trace.Component, "localproxy")
+	}
+	// copy the cert slice to avoid races when the proxy is running.
+	cfg.Certs = slices.Clone(cfg.Certs)
+	// set tls cert chain leaf to reduce per-handshake processing.
+	if err := utils.InitCertLeaves(cfg.Certs); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// If SNI is not set, default to cfg.RemoteProxyAddr.
@@ -174,6 +192,7 @@ func (l *LocalProxy) Start(ctx context.Context) error {
 			l.cfg.Log.WithError(err).Error("Failed to accept client connection.")
 			return trace.Wrap(err)
 		}
+		l.cfg.Log.Debug("Accepted downstream connection.")
 
 		if l.cfg.Middleware != nil {
 			if err := l.cfg.Middleware.OnNewConnection(ctx, l, conn); err != nil {
@@ -206,7 +225,12 @@ func (l *LocalProxy) GetAddr() string {
 func (l *LocalProxy) handleDownstreamConnection(ctx context.Context, downstreamConn net.Conn) error {
 	defer downstreamConn.Close()
 
-	tlsConn, err := DialALPN(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig())
+	certs, downstreamConn, err := l.getCertsForConn(ctx, downstreamConn)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	tlsConn, err := DialALPN(ctx, l.cfg.RemoteProxyAddr, l.getALPNDialerConfig(certs))
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -231,14 +255,14 @@ func (l *LocalProxy) Close() error {
 	return nil
 }
 
-func (l *LocalProxy) getALPNDialerConfig() ALPNDialerConfig {
+func (l *LocalProxy) getALPNDialerConfig(certs []tls.Certificate) ALPNDialerConfig {
 	return ALPNDialerConfig{
 		ALPNConnUpgradeRequired: l.cfg.ALPNConnUpgradeRequired,
 		TLSConfig: &tls.Config{
 			NextProtos:         common.ProtocolsToString(l.cfg.Protocols),
 			InsecureSkipVerify: l.cfg.InsecureSkipVerify,
 			ServerName:         l.cfg.SNI,
-			Certificates:       l.getCerts(),
+			Certificates:       certs,
 			RootCAs:            l.cfg.RootCAs,
 		},
 	}
@@ -282,7 +306,7 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 			http.Error(w, http.StatusText(code), code)
 		},
 		Transport: &http.Transport{
-			DialTLSContext: NewALPNDialer(l.getALPNDialerConfig()).DialContext,
+			DialTLSContext: NewALPNDialer(l.getALPNDialerConfig(l.getCerts())).DialContext,
 		},
 	}
 	err := http.Serve(l.cfg.Listener, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
@@ -305,8 +329,8 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 }
 
 // getCerts returns the local proxy's configured TLS certificates.
-// For thread-safety, it is important that the returned slice and its contents are not be mutated by callers,
-// therefore this method is not exported.
+// For thread-safety, it is important that the returned slice and its contents
+// are not be mutated by callers, therefore this method is not exported.
 func (l *LocalProxy) getCerts() []tls.Certificate {
 	l.certsMu.RLock()
 	defer l.certsMu.RUnlock()
@@ -321,7 +345,7 @@ func (l *LocalProxy) CheckDBCerts(dbRoute tlsca.RouteToDatabase) error {
 	if len(l.cfg.Certs) == 0 {
 		return trace.NotFound("local proxy has no TLS certificates configured")
 	}
-	cert, err := utils.TLSCertToX509(l.cfg.Certs[0])
+	cert, err := utils.TLSCertLeaf(l.cfg.Certs[0])
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -358,4 +382,63 @@ func (l *LocalProxy) SetCerts(certs []tls.Certificate) {
 	l.certsMu.Lock()
 	defer l.certsMu.Unlock()
 	l.cfg.Certs = certs
+}
+
+// getCertsForConn determines if certificates should be used when dialing
+// upstream to proxy a new downstream connection.
+// After calling getCertsForConn function, the returned
+// net.Conn should be used for further operation.
+func (l *LocalProxy) getCertsForConn(ctx context.Context, downstreamConn net.Conn) ([]tls.Certificate, net.Conn, error) {
+	if !l.cfg.CheckCertsNeeded {
+		return l.getCerts(), downstreamConn, nil
+	}
+	if l.isPostgresProxy() {
+		// `psql` cli doesn't send cancel requests with SSL, unfortunately.
+		// This is a problem when the local proxy has no certs configured,
+		// because normally the client is responsible for connecting with
+		// TLS certificates.
+		// So when the local proxy has no certs configured, we inspect
+		// the connection to see if it is a postgres cancel request and
+		// load certs for the connection.
+		startupMessage, conn, err := peekPostgresStartupMessage(ctx, downstreamConn)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+		_, isCancelReq := startupMessage.(*pgproto3.CancelRequest)
+		if !isCancelReq {
+			return nil, conn, nil
+		}
+		certs := l.getCerts()
+		if len(certs) == 0 {
+			return nil, nil, trace.NotFound("local proxy has no TLS certificates configured")
+		}
+		return certs, conn, nil
+	}
+	return nil, downstreamConn, nil
+}
+
+func (l *LocalProxy) isPostgresProxy() bool {
+	for _, proto := range common.ProtocolsToString(l.cfg.Protocols) {
+		if strings.HasPrefix(proto, string(common.ProtocolPostgres)) {
+			return true
+		}
+	}
+	return false
+}
+
+// peekPostgresStartupMessage reads and returns the startup message from a
+// connection. After calling peekPostgresStartupMessage function, the returned
+// net.Conn should be used for further operation.
+func peekPostgresStartupMessage(ctx context.Context, conn net.Conn) (pgproto3.FrontendMessage, net.Conn, error) {
+	// buffer the bytes we read so we can peek at the conn.
+	buff := new(bytes.Buffer)
+	// wrap the conn in a read-only conn to be sure the conn is not written to.
+	rConn := readOnlyConn{reader: io.TeeReader(conn, buff)}
+	// backend acts as a server for the Postgres wire protocol.
+	backend := pgproto3.NewBackend(pgproto3.NewChunkReader(rConn), rConn)
+	startupMessage, err := backend.ReceiveStartupMessage()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	return startupMessage, newBufferedConn(conn, buff), nil
 }

--- a/lib/srv/alpnproxy/local_proxy_test.go
+++ b/lib/srv/alpnproxy/local_proxy_test.go
@@ -36,6 +36,7 @@ import (
 	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gravitational/trace"
+	"github.com/jackc/pgproto3/v2"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -90,6 +91,9 @@ func TestHandleAWSAccessSigVerification(t *testing.T) {
 		},
 	}
 
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			lp := createAWSAccessProxySuite(t, tc.proxyCred)
@@ -108,7 +112,7 @@ func TestHandleAWSAccessSigVerification(t *testing.T) {
 				v4.NewSigner(tc.originCred).Sign(req, pr, awsService, awsRegion, time.Now())
 			}
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := httpClient.Do(req)
 			require.NoError(t, err)
 			require.Equal(t, tc.wantStatus, resp.StatusCode)
 			require.NoError(t, resp.Body.Close())
@@ -132,7 +136,11 @@ func TestHandleAWSAccessS3Signing(t *testing.T) {
 		WithEndpoint(lp.GetAddr()).
 		WithS3ForcePathStyle(true)
 
-	s3client := s3.New(session.Must(session.NewSession(awsConfig)))
+	s3client := s3.New(session.Must(session.NewSession(awsConfig)),
+		&aws.Config{
+			HTTPClient: &http.Client{Timeout: 5 * time.Second},
+			MaxRetries: aws.Int(0),
+		})
 
 	// Use a bucket name with special charaters. AWS SDK actually signs the
 	// request with the unescaped bucket name.
@@ -254,15 +262,17 @@ func TestMiddleware(t *testing.T) {
 }
 
 // mockCertRenewer is a mock middleware for the local proxy that always sets the local proxy certs slice.
-type mockCertRenewer struct{}
+type mockCertRenewer struct {
+	certs []tls.Certificate
+}
 
 func (m *mockCertRenewer) OnNewConnection(_ context.Context, lp *LocalProxy, _ net.Conn) error {
-	lp.SetCerts([]tls.Certificate{})
+	lp.SetCerts(append([]tls.Certificate(nil), m.certs...))
 	return nil
 }
 
 func (m *mockCertRenewer) OnStart(_ context.Context, lp *LocalProxy) error {
-	lp.SetCerts([]tls.Certificate{})
+	lp.SetCerts(append([]tls.Certificate(nil), m.certs...))
 	return nil
 }
 
@@ -278,7 +288,7 @@ func TestLocalProxyConcurrentCertRenewal(t *testing.T) {
 		Protocols:          []common.Protocol{common.ProtocolHTTP},
 		ParentContext:      context.Background(),
 		InsecureSkipVerify: true,
-		Middleware:         &mockCertRenewer{},
+		Middleware:         &mockCertRenewer{certs: []tls.Certificate{}},
 	})
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -431,7 +441,7 @@ func TestLocalProxyClosesConnOnError(t *testing.T) {
 	buf := make([]byte, 512)
 	_, err = conn.Read(buf)
 	require.Error(t, err)
-	require.ErrorIs(t, err, io.EOF)
+	require.ErrorIs(t, err, io.EOF, "connection should have been closed by local proxy")
 }
 
 func createAWSAccessProxySuite(t *testing.T, cred *credentials.Credentials) *LocalProxy {
@@ -482,4 +492,87 @@ func requireCertSubjectDatabaseErr(t require.TestingT, err error, _ ...interface
 	}
 	require.Error(t, err)
 	require.ErrorContains(t, err, "certificate subject is for database name")
+}
+
+// stubConn implements net.Conn interface and is used to stub a client
+// connection to local proxy.
+type stubConn struct {
+	net.Conn
+	buff bytes.Buffer
+}
+
+func (c *stubConn) Write(p []byte) (n int, err error) {
+	return c.buff.Write(p)
+}
+func (c *stubConn) Read(p []byte) (n int, err error) {
+	return c.buff.Read(p)
+}
+
+func TestGetCertsForConn(t *testing.T) {
+	suite := NewSuite(t)
+	dbRouteInCert := tlsca.RouteToDatabase{
+		ServiceName: "svc1",
+		Protocol:    defaults.ProtocolPostgres,
+		Username:    "user1",
+		Database:    "db1",
+	}
+	tlsCert := mustGenCertSignedWithCA(t, suite.ca,
+		withIdentity(tlsca.Identity{
+			Username:        "test-user",
+			Groups:          []string{"test-group"},
+			RouteToDatabase: dbRouteInCert,
+		}),
+	)
+
+	tests := map[string]struct {
+		checkCertsNeeded bool
+		addProtocols     []common.Protocol
+		stubConnBytes    []byte
+		wantCerts        bool
+	}{
+		"tunnel always": {
+			checkCertsNeeded: false,
+			wantCerts:        true,
+		},
+		"no tunnel when not needed for protocol": {
+			checkCertsNeeded: true,
+			wantCerts:        false,
+		},
+		"no tunnel when not needed for postgres protocol": {
+			checkCertsNeeded: true,
+			addProtocols:     []common.Protocol{common.ProtocolPostgres},
+			stubConnBytes:    (&pgproto3.SSLRequest{}).Encode(nil),
+			wantCerts:        false,
+		},
+		"tunnel when needed for postgres protocol": {
+			checkCertsNeeded: true,
+			addProtocols:     []common.Protocol{common.ProtocolPostgres},
+			stubConnBytes:    (&pgproto3.CancelRequest{}).Encode(nil),
+			wantCerts:        true,
+		},
+	}
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// we wont actually be listening for connections, but local proxy config needs to be valid to pass checks.
+			lp, err := NewLocalProxy(LocalProxyConfig{
+				RemoteProxyAddr:  "localhost",
+				Protocols:        append([]common.Protocol{"foo-bar-proto"}, tt.addProtocols...),
+				ParentContext:    context.Background(),
+				CheckCertsNeeded: tt.checkCertsNeeded,
+				Certs:            []tls.Certificate{tlsCert},
+			})
+			require.NoError(t, err)
+			conn := &stubConn{buff: *bytes.NewBuffer(tt.stubConnBytes)}
+			gotCerts, _, err := lp.getCertsForConn(context.Background(), conn)
+			require.NoError(t, err)
+			if tt.wantCerts {
+				require.Len(t, gotCerts, 1)
+				require.Equal(t, tlsCert, gotCerts[0])
+			} else {
+				require.Empty(t, gotCerts)
+			}
+		})
+	}
 }

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgproto3/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -295,21 +294,12 @@ func TestLocalProxyPostgresProtocol(t *testing.T) {
 		SNI:                "localhost",
 		ParentContext:      context.Background(),
 		InsecureSkipVerify: true,
-		// Since this a non-tunnel local proxy, we should check certs are needed
-		// for postgres.
-		// (this is how a local proxy would actually be configured for postgres).
-		CheckCertsNeeded: true,
 	}
 
 	mustStartLocalProxy(t, localProxyConfig)
 
 	conn, err := net.Dial("tcp", localProxyListener.Addr().String())
 	require.NoError(t, err)
-
-	// we have to send a request because the local proxy will inspect
-	// the client conn. It should see it's not a CancelRequest, and determine
-	// that certs are not needed.
-	mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 
 	mustReadFromConnection(t, conn, databaseHandleResponse)
 	mustCloseConnection(t, conn)
@@ -664,10 +654,6 @@ func TestProxyPingConnections(t *testing.T) {
 					}
 					return nil
 				},
-				// Since this a non-tunnel local proxy, we should check certs are needed
-				// for postgres.
-				// (this is how a local proxy would actually be configured for postgres).
-				CheckCertsNeeded: protocol == common.ProtocolPostgres,
 			}
 			mustStartLocalProxy(t, localProxyConfig)
 
@@ -682,13 +668,6 @@ func TestProxyPingConnections(t *testing.T) {
 					RootCAs:    suite.GetCertPool(),
 					ServerName: "localhost",
 				})
-			}
-
-			if protocol == common.ProtocolPostgres {
-				// we have to send a request because the local proxy will inspect
-				// the client conn. It should see it's not a CancelRequest, and determine
-				// that certs are not needed.
-				mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 			}
 
 			mustReadFromConnection(t, conn, dataWritten)

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -295,6 +295,10 @@ func TestLocalProxyPostgresProtocol(t *testing.T) {
 		SNI:                "localhost",
 		ParentContext:      context.Background(),
 		InsecureSkipVerify: true,
+		// Since this a non-tunnel local proxy, we should check certs are needed
+		// for postgres.
+		// (this is how a local proxy would actually be configured for postgres).
+		CheckCertsNeeded: true,
 	}
 
 	mustStartLocalProxy(t, localProxyConfig)
@@ -302,8 +306,8 @@ func TestLocalProxyPostgresProtocol(t *testing.T) {
 	conn, err := net.Dial("tcp", localProxyListener.Addr().String())
 	require.NoError(t, err)
 
-	// we have to send a request so that the local proxy will inspect
-	// the client conn, see it's not a CancelRequest, and determine
+	// we have to send a request because the local proxy will inspect
+	// the client conn. It should see it's not a CancelRequest, and determine
 	// that certs are not needed.
 	mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 
@@ -660,6 +664,10 @@ func TestProxyPingConnections(t *testing.T) {
 					}
 					return nil
 				},
+				// Since this a non-tunnel local proxy, we should check certs are needed
+				// for postgres.
+				// (this is how a local proxy would actually be configured for postgres).
+				CheckCertsNeeded: protocol == common.ProtocolPostgres,
 			}
 			mustStartLocalProxy(t, localProxyConfig)
 
@@ -677,6 +685,9 @@ func TestProxyPingConnections(t *testing.T) {
 			}
 
 			if protocol == common.ProtocolPostgres {
+				// we have to send a request because the local proxy will inspect
+				// the client conn. It should see it's not a CancelRequest, and determine
+				// that certs are not needed.
 				mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 			}
 

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgproto3/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -300,6 +301,11 @@ func TestLocalProxyPostgresProtocol(t *testing.T) {
 
 	conn, err := net.Dial("tcp", localProxyListener.Addr().String())
 	require.NoError(t, err)
+
+	// we have to send a request so that the local proxy will inspect
+	// the client conn, see it's not a CancelRequest, and determine
+	// that certs are not needed.
+	mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 
 	mustReadFromConnection(t, conn, databaseHandleResponse)
 	mustCloseConnection(t, conn)
@@ -668,6 +674,10 @@ func TestProxyPingConnections(t *testing.T) {
 					RootCAs:    suite.GetCertPool(),
 					ServerName: "localhost",
 				})
+			}
+
+			if protocol == common.ProtocolPostgres {
+				mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 			}
 
 			mustReadFromConnection(t, conn, dataWritten)

--- a/lib/srv/db/local_proxy_test.go
+++ b/lib/srv/db/local_proxy_test.go
@@ -19,8 +19,10 @@ package db
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgconn"
+	"github.com/jackc/pgerrcode"
 	"github.com/stretchr/testify/require"
 	"go.mongodb.org/mongo-driver/bson"
 
@@ -49,9 +51,21 @@ func TestLocalProxyPostgres(t *testing.T) {
 	})
 
 	// Execute a query.
-	result, err := conn.Exec(ctx, "select 1").ReadAll()
+	results, err := conn.Exec(ctx, "select 1").ReadAll()
 	require.NoError(t, err)
-	require.Equal(t, []*pgconn.Result{postgres.TestQueryResponse}, result)
+	require.Equal(t, []*pgconn.Result{postgres.TestQueryResponse}, results)
+
+	// Execute a "long running" query and cancel it.
+	resultReader := conn.Exec(ctx, postgres.TestLongRunningQuery)
+	require.NoError(t, conn.CancelRequest(ctx))
+	// timeout this test quickly if the cancel request fails to propagate.
+	conn.Conn().SetDeadline(time.Now().Add(time.Second * 10))
+	results, err = resultReader.ReadAll()
+	require.Error(t, err)
+	var pgErr *pgconn.PgError
+	require.ErrorAs(t, err, &pgErr)
+	require.Equal(t, pgerrcode.QueryCanceled, pgErr.Code)
+	require.Len(t, results, 0)
 }
 
 // TestLocalProxyMySQL verifies connecting to a MySQL database

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -18,8 +18,10 @@ package postgres
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 
 	"github.com/gravitational/trace"
@@ -27,6 +29,7 @@ import (
 	"github.com/jackc/pgproto3/v2"
 	"github.com/sirupsen/logrus"
 
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/cloud"
@@ -52,6 +55,9 @@ type Engine struct {
 	common.EngineConfig
 	// client is a client connection.
 	client *pgproto3.Backend
+	// cancelReq is a cancel request saved when a cancel request is received
+	// instead of a startup message.
+	cancelReq *pgproto3.CancelRequest
 }
 
 // InitializeConnection initializes the client connection.
@@ -107,6 +113,13 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	if e.cancelReq != nil {
+		// Special case when sending a cancel request.
+		// Postgres cancel request message flow is unique:
+		// 1. No startup message is sent by the client.
+		// 2. The server closes the connection without responding to the client.
+		return trace.Wrap(e.handleCancelRequest(ctx, sessionCtx))
+	}
 	// This is where we connect to the actual Postgres database.
 	server, hijackedConn, err := e.connect(ctx, sessionCtx)
 	if err != nil {
@@ -158,23 +171,27 @@ func (e *Engine) handleStartup(client *pgproto3.Backend, sessionCtx *common.Sess
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	e.Log.Debugf("Received startup message: %#v.", startupMessageI)
-	startupMessage, ok := startupMessageI.(*pgproto3.StartupMessage)
-	if !ok {
-		return trace.BadParameter("expected *pgproto3.StartupMessage, got %T", startupMessageI)
-	}
-	// Pass startup parameters received from the client along (this is how the
-	// client sets default date style format for example), but remove database
-	// name and user from them.
-	for key, value := range startupMessage.Parameters {
-		switch key {
-		case "database":
-			sessionCtx.DatabaseName = value
-		case "user":
-			sessionCtx.DatabaseUser = value
-		default:
-			sessionCtx.StartupParameters[key] = value
+	switch m := startupMessageI.(type) {
+	case *pgproto3.StartupMessage:
+		e.Log.Debugf("Received startup message: %#v.", m)
+		// Pass startup parameters received from the client along (this is how the
+		// client sets default date style format for example), but remove database
+		// name and user from them.
+		for key, value := range m.Parameters {
+			switch key {
+			case "database":
+				sessionCtx.DatabaseName = value
+			case "user":
+				sessionCtx.DatabaseUser = value
+			default:
+				sessionCtx.StartupParameters[key] = value
+			}
 		}
+	case *pgproto3.CancelRequest:
+		e.Log.Debugf("Received cancel request for PID: %v.", m.ProcessID)
+		e.cancelReq = m
+	default:
+		return trace.BadParameter("unexpected startup message type: %T", startupMessageI)
 	}
 	return nil
 }
@@ -457,6 +474,62 @@ func (e *Engine) getConnectConfig(ctx context.Context, sessionCtx *common.Sessio
 		config.User = services.MakeAzureDatabaseLoginUsername(sessionCtx.Database, config.User)
 	}
 	return config, nil
+}
+
+// handleCancelRequest handles a cancel request and returns immediately (closing the connection).
+func (e *Engine) handleCancelRequest(ctx context.Context, sessionCtx *common.Session) error {
+	config, err := pgconn.ParseConfig(fmt.Sprintf("postgres://%s", sessionCtx.Database.GetURI()))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	tlsConfig, err := e.Auth.GetTLSConfig(ctx, sessionCtx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	// We can't use pgconn in this case because it always sends a
+	// startup message.
+	// Instead, use the pgconn config string parser for convenience and dial
+	// db host:port ourselves.
+	network, address := pgconn.NetworkAddress(config.Host, config.Port)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	dialer := net.Dialer{Timeout: defaults.DefaultIOTimeout}
+	conn, err := dialer.DialContext(ctx, network, address)
+	if err != nil {
+		return common.ConvertConnectError(err, sessionCtx)
+	}
+	tlsConn, err := startPGWireTLS(conn, tlsConfig)
+	if err != nil {
+		return common.ConvertConnectError(err, sessionCtx)
+	}
+	frontend := pgproto3.NewFrontend(pgproto3.NewChunkReader(tlsConn), tlsConn)
+	if err = frontend.Send(e.cancelReq); err != nil {
+		return trace.Wrap(err)
+	}
+	response := make([]byte, 1)
+	if _, err := tlsConn.Read(response); err != io.EOF {
+		// server should close the connection after receiving cancel request.
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+// startPGWireTLS is a helper func that upgrades upstream connection to TLS.
+// copied from github.com/jackc/pgconn.startTLS.
+func startPGWireTLS(conn net.Conn, tlsConfig *tls.Config) (net.Conn, error) {
+	frontend := pgproto3.NewFrontend(pgproto3.NewChunkReader(conn), conn)
+	if err := frontend.Send(&pgproto3.SSLRequest{}); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	response := make([]byte, 1)
+	if _, err := io.ReadFull(conn, response); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if response[0] != 'S' {
+		return nil, trace.Errorf("server refused TLS connection")
+	}
+	return tls.Client(conn, tlsConfig), nil
 }
 
 // formatParameters converts parameters from the Postgres wire message into

--- a/lib/srv/db/postgres/proxy.go
+++ b/lib/srv/db/postgres/proxy.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/limiter"
-	"github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/utils"
@@ -64,14 +63,18 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	defer func() {
-		if err != nil {
-			if err := backend.Send(toErrorResponse(err)); err != nil {
-				p.Log.WithError(err).Warn("Failed to send error to backend.")
-			}
+	if err := p.handleConnection(ctx, tlsConn, startupMessage); err != nil {
+		if serr := backend.Send(toErrorResponse(err)); serr != nil {
+			p.Log.WithError(serr).Warn("Failed to send error to backend.")
 		}
-	}()
+		return trace.Wrap(err)
+	}
+	return nil
+}
 
+// handleConnection dials database service, sends the postgres startup
+// message, and begins proxying the connection.
+func (p *Proxy) handleConnection(ctx context.Context, clientConn utils.TLSConn, startupMessage pgproto3.FrontendMessage) error {
 	clientIP, err := utils.ClientIPFromConn(clientConn)
 	if err != nil {
 		return trace.Wrap(err)
@@ -84,7 +87,7 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 	}
 	defer releaseConn()
 
-	proxyCtx, err := p.Service.Authorize(ctx, tlsConn, common.ConnectParams{
+	proxyCtx, err := p.Service.Authorize(ctx, clientConn, common.ConnectParams{
 		ClientIP: clientIP,
 	})
 	if err != nil {
@@ -108,7 +111,7 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	err = p.Service.Proxy(ctx, proxyCtx, tlsConn, serviceConn)
+	err = p.Service.Proxy(ctx, proxyCtx, clientConn, serviceConn)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -120,7 +123,7 @@ func (p *Proxy) HandleConnection(ctx context.Context, clientConn net.Conn) (err 
 //
 // Returns the startup message that contains initial connect parameters and
 // the upgraded TLS connection.
-func (p *Proxy) handleStartup(ctx context.Context, clientConn net.Conn) (*pgproto3.StartupMessage, utils.TLSConn, *pgproto3.Backend, error) {
+func (p *Proxy) handleStartup(ctx context.Context, clientConn net.Conn) (pgproto3.FrontendMessage, utils.TLSConn, *pgproto3.Backend, error) {
 	receivedSSLRequest := false
 	receivedGSSEncRequest := false
 	for {
@@ -130,7 +133,19 @@ func (p *Proxy) handleStartup(ctx context.Context, clientConn net.Conn) (*pgprot
 		if err != nil {
 			return nil, nil, nil, trace.Wrap(err)
 		}
-		p.Log.Debugf("Received startup message: %#v.", startupMessage)
+
+		// We don't want to log the cancel request secret key, so we handle
+		// this case separately.
+		if m, ok := startupMessage.(*pgproto3.CancelRequest); ok {
+			p.Log.Debugf("Received cancel request for pid: %v.", m.ProcessID)
+			tlsConn, ok := clientConn.(utils.TLSConn)
+			if !ok {
+				return nil, nil, nil, trace.BadParameter(
+					"expected tls connection, got %T", clientConn)
+			}
+			return m, tlsConn, backend, nil
+		}
+
 		// When initiating an encrypted connection, psql will first check with
 		// the server whether it supports TLS by sending an SSLRequest message.
 		//
@@ -139,6 +154,7 @@ func (p *Proxy) handleStartup(ctx context.Context, clientConn net.Conn) (*pgprot
 		// user name, database name, etc.
 		//
 		// https://www.postgresql.org/docs/13/protocol-flow.html#id-1.10.5.7.11
+		p.Log.Debugf("Received startup message: %#v.", startupMessage)
 		switch m := startupMessage.(type) {
 		case *pgproto3.SSLRequest:
 			if receivedSSLRequest {
@@ -185,15 +201,12 @@ func (p *Proxy) handleStartup(ctx context.Context, clientConn net.Conn) (*pgprot
 		case *pgproto3.StartupMessage:
 			// TLS connection between the client and this proxy has been
 			// established, just return the startup message.
-			switch tlsConn := clientConn.(type) {
-			case *tls.Conn:
-				return m, tlsConn, backend, nil
-			case *alpnproxy.PingConn:
-				return m, tlsConn, backend, nil
-			default:
+			tlsConn, ok := clientConn.(utils.TLSConn)
+			if !ok {
 				return nil, nil, nil, trace.BadParameter(
 					"expected tls connection, got %T", clientConn)
 			}
+			return m, tlsConn, backend, nil
 		}
 		return nil, nil, nil, trace.BadParameter(
 			"unsupported startup message: %#v", startupMessage)

--- a/lib/srv/db/postgres/test.go
+++ b/lib/srv/db/postgres/test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"sync"
 	"sync/atomic"
 
 	"github.com/gravitational/trace"
@@ -72,6 +73,24 @@ type TestServer struct {
 	queryCount uint32
 	// parametersCh receives startup message connection parameters.
 	parametersCh chan map[string]string
+
+	// nextPid is a dummy variable used to assign each connection a unique fake "pid".
+	// it's incremented after each new startup connection. Starts counting from 1.
+	nextPid uint32
+	// pids is a map of fake connection pid handles, used for cancel requests.
+	pids map[uint32]*pidHandle
+	// pidMu is a lock protecting nextPid and pids.
+	pidMu sync.Mutex
+}
+
+// pidHandle represents a fake pid handle that can cancel operations in progress.
+// For test purposes, only a stub query "pg_sleep(forever)" will actually be
+// cancellable.
+type pidHandle struct {
+	// secretKey is checked for equality when cancel request is received.
+	secretKey uint32
+	// cancel cancels the operation in progress, if any.
+	cancel context.CancelFunc
 }
 
 // NewTestServer returns a new instance of a test Postgres server.
@@ -101,6 +120,7 @@ func NewTestServer(config common.TestServerConfig) (svr *TestServer, err error) 
 			"name":          config.Name,
 		}),
 		parametersCh: make(chan map[string]string, 100),
+		pids:         make(map[uint32]*pidHandle),
 	}, nil
 }
 
@@ -136,44 +156,20 @@ func (s *TestServer) handleConnection(conn net.Conn) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// Next should come StartupMessage.
-	err = s.handleStartup(client)
+	startupMessage, err := client.ReceiveStartupMessage()
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	// Enter the loop replying to client messages.
-	for {
-		message, err := client.Receive()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		s.log.Debugf("Received %#v.", message)
-		switch message.(type) {
-		case *pgproto3.Query:
-			if err := s.handleQuery(client); err != nil {
-				s.log.WithError(err).Error("Failed to handle query.")
-			}
-		// Following messages are for handling Postgres extended query
-		// protocol flow used by prepared statements.
-		case *pgproto3.Parse:
-			// Parse prepares the statement.
-		case *pgproto3.Bind:
-			// Bind binds prepared statement with parameters.
-		case *pgproto3.Describe:
-		case *pgproto3.Sync:
-			if err := s.handleSync(client); err != nil {
-				s.log.WithError(err).Error("Failed to handle sync.")
-			}
-		case *pgproto3.Execute:
-			// Execute executes prepared statement.
-			if err := s.handleQuery(client); err != nil {
-				s.log.WithError(err).Error("Failed to handle query.")
-			}
-		case *pgproto3.Terminate:
-			return nil
-		default:
-			return trace.BadParameter("unsupported message %#v", message)
-		}
+	s.log.Debugf("Received %#v.", startupMessage)
+	switch msg := startupMessage.(type) {
+	case *pgproto3.StartupMessage:
+		return s.handleStartup(client, msg)
+	case *pgproto3.CancelRequest:
+		s.handleCancelRequest(client, msg)
+		// never return errors on cancel requests.
+		return nil
+	default:
+		return trace.BadParameter("expected *pgproto3.StartupMessage or *pgproto3.CancelRequest, got: %T", msg)
 	}
 }
 
@@ -196,16 +192,7 @@ func (s *TestServer) startTLS(conn net.Conn) (*pgproto3.Backend, error) {
 	return pgproto3.NewBackend(pgproto3.NewChunkReader(conn), conn), nil
 }
 
-func (s *TestServer) handleStartup(client *pgproto3.Backend) error {
-	startupMessageI, err := client.ReceiveStartupMessage()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	startupMessage, ok := startupMessageI.(*pgproto3.StartupMessage)
-	if !ok {
-		return trace.BadParameter("expected *pgproto3.StartupMessage, got: %#v", startupMessage)
-	}
-	s.log.Debugf("Received %#v.", startupMessage)
+func (s *TestServer) handleStartup(client *pgproto3.Backend, startupMessage *pgproto3.StartupMessage) error {
 	// Push connect parameters into the channel so tests can consume them.
 	s.parametersCh <- startupMessage.Parameters
 	// If auth token is specified, used it for password authentication, this
@@ -224,10 +211,64 @@ func (s *TestServer) handleStartup(client *pgproto3.Backend) error {
 	if err := client.Send(&pgproto3.AuthenticationOk{}); err != nil {
 		return trace.Wrap(err)
 	}
+
+	pid := s.newPid()
+	defer s.cleanupPid(pid)
+
+	err := client.Send(&pgproto3.BackendKeyData{
+		ProcessID: pid,
+		SecretKey: testSecretKey,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	if err := client.Send(&pgproto3.ReadyForQuery{}); err != nil {
 		return trace.Wrap(err)
 	}
-	return nil
+	// Enter the loop replying to client messages.
+	for {
+		message, err := client.Receive()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		s.log.Debugf("Received %#v.", message)
+		switch msg := message.(type) {
+		case *pgproto3.Query:
+			if err := s.handleQuery(client, msg.String, pid); err != nil {
+				s.log.WithError(err).Error("Failed to handle query.")
+			}
+		// Following messages are for handling Postgres extended query
+		// protocol flow used by prepared statements.
+		case *pgproto3.Parse:
+			// Parse prepares the statement.
+		case *pgproto3.Bind:
+			// Bind binds prepared statement with parameters.
+		case *pgproto3.Describe:
+		case *pgproto3.Sync:
+			if err := s.handleSync(client); err != nil {
+				s.log.WithError(err).Error("Failed to handle sync.")
+			}
+		case *pgproto3.Execute:
+			// Execute executes prepared statement.
+			if err := s.handleQuery(client, "", pid); err != nil {
+				s.log.WithError(err).Error("Failed to handle query.")
+			}
+		case *pgproto3.Terminate:
+			return nil
+		default:
+			return trace.BadParameter("unsupported message %#v", message)
+		}
+	}
+}
+
+func (s *TestServer) handleCancelRequest(client *pgproto3.Backend, req *pgproto3.CancelRequest) {
+	s.pidMu.Lock()
+	defer s.pidMu.Unlock()
+	p, ok := s.pids[req.ProcessID]
+	if ok && p != nil && p.secretKey == req.SecretKey && p.cancel != nil {
+		p.cancel()
+	}
 }
 
 func (s *TestServer) handlePasswordAuth(client *pgproto3.Backend) error {
@@ -252,12 +293,39 @@ func (s *TestServer) handlePasswordAuth(client *pgproto3.Backend) error {
 	return nil
 }
 
-func (s *TestServer) handleQuery(client *pgproto3.Backend) error {
+func (s *TestServer) handleQuery(client *pgproto3.Backend, query string, pid uint32) error {
 	atomic.AddUint32(&s.queryCount, 1)
+	if query == TestLongRunningQuery {
+		return trace.Wrap(s.fakeLongRunningQuery(client, pid))
+	}
 	messages := []pgproto3.BackendMessage{
 		&pgproto3.RowDescription{Fields: TestQueryResponse.FieldDescriptions},
 		&pgproto3.DataRow{Values: TestQueryResponse.Rows[0]},
 		&pgproto3.CommandComplete{CommandTag: TestQueryResponse.CommandTag},
+		&pgproto3.ReadyForQuery{},
+	}
+	for _, message := range messages {
+		s.log.Debugf("Sending %#v.", message)
+		err := client.Send(message)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+func (s *TestServer) fakeLongRunningQuery(client *pgproto3.Backend, pid uint32) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := s.registerCancel(pid, cancel); err != nil {
+		return trace.Wrap(err)
+	}
+	<-ctx.Done()
+	messages := []pgproto3.BackendMessage{
+		&pgproto3.ErrorResponse{
+			Code:    pgerrcode.QueryCanceled,
+			Message: "canceling statement due to user request",
+		},
 		&pgproto3.ReadyForQuery{},
 	}
 	for _, message := range messages {
@@ -297,7 +365,53 @@ func (s *TestServer) ParametersCh() chan map[string]string {
 
 // Close closes the server listener.
 func (s *TestServer) Close() error {
-	return s.listener.Close()
+	closeErr := s.listener.Close()
+	s.cleanupPids()
+	return trace.Wrap(closeErr)
+}
+
+// newPid makes a unique PID and inserts it into the server's pid map.
+// For test purposes, every pid will have the same stub secret key.
+func (s *TestServer) newPid() uint32 {
+	s.pidMu.Lock()
+	defer s.pidMu.Unlock()
+	s.nextPid++
+	s.pids[s.nextPid] = &pidHandle{secretKey: testSecretKey}
+	return s.nextPid
+}
+
+// cleanupPid cleans up a pid by calling its cancel func and
+// deleting it from the pid map.
+func (s *TestServer) cleanupPid(pid uint32) {
+	s.pidMu.Lock()
+	defer s.pidMu.Unlock()
+	if entry, ok := s.pids[pid]; ok && entry != nil && entry.cancel != nil {
+		entry.cancel()
+		delete(s.pids, pid)
+	}
+}
+
+func (s *TestServer) cleanupPids() {
+	s.pidMu.Lock()
+	defer s.pidMu.Unlock()
+	for pid, entry := range s.pids {
+		if entry != nil && entry.cancel != nil {
+			entry.cancel()
+		}
+		delete(s.pids, pid)
+	}
+}
+
+// registerCancel registers a cancel func for a given pid and returns a context.
+func (s *TestServer) registerCancel(pid uint32, cancel context.CancelFunc) error {
+	s.pidMu.Lock()
+	defer s.pidMu.Unlock()
+	entry, ok := s.pids[pid]
+	if !ok || entry == nil {
+		return trace.BadParameter("expected registered info for pid %v", pid)
+	}
+	entry.cancel = cancel
+	return nil
 }
 
 // TestQueryResponse is the response test Postgres server sends to every query.
@@ -306,3 +420,10 @@ var TestQueryResponse = &pgconn.Result{
 	Rows:              [][][]byte{{[]byte("test-value")}},
 	CommandTag:        pgconn.CommandTag("select 1"),
 }
+
+// TestLongRunningQuery is a stub SQL query clients can use to simulate a long
+// running query that can be only be stopped by a cancel request.
+const TestLongRunningQuery = "pg_sleep(forever)"
+
+// testSecretKey is the secret key stub for all connections, used for cancel requests.
+const testSecretKey = 1234

--- a/lib/teleterm/gateway/gateway.go
+++ b/lib/teleterm/gateway/gateway.go
@@ -271,7 +271,7 @@ func (g *Gateway) ReloadCert() error {
 //
 // Before using the cert for the proxy, we have to perform this check.
 func checkCertSubject(tlsCert tls.Certificate, dbRoute tlsca.RouteToDatabase) error {
-	cert, err := utils.TLSCertToX509(tlsCert)
+	cert, err := utils.TLSCertLeaf(tlsCert)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/teleterm/gateway/local_proxy_middleware_test.go
+++ b/lib/teleterm/gateway/local_proxy_middleware_test.go
@@ -39,7 +39,7 @@ func TestLocalProxyMiddleware_OnNewConnection(t *testing.T) {
 	require.NoError(t, err)
 	tlsCert, err := keys.X509KeyPair(testCert.Cert, testCert.PrivateKey)
 	require.NoError(t, err)
-	x509cert, err := utils.TLSCertToX509(tlsCert)
+	x509cert, err := utils.TLSCertLeaf(tlsCert)
 	require.NoError(t, err)
 
 	clockAfterCertExpiry := clockwork.NewFakeClockAt(x509cert.NotAfter)


### PR DESCRIPTION
This backports https://github.com/gravitational/teleport/pull/22173 and the flaky test fix for the flaky test it introduced https://github.com/gravitational/teleport/pull/23355 to v12.

I stacked this PR against another backport (https://github.com/gravitational/teleport/pull/23466) that I had forgotten to take care of before, to make conflicts minimal. Will switch merge base to branch/v12 once that one merges.