### PR TITLE
Reworked AWS launch_configuration to launch_templates

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/auth_asg.tf
@@ -10,8 +10,12 @@ resource "aws_autoscaling_group" "auth" {
   health_check_type         = "EC2"
   desired_capacity          = length(local.azs)
   force_delete              = false
-  launch_configuration      = aws_launch_configuration.auth.name
   vpc_zone_identifier       = aws_subnet.auth.*.id
+
+  launch_template {
+    name    = aws_launch_template.auth.name
+    version = "$Latest"
+  }
 
   // These are target groups of the auth server network load balancer
   // this autoscaling group is associated with target groups of the NLB
@@ -40,14 +44,14 @@ resource "aws_autoscaling_group" "auth" {
   }
 }
 
-resource "aws_launch_configuration" "auth" {
+resource "aws_launch_template" "auth" {
   lifecycle {
     create_before_destroy = true
   }
   name_prefix   = "${var.cluster_name}-auth-"
   image_id      = data.aws_ami.base.id
   instance_type = var.auth_instance_type
-  user_data = templatefile(
+  user_data     = base64encode(templatefile(
     "${path.module}/auth-user-data.tpl",
     {
       region                   = var.region
@@ -65,16 +69,34 @@ resource "aws_launch_configuration" "auth" {
       teleport_uid             = var.teleport_uid
       use_acm                  = var.use_acm
     }
-  )
+  ))
+
   metadata_options {
-    http_tokens = "required"
+    http_tokens   = "required"
+    http_endpoint = "enabled"
+
   }
-  root_block_device {
-    encrypted = true
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      throughput            = 125
+      volume_type           = "gp3"
+    }
   }
-  key_name                    = var.key_name
-  ebs_optimized               = true
-  associate_public_ip_address = false
-  security_groups             = [aws_security_group.auth.id]
-  iam_instance_profile        = aws_iam_instance_profile.auth.id
+
+  key_name      = var.key_name
+  ebs_optimized = true
+
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups             = [aws_security_group.auth.id]
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.auth.name
+  }
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/monitor_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/monitor_asg.tf
@@ -11,8 +11,12 @@ resource "aws_autoscaling_group" "monitor" {
   health_check_type         = "EC2"
   desired_capacity          = 1
   force_delete              = false
-  launch_configuration      = aws_launch_configuration.monitor.name
   vpc_zone_identifier       = [aws_subnet.public[0].id]
+
+  launch_template {
+    id      = aws_launch_template.monitor.id
+    version = "$Latest"
+  }
 
   // Auto scaling group is associated with internal load balancer for metrics ingestion
   // and proxy load balancer for grafana
@@ -51,8 +55,12 @@ resource "aws_autoscaling_group" "monitor_acm" {
   health_check_type         = "EC2"
   desired_capacity          = 1
   force_delete              = false
-  launch_configuration      = aws_launch_configuration.monitor.name
   vpc_zone_identifier       = [aws_subnet.public[0].id]
+
+  launch_template {
+    id      = aws_launch_template.monitor.id
+    version = "$Latest"
+  }
 
   // Auto scaling group is associated with internal load balancer for metrics ingestion
   // and proxy load balancer for grafana
@@ -78,14 +86,14 @@ resource "aws_autoscaling_group" "monitor_acm" {
 
 // Needs to have a public IP
 // tfsec:ignore:aws-ec2-no-public-ip
-resource "aws_launch_configuration" "monitor" {
+resource "aws_launch_template" "monitor" {
   lifecycle {
     create_before_destroy = true
   }
   name_prefix   = "${var.cluster_name}-monitor-"
   image_id      = data.aws_ami.base.id
   instance_type = var.monitor_instance_type
-  user_data = templatefile(
+  user_data     = base64encode(templatefile(
     "${path.module}/monitor-user-data.tpl",
     {
       region           = var.region
@@ -97,18 +105,35 @@ resource "aws_launch_configuration" "monitor" {
       domain_name      = var.route53_domain
       use_acm          = var.use_acm
     }
-  )
+  ))
+
   metadata_options {
-    http_tokens = "required"
+    http_tokens   = "required"
+    http_endpoint = "enabled"
   }
-  root_block_device {
-    encrypted = true
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      throughput            = 125
+      volume_type           = "gp3"
+    }
   }
-  key_name                    = var.key_name
-  ebs_optimized               = true
-  associate_public_ip_address = true
-  security_groups             = [aws_security_group.monitor.id]
-  iam_instance_profile        = aws_iam_instance_profile.monitor.id
+
+  key_name      = var.key_name
+  ebs_optimized = true
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.monitor.id]
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.monitor.name
+  }
 }
 
 // Monitors support traffic coming from internal cluster subnets and expose 8443 for grafana

--- a/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/node_asg.tf
@@ -9,8 +9,12 @@ resource "aws_autoscaling_group" "node" {
   health_check_type         = "EC2"
   desired_capacity          = 1
   force_delete              = false
-  launch_configuration      = aws_launch_configuration.node.name
   vpc_zone_identifier       = aws_subnet.node.*.id
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = "$Latest"
+  }
 
   tag {
     key                 = "TeleportCluster"
@@ -34,14 +38,16 @@ resource "aws_autoscaling_group" "node" {
     ]
   }
 }
-resource "aws_launch_configuration" "node" {
+
+resource "aws_launch_template" "node" {
   lifecycle {
     create_before_destroy = true
   }
+
   name_prefix   = "${var.cluster_name}-node-"
   image_id      = data.aws_ami.base.id
   instance_type = var.node_instance_type
-  user_data = templatefile(
+  user_data     = base64encode(templatefile(
     "${path.module}/node-user-data.tpl",
     {
       region           = var.region
@@ -51,15 +57,32 @@ resource "aws_launch_configuration" "node" {
       influxdb_addr    = "http://${aws_lb.monitor.dns_name}:8086"
       use_acm          = var.use_acm
     }
-  )
+  ))
+
   metadata_options {
-    http_tokens = "required"
+    http_tokens   = "required"
+    http_endpoint = "enabled"
   }
-  root_block_device {
-    encrypted = true
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      throughput            = 125
+      volume_type           = "gp3"
+    }
   }
-  key_name                    = var.key_name
-  associate_public_ip_address = false
-  security_groups             = [aws_security_group.node.id]
-  iam_instance_profile        = aws_iam_instance_profile.node.id
+
+  key_name = var.key_name
+
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups             = [aws_security_group.node.id]
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.node.name
+  }
 }

--- a/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/proxy_asg.tf
@@ -11,8 +11,12 @@ resource "aws_autoscaling_group" "proxy" {
   health_check_type         = "EC2"
   desired_capacity          = length(local.azs)
   force_delete              = false
-  launch_configuration      = aws_launch_configuration.proxy.name
   vpc_zone_identifier       = aws_subnet.public.*.id
+
+  launch_template {
+    name    = aws_launch_template.proxy.name
+    version = "$Latest"
+  }
 
   // Auto scaling group is associated with load balancer
   target_group_arns = [
@@ -57,8 +61,12 @@ resource "aws_autoscaling_group" "proxy_acm" {
   health_check_type         = "EC2"
   desired_capacity          = length(local.azs)
   force_delete              = false
-  launch_configuration      = aws_launch_configuration.proxy.name
   vpc_zone_identifier       = aws_subnet.public.*.id
+
+  launch_template {
+    name    = aws_launch_template.proxy.name
+    version = "$Latest"
+  }
 
   // Auto scaling group is associated with load balancer
   target_group_arns = [
@@ -97,14 +105,15 @@ resource "aws_autoscaling_group" "proxy_acm" {
 
 // Needs to have a public IP
 // tfsec:ignore:aws-ec2-no-public-ip
-resource "aws_launch_configuration" "proxy" {
+resource "aws_launch_template" "proxy" {
   lifecycle {
     create_before_destroy = true
   }
+
   name_prefix   = "${var.cluster_name}-proxy-"
   image_id      = data.aws_ami.base.id
   instance_type = var.proxy_instance_type
-  user_data = templatefile(
+  user_data     = base64encode(templatefile(
     "${path.module}/proxy-user-data.tpl",
     {
       region                   = data.aws_region.current.name
@@ -122,16 +131,33 @@ resource "aws_launch_configuration" "proxy" {
       enable_postgres_listener = var.enable_postgres_listener
       use_acm                  = var.use_acm
     }
-  )
+  ))
+
   metadata_options {
-    http_tokens = "required"
+    http_tokens            = "required"
+    http_endpoint          = "enabled"
   }
-  root_block_device {
-    encrypted = true
+
+  block_device_mappings {
+    device_name = "/dev/xvda"
+    ebs {
+      delete_on_termination = true
+      encrypted             = true
+      iops                  = 3000
+      throughput            = 125
+      volume_type           = "gp3"
+    }
   }
-  key_name                    = var.key_name
-  ebs_optimized               = true
-  associate_public_ip_address = true
-  security_groups             = [aws_security_group.proxy.id]
-  iam_instance_profile        = aws_iam_instance_profile.proxy.id
+
+  key_name      = var.key_name
+  ebs_optimized = true
+
+  network_interfaces {
+    associate_public_ip_address = true
+    security_groups             = [aws_security_group.proxy.id]
+  }
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.proxy.id
+  }
 }


### PR DESCRIPTION
I tried to create identical launch template to the launch configuration you previously had. Launch templates are preferred over launch configuration per the AWS documentation ( https://docs.aws.amazon.com/autoscaling/ec2/userguide/launch-configurations.html ).

I didn't specify a disk size so it should take the default provided by the AMI ( which was 8Gb if I recall correctly ).
Default disk type is now explicitly GP3 with the minimum values.

I set `http_endpoint = "enabled"` in every `metadata_options`. This prevents a new version being created every time you execute the terraform code.

Let me know if you have any remarks on the code. I kept all the parameters in the same order, but feel  `key_name = var.key_name` and `ebs_optimized = true` would be easier to spot if I add them with the other parameters ( between `instance_type` and `user_data` ).