### PR TITLE
support cross-account AWS db access

### DIFF
--- a/lib/cloud/mocks/aws.go
+++ b/lib/cloud/mocks/aws.go
@@ -17,7 +17,9 @@ limitations under the License.
 package mocks
 
 import (
+	"context"
 	"sync"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -34,17 +36,63 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/exp/slices"
 )
 
 // STSMock mocks AWS STS API.
 type STSMock struct {
 	stsiface.STSAPI
-	ARN string
+	ARN                    string
+	assumedRoleARNs        []string
+	assumedRoleExternalIDs []string
+	mu                     sync.Mutex
+}
+
+func (m *STSMock) GetAssumedRoleARNs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.assumedRoleARNs
+}
+
+func (m *STSMock) GetAssumedRoleExternalIDs() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.assumedRoleExternalIDs
+}
+
+func (m *STSMock) ResetAssumeRoleHistory() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.assumedRoleARNs = nil
+	m.assumedRoleExternalIDs = nil
 }
 
 func (m *STSMock) GetCallerIdentityWithContext(aws.Context, *sts.GetCallerIdentityInput, ...request.Option) (*sts.GetCallerIdentityOutput, error) {
 	return &sts.GetCallerIdentityOutput{
 		Arn: aws.String(m.ARN),
+	}, nil
+}
+
+func (m *STSMock) AssumeRole(in *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	return m.AssumeRoleWithContext(context.Background(), in)
+}
+
+func (m *STSMock) AssumeRoleWithContext(ctx aws.Context, in *sts.AssumeRoleInput, _ ...request.Option) (*sts.AssumeRoleOutput, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if !slices.Contains(m.assumedRoleARNs, aws.StringValue(in.RoleArn)) {
+		m.assumedRoleARNs = append(m.assumedRoleARNs, aws.StringValue(in.RoleArn))
+		m.assumedRoleExternalIDs = append(m.assumedRoleExternalIDs, aws.StringValue(in.ExternalId))
+	}
+	expiry := time.Now().Add(60 * time.Minute)
+	return &sts.AssumeRoleOutput{
+		Credentials: &sts.Credentials{
+			AccessKeyId:     in.RoleArn,
+			SecretAccessKey: aws.String("secret"),
+			SessionToken:    aws.String("token"),
+			Expiration:      &expiry,
+		},
 	}, nil
 }
 
