### PR TITLE
App service handles Okta apps.

### DIFF
--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -406,46 +406,22 @@ func TestStart(t *testing.T) {
 
 	// Check that the services.Server sent via heartbeat is correct. For example,
 	// check that the dynamic labels have been evaluated.
-	appFoo, err := types.NewAppV3(types.Metadata{
-		Name:   "foo",
-		Labels: staticLabels,
-	}, types.AppSpecV3{
-		URI:                s.testhttp.URL,
-		PublicAddr:         "foo.example.com",
-		InsecureSkipVerify: true,
-		DynamicLabels: map[string]types.CommandLabelV2{
-			dynamicLabelName: {
-				Period:  dynamicLabelPeriod,
-				Command: dynamicLabelCommand,
-				Result:  "4",
-			},
+	appFoo := s.appServer.apps["foo"].(*types.AppV3)
+	appFoo.SetDynamicLabels(map[string]types.CommandLabel{
+		dynamicLabelName: &types.CommandLabelV2{
+			Period:  dynamicLabelPeriod,
+			Command: dynamicLabelCommand,
+			Result:  "4",
 		},
 	})
 	require.NoError(t, err)
 	serverFoo, err := types.NewAppServerV3FromApp(appFoo, "test", s.hostUUID)
 	require.NoError(t, err)
-	appAWS, err := types.NewAppV3(types.Metadata{
-		Name:   "awsconsole",
-		Labels: staticLabels,
-	}, types.AppSpecV3{
-		URI:        constants.AWSConsoleURL,
-		PublicAddr: "aws.example.com",
-	})
+	appAWS := s.appServer.apps["awsconsole"].(*types.AppV3)
 	require.NoError(t, err)
 	serverAWS, err := types.NewAppServerV3FromApp(appAWS, "test", s.hostUUID)
 	require.NoError(t, err)
-	oktaLabels := map[string]string{}
-	for k, v := range staticLabels {
-		oktaLabels[k] = v
-	}
-	oktaLabels[types.OriginLabel] = types.OriginOkta
-	appOkta, err := types.NewAppV3(types.Metadata{
-		Name:   "okta",
-		Labels: oktaLabels,
-	}, types.AppSpecV3{
-		URI:        oktaAppURL,
-		PublicAddr: "okta.example.com",
-	})
+	appOkta := s.appServer.apps["okta"].(*types.AppV3)
 	require.NoError(t, err)
 	serverOkta, err := types.NewAppServerV3FromApp(appOkta, "test", s.hostUUID)
 	require.NoError(t, err)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -406,7 +406,12 @@ func TestStart(t *testing.T) {
 
 	// Check that the services.Server sent via heartbeat is correct. For example,
 	// check that the dynamic labels have been evaluated.
-	appFoo := s.appServer.apps["foo"].(*types.AppV3)
+	s.appServer.mu.Lock()
+	appFoo := s.appServer.apps["foo"].Copy()
+	appAWS := s.appServer.apps["awsconsole"].Copy()
+	appOkta := s.appServer.apps["okta"].Copy()
+	s.appServer.mu.Unlock()
+
 	appFoo.SetDynamicLabels(map[string]types.CommandLabel{
 		dynamicLabelName: &types.CommandLabelV2{
 			Period:  dynamicLabelPeriod,
@@ -414,14 +419,10 @@ func TestStart(t *testing.T) {
 			Result:  "4",
 		},
 	})
-	require.NoError(t, err)
+
 	serverFoo, err := types.NewAppServerV3FromApp(appFoo, "test", s.hostUUID)
 	require.NoError(t, err)
-	appAWS := s.appServer.apps["awsconsole"].(*types.AppV3)
-	require.NoError(t, err)
 	serverAWS, err := types.NewAppServerV3FromApp(appAWS, "test", s.hostUUID)
-	require.NoError(t, err)
-	appOkta := s.appServer.apps["okta"].(*types.AppV3)
 	require.NoError(t, err)
 	serverOkta, err := types.NewAppServerV3FromApp(appOkta, "test", s.hostUUID)
 	require.NoError(t, err)

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -434,9 +434,24 @@ func TestStart(t *testing.T) {
 	require.NoError(t, err)
 	serverAWS, err := types.NewAppServerV3FromApp(appAWS, "test", s.hostUUID)
 	require.NoError(t, err)
+	oktaLabels := map[string]string{}
+	for k, v := range staticLabels {
+		oktaLabels[k] = v
+	}
+	oktaLabels[types.OriginLabel] = types.OriginOkta
+	appOkta, err := types.NewAppV3(types.Metadata{
+		Name:   "okta",
+		Labels: oktaLabels,
+	}, types.AppSpecV3{
+		URI:        oktaAppURL,
+		PublicAddr: "okta.example.com",
+	})
+	require.NoError(t, err)
+	serverOkta, err := types.NewAppServerV3FromApp(appOkta, "test", s.hostUUID)
+	require.NoError(t, err)
 
 	sort.Sort(types.AppServers(servers))
-	require.Empty(t, cmp.Diff([]types.AppServer{serverAWS, serverFoo}, servers,
+	require.Empty(t, cmp.Diff([]types.AppServer{serverAWS, serverFoo, serverOkta}, servers,
 		cmpopts.IgnoreFields(types.Metadata{}, "ID", "Expires")))
 
 	// Check the expiry time is correct.


### PR DESCRIPTION
Okta apps are now handled by the app_service by redirecting them directly to their URI.