### PR TITLE
[v11] Add Docker Hub login to Drone's Kubernetes pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -79,13 +80,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -103,6 +114,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -130,6 +143,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -166,6 +183,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -184,13 +202,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -206,6 +234,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -233,6 +263,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -269,6 +303,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -289,13 +324,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -313,6 +358,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -340,6 +387,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -376,6 +427,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -394,13 +446,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -416,6 +478,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -443,6 +507,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -818,13 +886,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -858,6 +936,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -882,6 +962,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -896,13 +978,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1142,6 +1228,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1160,13 +1247,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1182,6 +1279,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -1209,6 +1308,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1245,6 +1348,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1263,6 +1367,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
@@ -1288,6 +1393,8 @@ steps:
   when:
     status:
     - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -1659,6 +1766,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1682,13 +1790,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1704,8 +1822,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1719,6 +1840,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1743,6 +1865,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1755,6 +1878,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -1814,6 +1938,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1847,6 +1975,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1870,13 +1999,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1894,8 +2033,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1906,6 +2048,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1930,6 +2073,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1942,6 +2086,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2001,6 +2146,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2034,6 +2183,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2057,13 +2207,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2081,8 +2241,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2100,6 +2263,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2124,6 +2288,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2136,6 +2301,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2195,6 +2361,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2228,6 +2398,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2251,13 +2422,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2275,8 +2456,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2285,6 +2469,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2309,6 +2494,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2321,6 +2507,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2380,6 +2567,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2434,13 +2625,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2482,6 +2683,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2529,6 +2731,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2543,6 +2747,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2567,6 +2772,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2636,13 +2842,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2697,13 +2907,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2743,6 +2963,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2791,6 +3012,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2803,6 +3026,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2827,6 +3051,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2896,13 +3121,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2957,13 +3186,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3005,6 +3244,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3045,6 +3285,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3057,6 +3299,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3081,6 +3324,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3148,10 +3392,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3206,13 +3454,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3252,6 +3510,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3293,6 +3552,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3303,6 +3564,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3327,6 +3589,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3394,10 +3657,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3431,6 +3698,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -3454,13 +3722,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -3476,8 +3754,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -3488,6 +3769,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3512,6 +3794,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3524,6 +3807,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -3583,6 +3867,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3637,13 +3925,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3685,6 +3983,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3732,6 +4031,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -3746,6 +4047,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3770,6 +4072,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3839,13 +4142,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3900,13 +4207,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3948,6 +4265,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3988,6 +4306,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -4000,6 +4320,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -4024,6 +4345,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4091,10 +4413,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4778,6 +5104,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -4801,13 +5128,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -4823,8 +5160,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -4835,6 +5175,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -4859,6 +5200,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4871,6 +5213,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -4930,6 +5273,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4963,6 +5310,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -4981,6 +5329,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
@@ -4989,6 +5338,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5292,13 +5643,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5340,6 +5701,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5380,6 +5742,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -5392,6 +5756,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5416,6 +5781,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -5483,10 +5849,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5804,13 +6174,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5852,6 +6232,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5899,6 +6280,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -5913,6 +6296,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5937,6 +6321,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -6006,13 +6391,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6046,6 +6435,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -6069,13 +6459,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -6095,8 +6495,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.zip" -print -exec cp {} /go/artifacts \;
@@ -6106,6 +6509,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6130,6 +6534,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -6142,6 +6547,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -6201,6 +6607,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -6589,13 +6999,23 @@ steps:
   - git checkout ${DRONE_COMMIT}
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Configure Staging AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6620,6 +7040,7 @@ steps:
     path: /root/.aws
 - name: Configure Production AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6644,6 +7065,7 @@ steps:
     path: /root/.aws
 - name: Build and push buildbox
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6657,12 +7079,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6677,12 +7102,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-arm
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6697,12 +7125,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6717,12 +7148,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6737,10 +7171,12 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 services:
 - name: Start Docker
   image: docker:dind
@@ -6749,10 +7185,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6781,6 +7221,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6810,11 +7252,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -6824,6 +7268,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6871,6 +7316,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6959,6 +7405,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6987,6 +7435,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -7016,11 +7466,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -7030,6 +7482,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7077,6 +7530,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7166,6 +7620,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -7963,19 +8419,30 @@ depends_on:
 steps:
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
     != "200" ]; do sleep 1; done'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -7991,6 +8458,7 @@ steps:
   - echo $(cat "/go/var/full-version")
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8015,6 +8483,7 @@ steps:
     path: /root/.aws
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8041,6 +8510,7 @@ steps:
   - Assume ECR - staging AWS Role
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8146,6 +8616,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -8207,6 +8679,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -8268,6 +8742,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -8293,6 +8769,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -8316,6 +8794,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -8340,6 +8820,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8364,12 +8846,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
   - Tag and push image "teleport:v11-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8475,6 +8960,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -8536,6 +9023,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -8597,6 +9086,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -8622,6 +9113,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -8646,6 +9139,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -8670,6 +9165,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -8694,12 +9191,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8807,6 +9307,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -8832,6 +9334,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -8854,6 +9358,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -8885,6 +9391,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8922,6 +9430,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8959,6 +9469,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8989,6 +9501,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -9013,6 +9527,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -9037,6 +9553,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9061,6 +9579,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -9081,6 +9601,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -9112,6 +9636,7 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
