### PR TITLE
[v10] docs: label enterprise prereq as Teleport Enterprise, not just Teleport

### DIFF
--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -2,7 +2,7 @@
 <TabItem
   scope={["enterprise"]} label="Enterprise">
 
-- A running Teleport cluster, including the Auth Service and Proxy Service. For
+- A running Teleport Enterprise cluster, including the Auth Service and Proxy Service. For
   details on how to set this up, see our Enterprise [Getting
   Started](/docs/enterprise/getting-started) guide.
 

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -25,7 +25,7 @@ files in partials, this partial uses relative URL paths instead.
 <TabItem
   scope={["enterprise"]} label="Enterprise">
 
-- A running Teleport cluster. For details on how to set this up, see our Enterprise
+- A running Teleport Enterprise cluster. For details on how to set this up, see our Enterprise
   [Getting Started](/docs/enterprise/getting-started) guide.
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),


### PR DESCRIPTION
backport #23762