### PR TITLE
Fix multiple profile handling for kube credentials

### DIFF
--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -226,21 +226,29 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 // when the store has a lot of keys and when we call the function multiple times in
 // parallel.
 // Although this function speeds up the process since it removes all transversals,
-// it still has to read 4 different files
-// - $TSH_HOME/current_profile
+// it still has to read 3 different files if the proxy is specified, otherwise it also
+// has to read $TSH_HOME/current_profile.
 // - $TSH_HOME/$profile.yaml
 // - $TSH_HOME/keys/$PROXY/$USER-kube/$TELEPORT_CLUSTER/$KUBE_CLUSTER-x509.pem
 // - $TSH_HOME/keys/$PROXY/$USER
-func LoadKeysToKubeFromStore(dirPath string, teleportCluster, kubeCluster string) ([]byte, []byte, error) {
+func LoadKeysToKubeFromStore(dirPath, proxy, teleportCluster, kubeCluster string) ([]byte, []byte, error) {
 	dirPath = profile.FullProfilePath(dirPath)
 
 	profileStore := NewFSProfileStore(dirPath)
-	currentProfile, err := profileStore.CurrentProfile()
+	// tsh stores the profiles using the proxy host as the profile name.
+	profileName, err := utils.Host(proxy)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-
-	profile, err := profileStore.GetProfile(currentProfile)
+	if profileName == "" {
+		// If no profile name is provided, default to the current profile.
+		profileName, err = profileStore.CurrentProfile()
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
+		}
+	}
+	// Load the desired profile.
+	profile, err := profileStore.GetProfile(profileName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -574,14 +574,14 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 	// loading process since Teleport Store transverses the entire store to find the keys.
 	// This operation takes a long time when the store has a lot of keys and when
 	// we call the function multiple times in parallel.
-	// Although client.LoadKeysToKubeFromStore function speeds up the process
-	// since it removes all transversals, it still has to read 4 different files:
-	// - $TSH_HOME/current_profile
+	// Although client.LoadKeysToKubeFromStore function speeds up the process since
+	// it removes all transversals, it still has to read 3 different files from the disk:
 	// - $TSH_HOME/$profile.yaml
 	// - $TSH_HOME/keys/$PROXY/$USER-kube/$TELEPORT_CLUSTER/$KUBE_CLUSTER-x509.pem
 	// - $TSH_HOME/keys/$PROXY/$USER
 	if kubeCert, privKey, err := client.LoadKeysToKubeFromStore(
 		cf.HomePath,
+		cf.Proxy,
 		c.teleportCluster,
 		c.kubeCluster,
 	); err == nil {
@@ -1200,6 +1200,10 @@ func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient, path string) error
 	kubeStatus, err := fetchKubeStatus(cf.Context, tc)
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	if cf.Proxy == "" {
+		cf.Proxy = tc.WebProxyAddr
 	}
 
 	values, err := buildKubeConfigUpdate(cf, kubeStatus)


### PR DESCRIPTION
This PR fixes the multi profile handling for Kubernetes Access flow. Previously, `tsh kube credentials` assumed the default profile because no proxy was provided when kubectl invokes the credentials plugin which resulted in usage of wrong certificates.