### PR TITLE
[Docs] Update default Moderated Sessions participant mode

### DIFF
--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -170,9 +170,8 @@ A participant joining a session will always have one of three modes:
 
 
 When joining a session with `tsh join` or `tsh kube join`, a user can specify a
-mode with the `--mode <mode>` flag , where the mode is one of `peer`,
-`moderator` or `observer`. By default, the mode is `peer` for SSH and
-`moderator` for Kubernetes sessions.
+participant mode with the `--mode <mode>` flag , where the mode is one of `peer`,
+`moderator` or `observer`. By default, the mode is `observer`.
 
 A participant may leave a session with the shortcut `^c` (Control + c) while in observer or
 moderator mode. When in moderator mode, a participant may also forcefully


### PR DESCRIPTION
## Purpose

After this PR is merged: https://github.com/gravitational/teleport/pull/23886, the new default participant mode used when joining an active SSH or Kube session will be `observer`. This PR updates the docs to reflect that.