### PR TITLE
Add Docker Hub login to Drone's Kubernetes pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8657,6 +8657,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v13-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -8667,13 +8668,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_amd64.deb" artifacts from S3
@@ -8720,6 +8723,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v13-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -8730,13 +8734,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_arm.deb" artifacts from S3
@@ -8783,6 +8789,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v13-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -8793,13 +8800,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_arm64.deb" artifacts from S3
@@ -8811,6 +8820,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
@@ -8820,13 +8830,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v13-amd64"
 - name: Tag and push image "teleport:v13-arm" to ECR - staging
@@ -8836,6 +8848,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
@@ -8845,13 +8858,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v13-arm"
 - name: Tag and push image "teleport:v13-arm64" to ECR - staging
@@ -8862,6 +8877,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
@@ -8871,13 +8887,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v13-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8886,6 +8904,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
@@ -8897,13 +8916,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - staging
   - Tag and push image "teleport:v13-arm" to ECR - staging
@@ -9001,6 +9022,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v13-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -9011,13 +9033,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_amd64.deb" artifacts from S3
@@ -9064,6 +9088,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v13-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -9074,13 +9099,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
@@ -9127,6 +9154,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v13-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -9137,13 +9165,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
@@ -9155,6 +9185,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -9164,13 +9195,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-amd64"
 - name: Tag and push image "teleport-ent:v13-arm" to ECR - staging
@@ -9181,6 +9214,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -9190,13 +9224,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-arm"
 - name: Tag and push image "teleport-ent:v13-arm64" to ECR - staging
@@ -9207,6 +9243,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -9216,13 +9253,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -9231,6 +9270,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9242,13 +9282,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v13-arm" to ECR - staging
@@ -9347,6 +9389,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v13-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -9358,13 +9401,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag-fips_amd64.deb" artifacts from S3
@@ -9376,6 +9421,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -9385,13 +9431,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -9400,6 +9448,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9409,13 +9458,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v13-amd64"
@@ -9431,6 +9482,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v13-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -9442,13 +9494,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9470,6 +9524,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v13-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -9481,13 +9536,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9509,6 +9566,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v13-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -9520,13 +9578,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9543,6 +9603,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -9552,13 +9613,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v13-amd64"
 - name: Tag and push image "teleport-operator:v13-arm" to ECR - staging
@@ -9569,6 +9632,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -9578,13 +9642,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v13-arm"
 - name: Tag and push image "teleport-operator:v13-arm64" to ECR - staging
@@ -9595,6 +9661,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -9604,13 +9671,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v13-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9619,6 +9688,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
@@ -9630,13 +9700,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v13-arm" to ECR - staging
@@ -9894,6 +9966,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9902,13 +9975,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9924,6 +9999,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9932,13 +10008,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9954,6 +10032,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9962,13 +10041,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9984,6 +10065,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -9996,6 +10078,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10005,8 +10091,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm" to Quay
@@ -10014,6 +10098,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -10026,6 +10111,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10035,8 +10124,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm64" to Quay
@@ -10045,6 +10132,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -10057,6 +10145,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10066,8 +10158,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -10078,6 +10168,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -10085,6 +10176,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10094,8 +10189,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to Quay
   - Tag and push image "teleport:v13-arm" to Quay
@@ -10108,6 +10201,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -10115,6 +10209,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10124,8 +10222,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to Quay
   - Tag and push image "teleport:v13-arm" to Quay
@@ -10134,6 +10230,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -10142,6 +10239,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10151,8 +10252,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to Quay
   - Tag and push image "teleport:v13-arm" to Quay
@@ -10165,6 +10264,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -10178,13 +10278,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm" to ECR - production
@@ -10194,6 +10296,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -10207,13 +10310,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm64" to ECR - production
@@ -10224,6 +10329,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -10237,13 +10343,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -10256,6 +10364,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -10264,13 +10373,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
   - Tag and push image "teleport:v13-arm" to ECR - production
@@ -10285,6 +10396,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -10293,13 +10405,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
   - Tag and push image "teleport:v13-arm" to ECR - production
@@ -10310,6 +10424,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -10320,13 +10435,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
   - Tag and push image "teleport:v13-arm" to ECR - production
@@ -10337,6 +10454,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10345,13 +10463,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10367,6 +10487,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10375,13 +10496,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10397,6 +10520,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10405,13 +10529,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10427,6 +10553,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -10439,6 +10566,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10448,8 +10579,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm" to Quay
@@ -10458,6 +10587,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10470,6 +10600,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10479,8 +10613,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm64" to Quay
@@ -10489,6 +10621,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -10501,6 +10634,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10510,8 +10647,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -10522,6 +10657,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10529,6 +10665,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10538,8 +10678,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to Quay
   - Tag and push image "teleport-ent:v13-arm" to Quay
@@ -10552,6 +10690,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10559,6 +10698,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10568,8 +10711,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to Quay
   - Tag and push image "teleport-ent:v13-arm" to Quay
@@ -10578,6 +10719,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -10587,6 +10729,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10596,8 +10742,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to Quay
   - Tag and push image "teleport-ent:v13-arm" to Quay
@@ -10610,6 +10754,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10624,13 +10769,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10641,6 +10788,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10654,13 +10802,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm64" to ECR - production
@@ -10671,6 +10821,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10685,13 +10836,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -10704,6 +10857,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10712,13 +10866,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
   - Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10733,6 +10889,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10741,13 +10898,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
   - Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10758,6 +10917,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -10768,13 +10928,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
   - Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10785,6 +10947,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10794,13 +10957,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10816,6 +10981,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -10828,6 +10994,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10837,8 +11007,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10849,11 +11017,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10863,8 +11036,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10875,11 +11046,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10889,14 +11065,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -10904,6 +11079,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10913,8 +11092,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
@@ -10925,6 +11102,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10939,13 +11117,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10958,19 +11138,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10983,19 +11166,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -11004,6 +11190,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -11012,13 +11199,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v13-amd64 and push it to Local Registry
@@ -11027,6 +11216,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -11036,13 +11226,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -11058,6 +11250,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -11067,13 +11260,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -11089,6 +11284,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -11098,13 +11294,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -11120,6 +11318,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -11132,6 +11331,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11141,8 +11344,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm" to Quay
@@ -11151,6 +11352,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -11163,6 +11365,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11172,8 +11378,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm64" to Quay
@@ -11182,6 +11386,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -11194,6 +11399,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11203,8 +11412,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -11215,6 +11422,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11222,6 +11430,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11231,8 +11443,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to Quay
   - Tag and push image "teleport-operator:v13-arm" to Quay
@@ -11245,6 +11455,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11252,6 +11463,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11261,8 +11476,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to Quay
   - Tag and push image "teleport-operator:v13-arm" to Quay
@@ -11271,6 +11484,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -11280,6 +11494,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11289,8 +11507,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to Quay
   - Tag and push image "teleport-operator:v13-arm" to Quay