@@ -9133,16 +9658,26 @@ steps:
     '; echo 'a prerelease'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -9152,6 +9687,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -9179,6 +9715,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9206,6 +9743,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9251,6 +9789,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9279,6 +9819,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9307,6 +9849,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9343,6 +9887,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -9371,6 +9917,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -9400,6 +9948,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -9426,6 +9976,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -9454,6 +10006,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -9479,6 +10033,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -9509,6 +10065,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -9536,6 +10094,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -9564,6 +10124,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -9589,6 +10151,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -9616,6 +10180,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -9641,6 +10207,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -9664,6 +10232,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9692,6 +10262,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9720,6 +10292,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9756,6 +10330,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -9785,6 +10361,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -9814,6 +10392,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -9840,6 +10420,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -9868,6 +10450,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -9894,6 +10478,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -9925,6 +10511,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -9953,6 +10541,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -9982,6 +10572,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -10007,6 +10599,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -10034,6 +10628,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -10059,6 +10655,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -10083,6 +10681,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10119,6 +10719,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10143,6 +10745,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10167,6 +10771,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -10189,6 +10795,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -10218,6 +10826,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10241,6 +10851,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10264,6 +10876,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -10285,6 +10899,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v11-amd64 and push it to Local Registry
@@ -10307,6 +10923,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10336,6 +10954,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10365,6 +10985,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10401,6 +11023,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -10430,6 +11054,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -10459,6 +11085,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -10485,6 +11113,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -10513,6 +11143,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -10539,6 +11171,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -10570,6 +11204,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -10599,6 +11235,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -10628,6 +11266,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -10653,6 +11293,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -10680,6 +11322,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -10705,6 +11349,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -10725,6 +11371,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -10766,15 +11416,25 @@ steps:
     "v11"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v11
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -10783,6 +11443,7 @@ steps:
   - Find the latest available semver for v11
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -10809,6 +11470,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10835,6 +11497,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10862,6 +11525,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10889,6 +11553,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10998,6 +11663,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -11059,6 +11726,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -11120,6 +11789,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -11158,6 +11829,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11194,6 +11867,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -11231,6 +11906,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -11256,6 +11933,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11283,6 +11962,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11310,6 +11991,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11341,6 +12024,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -11369,6 +12054,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -11398,6 +12085,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -11420,6 +12109,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -11444,6 +12135,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -11469,6 +12162,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -11499,6 +12194,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -11526,6 +12223,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -11554,6 +12253,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -11575,6 +12276,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -11598,6 +12301,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -11623,12 +12328,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
   - Tag and push image "teleport:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -11738,6 +12446,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -11799,6 +12509,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -11860,6 +12572,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -11898,6 +12612,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -11935,6 +12651,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -11972,6 +12690,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -11997,6 +12717,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12024,6 +12746,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12051,6 +12775,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12082,6 +12808,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12111,6 +12839,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -12140,6 +12870,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -12162,6 +12894,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12186,6 +12920,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12212,6 +12948,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12243,6 +12981,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12271,6 +13011,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -12300,6 +13042,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -12321,6 +13065,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12344,6 +13090,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12369,12 +13117,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
   - Tag and push image "teleport-ent:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -12486,6 +13237,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -12524,6 +13277,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -12547,6 +13302,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -12570,6 +13327,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -12593,6 +13352,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -12622,6 +13383,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -12642,6 +13405,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -12662,6 +13427,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -12684,6 +13451,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -12713,6 +13482,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -12732,6 +13503,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -12751,6 +13524,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -12772,6 +13547,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -12803,6 +13580,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -12842,6 +13621,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -12881,6 +13662,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -12926,6 +13709,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -12963,6 +13748,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -13000,6 +13787,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -13025,6 +13814,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13052,6 +13843,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13079,6 +13872,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13110,6 +13905,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13139,6 +13936,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -13168,6 +13967,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -13190,6 +13991,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13214,6 +14017,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13240,6 +14045,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13271,6 +14078,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13300,6 +14109,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -13329,6 +14140,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -13350,6 +14163,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13373,6 +14188,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13398,6 +14215,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13418,6 +14237,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -13459,15 +14282,25 @@ steps:
     "v10"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v10
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -13476,6 +14309,7 @@ steps:
   - Find the latest available semver for v10
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -13502,6 +14336,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13528,6 +14363,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13555,6 +14391,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13582,6 +14419,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13691,6 +14529,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -13752,6 +14592,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -13813,6 +14655,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -13851,6 +14695,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -13887,6 +14733,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -13924,6 +14772,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -13949,6 +14799,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -13976,6 +14828,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14003,6 +14857,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14034,6 +14890,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -14062,6 +14920,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -14091,6 +14951,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -14113,6 +14975,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14137,6 +15001,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14162,6 +15028,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14192,6 +15060,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -14219,6 +15089,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -14247,6 +15119,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -14268,6 +15142,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -14291,6 +15167,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -14316,12 +15194,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
   - Tag and push image "teleport:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -14431,6 +15312,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -14492,6 +15375,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -14553,6 +15438,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -14591,6 +15478,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14628,6 +15517,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -14665,6 +15556,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -14690,6 +15583,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14717,6 +15612,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14744,6 +15641,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14775,6 +15674,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14804,6 +15705,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -14833,6 +15736,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -14855,6 +15760,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14879,6 +15786,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14905,6 +15814,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14936,6 +15847,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -14964,6 +15877,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -14993,6 +15908,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -15014,6 +15931,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15037,6 +15956,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15062,12 +15983,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
   - Tag and push image "teleport-ent:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -15179,6 +16103,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -15217,6 +16143,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -15240,6 +16168,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -15263,6 +16193,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -15286,6 +16218,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -15315,6 +16249,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -15335,6 +16271,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -15355,6 +16293,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -15377,6 +16317,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -15406,6 +16348,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -15425,6 +16369,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -15444,6 +16390,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -15465,6 +16413,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -15496,6 +16446,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -15535,6 +16487,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -15574,6 +16528,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -15619,6 +16575,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15656,6 +16614,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -15693,6 +16653,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -15718,6 +16680,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15745,6 +16709,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15772,6 +16738,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15803,6 +16771,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15832,6 +16802,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -15861,6 +16833,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -15883,6 +16857,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15907,6 +16883,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15933,6 +16911,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15964,6 +16944,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -15993,6 +16975,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -16022,6 +17006,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -16043,6 +17029,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16066,6 +17054,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16091,6 +17081,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16111,6 +17103,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -16151,15 +17147,25 @@ steps:
   - echo Found full semver "$(cat "/go/vars/full-version-v9")" for major version "v9"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v9
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -16168,6 +17174,7 @@ steps:
   - Find the latest available semver for v9
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -16193,6 +17200,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16219,6 +17227,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16246,6 +17255,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16273,6 +17283,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16382,6 +17393,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_amd64.deb" artifacts from S3
@@ -16443,6 +17456,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm.deb" artifacts from S3
@@ -16504,6 +17519,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm64.deb" artifacts from S3
@@ -16542,6 +17559,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16578,6 +17597,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - staging
@@ -16615,6 +17636,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -16640,6 +17663,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16667,6 +17692,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16694,6 +17721,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16725,6 +17754,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to Quay
@@ -16753,6 +17784,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to Quay
@@ -16782,6 +17815,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -16804,6 +17839,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -16828,6 +17865,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -16853,6 +17892,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -16883,6 +17924,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - production
@@ -16910,6 +17953,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - production
@@ -16938,6 +17983,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -16959,6 +18006,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -16982,6 +18031,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -17007,12 +18058,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
   - Tag and push image "teleport:v9-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17122,6 +18176,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_amd64.deb" artifacts from S3
