### PR TITLE
Drop gRPC call options from api/client.Client

### DIFF
--- a/api/client/auditstreamer.go
+++ b/api/client/auditstreamer.go
@@ -32,8 +32,7 @@ import (
 // createOrResumeAuditStream creates or resumes audit stream described in the request.
 func (c *Client) createOrResumeAuditStream(ctx context.Context, request proto.AuditStreamRequest) (events.Stream, error) {
 	closeCtx, cancel := context.WithCancel(ctx)
-	callOpts := append(c.callOpts, grpc.UseCompressor(ggzip.Name))
-	stream, err := c.grpc.CreateAuditStream(closeCtx, callOpts...)
+	stream, err := c.grpc.CreateAuditStream(closeCtx, grpc.UseCompressor(ggzip.Name))
 	if err != nil {
 		cancel()
 		return nil, trail.FromGRPC(err)

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -596,14 +596,6 @@ func (c *Client) setClosed() bool {
 	return atomic.CompareAndSwapInt32(c.closedFlag, 0, 1)
 }
 
-// WithCallOptions returns a copy of the client with the given call options set.
-// This function should be used for chaining - client.WithCallOptions().Ping()
-func (c *Client) WithCallOptions(opts ...grpc.CallOption) *Client {
-	clt := *c
-	clt.callOpts = append(clt.callOpts, opts...)
-	return &clt
-}
-
 // DevicesClient returns an unadorned Device Trust client, using the underlying
 // Auth gRPC connection.
 // Clients connecting to non-Enterprise clusters, or older Teleport versions,

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -92,8 +92,6 @@ type Client struct {
 	// closedFlag is set to indicate that the connection is closed.
 	// It's a pointer to allow the Client struct to be copied.
 	closedFlag *int32
-	// callOpts configure calls made by this client.
-	callOpts []grpc.CallOption
 }
 
 // New creates a new Client with an open connection to a Teleport server.
@@ -616,7 +614,7 @@ func (c *Client) CreateDeviceResource(ctx context.Context, res *types.DeviceV1) 
 	created, err := c.DevicesClient().CreateDevice(ctx, &devicepb.CreateDeviceRequest{
 		Device:           dev,
 		CreateAsResource: true,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -629,7 +627,7 @@ func (c *Client) CreateDeviceResource(ctx context.Context, res *types.DeviceV1) 
 func (c *Client) DeleteDeviceResource(ctx context.Context, id string) error {
 	_, err := c.DevicesClient().DeleteDevice(ctx, &devicepb.DeleteDeviceRequest{
 		DeviceId: id,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
@@ -639,7 +637,7 @@ func (c *Client) DeleteDeviceResource(ctx context.Context, id string) error {
 func (c *Client) GetDeviceResource(ctx context.Context, id string) (*types.DeviceV1, error) {
 	dev, err := c.DevicesClient().GetDevice(ctx, &devicepb.GetDeviceRequest{
 		DeviceId: id,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -658,7 +656,7 @@ func (c *Client) UpsertDeviceResource(ctx context.Context, res *types.DeviceV1) 
 	upserted, err := c.DevicesClient().UpsertDevice(ctx, &devicepb.UpsertDeviceRequest{
 		Device:           dev,
 		CreateAsResource: true,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -691,7 +689,7 @@ func (c *Client) TrustClient() trustpb.TrustServiceClient {
 
 // Ping gets basic info about the auth server.
 func (c *Client) Ping(ctx context.Context) (proto.PingResponse, error) {
-	rsp, err := c.grpc.Ping(ctx, &proto.PingRequest{}, c.callOpts...)
+	rsp, err := c.grpc.Ping(ctx, &proto.PingRequest{})
 	if err != nil {
 		return proto.PingResponse{}, trail.FromGRPC(err)
 	}
@@ -705,7 +703,7 @@ func (c *Client) UpdateRemoteCluster(ctx context.Context, rc types.RemoteCluster
 		return trace.BadParameter("unsupported remote cluster type %T", rcV3)
 	}
 
-	_, err := c.grpc.UpdateRemoteCluster(ctx, rcV3, c.callOpts...)
+	_, err := c.grpc.UpdateRemoteCluster(ctx, rcV3)
 	return trail.FromGRPC(err)
 }
 
@@ -716,7 +714,7 @@ func (c *Client) CreateUser(ctx context.Context, user types.User) error {
 		return trace.BadParameter("unsupported user type %T", user)
 	}
 
-	_, err := c.grpc.CreateUser(ctx, userV2, c.callOpts...)
+	_, err := c.grpc.CreateUser(ctx, userV2)
 	return trail.FromGRPC(err)
 }
 
@@ -727,7 +725,7 @@ func (c *Client) UpdateUser(ctx context.Context, user types.User) error {
 		return trace.BadParameter("unsupported user type %T", user)
 	}
 
-	_, err := c.grpc.UpdateUser(ctx, userV2, c.callOpts...)
+	_, err := c.grpc.UpdateUser(ctx, userV2)
 	return trail.FromGRPC(err)
 }
 
@@ -740,7 +738,7 @@ func (c *Client) GetUser(name string, withSecrets bool) (types.User, error) {
 	user, err := c.grpc.GetUser(context.TODO(), &proto.GetUserRequest{
 		Name:        name,
 		WithSecrets: withSecrets,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -778,7 +776,7 @@ func (c *Client) GetCurrentUserRoles(ctx context.Context) ([]types.Role, error) 
 func (c *Client) GetUsers(withSecrets bool) ([]types.User, error) {
 	stream, err := c.grpc.GetUsers(context.TODO(), &proto.GetUsersRequest{
 		WithSecrets: withSecrets,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -795,7 +793,7 @@ func (c *Client) GetUsers(withSecrets bool) ([]types.User, error) {
 // DeleteUser deletes a user by name.
 func (c *Client) DeleteUser(ctx context.Context, user string) error {
 	req := &proto.DeleteUserRequest{Name: user}
-	_, err := c.grpc.DeleteUser(ctx, req, c.callOpts...)
+	_, err := c.grpc.DeleteUser(ctx, req)
 	return trail.FromGRPC(err)
 }
 
@@ -803,7 +801,7 @@ func (c *Client) DeleteUser(ctx context.Context, user string) error {
 // text format, signs it using User Certificate Authority signing key and
 // returns the resulting certificates.
 func (c *Client) GenerateUserCerts(ctx context.Context, req proto.UserCertsRequest) (*proto.Certs, error) {
-	certs, err := c.grpc.GenerateUserCerts(ctx, &req, c.callOpts...)
+	certs, err := c.grpc.GenerateUserCerts(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -815,7 +813,7 @@ func (c *Client) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	certs, err := c.grpc.GenerateHostCerts(ctx, req, c.callOpts...)
+	certs, err := c.grpc.GenerateHostCerts(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -838,7 +836,7 @@ func (c *Client) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 // DELETE IN: 11.0 (server side method should continue to exist until 12.0 for back-compat reasons,
 // but v11 clients should no longer need this method)
 func (c *Client) UnstableAssertSystemRole(ctx context.Context, req proto.UnstableSystemRoleAssertion) error {
-	_, err := c.grpc.UnstableAssertSystemRole(ctx, &req, c.callOpts...)
+	_, err := c.grpc.UnstableAssertSystemRole(ctx, &req)
 	return trail.FromGRPC(err)
 }
 
@@ -848,7 +846,7 @@ func (c *Client) EmitAuditEvent(ctx context.Context, event events.AuditEvent) er
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.grpc.EmitAuditEvent(ctx, grpcEvent, c.callOpts...)
+	_, err = c.grpc.EmitAuditEvent(ctx, grpcEvent)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -859,7 +857,7 @@ func (c *Client) EmitAuditEvent(ctx context.Context, event events.AuditEvent) er
 func (c *Client) GetResetPasswordToken(ctx context.Context, tokenID string) (types.UserToken, error) {
 	token, err := c.grpc.GetResetPasswordToken(ctx, &proto.GetResetPasswordTokenRequest{
 		TokenID: tokenID,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -869,7 +867,7 @@ func (c *Client) GetResetPasswordToken(ctx context.Context, tokenID string) (typ
 
 // CreateResetPasswordToken creates reset password token.
 func (c *Client) CreateResetPasswordToken(ctx context.Context, req *proto.CreateResetPasswordTokenRequest) (types.UserToken, error) {
-	token, err := c.grpc.CreateResetPasswordToken(ctx, req, c.callOpts...)
+	token, err := c.grpc.CreateResetPasswordToken(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -879,7 +877,7 @@ func (c *Client) CreateResetPasswordToken(ctx context.Context, req *proto.Create
 
 // CreateBot creates a new bot from the specified descriptor.
 func (c *Client) CreateBot(ctx context.Context, req *proto.CreateBotRequest) (*proto.CreateBotResponse, error) {
-	response, err := c.grpc.CreateBot(ctx, req, c.callOpts...)
+	response, err := c.grpc.CreateBot(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -891,13 +889,13 @@ func (c *Client) CreateBot(ctx context.Context, req *proto.CreateBotRequest) (*p
 func (c *Client) DeleteBot(ctx context.Context, botName string) error {
 	_, err := c.grpc.DeleteBot(ctx, &proto.DeleteBotRequest{
 		Name: botName,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
 // GetBotUsers fetches all bot users.
 func (c *Client) GetBotUsers(ctx context.Context) ([]types.User, error) {
-	stream, err := c.grpc.GetBotUsers(ctx, &proto.GetBotUsersRequest{}, c.callOpts...)
+	stream, err := c.grpc.GetBotUsers(ctx, &proto.GetBotUsersRequest{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -913,7 +911,7 @@ func (c *Client) GetBotUsers(ctx context.Context) ([]types.User, error) {
 
 // GetAccessRequests retrieves a list of all access requests matching the provided filter.
 func (c *Client) GetAccessRequests(ctx context.Context, filter types.AccessRequestFilter) ([]types.AccessRequest, error) {
-	stream, err := c.grpc.GetAccessRequestsV2(ctx, &filter, c.callOpts...)
+	stream, err := c.grpc.GetAccessRequestsV2(ctx, &filter)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -940,13 +938,13 @@ func (c *Client) CreateAccessRequest(ctx context.Context, req types.AccessReques
 	if !ok {
 		return trace.BadParameter("unexpected access request type %T", req)
 	}
-	_, err := c.grpc.CreateAccessRequest(ctx, r, c.callOpts...)
+	_, err := c.grpc.CreateAccessRequest(ctx, r)
 	return trail.FromGRPC(err)
 }
 
 // DeleteAccessRequest deletes an access request.
 func (c *Client) DeleteAccessRequest(ctx context.Context, reqID string) error {
-	_, err := c.grpc.DeleteAccessRequest(ctx, &proto.RequestID{ID: reqID}, c.callOpts...)
+	_, err := c.grpc.DeleteAccessRequest(ctx, &proto.RequestID{ID: reqID})
 	return trail.FromGRPC(err)
 }
 
@@ -962,13 +960,13 @@ func (c *Client) SetAccessRequestState(ctx context.Context, params types.AccessR
 	if d := utils.GetDelegator(ctx); d != "" {
 		setter.Delegator = d
 	}
-	_, err := c.grpc.SetAccessRequestState(ctx, &setter, c.callOpts...)
+	_, err := c.grpc.SetAccessRequestState(ctx, &setter)
 	return trail.FromGRPC(err)
 }
 
 // SubmitAccessReview applies a review to a request and returns the post-application state.
 func (c *Client) SubmitAccessReview(ctx context.Context, params types.AccessReviewSubmission) (types.AccessRequest, error) {
-	req, err := c.grpc.SubmitAccessReview(ctx, &params, c.callOpts...)
+	req, err := c.grpc.SubmitAccessReview(ctx, &params)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -977,7 +975,7 @@ func (c *Client) SubmitAccessReview(ctx context.Context, params types.AccessRevi
 
 // GetAccessCapabilities requests the access capabilities of a user.
 func (c *Client) GetAccessCapabilities(ctx context.Context, req types.AccessCapabilitiesRequest) (*types.AccessCapabilities, error) {
-	caps, err := c.grpc.GetAccessCapabilities(ctx, &req, c.callOpts...)
+	caps, err := c.grpc.GetAccessCapabilities(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -986,7 +984,7 @@ func (c *Client) GetAccessCapabilities(ctx context.Context, req types.AccessCapa
 
 // GetPluginData loads all plugin data matching the supplied filter.
 func (c *Client) GetPluginData(ctx context.Context, filter types.PluginDataFilter) ([]types.PluginData, error) {
-	seq, err := c.grpc.GetPluginData(ctx, &filter, c.callOpts...)
+	seq, err := c.grpc.GetPluginData(ctx, &filter)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -999,13 +997,13 @@ func (c *Client) GetPluginData(ctx context.Context, filter types.PluginDataFilte
 
 // UpdatePluginData updates a per-resource PluginData entry.
 func (c *Client) UpdatePluginData(ctx context.Context, params types.PluginDataUpdateParams) error {
-	_, err := c.grpc.UpdatePluginData(ctx, &params, c.callOpts...)
+	_, err := c.grpc.UpdatePluginData(ctx, &params)
 	return trail.FromGRPC(err)
 }
 
 // AcquireSemaphore acquires lease with requested resources from semaphore.
 func (c *Client) AcquireSemaphore(ctx context.Context, params types.AcquireSemaphoreRequest) (*types.SemaphoreLease, error) {
-	lease, err := c.grpc.AcquireSemaphore(ctx, &params, c.callOpts...)
+	lease, err := c.grpc.AcquireSemaphore(ctx, &params)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1014,19 +1012,19 @@ func (c *Client) AcquireSemaphore(ctx context.Context, params types.AcquireSemap
 
 // KeepAliveSemaphoreLease updates semaphore lease.
 func (c *Client) KeepAliveSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
-	_, err := c.grpc.KeepAliveSemaphoreLease(ctx, &lease, c.callOpts...)
+	_, err := c.grpc.KeepAliveSemaphoreLease(ctx, &lease)
 	return trail.FromGRPC(err)
 }
 
 // CancelSemaphoreLease cancels semaphore lease early.
 func (c *Client) CancelSemaphoreLease(ctx context.Context, lease types.SemaphoreLease) error {
-	_, err := c.grpc.CancelSemaphoreLease(ctx, &lease, c.callOpts...)
+	_, err := c.grpc.CancelSemaphoreLease(ctx, &lease)
 	return trail.FromGRPC(err)
 }
 
 // GetSemaphores returns a list of all semaphores matching the supplied filter.
 func (c *Client) GetSemaphores(ctx context.Context, filter types.SemaphoreFilter) ([]types.Semaphore, error) {
-	rsp, err := c.grpc.GetSemaphores(ctx, &filter, c.callOpts...)
+	rsp, err := c.grpc.GetSemaphores(ctx, &filter)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1039,7 +1037,7 @@ func (c *Client) GetSemaphores(ctx context.Context, filter types.SemaphoreFilter
 
 // DeleteSemaphore deletes a semaphore matching the supplied filter.
 func (c *Client) DeleteSemaphore(ctx context.Context, filter types.SemaphoreFilter) error {
-	_, err := c.grpc.DeleteSemaphore(ctx, &filter, c.callOpts...)
+	_, err := c.grpc.DeleteSemaphore(ctx, &filter)
 	return trail.FromGRPC(err)
 }
 
@@ -1073,7 +1071,7 @@ func (c *Client) DeleteKubernetesServer(ctx context.Context, hostID, name string
 
 // DeleteAllKubernetesServers deletes all registered kubernetes servers.
 func (c *Client) DeleteAllKubernetesServers(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllKubernetesServers(ctx, &proto.DeleteAllKubernetesServersRequest{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllKubernetesServers(ctx, &proto.DeleteAllKubernetesServersRequest{})
 	return trail.FromGRPC(err)
 }
 
@@ -1084,7 +1082,7 @@ func (c *Client) UpsertKubernetesServer(ctx context.Context, s types.KubeServer)
 	if !ok {
 		return nil, trace.BadParameter("invalid type %T, expected *types.KubernetesServerV3", server)
 	}
-	keepAlive, err := c.grpc.UpsertKubernetesServer(ctx, &proto.UpsertKubernetesServerRequest{Server: server}, c.callOpts...)
+	keepAlive, err := c.grpc.UpsertKubernetesServer(ctx, &proto.UpsertKubernetesServerRequest{Server: server})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1117,7 +1115,7 @@ func (c *Client) UpsertApplicationServer(ctx context.Context, server types.AppSe
 	}
 	keepAlive, err := c.grpc.UpsertApplicationServer(ctx, &proto.UpsertApplicationServerRequest{
 		Server: s,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1130,7 +1128,7 @@ func (c *Client) DeleteApplicationServer(ctx context.Context, namespace, hostID,
 		Namespace: namespace,
 		HostID:    hostID,
 		Name:      name,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
@@ -1138,7 +1136,7 @@ func (c *Client) DeleteApplicationServer(ctx context.Context, namespace, hostID,
 func (c *Client) DeleteAllApplicationServers(ctx context.Context, namespace string) error {
 	_, err := c.grpc.DeleteAllApplicationServers(ctx, &proto.DeleteAllApplicationServersRequest{
 		Namespace: namespace,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
@@ -1146,7 +1144,7 @@ func (c *Client) DeleteAllApplicationServers(ctx context.Context, namespace stri
 func (c *Client) GetAppSession(ctx context.Context, req types.GetAppSessionRequest) (types.WebSession, error) {
 	resp, err := c.grpc.GetAppSession(ctx, &proto.GetAppSessionRequest{
 		SessionID: req.SessionID,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1190,9 +1188,7 @@ func (c *Client) ListAppSessions(ctx context.Context, pageSize int, pageToken, u
 			PageSize:  int32(pageSize),
 			PageToken: pageToken,
 			User:      user,
-		},
-		c.callOpts...,
-	)
+		})
 	if err != nil {
 		return nil, "", trail.FromGRPC(err)
 	}
@@ -1206,7 +1202,7 @@ func (c *Client) ListAppSessions(ctx context.Context, pageSize int, pageToken, u
 
 // GetSnowflakeSessions gets all Snowflake web sessions.
 func (c *Client) GetSnowflakeSessions(ctx context.Context) ([]types.WebSession, error) {
-	resp, err := c.grpc.GetSnowflakeSessions(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetSnowflakeSessions(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1226,9 +1222,7 @@ func (c *Client) ListSAMLIdPSessions(ctx context.Context, pageSize int, pageToke
 			PageSize:  int32(pageSize),
 			PageToken: pageToken,
 			User:      user,
-		},
-		c.callOpts...,
-	)
+		})
 	if err != nil {
 		return nil, "", trail.FromGRPC(err)
 	}
@@ -1250,7 +1244,7 @@ func (c *Client) CreateAppSession(ctx context.Context, req types.CreateAppSessio
 		AWSRoleARN:        req.AWSRoleARN,
 		AzureIdentity:     req.AzureIdentity,
 		GCPServiceAccount: req.GCPServiceAccount,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1264,7 +1258,7 @@ func (c *Client) CreateSnowflakeSession(ctx context.Context, req types.CreateSno
 		Username:     req.Username,
 		SessionToken: req.SessionToken,
 		TokenTTL:     proto.Duration(req.TokenTTL),
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1278,7 +1272,7 @@ func (c *Client) CreateSAMLIdPSession(ctx context.Context, req types.CreateSAMLI
 		SessionID:   req.SessionID,
 		Username:    req.Username,
 		SAMLSession: req.SAMLSession,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1290,7 +1284,7 @@ func (c *Client) CreateSAMLIdPSession(ctx context.Context, req types.CreateSAMLI
 func (c *Client) GetSnowflakeSession(ctx context.Context, req types.GetSnowflakeSessionRequest) (types.WebSession, error) {
 	resp, err := c.grpc.GetSnowflakeSession(ctx, &proto.GetSnowflakeSessionRequest{
 		SessionID: req.SessionID,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1302,7 +1296,7 @@ func (c *Client) GetSnowflakeSession(ctx context.Context, req types.GetSnowflake
 func (c *Client) GetSAMLIdPSession(ctx context.Context, req types.GetSAMLIdPSessionRequest) (types.WebSession, error) {
 	resp, err := c.grpc.GetSAMLIdPSession(ctx, &proto.GetSAMLIdPSessionRequest{
 		SessionID: req.SessionID,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1314,7 +1308,7 @@ func (c *Client) GetSAMLIdPSession(ctx context.Context, req types.GetSAMLIdPSess
 func (c *Client) DeleteAppSession(ctx context.Context, req types.DeleteAppSessionRequest) error {
 	_, err := c.grpc.DeleteAppSession(ctx, &proto.DeleteAppSessionRequest{
 		SessionID: req.SessionID,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
@@ -1322,7 +1316,7 @@ func (c *Client) DeleteAppSession(ctx context.Context, req types.DeleteAppSessio
 func (c *Client) DeleteSnowflakeSession(ctx context.Context, req types.DeleteSnowflakeSessionRequest) error {
 	_, err := c.grpc.DeleteSnowflakeSession(ctx, &proto.DeleteSnowflakeSessionRequest{
 		SessionID: req.SessionID,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
@@ -1330,31 +1324,31 @@ func (c *Client) DeleteSnowflakeSession(ctx context.Context, req types.DeleteSno
 func (c *Client) DeleteSAMLIdPSession(ctx context.Context, req types.DeleteSAMLIdPSessionRequest) error {
 	_, err := c.grpc.DeleteSAMLIdPSession(ctx, &proto.DeleteSAMLIdPSessionRequest{
 		SessionID: req.SessionID,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllAppSessions removes all application web sessions.
 func (c *Client) DeleteAllAppSessions(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllAppSessions(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllAppSessions(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllSnowflakeSessions removes all Snowflake web sessions.
 func (c *Client) DeleteAllSnowflakeSessions(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllAppSessions(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllAppSessions(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllSAMLIdPSessions removes all SAML IdP sessions.
 func (c *Client) DeleteAllSAMLIdPSessions(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllSAMLIdPSessions(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllSAMLIdPSessions(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
 // DeleteUserAppSessions deletes all user’s application sessions.
 func (c *Client) DeleteUserAppSessions(ctx context.Context, req *proto.DeleteUserAppSessionsRequest) error {
-	_, err := c.grpc.DeleteUserAppSessions(ctx, req, c.callOpts...)
+	_, err := c.grpc.DeleteUserAppSessions(ctx, req)
 	return trail.FromGRPC(err)
 }
 
@@ -1363,7 +1357,7 @@ func (c *Client) DeleteUserSAMLIdPSessions(ctx context.Context, username string)
 	req := &proto.DeleteUserSAMLIdPSessionsRequest{
 		Username: username,
 	}
-	_, err := c.grpc.DeleteUserSAMLIdPSessions(ctx, req, c.callOpts...)
+	_, err := c.grpc.DeleteUserSAMLIdPSessions(ctx, req)
 	return trail.FromGRPC(err)
 }
 
@@ -1394,7 +1388,7 @@ func (c *Client) GenerateSnowflakeJWT(ctx context.Context, req types.GenerateSno
 	resp, err := c.grpc.GenerateSnowflakeJWT(ctx, &proto.SnowflakeJWTRequest{
 		UserName:    req.Username,
 		AccountName: req.Account,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return "", trail.FromGRPC(err)
 	}
@@ -1428,7 +1422,7 @@ func (c *Client) UpsertDatabaseServer(ctx context.Context, server types.Database
 	}
 	keepAlive, err := c.grpc.UpsertDatabaseServer(ctx, &proto.UpsertDatabaseServerRequest{
 		Server: s,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1441,7 +1435,7 @@ func (c *Client) DeleteDatabaseServer(ctx context.Context, namespace, hostID, na
 		Namespace: namespace,
 		HostID:    hostID,
 		Name:      name,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -1452,7 +1446,7 @@ func (c *Client) DeleteDatabaseServer(ctx context.Context, namespace, hostID, na
 func (c *Client) DeleteAllDatabaseServers(ctx context.Context, namespace string) error {
 	_, err := c.grpc.DeleteAllDatabaseServers(ctx, &proto.DeleteAllDatabaseServersRequest{
 		Namespace: namespace,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -1462,7 +1456,7 @@ func (c *Client) DeleteAllDatabaseServers(ctx context.Context, namespace string)
 // SignDatabaseCSR generates a client certificate used by proxy when talking
 // to a remote database service.
 func (c *Client) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequest) (*proto.DatabaseCSRResponse, error) {
-	resp, err := c.grpc.SignDatabaseCSR(ctx, req, c.callOpts...)
+	resp, err := c.grpc.SignDatabaseCSR(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1472,7 +1466,7 @@ func (c *Client) SignDatabaseCSR(ctx context.Context, req *proto.DatabaseCSRRequ
 // GenerateDatabaseCert generates client certificate used by a database
 // service to authenticate with the database instance.
 func (c *Client) GenerateDatabaseCert(ctx context.Context, req *proto.DatabaseCertRequest) (*proto.DatabaseCertResponse, error) {
-	resp, err := c.grpc.GenerateDatabaseCert(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GenerateDatabaseCert(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1484,7 +1478,7 @@ func (c *Client) GetRole(ctx context.Context, name string) (types.Role, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing name")
 	}
-	role, err := c.grpc.GetRole(ctx, &proto.GetRoleRequest{Name: name}, c.callOpts...)
+	role, err := c.grpc.GetRole(ctx, &proto.GetRoleRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1493,7 +1487,7 @@ func (c *Client) GetRole(ctx context.Context, name string) (types.Role, error) {
 
 // GetRoles returns a list of roles
 func (c *Client) GetRoles(ctx context.Context) ([]types.Role, error) {
-	resp, err := c.grpc.GetRoles(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetRoles(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1511,7 +1505,7 @@ func (c *Client) UpsertRole(ctx context.Context, role types.Role) error {
 		return trace.BadParameter("invalid type %T", role)
 	}
 
-	_, err := c.grpc.UpsertRole(ctx, r, c.callOpts...)
+	_, err := c.grpc.UpsertRole(ctx, r)
 	return trail.FromGRPC(err)
 }
 
@@ -1520,12 +1514,12 @@ func (c *Client) DeleteRole(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing name")
 	}
-	_, err := c.grpc.DeleteRole(ctx, &proto.DeleteRoleRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteRole(ctx, &proto.DeleteRoleRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 func (c *Client) AddMFADevice(ctx context.Context) (proto.AuthService_AddMFADeviceClient, error) {
-	stream, err := c.grpc.AddMFADevice(ctx, c.callOpts...)
+	stream, err := c.grpc.AddMFADevice(ctx)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1533,7 +1527,7 @@ func (c *Client) AddMFADevice(ctx context.Context) (proto.AuthService_AddMFADevi
 }
 
 func (c *Client) DeleteMFADevice(ctx context.Context) (proto.AuthService_DeleteMFADeviceClient, error) {
-	stream, err := c.grpc.DeleteMFADevice(ctx, c.callOpts...)
+	stream, err := c.grpc.DeleteMFADevice(ctx)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1542,18 +1536,18 @@ func (c *Client) DeleteMFADevice(ctx context.Context) (proto.AuthService_DeleteM
 
 // AddMFADeviceSync adds a new MFA device (nonstream).
 func (c *Client) AddMFADeviceSync(ctx context.Context, in *proto.AddMFADeviceSyncRequest) (*proto.AddMFADeviceSyncResponse, error) {
-	res, err := c.grpc.AddMFADeviceSync(ctx, in, c.callOpts...)
+	res, err := c.grpc.AddMFADeviceSync(ctx, in)
 	return res, trail.FromGRPC(err)
 }
 
 // DeleteMFADeviceSync deletes a users MFA device (nonstream).
 func (c *Client) DeleteMFADeviceSync(ctx context.Context, in *proto.DeleteMFADeviceSyncRequest) error {
-	_, err := c.grpc.DeleteMFADeviceSync(ctx, in, c.callOpts...)
+	_, err := c.grpc.DeleteMFADeviceSync(ctx, in)
 	return trail.FromGRPC(err)
 }
 
 func (c *Client) GetMFADevices(ctx context.Context, in *proto.GetMFADevicesRequest) (*proto.GetMFADevicesResponse, error) {
-	resp, err := c.grpc.GetMFADevices(ctx, in, c.callOpts...)
+	resp, err := c.grpc.GetMFADevices(ctx, in)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1561,7 +1555,7 @@ func (c *Client) GetMFADevices(ctx context.Context, in *proto.GetMFADevicesReque
 }
 
 func (c *Client) GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthService_GenerateUserSingleUseCertsClient, error) {
-	stream, err := c.grpc.GenerateUserSingleUseCerts(ctx, c.callOpts...)
+	stream, err := c.grpc.GenerateUserSingleUseCerts(ctx)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1569,7 +1563,7 @@ func (c *Client) GenerateUserSingleUseCerts(ctx context.Context) (proto.AuthServ
 }
 
 func (c *Client) IsMFARequired(ctx context.Context, req *proto.IsMFARequiredRequest) (*proto.IsMFARequiredResponse, error) {
-	resp, err := c.grpc.IsMFARequired(ctx, req, c.callOpts...)
+	resp, err := c.grpc.IsMFARequired(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1582,7 +1576,7 @@ func (c *Client) GetOIDCConnector(ctx context.Context, name string, withSecrets 
 		return nil, trace.BadParameter("cannot get OIDC Connector, missing name")
 	}
 	req := &types.ResourceWithSecretsRequest{Name: name, WithSecrets: withSecrets}
-	resp, err := c.grpc.GetOIDCConnector(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetOIDCConnector(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1592,7 +1586,7 @@ func (c *Client) GetOIDCConnector(ctx context.Context, name string, withSecrets 
 // GetOIDCConnectors returns a list of OIDC connectors.
 func (c *Client) GetOIDCConnectors(ctx context.Context, withSecrets bool) ([]types.OIDCConnector, error) {
 	req := &types.ResourcesWithSecretsRequest{WithSecrets: withSecrets}
-	resp, err := c.grpc.GetOIDCConnectors(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetOIDCConnectors(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1609,7 +1603,7 @@ func (c *Client) UpsertOIDCConnector(ctx context.Context, oidcConnector types.OI
 	if !ok {
 		return trace.BadParameter("invalid type %T", oidcConnector)
 	}
-	_, err := c.grpc.UpsertOIDCConnector(ctx, connector, c.callOpts...)
+	_, err := c.grpc.UpsertOIDCConnector(ctx, connector)
 	return trail.FromGRPC(err)
 }
 
@@ -1618,13 +1612,13 @@ func (c *Client) DeleteOIDCConnector(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("cannot delete OIDC Connector, missing name")
 	}
-	_, err := c.grpc.DeleteOIDCConnector(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteOIDCConnector(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // CreateOIDCAuthRequest creates OIDCAuthRequest.
 func (c *Client) CreateOIDCAuthRequest(ctx context.Context, req types.OIDCAuthRequest) (*types.OIDCAuthRequest, error) {
-	resp, err := c.grpc.CreateOIDCAuthRequest(ctx, &req, c.callOpts...)
+	resp, err := c.grpc.CreateOIDCAuthRequest(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1634,7 +1628,7 @@ func (c *Client) CreateOIDCAuthRequest(ctx context.Context, req types.OIDCAuthRe
 // GetOIDCAuthRequest gets an OIDCAuthRequest by state token.
 func (c *Client) GetOIDCAuthRequest(ctx context.Context, stateToken string) (*types.OIDCAuthRequest, error) {
 	req := &proto.GetOIDCAuthRequestRequest{StateToken: stateToken}
-	resp, err := c.grpc.GetOIDCAuthRequest(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetOIDCAuthRequest(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1647,7 +1641,7 @@ func (c *Client) GetSAMLConnector(ctx context.Context, name string, withSecrets 
 		return nil, trace.BadParameter("cannot get SAML Connector, missing name")
 	}
 	req := &types.ResourceWithSecretsRequest{Name: name, WithSecrets: withSecrets}
-	resp, err := c.grpc.GetSAMLConnector(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetSAMLConnector(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1657,7 +1651,7 @@ func (c *Client) GetSAMLConnector(ctx context.Context, name string, withSecrets 
 // GetSAMLConnectors returns a list of SAML connectors.
 func (c *Client) GetSAMLConnectors(ctx context.Context, withSecrets bool) ([]types.SAMLConnector, error) {
 	req := &types.ResourcesWithSecretsRequest{WithSecrets: withSecrets}
-	resp, err := c.grpc.GetSAMLConnectors(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetSAMLConnectors(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1674,7 +1668,7 @@ func (c *Client) UpsertSAMLConnector(ctx context.Context, connector types.SAMLCo
 	if !ok {
 		return trace.BadParameter("invalid type %T", connector)
 	}
-	_, err := c.grpc.UpsertSAMLConnector(ctx, samlConnectorV2, c.callOpts...)
+	_, err := c.grpc.UpsertSAMLConnector(ctx, samlConnectorV2)
 	return trail.FromGRPC(err)
 }
 
@@ -1683,13 +1677,13 @@ func (c *Client) DeleteSAMLConnector(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("cannot delete SAML Connector, missing name")
 	}
-	_, err := c.grpc.DeleteSAMLConnector(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteSAMLConnector(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // CreateSAMLAuthRequest creates SAMLAuthRequest.
 func (c *Client) CreateSAMLAuthRequest(ctx context.Context, req types.SAMLAuthRequest) (*types.SAMLAuthRequest, error) {
-	resp, err := c.grpc.CreateSAMLAuthRequest(ctx, &req, c.callOpts...)
+	resp, err := c.grpc.CreateSAMLAuthRequest(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1699,7 +1693,7 @@ func (c *Client) CreateSAMLAuthRequest(ctx context.Context, req types.SAMLAuthRe
 // GetSAMLAuthRequest gets a SAMLAuthRequest by id.
 func (c *Client) GetSAMLAuthRequest(ctx context.Context, id string) (*types.SAMLAuthRequest, error) {
 	req := &proto.GetSAMLAuthRequestRequest{ID: id}
-	resp, err := c.grpc.GetSAMLAuthRequest(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetSAMLAuthRequest(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1712,7 +1706,7 @@ func (c *Client) GetGithubConnector(ctx context.Context, name string, withSecret
 		return nil, trace.BadParameter("cannot get GitHub Connector, missing name")
 	}
 	req := &types.ResourceWithSecretsRequest{Name: name, WithSecrets: withSecrets}
-	resp, err := c.grpc.GetGithubConnector(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetGithubConnector(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1722,7 +1716,7 @@ func (c *Client) GetGithubConnector(ctx context.Context, name string, withSecret
 // GetGithubConnectors returns a list of Github connectors.
 func (c *Client) GetGithubConnectors(ctx context.Context, withSecrets bool) ([]types.GithubConnector, error) {
 	req := &types.ResourcesWithSecretsRequest{WithSecrets: withSecrets}
-	resp, err := c.grpc.GetGithubConnectors(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetGithubConnectors(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1739,7 +1733,7 @@ func (c *Client) UpsertGithubConnector(ctx context.Context, connector types.Gith
 	if !ok {
 		return trace.BadParameter("invalid type %T", connector)
 	}
-	_, err := c.grpc.UpsertGithubConnector(ctx, githubConnector, c.callOpts...)
+	_, err := c.grpc.UpsertGithubConnector(ctx, githubConnector)
 	return trail.FromGRPC(err)
 }
 
@@ -1748,13 +1742,13 @@ func (c *Client) DeleteGithubConnector(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("cannot delete GitHub Connector, missing name")
 	}
-	_, err := c.grpc.DeleteGithubConnector(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteGithubConnector(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // CreateGithubAuthRequest creates GithubAuthRequest.
 func (c *Client) CreateGithubAuthRequest(ctx context.Context, req types.GithubAuthRequest) (*types.GithubAuthRequest, error) {
-	resp, err := c.grpc.CreateGithubAuthRequest(ctx, &req, c.callOpts...)
+	resp, err := c.grpc.CreateGithubAuthRequest(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1764,7 +1758,7 @@ func (c *Client) CreateGithubAuthRequest(ctx context.Context, req types.GithubAu
 // GetGithubAuthRequest gets a GithubAuthRequest by state token.
 func (c *Client) GetGithubAuthRequest(ctx context.Context, stateToken string) (*types.GithubAuthRequest, error) {
 	req := &proto.GetGithubAuthRequestRequest{StateToken: stateToken}
-	resp, err := c.grpc.GetGithubAuthRequest(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetGithubAuthRequest(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1774,7 +1768,7 @@ func (c *Client) GetGithubAuthRequest(ctx context.Context, stateToken string) (*
 // GetSSODiagnosticInfo returns SSO diagnostic info records for a specific SSO Auth request.
 func (c *Client) GetSSODiagnosticInfo(ctx context.Context, authRequestKind string, authRequestID string) (*types.SSODiagnosticInfo, error) {
 	req := &proto.GetSSODiagnosticInfoRequest{AuthRequestKind: authRequestKind, AuthRequestID: authRequestID}
-	resp, err := c.grpc.GetSSODiagnosticInfo(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetSSODiagnosticInfo(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1787,7 +1781,7 @@ func (c *Client) GetTrustedCluster(ctx context.Context, name string) (types.Trus
 		return nil, trace.BadParameter("cannot get trusted cluster, missing name")
 	}
 	req := &types.ResourceRequest{Name: name}
-	resp, err := c.grpc.GetTrustedCluster(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetTrustedCluster(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1796,7 +1790,7 @@ func (c *Client) GetTrustedCluster(ctx context.Context, name string) (types.Trus
 
 // GetTrustedClusters returns a list of Trusted Clusters.
 func (c *Client) GetTrustedClusters(ctx context.Context) ([]types.TrustedCluster, error) {
-	resp, err := c.grpc.GetTrustedClusters(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetTrustedClusters(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1813,7 +1807,7 @@ func (c *Client) UpsertTrustedCluster(ctx context.Context, trusedCluster types.T
 	if !ok {
 		return nil, trace.BadParameter("invalid type %T", trusedCluster)
 	}
-	resp, err := c.grpc.UpsertTrustedCluster(ctx, trustedCluster, c.callOpts...)
+	resp, err := c.grpc.UpsertTrustedCluster(ctx, trustedCluster)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1825,7 +1819,7 @@ func (c *Client) DeleteTrustedCluster(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("cannot delete trusted cluster, missing name")
 	}
-	_, err := c.grpc.DeleteTrustedCluster(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteTrustedCluster(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
@@ -1834,7 +1828,7 @@ func (c *Client) GetToken(ctx context.Context, name string) (types.ProvisionToke
 	if name == "" {
 		return nil, trace.BadParameter("cannot get token, missing name")
 	}
-	resp, err := c.grpc.GetToken(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	resp, err := c.grpc.GetToken(ctx, &types.ResourceRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1843,7 +1837,7 @@ func (c *Client) GetToken(ctx context.Context, name string) (types.ProvisionToke
 
 // GetTokens returns a list of active provision tokens for nodes and users.
 func (c *Client) GetTokens(ctx context.Context) ([]types.ProvisionToken, error) {
-	resp, err := c.grpc.GetTokens(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetTokens(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1870,7 +1864,7 @@ func (c *Client) UpsertToken(ctx context.Context, token types.ProvisionToken) er
 	if err != nil {
 		err := trail.FromGRPC(err)
 		if trace.IsNotImplemented(err) {
-			_, err := c.grpc.UpsertToken(ctx, tokenV2, c.callOpts...)
+			_, err := c.grpc.UpsertToken(ctx, tokenV2)
 			return trail.FromGRPC(err)
 		}
 		return err
@@ -1893,7 +1887,7 @@ func (c *Client) CreateToken(ctx context.Context, token types.ProvisionToken) er
 	if err != nil {
 		err := trail.FromGRPC(err)
 		if trace.IsNotImplemented(err) {
-			_, err := c.grpc.CreateToken(ctx, tokenV2, c.callOpts...)
+			_, err := c.grpc.CreateToken(ctx, tokenV2)
 			return trail.FromGRPC(err)
 		}
 		return err
@@ -1906,7 +1900,7 @@ func (c *Client) DeleteToken(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("cannot delete token, missing name")
 	}
-	_, err := c.grpc.DeleteToken(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteToken(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
@@ -1915,7 +1909,7 @@ func (c *Client) GetNode(ctx context.Context, namespace, name string) (types.Ser
 	resp, err := c.grpc.GetNode(ctx, &types.ResourceInNamespaceRequest{
 		Name:      name,
 		Namespace: namespace,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1950,7 +1944,7 @@ func (c *Client) UpsertNode(ctx context.Context, node types.Server) (*types.Keep
 	if !ok {
 		return nil, trace.BadParameter("invalid type %T", node)
 	}
-	keepAlive, err := c.grpc.UpsertNode(ctx, serverV2, c.callOpts...)
+	keepAlive, err := c.grpc.UpsertNode(ctx, serverV2)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -1968,7 +1962,7 @@ func (c *Client) DeleteNode(ctx context.Context, namespace, name string) error {
 	_, err := c.grpc.DeleteNode(ctx, &types.ResourceInNamespaceRequest{
 		Name:      name,
 		Namespace: namespace,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
@@ -1977,7 +1971,7 @@ func (c *Client) DeleteAllNodes(ctx context.Context, namespace string) error {
 	if namespace == "" {
 		return trace.BadParameter("missing parameter namespace")
 	}
-	_, err := c.grpc.DeleteAllNodes(ctx, &types.ResourcesInNamespaceRequest{Namespace: namespace}, c.callOpts...)
+	_, err := c.grpc.DeleteAllNodes(ctx, &types.ResourcesInNamespaceRequest{Namespace: namespace})
 	return trail.FromGRPC(err)
 }
 
@@ -2041,7 +2035,7 @@ func (c *Client) SearchEvents(ctx context.Context, fromUTC, toUTC time.Time, nam
 		Order:      proto.Order(order),
 	}
 
-	response, err := c.grpc.GetEvents(ctx, request, c.callOpts...)
+	response, err := c.grpc.GetEvents(ctx, request)
 	if err != nil {
 		return nil, "", trail.FromGRPC(err)
 	}
@@ -2072,7 +2066,7 @@ func (c *Client) SearchSessionEvents(ctx context.Context, fromUTC time.Time, toU
 		Order:     proto.Order(order),
 	}
 
-	response, err := c.grpc.GetSessionEvents(ctx, request, c.callOpts...)
+	response, err := c.grpc.GetSessionEvents(ctx, request)
 	if err != nil {
 		return nil, "", trail.FromGRPC(err)
 	}
@@ -2091,7 +2085,7 @@ func (c *Client) SearchSessionEvents(ctx context.Context, fromUTC time.Time, toU
 
 // GetClusterNetworkingConfig gets cluster networking configuration.
 func (c *Client) GetClusterNetworkingConfig(ctx context.Context) (types.ClusterNetworkingConfig, error) {
-	resp, err := c.grpc.GetClusterNetworkingConfig(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetClusterNetworkingConfig(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2104,19 +2098,19 @@ func (c *Client) SetClusterNetworkingConfig(ctx context.Context, netConfig types
 	if !ok {
 		return trace.BadParameter("invalid type %T", netConfig)
 	}
-	_, err := c.grpc.SetClusterNetworkingConfig(ctx, netConfigV2, c.callOpts...)
+	_, err := c.grpc.SetClusterNetworkingConfig(ctx, netConfigV2)
 	return trail.FromGRPC(err)
 }
 
 // ResetClusterNetworkingConfig resets cluster networking configuration to defaults.
 func (c *Client) ResetClusterNetworkingConfig(ctx context.Context) error {
-	_, err := c.grpc.ResetClusterNetworkingConfig(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.ResetClusterNetworkingConfig(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
 // GetSessionRecordingConfig gets session recording configuration.
 func (c *Client) GetSessionRecordingConfig(ctx context.Context) (types.SessionRecordingConfig, error) {
-	resp, err := c.grpc.GetSessionRecordingConfig(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetSessionRecordingConfig(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2129,19 +2123,19 @@ func (c *Client) SetSessionRecordingConfig(ctx context.Context, recConfig types.
 	if !ok {
 		return trace.BadParameter("invalid type %T", recConfig)
 	}
-	_, err := c.grpc.SetSessionRecordingConfig(ctx, recConfigV2, c.callOpts...)
+	_, err := c.grpc.SetSessionRecordingConfig(ctx, recConfigV2)
 	return trail.FromGRPC(err)
 }
 
 // ResetSessionRecordingConfig resets session recording configuration to defaults.
 func (c *Client) ResetSessionRecordingConfig(ctx context.Context) error {
-	_, err := c.grpc.ResetSessionRecordingConfig(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.ResetSessionRecordingConfig(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
 // GetAuthPreference gets cluster auth preference.
 func (c *Client) GetAuthPreference(ctx context.Context) (types.AuthPreference, error) {
-	pref, err := c.grpc.GetAuthPreference(ctx, &emptypb.Empty{}, c.callOpts...)
+	pref, err := c.grpc.GetAuthPreference(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2154,19 +2148,19 @@ func (c *Client) SetAuthPreference(ctx context.Context, authPref types.AuthPrefe
 	if !ok {
 		return trace.BadParameter("invalid type %T", authPref)
 	}
-	_, err := c.grpc.SetAuthPreference(ctx, authPrefV2, c.callOpts...)
+	_, err := c.grpc.SetAuthPreference(ctx, authPrefV2)
 	return trail.FromGRPC(err)
 }
 
 // ResetAuthPreference resets cluster auth preference to defaults.
 func (c *Client) ResetAuthPreference(ctx context.Context) error {
-	_, err := c.grpc.ResetAuthPreference(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.ResetAuthPreference(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
 // GetClusterAuditConfig gets cluster audit configuration.
 func (c *Client) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditConfig, error) {
-	resp, err := c.grpc.GetClusterAuditConfig(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetClusterAuditConfig(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2175,7 +2169,7 @@ func (c *Client) GetClusterAuditConfig(ctx context.Context) (types.ClusterAuditC
 
 // GetInstaller gets all installer script resources
 func (c *Client) GetInstallers(ctx context.Context) ([]types.Installer, error) {
-	resp, err := c.grpc.GetInstallers(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetInstallers(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2188,7 +2182,7 @@ func (c *Client) GetInstallers(ctx context.Context) ([]types.Installer, error) {
 
 // GetUIConfig gets the configuration for the UI served by the proxy service
 func (c *Client) GetUIConfig(ctx context.Context) (types.UIConfig, error) {
-	resp, err := c.grpc.GetUIConfig(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetUIConfig(ctx, &emptypb.Empty{})
 	return resp, trail.FromGRPC(err)
 }
 
@@ -2198,18 +2192,18 @@ func (c *Client) SetUIConfig(ctx context.Context, uic types.UIConfig) error {
 	if !ok {
 		return trace.BadParameter("invalid type %T", uic)
 	}
-	_, err := c.grpc.SetUIConfig(ctx, uicV1, c.callOpts...)
+	_, err := c.grpc.SetUIConfig(ctx, uicV1)
 	return trail.FromGRPC(err)
 }
 
 func (c *Client) DeleteUIConfig(ctx context.Context) error {
-	_, err := c.grpc.DeleteUIConfig(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteUIConfig(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
 // GetInstaller gets the cluster installer resource
 func (c *Client) GetInstaller(ctx context.Context, name string) (types.Installer, error) {
-	resp, err := c.grpc.GetInstaller(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	resp, err := c.grpc.GetInstaller(ctx, &types.ResourceRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2222,19 +2216,19 @@ func (c *Client) SetInstaller(ctx context.Context, inst types.Installer) error {
 	if !ok {
 		return trace.BadParameter("invalid type %T", inst)
 	}
-	_, err := c.grpc.SetInstaller(ctx, instV1, c.callOpts...)
+	_, err := c.grpc.SetInstaller(ctx, instV1)
 	return trail.FromGRPC(err)
 }
 
 // DeleteInstaller deletes the cluster installer resource
 func (c *Client) DeleteInstaller(ctx context.Context, name string) error {
-	_, err := c.grpc.DeleteInstaller(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteInstaller(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllInstallers deletes all the installer resources.
 func (c *Client) DeleteAllInstallers(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllInstallers(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllInstallers(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
@@ -2243,7 +2237,7 @@ func (c *Client) GetLock(ctx context.Context, name string) (types.Lock, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing lock name")
 	}
-	resp, err := c.grpc.GetLock(ctx, &proto.GetLockRequest{Name: name}, c.callOpts...)
+	resp, err := c.grpc.GetLock(ctx, &proto.GetLockRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2259,7 +2253,7 @@ func (c *Client) GetLocks(ctx context.Context, inForceOnly bool, targets ...type
 	resp, err := c.grpc.GetLocks(ctx, &proto.GetLocksRequest{
 		InForceOnly: inForceOnly,
 		Targets:     targetPtrs,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2276,7 +2270,7 @@ func (c *Client) UpsertLock(ctx context.Context, lock types.Lock) error {
 	if !ok {
 		return trace.BadParameter("invalid type %T", lock)
 	}
-	_, err := c.grpc.UpsertLock(ctx, lockV2, c.callOpts...)
+	_, err := c.grpc.UpsertLock(ctx, lockV2)
 	return trail.FromGRPC(err)
 }
 
@@ -2285,7 +2279,7 @@ func (c *Client) DeleteLock(ctx context.Context, name string) error {
 	if name == "" {
 		return trace.BadParameter("missing lock name")
 	}
-	_, err := c.grpc.DeleteLock(ctx, &proto.DeleteLockRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteLock(ctx, &proto.DeleteLockRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
@@ -2305,13 +2299,13 @@ func (c *Client) ReplaceRemoteLocks(ctx context.Context, clusterName string, loc
 	_, err := c.grpc.ReplaceRemoteLocks(ctx, &proto.ReplaceRemoteLocksRequest{
 		ClusterName: clusterName,
 		Locks:       lockV2s,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
 // GetNetworkRestrictions retrieves the network restrictions
 func (c *Client) GetNetworkRestrictions(ctx context.Context) (types.NetworkRestrictions, error) {
-	nr, err := c.grpc.GetNetworkRestrictions(ctx, &emptypb.Empty{}, c.callOpts...)
+	nr, err := c.grpc.GetNetworkRestrictions(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2324,7 +2318,7 @@ func (c *Client) SetNetworkRestrictions(ctx context.Context, nr types.NetworkRes
 	if !ok {
 		return trace.BadParameter("invalid type %T", nr)
 	}
-	_, err := c.grpc.SetNetworkRestrictions(ctx, restrictionsV4, c.callOpts...)
+	_, err := c.grpc.SetNetworkRestrictions(ctx, restrictionsV4)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -2333,7 +2327,7 @@ func (c *Client) SetNetworkRestrictions(ctx context.Context, nr types.NetworkRes
 
 // DeleteNetworkRestrictions deletes the network restrictions
 func (c *Client) DeleteNetworkRestrictions(ctx context.Context) error {
-	_, err := c.grpc.DeleteNetworkRestrictions(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteNetworkRestrictions(ctx, &emptypb.Empty{})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -2346,7 +2340,7 @@ func (c *Client) CreateApp(ctx context.Context, app types.Application) error {
 	if !ok {
 		return trace.BadParameter("unsupported application type %T", app)
 	}
-	_, err := c.grpc.CreateApp(ctx, appV3, c.callOpts...)
+	_, err := c.grpc.CreateApp(ctx, appV3)
 	return trail.FromGRPC(err)
 }
 
@@ -2356,7 +2350,7 @@ func (c *Client) UpdateApp(ctx context.Context, app types.Application) error {
 	if !ok {
 		return trace.BadParameter("unsupported application type %T", app)
 	}
-	_, err := c.grpc.UpdateApp(ctx, appV3, c.callOpts...)
+	_, err := c.grpc.UpdateApp(ctx, appV3)
 	return trail.FromGRPC(err)
 }
 
@@ -2365,7 +2359,7 @@ func (c *Client) GetApp(ctx context.Context, name string) (types.Application, er
 	if name == "" {
 		return nil, trace.BadParameter("missing application name")
 	}
-	app, err := c.grpc.GetApp(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	app, err := c.grpc.GetApp(ctx, &types.ResourceRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2374,7 +2368,7 @@ func (c *Client) GetApp(ctx context.Context, name string) (types.Application, er
 
 // GetApps returns all application resources.
 func (c *Client) GetApps(ctx context.Context) ([]types.Application, error) {
-	items, err := c.grpc.GetApps(ctx, &emptypb.Empty{}, c.callOpts...)
+	items, err := c.grpc.GetApps(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2387,13 +2381,13 @@ func (c *Client) GetApps(ctx context.Context) ([]types.Application, error) {
 
 // DeleteApp deletes specified application resource.
 func (c *Client) DeleteApp(ctx context.Context, name string) error {
-	_, err := c.grpc.DeleteApp(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteApp(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllApps deletes all application resources.
 func (c *Client) DeleteAllApps(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllApps(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllApps(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
@@ -2403,7 +2397,7 @@ func (c *Client) CreateKubernetesCluster(ctx context.Context, cluster types.Kube
 	if !ok {
 		return trace.BadParameter("unsupported kubernetes cluster type %T", cluster)
 	}
-	_, err := c.grpc.CreateKubernetesCluster(ctx, kubeClusterV3, c.callOpts...)
+	_, err := c.grpc.CreateKubernetesCluster(ctx, kubeClusterV3)
 	return trail.FromGRPC(err)
 }
 
@@ -2413,7 +2407,7 @@ func (c *Client) UpdateKubernetesCluster(ctx context.Context, cluster types.Kube
 	if !ok {
 		return trace.BadParameter("unsupported kubernetes cluster type %T", cluster)
 	}
-	_, err := c.grpc.UpdateKubernetesCluster(ctx, kubeClusterV3, c.callOpts...)
+	_, err := c.grpc.UpdateKubernetesCluster(ctx, kubeClusterV3)
 	return trail.FromGRPC(err)
 }
 
@@ -2422,7 +2416,7 @@ func (c *Client) GetKubernetesCluster(ctx context.Context, name string) (types.K
 	if name == "" {
 		return nil, trace.BadParameter("missing kubernetes cluster name")
 	}
-	cluster, err := c.grpc.GetKubernetesCluster(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	cluster, err := c.grpc.GetKubernetesCluster(ctx, &types.ResourceRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2431,7 +2425,7 @@ func (c *Client) GetKubernetesCluster(ctx context.Context, name string) (types.K
 
 // GetKubernetesClusters returns all kubernetes cluster resources.
 func (c *Client) GetKubernetesClusters(ctx context.Context) ([]types.KubeCluster, error) {
-	items, err := c.grpc.GetKubernetesClusters(ctx, &emptypb.Empty{}, c.callOpts...)
+	items, err := c.grpc.GetKubernetesClusters(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2444,13 +2438,13 @@ func (c *Client) GetKubernetesClusters(ctx context.Context) ([]types.KubeCluster
 
 // DeleteKubernetesCluster deletes specified kubernetes cluster resource.
 func (c *Client) DeleteKubernetesCluster(ctx context.Context, name string) error {
-	_, err := c.grpc.DeleteKubernetesCluster(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteKubernetesCluster(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllKubernetesClusters deletes all kubernetes cluster resources.
 func (c *Client) DeleteAllKubernetesClusters(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllKubernetesClusters(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllKubernetesClusters(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
@@ -2460,7 +2454,7 @@ func (c *Client) CreateDatabase(ctx context.Context, database types.Database) er
 	if !ok {
 		return trace.BadParameter("unsupported database type %T", database)
 	}
-	_, err := c.grpc.CreateDatabase(ctx, databaseV3, c.callOpts...)
+	_, err := c.grpc.CreateDatabase(ctx, databaseV3)
 	return trail.FromGRPC(err)
 }
 
@@ -2470,7 +2464,7 @@ func (c *Client) UpdateDatabase(ctx context.Context, database types.Database) er
 	if !ok {
 		return trace.BadParameter("unsupported database type %T", database)
 	}
-	_, err := c.grpc.UpdateDatabase(ctx, databaseV3, c.callOpts...)
+	_, err := c.grpc.UpdateDatabase(ctx, databaseV3)
 	return trail.FromGRPC(err)
 }
 
@@ -2479,7 +2473,7 @@ func (c *Client) GetDatabase(ctx context.Context, name string) (types.Database, 
 	if name == "" {
 		return nil, trace.BadParameter("missing database name")
 	}
-	database, err := c.grpc.GetDatabase(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	database, err := c.grpc.GetDatabase(ctx, &types.ResourceRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2488,7 +2482,7 @@ func (c *Client) GetDatabase(ctx context.Context, name string) (types.Database, 
 
 // GetDatabases returns all database resources.
 func (c *Client) GetDatabases(ctx context.Context) ([]types.Database, error) {
-	items, err := c.grpc.GetDatabases(ctx, &emptypb.Empty{}, c.callOpts...)
+	items, err := c.grpc.GetDatabases(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2501,13 +2495,13 @@ func (c *Client) GetDatabases(ctx context.Context) ([]types.Database, error) {
 
 // DeleteDatabase deletes specified database resource.
 func (c *Client) DeleteDatabase(ctx context.Context, name string) error {
-	_, err := c.grpc.DeleteDatabase(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteDatabase(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllDatabases deletes all database resources.
 func (c *Client) DeleteAllDatabases(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllDatabases(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllDatabases(ctx, &emptypb.Empty{})
 	return trail.FromGRPC(err)
 }
 
@@ -2519,27 +2513,27 @@ func (c *Client) UpsertDatabaseService(ctx context.Context, service types.Databa
 	}
 	keepAlive, err := c.grpc.UpsertDatabaseService(ctx, &proto.UpsertDatabaseServiceRequest{
 		Service: serviceV1,
-	}, c.callOpts...)
+	})
 
 	return keepAlive, trail.FromGRPC(err)
 }
 
 // DeleteDatabaseService deletes a specific DatabaseService resource.
 func (c *Client) DeleteDatabaseService(ctx context.Context, name string) error {
-	_, err := c.grpc.DeleteDatabaseService(ctx, &types.ResourceRequest{Name: name}, c.callOpts...)
+	_, err := c.grpc.DeleteDatabaseService(ctx, &types.ResourceRequest{Name: name})
 	return trail.FromGRPC(err)
 }
 
 // DeleteAllDatabaseServices deletes all DatabaseService resources.
 // If an error occurs, a partial delete may happen.
 func (c *Client) DeleteAllDatabaseServices(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllDatabaseServices(ctx, &proto.DeleteAllDatabaseServicesRequest{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllDatabaseServices(ctx, &proto.DeleteAllDatabaseServicesRequest{})
 	return trail.FromGRPC(err)
 }
 
 // GetWindowsDesktopServices returns all registered windows desktop services.
 func (c *Client) GetWindowsDesktopServices(ctx context.Context) ([]types.WindowsDesktopService, error) {
-	resp, err := c.grpc.GetWindowsDesktopServices(ctx, &emptypb.Empty{}, c.callOpts...)
+	resp, err := c.grpc.GetWindowsDesktopServices(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2552,7 +2546,7 @@ func (c *Client) GetWindowsDesktopServices(ctx context.Context) ([]types.Windows
 
 // GetWindowsDesktopService returns a registered windows desktop service by name.
 func (c *Client) GetWindowsDesktopService(ctx context.Context, name string) (types.WindowsDesktopService, error) {
-	resp, err := c.grpc.GetWindowsDesktopService(ctx, &proto.GetWindowsDesktopServiceRequest{Name: name}, c.callOpts...)
+	resp, err := c.grpc.GetWindowsDesktopService(ctx, &proto.GetWindowsDesktopServiceRequest{Name: name})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2565,7 +2559,7 @@ func (c *Client) UpsertWindowsDesktopService(ctx context.Context, service types.
 	if !ok {
 		return nil, trace.BadParameter("invalid type %T", service)
 	}
-	keepAlive, err := c.grpc.UpsertWindowsDesktopService(ctx, s, c.callOpts...)
+	keepAlive, err := c.grpc.UpsertWindowsDesktopService(ctx, s)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2576,7 +2570,7 @@ func (c *Client) UpsertWindowsDesktopService(ctx context.Context, service types.
 func (c *Client) DeleteWindowsDesktopService(ctx context.Context, name string) error {
 	_, err := c.grpc.DeleteWindowsDesktopService(ctx, &proto.DeleteWindowsDesktopServiceRequest{
 		Name: name,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -2585,7 +2579,7 @@ func (c *Client) DeleteWindowsDesktopService(ctx context.Context, name string) e
 
 // DeleteAllWindowsDesktopServices removes all registered windows desktop services.
 func (c *Client) DeleteAllWindowsDesktopServices(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllWindowsDesktopServices(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllWindowsDesktopServices(ctx, &emptypb.Empty{})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -2594,7 +2588,7 @@ func (c *Client) DeleteAllWindowsDesktopServices(ctx context.Context) error {
 
 // GetWindowsDesktops returns all registered windows desktop hosts.
 func (c *Client) GetWindowsDesktops(ctx context.Context, filter types.WindowsDesktopFilter) ([]types.WindowsDesktop, error) {
-	resp, err := c.grpc.GetWindowsDesktops(ctx, &filter, c.callOpts...)
+	resp, err := c.grpc.GetWindowsDesktops(ctx, &filter)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2611,7 +2605,7 @@ func (c *Client) CreateWindowsDesktop(ctx context.Context, desktop types.Windows
 	if !ok {
 		return trace.BadParameter("invalid type %T", desktop)
 	}
-	_, err := c.grpc.CreateWindowsDesktop(ctx, d, c.callOpts...)
+	_, err := c.grpc.CreateWindowsDesktop(ctx, d)
 	return trail.FromGRPC(err)
 }
 
@@ -2621,7 +2615,7 @@ func (c *Client) UpdateWindowsDesktop(ctx context.Context, desktop types.Windows
 	if !ok {
 		return trace.BadParameter("invalid type %T", desktop)
 	}
-	_, err := c.grpc.UpdateWindowsDesktop(ctx, d, c.callOpts...)
+	_, err := c.grpc.UpdateWindowsDesktop(ctx, d)
 	return trail.FromGRPC(err)
 }
 
@@ -2631,7 +2625,7 @@ func (c *Client) UpsertWindowsDesktop(ctx context.Context, desktop types.Windows
 	if !ok {
 		return trace.BadParameter("invalid type %T", desktop)
 	}
-	_, err := c.grpc.UpsertWindowsDesktop(ctx, d, c.callOpts...)
+	_, err := c.grpc.UpsertWindowsDesktop(ctx, d)
 	return trail.FromGRPC(err)
 }
 
@@ -2643,7 +2637,7 @@ func (c *Client) DeleteWindowsDesktop(ctx context.Context, hostID, name string) 
 	_, err := c.grpc.DeleteWindowsDesktop(ctx, &proto.DeleteWindowsDesktopRequest{
 		Name:   name,
 		HostID: hostID,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -2652,7 +2646,7 @@ func (c *Client) DeleteWindowsDesktop(ctx context.Context, hostID, name string) 
 
 // DeleteAllWindowsDesktops removes all registered windows desktop hosts.
 func (c *Client) DeleteAllWindowsDesktops(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllWindowsDesktops(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllWindowsDesktops(ctx, &emptypb.Empty{})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -2661,7 +2655,7 @@ func (c *Client) DeleteAllWindowsDesktops(ctx context.Context) error {
 
 // GenerateWindowsDesktopCert generates client certificate for Windows RDP authentication.
 func (c *Client) GenerateWindowsDesktopCert(ctx context.Context, req *proto.WindowsDesktopCertRequest) (*proto.WindowsDesktopCertResponse, error) {
-	resp, err := c.grpc.GenerateWindowsDesktopCert(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GenerateWindowsDesktopCert(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2671,7 +2665,7 @@ func (c *Client) GenerateWindowsDesktopCert(ctx context.Context, req *proto.Wind
 // ChangeUserAuthentication allows a user with a reset or invite token to change their password and if enabled also adds a new mfa device.
 // Upon success, creates new web session and creates new set of recovery codes (if user meets requirements).
 func (c *Client) ChangeUserAuthentication(ctx context.Context, req *proto.ChangeUserAuthenticationRequest) (*proto.ChangeUserAuthenticationResponse, error) {
-	res, err := c.grpc.ChangeUserAuthentication(ctx, req, c.callOpts...)
+	res, err := c.grpc.ChangeUserAuthentication(ctx, req)
 	return res, trail.FromGRPC(err)
 }
 
@@ -2679,7 +2673,7 @@ func (c *Client) ChangeUserAuthentication(ctx context.Context, req *proto.Change
 // This token is used as part of a URL that will be emailed to the user (not done in this request).
 // Represents step 1 of the account recovery process.
 func (c *Client) StartAccountRecovery(ctx context.Context, req *proto.StartAccountRecoveryRequest) (types.UserToken, error) {
-	res, err := c.grpc.StartAccountRecovery(ctx, req, c.callOpts...)
+	res, err := c.grpc.StartAccountRecovery(ctx, req)
 	return res, trail.FromGRPC(err)
 }
 
@@ -2687,7 +2681,7 @@ func (c *Client) StartAccountRecovery(ctx context.Context, req *proto.StartAccou
 // (authn depending on what user needed to recover). This token will allow users to perform protected actions while not logged in.
 // Represents step 2 of the account recovery process after RPC StartAccountRecovery.
 func (c *Client) VerifyAccountRecovery(ctx context.Context, req *proto.VerifyAccountRecoveryRequest) (types.UserToken, error) {
-	res, err := c.grpc.VerifyAccountRecovery(ctx, req, c.callOpts...)
+	res, err := c.grpc.VerifyAccountRecovery(ctx, req)
 	return res, trail.FromGRPC(err)
 }
 
@@ -2695,50 +2689,50 @@ func (c *Client) VerifyAccountRecovery(ctx context.Context, req *proto.VerifyAcc
 // allowing user to regain access to their account using the new credentials.
 // Represents the last step in the account recovery process after RPC's StartAccountRecovery and VerifyAccountRecovery.
 func (c *Client) CompleteAccountRecovery(ctx context.Context, req *proto.CompleteAccountRecoveryRequest) error {
-	_, err := c.grpc.CompleteAccountRecovery(ctx, req, c.callOpts...)
+	_, err := c.grpc.CompleteAccountRecovery(ctx, req)
 	return trail.FromGRPC(err)
 }
 
 // CreateAccountRecoveryCodes creates new set of recovery codes for a user, replacing and invalidating any previously owned codes.
 func (c *Client) CreateAccountRecoveryCodes(ctx context.Context, req *proto.CreateAccountRecoveryCodesRequest) (*proto.RecoveryCodes, error) {
-	res, err := c.grpc.CreateAccountRecoveryCodes(ctx, req, c.callOpts...)
+	res, err := c.grpc.CreateAccountRecoveryCodes(ctx, req)
 	return res, trail.FromGRPC(err)
 }
 
 // GetAccountRecoveryToken returns a user token resource after verifying the token in
 // request is not expired and is of the correct recovery type.
 func (c *Client) GetAccountRecoveryToken(ctx context.Context, req *proto.GetAccountRecoveryTokenRequest) (types.UserToken, error) {
-	res, err := c.grpc.GetAccountRecoveryToken(ctx, req, c.callOpts...)
+	res, err := c.grpc.GetAccountRecoveryToken(ctx, req)
 	return res, trail.FromGRPC(err)
 }
 
 // GetAccountRecoveryCodes returns the user in context their recovery codes resource without any secrets.
 func (c *Client) GetAccountRecoveryCodes(ctx context.Context, req *proto.GetAccountRecoveryCodesRequest) (*proto.RecoveryCodes, error) {
-	res, err := c.grpc.GetAccountRecoveryCodes(ctx, req, c.callOpts...)
+	res, err := c.grpc.GetAccountRecoveryCodes(ctx, req)
 	return res, trail.FromGRPC(err)
 }
 
 // CreateAuthenticateChallenge creates and returns MFA challenges for a users registered MFA devices.
 func (c *Client) CreateAuthenticateChallenge(ctx context.Context, in *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
-	resp, err := c.grpc.CreateAuthenticateChallenge(ctx, in, c.callOpts...)
+	resp, err := c.grpc.CreateAuthenticateChallenge(ctx, in)
 	return resp, trail.FromGRPC(err)
 }
 
 // CreatePrivilegeToken is implemented by AuthService.CreatePrivilegeToken.
 func (c *Client) CreatePrivilegeToken(ctx context.Context, req *proto.CreatePrivilegeTokenRequest) (*types.UserTokenV3, error) {
-	resp, err := c.grpc.CreatePrivilegeToken(ctx, req, c.callOpts...)
+	resp, err := c.grpc.CreatePrivilegeToken(ctx, req)
 	return resp, trail.FromGRPC(err)
 }
 
 // CreateRegisterChallenge creates and returns MFA register challenge for a new MFA device.
 func (c *Client) CreateRegisterChallenge(ctx context.Context, in *proto.CreateRegisterChallengeRequest) (*proto.MFARegisterChallenge, error) {
-	resp, err := c.grpc.CreateRegisterChallenge(ctx, in, c.callOpts...)
+	resp, err := c.grpc.CreateRegisterChallenge(ctx, in)
 	return resp, trail.FromGRPC(err)
 }
 
 // GenerateCertAuthorityCRL generates an empty CRL for a CA.
 func (c *Client) GenerateCertAuthorityCRL(ctx context.Context, req *proto.CertAuthorityRequest) (*proto.CRL, error) {
-	resp, err := c.grpc.GenerateCertAuthorityCRL(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GenerateCertAuthorityCRL(ctx, req)
 	return resp, trail.FromGRPC(err)
 }
 
@@ -2753,7 +2747,7 @@ func (c *Client) ListResources(ctx context.Context, req proto.ListResourcesReque
 		return nil, trace.Wrap(err)
 	}
 
-	resp, err := c.grpc.ListResources(ctx, &req, c.callOpts...)
+	resp, err := c.grpc.ListResources(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2898,7 +2892,7 @@ func (c *Client) CreateSessionTracker(ctx context.Context, st types.SessionTrack
 	}
 
 	req := &proto.CreateSessionTrackerRequest{SessionTracker: v1}
-	tracker, err := c.grpc.CreateSessionTracker(ctx, req, c.callOpts...)
+	tracker, err := c.grpc.CreateSessionTracker(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2908,7 +2902,7 @@ func (c *Client) CreateSessionTracker(ctx context.Context, st types.SessionTrack
 // GetSessionTracker returns the current state of a session tracker for an active session.
 func (c *Client) GetSessionTracker(ctx context.Context, sessionID string) (types.SessionTracker, error) {
 	req := &proto.GetSessionTrackerRequest{SessionID: sessionID}
-	resp, err := c.grpc.GetSessionTracker(ctx, req, c.callOpts...)
+	resp, err := c.grpc.GetSessionTracker(ctx, req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2917,7 +2911,7 @@ func (c *Client) GetSessionTracker(ctx context.Context, sessionID string) (types
 
 // GetActiveSessionTrackers returns a list of active session trackers.
 func (c *Client) GetActiveSessionTrackers(ctx context.Context) ([]types.SessionTracker, error) {
-	stream, err := c.grpc.GetActiveSessionTrackers(ctx, &emptypb.Empty{}, c.callOpts...)
+	stream, err := c.grpc.GetActiveSessionTrackers(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2941,7 +2935,7 @@ func (c *Client) GetActiveSessionTrackers(ctx context.Context) ([]types.SessionT
 
 // GetActiveSessionTrackersWithFilter returns a list of active sessions filtered by a filter.
 func (c *Client) GetActiveSessionTrackersWithFilter(ctx context.Context, filter *types.SessionTrackerFilter) ([]types.SessionTracker, error) {
-	stream, err := c.grpc.GetActiveSessionTrackersWithFilter(ctx, filter, c.callOpts...)
+	stream, err := c.grpc.GetActiveSessionTrackersWithFilter(ctx, filter)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -2965,19 +2959,19 @@ func (c *Client) GetActiveSessionTrackersWithFilter(ctx context.Context, filter 
 
 // RemoveSessionTracker removes a tracker resource for an active session.
 func (c *Client) RemoveSessionTracker(ctx context.Context, sessionID string) error {
-	_, err := c.grpc.RemoveSessionTracker(ctx, &proto.RemoveSessionTrackerRequest{SessionID: sessionID}, c.callOpts...)
+	_, err := c.grpc.RemoveSessionTracker(ctx, &proto.RemoveSessionTrackerRequest{SessionID: sessionID})
 	return trail.FromGRPC(err)
 }
 
 // UpdateSessionTracker updates a tracker resource for an active session.
 func (c *Client) UpdateSessionTracker(ctx context.Context, req *proto.UpdateSessionTrackerRequest) error {
-	_, err := c.grpc.UpdateSessionTracker(ctx, req, c.callOpts...)
+	_, err := c.grpc.UpdateSessionTracker(ctx, req)
 	return trail.FromGRPC(err)
 }
 
 // MaintainSessionPresence establishes a channel used to continuously verify the presence for a session.
 func (c *Client) MaintainSessionPresence(ctx context.Context) (proto.AuthService_MaintainSessionPresenceClient, error) {
-	stream, err := c.grpc.MaintainSessionPresence(ctx, c.callOpts...)
+	stream, err := c.grpc.MaintainSessionPresence(ctx)
 	return stream, trail.FromGRPC(err)
 }
 
@@ -3005,7 +2999,7 @@ func (c *Client) GetConnectionDiagnostic(ctx context.Context, name string) (type
 	req := &proto.GetConnectionDiagnosticRequest{
 		Name: name,
 	}
-	res, err := c.grpc.GetConnectionDiagnostic(ctx, req, c.callOpts...)
+	res, err := c.grpc.GetConnectionDiagnostic(ctx, req)
 	return res, trail.FromGRPC(err)
 }
 
@@ -3015,7 +3009,7 @@ func (c *Client) CreateConnectionDiagnostic(ctx context.Context, connectionDiagn
 	if !ok {
 		return trace.BadParameter("invalid type %T", connectionDiagnostic)
 	}
-	_, err := c.grpc.CreateConnectionDiagnostic(ctx, connectionDiagnosticV1, c.callOpts...)
+	_, err := c.grpc.CreateConnectionDiagnostic(ctx, connectionDiagnosticV1)
 	return trail.FromGRPC(err)
 }
 
@@ -3025,7 +3019,7 @@ func (c *Client) UpdateConnectionDiagnostic(ctx context.Context, connectionDiagn
 	if !ok {
 		return trace.BadParameter("invalid type %T", connectionDiagnostic)
 	}
-	_, err := c.grpc.UpdateConnectionDiagnostic(ctx, connectionDiagnosticV1, c.callOpts...)
+	_, err := c.grpc.UpdateConnectionDiagnostic(ctx, connectionDiagnosticV1)
 	return trail.FromGRPC(err)
 }
 
@@ -3035,7 +3029,7 @@ func (c *Client) AppendDiagnosticTrace(ctx context.Context, name string, t *type
 		Name:  name,
 		Trace: t,
 	}
-	connectionDiagnostic, err := c.grpc.AppendDiagnosticTrace(ctx, req, c.callOpts...)
+	connectionDiagnostic, err := c.grpc.AppendDiagnosticTrace(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3045,7 +3039,7 @@ func (c *Client) AppendDiagnosticTrace(ctx context.Context, name string, t *type
 
 // GetClusterAlerts loads matching cluster alerts.
 func (c *Client) GetClusterAlerts(ctx context.Context, query types.GetClusterAlertsRequest) ([]types.ClusterAlert, error) {
-	rsp, err := c.grpc.GetClusterAlerts(ctx, &query, c.callOpts...)
+	rsp, err := c.grpc.GetClusterAlerts(ctx, &query)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -3056,18 +3050,18 @@ func (c *Client) GetClusterAlerts(ctx context.Context, query types.GetClusterAle
 func (c *Client) UpsertClusterAlert(ctx context.Context, alert types.ClusterAlert) error {
 	_, err := c.grpc.UpsertClusterAlert(ctx, &proto.UpsertClusterAlertRequest{
 		Alert: alert,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
 func (c *Client) ChangePassword(ctx context.Context, req *proto.ChangePasswordRequest) error {
-	_, err := c.grpc.ChangePassword(ctx, req, c.callOpts...)
+	_, err := c.grpc.ChangePassword(ctx, req)
 	return trail.FromGRPC(err)
 }
 
 // SubmitUsageEvent submits an external usage event.
 func (c *Client) SubmitUsageEvent(ctx context.Context, req *proto.SubmitUsageEventRequest) error {
-	_, err := c.grpc.SubmitUsageEvent(ctx, req, c.callOpts...)
+	_, err := c.grpc.SubmitUsageEvent(ctx, req)
 
 	return trail.FromGRPC(err)
 }
@@ -3093,13 +3087,13 @@ func (c *Client) ListReleases(ctx context.Context, req *proto.ListReleasesReques
 
 // CreateAlertAck marks a cluster alert as acknowledged.
 func (c *Client) CreateAlertAck(ctx context.Context, ack types.AlertAcknowledgement) error {
-	_, err := c.grpc.CreateAlertAck(ctx, &ack, c.callOpts...)
+	_, err := c.grpc.CreateAlertAck(ctx, &ack)
 	return trail.FromGRPC(err)
 }
 
 // GetAlertAcks gets active alert acknowledgements.
 func (c *Client) GetAlertAcks(ctx context.Context) ([]types.AlertAcknowledgement, error) {
-	rsp, err := c.grpc.GetAlertAcks(ctx, &proto.GetAlertAcksRequest{}, c.callOpts...)
+	rsp, err := c.grpc.GetAlertAcks(ctx, &proto.GetAlertAcksRequest{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -3108,7 +3102,7 @@ func (c *Client) GetAlertAcks(ctx context.Context) ([]types.AlertAcknowledgement
 
 // ClearAlertAcks clears alert acknowledgments.
 func (c *Client) ClearAlertAcks(ctx context.Context, req proto.ClearAlertAcksRequest) error {
-	_, err := c.grpc.ClearAlertAcks(ctx, &req, c.callOpts...)
+	_, err := c.grpc.ClearAlertAcks(ctx, &req)
 	return trail.FromGRPC(err)
 }
 
@@ -3117,7 +3111,7 @@ func (c *Client) ListSAMLIdPServiceProviders(ctx context.Context, pageSize int, 
 	resp, err := c.grpc.ListSAMLIdPServiceProviders(ctx, &proto.ListSAMLIdPServiceProvidersRequest{
 		Limit:   int32(pageSize),
 		NextKey: nextKey,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, "", trail.FromGRPC(err)
 	}
@@ -3132,7 +3126,7 @@ func (c *Client) ListSAMLIdPServiceProviders(ctx context.Context, pageSize int, 
 func (c *Client) GetSAMLIdPServiceProvider(ctx context.Context, name string) (types.SAMLIdPServiceProvider, error) {
 	sp, err := c.grpc.GetSAMLIdPServiceProvider(ctx, &proto.GetSAMLIdPServiceProviderRequest{
 		Name: name,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -3146,7 +3140,7 @@ func (c *Client) CreateSAMLIdPServiceProvider(ctx context.Context, sp types.SAML
 		return trace.BadParameter("unsupported SAML IdP service provider type %T", sp)
 	}
 
-	_, err := c.grpc.CreateSAMLIdPServiceProvider(ctx, spV1, c.callOpts...)
+	_, err := c.grpc.CreateSAMLIdPServiceProvider(ctx, spV1)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3160,7 +3154,7 @@ func (c *Client) UpdateSAMLIdPServiceProvider(ctx context.Context, sp types.SAML
 		return trace.BadParameter("unsupported SAML IdP service provider type %T", sp)
 	}
 
-	_, err := c.grpc.UpdateSAMLIdPServiceProvider(ctx, spV1, c.callOpts...)
+	_, err := c.grpc.UpdateSAMLIdPServiceProvider(ctx, spV1)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3171,7 +3165,7 @@ func (c *Client) UpdateSAMLIdPServiceProvider(ctx context.Context, sp types.SAML
 func (c *Client) DeleteSAMLIdPServiceProvider(ctx context.Context, name string) error {
 	_, err := c.grpc.DeleteSAMLIdPServiceProvider(ctx, &proto.DeleteSAMLIdPServiceProviderRequest{
 		Name: name,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3180,7 +3174,7 @@ func (c *Client) DeleteSAMLIdPServiceProvider(ctx context.Context, name string) 
 
 // DeleteAllSAMLIdPServiceProviders removes all SAML IdP service providers.
 func (c *Client) DeleteAllSAMLIdPServiceProviders(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllSAMLIdPServiceProviders(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllSAMLIdPServiceProviders(ctx, &emptypb.Empty{})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3192,7 +3186,7 @@ func (c *Client) ListUserGroups(ctx context.Context, pageSize int, nextKey strin
 	resp, err := c.grpc.ListUserGroups(ctx, &proto.ListUserGroupsRequest{
 		Limit:   int32(pageSize),
 		NextKey: nextKey,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, "", trail.FromGRPC(err)
 	}
@@ -3207,7 +3201,7 @@ func (c *Client) ListUserGroups(ctx context.Context, pageSize int, nextKey strin
 func (c *Client) GetUserGroup(ctx context.Context, name string) (types.UserGroup, error) {
 	ug, err := c.grpc.GetUserGroup(ctx, &proto.GetUserGroupRequest{
 		Name: name,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -3221,7 +3215,7 @@ func (c *Client) CreateUserGroup(ctx context.Context, ug types.UserGroup) error 
 		return trace.BadParameter("unsupported user group type %T", ug)
 	}
 
-	_, err := c.grpc.CreateUserGroup(ctx, ugV1, c.callOpts...)
+	_, err := c.grpc.CreateUserGroup(ctx, ugV1)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3235,7 +3229,7 @@ func (c *Client) UpdateUserGroup(ctx context.Context, ug types.UserGroup) error 
 		return trace.BadParameter("unsupported user group type %T", ug)
 	}
 
-	_, err := c.grpc.UpdateUserGroup(ctx, ugV1, c.callOpts...)
+	_, err := c.grpc.UpdateUserGroup(ctx, ugV1)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3246,7 +3240,7 @@ func (c *Client) UpdateUserGroup(ctx context.Context, ug types.UserGroup) error 
 func (c *Client) DeleteUserGroup(ctx context.Context, name string) error {
 	_, err := c.grpc.DeleteUserGroup(ctx, &proto.DeleteUserGroupRequest{
 		Name: name,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3255,7 +3249,7 @@ func (c *Client) DeleteUserGroup(ctx context.Context, name string) error {
 
 // DeleteAllUserGroups removes all user groups.
 func (c *Client) DeleteAllUserGroups(ctx context.Context) error {
-	_, err := c.grpc.DeleteAllUserGroups(ctx, &emptypb.Empty{}, c.callOpts...)
+	_, err := c.grpc.DeleteAllUserGroups(ctx, &emptypb.Empty{})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3275,7 +3269,7 @@ func (c *Client) PluginsClient() pluginspb.PluginServiceClient {
 func (c *Client) GetLoginRule(ctx context.Context, name string) (*loginrulepb.LoginRule, error) {
 	rule, err := c.LoginRuleClient().GetLoginRule(ctx, &loginrulepb.GetLoginRuleRequest{
 		Name: name,
-	}, c.callOpts...)
+	})
 	return rule, trail.FromGRPC(err)
 }
 
@@ -3284,7 +3278,7 @@ func (c *Client) GetLoginRule(ctx context.Context, name string) (*loginrulepb.Lo
 func (c *Client) CreateLoginRule(ctx context.Context, rule *loginrulepb.LoginRule) (*loginrulepb.LoginRule, error) {
 	rule, err := c.LoginRuleClient().CreateLoginRule(ctx, &loginrulepb.CreateLoginRuleRequest{
 		LoginRule: rule,
-	}, c.callOpts...)
+	})
 	return rule, trail.FromGRPC(err)
 }
 
@@ -3293,7 +3287,7 @@ func (c *Client) CreateLoginRule(ctx context.Context, rule *loginrulepb.LoginRul
 func (c *Client) UpsertLoginRule(ctx context.Context, rule *loginrulepb.LoginRule) (*loginrulepb.LoginRule, error) {
 	rule, err := c.LoginRuleClient().UpsertLoginRule(ctx, &loginrulepb.UpsertLoginRuleRequest{
 		LoginRule: rule,
-	}, c.callOpts...)
+	})
 	return rule, trail.FromGRPC(err)
 }
 
@@ -3301,7 +3295,7 @@ func (c *Client) UpsertLoginRule(ctx context.Context, rule *loginrulepb.LoginRul
 func (c *Client) DeleteLoginRule(ctx context.Context, name string) error {
 	_, err := c.LoginRuleClient().DeleteLoginRule(ctx, &loginrulepb.DeleteLoginRuleRequest{
 		Name: name,
-	}, c.callOpts...)
+	})
 	return trail.FromGRPC(err)
 }
 
@@ -3364,7 +3358,7 @@ func (c *Client) UpdateHeadlessAuthenticationState(ctx context.Context, id strin
 		Id:          id,
 		State:       state,
 		MfaResponse: mfaResponse,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -3375,7 +3369,7 @@ func (c *Client) UpdateHeadlessAuthenticationState(ctx context.Context, id strin
 func (c *Client) GetHeadlessAuthentication(ctx context.Context, id string) (*types.HeadlessAuthentication, error) {
 	headlessAuthn, err := c.grpc.GetHeadlessAuthentication(ctx, &proto.GetHeadlessAuthenticationRequest{
 		Id: id,
-	}, c.callOpts...)
+	})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}

--- a/api/client/inventory.go
+++ b/api/client/inventory.go
@@ -197,7 +197,7 @@ func (d downstreamPipeControlStream) Recv() <-chan proto.DownstreamInventoryMess
 // UpstreamInventoryHello, and the first message received must be a DownstreamInventoryHello.
 func (c *Client) InventoryControlStream(ctx context.Context) (DownstreamInventoryControlStream, error) {
 	cancelCtx, cancel := context.WithCancel(ctx)
-	stream, err := c.grpc.InventoryControlStream(cancelCtx, c.callOpts...)
+	stream, err := c.grpc.InventoryControlStream(cancelCtx)
 	if err != nil {
 		cancel()
 		return nil, trail.FromGRPC(err)
@@ -206,7 +206,7 @@ func (c *Client) InventoryControlStream(ctx context.Context) (DownstreamInventor
 }
 
 func (c *Client) GetInventoryStatus(ctx context.Context, req proto.InventoryStatusRequest) (proto.InventoryStatusSummary, error) {
-	rsp, err := c.grpc.GetInventoryStatus(ctx, &req, c.callOpts...)
+	rsp, err := c.grpc.GetInventoryStatus(ctx, &req)
 	if err != nil {
 		return proto.InventoryStatusSummary{}, trail.FromGRPC(err)
 	}
@@ -215,7 +215,7 @@ func (c *Client) GetInventoryStatus(ctx context.Context, req proto.InventoryStat
 }
 
 func (c *Client) PingInventory(ctx context.Context, req proto.InventoryPingRequest) (proto.InventoryPingResponse, error) {
-	rsp, err := c.grpc.PingInventory(ctx, &req, c.callOpts...)
+	rsp, err := c.grpc.PingInventory(ctx, &req)
 	if err != nil {
 		return proto.InventoryPingResponse{}, trail.FromGRPC(err)
 	}
@@ -228,7 +228,7 @@ func (c *Client) GetInstances(ctx context.Context, filter types.InstanceFilter) 
 	// halts early.
 	ctx, cancel := context.WithCancel(ctx)
 
-	instances, err := c.grpc.GetInstances(ctx, &filter, c.callOpts...)
+	instances, err := c.grpc.GetInstances(ctx, &filter)
 	if err != nil {
 		cancel()
 		return stream.Fail[types.Instance](trail.FromGRPC(err))

--- a/api/client/keepaliver.go
+++ b/api/client/keepaliver.go
@@ -32,7 +32,7 @@ import (
 // returned value to release the keepAliver resources.
 func (c *Client) NewKeepAliver(ctx context.Context) (types.KeepAliver, error) {
 	cancelCtx, cancel := context.WithCancel(ctx)
-	stream, err := c.grpc.SendKeepAlives(cancelCtx, c.callOpts...)
+	stream, err := c.grpc.SendKeepAlives(cancelCtx)
 	if err != nil {
 		cancel()
 		return nil, trail.FromGRPC(err)

--- a/api/client/sessions.go
+++ b/api/client/sessions.go
@@ -39,7 +39,7 @@ func (c *Client) WebSessions() types.WebSessionInterface {
 
 // Get returns the web session for the specified request
 func (r *webSessions) Get(ctx context.Context, req types.GetWebSessionRequest) (types.WebSession, error) {
-	resp, err := r.c.grpc.GetWebSession(ctx, &req, r.c.callOpts...)
+	resp, err := r.c.grpc.GetWebSession(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -48,7 +48,7 @@ func (r *webSessions) Get(ctx context.Context, req types.GetWebSessionRequest) (
 
 // List returns the list of all web sessions
 func (r *webSessions) List(ctx context.Context) ([]types.WebSession, error) {
-	resp, err := r.c.grpc.GetWebSessions(ctx, &emptypb.Empty{}, r.c.callOpts...)
+	resp, err := r.c.grpc.GetWebSessions(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -66,7 +66,7 @@ func (r *webSessions) Upsert(ctx context.Context, session types.WebSession) erro
 
 // Delete deletes the web session specified with the request
 func (r *webSessions) Delete(ctx context.Context, req types.DeleteWebSessionRequest) error {
-	_, err := r.c.grpc.DeleteWebSession(ctx, &req, r.c.callOpts...)
+	_, err := r.c.grpc.DeleteWebSession(ctx, &req)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -75,7 +75,7 @@ func (r *webSessions) Delete(ctx context.Context, req types.DeleteWebSessionRequ
 
 // DeleteAll deletes all web sessions
 func (r *webSessions) DeleteAll(ctx context.Context) error {
-	_, err := r.c.grpc.DeleteAllWebSessions(ctx, &emptypb.Empty{}, r.c.callOpts...)
+	_, err := r.c.grpc.DeleteAllWebSessions(ctx, &emptypb.Empty{})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -99,7 +99,7 @@ func (c *Client) WebTokens() types.WebTokenInterface {
 
 // Get returns the web token for the specified request
 func (r *webTokens) Get(ctx context.Context, req types.GetWebTokenRequest) (types.WebToken, error) {
-	resp, err := r.c.grpc.GetWebToken(ctx, &req, r.c.callOpts...)
+	resp, err := r.c.grpc.GetWebToken(ctx, &req)
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -108,7 +108,7 @@ func (r *webTokens) Get(ctx context.Context, req types.GetWebTokenRequest) (type
 
 // List returns the list of all web tokens
 func (r *webTokens) List(ctx context.Context) ([]types.WebToken, error) {
-	resp, err := r.c.grpc.GetWebTokens(ctx, &emptypb.Empty{}, r.c.callOpts...)
+	resp, err := r.c.grpc.GetWebTokens(ctx, &emptypb.Empty{})
 	if err != nil {
 		return nil, trail.FromGRPC(err)
 	}
@@ -126,7 +126,7 @@ func (r *webTokens) Upsert(ctx context.Context, token types.WebToken) error {
 
 // Delete deletes the web token specified with the request
 func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest) error {
-	_, err := r.c.grpc.DeleteWebToken(ctx, &req, r.c.callOpts...)
+	_, err := r.c.grpc.DeleteWebToken(ctx, &req)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}
@@ -135,7 +135,7 @@ func (r *webTokens) Delete(ctx context.Context, req types.DeleteWebTokenRequest)
 
 // DeleteAll deletes all web tokens
 func (r *webTokens) DeleteAll(ctx context.Context) error {
-	_, err := r.c.grpc.DeleteAllWebTokens(ctx, &emptypb.Empty{}, r.c.callOpts...)
+	_, err := r.c.grpc.DeleteAllWebTokens(ctx, &emptypb.Empty{})
 	if err != nil {
 		return trail.FromGRPC(err)
 	}

--- a/api/client/streamwatcher.go
+++ b/api/client/streamwatcher.go
@@ -34,7 +34,7 @@ func (c *Client) NewWatcher(ctx context.Context, watch types.Watch) (types.Watch
 	for _, kind := range watch.Kinds {
 		protoWatch.Kinds = append(protoWatch.Kinds, proto.FromWatchKind(kind))
 	}
-	stream, err := c.grpc.WatchEvents(cancelCtx, &protoWatch, c.callOpts...)
+	stream, err := c.grpc.WatchEvents(cancelCtx, &protoWatch)
 	if err != nil {
 		cancel()
 		return nil, trail.FromGRPC(err)

--- a/integrations/access/common/config.go
+++ b/integrations/access/common/config.go
@@ -66,13 +66,15 @@ func (c BaseConfig) GetTeleportClient(ctx context.Context) (teleport.Client, err
 		Credentials: c.Teleport.Credentials(),
 		DialOpts: []grpc.DialOption{
 			grpc.WithConnectParams(grpc.ConnectParams{Backoff: bk, MinConnectTimeout: initTimeout}),
+			grpc.WithDefaultCallOptions(
+				grpc.WaitForReady(true),
+			),
 			grpc.WithReturnConnectionError(),
 		},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	clt = clt.WithCallOptions(grpc.WaitForReady(true))
 
 	return clt, nil
 }


### PR DESCRIPTION
Drops call options as a member of api/client.Client. Callers should prefer setting the dial options on initialization using [grpc.WithDefaultCallOptions][1].

[1]: https://pkg.go.dev/google.golang.org/grpc#WithDefaultCallOptions