@@ -11303,6 +11519,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11317,13 +11534,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -11334,6 +11553,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11348,13 +11568,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm64" to ECR - production
@@ -11365,6 +11587,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11379,13 +11602,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -11398,6 +11623,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11406,13 +11632,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - production
   - Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -11427,6 +11655,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11435,13 +11664,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - production
   - Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -11452,6 +11683,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -11462,13 +11694,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - production
   - Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -11766,6 +12000,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -11776,13 +12011,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_amd64.deb" artifacts from S3
@@ -11829,6 +12066,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -11839,13 +12077,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm.deb" artifacts from S3
@@ -11892,6 +12132,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -11902,13 +12143,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm64.deb" artifacts from S3
@@ -11920,6 +12163,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -11942,13 +12186,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11958,6 +12204,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -11980,13 +12227,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - staging
@@ -11997,6 +12246,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -12019,13 +12269,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -12034,6 +12286,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12046,13 +12299,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -12063,6 +12318,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12075,13 +12331,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -12092,6 +12350,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12104,13 +12363,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -12121,6 +12382,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -12133,6 +12395,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12142,8 +12408,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to Quay
@@ -12151,6 +12415,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12163,6 +12428,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12172,8 +12441,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to Quay
@@ -12182,6 +12449,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12194,6 +12462,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12203,14 +12475,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12218,6 +12489,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12227,8 +12502,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -12237,6 +12510,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12244,6 +12518,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12253,8 +12531,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -12263,6 +12539,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -12271,6 +12548,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12280,8 +12561,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -12294,6 +12573,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -12307,13 +12587,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - production
@@ -12323,6 +12605,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12336,13 +12619,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - production
@@ -12353,6 +12638,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12366,13 +12652,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -12381,6 +12669,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -12389,13 +12678,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -12406,6 +12697,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -12414,13 +12706,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -12431,6 +12725,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -12441,13 +12736,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -12549,6 +12846,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12559,13 +12857,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
@@ -12612,6 +12912,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -12622,13 +12923,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
@@ -12675,6 +12978,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12685,13 +12989,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
@@ -12703,6 +13009,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -12725,13 +13032,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12742,6 +13051,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -12764,13 +13074,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
@@ -12781,6 +13093,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -12803,13 +13116,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -12818,6 +13133,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12830,13 +13146,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12847,6 +13165,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12859,13 +13178,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12876,6 +13197,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12888,13 +13210,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12905,6 +13229,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -12917,6 +13242,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12926,8 +13255,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12936,6 +13263,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -12948,6 +13276,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12957,8 +13289,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to Quay
@@ -12967,6 +13297,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -12979,6 +13310,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12988,14 +13323,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -13003,6 +13337,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13012,8 +13350,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -13022,6 +13358,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -13029,6 +13366,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13038,8 +13379,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -13048,6 +13387,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -13057,6 +13397,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13066,8 +13410,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -13080,6 +13422,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13094,13 +13437,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13111,6 +13456,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -13124,13 +13470,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
@@ -13141,6 +13489,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13155,13 +13504,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -13170,6 +13521,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -13178,13 +13530,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13195,6 +13549,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -13203,13 +13558,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13220,6 +13577,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -13230,13 +13588,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13339,6 +13699,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -13350,13 +13711,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
@@ -13368,6 +13731,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -13390,13 +13754,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -13405,6 +13771,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13415,13 +13782,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -13430,6 +13799,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13440,13 +13810,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -13455,6 +13827,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13465,13 +13838,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to Quay
@@ -13480,6 +13855,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -13492,6 +13868,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13501,19 +13881,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13523,19 +13906,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13545,14 +13931,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -13560,6 +13945,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13569,8 +13958,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
@@ -13581,6 +13968,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13595,13 +13983,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -13610,19 +14000,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -13631,19 +14024,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -13652,6 +14048,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -13660,13 +14057,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v12-amd64"
@@ -13682,6 +14081,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -13693,13 +14093,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13723,6 +14125,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -13734,13 +14137,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13764,6 +14169,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -13775,13 +14181,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13800,6 +14208,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -13822,13 +14231,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13839,6 +14250,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -13861,13 +14273,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - staging
@@ -13878,6 +14292,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -13900,13 +14315,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -13915,6 +14332,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13927,13 +14345,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13944,6 +14364,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13956,13 +14377,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13973,6 +14396,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13985,13 +14409,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -14002,6 +14428,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -14014,6 +14441,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14023,8 +14454,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14033,6 +14462,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -14045,6 +14475,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14054,8 +14488,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to Quay
@@ -14064,6 +14496,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -14076,6 +14509,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14085,14 +14522,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -14100,6 +14536,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14109,8 +14549,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14119,6 +14557,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -14126,6 +14565,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14135,8 +14578,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14145,6 +14586,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -14154,6 +14596,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14163,8 +14609,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14177,6 +14621,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14191,13 +14636,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14208,6 +14655,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14222,13 +14670,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - production
@@ -14239,6 +14689,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14253,13 +14704,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -14268,6 +14721,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -14276,13 +14730,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14293,6 +14749,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -14301,13 +14758,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14318,6 +14777,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -14328,13 +14788,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14632,6 +15094,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -14642,13 +15105,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -14695,6 +15160,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -14705,13 +15171,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -14758,6 +15226,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -14768,13 +15237,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -14786,6 +15257,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -14808,13 +15280,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14824,6 +15298,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -14846,13 +15321,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -14863,6 +15340,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -14885,13 +15363,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -14900,6 +15380,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14912,13 +15393,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14929,6 +15412,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14941,13 +15425,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14958,6 +15444,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14970,13 +15457,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14987,6 +15476,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -14999,6 +15489,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15008,8 +15502,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -15017,6 +15509,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -15029,6 +15522,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15038,8 +15535,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -15048,6 +15543,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -15060,6 +15556,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15069,14 +15569,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -15084,6 +15583,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15093,8 +15596,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -15103,6 +15604,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -15110,6 +15612,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15119,8 +15625,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -15129,6 +15633,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -15137,6 +15642,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15146,8 +15655,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -15160,6 +15667,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -15173,13 +15681,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -15189,6 +15699,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -15202,13 +15713,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -15219,6 +15732,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -15232,13 +15746,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -15247,6 +15763,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -15255,13 +15772,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -15272,6 +15791,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -15280,13 +15800,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -15297,6 +15819,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -15307,13 +15830,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -15415,6 +15940,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15425,13 +15951,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -15478,6 +16006,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -15488,13 +16017,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -15541,6 +16072,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15551,13 +16083,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -15569,6 +16103,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -15591,13 +16126,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15608,6 +16145,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -15630,13 +16168,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -15647,6 +16187,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -15669,13 +16210,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -15684,6 +16227,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15696,13 +16240,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15713,6 +16259,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15725,13 +16272,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15742,6 +16291,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15754,13 +16304,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15771,6 +16323,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -15783,6 +16336,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15792,8 +16349,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15802,6 +16357,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15814,6 +16370,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15823,8 +16383,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -15833,6 +16391,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -15845,6 +16404,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15854,14 +16417,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -15869,6 +16431,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15878,8 +16444,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15888,6 +16452,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -15895,6 +16460,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15904,8 +16473,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15914,6 +16481,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -15923,6 +16491,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15932,8 +16504,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15946,6 +16516,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -15960,13 +16531,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15977,6 +16550,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15990,13 +16564,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -16007,6 +16583,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -16021,13 +16598,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -16036,6 +16615,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -16044,13 +16624,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -16061,6 +16643,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -16069,13 +16652,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -16086,6 +16671,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -16096,13 +16682,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -16205,6 +16793,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -16216,13 +16805,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -16234,6 +16825,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -16256,13 +16848,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -16271,6 +16865,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16281,13 +16876,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -16296,6 +16893,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16306,13 +16904,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -16321,6 +16921,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16331,13 +16932,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -16346,6 +16949,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -16358,6 +16962,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16367,19 +16975,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16389,19 +17000,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16411,14 +17025,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -16426,6 +17039,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16435,8 +17052,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -16447,6 +17062,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -16461,13 +17077,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -16476,19 +17094,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -16497,19 +17118,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -16518,6 +17142,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -16526,13 +17151,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -16548,6 +17175,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -16559,13 +17187,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -16589,6 +17219,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -16600,13 +17231,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -16630,6 +17263,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -16641,13 +17275,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -16666,6 +17302,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -16688,13 +17325,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16705,6 +17344,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -16727,13 +17367,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -16744,6 +17386,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -16766,13 +17409,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -16781,6 +17426,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16793,13 +17439,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16810,6 +17458,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16822,13 +17471,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16839,6 +17490,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16851,13 +17503,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16868,6 +17522,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -16880,6 +17535,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16889,8 +17548,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16899,6 +17556,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -16911,6 +17569,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16920,8 +17582,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -16930,6 +17590,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -16942,6 +17603,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16951,14 +17616,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -16966,6 +17630,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16975,8 +17643,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16985,6 +17651,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -16992,6 +17659,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17001,8 +17672,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -17011,6 +17680,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -17020,6 +17690,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17029,8 +17703,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -17043,6 +17715,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -17057,13 +17730,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17074,6 +17749,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -17088,13 +17764,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -17105,6 +17783,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -17119,13 +17798,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -17134,6 +17815,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -17142,13 +17824,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17159,6 +17843,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -17167,13 +17852,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17184,6 +17871,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -17194,13 +17882,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17498,6 +18188,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -17508,13 +18199,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -17561,6 +18254,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -17571,13 +18265,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -17624,6 +18320,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -17634,13 +18331,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -17652,6 +18351,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -17674,13 +18374,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17690,6 +18392,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -17712,13 +18415,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -17729,6 +18434,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -17751,13 +18457,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -17766,6 +18474,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17778,13 +18487,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17795,6 +18506,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17807,13 +18519,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17824,6 +18538,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17836,13 +18551,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17853,6 +18570,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -17865,6 +18583,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17874,8 +18596,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -17883,6 +18603,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -17895,6 +18616,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17904,8 +18629,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -17914,6 +18637,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -17926,6 +18650,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17935,14 +18663,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17950,6 +18677,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17959,8 +18690,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -17969,6 +18698,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17976,6 +18706,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17985,8 +18719,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -17995,6 +18727,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -18003,6 +18736,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18012,8 +18749,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -18026,6 +18761,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -18039,13 +18775,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -18055,6 +18793,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -18068,13 +18807,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -18085,6 +18826,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -18098,13 +18840,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -18113,6 +18857,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -18121,13 +18866,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -18138,6 +18885,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -18146,13 +18894,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -18163,6 +18913,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -18173,13 +18924,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -18281,6 +19034,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18291,13 +19045,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -18344,6 +19100,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -18354,13 +19111,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -18407,6 +19166,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18417,13 +19177,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -18435,6 +19197,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -18457,13 +19220,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18474,6 +19239,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -18496,13 +19262,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -18513,6 +19281,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -18535,13 +19304,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -18550,6 +19321,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18562,13 +19334,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18579,6 +19353,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18591,13 +19366,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18608,6 +19385,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18620,13 +19398,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18637,6 +19417,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -18649,6 +19430,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18658,8 +19443,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18668,6 +19451,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18680,6 +19464,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18689,8 +19477,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -18699,6 +19485,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -18711,6 +19498,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18720,14 +19511,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18735,6 +19525,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18744,8 +19538,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18754,6 +19546,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18761,6 +19554,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18770,8 +19567,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18780,6 +19575,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -18789,6 +19585,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18798,8 +19598,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18812,6 +19610,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18826,13 +19625,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -18843,6 +19644,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18856,13 +19658,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -18873,6 +19677,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18887,13 +19692,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -18902,6 +19709,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18910,13 +19718,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -18927,6 +19737,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18935,13 +19746,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -18952,6 +19765,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -18962,13 +19776,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -19071,6 +19887,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -19082,13 +19899,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -19100,6 +19919,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -19122,13 +19942,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -19137,6 +19959,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19147,13 +19970,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -19162,6 +19987,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19172,13 +19998,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -19187,6 +20015,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19197,13 +20026,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -19212,6 +20043,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -19224,6 +20056,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19233,19 +20069,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19255,19 +20094,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19277,14 +20119,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -19292,6 +20133,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19301,8 +20146,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -19313,6 +20156,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -19327,13 +20171,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -19342,19 +20188,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -19363,19 +20212,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -19384,6 +20236,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -19392,13 +20245,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -19414,6 +20269,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -19425,13 +20281,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -19455,6 +20313,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -19466,13 +20325,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -19496,6 +20357,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/integrations/operator/Dockerfile"
@@ -19507,13 +20369,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -19532,6 +20396,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -19554,13 +20419,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19571,6 +20438,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -19593,13 +20461,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -19610,6 +20480,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -19632,13 +20503,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -19647,6 +20520,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -19659,13 +20533,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19676,6 +20552,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -19688,13 +20565,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19705,6 +20584,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -19717,13 +20597,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19734,6 +20616,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -19746,6 +20629,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19755,8 +20642,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19765,6 +20650,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -19777,6 +20663,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19786,8 +20676,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -19796,6 +20684,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -19808,6 +20697,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19817,14 +20710,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -19832,6 +20724,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19841,8 +20737,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19851,6 +20745,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -19858,6 +20753,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19867,8 +20766,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19877,6 +20774,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -19886,6 +20784,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19895,8 +20797,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19909,6 +20809,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -19923,13 +20824,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -19940,6 +20843,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -19954,13 +20858,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -19971,6 +20877,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -19985,13 +20892,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -20000,6 +20909,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -20008,13 +20918,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -20025,6 +20937,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -20033,13 +20946,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -20050,6 +20965,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -20060,13 +20976,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -20235,6 +21153,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: b5760334b6dace5cbb363d0eb9630d0987b3fd22847c3344682095d2d9d2328a
+hmac: 5716e9f48dd13931530073425efe6b0c6b3ea01eedec38b59b347066c28239f4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -79,13 +80,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -103,6 +114,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -130,6 +143,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -166,6 +183,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -184,13 +202,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -206,6 +234,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -233,6 +263,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -269,6 +303,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -289,13 +324,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -313,6 +358,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -340,6 +387,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -376,6 +427,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -394,13 +446,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -416,6 +478,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -443,6 +507,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -818,13 +886,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -858,6 +936,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -882,6 +962,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -896,13 +978,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1144,6 +1230,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1162,13 +1249,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1184,6 +1281,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -1211,6 +1310,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1242,6 +1345,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1260,6 +1364,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -1286,6 +1391,8 @@ steps:
   when:
     status:
     - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -1535,6 +1642,7 @@ clone:
 steps:
   - name: Check out code
     image: alpine/git
