### PR TITLE
GHA: Flaky tests detector and cache tweaks

### DIFF
--- a/.github/actions/difftest/action.yml
+++ b/.github/actions/difftest/action.yml
@@ -12,7 +12,7 @@ inputs:
   attempts:
     description: Number of runs
     required: false
-    default: 30
+    default: 100
 
   bin:
     description: difftest binary location
@@ -23,7 +23,7 @@ inputs:
     description: difftest path
     required: false
     default: ${GITHUB_WORKSPACE}
-        
+
 runs:
   using: "composite"
   steps:
@@ -36,7 +36,7 @@ runs:
       shell: bash
       run: |
         ${{ inputs.bin }} diff --path ${{ inputs.path }} --branch remotes/origin/${GITHUB_BASE_REF} ${{ inputs.flags }}
-        echo "subject=$(${{ inputs.bin }} test --path ${{ inputs.path }} --branch remotes/origin/${GITHUB_BASE_REF} ${{ inputs.flags }} -u -d)" > $GITHUB_OUTPUT
+        echo "subject=$(${{ inputs.bin }} test --path ${{ inputs.path }} --branch remotes/origin/${GITHUB_BASE_REF} ${{ inputs.flags }} -d)" > $GITHUB_OUTPUT
 
     - name: Run
       shell: bash

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -6,12 +6,9 @@ on:
     paths:
       - '**.go'
 
-env:
-  ATTEMPTS: 100
-
 jobs:
   test:
-    name: Flaky tests detector
+    name: Flaky Tests Detector
     runs-on: ubuntu-latest # do not use large runner to catch more issues
 
     permissions:

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Flaky Tests Detector
-    runs-on: ubuntu-latest # do not use large runner to catch more issues
+    runs-on: ubuntu-22.04-16core
 
     permissions:
       contents: read

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths:
       - '**.go'

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths:
       - '**.go'

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths:
       - '**.go'

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths:
       - '/go.mod'

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1085,7 +1085,7 @@ func TestDiscoveryDatabase(t *testing.T) {
 					cmpopts.IgnoreFields(types.DatabaseStatusV3{}, "CACert"),
 				))
 			case <-time.After(time.Second):
-				t.Fatal("Didn't receive reconcile event after 1s.")
+				t.Fatal("Didn't receive reconcile event after 1s")
 			}
 		})
 	}


### PR DESCRIPTION
A couple of tweaks aiming to improve the flaky tests detector and cache effectiveness.

- Run detector on modified tests as well, not just new ones, and increase number of test run attempts to 100.
- Run tests on push events to release branches as well which should improve cache usage.
  - Cache is scoped to the PR branch + base branch + default branch so currently all PRs to release branches seem to initialize their own caches. Enabling this will create cache in the respective release branches which PRs will use.
- Restore large runner for flakiness check. It doesn't look like regular runner really increases the number of things it detects but the check takes a long time on it, around 20m, so it would be problematic to make it required otherwise.