### PR TITLE
release: Dont look for signing keys if not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,19 +436,9 @@ release-darwin-unsigned: RELEASE:=$(RELEASE)-unsigned
 release-darwin-unsigned: clean full build-archive
 
 .PHONY: release-darwin
-# Only run signing/notarization if Apple username/pass are provided.
-# Export DEVELOPER_ID_APPLICATION so it can be used by e/Makefile.
 release-darwin: ABSOLUTE_BINARY_PATHS:=$(addprefix $(CURDIR)/,$(BINARIES))
 release-darwin: release-darwin-unsigned
-	if [ -n "$$APPLE_USERNAME" -a -n "$$APPLE_PASSWORD" ]; then \
-		$(eval export DEVELOPER_ID_APPLICATION) \
-		cd ./build.assets/tooling/ && \
-		go run ./cmd/notarize-apple-binaries/*.go \
-			--developer-id=$(DEVELOPER_ID_APPLICATION) \
-			--bundle-id=$(TELEPORT_BUNDLEID) \
-			--log-level=debug \
-			$(ABSOLUTE_BINARY_PATHS); \
-	fi
+	$(NOTARIZE_BINARIES)
 	$(MAKE) build-archive
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 


### PR DESCRIPTION
Use a `make` conditional instead of a shell conditional when deciding
whether to run notarization or not, based on `APPLE_{USERNAME,PASSWORD}`
being set. When done as a shell conditional, `$(DEVELOPER_ID_APPLICATION)`
was still being evaluated, and that causes a key error if the key does
not exist in the keychain. If the `APPLE_{USERNAME,PASSWORD}` env vars
are not set, it should not matter if the key is present or not as it
will not be used.

By switching to `$(if ...)` in make, the recipe will not be evaluated at
all if the condition is false. To ensure the logs say what is going on,
add a message when we do not notarize the binaries.

Move the logic for notarization and checking the username/password into
`darwin-signing.mk` with the other signing/notarization variables. This
will make it reusable by the enterprise Makefile later.

This fixes the enterprise build pipeline, which does not set the
username/password for notarizing binaries.