### PR TITLE
release: Add build-connect target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,6 +503,28 @@ release-windows: release-windows-unsigned
 	@echo "---> Created $(RELEASE).zip."
 
 #
+# make release-connect produces a release package of Teleport Connect.
+# It is used only for MacOS releases. Windows releases do not use this
+# Makefile. Linux uses the `teleterm` target in build.assets/Makefile.
+#
+# Only export the CSC_NAME (developer key ID) when the recipe is run, so
+# that we do not shell out and run the `security` command if not necessary.
+#
+# Either CONNECT_TSH_BIN_PATH or CONNECT_TSH_APP_PATH environment variable
+# should be defined for the `yarn package-term` command to succeed. CI sets
+# this appropriately depending on whether a push build is running, or a
+# proper release (a proper release needs the APP_PATH as that points to
+# the complete signed package). See web/packages/teleterm/README.md for
+# details.
+#
+.PHONY: release-connect
+release-connect:
+	$(eval export CSC_NAME)
+	yarn install --frozen-lockfile
+	yarn build-term
+	yarn package-term -c.extraMetadata.version=$(VERSION)
+
+#
 # Remove trailing whitespace in all markdown files under docs/.
 #
 # Note: this runs in a busybox container to avoid incompatibilities between

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -35,9 +35,14 @@ TEAMID = $(TEAMID_$(ENVIRONMENT_NAME))
 DEVELOPER_ID_APPLICATION = $(call get_key_id,$(DEVELOPER_KEY_NAME_$(ENVIRONMENT_NAME)))
 DEVELOPER_ID_INSTALLER = $(call get_key_id,$(INSTALLER_KEY_NAME_$(ENVIRONMENT_NAME)))
 
-# Don't export DEVELOPER_ID_APPLICATION or DEVELOPER_ID_INSTALLER as it
-# evaluates them. They should only be evaluated them if used.
-unexport DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER
+# CSC_NAME is the key ID for signing used by electron-builder for signing
+# Teleport Connect.
+CSC_NAME = $(DEVELOPER_ID_APPLICATION)
+
+# Don't export DEVELOPER_ID_APPLICATION, DEVELOPER_ID_INSTALLER or CSC_NAME as
+# it causes them to be evaluated, which shells out to the `security` command.
+# They should only be evaluated if used.
+unexport CSC_NAME DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER
 
 # Bundle IDs identify packages/images. We use different bundle IDs for
 # release and development.

--- a/darwin-signing.mk
+++ b/darwin-signing.mk
@@ -104,7 +104,7 @@ define notarize_binaries_cmd
 		$(ABSOLUTE_BINARY_PATHS)
 endef
 
-not_notarizing_cmd = @echo Not notarizing binaries. APPLE_USERNAME or APPLE_PASSWORD not set.
+not_notarizing_cmd = echo Not notarizing binaries. APPLE_USERNAME or APPLE_PASSWORD not set.
 
 # Dont export not_notarizing_cmd since it contains DEVELOPER_ID_APPLICATION
 # and we do not want that evaluated.


### PR DESCRIPTION
Add a `build-connect` target to the `Makefile` to build Teleport Connect 
via yarn on MacOS. Linux uses the `build.assets/Makefile` `teleterm` 
target, and Windows build pipelines do not use `make`.

Add the `CSC_NAME` make variable containing the Developer Key ID to tell 
electron-builder which key to use to sign the package it produces.

This gives us a little more control over how the Connect built and packaged
and will simplify the CI scripts to have them just call make. It is also
required in order to set the `CSC_NAME` environment name correctly as the
developer ID is determined by the Makefile.

Also fix a bug with a leading `@` on an echo command in the Makefile.
This was intended to silence the `echo` command, but it prevents it
being used in a concatenated command (`cd .. && @echo foo` doesn't work)

Issue: https://github.com/gravitational/teleport/issues/20319