### PR TITLE
Reduce time spent setting ssh session envs

### DIFF
--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -392,7 +392,7 @@ func TestSetEnvs(t *testing.T) {
 		require.NoError(t, session.SetEnvs(ctx, expected))
 
 		envs := map[string]string{}
-		envsTimeout := time.NewTimer(3*time.Second)
+		envsTimeout := time.NewTimer(3 * time.Second)
 		defer envsTimeout.Stop()
 		for i := 0; i < len(expected); i++ {
 			select {

--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -406,7 +406,6 @@ func TestSetEnvs(t *testing.T) {
 		for k, v := range expected {
 			actual, ok := envs[k]
 			require.True(t, ok, "expected env %s to be set", k)
-
 			require.Equal(t, v, actual, "expected value %s for env %s, got %s", v, k, actual)
 		}
 	})

--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -392,12 +392,14 @@ func TestSetEnvs(t *testing.T) {
 		require.NoError(t, session.SetEnvs(ctx, expected))
 
 		envs := map[string]string{}
+		envsTimeout := time.NewTimer(3*time.Second)
+		defer envsTimeout.Stop()
 		for i := 0; i < len(expected); i++ {
 			select {
 			case env := <-envReqC:
 				envs[env.Name] = env.Value
-			case <-time.After(3 * time.Second):
-				t.Fatalf("time out waiting for env request %d to be processed", i)
+			case <-envsTimeout.C:
+				t.Fatalf("Time out waiting for env request %d to be processed", i)
 			}
 		}
 

--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -16,6 +16,7 @@ package ssh
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -260,5 +261,166 @@ func TestNewSession(t *testing.T) {
 			default:
 			}
 		})
+	}
+}
+
+// envReqParams are parameters for env request
+type envReqParams struct {
+	Name  string
+	Value string
+}
+
+// processEnvRequest unmarshals the env request and validates that the
+// received k,v match the provided values. Any mismatch or failure to
+// process the message results in sending a reply of false.
+func processEnvRequest(req *ssh.Request) (string, string) {
+	var e envReqParams
+	if err := ssh.Unmarshal(req.Payload, &e); err != nil {
+		_ = req.Reply(false, []byte(err.Error()))
+		return "", ""
+	}
+
+	_ = req.Reply(true, nil)
+
+	return e.Name, e.Value
+}
+
+// TestSetEnvs verifies that client uses EnvsRequest to
+// send multiple envs and falls back to sending individual "env"
+// requests if the server does not support EnvsRequests.
+func TestSetEnvs(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	errChan := make(chan error, 5)
+
+	expected := map[string]string{"a": "1", "b": "2", "c": "3"}
+
+	srv := newServer(t, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case ch := <-channels:
+				switch {
+				case ch == nil:
+					return
+				case ch.ChannelType() == "session":
+					ch, reqs, err := ch.Accept()
+					if err != nil {
+						errChan <- trace.Wrap(err, "failed to accept session channel")
+						return
+					}
+
+					go func() {
+						// used to collect individual envs requests
+						fallback := map[string]string{}
+
+						defer ch.Close()
+						for i := 0; ; i++ {
+							select {
+							case <-ctx.Done():
+								return
+
+							case req := <-reqs:
+								if req == nil {
+									return
+								}
+
+								switch {
+								case i == 0 && req.Type == EnvsRequest:
+									var envReq EnvsReq
+									if err := ssh.Unmarshal(req.Payload, &envReq); err != nil {
+										_ = req.Reply(false, []byte(err.Error()))
+										return
+									}
+
+									var envs map[string]string
+									if err := json.Unmarshal(envReq.Envs, &envs); err != nil {
+										_ = req.Reply(false, []byte(err.Error()))
+										return
+									}
+
+									for k, v := range expected {
+										actual, ok := envs[k]
+										if !ok {
+											_ = req.Reply(false, []byte(fmt.Sprintf("expected env %s not present", k)))
+											return
+										}
+
+										if actual != v {
+											_ = req.Reply(false, []byte(fmt.Sprintf("expected value %s for env %s, got %s", v, k, actual)))
+											return
+										}
+									}
+
+									_ = req.Reply(true, nil)
+								case i == 1 && req.Type == EnvsRequest:
+									_ = req.Reply(false, nil)
+								case i == 2 && req.Type == "env":
+									k, v := processEnvRequest(req)
+									fallback[k] = v
+								case i == 3 && req.Type == "env":
+									k, v := processEnvRequest(req)
+									fallback[k] = v
+								case i == 4 && req.Type == "env":
+									k, v := processEnvRequest(req)
+									fallback[k] = v
+
+									for k, v := range expected {
+										actual, ok := fallback[k]
+										if !ok {
+											_ = req.Reply(false, []byte(fmt.Sprintf("expected env %s not present", k)))
+											return
+										}
+
+										if actual != v {
+											_ = req.Reply(false, []byte(fmt.Sprintf("expected value %s for env %s, got %s", v, k, actual)))
+											return
+										}
+									}
+								default:
+									_ = req.Reply(false, []byte(fmt.Sprintf("unexpected ssh request %s on iteration %d", req.Type, i)))
+									return
+
+								}
+							}
+						}
+
+					}()
+
+				default:
+					if err := ch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unexpected channel %s", ch.ChannelType())); err != nil {
+						errChan <- err
+						return
+					}
+				}
+			}
+		}
+	})
+
+	go srv.Run(errChan)
+
+	// create a client and open a session
+	conn, chans, reqs := srv.GetClient(t)
+	client := NewClient(conn, chans, reqs)
+	session, err := client.NewSession(ctx)
+	require.NoError(t, err)
+
+	// the first request shouldn't fall back
+	t.Run("envs set via envs@goteleport.com", func(t *testing.T) {
+		require.NoError(t, session.SetEnvs(ctx, expected))
+	})
+
+	// subsequent requests should fall back to standard "env" requests
+	t.Run("envs set individually", func(t *testing.T) {
+		require.NoError(t, session.SetEnvs(ctx, expected))
+	})
+
+	select {
+	case err := <-errChan:
+		require.NoError(t, err)
+	default:
 	}
 }

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -37,6 +37,7 @@ import (
 const (
 	// EnvsRequest sets multiple environment variables that will be applied to any
 	// command executed by Shell or Run.
+	// See [EnvsReq] for the corresponding payload.
 	EnvsRequest = "envs@goteleport.com"
 
 	// TracingRequest is sent by clients to server to pass along tracing context.
@@ -50,11 +51,11 @@ const (
 )
 
 // EnvsReq contains json marshaled key:value pairs sent as the
-// payload for an EnvsRequest.
+// payload for an [EnvsRequest].
 type EnvsReq struct {
-	// Envs is a json marshaled map[string]string containing
+	// EnvsJSON is a json marshaled map[string]string containing
 	// environment variables.
-	Envs []byte
+	EnvsJSON []byte `json:"envs"`
 }
 
 // ContextFromRequest extracts any tracing data provided via an Envelope

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -35,6 +35,10 @@ import (
 )
 
 const (
+	// EnvsRequest sets multiple environment variables that will be applied to any
+	// command executed by Shell or Run.
+	EnvsRequest = "envs@goteleport.com"
+
 	// TracingRequest is sent by clients to server to pass along tracing context.
 	TracingRequest = "tracing@goteleport.com"
 
@@ -44,6 +48,14 @@ const (
 	// instrumentationName is the name of this instrumentation package.
 	instrumentationName = "otelssh"
 )
+
+// EnvsReq contains json marshaled key:value pairs sent as the
+// payload for an EnvsRequest.
+type EnvsReq struct {
+	// Envs is a json marshaled map[string]string containing
+	// environment variables.
+	Envs []byte
+}
 
 // ContextFromRequest extracts any tracing data provided via an Envelope
 // in the ssh.Request payload. If the payload contains an Envelope, then

--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -225,22 +225,22 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Sessi
 		return nil, trace.Wrap(err)
 	}
 
+	envs := map[string]string{}
+
 	// pass language info into the remote session.
-	evarsToPass := []string{"LANG", "LANGUAGE"}
-	for _, evar := range evarsToPass {
-		if value := os.Getenv(evar); value != "" {
-			err = sess.Setenv(ctx, evar, value)
-			if err != nil {
-				log.Warn(err)
-			}
+	langVars := []string{"LANG", "LANGUAGE"}
+	for _, env := range langVars {
+		if value := os.Getenv(env); value != "" {
+			envs[env] = value
 		}
 	}
 	// pass environment variables set by client
 	for key, val := range ns.env {
-		err = sess.Setenv(ctx, key, val)
-		if err != nil {
-			log.Warn(err)
-		}
+		envs[key] = val
+	}
+
+	if err := sess.SetEnvs(ctx, envs); err != nil {
+		log.Warn(err)
 	}
 
 	// if agent forwarding was requested (and we have a agent to forward),

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1331,12 +1331,12 @@ func (s *Server) handleEnvs(ctx context.Context, ch ssh.Channel, req *ssh.Reques
 	}
 
 	var envs map[string]string
-	if err := json.Unmarshal(raw.Envs, &envs); err != nil {
+	if err := json.Unmarshal(raw.EnvsJSON, &envs); err != nil {
 		return trace.Wrap(err, "failed to unmarshal envs")
 	}
 
 	if err := scx.RemoteSession.SetEnvs(ctx, envs); err != nil {
-		s.log.Debugf("Unable to set environment variables: %v", err)
+		s.log.WithError(err).Debug("Unable to set environment variables")
 	}
 
 	return nil

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -18,6 +18,7 @@ package forward
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -1080,7 +1081,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			return s.termHandlers.HandleWinChange(ctx, ch, req, scx)
 		case teleport.ForceTerminateRequest:
 			return s.termHandlers.HandleForceTerminate(ch, req, scx)
-		case sshutils.EnvRequest:
+		case sshutils.EnvRequest, tracessh.EnvsRequest:
 			// We ignore all SSH setenv requests for join-only principals.
 			// SSH will send them anyway but it seems fine to silently drop them.
 		case sshutils.SubsystemRequest:
@@ -1116,6 +1117,8 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		return s.termHandlers.HandleForceTerminate(ch, req, scx)
 	case sshutils.EnvRequest:
 		return s.handleEnv(ctx, ch, req, scx)
+	case tracessh.EnvsRequest:
+		return s.handleEnvs(ctx, ch, req, scx)
 	case sshutils.SubsystemRequest:
 		return s.handleSubsystem(ctx, ch, req, scx)
 	case sshutils.X11ForwardRequest:
@@ -1313,6 +1316,27 @@ func (s *Server) handleEnv(ctx context.Context, ch ssh.Channel, req *ssh.Request
 	err := scx.RemoteSession.Setenv(ctx, e.Name, e.Value)
 	if err != nil {
 		s.log.Debugf("Unable to set environment variable: %v: %v", e.Name, e.Value)
+	}
+
+	return nil
+}
+
+// handleEnvs accepts environment variables sent by the client and forwards them
+// to the remote session.
+func (s *Server) handleEnvs(ctx context.Context, ch ssh.Channel, req *ssh.Request, scx *srv.ServerContext) error {
+	var raw tracessh.EnvsReq
+	if err := ssh.Unmarshal(req.Payload, &raw); err != nil {
+		scx.Error(err)
+		return trace.Wrap(err, "failed to parse envs request")
+	}
+
+	var envs map[string]string
+	if err := json.Unmarshal(raw.Envs, &envs); err != nil {
+		return trace.Wrap(err, "failed to unmarshal envs")
+	}
+
+	if err := scx.RemoteSession.SetEnvs(ctx, envs); err != nil {
+		s.log.Debugf("Unable to set environment variables: %v", err)
 	}
 
 	return nil

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1843,7 +1843,7 @@ func (s *Server) handleEnvs(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerCon
 	}
 
 	var envs map[string]string
-	if err := json.Unmarshal(raw.Envs, &envs); err != nil {
+	if err := json.Unmarshal(raw.EnvsJSON, &envs); err != nil {
 		return trace.Wrap(err, "failed to unmarshal envs")
 	}
 

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -20,6 +20,7 @@ package regular
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -1570,8 +1571,9 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		case sshutils.SubsystemRequest:
 			return s.handleSubsystem(ctx, ch, req, serverContext)
 		case sshutils.EnvRequest:
-			// we currently ignore setting any environment variables via SSH for security purposes
 			return s.handleEnv(ch, req, serverContext)
+		case tracessh.EnvsRequest:
+			return s.handleEnvs(ch, req, serverContext)
 		case sshutils.AgentForwardRequest:
 			// process agent forwarding, but we will only forward agent to proxy in
 			// recording proxy mode.
@@ -1607,7 +1609,7 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 			return s.termHandlers.HandleWinChange(ctx, ch, req, serverContext)
 		case teleport.ForceTerminateRequest:
 			return s.termHandlers.HandleForceTerminate(ch, req, serverContext)
-		case sshutils.EnvRequest:
+		case sshutils.EnvRequest, tracessh.EnvsRequest:
 			// We ignore all SSH setenv requests for join-only principals.
 			// SSH will send them anyway but it seems fine to silently drop them.
 		case sshutils.SubsystemRequest:
@@ -1655,6 +1657,8 @@ func (s *Server) dispatch(ctx context.Context, ch ssh.Channel, req *ssh.Request,
 		return s.termHandlers.HandleForceTerminate(ch, req, serverContext)
 	case sshutils.EnvRequest:
 		return s.handleEnv(ch, req, serverContext)
+	case tracessh.EnvsRequest:
+		return s.handleEnvs(ch, req, serverContext)
 	case sshutils.SubsystemRequest:
 		// subsystems are SSH subsystems defined in http://tools.ietf.org/html/rfc4254 6.6
 		// they are in essence SSH session extensions, allowing to implement new SSH commands
@@ -1817,7 +1821,7 @@ func (s *Server) handleSubsystem(ctx context.Context, ch ssh.Channel, req *ssh.R
 	return nil
 }
 
-// handleEnv accepts environment variables sent by the client and stores them
+// handleEnv accepts an environment variable sent by the client and stores it
 // in connection context
 func (s *Server) handleEnv(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
 	var e sshutils.EnvReqParams
@@ -1826,6 +1830,27 @@ func (s *Server) handleEnv(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerCont
 		return trace.Wrap(err, "failed to parse env request")
 	}
 	ctx.SetEnv(e.Name, e.Value)
+	return nil
+}
+
+// handleEnvs accepts environment variables sent by the client and stores them
+// in connection context
+func (s *Server) handleEnvs(ch ssh.Channel, req *ssh.Request, ctx *srv.ServerContext) error {
+	var raw tracessh.EnvsReq
+	if err := ssh.Unmarshal(req.Payload, &raw); err != nil {
+		ctx.Error(err)
+		return trace.Wrap(err, "failed to parse envs request")
+	}
+
+	var envs map[string]string
+	if err := json.Unmarshal(raw.Envs, &envs); err != nil {
+		return trace.Wrap(err, "failed to unmarshal envs")
+	}
+
+	for k, v := range envs {
+		ctx.SetEnv(k, v)
+	}
+
 	return nil
 }
 

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -1650,7 +1650,8 @@ func TestPTY(t *testing.T) {
 	require.NoError(t, se.RequestPty(ctx, "xterm", 0, 0, ssh.TerminalModes{}))
 }
 
-// TestEnv requests setting environment variables. (We are currently ignoring these requests)
+// TestEnv requests setting environment variables via
+// a "env" request.
 func TestEnv(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
@@ -1661,7 +1662,37 @@ func TestEnv(t *testing.T) {
 	require.NoError(t, err)
 	defer se.Close()
 
-	require.NoError(t, se.Setenv(ctx, "HOME", "/"))
+	require.NoError(t, se.Setenv(ctx, "HOME_TEST", "/test"))
+	output, err := se.Output(ctx, "env")
+	require.NoError(t, err)
+	require.Contains(t, string(output), "HOME_TEST=/test")
+}
+
+// TestEnvs requests setting environment variables via
+// a "envs@goteleport.com" request.
+func TestEnvs(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	f := newFixtureWithoutDiskBasedLogging(t)
+
+	se, err := f.ssh.clt.NewSession(ctx)
+	require.NoError(t, err)
+	defer se.Close()
+
+	envs := map[string]string{
+		"HOME_TEST": "/test",
+		"LLAMA":     "ALPACA",
+		"FISH":      "FROG",
+	}
+
+	require.NoError(t, se.SetEnvs(ctx, envs))
+	output, err := se.Output(ctx, "env")
+	require.NoError(t, err)
+
+	for k, v := range envs {
+		require.Contains(t, string(output), k+"="+v)
+	}
 }
 
 // TestNoAuth tries to log in with no auth methods and should be rejected

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -694,6 +694,6 @@ func (t *remoteTerminal) prepareRemoteSession(ctx context.Context, session *trac
 	}
 
 	if err := session.SetEnvs(ctx, envs); err != nil {
-		t.log.Debugf("Unable to set environment variables: %v", err)
+		t.log.WithError(err).Debug("Unable to set environment variables")
 	}
 }

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -693,9 +693,7 @@ func (t *remoteTerminal) prepareRemoteSession(ctx context.Context, session *trac
 		teleport.SSHSessionID:           string(scx.SessionID()),
 	}
 
-	for k, v := range envs {
-		if err := session.Setenv(ctx, k, v); err != nil {
-			t.log.Debugf("Unable to set environment variable: %v: %v", k, v)
-		}
+	if err := session.SetEnvs(ctx, envs); err != nil {
+		t.log.Debugf("Unable to set environment variables: %v", err)
 	}
 }


### PR DESCRIPTION
`tsh` sets a number of environment variables when setting up the users session. Each key value pair is transmitted one at a time in a "env" ssh request, which adds a number of envs * RTT of additional latency per session.

This introduces a new `envs@goteleport.com` request which sets multiple environment variables in a single ssh request, which reduces the amount of time spent setting envs down to the RTT of a single ssh request. In order to ensure backward compat and interoperability with OpenSSH, if the server does not recognize the `envs@goteleport.com` request the ssh client will resort to sending individual "env" requests.