### PR TITLE
[v12] Add Docker Hub login to Drone's Kubernetes pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8655,6 +8655,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -8665,13 +8666,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_amd64.deb" artifacts from S3
@@ -8718,6 +8721,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -8728,13 +8732,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm.deb" artifacts from S3
@@ -8781,6 +8787,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -8791,13 +8798,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm64.deb" artifacts from S3
@@ -8809,6 +8818,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
@@ -8818,13 +8828,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - staging
@@ -8834,6 +8846,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
@@ -8843,13 +8856,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - staging
@@ -8860,6 +8875,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
@@ -8869,13 +8885,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8884,6 +8902,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
@@ -8895,13 +8914,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -8999,6 +9020,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -9009,13 +9031,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
@@ -9062,6 +9086,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -9072,13 +9097,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
@@ -9125,6 +9152,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -9135,13 +9163,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
@@ -9153,6 +9183,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -9162,13 +9193,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -9179,6 +9212,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -9188,13 +9222,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
@@ -9205,6 +9241,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -9214,13 +9251,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -9229,6 +9268,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9240,13 +9280,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -9345,6 +9387,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -9356,13 +9399,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
@@ -9374,6 +9419,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -9383,13 +9429,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -9398,6 +9446,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9407,13 +9456,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v12-amd64"
@@ -9429,6 +9480,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9440,13 +9492,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9468,6 +9522,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9479,13 +9534,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9507,6 +9564,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9518,13 +9576,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9541,6 +9601,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -9550,13 +9611,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -9567,6 +9630,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -9576,13 +9640,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - staging
@@ -9593,6 +9659,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -9602,13 +9669,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9617,6 +9686,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
@@ -9628,13 +9698,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -9892,6 +9964,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9900,13 +9973,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9922,6 +9997,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9930,13 +10006,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9952,6 +10030,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9960,13 +10039,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9982,6 +10063,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -9994,6 +10076,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10003,8 +10089,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm" to Quay
@@ -10012,6 +10096,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -10024,6 +10109,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10033,8 +10122,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm64" to Quay
@@ -10043,6 +10130,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -10055,6 +10143,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10064,8 +10156,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -10076,6 +10166,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -10083,6 +10174,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10092,8 +10187,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -10106,6 +10199,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -10113,6 +10207,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10122,8 +10220,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -10132,6 +10228,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -10140,6 +10237,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10149,8 +10250,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -10163,6 +10262,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -10176,13 +10276,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm" to ECR - production
@@ -10192,6 +10294,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -10205,13 +10308,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm64" to ECR - production
@@ -10222,6 +10327,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -10235,13 +10341,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -10254,6 +10362,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -10262,13 +10371,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -10283,6 +10394,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -10291,13 +10403,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -10308,6 +10422,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -10318,13 +10433,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -10335,6 +10452,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10343,13 +10461,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10365,6 +10485,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10373,13 +10494,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10395,6 +10518,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10403,13 +10527,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10425,6 +10551,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -10437,6 +10564,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10446,8 +10577,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm" to Quay
@@ -10456,6 +10585,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10468,6 +10598,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10477,8 +10611,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm64" to Quay
@@ -10487,6 +10619,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -10499,6 +10632,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10508,8 +10645,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -10520,6 +10655,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10527,6 +10663,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10536,8 +10676,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -10550,6 +10688,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10557,6 +10696,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10566,8 +10709,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -10576,6 +10717,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -10585,6 +10727,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10594,8 +10740,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -10608,6 +10752,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10622,13 +10767,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10639,6 +10786,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10652,13 +10800,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
@@ -10669,6 +10819,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10683,13 +10834,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -10702,6 +10855,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10710,13 +10864,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10731,6 +10887,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10739,13 +10896,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10756,6 +10915,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -10766,13 +10926,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10783,6 +10945,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10792,13 +10955,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10814,6 +10979,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -10826,6 +10992,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10835,8 +11005,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10847,11 +11015,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10861,8 +11034,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10873,11 +11044,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10887,14 +11063,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -10902,6 +11077,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10911,8 +11090,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
@@ -10923,6 +11100,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10937,13 +11115,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10956,19 +11136,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10981,19 +11164,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -11002,6 +11188,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -11010,13 +11197,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v12-amd64 and push it to Local Registry
@@ -11025,6 +11214,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -11034,13 +11224,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -11056,6 +11248,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -11065,13 +11258,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -11087,6 +11282,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -11096,13 +11292,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -11118,6 +11316,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -11130,6 +11329,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11139,8 +11342,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm" to Quay
@@ -11149,6 +11350,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -11161,6 +11363,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11170,8 +11376,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm64" to Quay
@@ -11180,6 +11384,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -11192,6 +11397,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11201,8 +11410,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -11213,6 +11420,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11220,6 +11428,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11229,8 +11441,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -11243,6 +11453,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11250,6 +11461,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11259,8 +11474,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -11269,6 +11482,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -11278,6 +11492,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11287,8 +11505,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -11301,6 +11517,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11315,13 +11532,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -11332,6 +11551,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11346,13 +11566,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - production
@@ -11363,6 +11585,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11377,13 +11600,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -11396,6 +11621,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11404,13 +11630,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -11425,6 +11653,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11433,13 +11662,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -11450,6 +11681,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -11460,13 +11692,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -11764,6 +11998,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -11774,13 +12009,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_amd64.deb" artifacts from S3
@@ -11827,6 +12064,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -11837,13 +12075,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm.deb" artifacts from S3
@@ -11890,6 +12130,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v12-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -11900,13 +12141,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm64.deb" artifacts from S3
@@ -11918,6 +12161,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -11940,13 +12184,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11956,6 +12202,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -11978,13 +12225,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - staging
@@ -11995,6 +12244,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -12017,13 +12267,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -12032,6 +12284,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12044,13 +12297,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -12061,6 +12316,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12073,13 +12329,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -12090,6 +12348,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12102,13 +12361,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -12119,6 +12380,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -12131,6 +12393,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12140,8 +12406,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to Quay
@@ -12149,6 +12413,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12161,6 +12426,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12170,8 +12439,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to Quay
@@ -12180,6 +12447,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12192,6 +12460,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12201,14 +12473,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12216,6 +12487,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12225,8 +12500,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -12235,6 +12508,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12242,6 +12516,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12251,8 +12529,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -12261,6 +12537,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -12269,6 +12546,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12278,8 +12559,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -12292,6 +12571,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -12305,13 +12585,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - production
@@ -12321,6 +12603,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12334,13 +12617,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - production
@@ -12351,6 +12636,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12364,13 +12650,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -12379,6 +12667,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -12387,13 +12676,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -12404,6 +12695,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -12412,13 +12704,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -12429,6 +12723,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -12439,13 +12734,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -12547,6 +12844,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12557,13 +12855,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
@@ -12610,6 +12910,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -12620,13 +12921,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
@@ -12673,6 +12976,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12683,13 +12987,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
@@ -12701,6 +13007,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -12723,13 +13030,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12740,6 +13049,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -12762,13 +13072,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
@@ -12779,6 +13091,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -12801,13 +13114,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -12816,6 +13131,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12828,13 +13144,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12845,6 +13163,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12857,13 +13176,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12874,6 +13195,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12886,13 +13208,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12903,6 +13227,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -12915,6 +13240,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12924,8 +13253,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12934,6 +13261,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -12946,6 +13274,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12955,8 +13287,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to Quay
@@ -12965,6 +13295,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -12977,6 +13308,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12986,14 +13321,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -13001,6 +13335,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13010,8 +13348,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -13020,6 +13356,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -13027,6 +13364,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13036,8 +13377,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -13046,6 +13385,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -13055,6 +13395,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13064,8 +13408,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -13078,6 +13420,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13092,13 +13435,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13109,6 +13454,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -13122,13 +13468,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
@@ -13139,6 +13487,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13153,13 +13502,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -13168,6 +13519,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -13176,13 +13528,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13193,6 +13547,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -13201,13 +13556,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13218,6 +13575,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -13228,13 +13586,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -13337,6 +13697,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v12-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -13348,13 +13709,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
@@ -13366,6 +13729,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -13388,13 +13752,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -13403,6 +13769,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13413,13 +13780,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -13428,6 +13797,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13438,13 +13808,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -13453,6 +13825,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13463,13 +13836,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to Quay
@@ -13478,6 +13853,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -13490,6 +13866,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13499,19 +13879,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13521,19 +13904,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13543,14 +13929,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -13558,6 +13943,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13567,8 +13956,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
@@ -13579,6 +13966,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13593,13 +13981,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -13608,19 +13998,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -13629,19 +14022,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -13650,6 +14046,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -13658,13 +14055,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v12-amd64"
@@ -13680,6 +14079,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13691,13 +14091,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13721,6 +14123,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13732,13 +14135,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13762,6 +14167,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v12-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13773,13 +14179,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13798,6 +14206,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -13820,13 +14229,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13837,6 +14248,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -13859,13 +14271,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - staging
@@ -13876,6 +14290,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -13898,13 +14313,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -13913,6 +14330,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13925,13 +14343,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13942,6 +14362,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13954,13 +14375,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13971,6 +14394,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13983,13 +14407,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -14000,6 +14426,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -14012,6 +14439,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14021,8 +14452,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14031,6 +14460,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -14043,6 +14473,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14052,8 +14486,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to Quay
@@ -14062,6 +14494,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -14074,6 +14507,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14083,14 +14520,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -14098,6 +14534,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14107,8 +14547,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14117,6 +14555,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -14124,6 +14563,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14133,8 +14576,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14143,6 +14584,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -14152,6 +14594,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14161,8 +14607,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -14175,6 +14619,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14189,13 +14634,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14206,6 +14653,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14220,13 +14668,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - production
@@ -14237,6 +14687,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14251,13 +14702,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -14266,6 +14719,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -14274,13 +14728,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14291,6 +14747,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -14299,13 +14756,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14316,6 +14775,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -14326,13 +14786,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -14630,6 +15092,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -14640,13 +15103,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -14693,6 +15158,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -14703,13 +15169,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -14756,6 +15224,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -14766,13 +15235,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -14784,6 +15255,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -14806,13 +15278,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14822,6 +15296,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -14844,13 +15319,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -14861,6 +15338,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -14883,13 +15361,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -14898,6 +15378,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14910,13 +15391,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14927,6 +15410,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14939,13 +15423,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14956,6 +15442,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14968,13 +15455,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14985,6 +15474,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -14997,6 +15487,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15006,8 +15500,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -15015,6 +15507,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -15027,6 +15520,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15036,8 +15533,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -15046,6 +15541,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -15058,6 +15554,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15067,14 +15567,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -15082,6 +15581,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15091,8 +15594,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -15101,6 +15602,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -15108,6 +15610,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15117,8 +15623,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -15127,6 +15631,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -15135,6 +15640,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15144,8 +15653,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -15158,6 +15665,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -15171,13 +15679,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -15187,6 +15697,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -15200,13 +15711,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -15217,6 +15730,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -15230,13 +15744,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -15245,6 +15761,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -15253,13 +15770,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -15270,6 +15789,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -15278,13 +15798,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -15295,6 +15817,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -15305,13 +15828,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -15413,6 +15938,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15423,13 +15949,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -15476,6 +16004,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -15486,13 +16015,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -15539,6 +16070,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15549,13 +16081,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -15567,6 +16101,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -15589,13 +16124,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15606,6 +16143,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -15628,13 +16166,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -15645,6 +16185,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -15667,13 +16208,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -15682,6 +16225,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15694,13 +16238,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15711,6 +16257,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15723,13 +16270,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15740,6 +16289,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15752,13 +16302,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -15769,6 +16321,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -15781,6 +16334,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15790,8 +16347,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15800,6 +16355,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15812,6 +16368,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15821,8 +16381,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -15831,6 +16389,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -15843,6 +16402,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15852,14 +16415,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -15867,6 +16429,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15876,8 +16442,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15886,6 +16450,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -15893,6 +16458,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15902,8 +16471,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15912,6 +16479,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -15921,6 +16489,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15930,8 +16502,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15944,6 +16514,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -15958,13 +16529,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15975,6 +16548,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15988,13 +16562,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -16005,6 +16581,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -16019,13 +16596,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -16034,6 +16613,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -16042,13 +16622,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -16059,6 +16641,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -16067,13 +16650,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -16084,6 +16669,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -16094,13 +16680,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -16203,6 +16791,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -16214,13 +16803,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -16232,6 +16823,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -16254,13 +16846,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -16269,6 +16863,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16279,13 +16874,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -16294,6 +16891,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16304,13 +16902,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -16319,6 +16919,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16329,13 +16930,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -16344,6 +16947,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -16356,6 +16960,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16365,19 +16973,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16387,19 +16998,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16409,14 +17023,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -16424,6 +17037,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16433,8 +17050,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -16445,6 +17060,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -16459,13 +17075,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -16474,19 +17092,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -16495,19 +17116,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -16516,6 +17140,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -16524,13 +17149,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -16546,6 +17173,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16557,13 +17185,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -16587,6 +17217,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16598,13 +17229,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -16628,6 +17261,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16639,13 +17273,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -16664,6 +17300,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -16686,13 +17323,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16703,6 +17342,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -16725,13 +17365,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -16742,6 +17384,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -16764,13 +17407,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -16779,6 +17424,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16791,13 +17437,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16808,6 +17456,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16820,13 +17469,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16837,6 +17488,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16849,13 +17501,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -16866,6 +17520,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -16878,6 +17533,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16887,8 +17546,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16897,6 +17554,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -16909,6 +17567,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16918,8 +17580,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -16928,6 +17588,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -16940,6 +17601,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16949,14 +17614,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -16964,6 +17628,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16973,8 +17641,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16983,6 +17649,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -16990,6 +17657,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16999,8 +17670,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -17009,6 +17678,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -17018,6 +17688,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17027,8 +17701,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -17041,6 +17713,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -17055,13 +17728,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17072,6 +17747,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -17086,13 +17762,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -17103,6 +17781,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -17117,13 +17796,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -17132,6 +17813,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -17140,13 +17822,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17157,6 +17841,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -17165,13 +17850,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17182,6 +17869,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -17192,13 +17880,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -17496,6 +18186,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -17506,13 +18197,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -17559,6 +18252,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -17569,13 +18263,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -17622,6 +18318,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -17632,13 +18329,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -17650,6 +18349,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -17672,13 +18372,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17688,6 +18390,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -17710,13 +18413,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -17727,6 +18432,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -17749,13 +18455,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -17764,6 +18472,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17776,13 +18485,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17793,6 +18504,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17805,13 +18517,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17822,6 +18536,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17834,13 +18549,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -17851,6 +18568,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -17863,6 +18581,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17872,8 +18594,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -17881,6 +18601,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -17893,6 +18614,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17902,8 +18627,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -17912,6 +18635,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -17924,6 +18648,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17933,14 +18661,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17948,6 +18675,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17957,8 +18688,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -17967,6 +18696,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17974,6 +18704,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17983,8 +18717,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -17993,6 +18725,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -18001,6 +18734,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18010,8 +18747,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -18024,6 +18759,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -18037,13 +18773,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -18053,6 +18791,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -18066,13 +18805,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -18083,6 +18824,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -18096,13 +18838,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -18111,6 +18855,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -18119,13 +18864,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -18136,6 +18883,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -18144,13 +18892,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -18161,6 +18911,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -18171,13 +18922,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -18279,6 +19032,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18289,13 +19043,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -18342,6 +19098,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -18352,13 +19109,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -18405,6 +19164,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18415,13 +19175,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -18433,6 +19195,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -18455,13 +19218,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18472,6 +19237,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -18494,13 +19260,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -18511,6 +19279,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -18533,13 +19302,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -18548,6 +19319,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18560,13 +19332,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18577,6 +19351,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18589,13 +19364,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18606,6 +19383,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18618,13 +19396,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -18635,6 +19415,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -18647,6 +19428,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18656,8 +19441,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18666,6 +19449,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18678,6 +19462,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18687,8 +19475,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -18697,6 +19483,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -18709,6 +19496,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18718,14 +19509,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18733,6 +19523,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18742,8 +19536,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18752,6 +19544,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18759,6 +19552,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18768,8 +19565,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18778,6 +19573,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -18787,6 +19583,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18796,8 +19596,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -18810,6 +19608,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18824,13 +19623,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -18841,6 +19642,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18854,13 +19656,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -18871,6 +19675,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18885,13 +19690,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -18900,6 +19707,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18908,13 +19716,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -18925,6 +19735,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18933,13 +19744,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -18950,6 +19763,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -18960,13 +19774,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -19069,6 +19885,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -19080,13 +19897,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -19098,6 +19917,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -19120,13 +19940,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -19135,6 +19957,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19145,13 +19968,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -19160,6 +19985,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19170,13 +19996,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -19185,6 +20013,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19195,13 +20024,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -19210,6 +20041,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -19222,6 +20054,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19231,19 +20067,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19253,19 +20092,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19275,14 +20117,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -19290,6 +20131,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19299,8 +20144,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -19311,6 +20154,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -19325,13 +20169,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -19340,19 +20186,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -19361,19 +20210,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -19382,6 +20234,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -19390,13 +20243,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -19412,6 +20267,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -19423,13 +20279,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -19453,6 +20311,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -19464,13 +20323,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -19494,6 +20355,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -19505,13 +20367,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -19530,6 +20394,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -19552,13 +20417,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19569,6 +20436,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -19591,13 +20459,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -19608,6 +20478,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -19630,13 +20501,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -19645,6 +20518,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -19657,13 +20531,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19674,6 +20550,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -19686,13 +20563,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19703,6 +20582,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -19715,13 +20595,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -19732,6 +20614,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -19744,6 +20627,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19753,8 +20640,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19763,6 +20648,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -19775,6 +20661,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19784,8 +20674,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -19794,6 +20682,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -19806,6 +20695,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19815,14 +20708,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -19830,6 +20722,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19839,8 +20735,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19849,6 +20743,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -19856,6 +20751,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19865,8 +20764,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19875,6 +20772,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -19884,6 +20782,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19893,8 +20795,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -19907,6 +20807,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -19921,13 +20822,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -19938,6 +20841,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -19952,13 +20856,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -19969,6 +20875,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -19983,13 +20890,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -19998,6 +20907,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -20006,13 +20916,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -20023,6 +20935,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -20031,13 +20944,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -20048,6 +20963,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -20058,13 +20974,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -20233,6 +21151,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: c211f5bf4d880547379dbfb5cbf9c7ed228eb6bc67396ecfb7feaa43b1f8f6d4
+hmac: 62c562ae6caa5c48fb8acc3ac20c40f811b6411048def39a770d0c934e1c3b1a
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -79,13 +80,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -103,6 +114,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -130,6 +143,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -166,6 +183,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -184,13 +202,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -206,6 +234,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -233,6 +263,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -269,6 +303,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -289,13 +324,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -313,6 +358,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -340,6 +387,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -376,6 +427,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -394,13 +446,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -416,6 +478,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -443,6 +507,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -818,13 +886,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -858,6 +936,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -882,6 +962,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -896,13 +978,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1144,6 +1230,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1162,13 +1249,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1184,6 +1281,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -1211,6 +1310,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1242,6 +1345,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1260,6 +1364,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -1285,6 +1390,8 @@ steps:
   when:
     status:
     - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -1534,6 +1641,7 @@ clone:
 steps:
   - name: Check out code
     image: alpine/git
