### PR TITLE
Add Teleport 12 features to comparison matrix

### DIFF
--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -6,6 +6,7 @@
 |[Single Sign-On](../access-controls/sso.mdx)|GitHub|GitHub, Google Workspace, OIDC, SAML|GitHub, Google Workspace, OIDC, SAML|
 |[Role-Based Access Control](../access-controls/guides/role-templates.mdx)|&#10004;|&#10004;|&#10004;|
 |[Moderated Sessions](../access-controls/guides/moderated-sessions.mdx)|&#10006;|&#10004;|&#10004;|
+|[Device Trust](../access-controls/guides/device-trust.mdx)|&#10006;|&#10004;|&#10004;|
 
 ### Infrastructure access
 
@@ -14,7 +15,8 @@
 |[Application Access](../application-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
 |[Server Access](../server-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
 |[Database Access](../database-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
-|[Desktop Access](../desktop-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
+|[Desktop Access - Active Directory](../desktop-access/active-directory.mdx)|&#10004;|&#10004;|&#10004;|
+|[Passwordless Windows Access for Local Users](../desktop-access/getting-started.mdx)|&#10006;|&#10004;|&#10004;|
 |[Kubernetes Access](../kubernetes-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
 |[Machine ID](../machine-id/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
 |Agentless integration with [OpenSSH servers](../server-access/guides/openssh.mdx)|&#10004;|&#10004;|&#10004;|
@@ -34,6 +36,7 @@
 |PCI DSS Features|Limited|&#10004;|&#10004;|
 |SOC 2 Features|Limited|&#10004;|&#10004;|
 |FIPS-compliant binaries available for FedRAMP High|&#10006;|&#10004;|&#10006;|
+|IP-Based Restrictions|&#10006;|&#10004;|&#10004;|
 
 ### Operations
 


### PR DESCRIPTION
Add Teleport 12 features to edition comparison matrix since most Teleport 12 features are only in Enterprise. 