### PR TITLE
docs: modify teleport binary reference to non-path specific in ec2 discovery

### DIFF
--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -155,7 +155,7 @@ will generate and display the additional IAM policies and AWS Systems Manager (S
 required to enable the Discovery Service:
 
 ```code
-$ sudo ./teleport discovery bootstrap
+$ sudo teleport discovery bootstrap
 Reading configuration at "/etc/teleport.yaml"...
 
 AWS


### PR DESCRIPTION
The example command will fail unless `teleport` binary is in the same directory as where it's run.  Only applies to `branch/v11` and `branch/v12`.