### PR TITLE
Remove `push` workflow for jobs that already run on PR and merge

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -2,9 +2,6 @@ name: Build on Mac OS
 run-name: Build on Mac OS
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - '**.go'

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -2,9 +2,6 @@ name: Build on Windows
 run-name: Build on Windows
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     # We only build tsh on Windows so only consider Go code as tsh doesn't
     # run any Rust.

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -1,9 +1,6 @@
 name: Lint (Docs)
 run-name: Lint (Docs)
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - 'docs/**'

--- a/.github/workflows/lint-bypass.yaml
+++ b/.github/workflows/lint-bypass.yaml
@@ -10,9 +10,6 @@
 name: Lint (Go)
 run-name: make lint
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - 'docs/**'

--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -2,9 +2,6 @@ name: Lint UI
 run-name: Lint UI - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - 'web/**'

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,6 @@
 name: Lint (Go)
 run-name: make lint
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/os-compatibility-test-bypass.yaml
+++ b/.github/workflows/os-compatibility-test-bypass.yaml
@@ -10,9 +10,6 @@
 name: OS Compatibility Test
 run-name: OS Compatibility Test
 on:
-  push:
-    branches:
-      - master
   pull_request:
    paths:
       - 'docs/**'

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -1,10 +1,6 @@
 name: OS Compatibility Test
 run-name: OS Compatibility Test
 on:
-  push:
-    branches:
-      - master
-      - branch/*
   pull_request:
     paths-ignore:
       - 'docs/**'

--- a/.github/workflows/terraform-lint.yaml
+++ b/.github/workflows/terraform-lint.yaml
@@ -1,14 +1,6 @@
 name: Lint (Terraform)
 
 on:
-  push:
-    branches:
-      - master
-      - branch/*
-    paths:
-      - '**.tf'
-      - '**.tf.json'
-      - '**.hcl'
   pull_request:
     paths:
       - '**.tf'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -1,10 +1,6 @@
 name: Trivy
 
 on:
-  push:
-    branches:
-      - master
-      - branch/*
   pull_request:
   merge_group:
 

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -2,9 +2,6 @@ name: Unit Tests (Helm)
 run-name: Unit Tests (Helm) - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - 'examples/chart/**'

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -2,9 +2,6 @@ name: Unit Tests (Rust)
 run-name: Unit Tests (Rust) - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - '**.rs'

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -2,9 +2,6 @@ name: Unit Tests UI
 run-name: Unit Tests UI - ${{ github.run_id }} - @${{ github.actor }}
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths:
       - 'web/**'


### PR DESCRIPTION
An attempt to reduce our Actions usage this PR removes the workflow execution for `push` actions on several jobs.