+    pull: if-not-exists
     commands:
       - mkdir -p /go/src/github.com/gravitational/teleport
       - cd /go/src/github.com/gravitational/teleport
@@ -1656,6 +1764,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1679,13 +1788,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1701,8 +1820,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1716,6 +1838,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1740,6 +1863,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1752,6 +1876,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -1811,6 +1936,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1844,6 +1973,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1867,13 +1997,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1891,8 +2031,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1903,6 +2046,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1927,6 +2071,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1939,6 +2084,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -1998,6 +2144,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2031,6 +2181,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2054,13 +2205,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2078,8 +2239,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2097,6 +2261,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2121,6 +2286,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2133,6 +2299,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2192,6 +2359,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2225,6 +2396,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2248,13 +2420,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2272,8 +2454,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2282,6 +2467,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2306,6 +2492,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2318,6 +2505,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2377,6 +2565,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2431,13 +2623,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2479,6 +2681,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2526,6 +2729,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2540,6 +2745,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2564,6 +2770,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2633,13 +2840,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2694,13 +2905,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2740,6 +2961,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2788,6 +3010,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2800,6 +3024,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2824,6 +3049,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2893,13 +3119,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2954,13 +3184,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3002,6 +3242,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3042,6 +3283,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3054,6 +3297,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3078,6 +3322,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3145,10 +3390,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3203,13 +3452,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3249,6 +3508,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3290,6 +3550,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3300,6 +3562,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3324,6 +3587,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3391,10 +3655,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3428,6 +3696,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -3451,13 +3720,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -3473,8 +3752,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -3485,6 +3767,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3509,6 +3792,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3521,6 +3805,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -3580,6 +3865,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3634,13 +3923,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3682,6 +3981,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3729,6 +4029,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -3743,6 +4045,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3767,6 +4070,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3836,13 +4140,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3897,13 +4205,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3945,6 +4263,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3985,6 +4304,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3997,6 +4318,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -4021,6 +4343,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4088,10 +4411,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4775,6 +5102,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -4798,13 +5126,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -4820,8 +5158,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -4832,6 +5173,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -4856,6 +5198,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4868,6 +5211,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -4927,6 +5271,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4957,6 +5305,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -4975,6 +5324,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -4983,6 +5333,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5286,13 +5638,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5334,6 +5696,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5374,6 +5737,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -5386,6 +5751,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5410,6 +5776,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -5477,10 +5844,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5798,13 +6169,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5846,6 +6227,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5893,6 +6275,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -5907,6 +6291,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5931,6 +6316,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -6000,13 +6386,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6040,6 +6430,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -6063,13 +6454,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -6089,8 +6490,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.zip" -print -exec cp {} /go/artifacts \;
@@ -6100,6 +6504,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6124,6 +6529,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -6136,6 +6542,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -6195,6 +6602,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -6583,13 +6994,23 @@ steps:
   - git checkout ${DRONE_COMMIT}
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Configure Staging AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6614,6 +7035,7 @@ steps:
     path: /root/.aws
 - name: Configure Production AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6638,6 +7060,7 @@ steps:
     path: /root/.aws
 - name: Build and push buildbox
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6651,12 +7074,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6671,12 +7097,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-arm
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6691,12 +7120,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6711,12 +7143,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6731,10 +7166,12 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 services:
 - name: Start Docker
   image: docker:dind
