### PR TITLE
chore: Bump libfido2 from 1.12.0 to 1.13.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -49,9 +49,9 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 
 
 # Install libfido2.
 # Depends on libcbor, libcrypto (OpenSSL 3.x), libudev and zlib1g-dev.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
+    [ "$(git rev-parse HEAD)" = '486a8f8667e42f55cee2bba301b41433cacec830' ] && \
     CFLAGS=-pthread cmake \
         -DBUILD_EXAMPLES=OFF \
         -DBUILD_MANPAGES=OFF \
@@ -316,14 +316,14 @@ COPY --from=libfido2 \
     /usr/local/lib/libcrypto.a \
     /usr/local/lib/libcrypto.so.3 \
     /usr/local/lib/libfido2.a \
-    /usr/local/lib/libfido2.so.1.12.0 \
+    /usr/local/lib/libfido2.so.1.13.0 \
     /usr/local/lib/libssl.a \
     /usr/local/lib/libssl.so.3 \
     /usr/local/lib/libudev.a \
     /usr/local/lib/
 RUN cd /usr/local/lib && \
     ln -s libcrypto.so.3 libcrypto.so && \
-    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.13.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ln -s libssl.so.3 libssl.so && \
     ldconfig

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -89,9 +89,9 @@ ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 # Install libfido2.
 # Depends on libcbor, libcrypto (OpenSSL 3.x), libudev and zlib-devel.
 # Linked so `make build/tsh` finds the library where it expects it.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
+    [ "$(git rev-parse HEAD)" = '486a8f8667e42f55cee2bba301b41433cacec830' ] && \
     scl enable ${DEVTOOLSET} "\
       CFLAGS=-pthread cmake3 \
           -DBUILD_EXAMPLES=OFF \
@@ -266,7 +266,7 @@ COPY --from=libfido2 \
     /usr/local/lib64/libcrypto.a \
     /usr/local/lib64/libcrypto.so.3 \
     /usr/local/lib64/libfido2.a \
-    /usr/local/lib64/libfido2.so.1.12.0 \
+    /usr/local/lib64/libfido2.so.1.13.0 \
     /usr/local/lib64/libssl.a \
     /usr/local/lib64/libssl.so.3 \
     /usr/local/lib64/libudev.a \
@@ -274,7 +274,7 @@ COPY --from=libfido2 \
 # Re-create usual lib64 links.
 RUN cd /usr/local/lib64 && \
     ln -s libcrypto.so.3 libcrypto.so && \
-    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.13.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ln -s libssl.so.3 libssl.so && \
 # Update ld.

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -27,7 +27,7 @@ RUN groupadd ci --gid=$GID -o && \
 RUN install --directory --mode=0700 --owner=ci --group=ci /var/lib/teleport
 
 ## LIBPCSCLITE ################################################################
-# 
+#
 FROM gcc AS libpcsclite
 ARG LIBPCSCLITE_VERSION
 
@@ -80,9 +80,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 # Install libfido2.
 # Depends on libcbor, openssl, zlib-devel and libudev.
 # Linked so `make build/tsh` finds the library where it expects it.
-RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
+RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
     cd libfido2 && \
