### PR TITLE
(v12) GHA: Cache tweaks

### DIFF
--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths:
       - '**.go'

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths:
       - '**.go'

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - branch/*
   pull_request:
     paths:
       - '**.go'


### PR DESCRIPTION
Backport part of https://github.com/gravitational/teleport/pull/23469 to enable running tests on push events to release branches which should improve cache usage effectiveness.