### PR TITLE
Leverage generics to make the `ListResources` api more user friendly

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1044,20 +1044,11 @@ func (c *Client) DeleteSemaphore(ctx context.Context, filter types.SemaphoreFilt
 // GetKubernetesServers returns the list of kubernetes servers registered in the
 // cluster.
 func (c *Client) GetKubernetesServers(ctx context.Context) ([]types.KubeServer, error) {
-	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+	servers, err := GetAllResources[types.KubeServer](ctx, c, &proto.ListResourcesRequest{
 		Namespace:    defaults.Namespace,
 		ResourceType: types.KindKubeServer,
 	})
-	if err != nil {
-		return nil, trail.FromGRPC(err)
-	}
-
-	servers, err := types.ResourcesWithLabels(resources).AsKubeServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return servers, nil
+	return servers, trace.Wrap(err)
 }
 
 // DeleteKubernetesServer deletes a named kubernetes server.
@@ -1091,20 +1082,11 @@ func (c *Client) UpsertKubernetesServer(ctx context.Context, s types.KubeServer)
 
 // GetApplicationServers returns all registered application servers.
 func (c *Client) GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error) {
-	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+	servers, err := GetAllResources[types.AppServer](ctx, c, &proto.ListResourcesRequest{
 		Namespace:    namespace,
 		ResourceType: types.KindAppServer,
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	servers, err := types.ResourcesWithLabels(resources).AsAppServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return servers, nil
+	return servers, trail.FromGRPC(err)
 }
 
 // UpsertApplicationServer registers an application server.
@@ -1398,20 +1380,11 @@ func (c *Client) GenerateSnowflakeJWT(ctx context.Context, req types.GenerateSno
 
 // GetDatabaseServers returns all registered database proxy servers.
 func (c *Client) GetDatabaseServers(ctx context.Context, namespace string) ([]types.DatabaseServer, error) {
-	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+	servers, err := GetAllResources[types.DatabaseServer](ctx, c, &proto.ListResourcesRequest{
 		Namespace:    namespace,
 		ResourceType: types.KindDatabaseServer,
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	servers, err := types.ResourcesWithLabels(resources).AsDatabaseServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return servers, nil
+	return servers, trail.FromGRPC(err)
 }
 
 // UpsertDatabaseServer registers a new database proxy server.
@@ -1918,20 +1891,12 @@ func (c *Client) GetNode(ctx context.Context, namespace, name string) (types.Ser
 
 // GetNodes returns a complete list of nodes that the user has access to in the given namespace.
 func (c *Client) GetNodes(ctx context.Context, namespace string) ([]types.Server, error) {
-	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
+	servers, err := GetAllResources[types.Server](ctx, c, &proto.ListResourcesRequest{
 		ResourceType: types.KindNode,
 		Namespace:    namespace,
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
-	servers, err := types.ResourcesWithLabels(resources).AsServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return servers, nil
+	return servers, trace.Wrap(err)
 }
 
 // UpsertNode is used by SSH servers to report their presence
@@ -2739,7 +2704,7 @@ func (c *Client) GenerateCertAuthorityCRL(ctx context.Context, req *proto.CertAu
 // ListResources returns a paginated list of nodes that the user has access to.
 // `nextKey` is used as `startKey` in another call to ListResources to retrieve
 // the next page. If you want to list all resources pages, check the
-// `GetResources` function.
+// `GetResourcesWithFilters` function.
 // It will return a `trace.LimitExceeded` error if the page exceeds gRPC max
 // message size.
 func (c *Client) ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
@@ -2783,6 +2748,129 @@ func (c *Client) ListResources(ctx context.Context, req proto.ListResourcesReque
 	}, nil
 }
 
+// GetResources returns a paginated list of resources that the user has access to.
+// `nextKey` is used as `startKey` in another call to GetResources to retrieve
+// the next page.
+// It will return a `trace.LimitExceeded` error if the page exceeds gRPC max
+// message size.
+func (c *Client) GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := c.grpc.ListResources(ctx, req)
+	return resp, trail.FromGRPC(err)
+}
+
+// GetResourcesClient is an interface used by GetResources to abstract over implementations of
+// the ListResources method.
+type GetResourcesClient interface {
+	GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error)
+}
+
+// ResourcePage holds a page of results from [GetResourcePage].
+type ResourcePage[T types.ResourceWithLabels] struct {
+	// Resources retrieved for a single [proto.ListResourcesRequest]. The length of
+	// the slice will be at most [proto.ListResourcesRequest.Limit].
+	Resources []T
+	// Total number of all resources matching the request. It will be greater than
+	// the length of [Resources] if the number of matches exceeds the request limit.
+	Total int
+	// NextKey is the start of the next page
+	NextKey string
+}
+
+// GetResourcePage is a helper for getting a single page of resources that match the provide request.
+func GetResourcePage[T types.ResourceWithLabels](ctx context.Context, clt GetResourcesClient, req *proto.ListResourcesRequest) (ResourcePage[T], error) {
+	var out ResourcePage[T]
+
+	// Set the limit to the default size if one was not provided within
+	// an acceptable range.
+	if req.Limit == 0 || req.Limit > int32(defaults.DefaultChunkSize) {
+		req.Limit = int32(defaults.DefaultChunkSize)
+	}
+
+	for {
+		resp, err := clt.GetResources(ctx, req)
+		if err != nil {
+			if trace.IsLimitExceeded(err) {
+				// Cut chunkSize in half if gRPC max message size is exceeded.
+				req.Limit /= 2
+				// This is an extremely unlikely scenario, but better to cover it anyways.
+				if req.Limit == 0 {
+					return out, trace.Wrap(trail.FromGRPC(err), "resource is too large to retrieve")
+				}
+
+				continue
+			}
+
+			return out, trail.FromGRPC(err)
+		}
+
+		for _, respResource := range resp.Resources {
+			var resource types.ResourceWithLabels
+			switch req.ResourceType {
+			case types.KindDatabaseServer:
+				resource = respResource.GetDatabaseServer()
+			case types.KindDatabaseService:
+				resource = respResource.GetDatabaseService()
+			case types.KindAppServer:
+				resource = respResource.GetAppServer()
+			case types.KindNode:
+				resource = respResource.GetNode()
+			case types.KindWindowsDesktop:
+				resource = respResource.GetWindowsDesktop()
+			case types.KindWindowsDesktopService:
+				resource = respResource.GetWindowsDesktopService()
+			case types.KindKubernetesCluster:
+				resource = respResource.GetKubeCluster()
+			case types.KindKubeServer:
+				resource = respResource.GetKubernetesServer()
+			default:
+				out.Resources = nil
+				return out, trace.NotImplemented("resource type %s does not support pagination", req.ResourceType)
+			}
+
+			t, ok := resource.(T)
+			if !ok {
+				out.Resources = nil
+				return out, trace.BadParameter("received unexpected resource type %T", resource)
+			}
+			out.Resources = append(out.Resources, t)
+		}
+
+		out.NextKey = resp.NextKey
+		out.Total = int(resp.TotalCount)
+
+		return out, nil
+	}
+}
+
+// GetAllResources is a helper for getting all existing resources that match the provided request. In addition to
+// iterating pages, it also correctly handles downsizing pages when LimitExceeded errors are encountered.
+func GetAllResources[T types.ResourceWithLabels](ctx context.Context, clt GetResourcesClient, req *proto.ListResourcesRequest) ([]T, error) {
+	var out []T
+
+	// Set the limit to the default size.
+	req.Limit = int32(defaults.DefaultChunkSize)
+	for {
+		page, err := GetResourcePage[T](ctx, clt, req)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		out = append(out, page.Resources...)
+
+		if page.NextKey == "" || len(page.Resources) == 0 {
+			break
+		}
+
+		req.StartKey = page.NextKey
+	}
+
+	return out, nil
+}
+
 // ListResourcesClient is an interface used by GetResourcesWithFilters to abstract over implementations of
 // the ListResources method.
 type ListResourcesClient interface {
@@ -2791,6 +2879,9 @@ type ListResourcesClient interface {
 
 // GetResourcesWithFilters is a helper for getting a list of resources with optional filtering. In addition to
 // iterating pages, it also correctly handles downsizing pages when LimitExceeded errors are encountered.
+//
+// GetAllResources or GetResourcePage should be preferred for client side operations to avoid converting
+// from []types.ResourceWithLabels to concrete types.
 func GetResourcesWithFilters(ctx context.Context, clt ListResourcesClient, req proto.ListResourcesRequest) ([]types.ResourceWithLabels, error) {
 	// Retrieve the complete list of resources in chunks.
 	var (

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4665,6 +4665,13 @@ func (a *ServerWithRoles) GenerateUserSingleUseCerts(ctx context.Context) (proto
 	return nil, trace.NotImplemented("bug: GenerateUserSingleUseCerts must not be called on auth.ServerWithRoles")
 }
 
+// GetResources exists to satisfy auth.ClientI but is not
+// implemented here. It is a client only interface to make
+// interacting with ListResources friendlier.
+func (a *ServerWithRoles) GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error) {
+	return nil, trace.NotImplemented("bug: GetResources must not be called on auth.ServerWithRoles")
+}
+
 func (a *ServerWithRoles) IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
 	if !hasLocalUserRole(a.context) && !hasRemoteUserRole(a.context) {
 		return nil, trace.AccessDenied("only a user role can call IsMFARequired, got %T", a.context.Checker)

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1773,7 +1773,7 @@ func TestGetAndList_DatabaseServers(t *testing.T) {
 	require.NoError(t, srv.Auth().UpsertRole(ctx, role))
 	servers, err := clt.GetDatabaseServers(ctx, defaults.Namespace)
 	require.NoError(t, err)
-	require.EqualValues(t, 1, len(servers))
+	require.Len(t, servers, 1)
 	require.Empty(t, cmp.Diff(testServers[0:1], servers))
 	resp, err := clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
@@ -1840,12 +1840,10 @@ func TestGetAndList_DatabaseServers(t *testing.T) {
 	require.NoError(t, srv.Auth().UpsertRole(ctx, role))
 	servers, err = clt.GetDatabaseServers(ctx, defaults.Namespace)
 	require.NoError(t, err)
-	require.EqualValues(t, 0, len(servers))
-	require.Empty(t, cmp.Diff([]types.DatabaseServer{}, servers))
+	require.Empty(t, servers)
 	resp, err = clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
-	require.Len(t, resp.Resources, 0)
-	require.Empty(t, cmp.Diff([]types.ResourceWithLabels{}, resp.Resources))
+	require.Empty(t, resp.Resources)
 }
 
 // TestGetAndList_ApplicationServers verifies RBAC and filtering is applied when fetching app servers.
@@ -1968,8 +1966,7 @@ func TestGetAndList_ApplicationServers(t *testing.T) {
 	require.EqualValues(t, 0, len(servers))
 	resp, err = clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
-	require.Len(t, resp.Resources, 0)
-	require.Empty(t, cmp.Diff([]types.ResourceWithLabels{}, resp.Resources))
+	require.Empty(t, resp.Resources)
 }
 
 // TestApps verifies RBAC is applied to app resources.
@@ -2503,11 +2500,9 @@ func TestGetAndList_KubernetesServers(t *testing.T) {
 	servers, err = clt.GetKubernetesServers(ctx)
 	require.NoError(t, err)
 	require.Len(t, servers, 0)
-	require.Empty(t, cmp.Diff(testServers[:0], servers))
 	resp, err = clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
-	require.Len(t, resp.Resources, 0)
-	require.Empty(t, cmp.Diff(testResources[:0], resp.Resources))
+	require.Empty(t, resp.Resources)
 }
 
 func TestListDatabaseServices(t *testing.T) {
@@ -2963,8 +2958,7 @@ func TestGetAndList_WindowsDesktops(t *testing.T) {
 
 	resp, err = clt.ListResources(ctx, listRequest)
 	require.NoError(t, err)
-	require.Len(t, resp.Resources, 0)
-	require.Empty(t, cmp.Diff([]types.ResourceWithLabels{}, resp.Resources))
+	require.Empty(t, resp.Resources)
 }
 
 func TestListResources_KindKubernetesCluster(t *testing.T) {

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -845,4 +845,7 @@ type ClientI interface {
 
 	// CloneHTTPClient creates a new HTTP client with the same configuration.
 	CloneHTTPClient(params ...roundtrip.ClientParam) (*HTTPClient, error)
+
+	// GetResources returns a paginated list of resources.
+	GetResources(ctx context.Context, req *proto.ListResourcesRequest) (*proto.ListResourcesResponse, error)
 }

--- a/lib/benchmark/ssh.go
+++ b/lib/benchmark/ssh.go
@@ -62,9 +62,7 @@ func (s SSHBenchmark) random(ctx context.Context, tc *client.TeleportClient) (Wo
 	}
 	defer clt.Close()
 
-	filter := tc.DefaultResourceFilter()
-	filter.ResourceType = types.KindNode
-	resources, err := apiclient.GetResourcesWithFilters(ctx, clt.AuthClient, *filter)
+	resources, err := apiclient.GetAllResources[types.Server](ctx, clt.AuthClient, tc.ResourceFilter(types.KindNode))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -79,7 +77,7 @@ func (s SSHBenchmark) random(ctx context.Context, tc *client.TeleportClient) (Wo
 }
 
 // chooseRandomHost returns a random hostport from the given slice.
-func chooseRandomHost(hosts []types.ResourceWithLabels) string {
+func chooseRandomHost(hosts []types.Server) string {
 	switch len(hosts) {
 	case 0:
 		return ""

--- a/lib/client/conntest/database.go
+++ b/lib/client/conntest/database.go
@@ -58,7 +58,7 @@ type ClientDatabaseConnectionTester interface {
 	client.ALPNAuthClient
 
 	services.ConnectionsDiagnostic
-	apiclient.ListResourcesClient
+	apiclient.GetResourcesClient
 }
 
 // DatabaseConnectionTesterConfig defines the config fields for DatabaseConnectionTester.
@@ -226,17 +226,12 @@ func (s *DatabaseConnectionTester) runALPNTunnel(ctx context.Context, req TestCo
 
 func (s *DatabaseConnectionTester) getDatabaseServers(ctx context.Context, databaseName string) ([]types.DatabaseServer, error) {
 	// Lookup the Database Server that's proxying the requested Database.
-	listResourcesResponse, err := s.cfg.UserClient.ListResources(ctx, proto.ListResourcesRequest{
+	page, err := apiclient.GetResourcePage[types.DatabaseServer](ctx, s.cfg.UserClient, &proto.ListResourcesRequest{
 		PredicateExpression: fmt.Sprintf(`name == "%s"`, databaseName),
 		ResourceType:        types.KindDatabaseServer,
 		Limit:               defaults.MaxIterationLimit,
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	databaseServers, err := types.ResourcesWithLabels(listResourcesResponse.Resources).AsDatabaseServers()
-	return databaseServers, trace.Wrap(err)
+	return page.Resources, trace.Wrap(err)
 }
 
 func checkDatabaseLogin(protocol, databaseUser, databaseName string) error {

--- a/lib/kube/utils/utils.go
+++ b/lib/kube/utils/utils.go
@@ -184,18 +184,12 @@ func KubeClusters(ctx context.Context, p KubeServicesPresence) ([]types.KubeClus
 	return extractAndSortKubeClusters(kubeServers), nil
 }
 
-// ListKubeClusterWithFilters returns a sorted list of unique kubernetes clusters
+// ListKubeClustersWithFilters returns a sorted list of unique kubernetes clusters
 // registered in p.
-func ListKubeClustersWithFilters(ctx context.Context, p client.ListResourcesClient, req proto.ListResourcesRequest) ([]types.KubeCluster, error) {
+func ListKubeClustersWithFilters(ctx context.Context, p client.GetResourcesClient, req proto.ListResourcesRequest) ([]types.KubeCluster, error) {
 	req.ResourceType = types.KindKubeServer
-	var kss []types.KubeServer
 
-	resources, err := client.GetResourcesWithFilters(ctx, p, req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	kss, err = types.ResourcesWithLabels(resources).AsKubeServers()
+	kss, err := client.GetAllResources[types.KubeServer](ctx, p, &req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/clusters/cluster_databases.go
+++ b/lib/teleterm/clusters/cluster_databases.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -72,7 +73,8 @@ func (c *Cluster) getAllDatabases(ctx context.Context) ([]Database, error) {
 		defer proxyClient.Close()
 
 		dbs, err = proxyClient.FindDatabasesByFilters(ctx, proto.ListResourcesRequest{
-			Namespace: defaults.Namespace,
+			Namespace:    defaults.Namespace,
+			ResourceType: types.KindDatabaseServer,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -97,11 +99,22 @@ func (c *Cluster) getAllDatabases(ctx context.Context) ([]Database, error) {
 
 func (c *Cluster) GetDatabases(ctx context.Context, r *api.GetDatabasesRequest) (*GetDatabasesResponse, error) {
 	var (
-		resp        *types.ListResourcesResponse
+		page        apiclient.ResourcePage[types.DatabaseServer]
 		authClient  auth.ClientI
 		proxyClient *client.ProxyClient
 		err         error
 	)
+
+	req := &proto.ListResourcesRequest{
+		Namespace:           defaults.Namespace,
+		ResourceType:        types.KindDatabaseServer,
+		Limit:               r.Limit,
+		SortBy:              types.GetSortByFromString(r.SortBy),
+		StartKey:            r.StartKey,
+		PredicateExpression: r.Query,
+		SearchKeywords:      client.ParseSearchKeywords(r.Search, ' '),
+		UseSearchAsRoles:    r.SearchAsRoles == "yes",
+	}
 
 	err = addMetadataToRetryableError(ctx, func() error {
 		proxyClient, err = c.clusterClient.ConnectToProxy(ctx)
@@ -115,38 +128,19 @@ func (c *Cluster) GetDatabases(ctx context.Context, r *api.GetDatabasesRequest) 
 			return trace.Wrap(err)
 		}
 		defer authClient.Close()
-		sortBy := types.GetSortByFromString(r.SortBy)
 
-		resp, err = authClient.ListResources(ctx, proto.ListResourcesRequest{
-			Namespace:           defaults.Namespace,
-			ResourceType:        types.KindDatabaseServer,
-			Limit:               r.Limit,
-			SortBy:              sortBy,
-			StartKey:            r.StartKey,
-			PredicateExpression: r.Query,
-			SearchKeywords:      client.ParseSearchKeywords(r.Search, ' '),
-			UseSearchAsRoles:    r.SearchAsRoles == "yes",
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		return nil
+		page, err = apiclient.GetResourcePage[types.DatabaseServer](ctx, authClient, req)
+		return trace.Wrap(err)
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	databases, err := types.ResourcesWithLabels(resp.Resources).AsDatabaseServers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	response := &GetDatabasesResponse{
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
+		StartKey:   page.NextKey,
+		TotalCount: page.Total,
 	}
-	for _, database := range databases {
+	for _, database := range page.Resources {
 		response.Databases = append(response.Databases, Database{
 			URI:      c.URI.AppendDB(database.GetName()),
 			Database: database.GetDatabase(),

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2273,12 +2273,12 @@ func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindNode)
+	req, err := convertListResourcesRequest(r, types.KindNode)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	servers, err := types.ResourcesWithLabels(resp.Resources).AsServers()
+	page, err := apiclient.GetResourcePage[types.Server](r.Context(), clt, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2288,15 +2288,15 @@ func (h *Handler) clusterNodesGet(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	uiServers, err := ui.MakeServers(site.GetName(), servers, accessChecker.Roles())
+	uiServers, err := ui.MakeServers(site.GetName(), page.Resources, accessChecker.Roles())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return listResourcesGetResponse{
 		Items:      uiServers,
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
+		StartKey:   page.NextKey,
+		TotalCount: page.Total,
 	}, nil
 }
 
@@ -2613,7 +2613,7 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 	if _, err := uuid.Parse(req.Server); err != nil {
 		// The requested server is either a hostname or an address. Get all
 		// servers that may fuzzily match by populating SearchKeywords
-		resources, err := apiclient.GetResourcesWithFilters(ctx, clt, proto.ListResourcesRequest{
+		servers, err := apiclient.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
 			ResourceType:   types.KindNode,
 			Namespace:      apidefaults.Namespace,
 			SearchKeywords: []string{req.Server},
@@ -2622,7 +2622,7 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 			return session.Session{}, trace.Wrap(err)
 		}
 
-		if len(resources) == 0 {
+		if len(servers) == 0 {
 			// If we didn't find the resource set host and port,
 			// so we can try direct dial.
 			host, port, err = serverHostPort(req.Server)
@@ -2633,12 +2633,7 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 		}
 
 		matches := 0
-		for _, resource := range resources {
-			server, ok := resource.(types.Server)
-			if !ok {
-				return session.Session{}, trace.BadParameter("expected types.Server, got: %T", resource)
-			}
-
+		for _, server := range servers {
 			// match by hostname
 			if server.GetHostname() == req.Server {
 				if matches > 0 {

--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -381,8 +381,7 @@ func ExtractResourceAndValidate(yaml string) (*services.UnknownResource, error) 
 	return &unknownRes, nil
 }
 
-// listResources gets a list of resources depending on the type of resource.
-func listResources(clt resourcesAPIGetter, r *http.Request, resourceKind string) (*types.ListResourcesResponse, error) {
+func convertListResourcesRequest(r *http.Request, kind string) (*proto.ListResourcesRequest, error) {
 	values := r.URL.Query()
 
 	limit, err := queryLimitAsInt32(values, "limit", defaults.MaxIterationLimit)
@@ -393,17 +392,15 @@ func listResources(clt resourcesAPIGetter, r *http.Request, resourceKind string)
 	sortBy := types.GetSortByFromString(values.Get("sort"))
 
 	startKey := values.Get("startKey")
-	req := proto.ListResourcesRequest{
-		ResourceType:        resourceKind,
+	return &proto.ListResourcesRequest{
+		ResourceType:        kind,
 		Limit:               limit,
 		StartKey:            startKey,
 		SortBy:              sortBy,
 		PredicateExpression: values.Get("query"),
 		SearchKeywords:      client.ParseSearchKeywords(values.Get("search"), ' '),
 		UseSearchAsRoles:    values.Get("searchAsRoles") == "yes",
-	}
-
-	return clt.ListResources(r.Context(), req)
+	}, nil
 }
 
 // listKubeResources gets a list of kubernetes resources depending on the type of resource.

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -626,15 +626,7 @@ func TestListResources(t *testing.T) {
 			httpReq, err := http.NewRequest("", tc.url, nil)
 			require.NoError(t, err)
 
-			m := &mockedResourceAPIGetter{}
-			m.mockListResources = func(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
-				if !tc.wantBadParamErr {
-					require.Equal(t, tc.expected, req)
-				}
-				return nil, nil
-			}
-
-			_, err = listResources(m, httpReq, types.KindNode)
+			_, err = convertListResourcesRequest(httpReq, types.KindNode)
 			if tc.wantBadParamErr {
 				require.True(t, trace.IsBadParameter(err))
 			} else {

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
+	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
@@ -35,24 +36,25 @@ func (h *Handler) clusterKubesGet(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindKubernetesCluster)
+	req, err := convertListResourcesRequest(r, types.KindKubernetesCluster)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	clusters, err := types.ResourcesWithLabels(resp.Resources).AsKubeClusters()
+	page, err := client.GetResourcePage[types.KubeCluster](r.Context(), clt, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	accessChecker, err := sctx.GetUserAccessChecker()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return listResourcesGetResponse{
-		Items:      ui.MakeKubeClusters(clusters, accessChecker.Roles()),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
+		Items:      ui.MakeKubeClusters(page.Resources, accessChecker.Roles()),
+		StartKey:   page.NextKey,
+		TotalCount: page.Total,
 	}, nil
 }
 
@@ -83,19 +85,19 @@ func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p 
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindDatabaseServer)
+	req, err := convertListResourcesRequest(r, types.KindDatabaseServer)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	servers, err := types.ResourcesWithLabels(resp.Resources).AsDatabaseServers()
+	page, err := client.GetResourcePage[types.DatabaseServer](r.Context(), clt, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	// Make a list of all proxied databases.
-	var databases []types.Database
-	for _, server := range servers {
+	databases := make([]types.Database, 0, len(page.Resources))
+	for _, server := range page.Resources {
 		databases = append(databases, server.GetDatabase())
 	}
 
@@ -111,8 +113,8 @@ func (h *Handler) clusterDatabasesGet(w http.ResponseWriter, r *http.Request, p 
 
 	return listResourcesGetResponse{
 		Items:      ui.MakeDatabases(databases, dbUsers, dbNames),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
+		StartKey:   page.NextKey,
+		TotalCount: page.Total,
 	}, nil
 }
 
@@ -153,20 +155,20 @@ func (h *Handler) clusterDatabaseServicesList(w http.ResponseWriter, r *http.Req
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindDatabaseService)
+	req, err := convertListResourcesRequest(r, types.KindDatabaseService)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	servers, err := types.ResourcesWithLabels(resp.Resources).AsDatabaseServices()
+	page, err := client.GetResourcePage[types.DatabaseService](r.Context(), clt, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return listResourcesGetResponse{
-		Items:      ui.MakeDatabaseServices(servers),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
+		Items:      ui.MakeDatabaseServices(page.Resources),
+		StartKey:   page.NextKey,
+		TotalCount: page.Total,
 	}, nil
 }
 
@@ -177,12 +179,12 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindWindowsDesktop)
+	req, err := convertListResourcesRequest(r, types.KindWindowsDesktop)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	windowsDesktops, err := types.ResourcesWithLabels(resp.Resources).AsWindowsDesktops()
+	page, err := client.GetResourcePage[types.WindowsDesktop](r.Context(), clt, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -192,15 +194,15 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	uiDesktops, err := ui.MakeDesktops(windowsDesktops, accessChecker.Roles())
+	uiDesktops, err := ui.MakeDesktops(page.Resources, accessChecker.Roles())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return listResourcesGetResponse{
 		Items:      uiDesktops,
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
+		StartKey:   page.NextKey,
+		TotalCount: page.Total,
 	}, nil
 }
 
@@ -213,20 +215,20 @@ func (h *Handler) clusterDesktopServicesGet(w http.ResponseWriter, r *http.Reque
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := listResources(clt, r, types.KindWindowsDesktopService)
+	req, err := convertListResourcesRequest(r, types.KindWindowsDesktopService)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	desktopServices, err := types.ResourcesWithLabels(resp.Resources).AsWindowsDesktopServices()
+	page, err := client.GetResourcePage[types.WindowsDesktopService](r.Context(), clt, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return listResourcesGetResponse{
-		Items:      ui.MakeDesktopServices(desktopServices),
-		StartKey:   resp.NextKey,
-		TotalCount: resp.TotalCount,
+		Items:      ui.MakeDesktopServices(page.Resources),
+		StartKey:   page.NextKey,
+		TotalCount: page.Total,
 	}, nil
 }
 

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -234,25 +234,18 @@ func (c *NodeCommand) ListActive(ctx context.Context, clt auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 
-	var nodes []types.Server
-	resources, err := client.GetResourcesWithFilters(ctx, clt, proto.ListResourcesRequest{
+	nodes, err := client.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
 		ResourceType:        types.KindNode,
 		Namespace:           c.namespace,
 		Labels:              labels,
 		PredicateExpression: c.predicateExpr,
 		SearchKeywords:      libclient.ParseSearchKeywords(c.searchKeywords, ','),
 	})
-	switch {
-	case err != nil:
+	if err != nil {
 		if utils.IsPredicateError(err) {
 			return trace.Wrap(utils.PredicateError{Err: err})
 		}
 		return trace.Wrap(err)
-	default:
-		nodes, err = types.ResourcesWithLabels(resources).AsServers()
-		if err != nil {
-			return trace.Wrap(err)
-		}
 	}
 
 	coll := &serverCollection{servers: nodes, verbose: c.verbose}

--- a/tool/tsh/app.go
+++ b/tool/tsh/app.go
@@ -266,6 +266,7 @@ func getRegisteredApp(cf *CLIConf, tc *client.TeleportClient) (app types.Applica
 	err = client.RetryWithRelogin(cf.Context, tc, func() error {
 		apps, err = tc.ListApps(cf.Context, &proto.ListResourcesRequest{
 			Namespace:           tc.Namespace,
+			ResourceType:        types.KindAppServer,
 			PredicateExpression: fmt.Sprintf(`name == "%s"`, cf.AppName),
 		})
 		return trace.Wrap(err)

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -77,7 +77,7 @@ func onListDatabases(cf *CLIConf) error {
 	}
 	defer proxy.Close()
 
-	databases, err := proxy.FindDatabasesByFiltersForCluster(cf.Context, *tc.DefaultResourceFilter(), tc.SiteName)
+	databases, err := proxy.FindDatabasesByFiltersForCluster(cf.Context, *tc.ResourceFilter(types.KindDatabaseServer), tc.SiteName)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -139,7 +139,7 @@ func (l databaseListings) Swap(i, j int) {
 
 func listDatabasesAllClusters(cf *CLIConf) error {
 	tracer := cf.TracingProvider.Tracer(teleport.ComponentTSH)
-	clusters, err := getClusterClients(cf)
+	clusters, err := getClusterClients(cf, types.KindDatabaseServer)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -881,6 +881,7 @@ func getDatabase(cf *CLIConf, tc *client.TeleportClient, dbName string) (types.D
 		var err error
 		databases, err = tc.ListDatabases(cf.Context, &proto.ListResourcesRequest{
 			Namespace:           tc.Namespace,
+			ResourceType:        types.KindDatabaseServer,
 			PredicateExpression: fmt.Sprintf(`name == "%s"`, dbName),
 		})
 		return trace.Wrap(err)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -2048,7 +2048,7 @@ func (c *clusterClient) Close() error {
 
 // getClusterClients establishes a ProxyClient to every cluster
 // that the user has valid credentials for
-func getClusterClients(cf *CLIConf) ([]*clusterClient, error) {
+func getClusterClients(cf *CLIConf, resource string) ([]*clusterClient, error) {
 	tracer := cf.TracingProvider.Tracer(teleport.ComponentTSH)
 
 	// mu guards access to clusters
@@ -2097,7 +2097,7 @@ func getClusterClients(cf *CLIConf) ([]*clusterClient, error) {
 				proxy:   proxy,
 				profile: profile,
 				name:    site.Name,
-				req:     *tc.DefaultResourceFilter(),
+				req:     *tc.ResourceFilter(resource),
 			})
 		}
 
@@ -2139,7 +2139,7 @@ func (l nodeListings) Swap(i, j int) {
 
 func listNodesAllClusters(cf *CLIConf) error {
 	tracer := cf.TracingProvider.Tracer(teleport.ComponentTSH)
-	clusters, err := getClusterClients(cf)
+	clusters, err := getClusterClients(cf, types.KindNode)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -2178,7 +2178,7 @@ func listNodesAllClusters(cf *CLIConf) error {
 			defer span.End()
 
 			logger := log.WithField("cluster", cluster.name)
-			nodes, err := cluster.proxy.FindNodesByFiltersForCluster(ctx, cluster.req, cluster.name)
+			nodes, err := cluster.proxy.FindNodesByFiltersForCluster(ctx, &cluster.req, cluster.name)
 			if err != nil {
 				logger.Errorf("Failed to get nodes: %v.", err)
 
@@ -2955,17 +2955,12 @@ func accessRequestForSSH(ctx context.Context, tc *client.TeleportClient) (types.
 	// Match on hostname or host ID, user could have given either
 	expr := fmt.Sprintf(hostnameOrIDPredicateTemplate, tc.Host)
 
-	resources, err := apiclient.GetResourcesWithFilters(ctx, clt.AuthClient, proto.ListResourcesRequest{
+	nodes, err := apiclient.GetAllResources[types.Server](ctx, clt.AuthClient, &proto.ListResourcesRequest{
 		Namespace:           apidefaults.Namespace,
 		ResourceType:        types.KindNode,
 		UseSearchAsRoles:    true,
 		PredicateExpression: expr,
 	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	nodes, err := types.ResourcesWithLabels(resources).AsServers()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Add `client.GetAllResources[T types.ResourceWithLabels]` and `client.GetResourcePage[T types.ResourceWithLabels]` to make getting resources less verbose:

#### Current API
```go
	resources, err := GetResourcesWithFilters(ctx, c, proto.ListResourcesRequest{
		ResourceType: types.KindNode,
		Namespace:    namespace,
	})	
	if err != nil {
		return nil, trace.Wrap(err)
	}
	servers, err := types.ResourcesWithLabels(resources).AsServers()

	return servers, nil

```

#### API with the changes in this PR

```go
	servers, err := GetAllResources[types.Server](ctx, c, &proto.ListResourcesRequest{
		ResourceType: types.KindNode,
		Namespace:    namespace,
	})
	return servers, trace.Wrap(err)