### PR TITLE
Allow Okta service reverse tunnel access.

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -724,8 +724,7 @@ type DiscoveryAccessPoint interface {
 // ReadOktaAccessPoint is a read only API interface to be
 // used by an Okta component.
 //
-// NOTE: This interface must provide read interfaces for the [types.WatchKind] registered in [cache.ForOkta]
-// except for access requests, which are expected to only be used by events.
+// NOTE: This interface must provide read interfaces for the [types.WatchKind] registered in [cache.ForOkta].
 type ReadOktaAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -761,6 +761,9 @@ type ReadOktaAccessPoint interface {
 
 	// GetApplicationServers returns all registered application servers.
 	GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error)
+
+	// ListResources returns a paginated list of resources.
+	ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error)
 }
 
 // OktaAccessPoint is a read caching interface used by an Okta component.

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -730,8 +730,13 @@ type ReadOktaAccessPoint interface {
 	// Closer closes all the resources
 	io.Closer
 
+	AccessCache
+
 	// NewWatcher returns a new event watcher.
 	NewWatcher(ctx context.Context, watch types.Watch) (types.Watcher, error)
+
+	// GetProxies returns a list of proxy servers registered in the cluster
+	GetProxies() ([]types.Server, error)
 
 	// GetUser returns a services.User for this cluster.
 	GetUser(name string, withSecrets bool) (types.User, error)
@@ -754,11 +759,8 @@ type ReadOktaAccessPoint interface {
 	// GetOktaAssignmen treturns the specified Okta assignment resources.
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
 
-	// GetApps returns all application resources.
-	GetApps(context.Context) ([]types.Application, error)
-
-	// GetApp returns the specified application resource.
-	GetApp(ctx context.Context, name string) (types.Application, error)
+	// GetApplicationServers returns all registered application servers.
+	GetApplicationServers(ctx context.Context, namespace string) ([]types.AppServer, error)
 }
 
 // OktaAccessPoint is a read caching interface used by an Okta component.
@@ -796,14 +798,8 @@ type OktaAccessPoint interface {
 	// DeleteOktaAssignment removes the specified Okta assignment resource.
 	DeleteOktaAssignment(ctx context.Context, name string) error
 
-	// CreateApp creates a new application resource.
-	CreateApp(context.Context, types.Application) error
-
-	// UpdateApp updates an existing application resource.
-	UpdateApp(context.Context, types.Application) error
-
-	// DeleteApp removes the specified application resource.
-	DeleteApp(ctx context.Context, name string) error
+	// DeleteApplicationServer removes specified application server.
+	DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error
 }
 
 // AccessCache is a subset of the interface working on the certificate authorities
@@ -1256,19 +1252,9 @@ func (w *OktaWrapper) DeleteOktaAssignment(ctx context.Context, name string) err
 	return w.NoCache.DeleteOktaAssignment(ctx, name)
 }
 
-// CreateApp creates a new application resource.
-func (w *OktaWrapper) CreateApp(ctx context.Context, app types.Application) error {
-	return w.NoCache.CreateApp(ctx, app)
-}
-
-// UpdateApp updates an existing application resource.
-func (w *OktaWrapper) UpdateApp(ctx context.Context, app types.Application) error {
-	return w.NoCache.UpdateApp(ctx, app)
-}
-
-// DeleteApp removes the specified application resource.
-func (w *OktaWrapper) DeleteApp(ctx context.Context, name string) error {
-	return w.NoCache.DeleteApp(ctx, name)
+// DeleteApplicationServer removes specified application server.
+func (w *OktaWrapper) DeleteApplicationServer(ctx context.Context, namespace, hostID, name string) error {
+	return w.NoCache.DeleteApplicationServer(ctx, namespace, hostID, name)
 }
 
 // Close closes all associated resources

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -807,7 +807,6 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					Rules: []types.Rule{
 						types.NewRule(types.KindSemaphore, services.RW()),
 						types.NewRule(types.KindEvent, services.RW()),
-						types.NewRule(types.KindAccessRequest, services.RO()),
 						types.NewRule(types.KindAppServer, services.RW()),
 						types.NewRule(types.KindClusterNetworkingConfig, services.RO()),
 						types.NewRule(types.KindUser, services.RO()),

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -805,6 +805,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					Namespaces: []string{types.Wildcard},
 					AppLabels:  types.Labels{types.Wildcard: []string{types.Wildcard}},
 					Rules: []types.Rule{
+						types.NewRule(types.KindSemaphore, services.RW()),
 						types.NewRule(types.KindEvent, services.RW()),
 						types.NewRule(types.KindAccessRequest, services.RO()),
 						types.NewRule(types.KindAppServer, services.RW()),

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -808,10 +808,12 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindEvent, services.RW()),
 						types.NewRule(types.KindAccessRequest, services.RO()),
 						types.NewRule(types.KindAppServer, services.RW()),
+						types.NewRule(types.KindClusterNetworkingConfig, services.RO()),
 						types.NewRule(types.KindUser, services.RO()),
 						types.NewRule(types.KindUserGroup, services.RW()),
 						types.NewRule(types.KindOktaImportRule, services.RO()),
 						types.NewRule(types.KindOktaAssignment, services.RW()),
+						types.NewRule(types.KindProxy, services.RO()),
 					},
 				},
 			})

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -370,6 +370,7 @@ func ForOkta(cfg Config) Config {
 	cfg.target = "okta"
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindUser},
+		{Kind: types.KindAppServer},
 		{Kind: types.KindClusterNetworkingConfig},
 		{Kind: types.KindUserGroup},
 		{Kind: types.KindOktaImportRule},

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -376,9 +376,11 @@ func ForOkta(cfg Config) Config {
 		// the cache.
 		{Kind: types.KindAccessRequest},
 		{Kind: types.KindApp},
+		{Kind: types.KindClusterNetworkingConfig},
 		{Kind: types.KindUserGroup},
 		{Kind: types.KindOktaImportRule},
 		{Kind: types.KindOktaAssignment},
+		{Kind: types.KindProxy},
 	}
 	cfg.QueueSize = defaults.DiscoveryQueueSize
 	return cfg

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -370,12 +370,6 @@ func ForOkta(cfg Config) Config {
 	cfg.target = "okta"
 	cfg.Watches = []types.WatchKind{
 		{Kind: types.KindUser},
-
-		// The access request entry here is primarily for event propagation and not for
-		// cache reads. The Okta service is not expected to read access requests from
-		// the cache.
-		{Kind: types.KindAccessRequest},
-		{Kind: types.KindApp},
 		{Kind: types.KindClusterNetworkingConfig},
 		{Kind: types.KindUserGroup},
 		{Kind: types.KindOktaImportRule},


### PR DESCRIPTION
In order to allow the Okta service to be connectable via the reverse tunnel, the following things were added.

* The cache has permissions to retrieve cluster configuration objects. While here, I removed access to the App objects, which was not necessary.
* The permissions have been updated to allow for AppServer access and ClusterNetworkingConfig access.
* The cache has been updated to cache app servers and cluster networking configuration resources. While here, access to App objects has been removed.
* The reverse tunnel now recognizes the Okta role.