### PR TITLE
Ignore unused-parameter on revive/golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,8 +43,6 @@ linters-settings:
       - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
       - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
       - go.uber.org/atomic: 'use "sync/atomic" instead'
-  misspell:
-    locale: US
   gci:
     sections:
       - standard # Standard section: captures all standard packages.
@@ -52,10 +50,17 @@ linters-settings:
       - prefix(github.com/gravitational/teleport) # Custom section: groups all imports with the specified Prefix.
     skip-generated: true # Skip generated files.
     custom-order: true # Required for "sections" to take effect.
+  misspell:
+    locale: US
   nolintlint:
     allow-unused: true # Enabled because of conditional builds / build tags.
     require-explanation: true
     require-specific: true
+  revive:
+    rules:
+    - name: unused-parameter
+      disabled: true
+
 output:
   uniq-by-line: false
 


### PR DESCRIPTION
Dropped the [unused-parameter][1] rule from revive/golangci-lint, as it makes the linter fail locally (although CI, somehow, seems fine).

We do have many offenders for the rule and I don't think the rule itself is a clear-cut win: often methods keep to certain signatures on purpose, and attaching a name to the parameter helps readability.

[1]: https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#unused-parameter