@@ -321,9 +369,16 @@ func (m *IAMMock) DeleteUserPolicyWithContext(ctx aws.Context, input *iam.Delete
 // RedshiftMock mocks AWS Redshift API.
 type RedshiftMock struct {
 	redshiftiface.RedshiftAPI
-	Clusters []*redshift.Cluster
+	Clusters                    []*redshift.Cluster
+	GetClusterCredentialsOutput *redshift.GetClusterCredentialsOutput
 }
 
+func (m *RedshiftMock) GetClusterCredentialsWithContext(aws.Context, *redshift.GetClusterCredentialsInput, ...request.Option) (*redshift.GetClusterCredentialsOutput, error) {
+	if m.GetClusterCredentialsOutput == nil {
+		return nil, trace.AccessDenied("access denied")
+	}
+	return m.GetClusterCredentialsOutput, nil
+}
 func (m *RedshiftMock) DescribeClustersWithContext(ctx aws.Context, input *redshift.DescribeClustersInput, options ...request.Option) (*redshift.DescribeClustersOutput, error) {
 	if aws.StringValue(input.ClusterIdentifier) == "" {
 		return &redshift.DescribeClustersOutput{
@@ -698,4 +753,16 @@ func instanceEngineMatches(instance *rds.DBInstance, filterSet map[string]struct
 func clusterEngineMatches(cluster *rds.DBCluster, filterSet map[string]struct{}) bool {
 	_, ok := filterSet[aws.StringValue(cluster.Engine)]
 	return ok
+}
+
+// RedshiftGetClusterCredentialsOutput return a sample redshift.GetClusterCredentialsOutput.
+func RedshiftGetClusterCredentialsOutput(user, password string, clock clockwork.Clock) *redshift.GetClusterCredentialsOutput {
+	if clock == nil {
+		clock = clockwork.NewRealClock()
+	}
+	return &redshift.GetClusterCredentialsOutput{
+		DbUser:     aws.String(user),
+		DbPassword: aws.String(password),
+		Expiration: aws.Time(clock.Now().Add(15 * time.Minute)),
+	}
 }

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -473,6 +473,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 				require.ElementsMatch(t, tt.wantCommandLabels, got.DynamicLabels)
 				require.Equal(t, tt.flags.DatabaseAWSRegion, got.AWS.Region)
 				require.Equal(t, tt.flags.DatabaseAWSAccountID, got.AWS.AccountID)
+				require.Equal(t, tt.flags.DatabaseAWSAssumeRoleARN, got.AWS.AssumeRoleARN)
 				require.Equal(t, tt.flags.DatabaseAWSExternalID, got.AWS.ExternalID)
 				require.Equal(t, tt.flags.DatabaseAWSRedshiftClusterID, got.AWS.Redshift.ClusterID)
 				require.Equal(t, tt.flags.DatabaseAWSRDSClusterID, got.AWS.RDS.ClusterID)

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -136,7 +136,9 @@ func getAWSCredentials(ctx context.Context, cloudClients cloud.Clients, cluster 
 // getAWSClientRestConfig creates a dynamicCredsClient that generates returns credentials to EKS clusters.
 func getAWSClientRestConfig(cloudClients cloud.Clients) dynamicCredsClient {
 	return func(ctx context.Context, cluster types.KubeCluster) (*rest.Config, time.Time, error) {
-		regionalClient, err := cloudClients.GetAWSEKSClient(cluster.GetAWSConfig().Region)
+		// TODO(gavin): support assume_role_arn for AWS EKS.
+		region := cluster.GetAWSConfig().Region
+		regionalClient, err := cloudClients.GetAWSEKSClient(ctx, region)
 		if err != nil {
 			return nil, time.Time{}, trace.Wrap(err)
 		}
@@ -158,7 +160,7 @@ func getAWSClientRestConfig(cloudClients cloud.Clients) dynamicCredsClient {
 			return nil, time.Time{}, trace.BadParameter("invalid api endpoint for cluster %q", cluster.GetAWSConfig().Name)
 		}
 
-		stsClient, err := cloudClients.GetAWSSTSClient(cluster.GetAWSConfig().Region)
+		stsClient, err := cloudClients.GetAWSSTSClient(ctx, region)
 		if err != nil {
 			return nil, time.Time{}, trace.Wrap(err)
 		}

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -121,7 +121,11 @@ func (c *TLSServerConfig) CheckAndSetDefaults() error {
 		c.Log = logrus.New()
 	}
 	if c.CloudClients == nil {
-		c.CloudClients = cloud.NewClients()
+		cloudClients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.CloudClients = cloudClients
 	}
 	if c.ConnectedProxyGetter == nil {
 		c.ConnectedProxyGetter = reversetunnel.NewConnectedProxyGetter()

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/discovery"
 )
 
@@ -57,7 +56,6 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 
 	discoveryService, err := discovery.New(process.ExitContext(), &discovery.Config{
-		Clients:       cloud.NewClients(),
 		AWSMatchers:   process.Config.Discovery.AWSMatchers,
 		AzureMatchers: process.Config.Discovery.AzureMatchers,
 		GCPMatchers:   process.Config.Discovery.GCPMatchers,

--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -88,7 +88,10 @@ func (s *HandlerConfig) CheckAndSetDefaults() error {
 		s.Log = logrus.WithField(trace.Component, "gcp:fwd")
 	}
 	if s.cloudClientGCP == nil {
-		clients := cloud.NewClients()
+		clients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		s.cloudClientGCP = &cloudClientGCPImpl[*gcpcredentials.IamCredentialsClient]{getGCPIAMClient: clients.GetGCPIAMClient}
 	}
 	return nil

--- a/lib/srv/db/auth_test.go
+++ b/lib/srv/db/auth_test.go
@@ -214,15 +214,19 @@ const (
 )
 
 // GetRDSAuthToken generates RDS/Aurora auth token.
-func (a *testAuth) GetRDSAuthToken(sessionCtx *common.Session) (string, error) {
+func (a *testAuth) GetRDSAuthToken(ctx context.Context, sessionCtx *common.Session) (string, error) {
 	a.Infof("Generating RDS auth token for %v.", sessionCtx)
 	return rdsAuthToken, nil
 }
 
 // GetRedshiftAuthToken generates Redshift auth token.
-func (a *testAuth) GetRedshiftAuthToken(sessionCtx *common.Session) (string, string, error) {
+func (a *testAuth) GetRedshiftAuthToken(ctx context.Context, sessionCtx *common.Session) (string, string, error) {
 	a.Infof("Generating Redshift auth token for %v.", sessionCtx)
 	return redshiftAuthUser, redshiftAuthToken, nil
+}
+
+func (a *testAuth) GetRedshiftServerlessAuthToken(ctx context.Context, sessionCtx *common.Session) (string, string, error) {
+	return "", "", trace.NotImplemented("GetRedshiftServerlessAuthToken is not implemented")
 }
 
 // GetCloudSQLAuthToken generates Cloud SQL auth token.

--- a/lib/srv/db/cassandra/engine.go
+++ b/lib/srv/db/cassandra/engine.go
@@ -291,14 +291,15 @@ func (e *Engine) handshake(sessionCtx *common.Session, clientConn, serverConn *p
 		return trace.Wrap(err)
 	}
 	e.handshakeTriggered = true
-	return auth.handleHandshake(clientConn, serverConn)
+	return auth.handleHandshake(e.Context, clientConn, serverConn)
 }
 
 func (e *Engine) getAuth(sessionCtx *common.Session) (handshakeHandler, error) {
 	switch {
 	case sessionCtx.Database.IsAWSHosted():
 		return &authAWSSigV4Auth{
-			ses: sessionCtx,
+			cloudClients: e.CloudClients,
+			ses:          sessionCtx,
 		}, nil
 	default:
 		return &basicHandshake{ses: sessionCtx}, nil

--- a/lib/srv/db/cassandra/handshake.go
+++ b/lib/srv/db/cassandra/handshake.go
@@ -17,8 +17,8 @@ limitations under the License.
 package cassandra
 
 import (
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
-	awssession "github.com/aws/aws-sdk-go/aws/session"
+	"context"
+
 	"github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin/sigv4"
 	"github.com/datastax/go-cassandra-native-protocol/frame"
 	"github.com/datastax/go-cassandra-native-protocol/message"
@@ -26,6 +26,7 @@ import (
 	"github.com/gocql/gocql"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/srv/db/cassandra/protocol"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
@@ -45,7 +46,7 @@ const (
 // Client -> Server: AuthResponse
 // Server <- Client: Ready/ErrorResponse/AuthSuccess
 type handshakeHandler interface {
-	handleHandshake(clientConn, serverConn *protocol.Conn) error
+	handleHandshake(ctx context.Context, clientConn, serverConn *protocol.Conn) error
 }
 
 // basicHandshake is a basic handshake handler that does not perform any
@@ -54,7 +55,7 @@ type basicHandshake struct {
 	ses *common.Session
 }
 
-func (pp *basicHandshake) handleHandshake(clientConn, serverConn *protocol.Conn) error {
+func (pp *basicHandshake) handleHandshake(_ context.Context, clientConn, serverConn *protocol.Conn) error {
 	for {
 		// Read a packet from the cassandra client.
 		req, err := clientConn.ReadPacket()
@@ -187,28 +188,35 @@ func sendAuthenticationErrorMessage(authErr error, clientConn *protocol.Conn, in
 
 // authHandler is a handler that performs the Cassandra authentication flow.
 type authAWSSigV4Auth struct {
-	ses *common.Session
+	ses          *common.Session
+	cloudClients cloud.Clients
 }
 
-func (a *authAWSSigV4Auth) getSigV4Authenticator(username string) (gocql.Authenticator, error) {
-	session, err := awssession.NewSessionWithOptions(awssession.Options{
-		SharedConfigState: awssession.SharedConfigEnable,
-	})
+func (a *authAWSSigV4Auth) getSigV4Authenticator(ctx context.Context) (gocql.Authenticator, error) {
+	meta := a.ses.Database.GetAWS()
+	roleARN, err := awsutils.BuildRoleARN(a.ses.DatabaseUser, meta.Region, meta.AccountID)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	region := a.ses.Database.GetAWS().Region
-	accountID := a.ses.Database.GetAWS().AccountID
-	roleARN, err := awsutils.BuildRoleARN(username, region, accountID)
+	baseSession, err := a.cloudClients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	cred, err := stscreds.NewCredentials(session, roleARN).Get()
+	var externalID string
+	if meta.AssumeRoleARN == "" {
+		externalID = meta.ExternalID
+	}
+	session, err := a.cloudClients.GetAWSSession(ctx, meta.Region,
+		cloud.WithChainedAssumeRole(baseSession, roleARN, externalID))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cred, err := session.Config.Credentials.GetWithContext(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	auth := sigv4.NewAwsAuthenticator()
-	auth.Region = region
+	auth.Region = meta.Region
 	auth.AccessKeyId = cred.AccessKeyID
 	auth.SessionToken = cred.SessionToken
 	auth.SecretAccessKey = cred.SecretAccessKey
@@ -231,7 +239,7 @@ func (a *authAWSSigV4Auth) initPasswordAuth(clientConn *protocol.Conn, req *prot
 	return pkt, nil
 }
 
-func (a *authAWSSigV4Auth) handleStartupMessage(clientConn, serverConn *protocol.Conn, req *protocol.Packet) error {
+func (a *authAWSSigV4Auth) handleStartupMessage(ctx context.Context, clientConn, serverConn *protocol.Conn, req *protocol.Packet) error {
 	authResp, err := a.initPasswordAuth(clientConn, req)
 	if err != nil {
 		return trace.Wrap(err)
@@ -247,7 +255,7 @@ func (a *authAWSSigV4Auth) handleStartupMessage(clientConn, serverConn *protocol
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.handleAuth(clientConn, serverConn, authFrame.Frame()); err != nil {
+	if err := a.handleAuth(ctx, clientConn, serverConn, authFrame.Frame()); err != nil {
 		// Likely the agent is not authorized to access AWS resources or
 		// the AWS configuration doesn't allow the agent to assume the role.
 		userErr := trace.AccessDenied(
@@ -278,7 +286,7 @@ func (a *authAWSSigV4Auth) handleStartupMessage(clientConn, serverConn *protocol
 // Client    Engine -> AWS: AuthResponse
 // Client    Engine <- AWS: AuthSuccess
 // Client <- Engine    AWS: AuthSuccess
-func (a *authAWSSigV4Auth) handleHandshake(clientConn, serverConn *protocol.Conn) error {
+func (a *authAWSSigV4Auth) handleHandshake(ctx context.Context, clientConn, serverConn *protocol.Conn) error {
 	for {
 		req, err := clientConn.ReadPacket()
 		if err != nil {
@@ -286,7 +294,7 @@ func (a *authAWSSigV4Auth) handleHandshake(clientConn, serverConn *protocol.Conn
 		}
 		switch req.Header().OpCode {
 		case primitive.OpCodeStartup:
-			if err := a.handleStartupMessage(clientConn, serverConn, req); err != nil {
+			if err := a.handleStartupMessage(ctx, clientConn, serverConn, req); err != nil {
 				return trace.Wrap(err)
 			}
 			return nil
@@ -308,12 +316,12 @@ func (a *authAWSSigV4Auth) handleHandshake(clientConn, serverConn *protocol.Conn
 // handleAuth is a function that handles the authentication flow with AWS Keyspaces.
 // Signature V4 is used to authenticate with AWS Keyspaces where the username is the role ARN.
 // STS AWS is used to get temporary credentials for the role.
-func (a *authAWSSigV4Auth) handleAuth(_, serverConn *protocol.Conn, fr *frame.Frame) error {
+func (a *authAWSSigV4Auth) handleAuth(ctx context.Context, _, serverConn *protocol.Conn, fr *frame.Frame) error {
 	authMsg, ok := fr.Body.Message.(*message.Authenticate)
 	if !ok {
 		return trace.BadParameter("unexpected message type %T", fr.Body.Message)
 	}
-	awsAuth, err := a.getSigV4Authenticator(a.ses.DatabaseUser)
+	awsAuth, err := a.getSigV4Authenticator(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/aws.go
+++ b/lib/srv/db/cloud/aws.go
@@ -68,11 +68,12 @@ func newAWS(ctx context.Context, config awsConfig) (*awsClient, error) {
 	if err := config.Check(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	rds, err := config.clients.GetAWSRDSClient(config.database.GetAWS().Region)
+	meta := config.database.GetAWS()
+	rds, err := config.clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	iam, err := config.clients.GetAWSIAMClient(config.database.GetAWS().Region)
+	iam, err := config.clients.GetAWSIAMClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -147,17 +148,18 @@ func (r *awsClient) ensureIAMAuth(ctx context.Context) error {
 func (r *awsClient) enableIAMAuthForRDS(ctx context.Context) error {
 	r.log.Debug("Enabling IAM auth for RDS.")
 	var err error
-	if r.cfg.database.GetAWS().RDS.ClusterID != "" {
+	meta := r.cfg.database.GetAWS()
+	if meta.RDS.ClusterID != "" {
 		_, err = r.rds.ModifyDBClusterWithContext(ctx, &rds.ModifyDBClusterInput{
-			DBClusterIdentifier:             aws.String(r.cfg.database.GetAWS().RDS.ClusterID),
+			DBClusterIdentifier:             aws.String(meta.RDS.ClusterID),
 			EnableIAMDatabaseAuthentication: aws.Bool(true),
 			ApplyImmediately:                aws.Bool(true),
 		})
 		return awslib.ConvertIAMError(err)
 	}
-	if r.cfg.database.GetAWS().RDS.InstanceID != "" {
+	if meta.RDS.InstanceID != "" {
 		_, err = r.rds.ModifyDBInstanceWithContext(ctx, &rds.ModifyDBInstanceInput{
-			DBInstanceIdentifier:            aws.String(r.cfg.database.GetAWS().RDS.InstanceID),
+			DBInstanceIdentifier:            aws.String(meta.RDS.InstanceID),
 			EnableIAMDatabaseAuthentication: aws.Bool(true),
 			ApplyImmediately:                aws.Bool(true),
 		})

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -59,7 +59,11 @@ func (c *IAMConfig) Check() error {
 		return trace.BadParameter("missing AccessPoint")
 	}
 	if c.Clients == nil {
-		c.Clients = cloud.NewClients()
+		cloudClients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Clients = cloudClients
 	}
 	if c.HostID == "" {
 		return trace.BadParameter("missing HostID")

--- a/lib/srv/db/cloud/iam.go
+++ b/lib/srv/db/cloud/iam.go
@@ -18,6 +18,7 @@ package cloud
 
 import (
 	"context"
+	"encoding/base64"
 	"sync"
 	"time"
 
@@ -83,11 +84,15 @@ type iamTask struct {
 // same policy. These tasks are processed in a background goroutine to avoid
 // blocking callers when acquiring the locks with retries.
 type IAM struct {
-	cfg         IAMConfig
-	log         logrus.FieldLogger
-	awsIdentity awslib.Identity
-	mu          sync.RWMutex
-	tasks       chan iamTask
+	cfg IAMConfig
+	log logrus.FieldLogger
+	// agentIdentity is the db agent's identity, as determined by
+	// shared config credential chain used to call AWS STS GetCallerIdentity.
+	// Use getAWSIdentity to get the correct identity for a database,
+	// which may have assume_role_arn set.
+	agentIdentity awslib.Identity
+	mu            sync.RWMutex
+	tasks         chan iamTask
 }
 
 // NewIAM returns a new IAM configurator service.
@@ -161,7 +166,7 @@ func (c *IAM) isSetupRequiredForDatabase(database types.Database) bool {
 
 // getAWSConfigurator returns configurator instance for the provided database.
 func (c *IAM) getAWSConfigurator(ctx context.Context, database types.Database) (*awsClient, error) {
-	identity, err := c.getAWSIdentity(ctx)
+	identity, err := c.getAWSIdentity(ctx, database)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -177,15 +182,23 @@ func (c *IAM) getAWSConfigurator(ctx context.Context, database types.Database) (
 	})
 }
 
-// getAWSIdentity returns this process' AWS identity.
-func (c *IAM) getAWSIdentity(ctx context.Context) (awslib.Identity, error) {
+// getAWSIdentity returns the identity used to access the given database,
+// that is either the agent's identity or the database's configured assume-role.
+func (c *IAM) getAWSIdentity(ctx context.Context, database types.Database) (awslib.Identity, error) {
+	meta := database.GetAWS()
+	if meta.AssumeRoleARN != "" {
+		// If the database has an assume role ARN, use that instead of
+		// agent identity. This avoids an unnecessary sts call too.
+		return awslib.IdentityFromArn(meta.AssumeRoleARN)
+	}
+
 	c.mu.RLock()
-	if c.awsIdentity != nil {
+	if c.agentIdentity != nil {
 		defer c.mu.RUnlock()
-		return c.awsIdentity, nil
+		return c.agentIdentity, nil
 	}
 	c.mu.RUnlock()
-	sts, err := c.cfg.Clients.GetAWSSTSClient("")
+	sts, err := c.cfg.Clients.GetAWSSTSClient(ctx, meta.Region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -195,8 +208,8 @@ func (c *IAM) getAWSIdentity(ctx context.Context) (awslib.Identity, error) {
 	}
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.awsIdentity = awsIdentity
-	return c.awsIdentity, nil
+	c.agentIdentity = awsIdentity
+	return c.agentIdentity, nil
 }
 
 // getPolicyName returns the inline policy name.
@@ -229,6 +242,10 @@ func (c *IAM) processTask(ctx context.Context, task iamTask) error {
 		return trace.Wrap(err)
 	}
 
+	// Encode the identity as base64 without padding, since the backend Sanetizer
+	// will reject any semaphor with "//" in it.
+	semName := configurator.cfg.identity.String()
+	encodedName := base64.RawStdEncoding.EncodeToString([]byte(semName))
 	// Acquire a semaphore before making changes to the shared IAM policy.
 	//
 	// TODO(greedy52) ideally tasks can be bundled so the semaphore is acquired
@@ -237,8 +254,11 @@ func (c *IAM) processTask(ctx context.Context, task iamTask) error {
 		Service: c.cfg.AccessPoint,
 		Request: types.AcquireSemaphoreRequest{
 			SemaphoreKind: configurator.cfg.policyName,
-			SemaphoreName: configurator.cfg.identity.GetName(),
+			// Use full identity string as the semaphore name, since two roles
+			// may have the same name in different AWS accounts.
+			SemaphoreName: encodedName,
 			MaxLeases:     1,
+			Holder:        c.cfg.HostID,
 
 			// If the semaphore fails to release for some reason, it will expire in a
 			// minute on its own.

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -49,7 +49,11 @@ type MetadataConfig struct {
 // Check validates the metadata service config.
 func (c *MetadataConfig) Check() error {
 	if c.Clients == nil {
-		c.Clients = cloud.NewClients()
+		cloudClients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Clients = cloudClients
 	}
 	return nil
 }

--- a/lib/srv/db/cloud/meta.go
+++ b/lib/srv/db/cloud/meta.go
@@ -92,7 +92,8 @@ func (m *Metadata) Update(ctx context.Context, database types.Database) error {
 
 // updateAWS updates cloud metadata of the provided AWS database.
 func (m *Metadata) updateAWS(ctx context.Context, database types.Database, fetchFn func(context.Context, types.Database) (*types.AWS, error)) error {
-	metadata, err := fetchFn(ctx, database)
+	meta := database.GetAWS()
+	fetchedMeta, err := fetchFn(ctx, database)
 	if err != nil {
 		if trace.IsAccessDenied(err) { // Permission errors are expected.
 			m.log.WithError(err).Debugf("No permissions to fetch metadata for %q.", database)
@@ -101,61 +102,65 @@ func (m *Metadata) updateAWS(ctx context.Context, database types.Database, fetch
 		return trace.Wrap(err)
 	}
 
-	m.log.Debugf("Fetched metadata for %q: %v.", database, metadata)
-	database.SetStatusAWS(*metadata)
+	m.log.Debugf("Fetched metadata for %q: %v.", database, fetchedMeta)
+	fetchedMeta.AssumeRoleARN = meta.AssumeRoleARN
+	fetchedMeta.ExternalID = meta.ExternalID
+	database.SetStatusAWS(*fetchedMeta)
 	return nil
 }
 
 // fetchRDSMetadata fetches metadata for the provided RDS or Aurora database.
 func (m *Metadata) fetchRDSMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
-	rds, err := m.cfg.Clients.GetAWSRDSClient(database.GetAWS().Region)
+	meta := database.GetAWS()
+	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if database.GetAWS().RDS.ClusterID != "" {
-		return fetchRDSClusterMetadata(ctx, rds, database.GetAWS().RDS.ClusterID)
+	if meta.RDS.ClusterID != "" {
+		return fetchRDSClusterMetadata(ctx, rds, meta.RDS.ClusterID)
 	}
 
-	// Try to fetch the RDS instance metadata.
-	metadata, err := fetchRDSInstanceMetadata(ctx, rds, database.GetAWS().RDS.InstanceID)
+	// Try to fetch the RDS instance fetchedMeta.
+	fetchedMeta, err := fetchRDSInstanceMetadata(ctx, rds, meta.RDS.InstanceID)
 	if err != nil && !trace.IsNotFound(err) && !trace.IsAccessDenied(err) {
 		return nil, trace.Wrap(err)
 	}
 	// If RDS instance metadata wasn't found, it may be an Aurora cluster.
-	if metadata == nil {
+	if fetchedMeta == nil {
 		// Aurora cluster ID may be either explicitly specified or parsed
 		// from endpoint in which case it will be in InstanceID field.
-		clusterID := database.GetAWS().RDS.ClusterID
+		clusterID := meta.RDS.ClusterID
 		if clusterID == "" {
-			clusterID = database.GetAWS().RDS.InstanceID
+			clusterID = meta.RDS.InstanceID
 		}
 		return fetchRDSClusterMetadata(ctx, rds, clusterID)
 	}
 	// If instance was found, it may be a part of an Aurora cluster.
-	if metadata.RDS.ClusterID != "" {
-		return fetchRDSClusterMetadata(ctx, rds, metadata.RDS.ClusterID)
+	if fetchedMeta.RDS.ClusterID != "" {
+		return fetchRDSClusterMetadata(ctx, rds, fetchedMeta.RDS.ClusterID)
 	}
-	return metadata, nil
+	return fetchedMeta, nil
 }
 
 // fetchRDSProxyMetadata fetches metadata for the provided RDS Proxy database.
 func (m *Metadata) fetchRDSProxyMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
-	rds, err := m.cfg.Clients.GetAWSRDSClient(database.GetAWS().Region)
+	meta := database.GetAWS()
+	rds, err := m.cfg.Clients.GetAWSRDSClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if database.GetAWS().RDSProxy.CustomEndpointName != "" {
-		return fetchRDSProxyCustomEndpointMetadata(ctx, rds, database.GetAWS().RDSProxy.CustomEndpointName, database.GetURI())
+	if meta.RDSProxy.CustomEndpointName != "" {
+		return fetchRDSProxyCustomEndpointMetadata(ctx, rds, meta.RDSProxy.CustomEndpointName, database.GetURI())
 	}
-	return fetchRDSProxyMetadata(ctx, rds, database.GetAWS().RDSProxy.Name)
+	return fetchRDSProxyMetadata(ctx, rds, meta.RDSProxy.Name)
 }
 
 // fetchRedshiftMetadata fetches metadata for the provided Redshift database.
 func (m *Metadata) fetchRedshiftMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	redshift, err := m.cfg.Clients.GetAWSRedshiftClient(meta.Region)
+	redshift, err := m.cfg.Clients.GetAWSRedshiftClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -163,18 +168,14 @@ func (m *Metadata) fetchRedshiftMetadata(ctx context.Context, database types.Dat
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	fetchedMetadata, err := services.MetadataFromRedshiftCluster(cluster)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return fetchedMetadata, nil
+	return services.MetadataFromRedshiftCluster(cluster)
 }
 
 // fetchRedshiftServerlessMetadata fetches metadata for the provided Redshift
 // Serverless database.
 func (m *Metadata) fetchRedshiftServerlessMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	client, err := m.cfg.Clients.GetAWSRedshiftServerlessClient(meta.Region)
+	client, err := m.cfg.Clients.GetAWSRedshiftServerlessClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -188,7 +189,7 @@ func (m *Metadata) fetchRedshiftServerlessMetadata(ctx context.Context, database
 // fetchElastiCacheMetadata fetches metadata for the provided ElastiCache database.
 func (m *Metadata) fetchElastiCacheMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	elastiCacheClient, err := m.cfg.Clients.GetAWSElastiCacheClient(meta.Region)
+	elastiCacheClient, err := m.cfg.Clients.GetAWSElastiCacheClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -205,7 +206,7 @@ func (m *Metadata) fetchElastiCacheMetadata(ctx context.Context, database types.
 // fetchMemoryDBMetadata fetches metadata for the provided MemoryDB database.
 func (m *Metadata) fetchMemoryDBMetadata(ctx context.Context, database types.Database) (*types.AWS, error) {
 	meta := database.GetAWS()
-	memoryDBClient, err := m.cfg.Clients.GetAWSMemoryDBClient(meta.Region)
+	memoryDBClient, err := m.cfg.Clients.GetAWSMemoryDBClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/meta_test.go
+++ b/lib/srv/db/cloud/meta_test.go
@@ -114,6 +114,8 @@ func TestAWSMetadata(t *testing.T) {
 		},
 	}
 
+	stsMock := &mocks.STSMock{}
+
 	// Configure Redshift Serverless API mock.
 	redshiftServerlessWorkgroup := mocks.RedshiftServerlessWorkgroup("my-workgroup", "us-west-1")
 	redshiftServerlessEndpoint := mocks.RedshiftServerlessEndpointAccess(redshiftServerlessWorkgroup, "my-endpoint", "us-west-1")
@@ -130,6 +132,7 @@ func TestAWSMetadata(t *testing.T) {
 			ElastiCache:        elasticache,
 			MemoryDB:           memorydb,
 			RedshiftServerless: redshiftServerless,
+			STS:                stsMock,
 		},
 	})
 	require.NoError(t, err)
@@ -142,13 +145,17 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "RDS instance",
 			inAWS: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDS: types.RDS{
 					InstanceID: "postgres-rds",
 				},
 			},
 			outAWS: types.AWS{
-				Region:    "us-west-1",
-				AccountID: "123456789012",
+				Region:        "us-west-1",
+				AccountID:     "123456789012",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDS: types.RDS{
 					InstanceID: "postgres-rds",
 					ResourceID: "db-xyz",
@@ -159,13 +166,17 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "Aurora cluster",
 			inAWS: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDS: types.RDS{
 					InstanceID: "postgres-aurora",
 				},
 			},
 			outAWS: types.AWS{
-				Region:    "us-east-1",
-				AccountID: "123456789012",
+				Region:        "us-east-1",
+				AccountID:     "123456789012",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDS: types.RDS{
 					ClusterID:  "postgres-aurora",
 					ResourceID: "cluster-xyz",
@@ -175,13 +186,17 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "RDS instance, part of Aurora cluster",
 			inAWS: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDS: types.RDS{
 					InstanceID: "postgres-aurora-1",
 				},
 			},
 			outAWS: types.AWS{
-				Region:    "us-east-1",
-				AccountID: "123456789012",
+				Region:        "us-east-1",
+				AccountID:     "123456789012",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDS: types.RDS{
 					ClusterID:  "postgres-aurora",
 					ResourceID: "cluster-xyz",
@@ -191,13 +206,17 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "Redshift cluster 1",
 			inAWS: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				Redshift: types.Redshift{
 					ClusterID: "redshift-cluster-1",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-west-1",
+				AccountID:     "123456789012",
+				Region:        "us-west-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				Redshift: types.Redshift{
 					ClusterID: "redshift-cluster-1",
 				},
@@ -206,13 +225,17 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "Redshift cluster 2",
 			inAWS: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				Redshift: types.Redshift{
 					ClusterID: "redshift-cluster-2",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "210987654321",
-				Region:    "us-east-2",
+				AccountID:     "210987654321",
+				Region:        "us-east-2",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				Redshift: types.Redshift{
 					ClusterID: "redshift-cluster-2",
 				},
@@ -221,14 +244,18 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "ElastiCache",
 			inAWS: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				ElastiCache: types.ElastiCache{
 					ReplicationGroupID: "my-redis",
 					EndpointType:       "configuration",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-west-1",
+				AccountID:     "123456789012",
+				Region:        "us-west-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				ElastiCache: types.ElastiCache{
 					ReplicationGroupID:       "my-redis",
 					UserGroupIDs:             []string{"my-user-group"},
@@ -240,14 +267,18 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "MemoryDB",
 			inAWS: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				MemoryDB: types.MemoryDB{
 					ClusterName:  "my-cluster",
 					EndpointType: "cluster",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-west-1",
+				AccountID:     "123456789012",
+				Region:        "us-west-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				MemoryDB: types.MemoryDB{
 					ClusterName:  "my-cluster",
 					ACLName:      "my-user-group",
@@ -259,14 +290,18 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "RDS Proxy",
 			inAWS: types.AWS{
-				Region: "us-east-1",
+				Region:        "us-east-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDSProxy: types.RDSProxy{
 					Name: "rds-proxy",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-east-1",
+				AccountID:     "123456789012",
+				Region:        "us-east-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDSProxy: types.RDSProxy{
 					Name:       "rds-proxy",
 					ResourceID: "prx-resource-id",
@@ -276,14 +311,18 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "RDS Proxy custom endpoint",
 			inAWS: types.AWS{
-				Region: "us-east-1",
+				Region:        "us-east-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDSProxy: types.RDSProxy{
 					CustomEndpointName: "rds-proxy-endpoint",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-east-1",
+				AccountID:     "123456789012",
+				Region:        "us-east-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDSProxy: types.RDSProxy{
 					Name:               "rds-proxy",
 					CustomEndpointName: "rds-proxy-endpoint",
@@ -294,14 +333,18 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "Redshift Serverless workgroup",
 			inAWS: types.AWS{
-				Region: "us-west-1",
+				Region:        "us-west-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RedshiftServerless: types.RedshiftServerless{
 					WorkgroupName: "my-workgroup",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-west-1",
+				AccountID:     "123456789012",
+				Region:        "us-west-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RedshiftServerless: types.RedshiftServerless{
 					WorkgroupName: "my-workgroup",
 					WorkgroupID:   "some-uuid-for-my-workgroup",
@@ -311,14 +354,18 @@ func TestAWSMetadata(t *testing.T) {
 		{
 			name: "Redshift Serverless VPC endpoint",
 			inAWS: types.AWS{
-				Region: "us-west-1",
+				Region:        "us-west-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RedshiftServerless: types.RedshiftServerless{
 					EndpointName: "my-endpoint",
 				},
 			},
 			outAWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-west-1",
+				AccountID:     "123456789012",
+				Region:        "us-west-1",
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RedshiftServerless: types.RedshiftServerless{
 					WorkgroupName: "my-workgroup",
 					EndpointName:  "my-endpoint",
@@ -343,6 +390,9 @@ func TestAWSMetadata(t *testing.T) {
 			err = metadata.Update(ctx, database)
 			require.NoError(t, err)
 			require.Equal(t, test.outAWS, database.GetAWS())
+			require.Equal(t, []string{test.inAWS.AssumeRoleARN}, stsMock.GetAssumedRoleARNs())
+			require.Equal(t, []string{test.inAWS.ExternalID}, stsMock.GetAssumedRoleExternalIDs())
+			stsMock.ResetAssumeRoleHistory()
 		})
 	}
 }
@@ -354,11 +404,14 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 	rds := &mocks.RDSMockUnauth{}
 	redshift := &mocks.RedshiftMockUnauth{}
 
+	stsMock := &mocks.STSMock{}
+
 	// Create metadata fetcher.
 	metadata, err := NewMetadata(MetadataConfig{
 		Clients: &cloud.TestCloudClients{
 			RDS:      rds,
 			Redshift: redshift,
+			STS:      stsMock,
 		},
 	})
 	require.NoError(t, err)
@@ -370,6 +423,8 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 		{
 			name: "RDS instance",
 			meta: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDS: types.RDS{
 					InstanceID: "postgres-rds",
 				},
@@ -378,6 +433,8 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 		{
 			name: "RDS proxy",
 			meta: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDSProxy: types.RDSProxy{
 					Name: "rds-proxy",
 				},
@@ -386,6 +443,8 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 		{
 			name: "RDS proxy endpoint",
 			meta: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				RDSProxy: types.RDSProxy{
 					CustomEndpointName: "rds-proxy-endpoint",
 				},
@@ -394,6 +453,8 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 		{
 			name: "Redshift cluster",
 			meta: types.AWS{
+				AssumeRoleARN: "arn:aws:iam::123456789012:role/DBDiscoverer",
+				ExternalID:    "externalID123",
 				Redshift: types.Redshift{
 					ClusterID: "redshift-cluster-1",
 				},
@@ -417,6 +478,9 @@ func TestAWSMetadataNoPermissions(t *testing.T) {
 			err = metadata.Update(ctx, database)
 			require.NoError(t, err)
 			require.Equal(t, test.meta, database.GetAWS())
+			require.Equal(t, []string{test.meta.AssumeRoleARN}, stsMock.GetAssumedRoleARNs())
+			require.Equal(t, []string{test.meta.ExternalID}, stsMock.GetAssumedRoleExternalIDs())
+			stsMock.ResetAssumeRoleHistory()
 		})
 	}
 }

--- a/lib/srv/db/cloud/users/elasticache.go
+++ b/lib/srv/db/cloud/users/elasticache.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
 	libaws "github.com/gravitational/teleport/lib/cloud/aws"
 	libsecrets "github.com/gravitational/teleport/lib/srv/db/secrets"
 	libutils "github.com/gravitational/teleport/lib/utils"
@@ -71,12 +72,12 @@ func (f *elastiCacheFetcher) FetchDatabaseUsers(ctx context.Context, database ty
 		return nil, nil
 	}
 
-	client, err := f.cfg.Clients.GetAWSElastiCacheClient(meta.Region)
+	client, err := f.cfg.Clients.GetAWSElastiCacheClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	secrets, err := newSecretStore(database, f.cfg.Clients)
+	secrets, err := newSecretStore(ctx, database, f.cfg.Clients)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/helpers.go
+++ b/lib/srv/db/cloud/users/helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package users
 
 import (
+	"context"
 	"strings"
 	"sync"
 
@@ -152,11 +153,11 @@ func genRandomPassword(length int) (string, error) {
 }
 
 // newSecretStore create a new secrets store helper for provided database.
-func newSecretStore(database types.Database, clients cloud.Clients) (secrets.Secrets, error) {
+func newSecretStore(ctx context.Context, database types.Database, clients cloud.Clients) (secrets.Secrets, error) {
 	secretStoreConfig := database.GetSecretStore()
 
 	meta := database.GetAWS()
-	client, err := clients.GetAWSSecretsManagerClient(meta.Region)
+	client, err := clients.GetAWSSecretsManagerClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/memorydb.go
+++ b/lib/srv/db/cloud/users/memorydb.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
 	libaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	libsecrets "github.com/gravitational/teleport/lib/srv/db/secrets"
@@ -72,12 +73,12 @@ func (f *memoryDBFetcher) FetchDatabaseUsers(ctx context.Context, database types
 		return nil, nil
 	}
 
-	client, err := f.cfg.Clients.GetAWSMemoryDBClient(meta.Region)
+	client, err := f.cfg.Clients.GetAWSMemoryDBClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	secrets, err := newSecretStore(database, f.cfg.Clients)
+	secrets, err := newSecretStore(ctx, database, f.cfg.Clients)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/cloud/users/users.go
+++ b/lib/srv/db/cloud/users/users.go
@@ -50,7 +50,11 @@ func (c *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing UpdateMeta")
 	}
 	if c.Clients == nil {
-		c.Clients = cloud.NewClients()
+		cloudClients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Clients = cloudClients
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -114,7 +114,11 @@ func (c *AuthConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing AuthClient")
 	}
 	if c.Clients == nil {
-		c.Clients = cloud.NewClients()
+		cloudClients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Clients = cloudClients
 	}
 	if c.Clock == nil {
 		c.Clock = clockwork.NewRealClock()

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -61,9 +61,9 @@ const azureVirtualMachineCacheTTL = 5 * time.Minute
 // Auth defines interface for creating auth tokens and TLS configurations.
 type Auth interface {
 	// GetRDSAuthToken generates RDS/Aurora auth token.
-	GetRDSAuthToken(sessionCtx *Session) (string, error)
+	GetRDSAuthToken(ctx context.Context, sessionCtx *Session) (string, error)
 	// GetRedshiftAuthToken generates Redshift auth token.
-	GetRedshiftAuthToken(sessionCtx *Session) (string, string, error)
+	GetRedshiftAuthToken(ctx context.Context, sessionCtx *Session) (string, string, error)
 	// GetRedshiftServerlessAuthToken generates Redshift Serverless auth token.
 	GetRedshiftServerlessAuthToken(ctx context.Context, sessionCtx *Session) (string, string, error)
 	// GetCloudSQLAuthToken generates Cloud SQL auth token.
@@ -157,9 +157,9 @@ func NewAuth(config AuthConfig) (Auth, error) {
 
 // GetRDSAuthToken returns authorization token that will be used as a password
 // when connecting to RDS and Aurora databases.
-func (a *dbAuth) GetRDSAuthToken(sessionCtx *Session) (string, error) {
+func (a *dbAuth) GetRDSAuthToken(ctx context.Context, sessionCtx *Session) (string, error) {
 	meta := sessionCtx.Database.GetAWS()
-	awsSession, err := a.cfg.Clients.GetAWSSession(meta.Region)
+	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -189,14 +189,14 @@ permissions (note that IAM changes may take a few minutes to propagate):
 
 // GetRedshiftAuthToken returns authorization token that will be used as a
 // password when connecting to Redshift databases.
-func (a *dbAuth) GetRedshiftAuthToken(sessionCtx *Session) (string, string, error) {
+func (a *dbAuth) GetRedshiftAuthToken(ctx context.Context, sessionCtx *Session) (string, string, error) {
 	meta := sessionCtx.Database.GetAWS()
-	awsSession, err := a.cfg.Clients.GetAWSSession(meta.Region)
+	redshiftClient, err := a.cfg.Clients.GetAWSRedshiftClient(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
 	a.cfg.Log.Debugf("Generating Redshift auth token for %s.", sessionCtx)
-	resp, err := redshift.New(awsSession).GetClusterCredentials(&redshift.GetClusterCredentialsInput{
+	resp, err := redshiftClient.GetClusterCredentialsWithContext(ctx, &redshift.GetClusterCredentialsInput{
 		ClusterIdentifier: aws.String(meta.Redshift.ClusterID),
 		DbUser:            aws.String(sessionCtx.DatabaseUser),
 		DbName:            aws.String(sessionCtx.DatabaseName),
@@ -237,7 +237,18 @@ func (a *dbAuth) GetRedshiftServerlessAuthToken(ctx context.Context, sessionCtx 
 	if err != nil {
 		return "", "", trace.Wrap(err)
 	}
-	client, err := a.cfg.Clients.GetAWSRedshiftServerlessClientForRole(ctx, meta.Region, roleARN)
+	baseSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	if err != nil {
+		return "", "", trace.Wrap(err)
+	}
+	var externalID string
+	if meta.AssumeRoleARN == "" {
+		externalID = meta.ExternalID
+	}
+	// Assume the configured AWS role before assuming the role we need to get the
+	// auth token. This allows cross-account AWS access.
+	client, err := a.cfg.Clients.GetAWSRedshiftServerlessClient(ctx, meta.Region,
+		cloud.WithChainedAssumeRole(baseSession, roleARN, externalID))
 	if err != nil {
 		return "", "", trace.AccessDenied(`Could not generate Redshift Serverless auth token:
 

--- a/lib/srv/db/common/auth_test.go
+++ b/lib/srv/db/common/auth_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
@@ -102,11 +103,14 @@ func TestAuthGetAzureCacheForRedisToken(t *testing.T) {
 func TestAuthGetRedshiftServerlessAuthToken(t *testing.T) {
 	t.Parallel()
 
+	// setup mock aws sessions.
+	stsMock := &mocks.STSMock{}
 	clock := clockwork.NewFakeClock()
 	auth, err := NewAuth(AuthConfig{
 		Clock:      clock,
 		AuthClient: new(authClientMock),
 		Clients: &cloud.TestCloudClients{
+			STS: stsMock,
 			RedshiftServerless: &mocks.RedshiftServerlessMock{
 				GetCredentialsOutput: mocks.RedshiftServerlessGetCredentialsOutput("IAM:some-user", "some-password", clock),
 			},
@@ -122,6 +126,8 @@ func TestAuthGetRedshiftServerlessAuthToken(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "IAM:some-user", dbUser)
 	require.Equal(t, "some-password", dbPassword)
+	require.Equal(t, []string{"arn:aws:iam::123456789012:role/some-user"}, stsMock.GetAssumedRoleARNs())
+	require.Equal(t, []string{""}, stsMock.GetAssumedRoleExternalIDs())
 }
 
 func TestAuthGetTLSConfig(t *testing.T) {
@@ -165,12 +171,12 @@ func TestAuthGetTLSConfig(t *testing.T) {
 		},
 		{
 			name:            "AWS ElastiCache Redis",
-			sessionDatabase: newElastiCacheRedisDatabase(t, fixtures.SAMLOktaCertPEM),
+			sessionDatabase: newElastiCacheRedisDatabase(t, withCA(fixtures.SAMLOktaCertPEM)),
 			expectRootCAs:   awsCertPool,
 		},
 		{
 			name:             "AWS Redshift",
-			sessionDatabase:  newRedshiftDatabase(t, fixtures.SAMLOktaCertPEM),
+			sessionDatabase:  newRedshiftDatabase(t, withCA(fixtures.SAMLOktaCertPEM)),
 			expectServerName: "redshift-cluster-1.abcdefghijklmnop.us-east-1.redshift.amazonaws.com",
 			expectRootCAs:    awsCertPool,
 		},
@@ -435,6 +441,107 @@ func TestRedshiftServerlessUsernameToRoleARN(t *testing.T) {
 	}
 }
 
+func TestAuthGetAWSTokenWithAssumedRole(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	tests := map[string]struct {
+		database       types.Database
+		checkGetAuthFn func(t *testing.T, auth Auth, sessionCtx *Session)
+		checkSTS       func(t *testing.T, stsMock *mocks.STSMock)
+	}{
+		"Redshift": {
+			database: newRedshiftDatabase(t,
+				withCA(fixtures.SAMLOktaCertPEM),
+				withAssumeRole(services.AssumeRole{
+					RoleARN:    "arn:aws:iam::123456789012:role/RedshiftRole",
+					ExternalID: "externalRedshift",
+				})),
+			checkGetAuthFn: func(t *testing.T, auth Auth, sessionCtx *Session) {
+				t.Helper()
+				dbUser, dbPassword, err := auth.GetRedshiftAuthToken(ctx, sessionCtx)
+				require.NoError(t, err)
+				require.Equal(t, "IAM:some-user", dbUser)
+				require.Equal(t, "some-password", dbPassword)
+			},
+			checkSTS: func(t *testing.T, stsMock *mocks.STSMock) {
+				t.Helper()
+				require.Contains(t, stsMock.GetAssumedRoleARNs(), "arn:aws:iam::123456789012:role/RedshiftRole")
+				require.Contains(t, stsMock.GetAssumedRoleExternalIDs(), "externalRedshift")
+			},
+		},
+		"Redshift Serverless": {
+			database: newRedshiftServerlessDatabase(t,
+				withAssumeRole(services.AssumeRole{
+					RoleARN:    "arn:aws:iam::123456789012:role/RedshiftServerlessRole",
+					ExternalID: "externalRedshiftServerless",
+				})),
+			checkGetAuthFn: func(t *testing.T, auth Auth, sessionCtx *Session) {
+				t.Helper()
+				dbUser, dbPassword, err := auth.GetRedshiftServerlessAuthToken(ctx, sessionCtx)
+				require.NoError(t, err)
+				require.Equal(t, "IAM:some-user", dbUser)
+				require.Equal(t, "some-password", dbPassword)
+			},
+			checkSTS: func(t *testing.T, stsMock *mocks.STSMock) {
+				t.Helper()
+				require.Contains(t, stsMock.GetAssumedRoleARNs(), "arn:aws:iam::123456789012:role/RedshiftServerlessRole")
+				require.Contains(t, stsMock.GetAssumedRoleExternalIDs(), "externalRedshiftServerless")
+				require.Contains(t, stsMock.GetAssumedRoleARNs(), "arn:aws:iam::123456789012:role/some-user")
+			},
+		},
+		"RDS Proxy": {
+			database: newRDSProxyDatabase(t, "my-proxy.proxy-abcdefghijklmnop.us-east-1.rds.amazonaws.com:5432",
+				withAssumeRole(services.AssumeRole{
+					RoleARN:    "arn:aws:iam::123456789012:role/RDSProxyRole",
+					ExternalID: "externalRDSProxy",
+				})),
+			checkGetAuthFn: func(t *testing.T, auth Auth, sessionCtx *Session) {
+				t.Helper()
+				token, err := auth.GetRDSAuthToken(ctx, sessionCtx)
+				require.NoError(t, err)
+				require.Contains(t, token, "DBUser=some-user")
+			},
+			checkSTS: func(t *testing.T, stsMock *mocks.STSMock) {
+				t.Helper()
+				require.Contains(t, stsMock.GetAssumedRoleARNs(), "arn:aws:iam::123456789012:role/RDSProxyRole")
+				require.Contains(t, stsMock.GetAssumedRoleExternalIDs(), "externalRDSProxy")
+			},
+		},
+	}
+
+	stsMock := &mocks.STSMock{}
+	clock := clockwork.NewFakeClock()
+	auth, err := NewAuth(AuthConfig{
+		Clock:      clock,
+		AuthClient: new(authClientMock),
+		Clients: &cloud.TestCloudClients{
+			STS: stsMock,
+			RDS: &mocks.RDSMock{},
+			Redshift: &mocks.RedshiftMock{
+				GetClusterCredentialsOutput: mocks.RedshiftGetClusterCredentialsOutput("IAM:some-user", "some-password", clock),
+			},
+			RedshiftServerless: &mocks.RedshiftServerlessMock{
+				GetCredentialsOutput: mocks.RedshiftServerlessGetCredentialsOutput("IAM:some-user", "some-password", clock),
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	for name, tt := range tests {
+		tt := tt
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			tt.checkGetAuthFn(t, auth, &Session{
+				DatabaseUser: "some-user",
+				DatabaseName: "some-database",
+				Database:     tt.database,
+			})
+			tt.checkSTS(t, stsMock)
+		})
+	}
+}
+
 func newAzureRedisDatabase(t *testing.T, resourceID string) types.Database {
 	t.Helper()
 
@@ -481,64 +588,89 @@ func newCloudSQLDatabase(t *testing.T, projectID, instanceID string) types.Datab
 	return database
 }
 
-func newElastiCacheRedisDatabase(t *testing.T, ca string) types.Database {
+type databaseSpecOpt func(spec *types.DatabaseSpecV3)
+
+func withCA(ca string) databaseSpecOpt {
+	return func(spec *types.DatabaseSpecV3) {
+		spec.TLS.CACert = ca
+	}
+}
+
+func withAssumeRole(assumeRole services.AssumeRole) databaseSpecOpt {
+	return func(spec *types.DatabaseSpecV3) {
+		spec.AWS.AssumeRoleARN = assumeRole.RoleARN
+		spec.AWS.ExternalID = assumeRole.ExternalID
+	}
+}
+
+func newElastiCacheRedisDatabase(t *testing.T, specOpts ...databaseSpecOpt) types.Database {
 	t.Helper()
 
-	database, err := types.NewDatabaseV3(types.Metadata{
-		Name: "test-database",
-	}, types.DatabaseSpecV3{
+	spec := types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
 		URI:      "master.example-cluster.xxxxxx.cac1.cache.amazonaws.com:6379",
-		TLS: types.DatabaseTLS{
-			CACert: ca,
-		},
-	})
+	}
+	for _, opt := range specOpts {
+		opt(&spec)
+	}
+	database, err := types.NewDatabaseV3(types.Metadata{
+		Name: "test-database",
+	}, spec)
 	require.NoError(t, err)
 	return database
 }
 
-func newRedshiftDatabase(t *testing.T, ca string) types.Database {
+func newRedshiftDatabase(t *testing.T, specOpts ...databaseSpecOpt) types.Database {
 	t.Helper()
 
-	database, err := types.NewDatabaseV3(types.Metadata{
-		Name: "test-database",
-	}, types.DatabaseSpecV3{
+	spec := types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "redshift-cluster-1.abcdefghijklmnop.us-east-1.redshift.amazonaws.com:5432",
-		TLS: types.DatabaseTLS{
-			CACert: ca,
-		},
-	})
+	}
+	for _, opt := range specOpts {
+		opt(&spec)
+	}
+	database, err := types.NewDatabaseV3(types.Metadata{
+		Name: "test-database",
+	}, spec)
 	require.NoError(t, err)
 	return database
 }
 
-func newRedshiftServerlessDatabase(t *testing.T) types.Database {
+func newRedshiftServerlessDatabase(t *testing.T, specOpts ...databaseSpecOpt) types.Database {
 	t.Helper()
 
-	database, err := types.NewDatabaseV3(types.Metadata{
-		Name: "test-database",
-	}, types.DatabaseSpecV3{
+	spec := types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      "my-workgroup.123456789012.eu-west-2.redshift-serverless.amazonaws.com:5439",
-	})
+	}
+	for _, opt := range specOpts {
+		opt(&spec)
+	}
+	database, err := types.NewDatabaseV3(types.Metadata{
+		Name: "test-database",
+	}, spec)
 	require.NoError(t, err)
 	return database
 }
 
-func newRDSProxyDatabase(t *testing.T, uri string) types.Database {
-	database, err := types.NewDatabaseV3(types.Metadata{
-		Name: "test-database",
-	}, types.DatabaseSpecV3{
+func newRDSProxyDatabase(t *testing.T, uri string, specOpts ...databaseSpecOpt) types.Database {
+	spec := types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
 		URI:      uri,
 		AWS: types.AWS{
-			Region: "us-east-1",
+			AccountID: "123456789012",
 			RDSProxy: types.RDSProxy{
 				Name: "test-database",
 			},
 		},
-	})
+	}
+	for _, opt := range specOpts {
+		opt(&spec)
+	}
+	database, err := types.NewDatabaseV3(types.Metadata{
+		Name: "test-database",
+	}, spec)
 	require.NoError(t, err)
 	return database
 }

--- a/lib/srv/db/common/engines_test.go
+++ b/lib/srv/db/common/engines_test.go
@@ -37,6 +37,8 @@ func TestRegisterEngine(t *testing.T) {
 		RegisterEngine(nil, "test")
 	})
 
+	cloudClients, err := cloud.NewClients()
+	require.NoError(t, err)
 	ec := EngineConfig{
 		Context:      context.Background(),
 		Clock:        clockwork.NewFakeClock(),
@@ -44,7 +46,7 @@ func TestRegisterEngine(t *testing.T) {
 		Auth:         &testAuth{},
 		Audit:        &testAudit{},
 		AuthClient:   &auth.Client{},
-		CloudClients: cloud.NewClients(),
+		CloudClients: cloudClients,
 	}
 
 	// No engine is registered initially.

--- a/lib/srv/db/dynamodb/engine.go
+++ b/lib/srv/db/dynamodb/engine.go
@@ -38,6 +38,7 @@ import (
 
 	apievents "github.com/gravitational/teleport/api/types/events"
 	apiaws "github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -57,9 +58,6 @@ func NewEngine(ec common.EngineConfig) common.Engine {
 // Engine handles connections from DynamoDB clients coming from Teleport
 // proxy over reverse tunnel.
 type Engine struct {
-	// signingSvc will be used by the engine to provide the AWS sigv4 authorization header
-	// required by AWS for request validation: https://docs.aws.amazon.com/general/latest/gr/signing-elements.html
-	signingSvc *libaws.SigningService
 	// EngineConfig is the common database engine configuration.
 	common.EngineConfig
 	// clientConn is a client connection.
@@ -79,19 +77,6 @@ var _ common.Engine = (*Engine)(nil)
 func (e *Engine) InitializeConnection(clientConn net.Conn, sessionCtx *common.Session) error {
 	e.clientConn = clientConn
 	e.sessionCtx = sessionCtx
-	awsSession, err := e.CloudClients.GetAWSSession(sessionCtx.Database.GetAWS().Region)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	svc, err := libaws.NewSigningService(libaws.SigningServiceConfig{
-		Clock:                 e.Clock,
-		Session:               awsSession,
-		GetSigningCredentials: e.GetSigningCredsFn,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	e.signingSvc = svc
 	return nil
 }
 
@@ -150,6 +135,20 @@ func (e *Engine) HandleConnection(ctx context.Context, _ *common.Session) error 
 	}
 	defer e.Audit.OnSessionEnd(e.Context, e.sessionCtx)
 
+	meta := e.sessionCtx.Database.GetAWS()
+	awsSession, err := e.CloudClients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	signer, err := libaws.NewSigningService(libaws.SigningServiceConfig{
+		Clock:                 e.Clock,
+		Session:               awsSession,
+		GetSigningCredentials: e.GetSigningCredsFn,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	clientConnReader := bufio.NewReader(e.clientConn)
 	for {
 		req, err := http.ReadRequest(clientConnReader)
@@ -157,7 +156,7 @@ func (e *Engine) HandleConnection(ctx context.Context, _ *common.Session) error 
 			return trace.Wrap(err)
 		}
 
-		if err := e.process(ctx, req); err != nil {
+		if err := e.process(ctx, req, signer); err != nil {
 			return trace.Wrap(err)
 		}
 	}
@@ -165,7 +164,7 @@ func (e *Engine) HandleConnection(ctx context.Context, _ *common.Session) error 
 
 // process reads request from connected dynamodb client, processes the requests/responses and sends data back
 // to the client.
-func (e *Engine) process(ctx context.Context, req *http.Request) (err error) {
+func (e *Engine) process(ctx context.Context, req *http.Request, signer *libaws.SigningService) (err error) {
 	if req.Body != nil {
 		// make sure we close the incoming request's body. ignore any close error.
 		defer req.Body.Close()
@@ -199,20 +198,23 @@ func (e *Engine) process(ctx context.Context, req *http.Request) (err error) {
 		return trace.Wrap(err)
 	}
 
+	meta := e.sessionCtx.Database.GetAWS()
 	roleArn, err := libaws.BuildRoleARN(e.sessionCtx.DatabaseUser,
-		re.SigningRegion, e.sessionCtx.Database.GetAWS().AccountID)
+		re.SigningRegion, meta.AccountID)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	signedReq, err := e.signingSvc.SignRequest(e.Context, outReq,
-		&libaws.SigningCtx{
-			SigningName:   re.SigningName,
-			SigningRegion: re.SigningRegion,
-			Expiry:        e.sessionCtx.Identity.Expires,
-			SessionName:   e.sessionCtx.Identity.Username,
-			AWSRoleArn:    roleArn,
-			AWSExternalID: e.sessionCtx.Database.GetAWS().ExternalID,
-		})
+	signingCtx := &libaws.SigningCtx{
+		SigningName:   re.SigningName,
+		SigningRegion: re.SigningRegion,
+		Expiry:        e.sessionCtx.Identity.Expires,
+		SessionName:   e.sessionCtx.Identity.Username,
+		AWSRoleArn:    roleArn,
+	}
+	if meta.AssumeRoleARN == "" {
+		signingCtx.AWSExternalID = meta.ExternalID
+	}
+	signedReq, err := signer.SignRequest(e.Context, outReq, signingCtx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/mysql/engine.go
+++ b/lib/srv/db/mysql/engine.go
@@ -185,7 +185,7 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (*clie
 	var password string
 	switch {
 	case sessionCtx.Database.IsRDS(), sessionCtx.Database.IsRDSProxy():
-		password, err = e.Auth.GetRDSAuthToken(sessionCtx)
+		password, err = e.Auth.GetRDSAuthToken(ctx, sessionCtx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/db/postgres/engine.go
+++ b/lib/srv/db/postgres/engine.go
@@ -428,12 +428,12 @@ func (e *Engine) getConnectConfig(ctx context.Context, sessionCtx *common.Sessio
 	// auth token and use it as a password.
 	switch sessionCtx.Database.GetType() {
 	case types.DatabaseTypeRDS, types.DatabaseTypeRDSProxy:
-		config.Password, err = e.Auth.GetRDSAuthToken(sessionCtx)
+		config.Password, err = e.Auth.GetRDSAuthToken(ctx, sessionCtx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
 	case types.DatabaseTypeRedshift:
-		config.User, config.Password, err = e.Auth.GetRedshiftAuthToken(sessionCtx)
+		config.User, config.Password, err = e.Auth.GetRedshiftAuthToken(ctx, sessionCtx)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -195,7 +195,11 @@ func (c *Config) CheckAndSetDefaults(ctx context.Context) (err error) {
 		return trace.BadParameter("missing ConnectionMonitor")
 	}
 	if c.CloudClients == nil {
-		c.CloudClients = clients.NewClients()
+		cloudClients, err := clients.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.CloudClients = cloudClients
 	}
 	if c.CloudMeta == nil {
 		c.CloudMeta, err = cloud.NewMetadata(cloud.MetadataConfig{

--- a/lib/srv/db/sqlserver/connect.go
+++ b/lib/srv/db/sqlserver/connect.go
@@ -126,7 +126,7 @@ func (c *connector) Connect(ctx context.Context, sessionCtx *common.Session, log
 		// method.
 		connector, err = c.getAzureConnector(ctx, sessionCtx, dsnConfig)
 	case sessionCtx.Database.GetType() == types.DatabaseTypeRDSProxy:
-		connector, err = c.getAccessTokenConnector(sessionCtx, dsnConfig)
+		connector, err = c.getAccessTokenConnector(ctx, sessionCtx, dsnConfig)
 	default:
 		connector, err = c.getKerberosConnector(ctx, sessionCtx, dsnConfig)
 	}
@@ -186,8 +186,8 @@ func (c *connector) getAzureConnector(ctx context.Context, sessionCtx *common.Se
 
 // getAccessTokenConnector generates a connector that uses a token to
 // authenticate.
-func (c *connector) getAccessTokenConnector(sessionCtx *common.Session, dsnConfig msdsn.Config) (*mssql.Connector, error) {
+func (c *connector) getAccessTokenConnector(ctx context.Context, sessionCtx *common.Session, dsnConfig msdsn.Config) (*mssql.Connector, error) {
 	return mssql.NewSecurityTokenConnector(dsnConfig, func(ctx context.Context) (string, error) {
-		return c.DBAuth.GetRDSAuthToken(sessionCtx)
+		return c.DBAuth.GetRDSAuthToken(ctx, sessionCtx)
 	})
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -167,7 +167,7 @@ func (s *Server) initAWSWatchers(matchers []services.AWSMatcher) error {
 	// Add database fetchers.
 	databaseMatchers, otherMatchers := splitAWSMatchers(otherMatchers, db.IsAWSMatcherType)
 	if len(databaseMatchers) > 0 {
-		databaseFetchers, err := db.MakeAWSFetchers(s.Clients, databaseMatchers)
+		databaseFetchers, err := db.MakeAWSFetchers(s.ctx, s.Clients, databaseMatchers)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -180,7 +180,8 @@ func (s *Server) initAWSWatchers(matchers []services.AWSMatcher) error {
 			for _, region := range matcher.Regions {
 				switch t {
 				case services.AWSMatcherEKS:
-					client, err := s.Clients.GetAWSEKSClient(region)
+					// TODO(gavin): support assume_role_arn for AWS EKS.
+					client, err := s.Clients.GetAWSEKSClient(s.ctx, region)
 					if err != nil {
 						return trace.Wrap(err)
 					}
@@ -358,7 +359,8 @@ func (s *Server) handleEC2Instances(instances *server.EC2Instances) error {
 	// TODO(amk): once agentless node inventory management is
 	//            implemented, create nodes after a successful SSM run
 
-	ec2Client, err := s.Clients.GetAWSSSMClient(instances.Region)
+	// TODO(gavin): support assume_role_arn for ec2.
+	ec2Client, err := s.Clients.GetAWSSSMClient(s.ctx, instances.Region)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -66,7 +66,11 @@ type Config struct {
 
 func (c *Config) CheckAndSetDefaults() error {
 	if c.Clients == nil {
-		c.Clients = cloud.NewClients()
+		cloudClients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		c.Clients = cloudClients
 	}
 	if len(c.AWSMatchers) == 0 && len(c.AzureMatchers) == 0 && len(c.GCPMatchers) == 0 {
 		return trace.BadParameter("no matchers configured for discovery")

--- a/lib/srv/discovery/fetchers/db/db.go
+++ b/lib/srv/discovery/fetchers/db/db.go
@@ -17,6 +17,8 @@ limitations under the License.
 package db
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
@@ -27,7 +29,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
-type makeAWSFetcherFunc func(cloud.AWSClients, string, types.Labels) (common.Fetcher, error)
+type makeAWSFetcherFunc func(context.Context, cloud.AWSClients, string, types.Labels) (common.Fetcher, error)
 type makeAzureFetcherFunc func(azureFetcherConfig) (common.Fetcher, error)
 
 var (
@@ -59,7 +61,7 @@ func IsAzureMatcherType(matcherType string) bool {
 }
 
 // MakeAWSFetchers creates new AWS database fetchers.
-func MakeAWSFetchers(clients cloud.AWSClients, matchers []services.AWSMatcher) (result []common.Fetcher, err error) {
+func MakeAWSFetchers(ctx context.Context, clients cloud.AWSClients, matchers []services.AWSMatcher) (result []common.Fetcher, err error) {
 	for _, matcher := range matchers {
 		for _, matcherType := range matcher.Types {
 			makeFetchers, found := makeAWSFetcherFuncs[matcherType]
@@ -69,7 +71,7 @@ func MakeAWSFetchers(clients cloud.AWSClients, matchers []services.AWSMatcher) (
 
 			for _, makeFetcher := range makeFetchers {
 				for _, region := range matcher.Regions {
-					fetcher, err := makeFetcher(clients, region, matcher.Tags)
+					fetcher, err := makeFetcher(ctx, clients, region, matcher.Tags)
 					if err != nil {
 						return nil, trace.Wrap(err)
 					}
@@ -114,8 +116,8 @@ func MakeAzureFetchers(clients cloud.AzureClients, matchers []services.AzureMatc
 }
 
 // makeRDSInstanceFetcher returns RDS instance fetcher for the provided region and tags.
-func makeRDSInstanceFetcher(clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
-	rds, err := clients.GetAWSRDSClient(region)
+func makeRDSInstanceFetcher(ctx context.Context, clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
+	rds, err := clients.GetAWSRDSClient(ctx, region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -129,8 +131,8 @@ func makeRDSInstanceFetcher(clients cloud.AWSClients, region string, tags types.
 }
 
 // makeRDSAuroraFetcher returns RDS Aurora fetcher for the provided region and tags.
-func makeRDSAuroraFetcher(clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
-	rds, err := clients.GetAWSRDSClient(region)
+func makeRDSAuroraFetcher(ctx context.Context, clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
+	rds, err := clients.GetAWSRDSClient(ctx, region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -144,8 +146,8 @@ func makeRDSAuroraFetcher(clients cloud.AWSClients, region string, tags types.La
 }
 
 // makeRDSProxyFetcher returns RDS proxy fetcher for the provided region and tags.
-func makeRDSProxyFetcher(clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
-	rds, err := clients.GetAWSRDSClient(region)
+func makeRDSProxyFetcher(ctx context.Context, clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
+	rds, err := clients.GetAWSRDSClient(ctx, region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -158,8 +160,8 @@ func makeRDSProxyFetcher(clients cloud.AWSClients, region string, tags types.Lab
 }
 
 // makeRedshiftFetcher returns Redshift fetcher for the provided region and tags.
-func makeRedshiftFetcher(clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
-	redshift, err := clients.GetAWSRedshiftClient(region)
+func makeRedshiftFetcher(ctx context.Context, clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
+	redshift, err := clients.GetAWSRedshiftClient(ctx, region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -171,8 +173,8 @@ func makeRedshiftFetcher(clients cloud.AWSClients, region string, tags types.Lab
 }
 
 // makeElastiCacheFetcher returns ElastiCache fetcher for the provided region and tags.
-func makeElastiCacheFetcher(clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
-	elastiCache, err := clients.GetAWSElastiCacheClient(region)
+func makeElastiCacheFetcher(ctx context.Context, clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
+	elastiCache, err := clients.GetAWSElastiCacheClient(ctx, region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -184,8 +186,8 @@ func makeElastiCacheFetcher(clients cloud.AWSClients, region string, tags types.
 }
 
 // makeMemoryDBFetcher returns MemoryDB fetcher for the provided region and tags.
-func makeMemoryDBFetcher(clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
-	memorydb, err := clients.GetAWSMemoryDBClient(region)
+func makeMemoryDBFetcher(ctx context.Context, clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
+	memorydb, err := clients.GetAWSMemoryDBClient(ctx, region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -198,8 +200,8 @@ func makeMemoryDBFetcher(clients cloud.AWSClients, region string, tags types.Lab
 
 // makeRedshiftServerlessFetcher returns Redshift Serverless fetcher for the
 // provided region and tags.
-func makeRedshiftServerlessFetcher(clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
-	client, err := clients.GetAWSRedshiftServerlessClient(region)
+func makeRedshiftServerlessFetcher(ctx context.Context, clients cloud.AWSClients, region string, tags types.Labels) (common.Fetcher, error) {
+	client, err := clients.GetAWSRedshiftServerlessClient(ctx, region)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/discovery/fetchers/db/helpers_test.go
+++ b/lib/srv/discovery/fetchers/db/helpers_test.go
@@ -46,7 +46,7 @@ func toTypeLabels(labels map[string]string) types.Labels {
 func mustMakeAWSFetchers(t *testing.T, clients cloud.AWSClients, matchers []services.AWSMatcher) []common.Fetcher {
 	t.Helper()
 
-	fetchers, err := MakeAWSFetchers(clients, matchers)
+	fetchers, err := MakeAWSFetchers(context.Background(), clients, matchers)
 	require.NoError(t, err)
 	require.NotEmpty(t, fetchers)
 

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -68,7 +68,8 @@ func NewEC2Watcher(ctx context.Context, matchers []services.AWSMatcher, clients 
 
 	for _, matcher := range matchers {
 		for _, region := range matcher.Regions {
-			ec2Client, err := clients.GetAWSEC2Client(region)
+			// TODO(gavin): support assume_role_arn for ec2.
+			ec2Client, err := clients.GetAWSEC2Client(ctx, region)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}

--- a/lib/srv/server/ec2_watcher_test.go
+++ b/lib/srv/server/ec2_watcher_test.go
@@ -40,7 +40,7 @@ type mockClients struct {
 	azureClient azure.VirtualMachinesClient
 }
 
-func (c *mockClients) GetAWSEC2Client(region string) (ec2iface.EC2API, error) {
+func (c *mockClients) GetAWSEC2Client(ctx context.Context, region string, _ ...cloud.AWSAssumeRoleOptionFn) (ec2iface.EC2API, error) {
 	return c.ec2Client, nil
 }
 


### PR DESCRIPTION
This PR is a follow-up for https://github.com/gravitational/teleport/pull/23158 as part of the larger issue: https://github.com/gravitational/teleport/issues/21872

The database agent will now assume a configured AWS role for a database when connecting to it, fetching metadata, or setting up IAM permissions.

I split out the implementation for database discovery separately for a follow-up PR; this PR is just for individual db config.

Note: `assume_role_arn` should be in the same account as the configured database, so that when the db agent assumes that role it will be able to access the database.

# Testing
I have tested that this works with `RDS` and `Aurora` (MySQL and Postgres), `Keyspaces`, `DynamoDB`, `Redshift Serverless`.

I have not tested: `MemoryDB`, `ElastiCache`, `RDS Proxy`, or `Redshift`. Working on doing those next, but it's time consuming to setup all these different databases.

# Special Cases
Three protocols that use IAM roles for `--db-user` are: AWS DynamoDB, Keyspaces, and Redshift Serverless. These protocols will assume the configured role (`assume_role_arn`) before assuming the role from `--db-user`. If there is no `assume_role_arn` in the database config, it will attempt to assume the `--db-user` role directly (prior behavior), except that now all 3 protocols will use `external_id`, if it's available. So technically, these protocols don't *need* a configured `assume_role_arn`, but we should advise customers to use that, as I explain below:

Cross-account AWS requires a bit more setup than assuming a role within the same account, namely:
  - within one account, a role's trust policy is enough to grant access to another principal, but assuming an external account role requires that the trust policy allows it AND the IAM identity assuming the role has `sts:AssumeRole` permission allowed for the role it will assume.
  - it is strongly recommended security practice to use an external ID when allowing an external account to assume a role.

For these reasons, in the doc guide update PR I will advise customers to use a configured `assume_role_arn` and `external_id` to access an external account, which can then be used to assume other roles within that account for DynamoDB, Keyspaces, or Redshift Serverless (from `--db-user`). This is a simpler setup than configuring cross-account access for multiple roles; instead we only need to configure one role for cross-account access.

# Example setup
Example permissions attached to an identity in AWS account "111111111111":
```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "VisualEditor0",
            "Effect": "Allow",
            "Action": "sts:AssumeRole",
            "Resource": "arn:aws:iam::222222222222:role/some-role"
        }
    ]
}
```

Example trust policy for "some-role" in AWS account "222222222222":
```json
        {
            "Sid": "ExternalAccess",
            "Effect": "Allow",
            "Principal": {
                "AWS": [
                    "arn:aws:iam::111111111111:root",
                ]
            },
            "Action": "sts:AssumeRole",
            "Condition": {
                "StringEquals": {
                    "sts:ExternalId": "someUniqueID"
                }
            }
        }
```

Example configuration for RDS postgres for a database agent running with credentials in account "111111111111":
```yaml
  databases:
    - name: "postgres-rds"
      protocol: "postgres"
      uri: "postgres-rds.abcdef123456.us-west-1.rds.amazonaws.com:5432"
      aws:
        region: "us-west-1"
        assume_role_arn: "arn:aws:iam::222222222222:role/some-role"
        external_id: "someUniqueID"
        rds:
          instance_id: "postgres-rds"
```