### PR TITLE
docs: Remove Open Source from Try out Teleport on a linux server

### DIFF
--- a/docs/pages/choose-an-edition/introduction.mdx
+++ b/docs/pages/choose-an-edition/introduction.mdx
@@ -13,7 +13,7 @@ which edition is most appropriate for your use case.
 We provide a free, open source distribution of Teleport that enables you to get
 secure access to databases, Windows desktops, Kubernetes clusters, and more.
 
-[Try out Open Source Teleport on a Linux
+[Try out Teleport on a Linux
 server](../try-out-teleport/linux-server.mdx). If you would like to take a look
 at the source, visit the [Teleport GitHub
 repository](https://github.com/gravitational/teleport).

--- a/docs/pages/try-out-teleport/introduction.mdx
+++ b/docs/pages/try-out-teleport/introduction.mdx
@@ -25,7 +25,7 @@ access to your home lab or demo project. Once you have set up your demo
 deployment, you can use it to add resources, set up RBAC, and enjoy secure
 access to your infrastructure:
 
-- [Try out Open Source Teleport on a Linux Server](./linux-server.mdx)
+- [Try out Teleport on a Linux Server](./linux-server.mdx)
 - [Use the 1-Click Digital Ocean Droplet for Teleport](./digitalocean.mdx)
 
 ## Local deployments

--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy Open Source Teleport on a Linux Server
+title: Deploy Teleport on a Linux Server
 description: This tutorial will guide you through the steps needed to install and run Teleport on a Linux server
 videoBanner: 8aiVin0LvmE
 ---

--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -1,5 +1,5 @@
 ---
-title: Deploy Teleport on a Linux Server
+title: Try out Teleport on a Linux Server
 description: This tutorial will guide you through the steps needed to install and run Teleport on a Linux server
 videoBanner: 8aiVin0LvmE
 ---


### PR DESCRIPTION
The page referenced includes community and enterprise example.  Also we don't use Open Source to refer to other examples.  Only applies for `branch/v12` and `branch/v11`.