@@ -17183,6 +18239,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm.deb" artifacts from S3
@@ -17244,6 +18302,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm64.deb" artifacts from S3
@@ -17282,6 +18342,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17319,6 +18381,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - staging
@@ -17356,6 +18420,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -17381,6 +18447,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17408,6 +18476,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17435,6 +18505,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17466,6 +18538,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17495,6 +18569,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to Quay
@@ -17524,6 +18600,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -17546,6 +18624,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17570,6 +18650,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17596,6 +18678,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17627,6 +18711,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -17655,6 +18741,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - production
@@ -17684,6 +18772,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -17705,6 +18795,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -17728,6 +18820,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -17753,12 +18847,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
   - Tag and push image "teleport-ent:v9-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17870,6 +18967,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag-fips_amd64.deb" artifacts from S3
@@ -17908,6 +19007,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -17931,6 +19032,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -17954,6 +19057,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -17977,6 +19082,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to Quay
@@ -18006,6 +19113,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -18026,6 +19135,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -18046,6 +19157,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -18068,6 +19181,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
@@ -18097,6 +19212,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -18116,6 +19233,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -18135,6 +19254,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -18156,6 +19277,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 services:
@@ -18174,6 +19297,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -18212,13 +19339,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -18252,6 +19389,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -18276,6 +19415,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -18290,15 +19431,19 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 60f27fed9d0e5786d54bd22e6b07f18d62225d78be34cdfce01a391360249d9d
+hmac: b6d72a50d21ce97f8a564b11d9c86071e679172de1a8e210d38c3d5cb186b098
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -8601,6 +8601,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -8611,13 +8612,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -8664,6 +8667,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -8674,13 +8678,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -8727,6 +8733,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -8737,13 +8744,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -8755,6 +8764,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
@@ -8764,13 +8774,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -8780,6 +8792,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
@@ -8789,13 +8802,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -8806,6 +8821,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
@@ -8815,13 +8831,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8830,6 +8848,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
@@ -8841,13 +8860,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -8945,6 +8966,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -8955,13 +8977,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -9008,6 +9032,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -9018,13 +9043,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -9071,6 +9098,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -9081,13 +9109,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -9099,6 +9129,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -9108,13 +9139,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -9125,6 +9158,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -9134,13 +9168,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -9151,6 +9187,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -9160,13 +9197,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -9175,6 +9214,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9186,13 +9226,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -9291,6 +9333,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -9302,13 +9345,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -9320,6 +9365,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -9329,13 +9375,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -9344,6 +9392,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9353,13 +9402,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -9375,6 +9426,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9386,13 +9438,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9414,6 +9468,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9425,13 +9480,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9453,6 +9510,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9464,13 +9522,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9487,6 +9547,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -9496,13 +9557,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -9513,6 +9576,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -9522,13 +9586,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -9539,6 +9605,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -9548,13 +9615,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9563,6 +9632,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
@@ -9574,13 +9644,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -9776,6 +9848,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9784,13 +9857,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9806,6 +9881,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9814,13 +9890,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9836,6 +9914,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9844,13 +9923,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9866,6 +9947,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -9878,6 +9960,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9887,8 +9973,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -9896,6 +9980,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -9908,6 +9993,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9917,8 +10006,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -9927,6 +10014,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -9939,6 +10027,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9948,8 +10040,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -9960,6 +10050,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -9967,6 +10058,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9976,8 +10071,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -9990,6 +10083,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -9997,6 +10091,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10006,8 +10104,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -10016,6 +10112,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -10024,6 +10121,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10033,8 +10134,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -10047,6 +10146,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -10060,13 +10160,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -10076,6 +10178,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -10089,13 +10192,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -10106,6 +10211,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -10119,13 +10225,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -10138,6 +10246,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -10146,13 +10255,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -10167,6 +10278,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -10175,13 +10287,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -10192,6 +10306,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -10202,13 +10317,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -10219,6 +10336,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10227,13 +10345,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10249,6 +10369,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10257,13 +10378,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10279,6 +10402,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10287,13 +10411,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10309,6 +10435,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -10321,6 +10448,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10330,8 +10461,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -10340,6 +10469,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10352,6 +10482,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10361,8 +10495,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -10371,6 +10503,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -10383,6 +10516,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10392,8 +10529,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -10404,6 +10539,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10411,6 +10547,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10420,8 +10560,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -10434,6 +10572,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10441,6 +10580,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10450,8 +10593,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -10460,6 +10601,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -10469,6 +10611,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10478,8 +10624,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -10492,6 +10636,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10506,13 +10651,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -10523,6 +10670,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10536,13 +10684,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -10553,6 +10703,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10567,13 +10718,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -10586,6 +10739,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10594,13 +10748,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -10615,6 +10771,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10623,13 +10780,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -10640,6 +10799,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -10650,13 +10810,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -10667,6 +10829,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10676,13 +10839,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10698,6 +10863,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -10710,6 +10876,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10719,8 +10889,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10731,11 +10899,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10745,8 +10918,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10757,11 +10928,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10771,14 +10947,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -10786,6 +10961,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10795,8 +10974,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -10807,6 +10984,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10821,13 +10999,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v11-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10840,19 +11020,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10865,19 +11048,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -10886,6 +11072,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -10894,13 +11081,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v11-amd64 and push it to Local Registry
@@ -10909,6 +11098,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10918,13 +11108,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10940,6 +11132,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10949,13 +11142,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10971,6 +11166,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10980,13 +11176,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -11002,6 +11200,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -11014,6 +11213,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11023,8 +11226,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -11033,6 +11234,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -11045,6 +11247,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11054,8 +11260,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -11064,6 +11268,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -11076,6 +11281,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11085,8 +11294,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -11097,6 +11304,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11104,6 +11312,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11113,8 +11325,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -11127,6 +11337,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11134,6 +11345,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11143,8 +11358,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -11153,6 +11366,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -11162,6 +11376,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11171,8 +11389,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -11185,6 +11401,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11199,13 +11416,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -11216,6 +11435,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11230,13 +11450,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -11247,6 +11469,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11261,13 +11484,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v11-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -11280,6 +11505,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11288,13 +11514,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -11309,6 +11537,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11317,13 +11546,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -11334,6 +11565,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -11344,13 +11576,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -11648,6 +11882,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -11658,13 +11893,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -11711,6 +11948,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -11721,13 +11959,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -11774,6 +12014,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -11784,13 +12025,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -11802,6 +12045,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -11824,13 +12068,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11840,6 +12086,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -11862,13 +12109,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -11879,6 +12128,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -11901,13 +12151,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -11916,6 +12168,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -11928,13 +12181,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11945,6 +12200,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -11957,13 +12213,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11974,6 +12232,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -11986,13 +12245,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -12003,6 +12264,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -12015,6 +12277,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12024,8 +12290,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -12033,6 +12297,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12045,6 +12310,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12054,8 +12323,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -12064,6 +12331,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12076,6 +12344,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12085,14 +12357,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12100,6 +12371,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12109,8 +12384,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -12119,6 +12392,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12126,6 +12400,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12135,8 +12413,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -12145,6 +12421,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -12153,6 +12430,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12162,8 +12443,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -12176,6 +12455,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -12189,13 +12469,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -12205,6 +12487,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12218,13 +12501,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -12235,6 +12520,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12248,13 +12534,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -12263,6 +12551,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -12271,13 +12560,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -12288,6 +12579,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -12296,13 +12588,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -12313,6 +12607,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -12323,13 +12618,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -12431,6 +12728,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12441,13 +12739,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -12494,6 +12794,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -12504,13 +12805,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -12557,6 +12860,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12567,13 +12871,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -12585,6 +12891,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -12607,13 +12914,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12624,6 +12933,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -12646,13 +12956,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -12663,6 +12975,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -12685,13 +12998,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -12700,6 +13015,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12712,13 +13028,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12729,6 +13047,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12741,13 +13060,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12758,6 +13079,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12770,13 +13092,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12787,6 +13111,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -12799,6 +13124,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12808,8 +13137,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12818,6 +13145,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -12830,6 +13158,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12839,8 +13171,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -12849,6 +13179,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -12861,6 +13192,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12870,14 +13205,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -12885,6 +13219,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12894,8 +13232,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12904,6 +13240,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -12911,6 +13248,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12920,8 +13261,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12930,6 +13269,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -12939,6 +13279,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12948,8 +13292,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12962,6 +13304,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -12976,13 +13319,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12993,6 +13338,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -13006,13 +13352,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -13023,6 +13371,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13037,13 +13386,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -13052,6 +13403,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -13060,13 +13412,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -13077,6 +13431,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -13085,13 +13440,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -13102,6 +13459,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -13112,13 +13470,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -13221,6 +13581,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -13232,13 +13593,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -13250,6 +13613,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -13272,13 +13636,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -13287,6 +13653,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13297,13 +13664,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -13312,6 +13681,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13322,13 +13692,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -13337,6 +13709,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13347,13 +13720,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -13362,6 +13737,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -13374,6 +13750,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13383,19 +13763,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13405,19 +13788,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13427,14 +13813,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -13442,6 +13827,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13451,8 +13840,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -13463,6 +13850,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13477,13 +13865,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -13492,19 +13882,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -13513,19 +13906,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -13534,6 +13930,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -13542,13 +13939,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -13564,6 +13963,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13575,13 +13975,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -13605,6 +14007,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13616,13 +14019,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -13646,6 +14051,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13657,13 +14063,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -13682,6 +14090,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -13704,13 +14113,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13721,6 +14132,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -13743,13 +14155,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -13760,6 +14174,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -13782,13 +14197,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -13797,6 +14214,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13809,13 +14227,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13826,6 +14246,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13838,13 +14259,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13855,6 +14278,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13867,13 +14291,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13884,6 +14310,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -13896,6 +14323,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13905,8 +14336,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13915,6 +14344,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -13927,6 +14357,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13936,8 +14370,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -13946,6 +14378,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -13958,6 +14391,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13967,14 +14404,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -13982,6 +14418,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13991,8 +14431,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -14001,6 +14439,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -14008,6 +14447,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14017,8 +14460,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -14027,6 +14468,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -14036,6 +14478,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14045,8 +14491,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -14059,6 +14503,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14073,13 +14518,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14090,6 +14537,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14104,13 +14552,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -14121,6 +14571,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14135,13 +14586,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -14150,6 +14603,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -14158,13 +14612,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14175,6 +14631,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -14183,13 +14640,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14200,6 +14659,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -14210,13 +14670,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14514,6 +14976,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -14524,13 +14987,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -14577,6 +15042,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -14587,13 +15053,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -14640,6 +15108,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -14650,13 +15119,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -14668,6 +15139,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -14690,13 +15162,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14706,6 +15180,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -14728,13 +15203,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -14745,6 +15222,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -14767,13 +15245,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -14782,6 +15262,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14794,13 +15275,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14811,6 +15294,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14823,13 +15307,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14840,6 +15326,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14852,13 +15339,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14869,6 +15358,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -14881,6 +15371,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14890,8 +15384,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -14899,6 +15391,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -14911,6 +15404,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14920,8 +15417,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -14930,6 +15425,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -14942,6 +15438,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14951,14 +15451,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -14966,6 +15465,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14975,8 +15478,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14985,6 +15486,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -14992,6 +15494,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15001,8 +15507,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -15011,6 +15515,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -15019,6 +15524,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15028,8 +15537,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -15042,6 +15549,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -15055,13 +15563,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -15071,6 +15581,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -15084,13 +15595,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -15101,6 +15614,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -15114,13 +15628,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -15129,6 +15645,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -15137,13 +15654,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -15154,6 +15673,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -15162,13 +15682,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -15179,6 +15701,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -15189,13 +15712,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -15297,6 +15822,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15307,13 +15833,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -15360,6 +15888,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -15370,13 +15899,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -15423,6 +15954,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15433,13 +15965,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -15451,6 +15985,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -15473,13 +16008,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15490,6 +16027,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -15512,13 +16050,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -15529,6 +16069,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -15551,13 +16092,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -15566,6 +16109,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15578,13 +16122,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15595,6 +16141,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15607,13 +16154,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15624,6 +16173,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15636,13 +16186,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15653,6 +16205,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -15665,6 +16218,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15674,8 +16231,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15684,6 +16239,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15696,6 +16252,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15705,8 +16265,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -15715,6 +16273,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -15727,6 +16286,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15736,14 +16299,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -15751,6 +16313,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15760,8 +16326,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15770,6 +16334,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -15777,6 +16342,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15786,8 +16355,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15796,6 +16363,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -15805,6 +16373,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15814,8 +16386,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15828,6 +16398,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -15842,13 +16413,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15859,6 +16432,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15872,13 +16446,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -15889,6 +16465,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -15903,13 +16480,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -15918,6 +16497,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -15926,13 +16506,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15943,6 +16525,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -15951,13 +16534,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15968,6 +16553,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -15978,13 +16564,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -16087,6 +16675,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -16098,13 +16687,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -16116,6 +16707,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -16138,13 +16730,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -16153,6 +16747,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16163,13 +16758,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -16178,6 +16775,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16188,13 +16786,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -16203,6 +16803,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16213,13 +16814,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -16228,6 +16831,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -16240,6 +16844,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16249,19 +16857,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16271,19 +16882,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16293,14 +16907,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -16308,6 +16921,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16317,8 +16934,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -16329,6 +16944,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -16343,13 +16959,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -16358,19 +16976,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -16379,19 +17000,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -16400,6 +17024,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -16408,13 +17033,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -16430,6 +17057,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16441,13 +17069,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -16471,6 +17101,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16482,13 +17113,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -16512,6 +17145,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16523,13 +17157,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -16548,6 +17184,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -16570,13 +17207,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16587,6 +17226,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -16609,13 +17249,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -16626,6 +17268,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -16648,13 +17291,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -16663,6 +17308,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16675,13 +17321,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16692,6 +17340,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16704,13 +17353,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16721,6 +17372,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16733,13 +17385,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16750,6 +17404,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -16762,6 +17417,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16771,8 +17430,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16781,6 +17438,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -16793,6 +17451,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16802,8 +17464,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -16812,6 +17472,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -16824,6 +17485,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16833,14 +17498,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -16848,6 +17512,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16857,8 +17525,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16867,6 +17533,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -16874,6 +17541,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16883,8 +17554,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16893,6 +17562,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -16902,6 +17572,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16911,8 +17585,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16925,6 +17597,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -16939,13 +17612,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16956,6 +17631,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -16970,13 +17646,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -16987,6 +17665,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -17001,13 +17680,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -17016,6 +17697,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -17024,13 +17706,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -17041,6 +17725,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -17049,13 +17734,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -17066,6 +17753,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -17076,13 +17764,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -17378,6 +18068,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v9-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -17388,13 +18079,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_amd64.deb" artifacts from S3
@@ -17441,6 +18134,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v9-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -17451,13 +18145,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm.deb" artifacts from S3
@@ -17504,6 +18200,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v9-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -17514,13 +18211,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm64.deb" artifacts from S3
@@ -17532,6 +18231,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -17554,13 +18254,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17570,6 +18272,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -17592,13 +18295,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - staging
@@ -17609,6 +18314,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -17631,13 +18337,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -17646,6 +18354,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17658,13 +18367,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17675,6 +18386,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17687,13 +18399,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17704,6 +18418,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17716,13 +18431,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17733,6 +18450,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -17745,6 +18463,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17754,8 +18476,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to Quay
@@ -17763,6 +18483,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -17775,6 +18496,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17784,8 +18509,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to Quay
@@ -17794,6 +18517,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -17806,6 +18530,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17815,14 +18543,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17830,6 +18557,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17839,8 +18570,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -17849,6 +18578,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17856,6 +18586,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17865,8 +18599,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -17875,6 +18607,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -17883,6 +18616,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17892,8 +18629,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -17906,6 +18641,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -17919,13 +18655,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - production
@@ -17935,6 +18673,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -17948,13 +18687,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - production
@@ -17965,6 +18706,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -17978,13 +18720,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -17993,6 +18737,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -18001,13 +18746,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -18018,6 +18765,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -18026,13 +18774,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -18043,6 +18793,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -18053,13 +18804,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -18161,6 +18914,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18171,13 +18925,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_amd64.deb" artifacts from S3
@@ -18224,6 +18980,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -18234,13 +18991,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm.deb" artifacts from S3
@@ -18287,6 +19046,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18297,13 +19057,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm64.deb" artifacts from S3
@@ -18315,6 +19077,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -18337,13 +19100,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18354,6 +19119,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -18376,13 +19142,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - staging
@@ -18393,6 +19161,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -18415,13 +19184,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -18430,6 +19201,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18442,13 +19214,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18459,6 +19233,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18471,13 +19246,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18488,6 +19265,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18500,13 +19278,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18517,6 +19297,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -18529,6 +19310,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18538,8 +19323,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18548,6 +19331,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18560,6 +19344,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18569,8 +19357,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to Quay
@@ -18579,6 +19365,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -18591,6 +19378,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18600,14 +19391,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18615,6 +19405,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18624,8 +19418,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18634,6 +19426,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18641,6 +19434,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18650,8 +19447,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18660,6 +19455,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -18669,6 +19465,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18678,8 +19478,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18692,6 +19490,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18706,13 +19505,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18723,6 +19524,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18736,13 +19538,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - production
@@ -18753,6 +19557,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18767,13 +19572,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -18782,6 +19589,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18790,13 +19598,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18807,6 +19617,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18815,13 +19626,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18832,6 +19645,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -18842,13 +19656,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18951,6 +19767,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -18962,13 +19779,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag-fips_amd64.deb" artifacts from S3
@@ -18980,6 +19799,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -19002,13 +19822,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -19017,6 +19839,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19027,13 +19850,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -19042,6 +19867,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19052,13 +19878,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -19067,6 +19895,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19077,13 +19906,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to Quay
@@ -19092,6 +19923,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -19104,6 +19936,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19113,19 +19949,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19135,19 +19974,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19157,14 +19999,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -19172,6 +20013,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19181,8 +20026,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
@@ -19193,6 +20036,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -19207,13 +20051,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -19222,19 +20068,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -19243,19 +20092,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -19264,6 +20116,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -19272,13 +20125,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 services:
@@ -19444,6 +20299,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: b6d72a50d21ce97f8a564b11d9c86071e679172de1a8e210d38c3d5cb186b098
+hmac: b7638c6f24250a5b96deede877819a690689054fd815039089c0f9bcd58ebfb1
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -936,8 +936,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -962,8 +960,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -20244,8 +20240,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -20270,8 +20264,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -20299,6 +20291,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: b7638c6f24250a5b96deede877819a690689054fd815039089c0f9bcd58ebfb1
+hmac: 9c4cdef9d7fd1b4b41929a4456e5b9e3370bd07f5f7acd13695012f29acff612
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -898,12 +898,13 @@ update-api-import-path:
 # 		- build binaries with 'make release'
 # 		- run `make tag` and use its output to 'git tag' and 'git push --tags'
 .PHONY: update-tag
