### PR TITLE
[v12] Allow app server origin of Okta if added by Okta built in role.

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -812,7 +812,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					Rules: []types.Rule{
 						types.NewRule(types.KindEvent, services.RW()),
 						types.NewRule(types.KindAccessRequest, services.RO()),
-						types.NewRule(types.KindApp, services.RW()),
+						types.NewRule(types.KindAppServer, services.RW()),
 						types.NewRule(types.KindUser, services.RO()),
 						types.NewRule(types.KindUserGroup, services.RW()),
 						types.NewRule(types.KindOktaImportRule, services.RO()),


### PR DESCRIPTION
Backporting https://github.com/gravitational/teleport/pull/23688 to branch/v12