@@ -6743,10 +7180,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6775,6 +7216,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6804,11 +7247,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -6818,6 +7263,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6865,6 +7311,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6953,6 +7400,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6981,6 +7430,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -7010,11 +7461,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -7024,6 +7477,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7071,6 +7525,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7160,6 +7615,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -7721,6 +8178,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -7739,6 +8197,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -7747,6 +8206,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -8012,19 +8473,30 @@ depends_on:
 steps:
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
     != "200" ]; do sleep 1; done'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -8040,6 +8512,7 @@ steps:
   - echo $(cat "/go/var/full-version")
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8064,6 +8537,7 @@ steps:
     path: /root/.aws
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8090,6 +8564,7 @@ steps:
   - Assume ECR - staging AWS Role
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8195,6 +8670,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_amd64.deb" artifacts from S3
@@ -8256,6 +8733,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm.deb" artifacts from S3
@@ -8317,6 +8796,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm64.deb" artifacts from S3
@@ -8342,6 +8823,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - staging
@@ -8365,6 +8848,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - staging
@@ -8389,6 +8874,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8413,12 +8900,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
   - Tag and push image "teleport:v12-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8524,6 +9014,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
@@ -8585,6 +9077,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
@@ -8646,6 +9140,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
@@ -8671,6 +9167,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -8695,6 +9193,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
@@ -8719,6 +9219,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -8743,12 +9245,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8856,6 +9361,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
@@ -8881,6 +9388,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -8903,6 +9412,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v12-amd64"
@@ -8934,6 +9445,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8971,6 +9484,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9008,6 +9523,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9038,6 +9555,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -9062,6 +9581,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - staging
@@ -9086,6 +9607,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9110,6 +9633,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -9130,6 +9655,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -9162,6 +9691,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -9180,6 +9710,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
@@ -9188,6 +9719,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -9219,6 +9752,7 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
@@ -9240,16 +9774,26 @@ steps:
     '; echo 'a prerelease'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -9259,6 +9803,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -9286,6 +9831,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9313,6 +9859,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9358,6 +9905,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9386,6 +9935,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9414,6 +9965,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9450,6 +10003,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm" to Quay
