### PR TITLE
Attempt ssh connections with and without mfa at the same time

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1580,7 +1580,7 @@ func (tc *TeleportClient) connectToNodeWithMFA(ctx context.Context, clt *Cluster
 	// per-session mfa isn't required, the user simply does not
 	// have access to the provided node
 	if !nodeDetails.MFACheck.Required {
-		return nil, trace.Wrap(trace.AccessDenied("user does not have access to %s", node))
+		return nil, trace.Wrap(trace.AccessDenied("no access to %s", nodeDetails.Addr))
 	}
 
 	// per-session mfa is required, perform the mfa ceremony

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1614,7 +1614,7 @@ func (tc *TeleportClient) connectToNodeWithMFA(ctx context.Context, clt *Cluster
 	defer span.End()
 
 	if nodeDetails.MFACheck != nil && !nodeDetails.MFACheck.Required {
-		return nil, MFARequiredUnknown(trace.AccessDenied("no access to %s", nodeDetails.Addr))
+		return nil, trace.Wrap(MFARequiredUnknown(trace.AccessDenied("no access to %s", nodeDetails.Addr)))
 	}
 
 	check, err := clt.AuthClient.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
@@ -1626,13 +1626,13 @@ func (tc *TeleportClient) connectToNodeWithMFA(ctx context.Context, clt *Cluster
 		},
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(MFARequiredUnknown(err))
 	}
 
 	// per-session mfa isn't required, the user simply does not
 	// have access to the provided node
 	if !check.Required {
-		return nil, MFARequiredUnknown(trace.AccessDenied("no access to %s", nodeDetails.Addr))
+		return nil, trace.Wrap(MFARequiredUnknown(trace.AccessDenied("no access to %s", nodeDetails.Addr)))
 	}
 
 	// per-session mfa is required, perform the mfa ceremony

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -75,12 +75,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 
 	key, err := c.tc.localAgent.GetKey(target.Cluster, WithAllCerts...)
 	if err != nil {
-		if trace.IsNotFound(err) {
-			// Either running inside the web UI in a proxy or using an identity
-			// file. Fall back to whatever AuthMethod we currently have.
-			return sshConfig, nil
-		}
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(MFARequiredUnknown(err))
 	}
 
 	params := ReissueParams{
@@ -93,7 +88,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 	if target.MFACheck == nil {
 		check, err := c.AuthClient.IsMFARequired(ctx, params.isMFARequiredRequest(c.tc.HostLogin))
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, trace.Wrap(MFARequiredUnknown(err))
 		}
 		target.MFACheck = check
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3849,6 +3849,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	}
 
 	tlscfg := serverTLSConfig.Clone()
+	setupTLSConfigClientCAsForCluster(tlscfg, accessPoint, clusterName)
 	tlscfg.ClientAuth = tls.RequireAndVerifyClientCert
 	if lib.IsInsecureDevMode() {
 		tlscfg.InsecureSkipVerify = true

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -781,11 +781,11 @@ func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, ws *websocke
 		},
 	})
 	if err != nil {
-		return nil, client.MFARequiredUnknown(trace.Wrap(err))
+		return nil, trace.Wrap(client.MFARequiredUnknown(err))
 	}
 
 	if !mfaRequiredResp.Required {
-		return nil, client.MFARequiredUnknown(trace.AccessDenied("no access to %s", t.sessionData.ServerHostname))
+		return nil, trace.Wrap(client.MFARequiredUnknown(trace.AccessDenied("no access to %s", t.sessionData.ServerHostname)))
 	}
 
 	// perform mfa ceremony and retrieve new certs


### PR DESCRIPTION
`tsh ssh` would fallback to doing the mfa ceremony if connecting to the node with the already provisioned certificates failed with an access denied error. This incurs the cost of a round trip to the target host when per session mfa is required. To combat the additional latency when per session mfa is required we can attempt both the connection with the certs on hand AND start the per session mfa flow at the same time. If per session mfa is not required the client won't attempt the mfa ceremony which adds no impact there. If per session mfa is required the initial connection to the host is going to fail so the mfa ceremony will need to be performed any how.

For this to work we need to ensure that users are not prompted for mfa if completing the mfa ceremony will not actually help the user gain access to the host. If users just flat out do not have access to the host we don't want to confuse them by prompting them to touch a hardware key. Since `tsh` first calls
`proto.AuthService/IsMFARequired` before initiating the mfa ceremony we are guaranteed not to initiate the mfa ceremony when not required.