+    pull: if-not-exists
     commands:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
@@ -1657,6 +1765,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1680,13 +1789,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1702,8 +1821,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1717,6 +1839,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1741,6 +1864,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1753,6 +1877,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -1812,6 +1937,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1845,6 +1974,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1868,13 +1998,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1892,8 +2032,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1904,6 +2047,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1928,6 +2072,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1940,6 +2085,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -1999,6 +2145,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2032,6 +2182,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2055,13 +2206,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2079,8 +2240,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2098,6 +2262,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2122,6 +2287,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2134,6 +2300,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2193,6 +2360,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2226,6 +2397,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2249,13 +2421,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2273,8 +2455,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2283,6 +2468,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2307,6 +2493,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2319,6 +2506,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2378,6 +2566,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2432,13 +2624,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2480,6 +2682,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2527,6 +2730,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2541,6 +2746,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2565,6 +2771,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2634,13 +2841,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2695,13 +2906,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2741,6 +2962,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2789,6 +3011,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2801,6 +3025,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2825,6 +3050,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2894,13 +3120,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2955,13 +3185,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3003,6 +3243,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3043,6 +3284,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3055,6 +3298,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3079,6 +3323,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3146,10 +3391,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3204,13 +3453,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3250,6 +3509,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3291,6 +3551,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3301,6 +3563,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3325,6 +3588,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3392,10 +3656,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3429,6 +3697,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -3452,13 +3721,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -3474,8 +3753,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -3486,6 +3768,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3510,6 +3793,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3522,6 +3806,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -3581,6 +3866,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3635,13 +3924,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3683,6 +3982,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3730,6 +4030,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -3744,6 +4046,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3768,6 +4071,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3837,13 +4141,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3898,13 +4206,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3946,6 +4264,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3986,6 +4305,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3998,6 +4319,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -4022,6 +4344,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4089,10 +4412,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4776,6 +5103,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -4799,13 +5127,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -4821,8 +5159,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -4833,6 +5174,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -4857,6 +5199,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4869,6 +5212,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -4928,6 +5272,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4958,6 +5306,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -4976,6 +5325,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -4985,6 +5335,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5288,13 +5640,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5336,6 +5698,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5376,6 +5739,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -5388,6 +5753,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5412,6 +5778,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -5479,10 +5846,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5800,13 +6171,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5848,6 +6229,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5895,6 +6277,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -5909,6 +6293,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5933,6 +6318,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -6002,13 +6388,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6042,6 +6432,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -6065,13 +6456,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -6091,8 +6492,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.zip" -print -exec cp {} /go/artifacts \;
@@ -6102,6 +6506,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6126,6 +6531,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -6138,6 +6544,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -6197,6 +6604,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -6585,13 +6996,23 @@ steps:
   - git checkout ${DRONE_COMMIT}
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Configure Staging AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6616,6 +7037,7 @@ steps:
     path: /root/.aws
 - name: Configure Production AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6640,6 +7062,7 @@ steps:
     path: /root/.aws
 - name: Build and push buildbox
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6653,12 +7076,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6673,12 +7099,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-arm
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6693,12 +7122,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6713,12 +7145,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6733,10 +7168,12 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 services:
 - name: Start Docker
   image: docker:dind
