### PR TITLE
Try to fix flaky test TestDatabaseServerResource

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1695,6 +1695,7 @@ func (process *TeleportProcess) initAuthService() error {
 	}
 	// use multiplexer to leverage support for proxy protocol.
 	mux, err := multiplexer.New(multiplexer.Config{
+		Context:                     process.ExitContext(),
 		EnableExternalProxyProtocol: cfg.Auth.EnableProxyProtocol,
 		Listener:                    listener,
 		ID:                          teleport.Component(process.id),
@@ -3109,6 +3110,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 		}
 
 		mux, err := multiplexer.New(multiplexer.Config{
+			Context:                     process.ExitContext(),
 			Listener:                    l,
 			EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 			ID:                          teleport.Component(teleport.ComponentProxy, "ssh"),
@@ -3203,6 +3205,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			return nil, trace.Wrap(err)
 		}
 		listeners.mux, err = multiplexer.New(multiplexer.Config{
+			Context:                     process.ExitContext(),
 			EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 			Listener:                    listener,
 			ID:                          teleport.Component(teleport.ComponentProxy, "tunnel", "web", process.id),
@@ -3233,6 +3236,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			return nil, trace.Wrap(err)
 		}
 		listeners.mux, err = multiplexer.New(multiplexer.Config{
+			Context:                     process.ExitContext(),
 			EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 			Listener:                    listener,
 			ID:                          teleport.Component(teleport.ComponentProxy, "web", process.id),
@@ -3286,6 +3290,7 @@ func (process *TeleportProcess) setupProxyListeners(networkingConfig types.Clust
 			if !cfg.Proxy.DisableDatabaseProxy && !cfg.Proxy.DisableTLS {
 				process.log.Debug("Setup Proxy: Multiplexing web and database proxy on the same port.")
 				listeners.mux, err = multiplexer.New(multiplexer.Config{
+					Context:                     process.ExitContext(),
 					EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 					Listener:                    listener,
 					ID:                          teleport.Component(teleport.ComponentProxy, "web", process.id),
@@ -3329,6 +3334,7 @@ func (process *TeleportProcess) initMinimalReverseTunnelListener(cfg *servicecfg
 		return trace.Wrap(err)
 	}
 	listeners.reverseTunnelMux, err = multiplexer.New(multiplexer.Config{
+		Context:                     process.ExitContext(),
 		EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
 		Listener:                    listener,
 		ID:                          teleport.Component(teleport.ComponentProxy, "tunnel", "web", process.id),
@@ -3513,6 +3519,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		tsrv, err = reversetunnel.NewServer(
 			reversetunnel.Config{
+				Context:                       process.ExitContext(),
 				Component:                     teleport.Component(teleport.ComponentProxy, process.id),
 				ID:                            process.Config.HostUUID,
 				ClusterName:                   clusterName,

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -1858,6 +1858,7 @@ func setupTestContext(ctx context.Context, t *testing.T, withDatabases ...withDa
 	listener, err := net.Listen("tcp", "localhost:0")
 	require.NoError(t, err)
 	testCtx.mux, err = multiplexer.New(multiplexer.Config{
+		Context:                     ctx,
 		ID:                          "test",
 		Listener:                    listener,
 		EnableExternalProxyProtocol: true,


### PR DESCRIPTION
## What: 
Try to fix `TestDatabaseServerResource` 
Reproduction steps:

```
 go test -failfast -count=100 ./tool/tctl/common -run TestDatabaseServerResource
 ```

```
goroutine 15973 [IO wait, 9 minutes]:
internal/poll.runtime_pollWait(0x137301308, 0x72)
	/usr/local/Cellar/go/1.19.4/libexec/src/runtime/netpoll.go:305 +0x89
internal/poll.(*pollDesc).wait(0xc001cd8180?, 0xc001f7d680?, 0x0)
	/usr/local/Cellar/go/1.19.4/libexec/src/internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
	/usr/local/Cellar/go/1.19.4/libexec/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Accept(0xc001cd8180)
	/usr/local/Cellar/go/1.19.4/libexec/src/internal/poll/fd_unix.go:614 +0x234
net.(*netFD).accept(0xc001cd8180)
	/usr/local/Cellar/go/1.19.4/libexec/src/net/fd_unix.go:172 +0x35
net.(*TCPListener).accept(0xc000ce2ca8)
	/usr/local/Cellar/go/1.19.4/libexec/src/net/tcpsock_posix.go:142 +0x28
net.(*TCPListener).Accept(0xc000ce2ca8)
	/usr/local/Cellar/go/1.19.4/libexec/src/net/tcpsock.go:288 +0x3d
github.com/gravitational/teleport/lib/multiplexer.(*Mux).Serve(0xc001800c40)
	/Users/marek/go/src/github.com/gravitational/teleport/lib/multiplexer/multiplexer.go:211 +0x14a
github.com/gravitational/teleport/lib/service.(*TeleportProcess).setupProxyListeners.func4()
	/Users/marek/go/src/github.com/gravitational/teleport/lib/service/service.go:3256 +0x3a
created by github.com/gravitational/teleport/lib/service.(*TeleportProcess).setupProxyListeners
	/Users/marek/go/src/github.com/gravitational/teleport/lib/service/service.go:3255 +0x14ed
```