@@ -9478,6 +10033,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm64" to Quay
@@ -9507,6 +10064,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -9533,6 +10092,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -9561,6 +10122,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -9586,6 +10149,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -9616,6 +10181,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm" to ECR - production
@@ -9643,6 +10210,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport:v12-arm64" to ECR - production
@@ -9671,6 +10240,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -9696,6 +10267,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -9723,6 +10296,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -9748,6 +10323,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -9771,6 +10348,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9799,6 +10378,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9827,6 +10408,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9863,6 +10446,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm" to Quay
@@ -9892,6 +10477,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm64" to Quay
@@ -9921,6 +10508,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -9947,6 +10536,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -9975,6 +10566,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -10001,6 +10594,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -10032,6 +10627,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10060,6 +10657,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
@@ -10089,6 +10688,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -10114,6 +10715,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10141,6 +10744,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10166,6 +10771,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -10190,6 +10797,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10226,6 +10835,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10250,6 +10861,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10274,6 +10887,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -10296,6 +10911,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
@@ -10325,6 +10942,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v12-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10348,6 +10967,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10371,6 +10992,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -10392,6 +11015,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v12-amd64 and push it to Local Registry
@@ -10414,6 +11039,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10443,6 +11070,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10472,6 +11101,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10508,6 +11139,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm" to Quay
@@ -10537,6 +11170,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm64" to Quay
@@ -10566,6 +11201,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -10592,6 +11229,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -10620,6 +11259,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -10646,6 +11287,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -10677,6 +11320,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -10706,6 +11351,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - production
@@ -10735,6 +11382,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v12-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -10760,6 +11409,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -10787,6 +11438,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -10812,6 +11465,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -10832,6 +11487,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -10873,15 +11532,25 @@ steps:
     "v12"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v12
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -10890,6 +11559,7 @@ steps:
   - Find the latest available semver for v12
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -10916,6 +11586,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10942,6 +11613,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10969,6 +11641,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10996,6 +11669,7 @@ steps:
   - Find the latest available semver for v12
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -11105,6 +11779,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_amd64.deb" artifacts from S3
@@ -11166,6 +11842,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm.deb" artifacts from S3
@@ -11227,6 +11905,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v12-tag_arm64.deb" artifacts from S3
@@ -11265,6 +11945,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11301,6 +11983,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - staging
@@ -11338,6 +12022,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -11363,6 +12049,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11390,6 +12078,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11417,6 +12107,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - staging
   - Tag and push image "teleport:v12-arm" to ECR - staging
