### PR TITLE
Refactor UserGroups local service to use generic service.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -190,7 +190,10 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		}
 	}
 	if cfg.UserGroups == nil {
-		cfg.UserGroups = local.NewUserGroupService(cfg.Backend)
+		cfg.UserGroups, err = local.NewUserGroupService(cfg.Backend)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	if cfg.ConnectionsDiagnostic == nil {
 		cfg.ConnectionsDiagnostic = local.NewConnectionsDiagnosticService(cfg.Backend)

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -807,6 +807,12 @@ func New(config Config) (*Cache, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	userGroupsSvc, err := local.NewUserGroupService(config.Backend)
+	if err != nil {
+		cancel()
+		return nil, trace.Wrap(err)
+	}
+
 	cs := &Cache{
 		ctx:                          ctx,
 		cancel:                       cancel,
@@ -832,7 +838,7 @@ func New(config Config) (*Cache, error) {
 		webTokenCache:                local.NewIdentityService(config.Backend).WebTokens(),
 		windowsDesktopsCache:         local.NewWindowsDesktopService(config.Backend),
 		samlIdPServiceProvidersCache: samlIdPServiceProvidersCache,
-		userGroupsCache:              local.NewUserGroupService(config.Backend),
+		userGroupsCache:              userGroupsSvc,
 		oktaCache:                    oktaSvc,
 		eventsFanout:                 services.NewFanoutSet(),
 		Logger: log.WithFields(log.Fields{

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -801,13 +801,13 @@ func New(config Config) (*Cache, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	oktaSvc, err := local.NewOktaService(config.Backend)
+	userGroupsCache, err := local.NewUserGroupService(config.Backend)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
 	}
 
-	userGroupsSvc, err := local.NewUserGroupService(config.Backend)
+	oktaCache, err := local.NewOktaService(config.Backend)
 	if err != nil {
 		cancel()
 		return nil, trace.Wrap(err)
@@ -838,8 +838,8 @@ func New(config Config) (*Cache, error) {
 		webTokenCache:                local.NewIdentityService(config.Backend).WebTokens(),
 		windowsDesktopsCache:         local.NewWindowsDesktopService(config.Backend),
 		samlIdPServiceProvidersCache: samlIdPServiceProvidersCache,
-		userGroupsCache:              userGroupsSvc,
-		oktaCache:                    oktaSvc,
+		userGroupsCache:              userGroupsCache,
+		oktaCache:                    oktaCache,
 		eventsFanout:                 services.NewFanoutSet(),
 		Logger: log.WithFields(log.Fields{
 			trace.Component: config.Component,

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -212,7 +212,10 @@ func newPackWithoutCache(dir string, opts ...packOption) (*testPack, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	p.userGroups = local.NewUserGroupService(p.backend)
+	p.userGroups, err = local.NewUserGroupService(p.backend)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	oktaSvc, err := local.NewOktaService(p.backend)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/usergroup.go
+++ b/lib/services/local/usergroup.go
@@ -24,131 +24,63 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
 )
 
 const groupMaxPageSize = 200
 
 // UserGroupService manages user groups in the Backend.
 type UserGroupService struct {
-	backend.Backend
+	svc generic.Service[types.UserGroup]
 }
 
 // NewUserGroupService creates a new UserGroupService.
-func NewUserGroupService(backend backend.Backend) *UserGroupService {
-	return &UserGroupService{Backend: backend}
+func NewUserGroupService(backend backend.Backend) (*UserGroupService, error) {
+	svc, err := generic.NewService(&generic.ServiceConfig[types.UserGroup]{
+		Backend:       backend,
+		PageLimit:     groupMaxPageSize,
+		ResourceKind:  types.KindUserGroup,
+		BackendPrefix: userGroupPrefix,
+		MarshalFunc:   services.MarshalUserGroup,
+		UnmarshalFunc: services.UnmarshalUserGroup,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &UserGroupService{
+		svc: *svc,
+	}, nil
 }
 
 // ListUserGroups returns a paginated list of user group resources.
 func (s *UserGroupService) ListUserGroups(ctx context.Context, pageSize int, pageToken string) ([]types.UserGroup, string, error) {
-	rangeStart := backend.Key(userGroupPrefix, pageToken)
-	rangeEnd := backend.RangeEnd(rangeStart)
-
-	// Adjust page size, so it can't be too large.
-	if pageSize <= 0 || pageSize > groupMaxPageSize {
-		pageSize = groupMaxPageSize
-	}
-
-	// Increment pageSize to allow for the extra item represented by nextKey.
-	// We skip this item in the results below.
-	limit := pageSize + 1
-
-	// no filter provided get the range directly
-	result, err := s.GetRange(ctx, rangeStart, rangeEnd, limit)
-	if err != nil {
-		return nil, "", trace.Wrap(err)
-	}
-
-	out := make([]types.UserGroup, 0, len(result.Items))
-	for _, item := range result.Items {
-		group, err := services.UnmarshalUserGroup(item.Value)
-		if err != nil {
-			return nil, "", trace.Wrap(err)
-		}
-		out = append(out, group)
-	}
-
-	var nextKey string
-	if len(out) > pageSize {
-		nextKey = backend.GetPaginationKey(out[len(out)-1])
-		// Truncate the last item that was used to determine next row existence.
-		out = out[:pageSize]
-	}
-
-	return out, nextKey, nil
+	return s.svc.ListResources(ctx, pageSize, pageToken)
 }
 
 // GetUserGroup returns the specified user group resource.
 func (s *UserGroupService) GetUserGroup(ctx context.Context, name string) (types.UserGroup, error) {
-	item, err := s.Get(ctx, backend.Key(userGroupPrefix, name))
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return nil, trace.NotFound("user_group %q doesn't exist", name)
-		}
-		return nil, trace.Wrap(err)
-	}
-	group, err := services.UnmarshalUserGroup(item.Value,
-		services.WithResourceID(item.ID), services.WithExpires(item.Expires))
-	return group, trace.Wrap(err)
+	return s.svc.GetResource(ctx, name)
 }
 
 // CreateUserGroup creates a new user group resource.
 func (s *UserGroupService) CreateUserGroup(ctx context.Context, group types.UserGroup) error {
-	if err := group.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-	value, err := services.MarshalUserGroup(group)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	item := backend.Item{
-		Key:     backend.Key(userGroupPrefix, group.GetName()),
-		Value:   value,
-		Expires: group.Expiry(),
-		ID:      group.GetResourceID(),
-	}
-	_, err = s.Create(ctx, item)
-	if trace.IsAlreadyExists(err) {
-		return trace.AlreadyExists("user_group %q already exists", group.GetName())
-	}
-	return trace.Wrap(err)
+	return s.svc.CreateResource(ctx, group)
 }
 
 // UpdateUserGroup updates an existing user group resource.
 func (s *UserGroupService) UpdateUserGroup(ctx context.Context, group types.UserGroup) error {
-	if err := group.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-	value, err := services.MarshalUserGroup(group)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	item := backend.Item{
-		Key:     backend.Key(userGroupPrefix, group.GetName()),
-		Value:   value,
-		Expires: group.Expiry(),
-		ID:      group.GetResourceID(),
-	}
-	_, err = s.Update(ctx, item)
-	return trace.Wrap(err)
+	return s.svc.UpdateResource(ctx, group)
 }
 
 // DeleteUserGroup removes the specified user group resource.
 func (s *UserGroupService) DeleteUserGroup(ctx context.Context, name string) error {
-	err := s.Delete(ctx, backend.Key(userGroupPrefix, name))
-	if err != nil {
-		if trace.IsNotFound(err) {
-			return trace.NotFound("user_group %q doesn't exist", name)
-		}
-		return trace.Wrap(err)
-	}
-	return nil
+	return s.svc.DeleteResource(ctx, name)
 }
 
 // DeleteAllUserGroups removes all user group resources.
 func (s *UserGroupService) DeleteAllUserGroups(ctx context.Context) error {
-	startKey := backend.Key(userGroupPrefix)
-	err := s.DeleteRange(ctx, startKey, backend.RangeEnd(startKey))
-	return trace.Wrap(err)
+	return s.svc.DeleteAllResources(ctx)
 }
 
 const (

--- a/lib/services/local/usergroup_test.go
+++ b/lib/services/local/usergroup_test.go
@@ -40,7 +40,8 @@ func TestUserGroupCRUD(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	service := NewUserGroupService(backend)
+	service, err := NewUserGroupService(backend)
+	require.NoError(t, err)
 
 	// Create a couple user groups.
 	g1, err := types.NewUserGroup(


### PR DESCRIPTION
The UserGroups local service now uses the generic service. This came about due to a bug in the pagination logic for the user group listing. This fixes that issue and simplifies the user group service logic.