### PR TITLE
[v11] Fix agent pool test flakiness

### DIFF
--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -132,14 +132,13 @@ func TestAgentPoolConnectionCount(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		return pool.Count() == 1
-	}, time.Second*1, time.Millisecond*10)
-
-	select {
-	case <-pool.tracker.Acquire():
-	default:
-		require.FailNow(t, "expected a lease to be available")
-	}
+		select {
+		case <-pool.tracker.Acquire():
+			return true
+		default:
+			return false
+		}
+	}, time.Second*1, time.Millisecond*10, "expected a lease to be available")
 
 	require.False(t, pool.isAgentRequired())
 	require.Equal(t, pool.Count(), 1)


### PR DESCRIPTION
Backport #23453 

The way acquiring a lease is implemented does not guarantee that the lease channel is always being sent on when a lease is available.

This fix tries to acquire the lease multiple times to get around this.