@@ -11448,6 +12140,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to Quay
@@ -11476,6 +12170,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to Quay
@@ -11505,6 +12201,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -11527,6 +12225,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -11551,6 +12251,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -11576,6 +12278,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to Quay
   - Tag and push image "teleport:v12-arm" to Quay
@@ -11606,6 +12310,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-amd64"
 - name: Tag and push image "teleport:v12-arm" to ECR - production
@@ -11633,6 +12339,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm"
 - name: Tag and push image "teleport:v12-arm64" to ECR - production
@@ -11661,6 +12369,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v12-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -11682,6 +12392,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -11705,6 +12417,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
@@ -11730,12 +12444,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v12-amd64" to ECR - production
   - Tag and push image "teleport:v12-arm" to ECR - production
   - Tag and push image "teleport:v12-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -11845,6 +12562,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_amd64.deb" artifacts from S3
@@ -11906,6 +12625,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm.deb" artifacts from S3
@@ -11967,6 +12688,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag_arm64.deb" artifacts from S3
@@ -12005,6 +12728,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12042,6 +12767,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - staging
@@ -12079,6 +12806,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -12104,6 +12833,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12131,6 +12862,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12158,6 +12891,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v12-arm" to ECR - staging
@@ -12189,6 +12924,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12218,6 +12955,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to Quay
@@ -12247,6 +12986,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -12269,6 +13010,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12293,6 +13036,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12319,6 +13064,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to Quay
   - Tag and push image "teleport-ent:v12-arm" to Quay
@@ -12350,6 +13097,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-amd64"
 - name: Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -12378,6 +13127,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm"
 - name: Tag and push image "teleport-ent:v12-arm64" to ECR - production
@@ -12407,6 +13158,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v12-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -12428,6 +13181,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -12451,6 +13206,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
@@ -12476,12 +13233,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-amd64" to ECR - production
   - Tag and push image "teleport-ent:v12-arm" to ECR - production
   - Tag and push image "teleport-ent:v12-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -12593,6 +13353,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v12-tag-fips_amd64.deb" artifacts from S3
@@ -12631,6 +13393,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -12654,6 +13418,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -12677,6 +13443,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -12700,6 +13468,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to Quay
@@ -12729,6 +13499,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -12749,6 +13521,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -12769,6 +13543,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -12791,6 +13567,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
@@ -12820,6 +13598,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v12-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -12839,6 +13619,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -12858,6 +13640,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -12879,6 +13663,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v12-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v12-amd64"
@@ -12910,6 +13696,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -12949,6 +13737,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -12988,6 +13778,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v12
@@ -13033,6 +13825,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13070,6 +13864,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - staging
@@ -13107,6 +13903,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -13132,6 +13930,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13159,6 +13959,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13186,6 +13988,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v12-arm" to ECR - staging
@@ -13217,6 +14021,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13246,6 +14052,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to Quay
@@ -13275,6 +14083,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -13297,6 +14107,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13321,6 +14133,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13347,6 +14161,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to Quay
   - Tag and push image "teleport-operator:v12-arm" to Quay
@@ -13378,6 +14194,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-amd64"
 - name: Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13407,6 +14225,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm"
 - name: Tag and push image "teleport-operator:v12-arm64" to ECR - production
@@ -13436,6 +14256,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v12-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -13457,6 +14279,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13480,6 +14304,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13505,6 +14331,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v12-amd64" to ECR - production
   - Tag and push image "teleport-operator:v12-arm" to ECR - production