-    [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
+    [ "$(git rev-parse HEAD)" = '486a8f8667e42f55cee2bba301b41433cacec830' ] && \
       LDFLAGS="-lpthread" cmake3 \
           -DBUILD_EXAMPLES=OFF \
           -DBUILD_MANPAGES=OFF \
@@ -129,7 +129,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
     cargo --version && \
     rustc --version && \
     rustup target add ${RUST_ARCH}
-    
+
 USER root
 
 # Copy dependencies
@@ -140,7 +140,7 @@ COPY --from=libfido2 \
     /usr/local/lib64/libcrypto.a \
     /usr/local/lib64/libcrypto.so.1.1 \
     /usr/local/lib64/libfido2.a \
-    /usr/local/lib64/libfido2.so.1.12.0 \
+    /usr/local/lib64/libfido2.so.1.13.0 \
     /usr/local/lib64/libssl.a \
     /usr/local/lib64/libssl.so.1.1 \
     /usr/local/lib64/libudev.a \
@@ -148,7 +148,7 @@ COPY --from=libfido2 \
 # Re-create usual lib64 links.
 RUN cd /usr/local/lib64 && \
     ln -s libcrypto.so.1.1 libcrypto.so && \
-    ln -s libfido2.so.1.12.0 libfido2.so.1 && \
+    ln -s libfido2.so.1.13.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
     ln -s libssl.so.1.1 libssl.so && \
 # Update ld.

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -55,16 +55,6 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
     [ "$(git rev-parse HEAD)" = '4154cf252c17297f98a8ca33693ead003b4509da' ] && \
     make install-static LIBDIR='$(PREFIX)/lib64'
 
-# Install openssl.
-# Pulled from source because repository versions are too old.
-# install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1t && \
-    cd openssl && \
-    [ "$(git rev-parse HEAD)" = '830bf8e1e4749ad65c51b6a1d0d769ae689404ba' ] && \
-    ./config --release --libdir=/usr/local/lib64 && \
-    make && \
-    make install_sw
-
 # Install libcbor.
 RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     cd libcbor && \
@@ -77,18 +67,29 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     make && \
     make install
 
+# Install openssl.
+# install_sw install only binaries, skips docs.
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 && \
+    cd openssl && \
+    [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
+    ./config --release --libdir=/usr/local/lib64 && \
+    make && \
+    make install_sw
+# Necessary for libfido2 to find the correct libcrypto.
+ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
+
 # Install libfido2.
-# Depends on libcbor, openssl, zlib-devel and libudev.
-# Linked so `make build/tsh` finds the library where it expects it.
+# Depends on libcbor, libcrypto (OpenSSL 3.x), libudev and zlib1g-dev.
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
     cd libfido2 && \
     [ "$(git rev-parse HEAD)" = '486a8f8667e42f55cee2bba301b41433cacec830' ] && \
-      LDFLAGS="-lpthread" cmake3 \
-          -DBUILD_EXAMPLES=OFF \
-          -DBUILD_MANPAGES=OFF \
-          -DBUILD_TOOLS=OFF \
-          -DCMAKE_BUILD_TYPE=Release . && \
-      make && \
+    CFLAGS="-lpthread" cmake3 \
+        -DBUILD_EXAMPLES=OFF \
+        -DBUILD_MANPAGES=OFF \
+        -DBUILD_TOOLS=OFF \
+        -DCMAKE_BUILD_TYPE=Release . && \
+    grep 'CRYPTO_VERSION:INTERNAL=3\.0\.' CMakeCache.txt && \
+    make && \
     make install && \
     make clean
 
@@ -132,29 +133,32 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
 
 USER root
 
-# Copy dependencies
+# Copy libfido2 libraries.
+# Do this near the end to take better advantage of the multi-stage build.
 COPY --from=libfido2 /usr/local/include/ /usr/local/include/
+COPY --from=libfido2 /usr/local/lib64/engines-3/ /usr/local/lib64/engines-3/
+COPY --from=libfido2 /usr/local/lib64/ossl-modules/ /usr/local/lib64/ossl-modules/
 COPY --from=libfido2 /usr/local/lib64/pkgconfig/ /usr/local/lib64/pkgconfig/
 COPY --from=libfido2 \
     /usr/local/lib64/libcbor.a \
     /usr/local/lib64/libcrypto.a \
-    /usr/local/lib64/libcrypto.so.1.1 \
+    /usr/local/lib64/libcrypto.so.3 \
     /usr/local/lib64/libfido2.a \
     /usr/local/lib64/libfido2.so.1.13.0 \
     /usr/local/lib64/libssl.a \
-    /usr/local/lib64/libssl.so.1.1 \
+    /usr/local/lib64/libssl.so.3 \
     /usr/local/lib64/libudev.a \
     /usr/local/lib64/
 # Re-create usual lib64 links.
 RUN cd /usr/local/lib64 && \
-    ln -s libcrypto.so.1.1 libcrypto.so && \
+    ln -s libcrypto.so.3 libcrypto.so && \
     ln -s libfido2.so.1.13.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
-    ln -s libssl.so.1.1 libssl.so && \
+    ln -s libssl.so.3 libssl.so && \
 # Update ld.
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig
-
+# Configure pkg-config.
 COPY pkgconfig/centos7/ /
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
 

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -18,8 +18,8 @@ readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
 readonly CRYPTO_VERSION=openssl-3.0.8
 readonly CRYPTO_COMMIT=31157bc0b46e04227b8468d3e6915e4d0332777c
-readonly FIDO2_VERSION=1.12.0
-readonly FIDO2_COMMIT=659a02679f99fd34a44e06e35dce90794f6ecc86
+readonly FIDO2_VERSION=1.13.0
+readonly FIDO2_COMMIT=486a8f8667e42f55cee2bba301b41433cacec830
 
 readonly LIB_CACHE="/tmp/teleport-fido2-cache"
 readonly PKGFILE_DIR="$LIB_CACHE/fido2-${FIDO2_VERSION}_cbor-${CBOR_VERSION}_crypto-${CRYPTO_VERSION}"

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.12.0
+Version: 1.13.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libfido2-static.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include
 Name: libfido2
 Description: A FIDO2 library
 URL: https://github.com/yubico/libfido2
-Version: 1.12.0
+Version: 1.13.0
 Requires: libcrypto-static
 # libfido2, libcbor and libudev combined here for simplicity.
 Libs: ${libdir}/libfido2.a ${libdir}/libcbor.a ${libdir}/libudev.a -pthread


### PR DESCRIPTION
Update libfido2 to the latest release.

Updates both libfido2 and OpenSSl on Dockerfile-multiarch (missed on #23810).

* https://github.com/Yubico/libfido2/blob/1.13.0/NEWS#L1

#23810