### PR TITLE
Increase DialTimeout when testing SSH Connection Diagnostics

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5580,6 +5580,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 				ResourceName: tt.resourceName,
 				SSHPrincipal: tt.nodeUser,
 				// Default is 30 seconds but since tests run locally, we can reduce this value to also improve test responsiveness
+				// A value too low (eg 1s) will introduce test flakiness on some systems.
 				DialTimeout: 5 * time.Second,
 			})
 			require.NoError(t, err)
@@ -5651,7 +5652,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 		ResourceName: nodeName,
 		SSHPrincipal: osUsername,
 		// Default is 30 seconds but since tests run locally, we can reduce this value to also improve test responsiveness
-		DialTimeout: time.Second,
+		DialTimeout: 5 * time.Second,
 		MFAResponse: client.MFAChallengeResponse{TOTPCode: totpCode},
 	})
 	require.NoError(t, err)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -5580,7 +5580,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 				ResourceName: tt.resourceName,
 				SSHPrincipal: tt.nodeUser,
 				// Default is 30 seconds but since tests run locally, we can reduce this value to also improve test responsiveness
-				DialTimeout: time.Second,
+				DialTimeout: 5 * time.Second,
 			})
 			require.NoError(t, err)
 			require.Equal(t, http.StatusOK, resp.Code())


### PR DESCRIPTION
Depending on the system, 1 second might not be enough to complete the test. Specifically for darwin/amd64 on either Intel or M1 hosts

I was able to get a failure by using amd64 on an M1 host. The error is: context canceled
Which indicates a context timeout.

After setting this value to 5, I was able to get a PASS on the test. The test time didn't increase significantly.
So, it seems a nice trade off.