@@ -6745,10 +7182,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6777,6 +7218,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6806,11 +7249,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -6820,6 +7265,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6867,6 +7313,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6955,6 +7402,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6983,6 +7432,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -7012,11 +7463,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -7026,6 +7479,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7073,6 +7527,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7162,6 +7617,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -7723,6 +8180,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -7741,6 +8199,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -7749,6 +8208,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -8014,19 +8475,30 @@ depends_on:
 steps:
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
     != "200" ]; do sleep 1; done'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -8042,6 +8514,7 @@ steps:
   - echo $(cat "/go/var/full-version")
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8066,6 +8539,7 @@ steps:
     path: /root/.aws
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8092,6 +8566,7 @@ steps:
   - Assume ECR - staging AWS Role
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8197,6 +8672,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_amd64.deb" artifacts from S3
@@ -8258,6 +8735,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_arm.deb" artifacts from S3
@@ -8319,6 +8798,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v13-tag_arm64.deb" artifacts from S3
@@ -8344,6 +8825,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v13-amd64"
 - name: Tag and push image "teleport:v13-arm" to ECR - staging
@@ -8367,6 +8850,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v13-arm"
 - name: Tag and push image "teleport:v13-arm64" to ECR - staging
@@ -8391,6 +8876,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v13-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8415,12 +8902,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - staging
   - Tag and push image "teleport:v13-arm" to ECR - staging
   - Tag and push image "teleport:v13-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8526,6 +9016,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_amd64.deb" artifacts from S3
@@ -8587,6 +9079,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_arm.deb" artifacts from S3
@@ -8648,6 +9142,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag_arm64.deb" artifacts from S3
@@ -8673,6 +9169,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-amd64"
 - name: Tag and push image "teleport-ent:v13-arm" to ECR - staging
@@ -8697,6 +9195,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-arm"
 - name: Tag and push image "teleport-ent:v13-arm64" to ECR - staging
@@ -8721,6 +9221,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v13-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -8745,12 +9247,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v13-arm" to ECR - staging
   - Tag and push image "teleport-ent:v13-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8858,6 +9363,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v13-tag-fips_amd64.deb" artifacts from S3
@@ -8883,6 +9390,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v13-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -8905,6 +9414,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v13-amd64"
@@ -8936,6 +9447,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8973,6 +9486,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9010,6 +9525,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9040,6 +9557,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v13-amd64"
 - name: Tag and push image "teleport-operator:v13-arm" to ECR - staging
