### PR TITLE
init PR templates

### DIFF
--- a/.github/dev_pr_template.md
+++ b/.github/dev_pr_template.md
@@ -1,0 +1,1 @@
+## Description

--- a/.github/docs_pr_change_template.md
+++ b/.github/docs_pr_change_template.md
@@ -1,0 +1,12 @@
+## Description
+
+<!-- Describe the changes made in this PR -->
+
+## Checklist
+- [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/)
+- [ ] I viewed the changes on the sev server (`yarn dev`) to confirm they render without error
+- [ ] The terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
+- [ ] I spellchecked the changes
+- [ ] I referenced any issues this PR will close
+- [ ] I checked for existing PRs related to this change.
+- [ ] I added appropriate backport labels (we support the previous two versions of Teleport)

--- a/.github/docs_pr_change_template.md
+++ b/.github/docs_pr_change_template.md
@@ -7,6 +7,5 @@
 - [ ] I viewed the changes on the dev server (`yarn dev`) to confirm they render without error
 - [ ] The terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
 - [ ] I spellchecked the changes
-- [ ] I referenced any issues this PR will close
 - [ ] I checked for existing PRs related to this change.
-- [ ] I added appropriate backport labels (we support the previous two versions of Teleport)
+- [ ] I added appropriate backport labels (we support the previous two major versions of Teleport)

--- a/.github/docs_pr_change_template.md
+++ b/.github/docs_pr_change_template.md
@@ -4,7 +4,7 @@
 
 ## Checklist
 - [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/)
-- [ ] I viewed the changes on the sev server (`yarn dev`) to confirm they render without error
+- [ ] I viewed the changes on the dev server (`yarn dev`) to confirm they render without error
 - [ ] The terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
 - [ ] I spellchecked the changes
 - [ ] I referenced any issues this PR will close

--- a/.github/docs_pr_change_template.md
+++ b/.github/docs_pr_change_template.md
@@ -3,9 +3,8 @@
 <!-- Describe the changes made in this PR -->
 
 ## Checklist
-- [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/)
+
+- [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/), and the terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
 - [ ] I viewed the changes on the dev server (`yarn dev`) to confirm they render without error
-- [ ] The terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
-- [ ] I spellchecked the changes
 - [ ] I checked for existing PRs related to this change.
 - [ ] I added appropriate backport labels (we support the previous two major versions of Teleport)

--- a/.github/docs_pr_new_template.md
+++ b/.github/docs_pr_new_template.md
@@ -3,14 +3,12 @@
 <!-- Describe the new documentation added in this PR -->
 
 ## Checklist
-- [ ] I updated `config.json` with any new docs pages.
-- [ ] I added an entry in the relevant menu page. For example, if a PR adds a new guide related to accessing servers, an author could add a link to `docs/pages/server-access/guides.mdx`.
+
+- [ ] I updated `config.json` with any new docs pages, and added an entry in the relevant menu page. For example, if a PR adds a new guide related to accessing servers, an author could add a link to `docs/pages/server-access/guides.mdx`.
 - [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/)
 - [ ] I viewed the changes on the dev server (`yarn dev`) to confirm they render without error
 - [ ] I updated relevant references with any new commands, flags, or configuration options introduced by the new docs page.
-- [ ] The terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
 - [ ] I successfully followed the instructions myself from the perspective of an engineer who is unfamiliar with the feature/behavior I'm documenting.
-- [ ] I spellchecked the changes
-- [ ] I referenced any issues this PR will close
-- [ ] I checked for existing PRs related to this change.
+- [ ] I spellchecked the changes, and the terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
+- [ ] I referenced any issues this PR will close, and checked for existing PRs related to this change.
 - [ ] I added appropriate backport labels (we support the previous two versions of Teleport)

--- a/.github/docs_pr_new_template.md
+++ b/.github/docs_pr_new_template.md
@@ -4,11 +4,9 @@
 
 ## Checklist
 