+update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))
-	git push origin $(GITTAG) && git push origin api/$(GITTAG)
+	git push $(TAG_REMOTE) $(GITTAG) && git push $(TAG_REMOTE) api/$(GITTAG)
 
 .PHONY: test-package
 test-package: remove-temp-files

--- a/dronegen/aws.go
+++ b/dronegen/aws.go
@@ -93,6 +93,7 @@ func kubernetesAssumeAwsRoleStep(s kubernetesRoleSettings) step {
 	return step{
 		Name:  s.name,
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_ACCESS_KEY_ID":     s.awsAccessKeyID,
 			"AWS_SECRET_ACCESS_KEY": s.awsSecretAccessKey,
@@ -125,6 +126,7 @@ func kubernetesUploadToS3Step(s kubernetesS3Settings) step {
 	return step{
 		Name:  "Upload to S3",
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_S3_BUCKET": {fromSecret: "AWS_S3_BUCKET"},
 			"AWS_REGION":    {raw: s.region},

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -70,7 +70,7 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
 		Pull:    "if-not-exists",
-		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes: []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -102,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -69,7 +69,8 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 	return step{
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
-		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
+		Pull:    "if-not-exists",
+		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -101,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = []volume{volumeDocker, volumeAwsConfig}
+	p.Volumes = dockerVolumes(volumeAwsConfig)
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -86,6 +86,25 @@ var (
 		Name: "awsconfig",
 		Path: "/root/.aws",
 	}
+
+	// volumeDockerConfig is a temporary volume for storing docker
+	// credentials for use with the Docker-in-Docker service we use
+	// to isolate the host machines docker daemon from the one used
+	// during the build. Mount this any time you use `volumeDocker`
+	//
+	// Drone claims to destroy the the temp volumes after a workflow
+	// has run, so it should be safe to write credentials etc.
+	volumeDockerConfig = volume{
+		Name: "dockerconfig",
+		Temp: &volumeTemp{},
+	}
+
+	// volumeRefDockerConfig is how you reference the docker config
+	// volume in a workflow step
+	volumeRefDockerConfig = volumeRef{
+		Name: "dockerconfig",
+		Path: "/root/.docker",
+	}
 )
 
 var buildboxVersion value
@@ -245,13 +264,13 @@ func dockerRegistryService() service {
 // dockerVolumes returns a slice of volumes
 // It includes the Docker socket volume by default, plus any extra volumes passed in
 func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker)
+	return append(v, volumeDocker, volumeDockerConfig)
 }
 
 // dockerVolumeRefs returns a slice of volumeRefs
 // It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
 func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker)
+	return append(v, volumeRefDocker, volumeRefDockerConfig)
 }
 
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
@@ -283,10 +302,16 @@ func waitForDockerStep() step {
 	return step{
 		Name:  "Wait for docker",
 		Image: "docker",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: []volumeRef{volumeRefDocker},
+		Volumes: dockerVolumeRefs(),
+		Environment: map[string]value{
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
+		},
 	}
 }
 
@@ -295,6 +320,7 @@ func waitForDockerRegistryStep() step {
 	return step{
 		Name:  "Wait for docker registry",
 		Image: "alpine",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"apk add curl",
 			fmt.Sprintf(`timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %%{http_code} http://%s/)" != "200" ]; do sleep 1; done'`, LocalRegistrySocket),
@@ -306,6 +332,7 @@ func verifyTaggedStep() step {
 	return step{
 		Name:  "Verify build is tagged",
 		Image: "alpine:latest",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"[ -n ${DRONE_TAG} ] || (echo 'DRONE_TAG is not set. Is the commit tagged?' && exit 1)",
 		},
@@ -317,6 +344,7 @@ func cloneRepoStep(clonePath, commit string) step {
 	return step{
 		Name:     "Check out code",
 		Image:    "alpine/git:latest",
+		Pull:     "if-not-exists",
 		Commands: cloneRepoCommands(clonePath, commit),
 	}
 }

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -261,18 +261,6 @@ func dockerRegistryService() service {
 	}
 }
 
-// dockerVolumes returns a slice of volumes
-// It includes the Docker socket volume by default, plus any extra volumes passed in
-func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker, volumeDockerConfig)
-}
-
-// dockerVolumeRefs returns a slice of volumeRefs
-// It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
-func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker, volumeRefDockerConfig)
-}
-
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
 func releaseMakefileTarget(b buildType) string {
 	makefileTarget := fmt.Sprintf("release-%s", b.arch)
@@ -307,7 +295,7 @@ func waitForDockerStep() step {
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
 			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: dockerVolumeRefs(),
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 		Environment: map[string]value{
 			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
 			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_images_release_version.go
+++ b/dronegen/container_images_release_version.go
@@ -48,7 +48,7 @@ func (rv *ReleaseVersion) buildVersionPipeline(triggerSetupSteps []step, flags *
 		dockerService(),
 		dockerRegistryService(),
 	}
-	pipeline.Volumes = dockerVolumes(volumeAwsConfig)
+	pipeline.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	pipeline.Environment = map[string]value{
 		"DEBIAN_FRONTEND": {
 			raw: "noninteractive",

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -62,6 +62,7 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 	loginCommands := []string{
 		"apk add --no-cache aws-cli",
 		fmt.Sprintf("aws %s get-login-password --region=%s | docker login -u=\"AWS\" --password-stdin %s", loginSubcommand, ecrRegion, domain),
+		`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 	}
 
 	if guaranteeUnique {
@@ -72,7 +73,9 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 		Name:        repoName,
 		IsImmutable: isImmutable,
 		EnvironmentVars: map[string]value{
-			"AWS_PROFILE": {raw: profileName},
+			"AWS_PROFILE":        {raw: profileName},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: domain,
 		RegistryOrg:    registryOrg,
@@ -112,17 +115,16 @@ func NewQuayContainerRepo(dockerUsername, dockerPassword string) *ContainerRepo 
 		Name:        "Quay",
 		IsImmutable: false,
 		EnvironmentVars: map[string]value{
-			"QUAY_USERNAME": {
-				fromSecret: dockerUsername,
-			},
-			"QUAY_PASSWORD": {
-				fromSecret: dockerPassword,
-			},
+			"QUAY_USERNAME":      {fromSecret: dockerUsername},
+			"QUAY_PASSWORD":      {fromSecret: dockerPassword},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: ProductionRegistryQuay,
 		RegistryOrg:    registryOrg,
 		LoginCommands: []string{
 			fmt.Sprintf("docker login -u=\"$QUAY_USERNAME\" -p=\"$QUAY_PASSWORD\" %q", ProductionRegistryQuay),
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
 	}
 }
@@ -254,7 +256,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +306,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +334,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -254,7 +254,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +304,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +332,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -41,6 +41,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -49,6 +50,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Delegate build to GitHub",
 			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GHA_APP_KEY": {fromSecret: "GITHUB_WORKFLOW_APP_PRIVATE_KEY"},
 			},

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -39,6 +39,22 @@ func main() {
 	pipelines = append(pipelines, buildContainerImagePipelines()...)
 	pipelines = append(pipelines, publishReleasePipeline())
 
+	// Inject the Drone-level dockerhub credentials into all non-exec
+	// pipelines. Drone will then use the docker credentials file in
+	// the named secret as its credentials when pulling images from
+	// dockerhub.
+	//
+	// Exec pipelines do not have the `image_pull_secrets` option, as
+	// their steps are invoked directly on the host runner and not
+	// into a per-step container.
+	for pidx := range pipelines {
+		p := &pipelines[pidx]
+		if p.Type == "exec" {
+			continue
+		}
+		p.ImagePullSecrets = append(p.ImagePullSecrets, "DOCKERHUB_CREDENTIALS")
+	}
+
 	if err := writePipelines(".drone.yml", pipelines); err != nil {
 		fmt.Println("failed writing drone pipelines:", err)
 		os.Exit(1)

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -121,7 +121,7 @@ func pushPipeline(b buildType) pipeline {
 	}
 	p.Trigger = triggerPush
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeDocker}
+	p.Volumes = []volume{volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -129,6 +129,7 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -138,8 +139,9 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:        "Build artifacts",
 			Image:       "docker",
+			Pull:        "if-not-exists",
 			Environment: pushEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker},
+			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 			Commands:    pushBuildCommands(b),
 		},
 		sendErrorToSlackStep(),

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,7 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
+	p.Volumes = []volume{volumeTmpfs, volumeAwsConfig, volumeDocker, volumeDockerConfig}
 
 	return p
 }
@@ -56,11 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -80,12 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefTmpfs,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,11 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = []volume{
-		volumeDocker,
-		volumeTmpfs,
-		volumeAwsConfig,
-	}
+	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
 
 	return p
 }
@@ -62,6 +58,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefAwsConfig,
 		},
 		Commands: []string{
@@ -85,6 +82,7 @@ func executeRelcliStep(name string, command string) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefTmpfs,
 			volumeRefAwsConfig,
 		},

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -56,7 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -76,7 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -254,7 +254,7 @@ func tagPipeline(b buildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeAwsConfig, volumeDocker}
+	p.Volumes = dockerVolumes(volumeAwsConfig)
 	p.Services = []service{
 		dockerService(),
 	}
@@ -262,6 +262,7 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -271,13 +272,15 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:        "Build artifacts",
 			Image:       "docker",
+			Pull:        "if-not-exists",
 			Environment: tagEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker},
+			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 			Commands:    tagBuildCommands(b),
 		},
 		{
 			Name:     "Copy artifacts",
 			Image:    "docker",
+			Pull:     "if-not-exists",
 			Commands: tagCopyArtifactCommands(b),
 		},
 		kubernetesAssumeAwsRoleStep(kubernetesRoleSettings{
@@ -297,6 +300,7 @@ func tagPipeline(b buildType) pipeline {
 		{
 			Name:     "Register artifacts",
 			Image:    "docker",
+			Pull:     "if-not-exists",
 			Commands: tagCreateReleaseAssetCommands(b, "", extraQualifications),
 			Environment: map[string]value{
 				"RELEASES_CERT": {fromSecret: "RELEASES_CERT"},
@@ -445,12 +449,10 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
-	packageDockerVolumes := []volume{
-		volumeDocker,
-		volumeAwsConfig,
-	}
+	packageDockerVolumes := dockerVolumes(volumeAwsConfig)
 	packageDockerVolumeRefs := []volumeRef{
 		volumeRefDocker,
+		volumeRefDockerConfig,
 		volumeRefAwsConfig,
 	}
 	packageDockerService := dockerService()

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -254,7 +254,7 @@ func tagPipeline(b buildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -449,7 +449,7 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
-	packageDockerVolumes := dockerVolumes(volumeAwsConfig)
+	packageDockerVolumes := []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	packageDockerVolumeRefs := []volumeRef{
 		volumeRefDocker,
 		volumeRefDockerConfig,

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -29,20 +29,21 @@ import (
 type pipeline struct {
 	comment string
 
-	Kind        string           `yaml:"kind"`
-	Type        string           `yaml:"type"`
-	Name        string           `yaml:"name"`
-	Environment map[string]value `yaml:"environment,omitempty"`
-	Trigger     trigger          `yaml:"trigger"`
-	Workspace   workspace        `yaml:"workspace,omitempty"`
-	Platform    platform         `yaml:"platform,omitempty"`
-	Node        map[string]value `yaml:"node,omitempty"`
-	Clone       clone            `yaml:"clone,omitempty"`
-	DependsOn   []string         `yaml:"depends_on,omitempty"`
-	Concurrency concurrency      `yaml:"concurrency,omitempty"`
-	Steps       []step           `yaml:"steps"`
-	Services    []service        `yaml:"services,omitempty"`
-	Volumes     []volume         `yaml:"volumes,omitempty"`
+	Kind             string           `yaml:"kind"`
+	Type             string           `yaml:"type"`
+	Name             string           `yaml:"name"`
+	Environment      map[string]value `yaml:"environment,omitempty"`
+	Trigger          trigger          `yaml:"trigger"`
+	Workspace        workspace        `yaml:"workspace,omitempty"`
+	Platform         platform         `yaml:"platform,omitempty"`
+	Node             map[string]value `yaml:"node,omitempty"`
+	Clone            clone            `yaml:"clone,omitempty"`
+	DependsOn        []string         `yaml:"depends_on,omitempty"`
+	Concurrency      concurrency      `yaml:"concurrency,omitempty"`
+	Steps            []step           `yaml:"steps"`
+	Services         []service        `yaml:"services,omitempty"`
+	Volumes          []volume         `yaml:"volumes,omitempty"`
+	ImagePullSecrets []string         `yaml:"image_pull_secrets,omitempty"`
 }
 
 func newKubePipeline(name string) pipeline {
@@ -170,6 +171,7 @@ type volumeRef struct {
 type step struct {
 	Name        string              `yaml:"name"`
 	Image       string              `yaml:"image,omitempty"`
+	Pull        string              `yaml:"pull,omitempty"`
 	Commands    []string            `yaml:"commands,omitempty"`
 	Environment map[string]value    `yaml:"environment,omitempty"`
 	Volumes     []volumeRef         `yaml:"volumes,omitempty"`


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/23956
Backports https://github.com/gravitational/teleport/pull/23957

## Summary

After moving Drone to AWS, we're seeing image pulls get rate limited because they're all coming from the same IP (an AWS NAT gateway). To avoid the rate limiting on AWS, we refactor pipelines to cache/reuse images where possible, as well as add authentication to Docker Hub pulls.

## Related Issues & PRs

Supersedes https://github.com/gravitational/teleport/pull/23955

Contributes to https://github.com/gravitational/SecOps/issues/285

See the orginal PRs to master for more context.

## Testing
This is undergoing final testing at:

* build: https://drone.platform.teleport.sh/gravitational/teleport-private/533
* promote: https://drone.platform.teleport.sh/gravitational/teleport-private/539

These tests are based off the most recent `branch/v11` so I'll be watching to see if they flush out unrelated issues, since there hasn't been a release in  ~80 commits.