@@ -9064,6 +9583,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v13-arm"
 - name: Tag and push image "teleport-operator:v13-arm64" to ECR - staging
@@ -9088,6 +9609,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v13-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9112,6 +9635,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v13-arm" to ECR - staging
@@ -9132,6 +9657,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -9164,6 +9693,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -9182,6 +9712,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -9190,6 +9721,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -9221,6 +9754,7 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
@@ -9242,16 +9776,26 @@ steps:
     '; echo 'a prerelease'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -9261,6 +9805,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -9288,6 +9833,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9315,6 +9861,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9360,6 +9907,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9388,6 +9937,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9416,6 +9967,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9452,6 +10005,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm" to Quay
@@ -9480,6 +10035,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm64" to Quay
@@ -9509,6 +10066,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -9535,6 +10094,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to Quay
   - Tag and push image "teleport:v13-arm" to Quay
@@ -9563,6 +10124,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to Quay
   - Tag and push image "teleport:v13-arm" to Quay
@@ -9588,6 +10151,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to Quay
   - Tag and push image "teleport:v13-arm" to Quay
@@ -9618,6 +10183,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm" to ECR - production
@@ -9645,6 +10212,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport:v13-arm64" to ECR - production
@@ -9673,6 +10242,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -9698,6 +10269,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
   - Tag and push image "teleport:v13-arm" to ECR - production
@@ -9725,6 +10298,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
   - Tag and push image "teleport:v13-arm" to ECR - production
@@ -9750,6 +10325,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v13-amd64" to ECR - production
   - Tag and push image "teleport:v13-arm" to ECR - production
@@ -9773,6 +10350,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9801,6 +10380,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9829,6 +10410,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9865,6 +10448,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm" to Quay
@@ -9894,6 +10479,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm64" to Quay
@@ -9923,6 +10510,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -9949,6 +10538,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to Quay
   - Tag and push image "teleport-ent:v13-arm" to Quay
@@ -9977,6 +10568,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to Quay
   - Tag and push image "teleport-ent:v13-arm" to Quay
@@ -10003,6 +10596,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to Quay
   - Tag and push image "teleport-ent:v13-arm" to Quay
@@ -10034,6 +10629,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10062,6 +10659,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v13-arm64" to ECR - production
@@ -10091,6 +10690,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -10116,6 +10717,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
   - Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10143,6 +10746,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
   - Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10168,6 +10773,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-amd64" to ECR - production
   - Tag and push image "teleport-ent:v13-arm" to ECR - production
@@ -10192,6 +10799,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10228,6 +10837,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10252,6 +10863,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10276,6 +10889,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -10298,6 +10913,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
@@ -10327,6 +10944,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v13-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10350,6 +10969,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10373,6 +10994,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -10394,6 +11017,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v13-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v13-amd64 and push it to Local Registry
@@ -10416,6 +11041,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10445,6 +11072,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10474,6 +11103,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10510,6 +11141,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm" to Quay
@@ -10539,6 +11172,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm64" to Quay
@@ -10568,6 +11203,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -10594,6 +11231,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to Quay
   - Tag and push image "teleport-operator:v13-arm" to Quay
@@ -10622,6 +11261,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to Quay
   - Tag and push image "teleport-operator:v13-arm" to Quay
@@ -10648,6 +11289,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to Quay
   - Tag and push image "teleport-operator:v13-arm" to Quay
@@ -10679,6 +11322,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -10708,6 +11353,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v13-arm64" to ECR - production
@@ -10737,6 +11384,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v13-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -10762,6 +11411,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - production
   - Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -10789,6 +11440,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - production
   - Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -10814,6 +11467,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v13-amd64" to ECR - production
   - Tag and push image "teleport-operator:v13-arm" to ECR - production
@@ -10834,6 +11489,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -10875,15 +11534,25 @@ steps:
     "v12"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v12
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -10892,6 +11561,7 @@ steps:
   - Find the latest available semver for v12
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -10918,6 +11588,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10944,6 +11615,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10971,6 +11643,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10998,6 +11671,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -11107,6 +11781,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_amd64.deb" artifacts from S3
@@ -11168,6 +11844,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm.deb" artifacts from S3
@@ -11229,6 +11907,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm64.deb" artifacts from S3
@@ -11267,6 +11947,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11303,6 +11985,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - staging
@@ -11340,6 +12024,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -11365,6 +12051,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11392,6 +12080,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11419,6 +12109,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11450,6 +12142,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to Quay
@@ -11478,6 +12172,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to Quay
@@ -11507,6 +12203,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -11529,6 +12227,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -11553,6 +12253,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -11578,6 +12280,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -11608,6 +12312,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - production
@@ -11635,6 +12341,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - production
@@ -11663,6 +12371,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -11684,6 +12394,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -11707,6 +12419,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -11732,12 +12446,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
   - Tag and push image "teleport:v12-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -11847,6 +12564,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
@@ -11908,6 +12627,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
@@ -11969,6 +12690,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
@@ -12007,6 +12730,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12044,6 +12769,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
@@ -12081,6 +12808,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -12106,6 +12835,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12133,6 +12864,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12160,6 +12893,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12191,6 +12926,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12220,6 +12957,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to Quay
@@ -12249,6 +12988,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -12271,6 +13012,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12295,6 +13038,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12321,6 +13066,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12352,6 +13099,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -12380,6 +13129,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
@@ -12409,6 +13160,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -12430,6 +13183,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -12453,6 +13208,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -12478,12 +13235,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
   - Tag and push image "teleport-ent:v12-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -12595,6 +13355,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
