### PR TITLE
Use `teleport-internal-join` login when joining a Moderated Session from the UI

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -291,13 +291,6 @@ func (t *TerminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If the displayLogin is set then use it instead of the login name used in
-	// the SSH connection. This is specifically for the use case when joining
-	// a session to avoid displaying "-teleport-internal-join" as the username.
-	if t.displayLogin != "" {
-		t.sessionData.Login = t.displayLogin
-	}
-
 	sendError := func(errMsg string, err error, ws *websocket.Conn) {
 		envelope := &Envelope{
 			Version: defaults.WebsocketVersion,
@@ -309,7 +302,19 @@ func (t *TerminalHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		ws.WriteMessage(websocket.BinaryMessage, envelopeBytes)
 	}
 
-	sessionMetadataResponse, err := json.Marshal(siteSessionGenerateResponse{Session: t.sessionData})
+	var sessionMetadataResponse []byte
+
+	// If the displayLogin is set then use it in the session metadata instead of the
+	// login name used in the SSH connection. This is specifically for the use case
+	// when joining a session to avoid displaying "-teleport-internal-join" as the username.
+	if t.displayLogin != "" {
+		sessionDataTemp := t.sessionData
+		sessionDataTemp.Login = t.displayLogin
+		sessionMetadataResponse, err = json.Marshal(siteSessionGenerateResponse{Session: sessionDataTemp})
+	} else {
+		sessionMetadataResponse, err = json.Marshal(siteSessionGenerateResponse{Session: t.sessionData})
+	}
+
 	if err != nil {
 		sendError("unable to marshal session response", err, ws)
 		return


### PR DESCRIPTION
## Purpose

This PR closes https://github.com/gravitational/teleport/issues/23238
This PR closes https://github.com/gravitational/customer-sensitive-requests/issues/37

Fixes a bug that causes a moderated session joiner to join with the OS login of the host. If the joiner doesn't have access to that login, they get an `Access Denied` error and cannot join the session. 


## Implementation

Previously, in order to avoid the `-teleport-internal-join` login name from being displayed when joining a session via the UI, we would instead show the `displayLogin`. The issue is that that implementation would mutate the `sessionData` directly and thus the connection would attempt to use that as the login. 

This PR makes sure to only replace the login name in the `sessionMedatadataResponse`, that way we get the desired behaviour of not displaying `teleport-internal-join` without the `sessionData` itself being affected.