### PR TITLE
[v11] Attempt to build the docs in "Lint (Docs)"

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -25,11 +25,24 @@ jobs:
     container:
       image: ghcr.io/gravitational/docs:latest
       volumes:
-        - ${{ github.workspace }}:/src/content
+        - ${{ github.workspace }}:/src/content/docs
 
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Prepare config
+        # The docs engine expects a config.json file at the root of the
+        # gravitational/docs clone that associates directories with git
+        # submodules. 
+        #
+        # By default, these directories represent versioned branches
+        # of gravitational/teleport. We override this in order to build only a
+        # single version of the docs.
+        run: 'echo "{\"versions\": [{\"name\": \"docs\", \"branch\": \"$GITHUB_REF_NAME\", \"deprecated\": false}]}" > /src/config.json'
+
+      - name: Test the docs build
+        run: cd /src && yarn install && yarn build
 
       - name: Run tests
         run: cd /src && yarn markdown-lint


### PR DESCRIPTION
Backports #23464

In gravitational/docs#253, we substantially reduced the resource consumption of docs builds. As a result, we can try building the docs as part of the "Lint (Docs)" GitHub Actions workflow in order to prevent build issues from breaking docs deployments.

It is currently possible to merge a docs content PR into gravitational/teleport that can later end up breaking deployments of the docs site, e.g., because a video ID is malformed, a code snippet label is unsupported, etc. By building the docs during the lint job, we can prevent this kind of thing from happening.

One complication is that the docs engine reads a `config.json` file to match git submodule directories with version of the docs. In the `gravitational/docs` container, `config.json` expects three submodules pointing to three versions of the docs.

To get GitHub Actions to build a single docs version, this change overrides the `config.json` file in the gravitational/docs container so it only expects a single version of the docs.