### PR TITLE
Create an OktaAssignment watcher.

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -297,7 +297,7 @@ type OktaAssignments []OktaAssignment
 
 // ToMap returns these Okta assignments as a map keyed by Okta assignment name.
 func (o OktaAssignments) ToMap() map[string]OktaAssignment {
-	m := make(map[string]OktaAssignment)
+	m := make(map[string]OktaAssignment, len(o))
 	for _, oktaAssignment := range o {
 		m[oktaAssignment.GetName()] = oktaAssignment
 	}
@@ -305,7 +305,8 @@ func (o OktaAssignments) ToMap() map[string]OktaAssignment {
 }
 
 // AsResources returns these Okta assignments as resources with labels.
-func (o OktaAssignments) AsResources() (resources ResourcesWithLabels) {
+func (o OktaAssignments) AsResources() ResourcesWithLabels {
+	resources := make(ResourcesWithLabels, 0, len(o))
 	for _, oktaAssignment := range o {
 		resources = append(resources, oktaAssignment)
 	}

--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -291,3 +291,32 @@ func (o *OktaAssignmentActionV1) GetTargetType() string {
 func (o *OktaAssignmentActionV1) GetID() string {
 	return o.Target.Id
 }
+
+// OktaAssignments is a list of OktaAssignment resources.
+type OktaAssignments []OktaAssignment
+
+// ToMap returns these Okta assignments as a map keyed by Okta assignment name.
+func (o OktaAssignments) ToMap() map[string]OktaAssignment {
+	m := make(map[string]OktaAssignment)
+	for _, oktaAssignment := range o {
+		m[oktaAssignment.GetName()] = oktaAssignment
+	}
+	return m
+}
+
+// AsResources returns these Okta assignments as resources with labels.
+func (o OktaAssignments) AsResources() (resources ResourcesWithLabels) {
+	for _, oktaAssignment := range o {
+		resources = append(resources, oktaAssignment)
+	}
+	return resources
+}
+
+// Len returns the slice length.
+func (o OktaAssignments) Len() int { return len(o) }
+
+// Less compares Okta assignments by name.
+func (o OktaAssignments) Less(i, j int) bool { return o[i].GetName() < o[j].GetName() }
+
+// Swap swaps two Okta assignments.
+func (o OktaAssignments) Swap(i, j int) { o[i], o[j] = o[j], o[i] }

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1845,7 +1845,7 @@ func (c *oktaAssignmentCollector) initializationChan() <-chan struct{} {
 // getResourcesAndUpdateCurrent refreshes the list of current resources.
 func (c *oktaAssignmentCollector) getResourcesAndUpdateCurrent(ctx context.Context) error {
 	var oktaAssignments []types.OktaAssignment
-	nextToken := ""
+	var nextToken string
 	for {
 		var oktaAssignmentsPage []types.OktaAssignment
 		var err error


### PR DESCRIPTION
Introduces a watcher for OktaAssignments that will be used by the upcoming Okta service enterprise feature.