### PR TITLE
[v10] Revert IdleTimeout on http.Server

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -168,7 +168,6 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		httpServer: &http.Server{
 			Handler:           httplib.MakeTracingHandler(limiter, teleport.ComponentAuth),
 			ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
-			IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		},
 		log: logrus.WithFields(logrus.Fields{
 			trace.Component: cfg.Component,

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -150,7 +150,6 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		Server: &http.Server{
 			Handler:           httplib.MakeTracingHandler(limiter, teleport.ComponentKube),
 			ReadHeaderTimeout: apidefaults.DefaultIOTimeout * 2,
-			IdleTimeout:       apidefaults.DefaultIdleTimeout,
 			TLSConfig:         cfg.TLS,
 		},
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2666,7 +2666,6 @@ func (process *TeleportProcess) initMetricsService() error {
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
-		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentMetrics),
 		TLSConfig:         tlsConfig,
 	}
@@ -2787,7 +2786,6 @@ func (process *TeleportProcess) initDiagnosticService() error {
 	server := &http.Server{
 		Handler:           mux,
 		ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
-		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentDiagnostic),
 	}
 
@@ -3632,7 +3630,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Server: &http.Server{
 				Handler:           httplib.MakeTracingHandler(proxyLimiter, teleport.ComponentProxy),
 				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
-				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
 			},
 			Handler: webHandler,
@@ -4124,7 +4121,6 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 		Server: &http.Server{
 			Handler:           httplib.MakeTracingHandler(minimalProxyLimiter, teleport.ComponentProxy),
 			ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
-			IdleTimeout:       apidefaults.DefaultIdleTimeout,
 			ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentReverseTunnelServer),
 		},
 		Handler: minimalWebHandler,

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1014,7 +1014,6 @@ func (s *Server) newHTTPServer() *http.Server {
 	return &http.Server{
 		Handler:           httplib.MakeTracingHandler(s.authMiddleware, teleport.ComponentApp),
 		ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
-		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		ErrorLog:          utils.NewStdlogger(s.log.Error, teleport.ComponentApp),
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {
 			return context.WithValue(ctx, connContextKey, c)


### PR DESCRIPTION
Due to v10 still being built with go1.19 setting the IdleTimeout has the opposite effect that was intended. We still need to account for the bug that was fixed by https://github.com/golang/go/commit/4e7e7ae1406c70d9cc0809ec11105a55a60a0b70 which means we should only be setting the ReadHeaderTimeout. By setting the IdleTimeout the Proxy experiences the same behavior in https://github.com/gravitational/teleport/issues/22757.