### PR TITLE
[v12] Plugins service no longer accepts getBackend().

### DIFF
--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/gravitational/trace"
 
@@ -37,17 +36,8 @@ type PluginsService struct {
 }
 
 // NewPluginsService constructs a new PluginsService
-// todo(mdwn): make the argument here just a backend.Backend once the
-// reference to getBackend() has been removed in e.
-func NewPluginsService(input any) *PluginsService {
-	switch value := input.(type) {
-	case func() backend.Backend:
-		return &PluginsService{backend: value()}
-	case backend.Backend:
-		return &PluginsService{backend: value}
-	}
-
-	panic(fmt.Sprintf("Unrecognized plugins service backend type: %T", input))
+func NewPluginsService(backend backend.Backend) *PluginsService {
+	return &PluginsService{backend: backend}
 }
 
 // CreatePlugin implements services.Plugins


### PR DESCRIPTION
Looks like the plugins service is not yet in enterprise, so we can safely remove the reference to the `getBackend()` call here without any further modifications.