### PR TITLE
ClusterItem: Remove usage of colors.secondary.lighter

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClusterItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Clusters/ClustersFilterableList/ClusterItem.tsx
@@ -91,16 +91,10 @@ function getBackgroundColor(props) {
     }
     return props.theme.colors.brand.main;
   }
-  if (props.isActive) {
-    return props.theme.colors.secondary.lighter;
-  }
 }
 
 function getHoverBackgroundColor(props) {
   if (props.isSelected) {
     return props.theme.colors.brand.accent;
-  }
-  if (props.isActive) {
-    return props.theme.colors.secondary.lighter;
   }
 }


### PR DESCRIPTION
There never was a color such as `secondary.lighter` so this piece of code never did anything, the background color was handled by the `ListItem` component that `ClusterItem` overwrites.

#23539 removed the `colors.secondary` object, so this code now throws an error on master.