### PR TITLE
remove postgres ssl request in tests

### DIFF
--- a/lib/srv/alpnproxy/helpers_test.go
+++ b/lib/srv/alpnproxy/helpers_test.go
@@ -32,7 +32,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgproto3/v2"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -214,13 +213,6 @@ func mustGenCertSignedWithCA(t *testing.T, ca *tlsca.CertAuthority, opts ...sign
 	require.NoError(t, err)
 	cert.Leaf = leaf
 	return cert
-}
-
-func mustSendPostgresMsg(t *testing.T, conn net.Conn, msg pgproto3.FrontendMessage) {
-	payload := msg.Encode(nil)
-	nWritten, err := conn.Write(payload)
-	require.NoError(t, err)
-	require.Equal(t, len(payload), nWritten, "failed to fully write payload")
 }
 
 func mustReadFromConnection(t *testing.T, conn net.Conn, want string) {

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -29,7 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgproto3/v2"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -295,21 +294,12 @@ func TestLocalProxyPostgresProtocol(t *testing.T) {
 		SNI:                "localhost",
 		ParentContext:      context.Background(),
 		InsecureSkipVerify: true,
-		// Since this a non-tunnel local proxy, we should check certs are needed
-		// for postgres.
-		// (this is how a local proxy would actually be configured for postgres).
-		CheckCertsNeeded: true,
 	}
 
 	mustStartLocalProxy(t, localProxyConfig)
 
 	conn, err := net.Dial("tcp", localProxyListener.Addr().String())
 	require.NoError(t, err)
-
-	// we have to send a request because the local proxy will inspect
-	// the client conn. It should see it's not a CancelRequest, and determine
-	// that certs are not needed.
-	mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 
 	mustReadFromConnection(t, conn, databaseHandleResponse)
 	mustCloseConnection(t, conn)
@@ -682,10 +672,6 @@ func TestProxyPingConnections(t *testing.T) {
 					}
 					return nil
 				},
-				// Since this a non-tunnel local proxy, we should check certs are needed
-				// for postgres.
-				// (this is how a local proxy would actually be configured for postgres).
-				CheckCertsNeeded: protocol == common.ProtocolPostgres,
 			}
 			mustStartLocalProxy(t, localProxyConfig)
 
@@ -700,13 +686,6 @@ func TestProxyPingConnections(t *testing.T) {
 					RootCAs:    suite.GetCertPool(),
 					ServerName: "localhost",
 				})
-			}
-
-			if protocol == common.ProtocolPostgres {
-				// we have to send a request because the local proxy will inspect
-				// the client conn. It should see it's not a CancelRequest, and determine
-				// that certs are not needed.
-				mustSendPostgresMsg(t, conn, &pgproto3.SSLRequest{})
 			}
 
 			mustReadFromConnection(t, conn, dataWritten)


### PR DESCRIPTION
Addresses "flaky" tests here until I can investigate what is going on with `utils.ProxyConn` more.

The issue is caused by the client writing to the local proxy and races with the mock server closing the connection. If the local proxy tries to write to the server and gets a TCP RST then the proxy  closes both client and server connections, sometimes before it sends the server's message to the client.

Flaky test issues:
https://github.com/gravitational/teleport/issues/23342
https://github.com/gravitational/teleport/issues/23528