### PR TITLE
Change default participant mode to `observer` & add a message when joining

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -1763,6 +1763,8 @@ func (tc *TeleportClient) Join(ctx context.Context, mode types.SessionParticipan
 		}
 	}
 
+	fmt.Printf("Joining session with participant mode: %v. \n\n", mode)
+
 	// running shell with a given session means "join" it:
 	err = tc.runShell(ctx, nc, mode, session, beforeStart)
 	return trace.Wrap(err)

--- a/lib/client/kubesession.go
+++ b/lib/client/kubesession.go
@@ -58,6 +58,8 @@ func NewKubeSession(ctx context.Context, tc *TeleportClient, meta types.SessionT
 		TLSClientConfig: tlsConfig,
 	}
 
+	fmt.Printf("Joining session with participant mode: %v. \n\n", mode)
+
 	ws, resp, err := dialer.Dial(joinEndpoint, nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -410,8 +410,8 @@ func TestModeratedSessions(t *testing.T) {
 
 					// checks if moderator has joined the session.
 					// Each time a user joins a session the following message is broadcasted
-					// User <user> joined the session.
-					if strings.Contains(stringData, fmt.Sprintf("User %s joined the session.", moderatorUsername)) {
+					// User <user> joined the session with participant mode: <mode>.
+					if strings.Contains(stringData, fmt.Sprintf("User %s joined the session with participant mode: moderator.", moderatorUsername)) {
 						t.Logf("identified that moderator joined the session")
 						// inform moderator goroutine that the user detected that he joined the
 						// session.

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -908,7 +908,7 @@ func (s *session) join(p *party) error {
 	}
 
 	s.io.AddWriter(stringID, p.Client.stdoutStream())
-	s.BroadcastMessage("User %v joined the session.", p.Ctx.User.GetName())
+	s.BroadcastMessage("User %v joined the session with participant mode: %v.", p.Ctx.User.GetName(), p.Mode)
 
 	if p.Mode == types.SessionModeratorMode {
 		s.eventsWaiter.Add(1)

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -1486,8 +1486,8 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 	// Register this party as one of the session writers (output will go to it).
 	s.io.AddWriter(string(p.id), p)
 
-	s.BroadcastMessage("User %v joined the session.", p.user)
-	s.log.Infof("New party %v joined session", p.String())
+	s.BroadcastMessage("User %v joined the session with participant mode: %v.", p.user, p.mode)
+	s.log.Infof("New party %v joined the session with participant mode: %v.", p.String(), p.mode)
 
 	if mode == types.SessionPeerMode {
 		s.term.AddParty(1)

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -98,7 +98,7 @@ func newKubeJoinCommand(parent *kingpin.CmdClause) *kubeJoinCommand {
 		CmdClause: parent.Command("join", "Join an active Kubernetes session."),
 	}
 
-	c.Flag("mode", "Mode of joining the session, valid modes are observer and moderator").Short('m').Default("moderator").StringVar(&c.mode)
+	c.Flag("mode", "Mode of joining the session, valid modes are observer, moderator and peer.").Short('m').Default("observer").EnumVar(&c.mode, "observer", "moderator", "peer")
 	c.Flag("cluster", clusterHelp).Short('c').StringVar(&c.siteName)
 	c.Arg("session", "The ID of the target session.").Required().StringVar(&c.session)
 	return c

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -800,7 +800,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	// join
 	join := app.Command("join", "Join the active SSH or Kubernetes session")
 	join.Flag("cluster", clusterHelp).Short('c').StringVar(&cf.SiteName)
-	join.Flag("mode", "Mode of joining the session, valid modes are observer and moderator").Short('m').Default("peer").StringVar(&cf.JoinMode)
+	join.Flag("mode", "Mode of joining the session, valid modes are observer, moderator and peer.").Short('m').Default("observer").EnumVar(&cf.JoinMode, "observer", "moderator", "peer")
 	join.Flag("reason", "The purpose of the session.").StringVar(&cf.Reason)
 	join.Flag("invite", "A comma separated list of people to mark as invited for the session.").StringsVar(&cf.Invited)
 	join.Arg("session-id", "ID of the session to join").Required().StringVar(&cf.SessionID)


### PR DESCRIPTION
## Purpose

Currently, the default participant mode used when joining an active session when the `--mode` flag is omitted is `peer`, which is the most privileged mode. In order to follow the principle of least privilege, this PR changes the default mode to `observer`. 

Also, when joining a session, a message will now be printed to inform you of the participant mode you are joining with. This is to prevent potential confusion caused by the default mode being changed. 