@@ -12633,6 +13395,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -12656,6 +13420,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -12679,6 +13445,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -12702,6 +13470,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to Quay
@@ -12731,6 +13501,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -12751,6 +13523,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -12771,6 +13545,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -12793,6 +13569,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
@@ -12822,6 +13600,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -12841,6 +13621,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -12860,6 +13642,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -12881,6 +13665,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v12-amd64"
@@ -12912,6 +13698,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -12951,6 +13739,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -12990,6 +13780,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13035,6 +13827,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13072,6 +13866,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - staging
@@ -13109,6 +13905,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -13134,6 +13932,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13161,6 +13961,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13188,6 +13990,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13219,6 +14023,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13248,6 +14054,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to Quay
@@ -13277,6 +14085,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -13299,6 +14109,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13323,6 +14135,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13349,6 +14163,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13380,6 +14196,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13409,6 +14227,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - production
@@ -13438,6 +14258,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -13459,6 +14281,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13482,6 +14306,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13507,6 +14333,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13527,6 +14355,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -13568,15 +14400,25 @@ steps:
     "v11"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v11
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -13585,6 +14427,7 @@ steps:
   - Find the latest available semver for v11
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -13611,6 +14454,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13637,6 +14481,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13664,6 +14509,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13691,6 +14537,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13800,6 +14647,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -13861,6 +14710,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -13922,6 +14773,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -13960,6 +14813,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -13996,6 +14851,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -14033,6 +14890,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -14058,6 +14917,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14085,6 +14946,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14112,6 +14975,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14143,6 +15008,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -14171,6 +15038,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -14200,6 +15069,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -14222,6 +15093,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -14246,6 +15119,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -14271,6 +15146,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -14301,6 +15178,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -14328,6 +15207,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -14356,6 +15237,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -14377,6 +15260,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -14400,6 +15285,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -14425,12 +15312,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
   - Tag and push image "teleport:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -14540,6 +15430,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -14601,6 +15493,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -14662,6 +15556,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -14700,6 +15596,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14737,6 +15635,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -14774,6 +15674,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -14799,6 +15701,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14826,6 +15730,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14853,6 +15759,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14884,6 +15792,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -14913,6 +15823,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -14942,6 +15854,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -14964,6 +15878,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -14988,6 +15904,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15014,6 +15932,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15045,6 +15965,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15073,6 +15995,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -15102,6 +16026,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -15123,6 +16049,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15146,6 +16074,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15171,12 +16101,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
   - Tag and push image "teleport-ent:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -15288,6 +16221,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -15326,6 +16261,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -15349,6 +16286,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -15372,6 +16311,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -15395,6 +16336,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -15424,6 +16367,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -15444,6 +16389,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -15464,6 +16411,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -15486,6 +16435,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -15515,6 +16466,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -15534,6 +16487,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -15553,6 +16508,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -15574,6 +16531,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -15605,6 +16564,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -15644,6 +16605,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -15683,6 +16646,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -15728,6 +16693,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15765,6 +16732,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -15802,6 +16771,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -15827,6 +16798,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15854,6 +16827,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15881,6 +16856,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15912,6 +16889,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -15941,6 +16920,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -15970,6 +16951,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -15992,6 +16975,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16016,6 +17001,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16042,6 +17029,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16073,6 +17062,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16102,6 +17093,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -16131,6 +17124,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -16152,6 +17147,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16175,6 +17172,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16200,6 +17199,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16220,6 +17221,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -16261,15 +17266,25 @@ steps:
     "v10"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v10
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -16278,6 +17293,7 @@ steps:
   - Find the latest available semver for v10
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -16304,6 +17320,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16330,6 +17347,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16357,6 +17375,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16384,6 +17403,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16493,6 +17513,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -16554,6 +17576,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -16615,6 +17639,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -16653,6 +17679,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16689,6 +17717,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -16726,6 +17756,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -16751,6 +17783,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16778,6 +17812,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16805,6 +17841,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16836,6 +17874,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -16864,6 +17904,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -16893,6 +17935,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -16915,6 +17959,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -16939,6 +17985,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -16964,6 +18012,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -16994,6 +18044,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -17021,6 +18073,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -17049,6 +18103,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -17070,6 +18126,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -17093,6 +18151,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -17118,12 +18178,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
   - Tag and push image "teleport:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17233,6 +18296,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -17294,6 +18359,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -17355,6 +18422,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -17393,6 +18462,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17430,6 +18501,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -17467,6 +18540,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -17492,6 +18567,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17519,6 +18596,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17546,6 +18625,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17577,6 +18658,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17606,6 +18689,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -17635,6 +18720,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -17657,6 +18744,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17681,6 +18770,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17707,6 +18798,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17738,6 +18831,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -17766,6 +18861,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -17795,6 +18892,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -17816,6 +18915,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -17839,6 +18940,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -17864,12 +18967,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
   - Tag and push image "teleport-ent:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17981,6 +19087,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -18019,6 +19127,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -18042,6 +19152,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -18065,6 +19177,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -18088,6 +19202,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -18117,6 +19233,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -18137,6 +19255,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -18157,6 +19277,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -18179,6 +19301,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -18208,6 +19332,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -18227,6 +19353,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -18246,6 +19374,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -18267,6 +19397,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -18298,6 +19430,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -18337,6 +19471,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -18376,6 +19512,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -18421,6 +19559,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18458,6 +19598,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -18495,6 +19637,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -18520,6 +19664,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18547,6 +19693,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18574,6 +19722,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18605,6 +19755,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18634,6 +19786,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -18663,6 +19817,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -18685,6 +19841,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18709,6 +19867,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18735,6 +19895,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18766,6 +19928,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18795,6 +19959,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -18824,6 +19990,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -18845,6 +20013,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18868,6 +20038,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18893,6 +20065,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18913,6 +20087,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -18952,13 +20130,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -18992,6 +20180,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -19016,6 +20206,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -19030,15 +20222,19 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 4107c52101a8fbd297c24a1408d6bb96999140c0a3d67cc7fba23abaa447ea38
+hmac: b5760334b6dace5cbb363d0eb9630d0987b3fd22847c3344682095d2d9d2328a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -936,8 +936,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -962,8 +960,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -21098,8 +21094,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -21124,8 +21118,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -21153,6 +21145,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 5716e9f48dd13931530073425efe6b0c6b3ea01eedec38b59b347066c28239f4
+hmac: d5d88db9889331c6bff21f5184b3f54bed9eb6dac632c75de0b928879f1af5e3
 
 ...

