### PR TITLE
Reduce DefaultIdleTimeout to 30s

### DIFF
--- a/api/defaults/defaults.go
+++ b/api/defaults/defaults.go
@@ -32,7 +32,7 @@ const (
 	DefaultIOTimeout = 30 * time.Second
 
 	// DefaultIdleTimeout is a default idle connection timeout.
-	DefaultIdleTimeout = 360 * time.Second
+	DefaultIdleTimeout = 30 * time.Second
 
 	// KeepAliveCountMax is the number of keep-alive messages that can be sent
 	// without receiving a response from the client before the client is


### PR DESCRIPTION
An idle timeout of 6m keeps web api connections open too long on Proxies that have any agents which do not have the changes from #22832. Because the http.Server.IdleTimeout is set on all release versions now, even when built with go.19, we experience this issue because we no longer exercise the bug that was fixed in go1.20.