### PR TITLE
Fix listing of available participant modes in the UI for Moderated Sessions

### DIFF
--- a/lib/auth/session_access.go
+++ b/lib/auth/session_access.go
@@ -162,7 +162,7 @@ func (e *SessionAccessEvaluator) matchesJoin(allow *types.SessionJoinPolicy) boo
 
 	for _, allowRole := range allow.Roles {
 		// GlobToRegexp makes sure this is always a valid regexp.
-		expr := regexp.MustCompile(utils.GlobToRegexp(allowRole))
+		expr := regexp.MustCompile("^" + utils.GlobToRegexp(allowRole) + "$")
 
 		for _, policySet := range e.policySets {
 			if expr.MatchString(policySet.Name) {

--- a/lib/auth/session_access_test.go
+++ b/lib/auth/session_access_test.go
@@ -459,6 +459,35 @@ func failKindJoinTestCase(t *testing.T) joinTestCase {
 	}
 }
 
+// Tests to make sure that the regexp matching for roles only matches a full string
+// match and not just any substring match.
+// In this test case, we are making sure that having access to sessions hosted
+// by someone with the role `test` doesn't also grant you access to sessions
+// hosted by someone with the role `prod-test`.
+func failJoinRoleNameInSubstringTestCase(t *testing.T) joinTestCase {
+	hostRole, err := types.NewRole("prod-test", types.RoleSpecV6{})
+	require.NoError(t, err)
+	participantRole, err := types.NewRole("participant", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	participantRole.SetSessionJoinPolicies([]*types.SessionJoinPolicy{{
+		Roles: []string{"test"},
+		Kinds: []string{string(types.SSHSessionKind), string(types.KubernetesSessionKind)},
+		Modes: []string{types.Wildcard},
+	}})
+
+	return joinTestCase{
+		name:         "failRoleInSubstring",
+		host:         hostRole,
+		sessionKinds: []types.SessionKind{types.SSHSessionKind, types.KubernetesSessionKind},
+		participant: SessionAccessContext{
+			Username: "participant",
+			Roles:    []types.Role{participantRole},
+		},
+		expected: []bool{false, false},
+	}
+}
+
 func versionDefaultJoinTestCase(t *testing.T) joinTestCase {
 	hostRole, err := types.NewRole("host", types.RoleSpecV6{})
 	require.NoError(t, err)
@@ -495,6 +524,7 @@ func TestSessionAccessJoin(t *testing.T) {
 		successSameUserJoinTestCase(t),
 		failRoleJoinTestCase(t),
 		failKindJoinTestCase(t),
+		failJoinRoleNameInSubstringTestCase(t),
 		versionDefaultJoinTestCase(t),
 	}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2862,12 +2862,6 @@ func (h *Handler) siteSessionsGet(w http.ResponseWriter, r *http.Request, p http
 		return nil, trace.Wrap(err)
 	}
 
-	var policySets []*types.SessionTrackerPolicySet
-	for _, role := range userRoles {
-		policySet := role.GetSessionPolicySet()
-		policySets = append(policySets, &policySet)
-	}
-
 	accessContext := auth.SessionAccessContext{
 		Username: sctx.GetUser(),
 		Roles:    userRoles,
@@ -2878,7 +2872,7 @@ func (h *Handler) siteSessionsGet(w http.ResponseWriter, r *http.Request, p http
 		if tracker.GetState() != types.SessionState_SessionStateTerminated {
 			session := trackerToLegacySession(tracker, p.ByName("site"))
 			// Get the participant modes available to the user from their roles.
-			accessEvaluator := auth.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, session.Owner)
+			accessEvaluator := auth.NewSessionAccessEvaluator(tracker.GetHostPolicySets(), types.SSHSessionKind, tracker.GetHostUser())
 			participantModes := accessEvaluator.CanJoin(accessContext)
 
 			sessions = append(sessions, siteSessionsGetResponseSession{Session: session, ParticipantModes: participantModes})

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1924,6 +1924,9 @@ func TestActiveSessions(t *testing.T) {
 	s := newWebSuite(t)
 	pack := s.authPack(t, "foo")
 
+	// Use enterprise license (required for moderated sessions).
+	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+
 	start := time.Now()
 	kinds := []types.SessionKind{
 		types.SSHSessionKind,
@@ -1950,6 +1953,17 @@ func TestActiveSessions(t *testing.T) {
 			Login:        pack.login,
 			Participants: []types.Participant{
 				{ID: "id", User: "user-1", LastActive: start},
+			},
+			HostPolicies: []*types.SessionTrackerPolicySet{
+				{
+					Name:    "foo",
+					Version: "5",
+					RequireSessionJoin: []*types.SessionRequirePolicy{
+						{
+							Name: "foo",
+						},
+					},
+				},
 			},
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
## Purpose

This PR closes https://github.com/gravitational/teleport/issues/23237

https://github.com/gravitational/teleport/pull/23807 should be merged first.

Fixes a bug that caused the available participant modes in the UI to be inaccurate and only show up if your own role was defined in your `join_sessions` policy.

## Implementation

The bug was caused by a typo when initializing the `sessionAccessEvaluator`, it was using the policy sets of the user, rather than the policy sets of the session host.

While reading the code I discovered another bug with the way we used `regexp.MatchString()` to match the join policy roles with the roles in the policy set. The way we used `MatchString()` before only checked for any match of the expression within the string, so if the string contained a substring that matches the expression, it would return `true` even if the full string isn't an exact match. For example this means that if your join policy only allowed you to join users with the role `auditor`, it would still return `true` for roles such as `prod-auditor`.