--- a/dronegen/aws.go
+++ b/dronegen/aws.go
@@ -93,6 +93,7 @@ func kubernetesAssumeAwsRoleStep(s kubernetesRoleSettings) step {
 	return step{
 		Name:  s.name,
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_ACCESS_KEY_ID":     s.awsAccessKeyID,
 			"AWS_SECRET_ACCESS_KEY": s.awsSecretAccessKey,
@@ -125,6 +126,7 @@ func kubernetesUploadToS3Step(s kubernetesS3Settings) step {
 	return step{
 		Name:  "Upload to S3",
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_S3_BUCKET": {fromSecret: "AWS_S3_BUCKET"},
 			"AWS_REGION":    {raw: s.region},

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -70,7 +70,7 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
 		Pull:    "if-not-exists",
-		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes: []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -102,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -69,7 +69,8 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 	return step{
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
-		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
+		Pull:    "if-not-exists",
+		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -101,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = []volume{volumeDocker, volumeAwsConfig}
+	p.Volumes = dockerVolumes(volumeAwsConfig)
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -261,18 +261,6 @@ func dockerRegistryService() service {
 	}
 }
 
-// dockerVolumes returns a slice of volumes
-// It includes the Docker socket volume by default, plus any extra volumes passed in
-func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker, volumeDockerConfig)
-}
-
-// dockerVolumeRefs returns a slice of volumeRefs
-// It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
-func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker, volumeRefDockerConfig)
-}
-
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
 func releaseMakefileTarget(b buildType) string {
 	makefileTarget := fmt.Sprintf("release-%s", b.arch)
@@ -307,7 +295,7 @@ func waitForDockerStep() step {
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
 			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: dockerVolumeRefs(),
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 		Environment: map[string]value{
 			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
 			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -90,7 +90,7 @@ var (
 	// volumeDockerConfig is a temporary volume for storing docker
 	// credentials for use with the Docker-in-Docker service we use
 	// to isolate the host machines docker daemon from the one used
-	// during the build. Mount this any tome you use `volumeDocker`
+	// during the build. Mount this any time you use `volumeDocker`
 	//
 	// Drone claims to destroy the the temp volumes after a workflow
 	// has run, so it should be safe to write credentials etc.

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -86,6 +86,25 @@ var (
 		Name: "awsconfig",
 		Path: "/root/.aws",
 	}
+
+	// volumeDockerConfig is a temporary volume for storing docker
+	// credentials for use with the Docker-in-Docker service we use
+	// to isolate the host machines docker daemon from the one used
+	// during the build. Mount this any tome you use `volumeDocker`
+	//
+	// Drone claims to destroy the the temp volumes after a workflow
+	// has run, so it should be safe to write credentials etc.
+	volumeDockerConfig = volume{
+		Name: "dockerconfig",
+		Temp: &volumeTemp{},
+	}
+
+	// volumeRefDockerConfig is how you reference the docker config
+	// volume in a workflow step
+	volumeRefDockerConfig = volumeRef{
+		Name: "dockerconfig",
+		Path: "/root/.docker",
+	}
 )
 
 var buildboxVersion value
@@ -245,13 +264,13 @@ func dockerRegistryService() service {
 // dockerVolumes returns a slice of volumes
 // It includes the Docker socket volume by default, plus any extra volumes passed in
 func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker)
+	return append(v, volumeDocker, volumeDockerConfig)
 }
 
 // dockerVolumeRefs returns a slice of volumeRefs
 // It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
 func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker)
+	return append(v, volumeRefDocker, volumeRefDockerConfig)
 }
 
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
@@ -283,10 +302,16 @@ func waitForDockerStep() step {
 	return step{
 		Name:  "Wait for docker",
 		Image: "docker",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: []volumeRef{volumeRefDocker},
+		Volumes: dockerVolumeRefs(),
+		Environment: map[string]value{
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
+		},
 	}
 }
 
