### PR TITLE
Add in a Okta assignments copy method.

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -19,6 +19,7 @@ package types
 import (
 	"fmt"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -179,6 +180,8 @@ type OktaAssignment interface {
 	GetUser() string
 	// GetActions will return the list of actions that will be performed as part of this assignment.
 	GetActions() []OktaAssignmentAction
+	// Copy returns a copy of this Okta assignment resource.
+	Copy() OktaAssignment
 }
 
 // NewOktaAssignment creates a new Okta assignment object.
@@ -200,6 +203,7 @@ func (o *OktaAssignmentV1) GetUser() string {
 	return o.Spec.User
 }
 
+// GetActions returns the actions associated with the Okta assignment.
 func (o *OktaAssignmentV1) GetActions() []OktaAssignmentAction {
 	actions := make([]OktaAssignmentAction, len(o.Spec.Actions))
 
@@ -208,6 +212,11 @@ func (o *OktaAssignmentV1) GetActions() []OktaAssignmentAction {
 	}
 
 	return actions
+}
+
+// Copy returns a copy of this Okta assignment resource.
+func (o *OktaAssignmentV1) Copy() OktaAssignment {
+	return proto.Clone(o).(*OktaAssignmentV1)
 }
 
 // String returns the Okta assignment rule string representation.


### PR DESCRIPTION
The OktaAssignment type has been given a Copy method to aid with OktaAssignment reconciliation.