### PR TITLE
[v10] Add Docker Hub login to Drone's Kubernetes pipelines

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8557,6 +8557,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -8567,13 +8568,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -8620,6 +8623,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -8630,13 +8634,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -8683,6 +8689,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -8693,13 +8700,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -8711,6 +8720,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
@@ -8720,13 +8730,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -8736,6 +8748,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
@@ -8745,13 +8758,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -8762,6 +8777,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
@@ -8771,13 +8787,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8786,6 +8804,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
@@ -8797,13 +8816,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -8901,6 +8922,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -8911,13 +8933,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -8964,6 +8988,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -8974,13 +8999,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -9027,6 +9054,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -9037,13 +9065,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -9055,6 +9085,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -9064,13 +9095,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -9081,6 +9114,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -9090,13 +9124,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -9107,6 +9143,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -9116,13 +9153,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -9131,6 +9170,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9142,13 +9182,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -9247,6 +9289,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -9258,13 +9301,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -9276,6 +9321,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -9285,13 +9331,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -9300,6 +9348,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
@@ -9309,13 +9358,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -9331,6 +9382,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9342,13 +9394,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9370,6 +9424,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9381,13 +9436,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9409,6 +9466,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -9420,13 +9478,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -9443,6 +9503,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -9452,13 +9513,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -9469,6 +9532,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -9478,13 +9542,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -9495,6 +9561,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64 > /dev/null 2>&1 && echo 'Found existing image,
     skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -9504,13 +9571,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9519,6 +9588,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version") > /dev/null 2>&1 && echo 'Found existing image, skipping'
     || (docker manifest create 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
@@ -9530,13 +9600,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -9732,6 +9804,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9740,13 +9813,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9762,6 +9837,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9770,13 +9846,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9792,6 +9870,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -9800,13 +9879,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9822,6 +9903,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -9834,6 +9916,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9843,8 +9929,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -9852,6 +9936,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -9864,6 +9949,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9873,8 +9962,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -9883,6 +9970,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -9895,6 +9983,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9904,8 +9996,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -9916,6 +10006,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -9923,6 +10014,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9932,8 +10027,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -9946,6 +10039,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -9953,6 +10047,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9962,8 +10060,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -9972,6 +10068,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -9980,6 +10077,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -9989,8 +10090,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -10003,6 +10102,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -10016,13 +10116,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -10032,6 +10134,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -10045,13 +10148,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -10062,6 +10167,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -10075,13 +10181,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -10094,6 +10202,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -10102,13 +10211,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -10123,6 +10234,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -10131,13 +10243,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -10148,6 +10262,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -10158,13 +10273,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -10175,6 +10292,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10183,13 +10301,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10205,6 +10325,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10213,13 +10334,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10235,6 +10358,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10243,13 +10367,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10265,6 +10391,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -10277,6 +10404,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10286,8 +10417,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -10296,6 +10425,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10308,6 +10438,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10317,8 +10451,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -10327,6 +10459,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -10339,6 +10472,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10348,8 +10485,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -10360,6 +10495,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10367,6 +10503,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10376,8 +10516,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -10390,6 +10528,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10397,6 +10536,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10406,8 +10549,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -10416,6 +10557,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -10425,6 +10567,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10434,8 +10580,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -10448,6 +10592,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10462,13 +10607,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -10479,6 +10626,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -10492,13 +10640,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -10509,6 +10659,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10523,13 +10674,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -10542,6 +10695,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -10550,13 +10704,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -10571,6 +10727,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -10579,13 +10736,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -10596,6 +10755,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -10606,13 +10766,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -10623,6 +10785,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10632,13 +10795,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10654,6 +10819,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -10666,6 +10832,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10675,8 +10845,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10687,11 +10855,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10701,8 +10874,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10713,11 +10884,16 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10727,14 +10903,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -10742,6 +10917,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10751,8 +10930,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -10763,6 +10940,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -10777,13 +10955,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10796,19 +10976,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10821,19 +11004,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -10842,6 +11028,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -10850,13 +11037,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v10-amd64 and push it to Local Registry
@@ -10865,6 +11054,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10874,13 +11064,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10896,6 +11088,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10905,13 +11098,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10927,6 +11122,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker pull 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
@@ -10936,13 +11132,15 @@ steps:
   - docker push drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10958,6 +11156,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -10970,6 +11169,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -10979,8 +11182,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -10989,6 +11190,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -11001,6 +11203,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11010,8 +11216,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -11020,6 +11224,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -11032,6 +11237,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11041,8 +11250,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -11053,6 +11260,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11060,6 +11268,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11069,8 +11281,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -11083,6 +11293,7 @@ steps:
     ] && echo "skipping" || echo "continuing"
   - '[ -f /go/vars/release-is-prerelease ] && exit 0'
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11090,6 +11301,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11099,8 +11314,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -11109,6 +11322,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -11118,6 +11332,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11127,8 +11345,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -11141,6 +11357,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11155,13 +11372,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -11172,6 +11391,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11186,13 +11406,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -11203,6 +11425,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -11217,13 +11440,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -11236,6 +11461,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -11244,13 +11470,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -11265,6 +11493,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -11273,13 +11502,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -11290,6 +11521,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -11300,13 +11532,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -11604,6 +11838,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -11614,13 +11849,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -11667,6 +11904,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -11677,13 +11915,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -11730,6 +11970,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v11-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -11740,13 +11981,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -11758,6 +12001,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -11780,13 +12024,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11796,6 +12042,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -11818,13 +12065,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -11835,6 +12084,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -11857,13 +12107,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -11872,6 +12124,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -11884,13 +12137,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11901,6 +12156,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -11913,13 +12169,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11930,6 +12188,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -11942,13 +12201,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11959,6 +12220,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -11971,6 +12233,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -11980,8 +12246,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -11989,6 +12253,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12001,6 +12266,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12010,8 +12279,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -12020,6 +12287,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12032,6 +12300,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12041,14 +12313,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12056,6 +12327,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12065,8 +12340,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -12075,6 +12348,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -12082,6 +12356,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12091,8 +12369,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -12101,6 +12377,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -12109,6 +12386,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12118,8 +12399,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -12132,6 +12411,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -12145,13 +12425,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -12161,6 +12443,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -12174,13 +12457,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -12191,6 +12476,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -12204,13 +12490,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -12219,6 +12507,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -12227,13 +12516,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -12244,6 +12535,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -12252,13 +12544,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -12269,6 +12563,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -12279,13 +12574,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -12387,6 +12684,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12397,13 +12695,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -12450,6 +12750,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -12460,13 +12761,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -12513,6 +12816,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -12523,13 +12827,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -12541,6 +12847,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -12563,13 +12870,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12580,6 +12889,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -12602,13 +12912,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -12619,6 +12931,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -12641,13 +12954,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -12656,6 +12971,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12668,13 +12984,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12685,6 +13003,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12697,13 +13016,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12714,6 +13035,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -12726,13 +13048,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12743,6 +13067,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -12755,6 +13080,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12764,8 +13093,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12774,6 +13101,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -12786,6 +13114,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12795,8 +13127,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -12805,6 +13135,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -12817,6 +13148,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12826,14 +13161,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -12841,6 +13175,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12850,8 +13188,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12860,6 +13196,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -12867,6 +13204,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12876,8 +13217,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12886,6 +13225,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -12895,6 +13235,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -12904,8 +13248,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12918,6 +13260,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -12932,13 +13275,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12949,6 +13294,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -12962,13 +13308,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -12979,6 +13327,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -12993,13 +13342,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -13008,6 +13359,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -13016,13 +13368,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -13033,6 +13387,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -13041,13 +13396,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -13058,6 +13415,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -13068,13 +13426,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -13177,6 +13537,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v11-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -13188,13 +13549,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -13206,6 +13569,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -13228,13 +13592,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -13243,6 +13609,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13253,13 +13620,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -13268,6 +13637,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13278,13 +13648,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -13293,6 +13665,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -13303,13 +13676,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -13318,6 +13693,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -13330,6 +13706,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13339,19 +13719,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13361,19 +13744,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13383,14 +13769,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -13398,6 +13783,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13407,8 +13796,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -13419,6 +13806,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -13433,13 +13821,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -13448,19 +13838,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -13469,19 +13862,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -13490,6 +13886,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -13498,13 +13895,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -13520,6 +13919,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13531,13 +13931,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -13561,6 +13963,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13572,13 +13975,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -13602,6 +14007,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v11-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -13613,13 +14019,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -13638,6 +14046,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -13660,13 +14069,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13677,6 +14088,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -13699,13 +14111,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -13716,6 +14130,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -13738,13 +14153,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -13753,6 +14170,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13765,13 +14183,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13782,6 +14202,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13794,13 +14215,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13811,6 +14234,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -13823,13 +14247,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13840,6 +14266,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -13852,6 +14279,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13861,8 +14292,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13871,6 +14300,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -13883,6 +14313,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13892,8 +14326,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -13902,6 +14334,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -13914,6 +14347,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13923,14 +14360,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -13938,6 +14374,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13947,8 +14387,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13957,6 +14395,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -13964,6 +14403,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -13973,8 +14416,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13983,6 +14424,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -13992,6 +14434,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14001,8 +14447,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -14015,6 +14459,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14029,13 +14474,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14046,6 +14493,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14060,13 +14508,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -14077,6 +14527,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -14091,13 +14542,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -14106,6 +14559,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -14114,13 +14568,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14131,6 +14587,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -14139,13 +14596,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14156,6 +14615,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -14166,13 +14626,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -14470,6 +14932,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -14480,13 +14943,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -14533,6 +14998,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -14543,13 +15009,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -14596,6 +15064,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v10-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -14606,13 +15075,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -14624,6 +15095,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -14646,13 +15118,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14662,6 +15136,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -14684,13 +15159,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -14701,6 +15178,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -14723,13 +15201,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -14738,6 +15218,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14750,13 +15231,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14767,6 +15250,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14779,13 +15263,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14796,6 +15282,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -14808,13 +15295,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -14825,6 +15314,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -14837,6 +15327,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14846,8 +15340,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -14855,6 +15347,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -14867,6 +15360,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14876,8 +15373,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -14886,6 +15381,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -14898,6 +15394,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14907,14 +15407,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -14922,6 +15421,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14931,8 +15434,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14941,6 +15442,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -14948,6 +15450,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14957,8 +15463,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14967,6 +15471,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -14975,6 +15480,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -14984,8 +15493,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14998,6 +15505,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -15011,13 +15519,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -15027,6 +15537,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -15040,13 +15551,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -15057,6 +15570,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -15070,13 +15584,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -15085,6 +15601,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -15093,13 +15610,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -15110,6 +15629,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -15118,13 +15638,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -15135,6 +15657,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -15145,13 +15668,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -15253,6 +15778,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15263,13 +15789,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -15316,6 +15844,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -15326,13 +15855,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -15379,6 +15910,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -15389,13 +15921,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -15407,6 +15941,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -15429,13 +15964,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15446,6 +15983,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -15468,13 +16006,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -15485,6 +16025,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -15507,13 +16048,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -15522,6 +16065,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15534,13 +16078,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15551,6 +16097,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15563,13 +16110,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15580,6 +16129,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -15592,13 +16142,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -15609,6 +16161,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -15621,6 +16174,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15630,8 +16187,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15640,6 +16195,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15652,6 +16208,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15661,8 +16221,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -15671,6 +16229,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -15683,6 +16242,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15692,14 +16255,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -15707,6 +16269,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15716,8 +16282,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15726,6 +16290,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -15733,6 +16298,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15742,8 +16311,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15752,6 +16319,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -15761,6 +16329,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -15770,8 +16342,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -15784,6 +16354,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -15798,13 +16369,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15815,6 +16388,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -15828,13 +16402,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -15845,6 +16421,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -15859,13 +16436,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -15874,6 +16453,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -15882,13 +16462,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15899,6 +16481,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -15907,13 +16490,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15924,6 +16509,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -15934,13 +16520,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -16043,6 +16631,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v10-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -16054,13 +16643,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -16072,6 +16663,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -16094,13 +16686,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -16109,6 +16703,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16119,13 +16714,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -16134,6 +16731,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16144,13 +16742,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -16159,6 +16759,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -16169,13 +16770,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -16184,6 +16787,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -16196,6 +16800,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16205,19 +16813,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16227,19 +16838,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16249,14 +16863,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -16264,6 +16877,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16273,8 +16890,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -16285,6 +16900,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -16299,13 +16915,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -16314,19 +16932,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -16335,19 +16956,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -16356,6 +16980,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -16364,13 +16989,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -16386,6 +17013,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-amd64-builder" --platform
     "linux/amd64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-amd64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16397,13 +17025,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -16427,6 +17057,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm-builder" --platform
     "linux/arm" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16438,13 +17069,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -16468,6 +17101,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-operator-v10-arm64-builder" --platform
     "linux/arm64" --tag drone-docker-registry:5000/teleport-operator:$(cat "/go/var/full-version")-arm64
     --file "/go/src/github.com/gravitational/teleport/operator/Dockerfile" --build-arg
