### PR TITLE
GHA: Add dummy post-release workflows

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -1,0 +1,11 @@
+name: Post-release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Greeting
+        run: echo "This is a dummy build to placate GitHub."

--- a/.github/workflows/update-ami-ids.yaml
+++ b/.github/workflows/update-ami-ids.yaml
@@ -1,0 +1,11 @@
+name: Update AMI IDs
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dummy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Greeting
+        run: echo "This is a dummy build to placate GitHub."


### PR DESCRIPTION
Add dummy post-release workflows to allow testing the actual workflows in https://github.com/gravitational/teleport/pull/23583 via manual dispatch as Github requires workflow_dispatch workflows to be present in the default branch in order to be executable.