### PR TITLE
Updated Cloud FAQ for IP allowlists.

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -173,12 +173,29 @@ for customer data including session recordings and user records.
 
 ## Can I get a list of IP addresses to configure a firewall?
 
-We don't currently offer a list of addresses for firewall configuration and plan to make this available in the future.
+We do not have plans to offer a list of IP addresses for Teleport Enterprise
+Cloud at the moment.
 
-## Can I configure Teleport Enterprise Cloud to only allow connections from an allowlist of IP addresses?
+Teleport Enterprise Cloud infrastructure is elastic and IP addresses can and do
+change when we make infrastructure changes. This would make the maintenance of
+IP allowlists a cumbersome and brittle process for customers.
 
-No. We believe mTLS with strong identity is the best standard available for authenticating and access clients.
-We are also investigating additional and new features that can be used as a defense in depth strategy for use with Teleport Enterprise Cloud in 2022.
+However, we do provide customers with a stable tenant DNS name backed with a
+TLS certificates from [letsencrypt.org](https://letsencrypt.org) that can be
+utilized to verify the integrity of any outbound connections to Teleport
+Enterprise Cloud.
+
+## Can I configure an allowlist of inbound IP addresses to Teleport Enterprise Cloud?
+
+We do not have plans to offer support for inbound connection IP allowlists.
+
+We believe mTLS with strong user and [device
+identity](../../access-controls/guides/device-trust.mdx) provide the best
+available security for client authentication.
+
+For customers that require IP-based control for compliance purposes, we do
+support IP Pinning. For more information see `pin_source_ip` in our [Teleport
+Access Controls Reference](../../access-controls/reference.mdx).
 
 ## Is IPv6 Supported for connections to Teleport Enterprise Cloud?
 


### PR DESCRIPTION
This question often comes up in two contexts.

> Do we support configuring Teleport Cloud to only allow connections from a specific IP-range?

The answer is no. We encourage the use of client certificates and device trust as they provide stronger security properties.

> Can we share the IP addresses that Teleport Cloud is available at so users can configure their own firewalls to allow traffic to Teleport Cloud?

The answer for this is also no. While this [may be possible with AWS GA](https://docs.aws.amazon.com/global-accelerator/latest/dg/about-accelerators.eip-accelerator.html) we don't have plans for it at the moment and offered an alternative (stable DNS name and TLS).