@@ -16479,13 +17113,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -16504,6 +17140,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -16526,13 +17163,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16543,6 +17182,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -16565,13 +17205,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -16582,6 +17224,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -16604,13 +17247,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -16619,6 +17264,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16631,13 +17277,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16648,6 +17296,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16660,13 +17309,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16677,6 +17328,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-operator:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -16689,13 +17341,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -16706,6 +17360,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
@@ -16718,6 +17373,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16727,8 +17386,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16737,6 +17394,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
@@ -16749,6 +17407,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16758,8 +17420,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -16768,6 +17428,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
@@ -16780,6 +17441,10 @@ steps:
   - docker push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16789,14 +17454,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -16804,6 +17468,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16813,8 +17481,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16823,6 +17489,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -16830,6 +17497,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16839,8 +17510,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16849,6 +17518,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version") --amend
@@ -16858,6 +17528,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-operator:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -16867,8 +17541,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -16881,6 +17553,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -16895,13 +17568,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16912,6 +17587,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -16926,13 +17602,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -16943,6 +17621,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-operator:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-operator:$(cat
@@ -16957,13 +17636,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -16972,6 +17653,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/major-version")-arm
@@ -16980,13 +17662,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16997,6 +17681,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/minor-version")-arm
@@ -17005,13 +17690,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -17022,6 +17709,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-operator:$(cat "/go/var/full-version")
@@ -17032,13 +17720,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -17334,6 +18024,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v9-amd64-builder" --target "teleport"
     --platform "linux/amd64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-amd64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_amd64.deb
@@ -17344,13 +18035,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_amd64.deb" artifacts from S3
@@ -17397,6 +18090,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v9-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm.deb
@@ -17407,13 +18101,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm.deb" artifacts from S3
@@ -17460,6 +18156,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-v9-arm64-builder" --target "teleport"
     --platform "linux/arm64" --tag drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm64
     --file "/go/build/Dockerfile-teleport" --build-arg DEB_PATH=teleport_$(cat "/go/var/full-version")_arm64.deb
@@ -17470,13 +18167,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm64.deb" artifacts from S3
@@ -17488,6 +18187,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -17510,13 +18210,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17526,6 +18228,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -17548,13 +18251,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - staging
@@ -17565,6 +18270,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -17587,13 +18293,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -17602,6 +18310,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17614,13 +18323,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17631,6 +18342,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17643,13 +18355,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17660,6 +18374,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -17672,13 +18387,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -17689,6 +18406,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -17701,6 +18419,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17710,8 +18432,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to Quay
@@ -17719,6 +18439,7 @@ steps:
   commands:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport:$(cat "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -17731,6 +18452,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17740,8 +18465,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to Quay
@@ -17750,6 +18473,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -17762,6 +18486,10 @@ steps:
   - docker push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17771,14 +18499,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/major-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/major-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17786,6 +18513,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17795,8 +18526,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -17805,6 +18534,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-amd64 --amend
     quay.io/gravitational/teleport:$(cat "/go/var/minor-version")-arm --amend quay.io/gravitational/teleport:$(cat
@@ -17812,6 +18542,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17821,8 +18555,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -17831,6 +18563,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport:$(cat "/go/var/full-version") --amend quay.io/gravitational/teleport:$(cat
@@ -17839,6 +18572,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport:$(cat "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -17848,8 +18585,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -17862,6 +18597,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-amd64
@@ -17875,13 +18611,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - production
@@ -17891,6 +18629,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm
@@ -17904,13 +18643,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - production
@@ -17921,6 +18662,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")-arm64
@@ -17934,13 +18676,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -17949,6 +18693,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/major-version")-arm
@@ -17957,13 +18702,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -17974,6 +18721,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport:$(cat "/go/var/minor-version")-arm
@@ -17982,13 +18730,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -17999,6 +18749,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport:$(cat "/go/var/full-version") --amend
@@ -18009,13 +18760,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -18117,6 +18870,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-amd64-builder" --target
     "teleport" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18127,13 +18881,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_amd64.deb" artifacts from S3
@@ -18180,6 +18936,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-arm-builder" --target "teleport"
     --platform "linux/arm" --tag drone-docker-registry:5000/teleport-ent:$(cat "/go/var/full-version")-arm
     --file "/go/build/Dockerfile-teleport-ent" --build-arg DEB_PATH=teleport-ent_$(cat
@@ -18190,13 +18947,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm.deb" artifacts from S3
@@ -18243,6 +19002,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-arm64-builder" --target
     "teleport" --platform "linux/arm64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 --file "/go/build/Dockerfile-teleport-ent" --build-arg
@@ -18253,13 +19013,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm64.deb" artifacts from S3
@@ -18271,6 +19033,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-amd64 > /dev/null 2>&1 && echo 'Found existing
@@ -18293,13 +19056,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18310,6 +19075,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm > /dev/null 2>&1 && echo 'Found existing
@@ -18332,13 +19098,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - staging
@@ -18349,6 +19117,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-arm64 > /dev/null 2>&1 && echo 'Found existing
@@ -18371,13 +19140,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -18386,6 +19157,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18398,13 +19170,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18415,6 +19189,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18427,13 +19202,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18444,6 +19221,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP > /dev/null 2>&1 && echo 'Found existing image,
@@ -18456,13 +19234,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -18473,6 +19253,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
@@ -18485,6 +19266,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18494,8 +19279,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18504,6 +19287,7 @@ steps:
   - docker pull --platform "linux/arm" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18516,6 +19300,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18525,8 +19313,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to Quay
@@ -18535,6 +19321,7 @@ steps:
   - docker pull --platform "linux/arm64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
@@ -18547,6 +19334,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18556,14 +19347,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18571,6 +19361,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18580,8 +19374,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18590,6 +19382,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18597,6 +19390,10 @@ steps:
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18606,8 +19403,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18616,6 +19411,7 @@ steps:
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version") --amend
@@ -18625,6 +19421,10 @@ steps:
     "/go/var/full-version"))
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -18634,8 +19434,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -18648,6 +19446,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18662,13 +19461,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18679,6 +19480,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm
@@ -18692,13 +19494,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - production
@@ -18709,6 +19513,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-arm64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-arm64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -18723,13 +19528,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -18738,6 +19545,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-arm
@@ -18746,13 +19554,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18763,6 +19573,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-amd64
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-arm
@@ -18771,13 +19582,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18788,6 +19601,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")
@@ -18798,13 +19612,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -18907,6 +19723,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker buildx build --push --builder "teleport-ent-v9-fips-amd64-builder" --target
     "teleport-fips" --platform "linux/amd64" --tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 --file "/go/build/Dockerfile-teleport-ent-fips"
@@ -18918,13 +19735,15 @@ steps:
   environment:
     AWS_PROFILE: ecr-authenticated-pull
     DOCKER_BUILDKIT: "1"
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag-fips_amd64.deb" artifacts from S3
@@ -18936,6 +19755,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips-amd64 > /dev/null 2>&1 && echo 'Found
@@ -18958,13 +19778,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -18973,6 +19795,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/major-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -18983,13 +19806,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -18998,6 +19823,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/minor-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19008,13 +19834,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -19023,6 +19851,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr get-login-password --region=us-west-2 | docker login -u="AWS" --password-stdin
     146628656107.dkr.ecr.us-west-2.amazonaws.com
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - TIMESTAMP=$(date -d @"$DRONE_BUILD_CREATED" '+%Y%m%d%H%M')
   - docker manifest inspect 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-ent:$(cat
     "/go/var/full-version")-$TIMESTAMP-fips > /dev/null 2>&1 && echo 'Found existing
@@ -19033,13 +19862,15 @@ steps:
   - docker logout "146628656107.dkr.ecr.us-west-2.amazonaws.com"
   environment:
     AWS_PROFILE: ecr-staging
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to Quay
@@ -19048,6 +19879,7 @@ steps:
   - docker pull --platform "linux/amd64" drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
@@ -19060,6 +19892,10 @@ steps:
   - docker push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19069,19 +19905,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19091,19 +19930,22 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19113,14 +19955,13 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
   image: docker
   commands:
   - docker login -u="$QUAY_USERNAME" -p="$QUAY_PASSWORD" "quay.io"
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips --amend
@@ -19128,6 +19969,10 @@ steps:
     docker manifest push quay.io/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips)
   - docker logout "quay.io"
   environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
     QUAY_PASSWORD:
       from_secret: PRODUCTION_QUAYIO_DOCKER_PASSWORD
     QUAY_USERNAME:
@@ -19137,8 +19982,6 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
@@ -19149,6 +19992,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips-amd64
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker tag drone-docker-registry:5000/teleport-ent:$(cat
     "/go/var/full-version")-fips-amd64 public.ecr.aws/gravitational/teleport-ent:$(cat
@@ -19163,13 +20007,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -19178,19 +20024,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/major-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -19199,19 +20048,22 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
     --amend public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips-amd64
   - docker manifest push public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/minor-version")-fips
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -19220,6 +20072,7 @@ steps:
   - apk add --no-cache aws-cli
   - aws ecr-public get-login-password --region=us-east-1 | docker login -u="AWS" --password-stdin
     public.ecr.aws
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
   - docker manifest inspect public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
     > /dev/null 2>&1 && echo 'Found existing image, skipping' || (docker manifest
     create public.ecr.aws/gravitational/teleport-ent:$(cat "/go/var/full-version")-fips
@@ -19228,13 +20081,15 @@ steps:
   - docker logout "public.ecr.aws"
   environment:
     AWS_PROFILE: ecr-production
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: awsconfig
     path: /root/.aws
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 services:
@@ -19400,6 +20255,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 1786009bcdd1c95bd4eddfb04bf2939b1105e2bdd6c00049dc109bbc612b0866
+hmac: cbe93fa7e2ef50d7d9ba09b9504673dcbfcc2253d348bb1413fa6e8c9774fd63
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -908,8 +908,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -934,8 +932,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -20200,8 +20196,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -20226,8 +20220,6 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -20255,6 +20247,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: cbe93fa7e2ef50d7d9ba09b9504673dcbfcc2253d348bb1413fa6e8c9774fd63
+hmac: 3fa6da738b8cc780170001d7791c96115662e94d044b6c4ed524d752303a1a53
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -61,6 +61,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -79,13 +80,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -103,6 +114,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -130,6 +143,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -166,6 +183,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -184,13 +202,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -206,6 +234,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -233,6 +263,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -269,6 +303,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -289,13 +324,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -313,6 +358,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -340,6 +387,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -376,6 +427,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -394,13 +446,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -416,6 +478,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -443,6 +507,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -790,13 +858,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -830,6 +908,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Clean up previously built artifacts
@@ -854,6 +934,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -868,13 +950,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1098,6 +1184,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1116,13 +1203,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1138,6 +1235,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Send Slack notification
   image: plugins/slack
   settings:
@@ -1165,6 +1264,10 @@ services:
 volumes:
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1201,6 +1304,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -1219,6 +1323,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
@@ -1244,6 +1349,8 @@ steps:
   when:
     status:
     - failure
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -1614,6 +1721,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1637,13 +1745,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1659,8 +1777,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1674,6 +1795,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1698,6 +1820,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1710,6 +1833,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -1769,6 +1893,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1802,6 +1930,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -1825,13 +1954,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -1849,8 +1988,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -1861,6 +2003,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -1885,6 +2028,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -1897,6 +2041,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -1956,6 +2101,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -1989,6 +2138,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2012,13 +2162,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2036,8 +2196,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2055,6 +2218,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2079,6 +2243,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2091,6 +2256,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2150,6 +2316,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2183,6 +2353,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -2206,13 +2377,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -2230,8 +2411,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -2240,6 +2424,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2264,6 +2449,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2276,6 +2462,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -2335,6 +2522,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2389,13 +2580,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2437,6 +2638,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2484,6 +2686,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2498,6 +2702,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2522,6 +2727,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2591,13 +2797,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2652,13 +2862,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2698,6 +2918,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2746,6 +2967,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -2758,6 +2981,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2782,6 +3006,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -2851,13 +3076,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -2912,13 +3141,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -2960,6 +3199,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3000,6 +3240,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3012,6 +3254,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3036,6 +3279,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3103,10 +3347,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3161,13 +3409,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3207,6 +3465,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3248,6 +3507,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3258,6 +3519,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3282,6 +3544,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3349,10 +3612,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3386,6 +3653,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -3409,13 +3677,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -3431,8 +3709,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -3443,6 +3724,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3467,6 +3749,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3479,6 +3762,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -3538,6 +3822,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3592,13 +3880,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3640,6 +3938,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3687,6 +3986,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -3701,6 +4002,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3725,6 +4027,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -3794,13 +4097,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -3855,13 +4162,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3903,6 +4220,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3943,6 +4261,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -3955,6 +4275,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -3979,6 +4300,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4046,10 +4368,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4733,6 +5059,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -4756,13 +5083,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -4778,8 +5115,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
@@ -4790,6 +5130,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -4814,6 +5155,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -4826,6 +5168,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -4885,6 +5228,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -4918,6 +5265,7 @@ clone:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -4936,6 +5284,7 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
+  pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
@@ -4944,6 +5293,8 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5247,13 +5598,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5295,6 +5656,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5335,6 +5697,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Copy artifacts
@@ -5347,6 +5711,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5371,6 +5736,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -5438,10 +5804,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -5759,13 +6129,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5807,6 +6187,7 @@ steps:
     path: /root/.aws
 - name: Assume Build AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5854,6 +6235,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
   - name: tmpfs
@@ -5868,6 +6251,7 @@ steps:
     \;
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -5892,6 +6276,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -5961,13 +6346,17 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
+- name: awsconfig
+  temp: {}
 - name: dockersock
   temp: {}
-- name: awsconfig
+- name: dockerconfig
   temp: {}
 - name: tmpfs
   temp:
     medium: memory
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6001,6 +6390,7 @@ depends_on:
 steps:
 - name: Check out code
   image: docker:git
+  pull: if-not-exists
   commands:
   - mkdir -p /go/src/github.com/gravitational/teleport
   - cd /go/src/github.com/gravitational/teleport
@@ -6024,13 +6414,23 @@ steps:
       from_secret: GITHUB_PRIVATE_KEY
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make
   - chown -R $UID:$GID /go
@@ -6050,8 +6450,11 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Copy artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - cd /go/src/github.com/gravitational/teleport
   - find . -maxdepth 1 -iname "teleport*.zip" -print -exec cp {} /go/artifacts \;
@@ -6061,6 +6464,7 @@ steps:
     done && ls -l
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6085,6 +6489,7 @@ steps:
     path: /root/.aws
 - name: Upload to S3
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - cd /go/artifacts/
   - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
@@ -6097,6 +6502,7 @@ steps:
     path: /root/.aws
 - name: Register artifacts
   image: docker
+  pull: if-not-exists
   commands:
   - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
   - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
@@ -6156,6 +6562,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -6544,13 +6954,23 @@ steps:
   - git checkout ${DRONE_COMMIT}
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Configure Staging AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6575,6 +6995,7 @@ steps:
     path: /root/.aws
 - name: Configure Production AWS Profile
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6599,6 +7020,7 @@ steps:
     path: /root/.aws
 - name: Build and push buildbox
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6612,12 +7034,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6632,12 +7057,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-arm
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6652,12 +7080,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-arm:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6672,12 +7103,15 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Build and push buildbox-centos7-fips
   image: docker
+  pull: if-not-exists
   commands:
   - apk add --no-cache make aws-cli
   - chown -R $UID:$GID /go
@@ -6692,10 +7126,12 @@ steps:
     login -u="AWS" --password-stdin public.ecr.aws
   - docker push public.ecr.aws/gravitational/teleport-buildbox-centos7-fips:$BUILDBOX_VERSION
   volumes:
-  - name: dockersock
-    path: /var/run
   - name: awsconfig
     path: /root/.aws
+  - name: dockersock
+    path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 services:
 - name: Start Docker
   image: docker:dind
@@ -6704,10 +7140,14 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6736,6 +7176,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6765,11 +7207,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -6779,6 +7223,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6826,6 +7271,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -6914,6 +7360,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6942,6 +7390,8 @@ steps:
   image: alpine:latest
   commands:
   - echo "This command, step, and pipeline never runs"
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -6971,11 +7421,13 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -6985,6 +7437,7 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
 - name: Assume Download AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7032,6 +7485,7 @@ steps:
   - Check out code
 - name: Assume Upload AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7121,6 +7575,8 @@ volumes:
     medium: memory
 - name: awsconfig
   temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 kind: pipeline
@@ -7919,19 +8375,30 @@ depends_on:
 steps:
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
     != "200" ]; do sleep 1; done'
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -7947,6 +8414,7 @@ steps:
   - echo $(cat "/go/var/full-version")
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7971,6 +8439,7 @@ steps:
     path: /root/.aws
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -7997,6 +8466,7 @@ steps:
   - Assume ECR - staging AWS Role
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8102,6 +8572,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -8163,6 +8635,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -8224,6 +8698,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -8249,6 +8725,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -8272,6 +8750,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -8296,6 +8776,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:full" to ECR - staging
@@ -8320,12 +8802,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
   - Tag and push image "teleport:v10-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8431,6 +8916,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -8492,6 +8979,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -8553,6 +9042,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -8578,6 +9069,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -8602,6 +9095,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -8626,6 +9121,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:full" to ECR - staging
@@ -8650,12 +9147,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm64" to ECR - staging
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -8763,6 +9263,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -8788,6 +9290,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - staging
@@ -8810,6 +9314,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -8841,6 +9347,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8878,6 +9386,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8915,6 +9425,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Wait for docker
@@ -8945,6 +9457,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -8969,6 +9483,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -8993,6 +9509,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:full" to ECR - staging
@@ -9017,6 +9535,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -9037,6 +9557,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -9068,6 +9592,7 @@ clone:
 steps:
 - name: Verify build is tagged
   image: alpine:latest
+  pull: if-not-exists
   commands:
   - '[ -n ${DRONE_TAG} ] || (echo ''DRONE_TAG is not set. Is the commit tagged?''
     && exit 1)'
@@ -9089,16 +9614,26 @@ steps:
     '; echo 'a prerelease'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -9108,6 +9643,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -9135,6 +9671,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9162,6 +9699,7 @@ steps:
   - Record if tag ($DRONE_TAG) is prerelease
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -9207,6 +9745,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9235,6 +9775,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9263,6 +9805,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9299,6 +9843,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -9327,6 +9873,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -9356,6 +9904,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to Quay
@@ -9382,6 +9932,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -9410,6 +9962,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -9435,6 +9989,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -9465,6 +10021,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -9492,6 +10050,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -9520,6 +10080,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -9545,6 +10107,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -9572,6 +10136,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -9597,6 +10163,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -9620,6 +10188,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9648,6 +10218,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9676,6 +10248,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -9712,6 +10286,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -9741,6 +10317,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -9770,6 +10348,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -9796,6 +10376,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -9824,6 +10406,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -9850,6 +10434,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -9881,6 +10467,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -9909,6 +10497,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -9938,6 +10528,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -9963,6 +10555,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -9990,6 +10584,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -10015,6 +10611,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -10039,6 +10637,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10075,6 +10675,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -10099,6 +10701,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -10123,6 +10727,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -10145,6 +10751,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -10174,6 +10782,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-ent:v10-fips-amd64 and push it to Local Registry
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -10197,6 +10807,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -10220,6 +10832,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -10241,6 +10855,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Pull teleport-operator:v10-amd64 and push it to Local Registry
@@ -10263,6 +10879,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10292,6 +10910,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10321,6 +10941,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Verify build is tagged
   - Record if tag ($DRONE_TAG) is prerelease
@@ -10357,6 +10979,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -10386,6 +11010,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -10415,6 +11041,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -10441,6 +11069,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -10469,6 +11099,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -10495,6 +11127,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -10526,6 +11160,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-amd64 and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -10555,6 +11191,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm and push it to Local Registry
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -10584,6 +11222,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Pull teleport-operator:v10-arm64 and push it to Local Registry
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -10609,6 +11249,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -10636,6 +11278,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -10661,6 +11305,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -10681,6 +11327,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -10722,15 +11372,25 @@ steps:
     "v11"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v11
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -10739,6 +11399,7 @@ steps:
   - Find the latest available semver for v11
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -10765,6 +11426,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10791,6 +11453,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10818,6 +11481,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10845,6 +11509,7 @@ steps:
   - Find the latest available semver for v11
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -10954,6 +11619,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_amd64.deb" artifacts from S3
@@ -11015,6 +11682,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm.deb" artifacts from S3
@@ -11076,6 +11745,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v11-tag_arm64.deb" artifacts from S3
@@ -11114,6 +11785,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11150,6 +11823,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - staging
@@ -11187,6 +11862,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -11212,6 +11889,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11239,6 +11918,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11266,6 +11947,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - staging
   - Tag and push image "teleport:v11-arm" to ECR - staging
@@ -11297,6 +11980,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to Quay
@@ -11325,6 +12010,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to Quay
@@ -11354,6 +12041,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -11376,6 +12065,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -11400,6 +12091,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -11425,6 +12118,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to Quay
   - Tag and push image "teleport:v11-arm" to Quay
@@ -11455,6 +12150,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-amd64"
 - name: Tag and push image "teleport:v11-arm" to ECR - production
@@ -11482,6 +12179,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm"
 - name: Tag and push image "teleport:v11-arm64" to ECR - production
@@ -11510,6 +12209,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v11-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -11531,6 +12232,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -11554,6 +12257,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
@@ -11579,12 +12284,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v11-amd64" to ECR - production
   - Tag and push image "teleport:v11-arm" to ECR - production
   - Tag and push image "teleport:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -11694,6 +12402,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_amd64.deb" artifacts from S3
@@ -11755,6 +12465,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm.deb" artifacts from S3
@@ -11816,6 +12528,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag_arm64.deb" artifacts from S3
@@ -11854,6 +12568,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -11891,6 +12607,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - staging
@@ -11928,6 +12646,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -11953,6 +12673,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -11980,6 +12702,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12007,6 +12731,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v11-arm" to ECR - staging
@@ -12038,6 +12764,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12067,6 +12795,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to Quay
@@ -12096,6 +12826,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -12118,6 +12850,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12142,6 +12876,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12168,6 +12904,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to Quay
   - Tag and push image "teleport-ent:v11-arm" to Quay
@@ -12199,6 +12937,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-amd64"
 - name: Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12227,6 +12967,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm"
 - name: Tag and push image "teleport-ent:v11-arm64" to ECR - production
@@ -12256,6 +12998,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v11-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -12277,6 +13021,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12300,6 +13046,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
@@ -12325,12 +13073,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-amd64" to ECR - production
   - Tag and push image "teleport-ent:v11-arm" to ECR - production
   - Tag and push image "teleport-ent:v11-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -12442,6 +13193,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v11-tag-fips_amd64.deb" artifacts from S3
@@ -12480,6 +13233,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -12503,6 +13258,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -12526,6 +13283,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -12549,6 +13308,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to Quay
@@ -12578,6 +13339,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -12598,6 +13361,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -12618,6 +13383,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -12640,6 +13407,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
@@ -12669,6 +13438,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v11-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -12688,6 +13459,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -12707,6 +13480,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -12728,6 +13503,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v11-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v11-amd64"
@@ -12759,6 +13536,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -12798,6 +13577,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -12837,6 +13618,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v11
@@ -12882,6 +13665,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -12919,6 +13704,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - staging
@@ -12956,6 +13743,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -12981,6 +13770,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13008,6 +13799,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13035,6 +13828,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v11-arm" to ECR - staging
@@ -13066,6 +13861,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13095,6 +13892,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to Quay
@@ -13124,6 +13923,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -13146,6 +13947,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13170,6 +13973,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13196,6 +14001,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to Quay
   - Tag and push image "teleport-operator:v11-arm" to Quay
@@ -13227,6 +14034,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-amd64"
 - name: Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13256,6 +14065,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm"
 - name: Tag and push image "teleport-operator:v11-arm64" to ECR - production
@@ -13285,6 +14096,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v11-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -13306,6 +14119,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13329,6 +14144,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13354,6 +14171,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v11-amd64" to ECR - production
   - Tag and push image "teleport-operator:v11-arm" to ECR - production
@@ -13374,6 +14193,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -13415,15 +14238,25 @@ steps:
     "v10"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v10
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -13432,6 +14265,7 @@ steps:
   - Find the latest available semver for v10
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -13458,6 +14292,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13484,6 +14319,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13511,6 +14347,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13538,6 +14375,7 @@ steps:
   - Find the latest available semver for v10
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -13647,6 +14485,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_amd64.deb" artifacts from S3
@@ -13708,6 +14548,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm.deb" artifacts from S3
@@ -13769,6 +14611,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v10-tag_arm64.deb" artifacts from S3
@@ -13807,6 +14651,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - staging
@@ -13843,6 +14689,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - staging
@@ -13880,6 +14728,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -13905,6 +14755,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -13932,6 +14784,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -13959,6 +14813,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - staging
   - Tag and push image "teleport:v10-arm" to ECR - staging
@@ -13990,6 +14846,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to Quay
@@ -14018,6 +14876,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to Quay
@@ -14047,6 +14907,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -14069,6 +14931,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14093,6 +14957,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14118,6 +14984,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to Quay
   - Tag and push image "teleport:v10-arm" to Quay
@@ -14148,6 +15016,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-amd64"
 - name: Tag and push image "teleport:v10-arm" to ECR - production
@@ -14175,6 +15045,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm"
 - name: Tag and push image "teleport:v10-arm64" to ECR - production
@@ -14203,6 +15075,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v10-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -14224,6 +15098,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -14247,6 +15123,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
@@ -14272,12 +15150,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v10-amd64" to ECR - production
   - Tag and push image "teleport:v10-arm" to ECR - production
   - Tag and push image "teleport:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -14387,6 +15268,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_amd64.deb" artifacts from S3
@@ -14448,6 +15331,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm.deb" artifacts from S3
@@ -14509,6 +15394,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag_arm64.deb" artifacts from S3
@@ -14547,6 +15434,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14584,6 +15473,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - staging
@@ -14621,6 +15512,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -14646,6 +15539,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14673,6 +15568,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14700,6 +15597,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v10-arm" to ECR - staging
@@ -14731,6 +15630,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14760,6 +15661,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to Quay
@@ -14789,6 +15692,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -14811,6 +15716,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14835,6 +15742,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14861,6 +15770,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to Quay
   - Tag and push image "teleport-ent:v10-arm" to Quay
@@ -14892,6 +15803,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-amd64"
 - name: Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -14920,6 +15833,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm"
 - name: Tag and push image "teleport-ent:v10-arm64" to ECR - production
@@ -14949,6 +15864,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v10-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -14970,6 +15887,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -14993,6 +15912,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
@@ -15018,12 +15939,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-amd64" to ECR - production
   - Tag and push image "teleport-ent:v10-arm" to ECR - production
   - Tag and push image "teleport-ent:v10-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -15135,6 +16059,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v10-tag-fips_amd64.deb" artifacts from S3
@@ -15173,6 +16099,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -15196,6 +16124,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -15219,6 +16149,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -15242,6 +16174,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to Quay
@@ -15271,6 +16205,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -15291,6 +16227,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -15311,6 +16249,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -15333,6 +16273,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
@@ -15362,6 +16304,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v10-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -15381,6 +16325,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -15400,6 +16346,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -15421,6 +16369,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v10-fips-amd64" to ECR - production
 - name: Build teleport-operator image "teleport-operator:v10-amd64"
@@ -15452,6 +16402,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -15491,6 +16443,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -15530,6 +16484,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Find the latest available semver for v10
@@ -15575,6 +16531,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15612,6 +16570,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - staging
@@ -15649,6 +16609,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major-$TIMESTAMP" to ECR - staging
@@ -15674,6 +16636,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15701,6 +16665,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15728,6 +16694,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - staging
   - Tag and push image "teleport-operator:v10-arm" to ECR - staging
@@ -15759,6 +16727,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15788,6 +16758,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to Quay
@@ -15817,6 +16789,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to Quay
@@ -15839,6 +16813,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15863,6 +16839,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15889,6 +16867,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to Quay
   - Tag and push image "teleport-operator:v10-arm" to Quay
@@ -15920,6 +16900,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-amd64"
 - name: Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -15949,6 +16931,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm"
 - name: Tag and push image "teleport-operator:v10-arm64" to ECR - production
@@ -15978,6 +16962,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-operator image "teleport-operator:v10-arm64"
 - name: Create manifest and push "teleport-operator:major" to ECR - production
@@ -15999,6 +16985,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16022,6 +17010,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16047,6 +17037,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-operator:v10-amd64" to ECR - production
   - Tag and push image "teleport-operator:v10-arm" to ECR - production
@@ -16067,6 +17059,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -16107,15 +17103,25 @@ steps:
   - echo Found full semver "$(cat "/go/vars/full-version-v9")" for major version "v9"
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Find the latest available semver for v9
 - name: Wait for docker registry
   image: alpine
+  pull: if-not-exists
   commands:
   - apk add curl
   - timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %{http_code} http://drone-docker-registry:5000/)"
@@ -16124,6 +17130,7 @@ steps:
   - Find the latest available semver for v9
 - name: Check out code
   image: alpine/git:latest
+  pull: if-not-exists
   commands:
   - mkdir -pv "/go/src/github.com/gravitational/teleport"
   - cd "/go/src/github.com/gravitational/teleport"
@@ -16149,6 +17156,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume ECR - staging AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16175,6 +17183,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume ECR - authenticated-pull AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16202,6 +17211,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume ECR - production AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16229,6 +17239,7 @@ steps:
   - Find the latest available semver for v9
 - name: Assume S3 Download AWS Role for teleport
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -16338,6 +17349,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_amd64.deb" artifacts from S3
@@ -16399,6 +17412,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm.deb" artifacts from S3
@@ -16460,6 +17475,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport_v9-tag_arm64.deb" artifacts from S3
@@ -16498,6 +17515,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16534,6 +17553,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - staging
@@ -16571,6 +17592,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major-$TIMESTAMP" to ECR - staging
@@ -16596,6 +17619,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16623,6 +17648,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16650,6 +17677,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - staging
   - Tag and push image "teleport:v9-arm" to ECR - staging
@@ -16681,6 +17710,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to Quay
@@ -16709,6 +17740,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to Quay
@@ -16738,6 +17771,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to Quay
@@ -16760,6 +17795,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -16784,6 +17821,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -16809,6 +17848,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to Quay
   - Tag and push image "teleport:v9-arm" to Quay
@@ -16839,6 +17880,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-amd64"
 - name: Tag and push image "teleport:v9-arm" to ECR - production
@@ -16866,6 +17909,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm"
 - name: Tag and push image "teleport:v9-arm64" to ECR - production
@@ -16894,6 +17939,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport image "teleport:v9-arm64"
 - name: Create manifest and push "teleport:major" to ECR - production
@@ -16915,6 +17962,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -16938,6 +17987,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
@@ -16963,12 +18014,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport:v9-amd64" to ECR - production
   - Tag and push image "teleport:v9-arm" to ECR - production
   - Tag and push image "teleport:v9-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17078,6 +18132,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_amd64.deb" artifacts from S3
@@ -17139,6 +18195,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm.deb" artifacts from S3
@@ -17200,6 +18258,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag_arm64.deb" artifacts from S3
@@ -17238,6 +18298,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17275,6 +18337,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - staging
@@ -17312,6 +18376,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP" to ECR - staging
@@ -17337,6 +18403,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17364,6 +18432,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17391,6 +18461,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - staging
   - Tag and push image "teleport-ent:v9-arm" to ECR - staging
@@ -17422,6 +18494,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17451,6 +18525,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to Quay
@@ -17480,6 +18556,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to Quay
@@ -17502,6 +18580,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17526,6 +18606,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17552,6 +18634,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to Quay
   - Tag and push image "teleport-ent:v9-arm" to Quay
@@ -17583,6 +18667,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-amd64"
 - name: Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -17611,6 +18697,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm"
 - name: Tag and push image "teleport-ent:v9-arm64" to ECR - production
@@ -17640,6 +18728,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent image "teleport-ent:v9-arm64"
 - name: Create manifest and push "teleport-ent:major" to ECR - production
@@ -17661,6 +18751,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -17684,6 +18776,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
@@ -17709,12 +18803,15 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-amd64" to ECR - production
   - Tag and push image "teleport-ent:v9-arm" to ECR - production
   - Tag and push image "teleport-ent:v9-arm64" to ECR - production
 - name: Assume S3 Download AWS Role for teleport-ent-fips
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -17826,6 +18923,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Assume ECR - authenticated-pull AWS Role
   - Download "teleport-ent_v9-tag-fips_amd64.deb" artifacts from S3
@@ -17864,6 +18963,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-$TIMESTAMP-fips" to ECR - staging
@@ -17887,6 +18988,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:minor-$TIMESTAMP-fips" to ECR - staging
@@ -17910,6 +19013,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Create manifest and push "teleport-ent:full-$TIMESTAMP-fips" to ECR - staging
@@ -17933,6 +19038,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - staging
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to Quay
@@ -17962,6 +19069,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to Quay
@@ -17982,6 +19091,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:minor-fips" to Quay
@@ -18002,6 +19113,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Create manifest and push "teleport-ent:full-fips" to Quay
@@ -18024,6 +19137,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to Quay
 - name: Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
@@ -18053,6 +19168,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Build teleport-ent-fips image "teleport-ent:v9-fips-amd64"
 - name: Create manifest and push "teleport-ent:major-fips" to ECR - production
@@ -18072,6 +19189,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:minor-fips" to ECR - production
@@ -18091,6 +19210,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 - name: Create manifest and push "teleport-ent:full-fips" to ECR - production
@@ -18112,6 +19233,8 @@ steps:
     path: /root/.aws
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   depends_on:
   - Tag and push image "teleport-ent:v9-fips-amd64" to ECR - production
 services:
@@ -18130,6 +19253,10 @@ volumes:
   temp: {}
 - name: dockersock
   temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -18168,13 +19295,23 @@ steps:
     && exit 1)'
 - name: Wait for docker
   image: docker
+  pull: if-not-exists
   commands:
   - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
+  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  environment:
+    DOCKERHUB_PASSWORD:
+      from_secret: DOCKERHUB_READONLY_TOKEN
+    DOCKERHUB_USERNAME:
+      from_secret: DOCKERHUB_USERNAME
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
 - name: Assume AWS Role
   image: amazon/aws-cli
+  pull: if-not-exists
   commands:
   - aws sts get-caller-identity
   - |-
@@ -18208,6 +19345,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: awsconfig
     path: /root/.aws
 - name: Publish in Release API
@@ -18232,6 +19371,8 @@ steps:
   volumes:
   - name: dockersock
     path: /var/run
+  - name: dockerconfig
+    path: /root/.docker
   - name: tmpfs
     path: /tmpfs
   - name: awsconfig
@@ -18246,15 +19387,19 @@ services:
   - name: dockersock
     path: /var/run
 volumes:
-- name: dockersock
-  temp: {}
 - name: tmpfs
   temp:
     medium: memory
 - name: awsconfig
   temp: {}
+- name: dockersock
+  temp: {}
+- name: dockerconfig
+  temp: {}
+image_pull_secrets:
+- DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 79aefb0fdd0af5f5312e1dd4ffb56d71db8330ae9d3311b555d7627a1a03939c
+hmac: 1786009bcdd1c95bd4eddfb04bf2939b1105e2bdd6c00049dc109bbc612b0866
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -854,12 +854,13 @@ update-api-import-path:
 # 		- build binaries with 'make release'
 # 		- run `make tag` and use its output to 'git tag' and 'git push --tags'
 .PHONY: update-tag
+update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))
-	git push origin $(GITTAG) && git push origin api/$(GITTAG)
+	git push $(TAG_REMOTE) $(GITTAG) && git push $(TAG_REMOTE) api/$(GITTAG)
 
 # build/webassets directory contains the web assets (UI) which get
 # embedded in the teleport binary