@@ -295,6 +320,7 @@ func waitForDockerRegistryStep() step {
 	return step{
 		Name:  "Wait for docker registry",
 		Image: "alpine",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"apk add curl",
 			fmt.Sprintf(`timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %%{http_code} http://%s/)" != "200" ]; do sleep 1; done'`, LocalRegistrySocket),
@@ -306,6 +332,7 @@ func verifyTaggedStep() step {
 	return step{
 		Name:  "Verify build is tagged",
 		Image: "alpine:latest",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"[ -n ${DRONE_TAG} ] || (echo 'DRONE_TAG is not set. Is the commit tagged?' && exit 1)",
 		},
@@ -317,6 +344,7 @@ func cloneRepoStep(clonePath, commit string) step {
 	return step{
 		Name:     "Check out code",
 		Image:    "alpine/git:latest",
+		Pull:     "if-not-exists",
 		Commands: cloneRepoCommands(clonePath, commit),
 	}
 }

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_images_release_version.go
+++ b/dronegen/container_images_release_version.go
@@ -48,7 +48,7 @@ func (rv *ReleaseVersion) buildVersionPipeline(triggerSetupSteps []step, flags *
 		dockerService(),
 		dockerRegistryService(),
 	}
-	pipeline.Volumes = dockerVolumes(volumeAwsConfig)
+	pipeline.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	pipeline.Environment = map[string]value{
 		"DEBIAN_FRONTEND": {
 			raw: "noninteractive",

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -62,6 +62,7 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 	loginCommands := []string{
 		"apk add --no-cache aws-cli",
 		fmt.Sprintf("aws %s get-login-password --region=%s | docker login -u=\"AWS\" --password-stdin %s", loginSubcommand, ecrRegion, domain),
+		`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 	}
 
 	if guaranteeUnique {
@@ -72,7 +73,9 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 		Name:        repoName,
 		IsImmutable: isImmutable,
 		EnvironmentVars: map[string]value{
-			"AWS_PROFILE": {raw: profileName},
+			"AWS_PROFILE":        {raw: profileName},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: domain,
 		RegistryOrg:    registryOrg,
@@ -112,17 +115,16 @@ func NewQuayContainerRepo(dockerUsername, dockerPassword string) *ContainerRepo 
 		Name:        "Quay",
 		IsImmutable: false,
 		EnvironmentVars: map[string]value{
-			"QUAY_USERNAME": {
-				fromSecret: dockerUsername,
-			},
-			"QUAY_PASSWORD": {
-				fromSecret: dockerPassword,
-			},
+			"QUAY_USERNAME":      {fromSecret: dockerUsername},
+			"QUAY_PASSWORD":      {fromSecret: dockerPassword},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: ProductionRegistryQuay,
 		RegistryOrg:    registryOrg,
 		LoginCommands: []string{
 			fmt.Sprintf("docker login -u=\"$QUAY_USERNAME\" -p=\"$QUAY_PASSWORD\" %q", ProductionRegistryQuay),
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
 	}
 }
@@ -254,7 +256,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +306,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +334,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -254,7 +254,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +304,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +332,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -62,6 +62,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -70,6 +71,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Delegate build to GitHub",
 			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GHA_APP_KEY": {fromSecret: "GITHUB_WORKFLOW_APP_PRIVATE_KEY"},
 			},

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -44,7 +44,7 @@ func main() {
 	// the named secret as its credentials when pulling images from
 	// dockerhub.
 	//
-	// Exec pipelines to not have the `image_pull_secrets` option, as
+	// Exec pipelines do not have the `image_pull_secrets` option, as
 	// their steps are invoked directly on the host runner and not
 	// into a per-step container.
 	for pidx := range pipelines {

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -39,6 +39,22 @@ func main() {
 	pipelines = append(pipelines, buildContainerImagePipelines()...)
 	pipelines = append(pipelines, publishReleasePipeline())
 
+	// Inject the Drone-level dockerhub credentials into all non-exec
+	// pipelines. Drone will then use the docker credentials file in
+	// the named secret as its credentials when pulling images from
+	// dockerhub.
+	//
+	// Exec pipelines to not have the `image_pull_secrets` option, as
+	// their steps are invoked directly on the host runner and not
+	// into a per-step container.
+	for pidx := range pipelines {
+		p := &pipelines[pidx]
+		if p.Type == "exec" {
+			continue
+		}
+		p.ImagePullSecrets = append(p.ImagePullSecrets, "DOCKERHUB_CREDENTIALS")
+	}
+
 	if err := writePipelines(".drone.yml", pipelines); err != nil {
 		fmt.Println("failed writing drone pipelines:", err)
 		os.Exit(1)

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -126,7 +126,7 @@ func pushPipeline(b buildType) pipeline {
 	}
 	p.Trigger = triggerPush
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeDocker}
+	p.Volumes = []volume{volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -134,6 +134,7 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -143,8 +144,9 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:        "Build artifacts",
 			Image:       "docker",
+			Pull:        "if-not-exists",
 			Environment: pushEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker},
+			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 			Commands:    pushBuildCommands(b),
 		},
 		sendErrorToSlackStep(),

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,7 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
+	p.Volumes = []volume{volumeTmpfs, volumeAwsConfig, volumeDocker, volumeDockerConfig}
 
 	return p
 }
@@ -56,11 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -80,12 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefTmpfs,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,11 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = []volume{
-		volumeDocker,
-		volumeTmpfs,
-		volumeAwsConfig,
-	}
+	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
 
 	return p
 }
@@ -62,6 +58,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefAwsConfig,
 		},
 		Commands: []string{
@@ -85,6 +82,7 @@ func executeRelcliStep(name string, command string) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefTmpfs,
 			volumeRefAwsConfig,
 		},

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -56,7 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -76,7 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -274,7 +274,7 @@ func tagPipeline(b buildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -469,7 +469,7 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
-	packageDockerVolumes := dockerVolumes(volumeAwsConfig)
+	packageDockerVolumes := []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	packageDockerVolumeRefs := []volumeRef{
 		volumeRefDocker,
 		volumeRefDockerConfig,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -274,7 +274,7 @@ func tagPipeline(b buildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeAwsConfig, volumeDocker}
+	p.Volumes = dockerVolumes(volumeAwsConfig)
 	p.Services = []service{
 		dockerService(),
 	}
@@ -282,6 +282,7 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -291,13 +292,15 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:        "Build artifacts",
 			Image:       "docker",
+			Pull:        "if-not-exists",
 			Environment: tagEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker},
+			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 			Commands:    tagBuildCommands(b),
 		},
 		{
 			Name:     "Copy artifacts",
 			Image:    "docker",
+			Pull:     "if-not-exists",
 			Commands: tagCopyArtifactCommands(b),
 		},
 		kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
@@ -317,6 +320,7 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:     "Register artifacts",
 			Image:    "docker",
+			Pull:     "if-not-exists",
 			Commands: tagCreateReleaseAssetCommands(b, "", extraQualifications),
 			Environment: map[string]value{
 				"RELEASES_CERT": {fromSecret: "RELEASES_CERT"},
@@ -465,12 +469,10 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
-	packageDockerVolumes := []volume{
-		volumeDocker,
-		volumeAwsConfig,
-	}
+	packageDockerVolumes := dockerVolumes(volumeAwsConfig)
 	packageDockerVolumeRefs := []volumeRef{
 		volumeRefDocker,
+		volumeRefDockerConfig,
 		volumeRefAwsConfig,
 	}
 	packageDockerService := dockerService()

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -29,20 +29,21 @@ import (
 type pipeline struct {
 	comment string
 
-	Kind        string           `yaml:"kind"`
-	Type        string           `yaml:"type"`
-	Name        string           `yaml:"name"`
-	Environment map[string]value `yaml:"environment,omitempty"`
-	Trigger     trigger          `yaml:"trigger"`
-	Workspace   workspace        `yaml:"workspace,omitempty"`
-	Platform    platform         `yaml:"platform,omitempty"`
-	Node        map[string]value `yaml:"node,omitempty"`
-	Clone       clone            `yaml:"clone,omitempty"`
-	DependsOn   []string         `yaml:"depends_on,omitempty"`
-	Concurrency concurrency      `yaml:"concurrency,omitempty"`
-	Steps       []step           `yaml:"steps"`
-	Services    []service        `yaml:"services,omitempty"`
-	Volumes     []volume         `yaml:"volumes,omitempty"`
+	Kind             string           `yaml:"kind"`
+	Type             string           `yaml:"type"`
+	Name             string           `yaml:"name"`
+	Environment      map[string]value `yaml:"environment,omitempty"`
+	Trigger          trigger          `yaml:"trigger"`
+	Workspace        workspace        `yaml:"workspace,omitempty"`
+	Platform         platform         `yaml:"platform,omitempty"`
+	Node             map[string]value `yaml:"node,omitempty"`
+	Clone            clone            `yaml:"clone,omitempty"`
+	DependsOn        []string         `yaml:"depends_on,omitempty"`
+	Concurrency      concurrency      `yaml:"concurrency,omitempty"`
+	Steps            []step           `yaml:"steps"`
+	Services         []service        `yaml:"services,omitempty"`
+	Volumes          []volume         `yaml:"volumes,omitempty"`
+	ImagePullSecrets []string         `yaml:"image_pull_secrets,omitempty"`
 }
 
 func newKubePipeline(name string) pipeline {
@@ -169,6 +170,7 @@ type volumeRef struct {
 type step struct {
 	Name        string              `yaml:"name"`
 	Image       string              `yaml:"image,omitempty"`
+	Pull        string              `yaml:"pull,omitempty"`
 	Commands    []string            `yaml:"commands,omitempty"`
 	Environment map[string]value    `yaml:"environment,omitempty"`
 	Volumes     []volumeRef         `yaml:"volumes,omitempty"`


### PR DESCRIPTION
## Summary

After moving Drone to AWS, we're seeing image pulls get rate limited because they're all coming from the same IP (an AWS NAT gateway). To avoid the rate limiting on AWS, we refactor pipelines to cache/reuse images where possible, as well as add authentication to Docker Hub pulls.

## Related Issues & PRs

Supersedes https://github.com/gravitational/teleport/pull/23831

Contributes to https://github.com/gravitational/SecOps/issues/285

These credentials were added to Drone in:
* GCP https://github.com/gravitational/ops/pull/485
* AWS https://github.com/gravitational/cloud-terraform/pull/1848

Backports:
* https://github.com/gravitational/teleport/pull/23958
* https://github.com/gravitational/teleport/pull/23959
* https://github.com/gravitational/teleport/pull/23972
* https://github.com/gravitational/teleport/pull/23973

## Notes
Most credit goes to @tcsc for this patch.  This is his work from #23831, with the testing changes rebased out and a race condition fixed (see the later commits).

GCP did not have this issue for a variety of reasons:
1) Each node had their own IP -- they weren't on private subnets.  These IPs were rotated regularly as the pool scaled up and down, getting arbitrary IPs from GCPs pools.
2) GKE has caching for frequently used images that may have eliminated some traffic to Docker Hub: https://cloud.google.com/container-registry/docs/pulling-cached-images

## Testing
This is undergoing final testing at:

* build: https://drone.platform.teleport.sh/gravitational/teleport-private/515
* promote: https://drone.platform.teleport.sh/gravitational/teleport-private/534

There are some failures latent in master (related to tenant-operator + arm64 + sqlite) that I expect the above to hit.  As long as we're not hitting Docker Hub rate limits, we're good to merge.

