### PR TITLE
Expose SingleProcessModeResolver and GetRotation.

### DIFF
--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -65,7 +65,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 
 	tunnelAddrResolver := conn.TunnelProxyResolver()
 	if tunnelAddrResolver == nil {
-		tunnelAddrResolver = process.singleProcessModeResolver(resp.GetProxyListenerMode())
+		tunnelAddrResolver = process.SingleProcessModeResolver(resp.GetProxyListenerMode())
 
 		// run the resolver. this will check configuration for errors.
 		_, _, err := tunnelAddrResolver(process.ExitContext())
@@ -160,7 +160,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		Authorizer:           authorizer,
 		TLSConfig:            tlsConfig,
 		Limiter:              connLimiter,
-		GetRotation:          process.getRotation,
+		GetRotation:          process.GetRotation,
 		Hostname:             process.Config.Hostname,
 		HostID:               process.Config.HostUUID,
 		Databases:            databases,

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -236,7 +236,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		AccessPoint:          accessPoint,
 		LimiterConfig:        cfg.Kube.Limiter,
 		OnHeartbeat:          process.onHeartbeat(teleport.ComponentKube),
-		GetRotation:          process.getRotation,
+		GetRotation:          process.GetRotation,
 		ConnectedProxyGetter: proxyGetter,
 		ResourceMatchers:     cfg.Kube.ResourceMatchers,
 		StaticLabels:         cfg.Kube.StaticLabels,


### PR DESCRIPTION
The SingleProcessModeResolver and GetRotation functions have been exposed to be used by enterprise only processes.