### PR TITLE
GHA: Update path filters to include workflow files and Makefile

### DIFF
--- a/.github/workflows/build-macos-bypass.yaml
+++ b/.github/workflows/build-macos-bypass.yaml
@@ -14,6 +14,7 @@ run-name: Skip Build on Mac OS
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/build-macos.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
@@ -22,8 +23,10 @@ on:
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths-ignore:
+      - '.github/workflows/build-macos.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
@@ -32,6 +35,7 @@ on:
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   build:

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -4,6 +4,7 @@ run-name: Build on Mac OS
 on:
   pull_request:
     paths:
+      - '.github/workflows/build-macos.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
@@ -12,8 +13,10 @@ on:
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths:
+      - '.github/workflows/build-macos.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
@@ -22,6 +25,7 @@ on:
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   build:

--- a/.github/workflows/build-windows-bypass.yaml
+++ b/.github/workflows/build-windows-bypass.yaml
@@ -16,20 +16,24 @@ on:
     # We only build tsh on Windows so only consider Go code as tsh doesn't
     # run any Rust.
     paths-ignore:
+      - '.github/workflows/build-windows.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     # We only build tsh on Windows so only consider Go code as tsh doesn't
     # run any Rust.
     paths-ignore:
+      - '.github/workflows/build-windows.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   build:

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -6,20 +6,24 @@ on:
     # We only build tsh on Windows so only consider Go code as tsh doesn't
     # run any Rust.
     paths:
+      - '.github/workflows/build-windows.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     # We only build tsh on Windows so only consider Go code as tsh doesn't
     # run any Rust.
     paths:
+      - '.github/workflows/build-windows.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   build:

--- a/.github/workflows/integration-tests-non-root-bypass.yaml
+++ b/.github/workflows/integration-tests-non-root-bypass.yaml
@@ -14,18 +14,22 @@ run-name: Skip Integration Tests (Non-root) - ${{ github.run_id }} - @${{ github
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/integration-tests-non-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths-ignore:
+      - '.github/workflows/integration-tests-non-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -8,18 +8,22 @@ on:
       - branch/*
   pull_request:
     paths:
+      - '.github/workflows/integration-tests-non-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths:
+      - '.github/workflows/integration-tests-non-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-root-bypass.yaml
+++ b/.github/workflows/integration-tests-root-bypass.yaml
@@ -14,18 +14,22 @@ run-name: Skip Integration Tests (Root) - ${{ github.run_id }} - @${{ github.act
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/integration-tests-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths-ignore:
+      - '.github/workflows/integration-tests-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -8,18 +8,22 @@ on:
       - branch/*
   pull_request:
     paths:
+      - '.github/workflows/integration-tests-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths:
+      - '.github/workflows/integration-tests-root.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/lint-bypass.yaml
+++ b/.github/workflows/lint-bypass.yaml
@@ -22,10 +22,10 @@ on:
 jobs:
   lint:
     name: Lint (Go)
-    runs-on: ubuntu-latest  
-    
+    runs-on: ubuntu-latest
+
     permissions:
       contents: none
 
     steps:
-    - run: 'echo "No changes to verify"' 
+    - run: 'echo "No changes to verify"'

--- a/.github/workflows/unit-tests-code-bypass.yaml
+++ b/.github/workflows/unit-tests-code-bypass.yaml
@@ -14,18 +14,22 @@ run-name: Skip Unit Tests (Go) - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/unit-tests-code.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths-ignore:
+      - '.github/workflows/unit-tests-code.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-code.yaml
+++ b/.github/workflows/unit-tests-code.yaml
@@ -8,18 +8,22 @@ on:
       - branch/*
   pull_request:
     paths:
+      - '.github/workflows/unit-tests-code.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths:
+      - '.github/workflows/unit-tests-code.yaml'
       - '**.go'
       - 'go.mod'
       - 'go.sum'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-helm-bypass.yaml
+++ b/.github/workflows/unit-tests-helm-bypass.yaml
@@ -14,9 +14,11 @@ run-name: Skip Unit Tests (Helm) - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/unit-tests-helm.yaml'
       - 'examples/chart/**'
   merge_group:
     paths-ignore:
+      - '.github/workflows/unit-tests-helm.yaml'
       - 'examples/chart/**'
 
 jobs:

--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -4,9 +4,11 @@ run-name: Unit Tests (Helm) - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths:
+      - '.github/workflows/unit-tests-helm.yaml'
       - 'examples/chart/**'
   merge_group:
     paths:
+      - '.github/workflows/unit-tests-helm.yaml'
       - 'examples/chart/**'
 
 jobs:

--- a/.github/workflows/unit-tests-rust-bypass.yaml
+++ b/.github/workflows/unit-tests-rust-bypass.yaml
@@ -14,18 +14,22 @@ run-name: Skip Unit Tests (Rust) - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/unit-tests-rust.yaml'
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths-ignore:
+      - '.github/workflows/unit-tests-rust.yaml'
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-rust.yaml
+++ b/.github/workflows/unit-tests-rust.yaml
@@ -4,18 +4,22 @@ run-name: Unit Tests (Rust) - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths:
+      - '.github/workflows/unit-tests-rust.yaml'
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
   merge_group:
     paths:
+      - '.github/workflows/unit-tests-rust.yaml'
       - '**.rs'
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'build.assets/Makefile'
       - 'build.assets/Dockerfile*'
+      - 'Makefile'
 
 jobs:
   test:

--- a/.github/workflows/unit-tests-ui-bypass.yaml
+++ b/.github/workflows/unit-tests-ui-bypass.yaml
@@ -14,9 +14,11 @@ run-name: Unit Tests UI - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths-ignore:
+      - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
   merge_group:
     paths-ignore:
+      - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
 
 jobs:

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -4,9 +4,11 @@ run-name: Unit Tests UI - ${{ github.run_id }} - @${{ github.actor }}
 on:
   pull_request:
     paths:
+      - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
   merge_group:
     paths:
+      - '.github/workflows/unit-tests-ui.yaml'
       - 'web/**'
 
 jobs:

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -138,7 +138,7 @@ func TestAgentPoolConnectionCount(t *testing.T) {
 		default:
 			return false
 		}
-	}, time.Second*1, time.Millisecond*10, "expected a lease to be available")
+	}, time.Second*5, time.Millisecond*10, "expected a lease to be available")
 
 	require.False(t, pool.isAgentRequired())
 	require.Equal(t, pool.Count(), 1)
@@ -161,7 +161,7 @@ func TestAgentPoolConnectionCount(t *testing.T) {
 
 	require.Eventually(t, func() bool {
 		return pool.Count() == 3
-	}, time.Second*1, time.Millisecond*10)
+	}, time.Second*5, time.Millisecond*10)
 
 	select {
 	case <-pool.tracker.Acquire():


### PR DESCRIPTION
Add Makefile to path filters for build and test workflows to make sure that PRs that only update the Makefile don't break the build (we've had an instance of this [here](https://github.com/gravitational/teleport/pull/23856#issuecomment-1491115078)).

Also, include workflow files themselves in path filters to make sure workflows always run when they change.

Also, bump timeout for `TestAgentPoolConnectionCount` from 1s to 5s in an attempt to reduce [flakiness](https://github.com/gravitational/teleport/issues/22984).