@@ -13525,6 +14353,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -13566,15 +14398,25 @@ steps:
     "v11"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v11
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -13583,6 +14425,7 @@ steps:
   - Find the latest available semver for v11
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -13609,6 +14452,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13635,6 +14479,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13662,6 +14507,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13689,6 +14535,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13798,6 +14645,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -13859,6 +14708,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -13920,6 +14771,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -13958,6 +14811,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -13994,6 +14849,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -14031,6 +14888,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -14056,6 +14915,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14083,6 +14944,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14110,6 +14973,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -14141,6 +15006,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -14169,6 +15036,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -14198,6 +15067,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -14220,6 +15091,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -14244,6 +15117,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -14269,6 +15144,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -14299,6 +15176,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -14326,6 +15205,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -14354,6 +15235,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -14375,6 +15258,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -14398,6 +15283,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -14423,12 +15310,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
   - Tag and push image "teleport:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -14538,6 +15428,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -14599,6 +15491,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -14660,6 +15554,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -14698,6 +15594,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14735,6 +15633,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -14772,6 +15672,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -14797,6 +15699,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14824,6 +15728,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14851,6 +15757,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -14882,6 +15790,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -14911,6 +15821,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -14940,6 +15852,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -14962,6 +15876,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -14986,6 +15902,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15012,6 +15930,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -15043,6 +15963,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15071,6 +15993,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -15100,6 +16024,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -15121,6 +16047,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15144,6 +16072,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -15169,12 +16099,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
   - Tag and push image "teleport-ent:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -15286,6 +16219,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -15324,6 +16259,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -15347,6 +16284,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -15370,6 +16309,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -15393,6 +16334,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -15422,6 +16365,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -15442,6 +16387,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -15462,6 +16409,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -15484,6 +16433,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -15513,6 +16464,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -15532,6 +16485,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -15551,6 +16506,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -15572,6 +16529,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -15603,6 +16562,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -15642,6 +16603,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -15681,6 +16644,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -15726,6 +16691,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15763,6 +16730,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -15800,6 +16769,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -15825,6 +16796,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15852,6 +16825,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15879,6 +16854,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -15910,6 +16887,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -15939,6 +16918,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -15968,6 +16949,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -15990,6 +16973,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16014,6 +16999,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16040,6 +17027,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -16071,6 +17060,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16100,6 +17091,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -16129,6 +17122,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -16150,6 +17145,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16173,6 +17170,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16198,6 +17197,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -16218,6 +17219,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -16259,15 +17264,25 @@ steps:
     "v10"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v10
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -16276,6 +17291,7 @@ steps:
   - Find the latest available semver for v10
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -16302,6 +17318,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16328,6 +17345,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16355,6 +17373,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16382,6 +17401,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16491,6 +17511,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -16552,6 +17574,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -16613,6 +17637,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -16651,6 +17677,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16687,6 +17715,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -16724,6 +17754,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -16749,6 +17781,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16776,6 +17810,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16803,6 +17839,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -16834,6 +17872,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -16862,6 +17902,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -16891,6 +17933,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -16913,6 +17957,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -16937,6 +17983,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -16962,6 +18010,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -16992,6 +18042,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -17019,6 +18071,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -17047,6 +18101,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -17068,6 +18124,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -17091,6 +18149,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -17116,12 +18176,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
   - Tag and push image "teleport:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17231,6 +18294,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -17292,6 +18357,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -17353,6 +18420,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -17391,6 +18460,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17428,6 +18499,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -17465,6 +18538,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -17490,6 +18565,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17517,6 +18594,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17544,6 +18623,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -17575,6 +18656,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17604,6 +18687,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -17633,6 +18718,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -17655,6 +18742,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17679,6 +18768,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17705,6 +18796,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -17736,6 +18829,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -17764,6 +18859,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -17793,6 +18890,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -17814,6 +18913,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -17837,6 +18938,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -17862,12 +18965,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
   - Tag and push image "teleport-ent:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17979,6 +19085,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -18017,6 +19125,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -18040,6 +19150,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -18063,6 +19175,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -18086,6 +19200,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -18115,6 +19231,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -18135,6 +19253,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -18155,6 +19275,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -18177,6 +19299,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -18206,6 +19330,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -18225,6 +19351,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -18244,6 +19372,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -18265,6 +19395,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -18296,6 +19428,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -18335,6 +19469,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -18374,6 +19510,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -18419,6 +19557,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18456,6 +19596,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -18493,6 +19635,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -18518,6 +19662,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18545,6 +19691,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18572,6 +19720,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -18603,6 +19753,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18632,6 +19784,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -18661,6 +19815,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -18683,6 +19839,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18707,6 +19865,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18733,6 +19893,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -18764,6 +19926,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18793,6 +19957,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -18822,6 +19988,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -18843,6 +20011,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18866,6 +20036,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18891,6 +20063,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -18911,6 +20085,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -18950,13 +20128,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -18990,6 +20178,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -19014,6 +20204,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -19028,15 +20220,19 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 141197d3fb11b106cb06396e8584483741e16aee15464513a8dd748f9546788e
+hmac: c211f5bf4d880547379dbfb5cbf9c7ed228eb6bc67396ecfb7feaa43b1f8f6d4
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -936,8 +936,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -962,8 +960,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -21096,8 +21092,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -21122,8 +21116,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -21151,6 +21143,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 62c562ae6caa5c48fb8acc3ac20c40f811b6411048def39a770d0c934e1c3b1a
+hmac: ef96b296dbb1cd38348e5407f3bc13248fc43f7ff7cb1439f34ab34f0beffc04
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -879,12 +879,13 @@ $(VERSRC): Makefile
 # 		- build binaries with 'make release'
 # 		- run `make tag` and use its output to 'git tag' and 'git push --tags'
 .PHONY: update-tag
+update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))
-	git push origin $(GITTAG) && git push origin api/$(GITTAG)
+	git push $(TAG_REMOTE) $(GITTAG) && git push $(TAG_REMOTE) api/$(GITTAG)
 
 .PHONY: test-package
 test-package: remove-temp-files

