### PR TITLE
Add Okta import rules, Okta assignments, and user groups to CLI.

### DIFF
--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -189,6 +189,10 @@ func ParseShortcut(in string) (string, error) {
 		return types.KindUserGroup, nil
 	case types.KindDevice, types.KindDevice + "s":
 		return types.KindDevice, nil
+	case types.KindOktaImportRule, types.KindOktaImportRule + "s", "oktaimportrule", "oktaimportrules":
+		return types.KindOktaImportRule, nil
+	case types.KindOktaAssignment, types.KindOktaAssignment + "s", "oktaassignment", "oktaassignments":
+		return types.KindOktaAssignment, nil
 	}
 	return "", trace.BadParameter("unsupported resource: %q - resources should be expressed as 'type/name', for example 'connector/github'", in)
 }

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -145,6 +145,19 @@ func TestParseShortcut(t *testing.T) {
 		"usergroup":   {expectedOutput: types.KindUserGroup},
 		"usergroups":  {expectedOutput: types.KindUserGroup},
 
+		"device":  {expectedOutput: types.KindDevice},
+		"devices": {expectedOutput: types.KindDevice},
+
+		"okta_import_rule":  {expectedOutput: types.KindOktaImportRule},
+		"okta_import_rules": {expectedOutput: types.KindOktaImportRule},
+		"oktaimportrule":    {expectedOutput: types.KindOktaImportRule},
+		"oktaimportrules":   {expectedOutput: types.KindOktaImportRule},
+
+		"okta_assignment":  {expectedOutput: types.KindOktaAssignment},
+		"okta_assignments": {expectedOutput: types.KindOktaAssignment},
+		"oktaassignment":   {expectedOutput: types.KindOktaAssignment},
+		"oktaassignments":  {expectedOutput: types.KindOktaAssignment},
+
 		"SamL_IDP_sERVICe_proVidER": {expectedOutput: types.KindSAMLIdPServiceProvider},
 
 		"unknown_type": {expectedErr: true},

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -1075,3 +1075,69 @@ func (c *deviceCollection) writeText(w io.Writer) error {
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
 }
+
+type oktaImportRuleCollection struct {
+	importRules []types.OktaImportRule
+}
+
+func (c *oktaImportRuleCollection) resources() []types.Resource {
+	r := make([]types.Resource, len(c.importRules))
+	for i, resource := range c.importRules {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *oktaImportRuleCollection) writeText(w io.Writer) error {
+	t := asciitable.MakeTable([]string{"Name"})
+	for _, importRule := range c.importRules {
+		t.AddRow([]string{importRule.GetName()})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+type oktaAssignmentCollection struct {
+	assignments []types.OktaAssignment
+}
+
+func (c *oktaAssignmentCollection) resources() []types.Resource {
+	r := make([]types.Resource, len(c.assignments))
+	for i, resource := range c.assignments {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *oktaAssignmentCollection) writeText(w io.Writer) error {
+	t := asciitable.MakeTable([]string{"Name"})
+	for _, assignment := range c.assignments {
+		t.AddRow([]string{assignment.GetName()})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}
+
+type userGroupCollection struct {
+	userGroups []types.UserGroup
+}
+
+func (c *userGroupCollection) resources() []types.Resource {
+	r := make([]types.Resource, len(c.userGroups))
+	for i, resource := range c.userGroups {
+		r[i] = resource
+	}
+	return r
+}
+
+func (c *userGroupCollection) writeText(w io.Writer) error {
+	t := asciitable.MakeTable([]string{"Name", "Origin"})
+	for _, userGroup := range c.userGroups {
+		t.AddRow([]string{
+			userGroup.GetName(),
+			userGroup.Origin(),
+		})
+	}
+	_, err := t.AsBuffer().WriteTo(w)
+	return trace.Wrap(err)
+}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -123,6 +123,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindLoginRule:               rc.createLoginRule,
 		types.KindSAMLIdPServiceProvider:  rc.createSAMLIdPServiceProvider,
 		types.KindDevice:                  rc.createDevice,
+		types.KindOktaImportRule:          rc.createOktaImportRule,
 	}
 	rc.config = config
 
@@ -805,6 +806,31 @@ func (rc *ResourceCommand) createDevice(ctx context.Context, client auth.ClientI
 	return nil
 }
 
+func (rc *ResourceCommand) createOktaImportRule(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+	importRule, err := services.UnmarshalOktaImportRule(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := importRule.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	exists := false
+	if _, err = client.OktaClient().CreateOktaImportRule(ctx, importRule); err != nil {
+		if trace.IsAlreadyExists(err) {
+			exists = true
+			_, err = client.OktaClient().UpdateOktaImportRule(ctx, importRule)
+		}
+
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	fmt.Printf("Okta import rule '%s' has been %s\n", importRule.GetName(), UpsertVerb(exists, rc.IsForced()))
+	return nil
+}
+
 // Delete deletes resource by name
 func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err error) {
 	singletonResources := []string{
@@ -1077,6 +1103,21 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err
 			return trace.NotFound("application server %q not found", rc.ref.Name)
 		}
 		fmt.Printf("application server %q has been deleted\n", rc.ref.Name)
+	case types.KindOktaImportRule:
+		if err := client.OktaClient().DeleteOktaImportRule(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Okta import rule %q has been deleted\n", rc.ref.Name)
+	case types.KindOktaAssignment:
+		if err := client.OktaClient().DeleteOktaAssignment(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("Okta assignment %q has been deleted\n", rc.ref.Name)
+	case types.KindUserGroup:
+		if err := client.DeleteUserGroup(ctx, rc.ref.Name); err != nil {
+			return trace.Wrap(err)
+		}
+		fmt.Printf("User group %q has been deleted\n", rc.ref.Name)
 	default:
 		return trace.BadParameter("deleting resources of type %q is not supported", rc.ref.Kind)
 	}
@@ -1718,6 +1759,78 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 		})
 
 		return &deviceCollection{devices: devs}, nil
+	case types.KindOktaImportRule:
+		if rc.ref.Name != "" {
+			importRule, err := client.OktaClient().GetOktaImportRule(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &oktaImportRuleCollection{importRules: []types.OktaImportRule{importRule}}, nil
+		}
+		var resources []types.OktaImportRule
+		nextKey := ""
+		for {
+			var importRules []types.OktaImportRule
+			var err error
+			importRules, nextKey, err = client.OktaClient().ListOktaImportRules(ctx, 0, nextKey)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			resources = append(resources, importRules...)
+			if nextKey == "" {
+				break
+			}
+		}
+		return &oktaImportRuleCollection{importRules: resources}, nil
+	case types.KindOktaAssignment:
+		if rc.ref.Name != "" {
+			assignment, err := client.OktaClient().GetOktaAssignment(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &oktaAssignmentCollection{assignments: []types.OktaAssignment{assignment}}, nil
+		}
+		var resources []types.OktaAssignment
+		nextKey := ""
+		for {
+			var assignments []types.OktaAssignment
+			var err error
+			assignments, nextKey, err = client.OktaClient().ListOktaAssignments(ctx, 0, nextKey)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			resources = append(resources, assignments...)
+			if nextKey == "" {
+				break
+			}
+		}
+		return &oktaAssignmentCollection{assignments: resources}, nil
+	case types.KindUserGroup:
+		if rc.ref.Name != "" {
+			userGroup, err := client.GetUserGroup(ctx, rc.ref.Name)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			return &userGroupCollection{userGroups: []types.UserGroup{userGroup}}, nil
+		}
+		var resources []types.UserGroup
+		nextKey := ""
+		for {
+			var userGroups []types.UserGroup
+			var err error
+			userGroups, nextKey, err = client.ListUserGroups(ctx, 0, nextKey)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			resources = append(resources, userGroups...)
+			if nextKey == "" {
+				break
+			}
+		}
+		return &userGroupCollection{userGroups: resources}, nil
 	}
 	return nil, trace.BadParameter("getting %q is not supported", rc.ref.String())
 }


### PR DESCRIPTION
Creation/listing/deletion of Okta import rules, listing/deletion of Okta assignments, and listing/deletion of user groups has been added to the Teleport CLI.

Deletion of user groups and Okta assignments is not expected to be done on a regular basis, but the option is available for administrators.