### PR TITLE
docs: configure windows service to listen on all interfaces

### DIFF
--- a/docs/pages/includes/config-reference/desktop-config.yaml
+++ b/docs/pages/includes/config-reference/desktop-config.yaml
@@ -1,7 +1,7 @@
 windows_desktop_service:
   enabled: yes
   # This is the address that windows_desktop_service will listen on.
-  listen_addr: "localhost:3028"
+  listen_addr: "0.0.0.0:3028"
   # (optional) This is the address that windows_desktop_service will advertise
   # to the rest of Teleport for incoming connections. Only proxy_service should
   # connect to windows_desktop_service, users connect to the proxy's web UI


### PR DESCRIPTION
The desktop listen address is for the proxy to be able to connect. If it's set to localhost/127.0.0.01 then a Proxy from a external can't reach it.  This makes it more in-line with SSH listener example.

Also if no public address is set but a listen address is set within a proxy/auth/desktop service node it will attempt the host:3028, not automatically use localhost:3028.  On a standalone you can set `localhost:3028` as the public address for desktop which will work.  This doesn't seem typical though.