### PR TITLE
[v12] Correct linux download name of Teleport Connect

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -26,7 +26,7 @@ your package manager. Repeat the process for in-place upgrades.
 You can also download the project as a `tar.gz` file to extract and run it in place:
 
 ```code
-$ tar -xf  teleport-(=teleport.version=)-linux-*.tar.gz
+$ tar -xf  teleport-connect-(=teleport.version=)-linux-*.tar.gz
 ```
 </TabItem>
 <TabItem label="Windows">


### PR DESCRIPTION
Backports #23604 to `branch/v12`.