### PR TITLE
Support credentials forwarding in Kubernetes Access

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -17,6 +17,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"net"
 	"net/url"
@@ -35,6 +36,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/azure"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/transport"
 
 	"github.com/gravitational/teleport/api/types"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
@@ -166,6 +168,11 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 		return nil, trace.Wrap(err, "failed to generate transport config from kubeconfig: %v", err)
 	}
 
+	transport, err := newDirectTransports(tlsConfig, transportConfig)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed to generate transport from kubeconfig: %v", err)
+	}
+
 	log.Debug("Initialized Kubernetes credentials")
 	return &staticKubeCreds{
 		tlsConfig:       tlsConfig,
@@ -173,6 +180,30 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 		targetAddr:      targetAddr,
 		kubeClient:      client,
 		clientRestCfg:   clientCfg,
+		transport:       transport,
+	}, nil
+}
+
+// newDirectTransports creates a new http.Transport that will be used to connect to the Kubernetes API server.
+// It is a direct connection, not going through a proxy.
+func newDirectTransports(tlsConfig *tls.Config, transportConfig *transport.Config) (httpTransport, error) {
+	h1Transport, err := wrapTransport(newH1Transport(tlsConfig, nil), transportConfig)
+	if err != nil {
+		return httpTransport{}, trace.Wrap(err)
+	}
+
+	h2HTTPTransport, err := newH2Transport(tlsConfig, nil)
+	if err != nil {
+		return httpTransport{}, trace.Wrap(err)
+	}
+	h2Transport, err := wrapTransport(h2HTTPTransport, transportConfig)
+	if err != nil {
+		return httpTransport{}, trace.Wrap(err)
+	}
+
+	return httpTransport{
+		h1Transport: h1Transport,
+		h2Transport: h2Transport,
 	}, nil
 }
 

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -287,9 +287,11 @@ current-context: foo
 			require.Empty(t, cmp.Diff(got, tt.want,
 				cmp.AllowUnexported(staticKubeCreds{}),
 				cmp.AllowUnexported(kubeDetails{}),
+				cmp.AllowUnexported(httpTransport{}),
 				cmp.Comparer(func(a, b *transport.Config) bool { return (a == nil) == (b == nil) }),
 				cmp.Comparer(func(a, b *kubernetes.Clientset) bool { return (a == nil) == (b == nil) }),
 				cmp.Comparer(func(a, b *rest.Config) bool { return (a == nil) == (b == nil) }),
+				cmp.Comparer(func(a, b httpTransport) bool { return true }),
 			))
 		})
 	}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -51,7 +51,6 @@ import (
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/slices"
-	"golang.org/x/net/http2"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -168,6 +167,10 @@ type ForwarderConfig struct {
 	TracerProvider oteltrace.TracerProvider
 	// Tracer is used to start spans.
 	tracer oteltrace.Tracer
+	// ConnTLSConfig is the TLS client configuration to use when connecting to
+	// the upstream Teleport proxy or Kubernetes service when forwarding requests
+	// using the forward identity (i.e. proxy impersonating a user) method.
+	ConnTLSConfig *tls.Config
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -227,8 +230,13 @@ func (f *ForwarderConfig) CheckAndSetDefaults() error {
 
 	switch f.KubeServiceType {
 	case KubeService:
-	case ProxyService:
-	case LegacyProxyService:
+	case ProxyService, LegacyProxyService:
+		if f.ConnTLSConfig == nil {
+			return trace.BadParameter("missing parameter TLSConfig")
+		}
+		// Reset the ServerName to ensure that the proxy does not use the
+		// proxy's hostname as the SNI when connecting to the Kubernetes service.
+		f.ConnTLSConfig.ServerName = ""
 	default:
 		return trace.BadParameter("unknown value for KubeServiceType")
 	}
@@ -256,6 +264,15 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	// TODO (tigrato): remove this once we have a better way to handle
+	// deleting expired entried clusters and kube_servers entries.
+	// In the meantime, we need to make sure that the cache is cleaned
+	// from time to time.
+	transportClients, err := ttlmap.New(defaults.ClientCacheSize)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	closeCtx, close := context.WithCancel(cfg.Context)
 
 	fwd := &Forwarder{
@@ -270,7 +287,8 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},
-		clusterDetails: make(map[string]*kubeDetails),
+		clusterDetails:  make(map[string]*kubeDetails),
+		cachedTransport: transportClients,
 	}
 	router := httprouter.New()
 
@@ -359,6 +377,13 @@ type Forwarder struct {
 	// local kubernetes clusters. If the service type is Proxy, it will
 	// use the heartbeat clusters.
 	getKubernetesServersForKubeCluster getKubeServersByNameFunc
+
+	// cachedTransport is a cache of http.Transport objects used to
+	// connect to Teleport services.
+	// TODO(tigrato): Implement a cache eviction policy using watchers.
+	cachedTransport *ttlmap.TTLMap
+	// cachedTransportMu is a mutex used to protect the cachedTransport.
+	cachedTransportMu sync.Mutex
 }
 
 // getKubeServersByNameFunc is a function that returns a list of
@@ -1514,7 +1539,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 		return nil, trace.AccessDenied("insufficient permissions to launch non-interactive session")
 	}
 
-	eventPodMeta := request.eventPodMeta(request.context, sess.creds)
+	eventPodMeta := request.eventPodMeta(request.context, sess.kubeAPICreds)
 
 	sessionStart := f.cfg.Clock.Now().UTC()
 
@@ -1901,8 +1926,8 @@ func (f *Forwarder) setupForwardingHeaders(sess *clusterSession, req *http.Reque
 	// We only have a direct host to provide when using local creds.
 	// Otherwise, use kube-teleport-proxy-alpn.teleport.cluster.local to pass TLS handshake and leverage TLS Routing.
 	req.URL.Host = fmt.Sprintf("%s%s", constants.KubeTeleportProxyALPNPrefix, constants.APIDomain)
-	if sess.creds != nil {
-		req.URL.Host = sess.creds.getTargetAddr()
+	if sess.kubeAPICreds != nil {
+		req.URL.Host = sess.kubeAPICreds.getTargetAddr()
 	}
 
 	// add origin headers so the service consuming the request on the other site
@@ -2100,9 +2125,9 @@ func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http
 		originalHeaders: req.Header,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
-	if sess.creds != nil {
+	if sess.kubeAPICreds != nil {
 		var err error
-		rt, err = sess.creds.wrapTransport(rt)
+		rt, err = sess.kubeAPICreds.wrapTransport(rt)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2122,9 +2147,9 @@ func (f *Forwarder) getDialer(ctx authContext, sess *clusterSession, req *http.R
 		originalHeaders: req.Header,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
-	if sess.creds != nil {
+	if sess.kubeAPICreds != nil {
 		var err error
-		rt, err = sess.creds.wrapTransport(rt)
+		rt, err = sess.kubeAPICreds.wrapTransport(rt)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2140,10 +2165,13 @@ func (f *Forwarder) getDialer(ctx authContext, sess *clusterSession, req *http.R
 // x509 short lived credentials, forwarding proxies and other data
 type clusterSession struct {
 	authContext
-	parent    *Forwarder
-	creds     kubeCreds
-	tlsConfig *tls.Config
-	forwarder *forward.Forwarder
+	parent *Forwarder
+	// kubeAPICreds are the credentials used to authenticate to the Kubernetes API server.
+	// It is non-nil if the kubernetes cluster is served by this teleport service,
+	// nil otherwise.
+	kubeAPICreds kubeCreds
+	tlsConfig    *tls.Config
+	forwarder    *forward.Forwarder
 	// noAuditEvents is true if this teleport service should leave audit event
 	// logging to another service.
 	noAuditEvents        bool
@@ -2335,7 +2363,7 @@ func (f *Forwarder) newClusterSessionLocal(ctx authContext) (*clusterSession, er
 	return &clusterSession{
 		parent:               f,
 		authContext:          ctx,
-		creds:                details.kubeCreds,
+		kubeAPICreds:         details.kubeCreds,
 		kubeClusterEndpoints: []kubeClusterEndpoint{{addr: details.getTargetAddr()}},
 		tlsConfig:            details.getTLSConfig().Clone(),
 	}, nil
@@ -2371,30 +2399,14 @@ func (f *Forwarder) newClusterSessionDirect(ctx context.Context, authCtx authCon
 // The reason being is that streaming requests are going to be upgraded to SPDY, which is only
 // supported coming from an HTTP1 request.
 func (f *Forwarder) makeSessionForwarder(sess *clusterSession) (*forward.Forwarder, error) {
-	var err error
-	transport := f.newTransport(sess.DialWithContext, sess.tlsConfig)
-
-	if sess.upgradeToHTTP2 {
-		// Upgrade transport to h2 where HTTP_PROXY and HTTPS_PROXY
-		// envs are not take into account purposely.
-		if err := http2.ConfigureTransport(transport); err != nil {
-			return nil, trace.Wrap(err)
-		}
+	transport, err := f.transportForRequest(sess)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
-
-	rt := http.RoundTripper(transport)
-	if sess.creds != nil {
-		rt, err = sess.creds.wrapTransport(rt)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
-
-	rt = tracehttp.NewTransport(rt)
 
 	forwarder, err := forward.New(
 		forward.FlushInterval(100*time.Millisecond),
-		forward.RoundTripper(rt),
+		forward.RoundTripper(transport),
 		forward.WebsocketDial(sess.Dial),
 		forward.Logger(f.log),
 		forward.ErrorHandler(fwdutils.ErrorHandlerFunc(f.formatForwardResponseError)),
@@ -2404,25 +2416,6 @@ func (f *Forwarder) makeSessionForwarder(sess *clusterSession) (*forward.Forward
 	}
 
 	return forwarder, nil
-}
-
-// DialContextFunc is a context network dialer function that returns a network connection
-type DialContextFunc func(context.Context, string, string) (net.Conn, error)
-
-func (f *Forwarder) newTransport(dial DialContextFunc, tlsConfig *tls.Config) *http.Transport {
-	return &http.Transport{
-		DialContext:     dial,
-		TLSClientConfig: tlsConfig,
-		// Increase the size of the connection pool. This substantially improves the
-		// performance of Teleport under load as it reduces the number of TLS
-		// handshakes performed.
-		MaxIdleConns:        defaults.HTTPMaxIdleConns,
-		MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
-		// IdleConnTimeout defines the maximum amount of time before idle connections
-		// are closed. Leaving this unset will lead to connections open forever and
-		// will cause memory leaks in a long running process.
-		IdleConnTimeout: defaults.HTTPIdleTimeout,
-	}
 }
 
 // getOrCreateRequestContext creates a new certificate request for a given context,
@@ -2445,47 +2438,6 @@ func (f *Forwarder) getOrCreateRequestContext(key string) (context.Context, cont
 		defer f.mu.Unlock()
 		delete(f.activeRequests, key)
 	}
-}
-
-func (f *Forwarder) getOrRequestClientCreds(tracingCtx context.Context, authCtx authContext) (*tls.Config, error) {
-	c := f.getClientCreds(authCtx)
-	if c == nil {
-		return f.serializedRequestClientCreds(tracingCtx, authCtx)
-	}
-	return c, nil
-}
-
-func (f *Forwarder) getClientCreds(ctx authContext) *tls.Config {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	creds, ok := f.clientCredentials.Get(ctx.key())
-	if !ok {
-		return nil
-	}
-	c := creds.(*tls.Config)
-	if !validClientCreds(f.cfg.Clock, c) {
-		return nil
-	}
-	return c
-}
-
-func (f *Forwarder) saveClientCreds(ctx authContext, c *tls.Config) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	return f.clientCredentials.Set(ctx.key(), c, ctx.sessionTTL)
-}
-
-func validClientCreds(clock clockwork.Clock, c *tls.Config) bool {
-	if len(c.Certificates) == 0 || len(c.Certificates[0].Certificate) == 0 {
-		return false
-	}
-	crt, err := x509.ParseCertificate(c.Certificates[0].Certificate[0])
-	if err != nil {
-		return false
-	}
-	// Make sure that the returned cert will be valid for at least 1 more
-	// minute.
-	return clock.Now().Add(time.Minute).Before(crt.NotAfter)
 }
 
 func (f *Forwarder) serializedRequestClientCreds(tracingCtx context.Context, authContext authContext) (*tls.Config, error) {
@@ -2713,7 +2665,6 @@ func (f *Forwarder) listPods(authCtx *authContext, w http.ResponseWriter, req *h
 	}
 
 	f.emitAuditEvent(authCtx, req, sess, status)
-
 	return nil, nil
 }
 

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1164,6 +1164,7 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	f := newMockForwader(ctx, t)
+
 	authCtx := mockAuthCtx(ctx, t, "kube-cluster", false)
 
 	lockWatcher, err := services.NewLockWatcher(ctx, services.LockWatcherConfig{
@@ -1194,6 +1195,10 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 		return rt
 	}
 
+	h2Transport, err := newH2Transport(&tls.Config{
+		InsecureSkipVerify: true,
+	}, nil)
+	require.NoError(t, err)
 	f.clusterDetails = map[string]*kubeDetails{
 		"local": {
 			kubeCreds: &staticKubeCreds{
@@ -1201,6 +1206,12 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 				tlsConfig:  mockKubeAPI.TLS,
 				transportConfig: &transport.Config{
 					WrapTransport: checkTransportProxy,
+				},
+				transport: httpTransport{
+					h1Transport: newH1Transport(&tls.Config{
+						InsecureSkipVerify: true,
+					}, nil),
+					h2Transport: h2Transport,
 				},
 			},
 		},
@@ -1243,7 +1254,8 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 func newMockForwader(ctx context.Context, t *testing.T) *Forwarder {
 	clientCreds, err := ttlmap.New(defaults.ClientCacheSize)
 	require.NoError(t, err)
-
+	cachedTransport, err := ttlmap.New(defaults.ClientCacheSize)
+	require.NoError(t, err)
 	csrClient, err := newMockCSRClient()
 	require.NoError(t, err)
 
@@ -1262,6 +1274,7 @@ func newMockForwader(ctx context.Context, t *testing.T) *Forwarder {
 		clientCredentials: clientCreds,
 		activeRequests:    make(map[string]context.Context),
 		ctx:               ctx,
+		cachedTransport:   cachedTransport,
 	}
 }
 

--- a/lib/kube/proxy/kube_creds.go
+++ b/lib/kube/proxy/kube_creds.go
@@ -39,6 +39,7 @@ type kubeCreds interface {
 	getTargetAddr() string
 	getKubeRestConfig() *rest.Config
 	getKubeClient() *kubernetes.Clientset
+	getTransport(upgradeH2 bool) http.RoundTripper
 	wrapTransport(http.RoundTripper) (http.RoundTripper, error)
 	close() error
 }
@@ -63,10 +64,28 @@ type staticKubeCreds struct {
 	kubeClient *kubernetes.Clientset
 	// clientRestCfg is the Kubernetes Rest config for the cluster.
 	clientRestCfg *rest.Config
+	transport     httpTransport
+}
+
+type httpTransport struct {
+	// h1Transport is the HTTP/1 transport used for requests that cannot be
+	// sent via HTTP/2. Examples include requests that use the websockets or
+	// SPDY protocols.
+	h1Transport http.RoundTripper
+	// h2Transport is the HTTP/2 transport used for requests that can be sent
+	// via HTTP/2.
+	h2Transport http.RoundTripper
 }
 
 func (s *staticKubeCreds) getTLSConfig() *tls.Config {
 	return s.tlsConfig
+}
+
+func (s *staticKubeCreds) getTransport(upgradeH2 bool) http.RoundTripper {
+	if upgradeH2 {
+		return s.transport.h2Transport
+	}
+	return s.transport.h1Transport
 }
 
 func (s *staticKubeCreds) getTransportConfig() *transport.Config {
@@ -219,6 +238,12 @@ func (d *dynamicKubeCreds) wrapTransport(rt http.RoundTripper) (http.RoundTrippe
 func (d *dynamicKubeCreds) close() error {
 	close(d.closeC)
 	return nil
+}
+
+func (d *dynamicKubeCreds) getTransport(upgradeH2 bool) http.RoundTripper {
+	d.RLock()
+	defer d.RUnlock()
+	return d.staticCreds.getTransport(upgradeH2)
 }
 
 // renewClientset generates the credentials required for accessing the cluster using the client function.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -200,6 +200,12 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 	authMiddleware := &auth.Middleware{
 		ClusterName:   clustername.GetClusterName(),
 		AcceptedUsage: []string{teleport.UsageKubeOnly},
+		// EnableCredentialsForwarding is set to true to allow the proxy to forward
+		// the client identity to the target service using headers instead of TLS
+		// certificates. This is required for the kube service and leaf cluster proxy
+		// to be able to replace the client identity with the header payload when
+		// the request is forwarded from a Teleport Proxy.
+		EnableCredentialsForwarding: true,
 	}
 	authMiddleware.Wrap(fwd)
 	// Wrap sets the next middleware in chain to the authMiddleware

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -512,7 +512,7 @@ func (s *session) launch() error {
 	s.podName = request.podName
 	s.BroadcastMessage("Connecting to %v over K8S", s.podName)
 
-	eventPodMeta := request.eventPodMeta(request.context, s.sess.creds)
+	eventPodMeta := request.eventPodMeta(request.context, s.sess.kubeAPICreds)
 
 	onFinished, err := s.lockedSetupLaunch(request, q, eventPodMeta)
 	if err != nil {

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -1,0 +1,497 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"math/rand"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/coreos/go-semver/semver"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/net/http2"
+	"k8s.io/client-go/transport"
+
+	"github.com/gravitational/teleport"
+	tracehttp "github.com/gravitational/teleport/api/observability/tracing/http"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// transportForRequest determines the transport to use for a request to a specific
+// Kubernetes cluster. If the servers don't support impersonation, a single
+// transport is used per request. Otherwise, a new transport is used for all
+// requests in order to improve performance.
+// TODO(tigrato): Remove the check once all servers support impersonation.
+func (f *Forwarder) transportForRequest(sess *clusterSession) (http.RoundTripper, error) {
+	// If the cluster is remote, we need to check if all remote proxies support
+	// impersonation. If it does, use a single transport per request. Otherwise,
+	// fall back to using a new transport for each request.
+	if sess.teleportCluster.isRemote {
+		if proxies, err := f.getRemoteClusterProxies(sess.teleportCluster.name); err == nil &&
+			allServersSupportImpersonation(proxies) {
+			return f.transportForRequestWithImpersonation(sess)
+		}
+		// If the cluster is not remote, validate the kube services support of
+		// impersonation.
+	} else if allServersSupportImpersonation(sess.kubeServers) {
+		// If all servers support impersonation, use a new transport for each
+		// request. This will ensure that the client certificate is valid for the
+		// server that the request is being sent to.
+		return f.transportForRequestWithImpersonation(sess)
+	}
+	// Otherwise, use a single transport per request.
+	return f.transportForRequestWithoutImpersonation(sess)
+}
+
+// getRemoteClusterProxies returns a list of proxies registered at the remote cluster.
+// It's used to determine whether the remote cluster supports identity forwarding.
+func (f *Forwarder) getRemoteClusterProxies(clusterName string) ([]types.Server, error) {
+	targetCluster, err := f.cfg.ReverseTunnelSrv.GetSite(clusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Get the remote cluster's cache.
+	caching, err := targetCluster.CachingAccessPoint()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	proxies, err := caching.GetProxies()
+	return proxies, trace.Wrap(err)
+}
+
+// dialContextFunc is a context network dialer function that returns a network connection
+type dialContextFunc func(context.Context, string, string) (net.Conn, error)
+
+// transportForRequestWithoutImpersonation returns a transport that does not
+// support impersonation. This is used when the at least one kube_server or proxy
+// don't support impersonation in order to ensure that the client request
+// can be routed correctly.
+//
+// DELETE IN 15.0.0
+// TODO(tigrato): Remove this once all servers support impersonation.
+func (f *Forwarder) transportForRequestWithoutImpersonation(sess *clusterSession) (http.RoundTripper, error) {
+	if sess.kubeAPICreds != nil {
+		return sess.kubeAPICreds.getTransport(sess.upgradeToHTTP2), nil
+	}
+	transport := newTransport(sess.DialWithContext, sess.tlsConfig)
+	if !sess.upgradeToHTTP2 {
+		return tracehttp.NewTransport(transport), nil
+	}
+	if err := http2.ConfigureTransport(transport); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return tracehttp.NewTransport(transport), nil
+}
+
+// transportForRequestWithImpersonation returns a transport that supports
+// impersonation. This allows the client to reuse the same transport for all
+// requests to the cluster in order to improve performance.
+// The transport is cached in the forwarder so that it can be reused for future
+// requests. If the transport is not cached, a new one is created and cached.
+func (f *Forwarder) transportForRequestWithImpersonation(sess *clusterSession) (http.RoundTripper, error) {
+	// transportCacheTTL is the TTL for the transport cache.
+	const transportCacheTTL = 5 * time.Hour
+	// If the cluster is remote, the key is the teleport cluster name.
+	// If the cluster is local, the key is the teleport cluster name and the kubernetes
+	// cluster name: <teleport-cluster-name>/<kubernetes-cluster-name>.
+	key := transportCacheKey(sess)
+
+	// Check if the transport is cached.
+	f.cachedTransportMu.Lock()
+	cachedI, ok := f.cachedTransport.Get(key)
+	f.cachedTransportMu.Unlock()
+	if ok {
+		if cached, ok := cachedI.(*httpTransport); ok {
+			if sess.upgradeToHTTP2 {
+				return cached.h2Transport, nil
+			}
+			return cached.h1Transport, nil
+		}
+	}
+
+	var httpTransport *httpTransport
+	var err error
+	if sess.teleportCluster.isRemote {
+		// If the cluster is remote, create a new transport for the remote cluster.
+		httpTransport, err = f.newRemoteClusterTransport(sess.teleportCluster.name)
+	} else if sess.kubeAPICreds != nil {
+		// If agent is running in agent mode, get the transport from the configured cluster
+		// credentials.
+		return sess.kubeAPICreds.getTransport(sess.upgradeToHTTP2), nil
+	} else if f.cfg.ReverseTunnelSrv != nil {
+		// If agent is running in proxy mode, create a new transport for the local cluster.
+		httpTransport, err = f.newLocalClusterTransport(sess.kubeClusterName)
+	} else {
+		return nil, trace.BadParameter("no reverse tunnel server or credentials provided")
+	}
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Cache the transport.
+	f.cachedTransportMu.Lock()
+	f.cachedTransport.Set(key, httpTransport, transportCacheTTL)
+	f.cachedTransportMu.Unlock()
+	// Return the transport depending on whether HTTP/2 is enabled.
+	// Distinction is made because the SPDY protocol is not supported by HTTP/2
+	// and we must use HTTP/1.1 for it.
+	if sess.upgradeToHTTP2 {
+		return httpTransport.h2Transport, nil
+	}
+	return httpTransport.h1Transport, nil
+}
+
+// transportCacheKey returns a key used to cache transports.
+// If the cluster is remote, the key is the teleport cluster name.
+// If the cluster is local, the key is the teleport cluster name and the kubernetes
+// cluster name.
+// The key is used to cache transports so that they can be reused for future requests.
+// Each transport contains a custom dialer that is valid for a specific Teleport
+// remote proxy or Teleport Kubernetes Services that serves the target cluster.
+func transportCacheKey(sess *clusterSession) string {
+	if sess.teleportCluster.isRemote {
+		return fmt.Sprintf("%x", sess.teleportCluster.name)
+	}
+	return fmt.Sprintf("%x/%x", sess.teleportCluster.name, sess.kubeClusterName)
+}
+
+// wrapTransport wraps the provided transport with the Kubernetes transport config
+// if it is not nil.
+func wrapTransport(rt http.RoundTripper, transportConfig *transport.Config) (http.RoundTripper, error) {
+	if transportConfig == nil {
+		return rt, nil
+	}
+
+	wrapped, err := transport.HTTPWrappersForConfig(transportConfig, rt)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return enforceCloseIdleConnections(wrapped, rt), nil
+}
+
+// newTransport creates a new [http.Transport] with the provided dialer and TLS
+// config.
+// The transport is configured to use a connection pool and to close idle
+// connections after a timeout.
+func newTransport(dial dialContextFunc, tlsConfig *tls.Config) *http.Transport {
+	return &http.Transport{
+		DialContext:     dial,
+		TLSClientConfig: tlsConfig,
+		// Increase the size of the connection pool. This substantially improves the
+		// performance of Teleport under load as it reduces the number of TLS
+		// handshakes performed.
+		MaxIdleConns:        defaults.HTTPMaxIdleConns,
+		MaxIdleConnsPerHost: defaults.HTTPMaxIdleConnsPerHost,
+		// IdleConnTimeout defines the maximum amount of time before idle connections
+		// are closed. Leaving this unset will lead to connections open forever and
+		// will cause memory leaks in a long running process.
+		IdleConnTimeout: defaults.HTTPIdleTimeout,
+	}
+}
+
+// versionWithoutImpersonation is the version of Teleport that starts supporting
+// impersonation. Before this version, the client will not use impersonation.
+var versionWithoutImpersonation = semver.New(utils.VersionBeforeAlpha("13.0.0"))
+
+// teleportVersionInterface is an interface that allows to get the Teleport version of
+// a server.
+// DELETE IN 15.0.0
+type teleportVersionInterface interface {
+	GetTeleportVersion() string
+}
+
+// allServersSupportImpersonation returns true if all servers in the list
+// support impersonation. This is used to determine if the client should
+// create a new client certificate and use a different [http.Transport]
+// (https://golang.org/pkg/net/http/#Transport) for each request.
+// Only returns true if all servers in the list support impersonation.
+// DELETE IN 15.0.0
+func allServersSupportImpersonation[T teleportVersionInterface](servers []T) bool {
+	if len(servers) == 0 {
+		return false
+	}
+	for _, server := range servers {
+		serverVersion := server.GetTeleportVersion()
+		semVer, err := semver.NewVersion(serverVersion)
+		if err != nil || semVer.LessThan(*versionWithoutImpersonation) {
+			return false
+		}
+	}
+	return true
+}
+
+// getOrRequestClientCreds returns the client credentials for the provided auth context.
+// If the credentials are not cached, they will be requested from the auth server.
+// DELETE IN 15.0.0
+func (f *Forwarder) getOrRequestClientCreds(tracingCtx context.Context, authCtx authContext) (*tls.Config, error) {
+	c := f.getClientCreds(authCtx)
+	if c == nil {
+		return f.serializedRequestClientCreds(tracingCtx, authCtx)
+	}
+	return c, nil
+}
+
+// getClientCreds returns the client credentials for the provided auth context.
+// DELETE IN 15.0.0
+func (f *Forwarder) getClientCreds(ctx authContext) *tls.Config {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	creds, ok := f.clientCredentials.Get(ctx.key())
+	if !ok {
+		return nil
+	}
+	c := creds.(*tls.Config)
+	if !validClientCreds(f.cfg.Clock, c) {
+		return nil
+	}
+	return c
+}
+
+// saveClientCreds saves the client credentials for the provided auth context.
+// DELETE IN 15.0.0
+func (f *Forwarder) saveClientCreds(ctx authContext, c *tls.Config) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.clientCredentials.Set(ctx.key(), c, ctx.sessionTTL)
+}
+
+// validClientCreds returns true if the provided client credentials are valid.
+// DELETE IN 15.0.0
+func validClientCreds(clock clockwork.Clock, c *tls.Config) bool {
+	if len(c.Certificates) == 0 || len(c.Certificates[0].Certificate) == 0 {
+		return false
+	}
+	crt, err := x509.ParseCertificate(c.Certificates[0].Certificate[0])
+	if err != nil {
+		return false
+	}
+	// Make sure that the returned cert will be valid for at least 1 more
+	// minute.
+	return clock.Now().After(crt.NotBefore) && clock.Now().Add(time.Minute).Before(crt.NotAfter)
+}
+
+// newRemoteClusterTransport returns a new [http.Transport] (https://golang.org/pkg/net/http/#Transport)
+// that can be used to dial Kubernetes Proxy in a remote Teleport cluster.
+// The transport is configured to use a connection pool and to close idle
+// connections after a timeout.
+func (f *Forwarder) newRemoteClusterTransport(clusterName string) (*httpTransport, error) {
+	// Tunnel is nil for a teleport process with "kubernetes_service" but
+	// not "proxy_service".
+	if f.cfg.ReverseTunnelSrv == nil {
+		return nil, trace.BadParameter("this Teleport process can not dial Kubernetes endpoints in remote Teleport clusters; only proxy_service supports this, make sure a Teleport proxy is first in the request path")
+	}
+	// Dialer that will be used to dial the remote cluster via the reverse tunnel.
+	dialFn := f.remoteClusterDiater(clusterName)
+	tlsConfig, err := f.getTLSConfigForLeafCluster(clusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// Create a new HTTP/1 transport that will be used to dial the remote cluster.
+	h1Transport := newH1Transport(tlsConfig, dialFn)
+	// Create a new HTTP/2 transport that will be used to dial the remote cluster.
+	h2Transport, err := newH2Transport(tlsConfig, dialFn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &httpTransport{
+		h1Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h1Transport)),
+		h2Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h2Transport)),
+	}, nil
+}
+
+// getTLSConfigForLeafCluster returns a TLS config with the Proxy certificate
+// and the root CAs for the leaf cluster. Root proxy uses its own certificate
+// to connect to the leaf proxy.
+func (f *Forwarder) getTLSConfigForLeafCluster(clusterName string) (*tls.Config, error) {
+	ctx, cancel := context.WithTimeout(f.ctx, 5*time.Second)
+	defer cancel()
+	// Get the host CA for the target cluster from Auth to ensure we trust the
+	// leaf proxy certificate.
+	hostCA, err := f.cfg.CachingAuthClient.GetCertAuthority(ctx, types.CertAuthID{
+		Type:       types.HostCA,
+		DomainName: clusterName,
+	}, false)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	pool := x509.NewCertPool()
+	for _, certAuthority := range services.GetTLSCerts(hostCA) {
+		if ok := pool.AppendCertsFromPEM(certAuthority); !ok {
+			return nil, trace.BadParameter("failed to append certificates, check that kubeconfig has correctly encoded certificate authority data")
+		}
+	}
+	// Clone the TLS config and set the root CAs to the leaf host CA pool.
+	tlsConfig := f.cfg.ConnTLSConfig.Clone()
+	tlsConfig.RootCAs = pool
+
+	return tlsConfig, nil
+}
+
+// remoteClusterDiater returns a dialer that can be used to dial Kubernetes Proxy
+// in a remote Teleport cluster via the reverse tunnel.
+func (f *Forwarder) remoteClusterDiater(clusterName string) dialContextFunc {
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		_, span := f.cfg.tracer.Start(
+			ctx,
+			"kube.Forwarder/remoteClusterDiater",
+			oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+			oteltrace.WithAttributes(
+				semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+				semconv.RPCMethodKey.String("reverse_tunnel.Dial"),
+				semconv.RPCSystemKey.String("kube"),
+			),
+		)
+		defer span.End()
+
+		targetCluster, err := f.cfg.ReverseTunnelSrv.GetSite(clusterName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return targetCluster.DialTCP(reversetunnel.DialParams{
+			// Proxy uses reverse tunnel dialer to connect to Kubernetes in a leaf cluster
+			// and the targetKubernetes cluster endpoint is determined from the identity
+			// encoded in the TLS certificate. We're setting the dial endpoint to a hardcoded
+			// `kube.teleport.cluster.local` value to indicate this is a Kubernetes proxy request
+			To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: reversetunnel.LocalKubernetes},
+			ConnType: types.KubeTunnel,
+		})
+	}
+}
+
+// newLocalClusterTransport returns a new [http.Transport] (https://golang.org/pkg/net/http/#Transport)
+// that can be used to dial Kubernetes Service in a local Teleport cluster.
+func (f *Forwarder) newLocalClusterTransport(kubeClusterName string) (*httpTransport, error) {
+	dialFn := f.localClusterDiater(kubeClusterName)
+
+	h1Transport := newH1Transport(f.cfg.ConnTLSConfig, dialFn)
+	h2Transport, err := newH2Transport(f.cfg.ConnTLSConfig, dialFn)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &httpTransport{
+		h1Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h1Transport)),
+		h2Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h2Transport)),
+	}, nil
+}
+
+// localClusterDiater returns a dialer that can be used to dial Kubernetes Service
+// in a local Teleport cluster using the reverse tunnel.
+// The endpoints are fetched from the cached auth client and are shuffled
+// to avoid hotspots.
+func (f *Forwarder) localClusterDiater(kubeClusterName string) dialContextFunc {
+	return func(ctx context.Context, _, _ string) (net.Conn, error) {
+		_, span := f.cfg.tracer.Start(
+			ctx,
+			"kube.Forwarder/localClusterDiater",
+			oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+			oteltrace.WithAttributes(
+				semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
+				semconv.RPCMethodKey.String("reverse_tunnel.Dial"),
+				semconv.RPCSystemKey.String("kube"),
+			),
+		)
+		defer span.End()
+
+		// Not a remote cluster and we have a reverse tunnel server.
+		// Use the local reversetunnel.Site which knows how to dial by serverID
+		// (for "kubernetes_service" connected over a tunnel) and falls back to
+		// direct dial if needed.
+		localCluster, err := f.cfg.ReverseTunnelSrv.GetSite(f.cfg.ClusterName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		kubeServers, err := f.getKubernetesServersForKubeCluster(ctx, kubeClusterName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		// Shuffle the list of servers to avoid always connecting to the same
+		// server.
+		rand.Shuffle(
+			len(kubeServers),
+			func(i, j int) {
+				kubeServers[i], kubeServers[j] = kubeServers[j], kubeServers[i]
+			},
+		)
+
+		// Validate that the requested kube cluster is registered.
+		for _, s := range kubeServers {
+			kubeCluster := s.GetCluster()
+			if kubeCluster.GetName() != kubeClusterName {
+				continue
+			}
+			// serverID is a unique identifier of the server in the cluster.
+			// It is a combination of the server's hostname and the cluster name.
+			// <host_id>.<cluster_name>
+			serverID := fmt.Sprintf("%s.%s", s.GetHostID(), f.cfg.ClusterName)
+			if conn, err := localCluster.DialTCP(reversetunnel.DialParams{
+				To:       &utils.NetAddr{AddrNetwork: "tcp", Addr: s.GetHostname()},
+				ConnType: types.KubeTunnel,
+				ServerID: serverID,
+				ProxyIDs: s.GetProxyIDs(),
+			}); err == nil {
+				return conn, nil
+			}
+		}
+
+		return nil, trace.NotFound("kubernetes cluster %q is not found in teleport cluster %q", kubeClusterName, f.cfg.ClusterName)
+	}
+}
+
+// newH1Transport creates a new HTTP/1.1 transport.
+func newH1Transport(tlsConfig *tls.Config, dial dialContextFunc) *http.Transport {
+	tlsConfig = tlsConfig.Clone()
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	tlsConfig.NextProtos = []string{teleport.HTTPNextProtoTLS}
+	return newTransport(dial, tlsConfig)
+}
+
+// newH2Transport creates a new HTTP/2 transport with ALPN support.
+func newH2Transport(tlsConfig *tls.Config, dial dialContextFunc) (*http.Transport, error) {
+	tlsConfig = tlsConfig.Clone()
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{}
+	}
+	tlsConfig.NextProtos = []string{http2.NextProtoTLS, teleport.HTTPNextProtoTLS}
+	h2HTTPTransport := newTransport(dial, tlsConfig)
+	// Upgrade transport to h2 where HTTP_PROXY and HTTPS_PROXY
+	// envs are not take into account purposely.
+	if err := http2.ConfigureTransport(h2HTTPTransport); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return h2HTTPTransport, nil
+}

--- a/lib/kube/proxy/transport_test.go
+++ b/lib/kube/proxy/transport_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func Test_allServersSupportImpersonation(t *testing.T) {
+	type args struct {
+		servers []teleportVersionInterface
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "all servers support impersonation",
+			args: args{
+				servers: []teleportVersionInterface{
+					newKubeServerForVersion(t, "13.0.0"),
+					newKubeServerForVersion(t, "13.0.0-alpha.1"),
+					newKubeServerForVersion(t, "14.0.0"),
+					newKubeServerForVersion(t, "15.0.0"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "a server does support impersonation",
+			args: args{
+				servers: []teleportVersionInterface{
+					newKubeServerForVersion(t, "13.0.0"),
+					newKubeServerForVersion(t, "13.0.0-alpha.1"),
+					newKubeServerForVersion(t, "14.0.0"),
+					newKubeServerForVersion(t, "12.1.0"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "a server without valid version",
+			args: args{
+				servers: []teleportVersionInterface{
+					newKubeServerForVersion(t, "13.0.0"),
+					newKubeServerForVersion(t, ".0.0-alpha.1"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "all proxy support impersonation",
+			args: args{
+				servers: []teleportVersionInterface{
+					newProxyServerForVersion(t, "13.0.0"),
+					newProxyServerForVersion(t, "13.0.0-alpha.1"),
+					newProxyServerForVersion(t, "14.0.0"),
+					newProxyServerForVersion(t, "15.0.0"),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "a proxy does support impersonation",
+			args: args{
+				servers: []teleportVersionInterface{
+					newProxyServerForVersion(t, "13.0.0"),
+					newProxyServerForVersion(t, "13.0.0-alpha.1"),
+					newProxyServerForVersion(t, "14.0.0"),
+					newProxyServerForVersion(t, "12.1.0"),
+				},
+			},
+			want: false,
+		},
+		{
+			name: "a proxy without valid version",
+			args: args{
+				servers: []teleportVersionInterface{
+					newProxyServerForVersion(t, "13.0.0"),
+					newProxyServerForVersion(t, ".0.0-alpha.1"),
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, allServersSupportImpersonation(tt.args.servers))
+		})
+	}
+}
+
+func newKubeServerForVersion(t *testing.T, version string) types.KubeServer {
+	k, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name: "cluster",
+	}, types.KubernetesClusterSpecV3{})
+	require.NoError(t, err)
+
+	ks, err := types.NewKubernetesServerV3FromCluster(k, "host", "uiid")
+	require.NoError(t, err)
+	ks.Spec.Version = version
+	return ks
+}
+
+func newProxyServerForVersion(t *testing.T, version string) types.Server {
+	server, err := types.NewServer("host", types.KindProxy, types.ServerSpecV2{
+		Version: version,
+	})
+	require.NoError(t, err)
+	return server
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3948,8 +3948,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				LockWatcher:                   lockWatcher,
 				CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 				PROXYSigner:                   proxySigner,
+				// ConnTLSConfig is used by the proxy authenticate to the upstream kubernetes
+				// services or remote clustes to be able to send the client identity
+				// using Impersonation headers. The upstream service will validate if
+				// the provided connection certificate is from a proxy server and
+				// will impersonate the identity of the user that is making the request.
+				ConnTLSConfig: tlsConfig.Clone(),
 			},
-			TLS:             tlsConfig,
+			TLS:             tlsConfig.Clone(),
 			LimiterConfig:   cfg.Proxy.Limiter,
 			AccessPoint:     accessPoint,
 			GetRotation:     process.GetRotation,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2301,7 +2301,6 @@ func TestMotD(t *testing.T) {
 
 // TestPingAutomaticUpgrades ensures /webapi/ping returns whether AutomaticUpgrades are enabled.
 func TestPingAutomaticUpgrades(t *testing.T) {
-
 	t.Run("Automatic Upgrades are enabled", func(t *testing.T) {
 		// Enable Automatic Upgrades
 		modules.SetTestModules(t, &modules.TestModules{TestFeatures: modules.Features{
@@ -7899,7 +7898,8 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 			CheckImpersonationPermissions: func(ctx context.Context, clusterName string, sarClient authztypes.SelfSubjectAccessReviewInterface) error {
 				return nil
 			},
-			Clock: clockwork.NewRealClock(),
+			ConnTLSConfig: tlsConfig,
+			Clock:         clockwork.NewRealClock(),
 		},
 		TLS:           tlsConfig,
 		AccessPoint:   client,
@@ -8204,12 +8204,10 @@ func TestForwardingTraces(t *testing.T) {
 	}
 }
 
-type mockPROXYSigner struct {
-}
+type mockPROXYSigner struct{}
 
 func (m *mockPROXYSigner) SignPROXYHeader(source, destination net.Addr) ([]byte, error) {
 	return nil, nil
-
 }
 
 type mockTraceClient struct {


### PR DESCRIPTION
This PR introduces a new process for forwarding the user's identity for Kubernetes Access.

The identity forwarding is only enabled if all the `kube_servers` support the new impersonation mechanism and if the request isn't forwarded into a remote cluster. Remote clusters still use mTLS where the user identity is embedded in a proxy-cached certificate.

Only proxies are allowed to impersonate users.

In Teleport 14 we will remove all the mTLS code and we will support impersonation only.

The following benchmarks show the improvement between old and new versions.

## Old: mTLS benchmark 

```
Histogram

Percentile Response Duration 
---------- ----------------- 
25         31 ms             
50         32 ms             
75         33 ms             
90         33 ms             
95         37 ms             
99         44 ms             
100        88 ms   
```

## New: Impersonation benchmark

```
Histogram

Percentile Response Duration 
---------- ----------------- 
25         10 ms             
50         11 ms             
75         12 ms             
90         15 ms             
95         15 ms             
99         20 ms             
100        23 ms     

```

Part of #22533
Closes #21609 