### PR TITLE
Add device event update code to Web

### DIFF
--- a/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
+++ b/web/packages/teleport/src/Audit/EventList/EventTypeCell.tsx
@@ -171,6 +171,7 @@ const EventIconMap: Record<EventCode, React.FC> = {
   [eventCodes.DEVICE_ENROLL]: Icons.Info,
   [eventCodes.DEVICE_ENROLL_TOKEN_CREATE]: Icons.Info,
   [eventCodes.DEVICE_ENROLL_TOKEN_SPENT]: Icons.Info,
+  [eventCodes.DEVICE_UPDATE]: Icons.Info,
   [eventCodes.MFA_DEVICE_ADD]: Icons.Info,
   [eventCodes.MFA_DEVICE_DELETE]: Icons.Info,
   [eventCodes.BILLING_CARD_CREATE]: Icons.CreditCardAlt2,

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -359,12 +359,12 @@ exports[`list of all events 1`] = `
           </strong>
            - 
           <strong>
-            178
+            179
           </strong>
            of
            
           <strong>
-            178
+            179
           </strong>
         </div>
         <button
@@ -905,6 +905,43 @@ exports[`list of all events 1`] = `
           style="min-width: 120px;"
         >
           2023-01-25T19:21:36.144Z
+        </td>
+        <td
+          align="right"
+        >
+          <button
+            class="c16"
+            kind="border"
+            width="87px"
+          >
+            Details
+          </button>
+        </td>
+      </tr>
+      <tr>
+        <td
+          style="vertical-align: inherit;"
+        >
+          <div
+            class="c14"
+          >
+            <span
+              class="c10 c15 icon icon-info_outline c10 c15"
+              color="light"
+              font-size="3"
+            />
+            Device Update
+          </div>
+        </td>
+        <td
+          style="word-break: break-word;"
+        >
+          User [lisa] has updated a device
+        </td>
+        <td
+          style="min-width: 120px;"
+        >
+          2023-01-12T21:31:29.191Z
         </td>
         <td
           align="right"

--- a/web/packages/teleport/src/Audit/fixtures/index.ts
+++ b/web/packages/teleport/src/Audit/fixtures/index.ts
@@ -2673,6 +2673,25 @@ export const events = [
   },
   {
     cluster_name: 'im-a-cluster-name',
+    code: 'TV007I',
+    device: {
+      asset_tag: 'M2CQVQV64R',
+      device_id: '0e288b23-f99f-4635-b182-06e9308095a8',
+      os_type: 2,
+    },
+    ei: 0,
+    event: 'device',
+    status: {
+      success: true,
+    },
+    time: '2023-01-12T21:31:29.191Z',
+    uid: 'bbbc496f-820b-4f49-ae0d-1c1b29faee85',
+    user: {
+      user: 'lisa',
+    },
+  },
+  {
+    cluster_name: 'im-a-cluster-name',
     code: 'TLR00I',
     ei: 0,
     event: 'login_rule.create',

--- a/web/packages/teleport/src/services/audit/makeEvent.ts
+++ b/web/packages/teleport/src/services/audit/makeEvent.ts
@@ -1192,6 +1192,14 @@ export const formatters: Formatters = {
         ? `User [${user.user}] has spent a device enroll token`
         : `User [${user.user}] has failed to spend a device enroll token`,
   },
+  [eventCodes.DEVICE_UPDATE]: {
+    type: 'device',
+    desc: 'Device Update',
+    format: ({ user, status }) =>
+      status.success
+        ? `User [${user.user}] has updated a device`
+        : `User [${user.user}] has failed to update a device`,
+  },
   [eventCodes.X11_FORWARD]: {
     type: 'x11-forward',
     desc: 'X11 Forwarding Requested',

--- a/web/packages/teleport/src/services/audit/types.ts
+++ b/web/packages/teleport/src/services/audit/types.ts
@@ -112,6 +112,7 @@ export const eventCodes = {
   DEVICE_ENROLL_TOKEN_SPENT: 'TV004I',
   DEVICE_ENROLL: 'TV005I',
   DEVICE_AUTHENTICATE: 'TV006I',
+  DEVICE_UPDATE: 'TV007I',
   EXEC_FAILURE: 'T3002E',
   EXEC: 'T3002I',
   GITHUB_CONNECTOR_CREATED: 'T8000I',
@@ -1051,6 +1052,7 @@ export type RawEvents = {
   [eventCodes.DEVICE_AUTHENTICATE]: RawDeviceEvent<
     typeof eventCodes.DEVICE_AUTHENTICATE
   >;
+  [eventCodes.DEVICE_UPDATE]: RawDeviceEvent<typeof eventCodes.DEVICE_UPDATE>;
   [eventCodes.UNKNOWN]: RawEvent<
     typeof eventCodes.UNKNOWN,
     {


### PR DESCRIPTION
Add the audit event code for device updates. Web UI counterpart of #23709.

https://github.com/gravitational/teleport.e/issues/826