### PR TITLE
docs: point to release 12.1.1 for exe download for windows local users

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -58,7 +58,7 @@ Copy this certificate to your Windows system, if you didn't run `tctl` from ther
 ### Install the Teleport service for Windows
 
 From the Windows system, download the [Teleport Windows Auth
-Setup](https://github.com/gravitational/teleport/releases/tag/v12.0.0-passwordless-windows).
+Setup](https://github.com/gravitational/teleport/releases/tag/v12.1.1-passwordless-windows).
 Extract the `.exe` file from the archive and run it. When prompted, select the
 Teleport certificate file from the previous step. Once complete, reboot the system.
 


### PR DESCRIPTION
Still pointing at `12.0.0` version.  ONly required to backport to `branch/v12`