### PR TITLE
Change MySQL Default Value

### DIFF
--- a/lib/srv/db/mysql/proxy.go
+++ b/lib/srv/db/mysql/proxy.go
@@ -279,5 +279,5 @@ const (
 	//
 	// Some clients may refuse to work with older servers (e.g. MySQL
 	// Workbench requires > 5.5).
-	serverVersion = "8.0.0-Teleport"
+	serverVersion = "8.0.4-Teleport"
 )


### PR DESCRIPTION
See: https://github.com/gravitational/teleport/issues/19336 as an example of the issue.

The MySQL connections are falling back to this value when it's unable to auto-detect (or other issues at play).

Since `8.0.3` removed the `query_cache_size` option and fails when connecting, for the likely majority of us on newer MySQL versions, this default value breaks compatibility with JDBC drivers.

Original issue: https://github.com/gravitational/teleport/issues/6584