--- a/dronegen/aws.go
+++ b/dronegen/aws.go
@@ -93,6 +93,7 @@ func kubernetesAssumeAwsRoleStep(s kubernetesRoleSettings) step {
 	return step{
 		Name:  s.name,
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_ACCESS_KEY_ID":     s.awsAccessKeyID,
 			"AWS_SECRET_ACCESS_KEY": s.awsSecretAccessKey,
@@ -125,6 +126,7 @@ func kubernetesUploadToS3Step(s kubernetesS3Settings) step {
 	return step{
 		Name:  "Upload to S3",
 		Image: "amazon/aws-cli",
+		Pull:  "if-not-exists",
 		Environment: map[string]value{
 			"AWS_S3_BUCKET": {fromSecret: "AWS_S3_BUCKET"},
 			"AWS_REGION":    {raw: s.region},

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -70,7 +70,7 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
 		Pull:    "if-not-exists",
-		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes: []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -102,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -69,7 +69,8 @@ func buildboxPipelineStep(buildboxName string, fips bool) step {
 	return step{
 		Name:    "Build and push " + buildboxName,
 		Image:   "docker",
-		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
+		Pull:    "if-not-exists",
+		Volumes: dockerVolumeRefs(volumeRefAwsConfig),
 		Commands: []string{
 			`apk add --no-cache make aws-cli`,
 			`chown -R $UID:$GID /go`,
@@ -101,7 +102,7 @@ func buildboxPipeline() pipeline {
 	// only on master for now; add the release branch name when forking a new release series.
 	p.Trigger = pushTriggerForBranch("master", "branch/*")
 	p.Workspace = workspace{Path: "/go/src/github.com/gravitational/teleport"}
-	p.Volumes = []volume{volumeDocker, volumeAwsConfig}
+	p.Volumes = dockerVolumes(volumeAwsConfig)
 	p.Services = []service{
 		dockerService(),
 	}

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -86,6 +86,25 @@ var (
 		Name: "awsconfig",
 		Path: "/root/.aws",
 	}
+
+	// volumeDockerConfig is a temporary volume for storing docker
+	// credentials for use with the Docker-in-Docker service we use
+	// to isolate the host machines docker daemon from the one used
+	// during the build. Mount this any time you use `volumeDocker`
+	//
+	// Drone claims to destroy the the temp volumes after a workflow
+	// has run, so it should be safe to write credentials etc.
+	volumeDockerConfig = volume{
+		Name: "dockerconfig",
+		Temp: &volumeTemp{},
+	}
+
+	// volumeRefDockerConfig is how you reference the docker config
+	// volume in a workflow step
+	volumeRefDockerConfig = volumeRef{
+		Name: "dockerconfig",
+		Path: "/root/.docker",
+	}
 )
 
 var buildboxVersion value
@@ -245,13 +264,13 @@ func dockerRegistryService() service {
 // dockerVolumes returns a slice of volumes
 // It includes the Docker socket volume by default, plus any extra volumes passed in
 func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker)
+	return append(v, volumeDocker, volumeDockerConfig)
 }
 
 // dockerVolumeRefs returns a slice of volumeRefs
 // It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
 func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker)
+	return append(v, volumeRefDocker, volumeRefDockerConfig)
 }
 
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
@@ -283,10 +302,16 @@ func waitForDockerStep() step {
 	return step{
 		Name:  "Wait for docker",
 		Image: "docker",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: []volumeRef{volumeRefDocker},
+		Volumes: dockerVolumeRefs(),
+		Environment: map[string]value{
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
+		},
 	}
 }
 
@@ -295,6 +320,7 @@ func waitForDockerRegistryStep() step {
 	return step{
 		Name:  "Wait for docker registry",
 		Image: "alpine",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"apk add curl",
 			fmt.Sprintf(`timeout 30s /bin/sh -c 'while [ "$(curl -s -o /dev/null -w %%{http_code} http://%s/)" != "200" ]; do sleep 1; done'`, LocalRegistrySocket),
@@ -306,6 +332,7 @@ func verifyTaggedStep() step {
 	return step{
 		Name:  "Verify build is tagged",
 		Image: "alpine:latest",
+		Pull:  "if-not-exists",
 		Commands: []string{
 			"[ -n ${DRONE_TAG} ] || (echo 'DRONE_TAG is not set. Is the commit tagged?' && exit 1)",
 		},
@@ -317,6 +344,7 @@ func cloneRepoStep(clonePath, commit string) step {
 	return step{
 		Name:     "Check out code",
 		Image:    "alpine/git:latest",
+		Pull:     "if-not-exists",
 		Commands: cloneRepoCommands(clonePath, commit),
 	}
 }

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -261,18 +261,6 @@ func dockerRegistryService() service {
 	}
 }
 
-// dockerVolumes returns a slice of volumes
-// It includes the Docker socket volume by default, plus any extra volumes passed in
-func dockerVolumes(v ...volume) []volume {
-	return append(v, volumeDocker, volumeDockerConfig)
-}
-
-// dockerVolumeRefs returns a slice of volumeRefs
-// It includes the Docker socket volumeRef as a default, plus any extra volumeRefs passed in
-func dockerVolumeRefs(v ...volumeRef) []volumeRef {
-	return append(v, volumeRefDocker, volumeRefDockerConfig)
-}
-
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
 func releaseMakefileTarget(b buildType) string {
 	makefileTarget := fmt.Sprintf("release-%s", b.arch)
@@ -307,7 +295,7 @@ func waitForDockerStep() step {
 			`timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'`,
 			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
-		Volumes: dockerVolumeRefs(),
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 		Environment: map[string]value{
 			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
 			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_image_products.go
+++ b/dronegen/container_image_products.go
@@ -478,7 +478,7 @@ func (p *Product) createBuildStep(arch string, version *ReleaseVersion, publicEc
 	step := step{
 		Name:        p.GetBuildStepName(arch, version),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: envVars,
 		Commands:    commands,
 		DependsOn:   getStepNames(publicEcrPullRegistry.SetupSteps),

--- a/dronegen/container_images_release_version.go
+++ b/dronegen/container_images_release_version.go
@@ -48,7 +48,7 @@ func (rv *ReleaseVersion) buildVersionPipeline(triggerSetupSteps []step, flags *
 		dockerService(),
 		dockerRegistryService(),
 	}
-	pipeline.Volumes = dockerVolumes(volumeAwsConfig)
+	pipeline.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	pipeline.Environment = map[string]value{
 		"DEBIAN_FRONTEND": {
 			raw: "noninteractive",

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -62,6 +62,7 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 	loginCommands := []string{
 		"apk add --no-cache aws-cli",
 		fmt.Sprintf("aws %s get-login-password --region=%s | docker login -u=\"AWS\" --password-stdin %s", loginSubcommand, ecrRegion, domain),
+		`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 	}
 
 	if guaranteeUnique {
@@ -72,7 +73,9 @@ func NewEcrContainerRepo(accessKeyIDSecret, secretAccessKeySecret, roleSecret, d
 		Name:        repoName,
 		IsImmutable: isImmutable,
 		EnvironmentVars: map[string]value{
-			"AWS_PROFILE": {raw: profileName},
+			"AWS_PROFILE":        {raw: profileName},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: domain,
 		RegistryOrg:    registryOrg,
@@ -112,17 +115,16 @@ func NewQuayContainerRepo(dockerUsername, dockerPassword string) *ContainerRepo 
 		Name:        "Quay",
 		IsImmutable: false,
 		EnvironmentVars: map[string]value{
-			"QUAY_USERNAME": {
-				fromSecret: dockerUsername,
-			},
-			"QUAY_PASSWORD": {
-				fromSecret: dockerPassword,
-			},
+			"QUAY_USERNAME":      {fromSecret: dockerUsername},
+			"QUAY_PASSWORD":      {fromSecret: dockerPassword},
+			"DOCKERHUB_USERNAME": {fromSecret: "DOCKERHUB_USERNAME"},
+			"DOCKERHUB_PASSWORD": {fromSecret: "DOCKERHUB_READONLY_TOKEN"},
 		},
 		RegistryDomain: ProductionRegistryQuay,
 		RegistryOrg:    registryOrg,
 		LoginCommands: []string{
 			fmt.Sprintf("docker login -u=\"$QUAY_USERNAME\" -p=\"$QUAY_PASSWORD\" %q", ProductionRegistryQuay),
+			`printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin`,
 		},
 	}
 }
@@ -254,7 +256,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +306,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +334,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker}, // no docker config volume, as this will race
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/container_images_repos.go
+++ b/dronegen/container_images_repos.go
@@ -254,7 +254,7 @@ func (cr *ContainerRepo) pullPushStep(image *Image, dependencySteps []string) (s
 	return step{
 		Name:        fmt.Sprintf("Pull %s and push it to %s", image.GetDisplayName(), localRepo.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -304,7 +304,7 @@ func (cr *ContainerRepo) tagAndPushStep(buildStepDetails *buildStepOutput, image
 	step := step{
 		Name:        fmt.Sprintf("Tag and push image %q to %s", buildStepDetails.BuiltImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    commands,
 		DependsOn:   dependencySteps,
@@ -332,7 +332,7 @@ func (cr *ContainerRepo) createAndPushManifestStep(manifestImage *Image, pushSte
 	return step{
 		Name:        fmt.Sprintf("Create manifest and push %q to %s", manifestImage.GetDisplayName(), cr.Name),
 		Image:       "docker",
-		Volumes:     dockerVolumeRefs(volumeRefAwsConfig),
+		Volumes:     []volumeRef{volumeRefAwsConfig, volumeRefDocker, volumeRefDockerConfig},
 		Environment: cr.EnvironmentVars,
 		Commands:    cr.buildCommandsWithLogin(commands),
 		DependsOn:   pushStepNames,

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -41,6 +41,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -49,6 +50,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		{
 			Name:  "Delegate build to GitHub",
 			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GHA_APP_KEY": {fromSecret: "GITHUB_WORKFLOW_APP_PRIVATE_KEY"},
 			},

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -39,6 +39,22 @@ func main() {
 	pipelines = append(pipelines, buildContainerImagePipelines()...)
 	pipelines = append(pipelines, publishReleasePipeline())
 
+	// Inject the Drone-level dockerhub credentials into all non-exec
+	// pipelines. Drone will then use the docker credentials file in
+	// the named secret as its credentials when pulling images from
+	// dockerhub.
+	//
+	// Exec pipelines do not have the `image_pull_secrets` option, as
+	// their steps are invoked directly on the host runner and not
+	// into a per-step container.
+	for pidx := range pipelines {
+		p := &pipelines[pidx]
+		if p.Type == "exec" {
+			continue
+		}
+		p.ImagePullSecrets = append(p.ImagePullSecrets, "DOCKERHUB_CREDENTIALS")
+	}
+
 	if err := writePipelines(".drone.yml", pipelines); err != nil {
 		fmt.Println("failed writing drone pipelines:", err)
 		os.Exit(1)

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -122,7 +122,7 @@ func pushPipeline(b buildType) pipeline {
 	}
 	p.Trigger = triggerPush
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeDocker}
+	p.Volumes = []volume{volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -130,6 +130,7 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:  "Check out code",
 			Image: "docker:git",
+			Pull:  "if-not-exists",
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
@@ -139,8 +140,9 @@ func pushPipeline(b buildType) pipeline {
 		{
 			Name:        "Build artifacts",
 			Image:       "docker",
+			Pull:        "if-not-exists",
 			Environment: pushEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker},
+			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
 			Commands:    pushBuildCommands(b),
 		},
 		sendErrorToSlackStep(),

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,7 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
+	p.Volumes = []volume{volumeTmpfs, volumeAwsConfig, volumeDocker, volumeDockerConfig}
 
 	return p
 }
@@ -56,11 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -80,12 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{
-			volumeRefDocker,
-			volumeRefDockerConfig,
-			volumeRefTmpfs,
-			volumeRefAwsConfig,
-		},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -44,11 +44,7 @@ func relcliPipeline(trigger trigger, name string, stepName string, command strin
 	}
 
 	p.Services = []service{dockerService(volumeRefTmpfs)}
-	p.Volumes = []volume{
-		volumeDocker,
-		volumeTmpfs,
-		volumeAwsConfig,
-	}
+	p.Volumes = dockerVolumes(volumeTmpfs, volumeAwsConfig)
 
 	return p
 }
@@ -62,6 +58,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefAwsConfig,
 		},
 		Commands: []string{
@@ -85,6 +82,7 @@ func executeRelcliStep(name string, command string) step {
 		},
 		Volumes: []volumeRef{
 			volumeRefDocker,
+			volumeRefDockerConfig,
 			volumeRefTmpfs,
 			volumeRefAwsConfig,
 		},

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -56,7 +56,7 @@ func pullRelcliStep(awsConfigVolumeRef volumeRef) step {
 		Environment: map[string]value{
 			"AWS_DEFAULT_REGION": {raw: "us-west-2"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefAwsConfig},
 		Commands: []string{
 			`apk add --no-cache aws-cli`,
 			`aws ecr get-login-password | docker login -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com`,
@@ -76,7 +76,7 @@ func executeRelcliStep(name string, command string) step {
 			"RELCLI_CERT":     {raw: "/tmpfs/creds/releases.crt"},
 			"RELCLI_KEY":      {raw: "/tmpfs/creds/releases.key"},
 		},
-		Volumes: []volumeRef{volumeRefDocker, volumeRefDockerConfig, volumeRefTmpfs, volumeRefAwsConfig},
+		Volumes: []volumeRef{volumeRefDocker, volumeRefTmpfs, volumeRefAwsConfig},
 		Commands: []string{
 			`mkdir -p /tmpfs/creds`,
 			`echo "$RELEASES_CERT" | base64 -d > "$RELCLI_CERT"`,

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -256,7 +256,7 @@ func tagPipeline(b buildType) pipeline {
 	p.Trigger = triggerTag
 	p.DependsOn = []string{tagCleanupPipelineName}
 	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = dockerVolumes(volumeAwsConfig)
+	p.Volumes = []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	p.Services = []service{
 		dockerService(),
 	}
@@ -451,7 +451,7 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 		environment["OSS_TARBALL_PATH"] = value{raw: "/go/artifacts"}
 	}
 
-	packageDockerVolumes := dockerVolumes(volumeAwsConfig)
+	packageDockerVolumes := []volume{volumeAwsConfig, volumeDocker, volumeDockerConfig}
 	packageDockerVolumeRefs := []volumeRef{
 		volumeRefDocker,
 		volumeRefDockerConfig,

--- a/dronegen/types.go
+++ b/dronegen/types.go
@@ -29,20 +29,21 @@ import (
 type pipeline struct {
 	comment string
 
-	Kind        string           `yaml:"kind"`
-	Type        string           `yaml:"type"`
-	Name        string           `yaml:"name"`
-	Environment map[string]value `yaml:"environment,omitempty"`
-	Trigger     trigger          `yaml:"trigger"`
-	Workspace   workspace        `yaml:"workspace,omitempty"`
-	Platform    platform         `yaml:"platform,omitempty"`
-	Node        map[string]value `yaml:"node,omitempty"`
-	Clone       clone            `yaml:"clone,omitempty"`
-	DependsOn   []string         `yaml:"depends_on,omitempty"`
-	Concurrency concurrency      `yaml:"concurrency,omitempty"`
-	Steps       []step           `yaml:"steps"`
-	Services    []service        `yaml:"services,omitempty"`
-	Volumes     []volume         `yaml:"volumes,omitempty"`
+	Kind             string           `yaml:"kind"`
+	Type             string           `yaml:"type"`
+	Name             string           `yaml:"name"`
+	Environment      map[string]value `yaml:"environment,omitempty"`
+	Trigger          trigger          `yaml:"trigger"`
+	Workspace        workspace        `yaml:"workspace,omitempty"`
+	Platform         platform         `yaml:"platform,omitempty"`
+	Node             map[string]value `yaml:"node,omitempty"`
+	Clone            clone            `yaml:"clone,omitempty"`
+	DependsOn        []string         `yaml:"depends_on,omitempty"`
+	Concurrency      concurrency      `yaml:"concurrency,omitempty"`
+	Steps            []step           `yaml:"steps"`
+	Services         []service        `yaml:"services,omitempty"`
+	Volumes          []volume         `yaml:"volumes,omitempty"`
+	ImagePullSecrets []string         `yaml:"image_pull_secrets,omitempty"`
 }
 
 func newKubePipeline(name string) pipeline {
@@ -170,6 +171,7 @@ type volumeRef struct {
 type step struct {
 	Name        string              `yaml:"name"`
 	Image       string              `yaml:"image,omitempty"`
+	Pull        string              `yaml:"pull,omitempty"`
 	Commands    []string            `yaml:"commands,omitempty"`
 	Environment map[string]value    `yaml:"environment,omitempty"`
 	Volumes     []volumeRef         `yaml:"volumes,omitempty"`


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/23956
Backports https://github.com/gravitational/teleport/pull/23957

## Summary

After moving Drone to AWS, we're seeing image pulls get rate limited because they're all coming from the same IP (an AWS NAT gateway). To avoid the rate limiting on AWS, we refactor pipelines to cache/reuse images where possible, as well as add authentication to Docker Hub pulls.

## Related Issues & PRs

Contributes to https://github.com/gravitational/SecOps/issues/285

See the orginal PRs to master for more context.

## Testing
This is undergoing final testing at:

* build: https://drone.platform.teleport.sh/gravitational/teleport-private/536
* promote: https://drone.platform.teleport.sh/gravitational/teleport-private/540

These tests are based off the most recent `branch/v10` so I'll be watching to see if they flush out unrelated issues, since there hasn't been a release in  ~130 commits.