### PR TITLE
Machine ID FIPS support

### DIFF
--- a/integrations/operator/sidecar/tbot.go
+++ b/integrations/operator/sidecar/tbot.go
@@ -155,7 +155,7 @@ func (c clientCredentials) TLSConfig() (*tls.Config, error) {
 }
 
 func (c clientCredentials) SSHClientConfig() (*ssh.ClientConfig, error) {
-	return c.id.SSHClientConfig()
+	return c.id.SSHClientConfig(false)
 }
 
 func (b *Bot) NeedLeaderElection() bool {

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -153,6 +153,12 @@ type CLIConf struct {
 	// require them.
 	RemainingArgs []string
 
+	// FIPS instructs `tbot` to run in a mode designed to comply with FIPS
+	// regulations. This means the bot should:
+	// - Refuse to run if not compiled with boringcrypto
+	// - Use FIPS relevant endpoints for cloud providers (e.g AWS)
+	// - Restrict TLS / SSH cipher suites and TLS version
+	// - RSA2048 should be used for private key generation
 	FIPS bool
 }
 

--- a/lib/tbot/identity/identity.go
+++ b/lib/tbot/identity/identity.go
@@ -33,6 +33,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/keys"
 	apisshutils "github.com/gravitational/teleport/api/utils/sshutils"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -228,10 +229,11 @@ func (i *Identity) getSSHCheckers() ([]ssh.PublicKey, error) {
 
 // SSHClientConfig returns a ssh.ClientConfig used by the bot to connect to
 // the reverse tunnel server.
-func (i *Identity) SSHClientConfig() (*ssh.ClientConfig, error) {
+func (i *Identity) SSHClientConfig(fips bool) (*ssh.ClientConfig, error) {
 	callback, err := apisshutils.NewHostKeyCallback(
 		apisshutils.HostKeyCallbackConfig{
 			GetHostCheckers: i.getSSHCheckers,
+			FIPS:            fips,
 		})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -239,12 +241,21 @@ func (i *Identity) SSHClientConfig() (*ssh.ClientConfig, error) {
 	if len(i.SSHCert.ValidPrincipals) < 1 {
 		return nil, trace.BadParameter("user cert has no valid principals")
 	}
-	return &ssh.ClientConfig{
+	config := &ssh.ClientConfig{
 		User:            i.SSHCert.ValidPrincipals[0],
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(i.KeySigner)},
 		HostKeyCallback: callback,
 		Timeout:         apidefaults.DefaultIOTimeout,
-	}, nil
+	}
+	if fips {
+		config.Config = ssh.Config{
+			KeyExchanges: defaults.FIPSKEXAlgorithms,
+			MACs:         defaults.FIPSMACAlgorithms,
+			Ciphers:      defaults.FIPSCiphers,
+		}
+	}
+
+	return config, nil
 }
 
 // ReadIdentityFromStore reads stored identity credentials

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -75,12 +75,12 @@ func (b *Bot) AuthenticatedUserClientFromIdentity(ctx context.Context, id *ident
 		return nil, trace.BadParameter("auth client requires a fully formed identity")
 	}
 
-	tlsConfig, err := id.TLSConfig(nil /* cipherSuites */)
+	tlsConfig, err := id.TLSConfig(b.cfg.CipherSuites())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	sshConfig, err := id.SSHClientConfig()
+	sshConfig, err := id.SSHClientConfig(b.cfg.FIPS)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -473,6 +473,8 @@ func (b *Bot) getIdentityFromToken() (*identity.Identity, error) {
 		GetHostCredentials: client.HostCredentials,
 		JoinMethod:         b.cfg.Onboarding.JoinMethod,
 		Expires:            &expires,
+		FIPS:               b.cfg.FIPS,
+		CipherSuites:       b.cfg.CipherSuites(),
 	}
 	if params.JoinMethod == types.JoinMethodAzure {
 		params.AzureParams = auth.AzureParams{

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -65,6 +65,7 @@ func Run(args []string, stdout io.Writer) error {
 	app := utils.InitCLIParser("tbot", appHelp).Interspersed(false)
 	app.Flag("debug", "Verbose logging to stdout.").Short('d').BoolVar(&cf.Debug)
 	app.Flag("config", "Path to a configuration file.").Short('c').StringVar(&cf.ConfigPath)
+	app.Flag("fips", "Runs tbot in FIPS compliance mode. This requires the FIPS binary is in use.").BoolVar(&cf.FIPS)
 	app.HelpFlag.Short('h')
 
 	joinMethodList := fmt.Sprintf(

--- a/tool/tbot/main_test.go
+++ b/tool/tbot/main_test.go
@@ -65,6 +65,7 @@ func TestRun_Configure(t *testing.T) {
 				"--oneshot",
 				"--certificate-ttl", "42m",
 				"--renewal-interval", "21m",
+				"--fips",
 			}...),
 		},
 	}

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/file.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/file.golden
@@ -15,3 +15,4 @@ auth_server: example.com
 certificate_ttl: 42m0s
 renewal_interval: 21m0s
 oneshot: true
+fips: true

--- a/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/all_parameters_provided/stdout.golden
@@ -15,3 +15,4 @@ auth_server: example.com
 certificate_ttl: 42m0s
 renewal_interval: 21m0s
 oneshot: true
+fips: true

--- a/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/file.golden
+++ b/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/file.golden
@@ -9,3 +9,4 @@ auth_server: ""
 certificate_ttl: 1h0m0s
 renewal_interval: 20m0s
 oneshot: false
+fips: false

--- a/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/stdout.golden
+++ b/tool/tbot/testdata/TestRun_Configure/no_parameters_provided/stdout.golden
@@ -9,3 +9,4 @@ auth_server: ""
 certificate_ttl: 1h0m0s
 renewal_interval: 20m0s
 oneshot: false
+fips: false


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/22448

Goals:
- Refuse to run if not compiled with boringcrypto
- Use FIPS relevant endpoints for cloud providers (e.g AWS)
- Restrict TLS / SSH cipher suites and TLS version to the good-listed sets
- RSA2048 should be used for private key generation