### PR TITLE
[v12] Bump bitflags from 1.3.2 to 2.0.2 (#23741)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -100,7 +100,7 @@ version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "062dddbc1ba4aca46de6338e2bf87771414c335f7b2f2036e8f3e9befebf88e6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -118,6 +118,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "487f1e0fcbe47deb8b0574e646def1c903389d95241dd1bbcc6ce4a715dfc0c1"
 
 [[package]]
 name = "block-buffer"
@@ -146,7 +152,7 @@ version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c713ad6d8d7a681a43870ac37b89efd2a08015ceb4b256d82707509c1f0b6bb"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "boring-sys",
  "foreign-types",
  "lazy_static",
@@ -255,7 +261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex",
  "indexmap",
  "strsim",
@@ -1045,7 +1051,7 @@ version = "0.17.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "flate2",
  "miniz_oxide",
@@ -1168,7 +1174,7 @@ dependencies = [
 name = "rdp-client"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 2.0.2",
  "byteorder",
  "cbindgen",
  "env_logger",
@@ -1219,7 +1225,7 @@ version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1334,7 +1340,7 @@ version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3807b5d10909833d3e9acd1eb5fb988f79376ff10fce42937de71a449c4c588"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["staticlib"]
 
 [dependencies]
-bitflags = "1.3.2"
+bitflags = "2.0.2"
 byteorder = "1.4.3"
 env_logger = "0.10.0"
 iso7816 = "0.1.0"

--- a/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/cliprdr.rs
@@ -335,6 +335,7 @@ impl Client {
 }
 
 bitflags! {
+    #[derive(PartialEq, Eq, Debug)]
     struct ClipboardHeaderFlags: u16 {
         /// Indicates that the assocated request was processed successfully.
         const CB_RESPONSE_OK = 0x0001;
@@ -428,7 +429,7 @@ impl ClipboardCapabilitiesPDU {
             w.write_u16::<LittleEndian>(ClipboardCapabilitySetType::General as u16)?;
             w.write_u16::<LittleEndian>(12)?; // length
             w.write_u32::<LittleEndian>(CB_CAPS_VERSION_2)?;
-            w.write_u32::<LittleEndian>(set.flags.bits)?;
+            w.write_u32::<LittleEndian>(set.flags.bits())?;
         }
 
         Ok(w)
@@ -489,6 +490,7 @@ struct GeneralClipboardCapabilitySet {
 }
 
 bitflags! {
+    #[derive(Debug, PartialEq)]
     struct ClipboardGeneralCapabilityFlags: u32 {
         /// Indicates that long format names will be used in the format list PDU.
         /// If this flag is not set, then the short format names MUST be used.

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/flags.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/flags.rs
@@ -23,6 +23,7 @@ bitflags! {
     /// This implements the combination of the two. For flags where the names and/or functions are distinct between the two,
     /// the names are appended with an "_OR_", and the File_Pipe_Printer_Access_Mask functionality is described on the top line comment,
     /// and the Directory_Access_Mask functionality is described on the bottom (2nd) line comment.
+    #[derive(Debug, Clone)]
     pub struct DesiredAccess: u32 {
         /// This value indicates the right to read data from the file or named pipe.
         /// This value indicates the right to enumerate the contents of the directory.
@@ -75,6 +76,7 @@ bitflags! {
 bitflags! {
     /// 2.6 File Attributes [MS-FSCC]
     /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ca28ec38-f155-4768-81d6-4bfeb8586fc9
+    #[derive(Debug, Clone)]
     pub struct FileAttributes: u32 {
         const FILE_ATTRIBUTE_READONLY = 0x00000001;
         const FILE_ATTRIBUTE_HIDDEN = 0x00000002;
@@ -101,6 +103,7 @@ bitflags! {
 bitflags! {
     /// Specifies the sharing mode for the open. If ShareAccess values of FILE_SHARE_READ, FILE_SHARE_WRITE and FILE_SHARE_DELETE are set for a printer file or a named pipe, the server SHOULD<35> ignore these values. The field MUST be pub constructed using a combination of zero or more of the following bit values.
     /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+    #[derive(Debug, Clone)]
     pub struct SharedAccess: u32 {
         const FILE_SHARE_READ = 0x00000001;
         const FILE_SHARE_WRITE = 0x00000002;
@@ -113,6 +116,7 @@ bitflags! {
     /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
     /// See https://github.com/FreeRDP/FreeRDP/blob/511444a65e7aa2f537c5e531fa68157a50c1bd4d/channels/drive/client/drive_file.c#L207
     /// for information about how these should be interpreted.
+    #[derive(PartialEq, Eq, Debug, Clone)]
     pub struct CreateDisposition: u32 {
         const FILE_SUPERSEDE = 0x00000000;
         const FILE_OPEN = 0x00000001;
@@ -126,6 +130,7 @@ bitflags! {
 bitflags! {
     /// Specifies the options to be applied when creating or opening the file. Combinations of the bit positions listed below are valid, unless otherwise noted. This field MUST be pub constructed using the following values.
     /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e8fb45c1-a03d-44ca-b7ae-47385cfd7997
+    #[derive(Debug, Clone)]
     pub struct CreateOptions: u32 {
         const FILE_DIRECTORY_FILE = 0x00000001;
         const FILE_WRITE_THROUGH = 0x00000002;
@@ -157,6 +162,7 @@ bitflags! {
     /// (section 2.2.1.4.1). If the IoStatus field is set to 0x00000000, this field MAY be skipped, in which case the
     /// server MUST assume that the Information field is set to 0x00.
     /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpefs/99e5fca5-b37a-41e4-bc69-8d7da7860f76
+    #[derive(Debug)]
     pub struct Information: u8 {
         /// A new file was created.
         const FILE_SUPERSEDED = 0x00000000;
@@ -171,6 +177,7 @@ bitflags! {
     /// Specifies the types of changes to monitor. It is valid to choose multiple trigger conditions.
     /// In this case, if any condition is met, the client is notified of the change and the CHANGE_NOTIFY operation is completed.
     /// See CompletionFilter at: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/598f395a-e7a2-4cc8-afb3-ccb30dd2df7c
+    #[derive(Debug)]
     pub struct CompletionFilter: u32 {
         /// The client is notified if a file-name changes.
         const FILE_NOTIFY_CHANGE_FILE_NAME = 0x00000001;
@@ -202,6 +209,7 @@ bitflags! {
 bitflags! {
     /// Only defines the subset we require from
     /// https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-fscc/ebc7e6e5-4650-4e54-b17c-cf60f6fbeeaa
+    #[derive(Debug)]
     pub struct FileSystemAttributes: u32 {
         const FILE_CASE_SENSITIVE_SEARCH = 0x00000001;
         const FILE_CASE_PRESERVED_NAMES = 0x00000002;

--- a/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/rdpdr/scard.rs
@@ -1156,6 +1156,7 @@ impl ReaderState_Common_Call {
 }
 
 bitflags! {
+    #[derive(Debug, PartialEq, Clone, Copy)]
     struct CardStateFlags: u32 {
         const SCARD_STATE_UNAWARE = 0x0000;
         const SCARD_STATE_IGNORE = 0x0001;
@@ -1309,6 +1310,7 @@ impl Encode for Connect_Call {
 }
 
 bitflags! {
+    #[derive(Debug, Clone)]
     struct CardProtocol: u32 {
         const SCARD_PROTOCOL_UNDEFINED = 0x00000000;
         const SCARD_PROTOCOL_T0 = 0x00000001;

--- a/lib/srv/desktop/rdp/rdpclient/src/vchan.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/vchan.rs
@@ -145,6 +145,7 @@ bitflags! {
     /// Channel control flags, as specified in section 2.2.6.1.1 of MS-RDPBCGR.
     ///
     /// See: https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-rdpbcgr/f125c65e-6901-43c3-8071-d7d5aaee7ae4
+    #[derive(Debug, PartialEq, Copy, Clone)]
     pub struct ChannelPDUFlags: u32 {
         const CHANNEL_FLAG_FIRST = 0x00000001;
         const CHANNEL_FLAG_LAST = 0x00000002;
@@ -156,7 +157,7 @@ bitflags! {
         const CHANNEL_PACKET_AT_FRONT = 0x00400000;
         const CHANNEL_PACKET_FLUSHED = 0x00800000;
 
-        const CHANNEL_FLAG_ONLY = Self::CHANNEL_FLAG_FIRST.bits | Self::CHANNEL_FLAG_LAST.bits;
+        const CHANNEL_FLAG_ONLY = Self::CHANNEL_FLAG_FIRST.bits() | Self::CHANNEL_FLAG_LAST.bits();
     }
 }
 


### PR DESCRIPTION
backports https://github.com/gravitational/teleport/pull/23741 to branch/v12