### PR TITLE
Fix Flaky Tests Detector bypass on merge queue

### DIFF
--- a/.github/workflows/flaky-tests-bypass.yaml
+++ b/.github/workflows/flaky-tests-bypass.yaml
@@ -15,6 +15,9 @@ on:
   pull_request:
     paths-ignore:
       - '**.go'
+  merge_group:
+    paths-ignore:
+      - '**.go'
 
 jobs:
   test:

--- a/.github/workflows/flaky-tests-merge-queue.yaml
+++ b/.github/workflows/flaky-tests-merge-queue.yaml
@@ -1,23 +1,17 @@
-# This workflow is required to ensure that required Github check passes even if
-# the actual "Flaky Tests Detector" workflow is skipped due to path filtering.
-# Otherwise it will stay forever pending.
+# This check runs only on PRs that are in the merge queue.
+#
+# PRs in the merge queue have already been approved but the reviewers check
+# is still required so this workflow allows the required check to succeed,
+# otherwise PRs in the merge queue would be blocked indefinitely.
 #
 # See "Handling skipped but required checks" for more info:
 #
 # https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
 #
 # Note both workflows must have the same name.
-
 name: Flaky Tests Detector
-run-name: Skip Flaky Tests Detector - ${{ github.run_id }} - @${{ github.actor }}
-
 on:
-  pull_request:
-    paths-ignore:
-      - '**.go'
   merge_group:
-    paths-ignore:
-      - '**.go'
 
 jobs:
   test:
@@ -28,4 +22,4 @@ jobs:
       contents: none
 
     steps:
-      - run: 'echo "No changes to verify"'
+      - run: 'echo "Skipping reviewers check in merge queue"'

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -5,9 +5,7 @@ on:
   pull_request:
     paths:
       - '**.go'
-  merge_group:
-    paths:
-      - '**.go'
+      - '.github/workflows/flaky-tests.yaml'
 
 jobs:
   test:

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -5,6 +5,9 @@ on:
   pull_request:
     paths:
       - '**.go'
+  merge_group:
+    paths:
+      - '**.go'
 
 jobs:
   test:


### PR DESCRIPTION
Fixes bypass not running on merge queue and blocking merges since Flaky Tests Detector is now a required step