-- [ ] I updated `config.json` with any new docs pages, and added an entry in the relevant menu page. For example, if a PR adds a new guide related to accessing servers, an author could add a link to `docs/pages/server-access/guides.mdx`.
-- [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/)
-- [ ] I viewed the changes on the dev server (`yarn dev`) to confirm they render without error
+- [ ] I viewed the changes on the dev server (`yarn dev`) to confirm they render without error, and any new pages are listed in the nav bar and section index.
+- [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/), and the terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
 - [ ] I updated relevant references with any new commands, flags, or configuration options introduced by the new docs page.
 - [ ] I successfully followed the instructions myself from the perspective of an engineer who is unfamiliar with the feature/behavior I'm documenting.
-- [ ] I spellchecked the changes, and the terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
 - [ ] I referenced any issues this PR will close, and checked for existing PRs related to this change.
 - [ ] I added appropriate backport labels (we support the previous two versions of Teleport)

--- a/.github/docs_pr_new_template.md
+++ b/.github/docs_pr_new_template.md
@@ -3,13 +3,13 @@
 <!-- Describe the new documentation added in this PR -->
 
 ## Checklist
-- [ ] The new docs pages was added to `config.json`.
-- [ ] I added an entry in the relevant menu page. For example, if a PR adds a new guide related to accessing servers, an author could add a link to docs/pages/server-access/guides.mdx.
+- [ ] I updated `config.json` with any new docs pages.
+- [ ] I added an entry in the relevant menu page. For example, if a PR adds a new guide related to accessing servers, an author could add a link to `docs/pages/server-access/guides.mdx`.
 - [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/)
-- [ ] I viewed the changes on the sev server (`yarn dev`) to confirm they render without error
+- [ ] I viewed the changes on the dev server (`yarn dev`) to confirm they render without error
 - [ ] I updated relevant references with any new commands, flags, or configuration options introduced by the new docs page.
 - [ ] The terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
-- [ ] I successfully follow the instructions myself from the perspective of an engineer who is unfamiliar with the feature/behavior I'm documenting.
+- [ ] I successfully followed the instructions myself from the perspective of an engineer who is unfamiliar with the feature/behavior I'm documenting.
 - [ ] I spellchecked the changes
 - [ ] I referenced any issues this PR will close
 - [ ] I checked for existing PRs related to this change.

--- a/.github/docs_pr_new_template.md
+++ b/.github/docs_pr_new_template.md
@@ -1,0 +1,16 @@
+## Description
+
+<!-- Describe the new documentation added in this PR -->
+
+## Checklist
+- [ ] The new docs pages was added to `config.json`.
+- [ ] I added an entry in the relevant menu page. For example, if a PR adds a new guide related to accessing servers, an author could add a link to docs/pages/server-access/guides.mdx.
+- [ ] This change matches the [docs style guide](https://goteleport.com/docs/contributing/documentation/style-guide/)
+- [ ] I viewed the changes on the sev server (`yarn dev`) to confirm they render without error
+- [ ] I updated relevant references with any new commands, flags, or configuration options introduced by the new docs page.
+- [ ] The terms used in this change correspond to those in [Teleport Core Concepts](https://goteleport.com/docs/core-concepts)
+- [ ] I successfully follow the instructions myself from the perspective of an engineer who is unfamiliar with the feature/behavior I'm documenting.
+- [ ] I spellchecked the changes
+- [ ] I referenced any issues this PR will close
+- [ ] I checked for existing PRs related to this change.
+- [ ] I added appropriate backport labels (we support the previous two versions of Teleport)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+Please go the the `Preview` tab and select the appropriate sub-template:
+
+* [Code Change](?expand=1&template=dev_pr_template.md)
+* [Docs Change](?expand=1&template=docs_pr_change_template.md)
+* [New Docs](?expand=1&template=docs_new_pr_template.md)


### PR DESCRIPTION
Assuming [this](https://stackoverflow.com/questions/73771068/multiple-templates-for-pull-requests-on-github) stackoverflow page is correct, we can have multiple PR templates. Docs [wants](https://github.com/gravitational/teleport/issues/23518) to use PR templates for docs changes and new PRs. I also made a stub template for other non-docs changes.