--- a/dronegen/aws.go
+++ b/dronegen/aws.go
@@ -93,6 +93,7 @@ func kubernetesAssumeAwsRoleStep(s kubernetesRoleSettings) step {
 	return step{
 		Name:  s.name,
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_ACCESS_KEY_ID":     s.awsAccessKeyID,
 			"AWS_SECRET_ACCESS_KEY": s.awsSecretAccessKey,
@@ -125,6 +126,7 @@ func kubernetesUploadToS3Step(s kubernetesS3Settings) step {
 	return step{
 		Name:  "Upload to S3",
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_S3_BUCKET": {fromSecret: "AWS_S3_BUCKET"},
 			"AWS_REGION":    {raw: s.region},

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -70,7 +70,7 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
 		Pull:    "if-not-exists",
-		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes: []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -102,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -69,7 +69,8 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 	return step{
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
-		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
+		Pull:    "if-not-exists",
+		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -101,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = []volume{volumeDocker, volumeAwsConfig}
+	p.Volumes = dockerVolumes(volumeAwsConfig)
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -86,6 +86,25 @@ var (
 		Name: "awsconfig",
 		Path: "/root/.aws",
 	}
+
+	// volumeDockerConfig is a temporary volume for storing docker
+	// credentials for use with the Docker-in-Docker service we use
+	// to isolate the host machines docker daemon from the one used
+	// during the build. Mount this any time you use `volumeDocker`
+	//
+	// Drone claims to destroy the the temp volumes after a workflow
+	// has run, so it should be safe to write credentials etc.
+	volumeDockerConfig = volume{
+		Name: "dockerconfig",
+		Temp: &volumeTemp{},
+	}
+
+	// volumeRefDockerConfig is how you reference the docker config
+	// volume in a workflow step
+	volumeRefDockerConfig = volumeRef{
+		Name: "dockerconfig",
+		Path: "/root/.docker",
+	}
 )
 
 var buildboxVersion value
@@ -245,13 +264,13 @@ func dockerRegistryService() service {
 // dockerVolumes returns a slice of volumes
 // It includes the Docker socket volume by default, plus any extra volumes passed in
 func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker)
+	return append(v, volumeDocker, volumeDockerConfig)
 }
 
 // dockerVolumeRefs returns a slice of volumeRefs
 // It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
 func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker)
+	return append(v, volumeRefDocker, volumeRefDockerConfig)
 }
 
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
@@ -283,10 +302,16 @@ func waitForDockerStep() step {
 	return step{
 		Name:  "Wait for docker",
 		Image: "docker",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: []volumeRef{volumeRefDocker},
+		Volumes: dockerVolumeRefs(),
+		Environment: map[string]value{
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
+		},
 	}
 }
 
@@ -295,6 +320,7 @@ func waitForDockerRegistryStep() step {
 	return step{
 		Name:  "Wait for docker registry",
 		Image: "alpine",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"apk add curl",
 			fmt.Sprintf(`timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %%{http_code} http://%s/)" != "200" ]; do sleep 1; done'`, LocalRegistrySocket),
@@ -306,6 +332,7 @@ func verifyTaggedStep() step {
 	return step{
 		Name:  "Verify build is tagged",
 		Image: "alpine:latest",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"[ -n ${DRONE_TAG} ] || (echo 'DRONE_TAG is not set. Is the commit tagged?' && exit 1)",
 		},
@@ -317,6 +344,7 @@ func cloneRepoStep(clonePath, commit string) step {
 	return step{
 		Name:     "Check out code",
 		Image:    "alpine/git:latest",
+		Pull:     "if-not-exists",
 		Commands: cloneRepoCommands(clonePath, commit),
 	}
 }

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -261,18 +261,6 @@ func dockerRegistryService() service {
 	}
 }
 
-// dockerVolumes returns a slice of volumes
-// It includes the Docker socket volume by default, plus any extra volumes passed in
-func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker, volumeDockerConfig)
-}
-
-// dockerVolumeRefs returns a slice of volumeRefs
-// It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
-func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker, volumeRefDockerConfig)
-}
-
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
 func releaseMakefileTarget(b buildType) string {
 	makefileTarget := fmt.Sprintf("release-%s", b.arch)
@@ -307,7 +295,7 @@ func waitForDockerStep() step {
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
 			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: dockerVolumeRefs(),
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 		Environment: map[string]value{
 			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
 			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_images_release_version.go
+++ b/dronegen/container_images_release_version.go
@@ -48,7 +48,7 @@ func (rv *ReleaseVersion) buildVersionPipeline(triggerSetupSteps []step, flags *
 		dockerService(),
 		dockerRegistryService(),
 	}
-	pipeline.Volumes = dockerVolumes(volumeAwsConfig)
+	pipeline.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	pipeline.Environment = map[string]value{
 		"DEBIAN_FRONTEND": {
 			raw: "noninteractive",

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -62,6 +62,7 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 	loginCommands := []string{
 		"apk add --no-cache aws-cli",
 		fmt.Sprintf("aws %s get-login-password --region=%s | docker login -u=\"AWS\" --password-stdin %s", loginSubcommand, ecrRegion, domain),
+		`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 	}
 
 	if guaranteeUnique {
@@ -72,7 +73,9 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 		Name:        repoName,
 		IsImmutable: isImmutable,
 		EnvironmentVars: map[string]value{
-			"AWS_PROFILE": {raw: profileName},
+			"AWS_PROFILE":        {raw: profileName},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: domain,
 		RegistryOrg:    registryOrg,
@@ -112,17 +115,16 @@ func NewQuayContainerRepo(dockerUsername, dockerPassword string) *ContainerRepo 
 		Name:        "Quay",
 		IsImmutable: false,
 		EnvironmentVars: map[string]value{
-			"QUAY_USERNAME": {
-				fromSecret: dockerUsername,
-			},
-			"QUAY_PASSWORD": {
-				fromSecret: dockerPassword,
-			},
+			"QUAY_USERNAME":      {fromSecret: dockerUsername},
+			"QUAY_PASSWORD":      {fromSecret: dockerPassword},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: ProductionRegistryQuay,
 		RegistryOrg:    registryOrg,
 		LoginCommands: []string{
 			fmt.Sprintf("docker login -u=\"$QUAY_USERNAME\" -p=\"$QUAY_PASSWORD\" %q", ProductionRegistryQuay),
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
 	}
 }
@@ -254,7 +256,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +306,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +334,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -254,7 +254,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +304,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +332,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -58,6 +58,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -66,6 +67,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Delegate build to GitHub",
 			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GHA_APP_KEY": {fromSecret: "GITHUB_WORKFLOW_APP_PRIVATE_KEY"},
 			},

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -39,6 +39,22 @@ func main() {
 	pipelines = append(pipelines, buildContainerImagePipelines()...)
 	pipelines = append(pipelines, publishReleasePipeline())
 
+	// Inject the Drone-level dockerhub credentials into all non-exec
+	// pipelines. Drone will then use the docker credentials file in
+	// the named secret as its credentials when pulling images from
+	// dockerhub.
+	//
+	// Exec pipelines do not have the `image_pull_secrets` option, as
+	// their steps are invoked directly on the host runner and not
+	// into a per-step container.
+	for pidx := range pipelines {
+		p := &pipelines[pidx]
+		if p.Type == "exec" {
+			continue
+		}
+		p.ImagePullSecrets = append(p.ImagePullSecrets, "DOCKERHUB_CREDENTIALS")
+	}
+
 	if err := writePipelines(".drone.yml", pipelines); err != nil {
 		fmt.Println("failed writing drone pipelines:", err)
 		os.Exit(1)

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -122,7 +122,7 @@ func pushPipeline(b buildType) pipeline {
 	}
 	p.Trigger = triggerPush
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeDocker}
+	p.Volumes = []volume{volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -130,6 +130,7 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -139,8 +140,9 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:        "Build artifacts",
 			Image:       "docker",
+			Pull:        "if-not-exists",
 			Environment: pushEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker},
+			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 			Commands:    pushBuildCommands(b),
 		},
 		sendErrorToSlackStep(),

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,7 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
+	p.Volumes = []volume{volumeTmpfs, volumeAwsConfig, volumeDocker, volumeDockerConfig}
 
 	return p
 }
@@ -56,11 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -80,12 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefTmpfs,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,11 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = []volume{
-		volumeDocker,
-		volumeTmpfs,
-		volumeAwsConfig,
-	}
+	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
 
 	return p
 }
@@ -62,6 +58,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefAwsConfig,
 		},
 		Commands: []string{
@@ -85,6 +82,7 @@ func executeRelcliStep(name string, command string) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefTmpfs,
 			volumeRefAwsConfig,
 		},

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -56,7 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -76,7 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -271,7 +271,7 @@ func tagPipeline(b buildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -466,7 +466,7 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
-	packageDockerVolumes := dockerVolumes(volumeAwsConfig)
+	packageDockerVolumes := []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	packageDockerVolumeRefs := []volumeRef{
 		volumeRefDocker,
 		volumeRefDockerConfig,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -271,7 +271,7 @@ func tagPipeline(b buildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeAwsConfig, volumeDocker}
+	p.Volumes = dockerVolumes(volumeAwsConfig)
 	p.Services = []service{
 		dockerService(),
 	}
@@ -279,6 +279,7 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -288,13 +289,15 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:        "Build artifacts",
 			Image:       "docker",
+			Pull:        "if-not-exists",
 			Environment: tagEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker},
+			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 			Commands:    tagBuildCommands(b),
 		},
 		{
 			Name:     "Copy artifacts",
 			Image:    "docker",
+			Pull:     "if-not-exists",
 			Commands: tagCopyArtifactCommands(b),
 		},
 		kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
@@ -314,6 +317,7 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:     "Register artifacts",
 			Image:    "docker",
+			Pull:     "if-not-exists",
 			Commands: tagCreateReleaseAssetCommands(b, "", extraQualifications),
 			Environment: map[string]value{
 				"RELEASES_CERT": {fromSecret: "RELEASES_CERT"},
@@ -462,12 +466,10 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
-	packageDockerVolumes := []volume{
-		volumeDocker,
-		volumeAwsConfig,
-	}
+	packageDockerVolumes := dockerVolumes(volumeAwsConfig)
 	packageDockerVolumeRefs := []volumeRef{
 		volumeRefDocker,
+		volumeRefDockerConfig,
 		volumeRefAwsConfig,
 	}
 	packageDockerService := dockerService()

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -29,20 +29,21 @@ import (
 type pipeline struct {
 	comment string
 
-	Kind        string           `yaml:"kind"`
-	Type        string           `yaml:"type"`
-	Name        string           `yaml:"name"`
-	Environment map[string]value `yaml:"environment,omitempty"`
-	Trigger     trigger          `yaml:"trigger"`
-	Workspace   workspace        `yaml:"workspace,omitempty"`
-	Platform    platform         `yaml:"platform,omitempty"`
-	Node        map[string]value `yaml:"node,omitempty"`
-	Clone       clone            `yaml:"clone,omitempty"`
-	DependsOn   []string         `yaml:"depends_on,omitempty"`
-	Concurrency concurrency      `yaml:"concurrency,omitempty"`
-	Steps       []step           `yaml:"steps"`
-	Services    []service        `yaml:"services,omitempty"`
-	Volumes     []volume         `yaml:"volumes,omitempty"`
+	Kind             string           `yaml:"kind"`
+	Type             string           `yaml:"type"`
+	Name             string           `yaml:"name"`
+	Environment      map[string]value `yaml:"environment,omitempty"`
+	Trigger          trigger          `yaml:"trigger"`
+	Workspace        workspace        `yaml:"workspace,omitempty"`
+	Platform         platform         `yaml:"platform,omitempty"`
+	Node             map[string]value `yaml:"node,omitempty"`
+	Clone            clone            `yaml:"clone,omitempty"`
+	DependsOn        []string         `yaml:"depends_on,omitempty"`
+	Concurrency      concurrency      `yaml:"concurrency,omitempty"`
+	Steps            []step           `yaml:"steps"`
+	Services         []service        `yaml:"services,omitempty"`
+	Volumes          []volume         `yaml:"volumes,omitempty"`
+	ImagePullSecrets []string         `yaml:"image_pull_secrets,omitempty"`
 }
 
 func newKubePipeline(name string) pipeline {
@@ -169,6 +170,7 @@ type volumeRef struct {
 type step struct {
 	Name        string              `yaml:"name"`
 	Image       string              `yaml:"image,omitempty"`
+	Pull        string              `yaml:"pull,omitempty"`
 	Commands    []string            `yaml:"commands,omitempty"`
 	Environment map[string]value    `yaml:"environment,omitempty"`
 	Volumes     []volumeRef         `yaml:"volumes,omitempty"`


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/23956
Backports https://github.com/gravitational/teleport/pull/23957

## Summary

After moving Drone to AWS, we're seeing image pulls get rate limited because they're all coming from the same IP (an AWS NAT gateway). To avoid the rate limiting on AWS, we refactor pipelines to cache/reuse images where possible, as well as add authentication to Docker Hub pulls.

## Related Issues & PRs

Contributes to https://github.com/gravitational/SecOps/issues/285

See the orginal PRs to master for more context.

## Testing
This is undergoing final testing at:

* build: https://drone.platform.teleport.sh/gravitational/teleport-private/522
* promote: https://drone.platform.teleport.sh/gravitational/teleport-private/531

These tests are based off 12.1.5 -- so they should be fully clean.