### PR TITLE
Add systemctl instructions to Connecting Apps

### DIFF
--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -26,11 +26,7 @@ ssh_service:
 
 (!docs/pages/includes/permission-warning.mdx!)
 
-Start the service:
-
-```code
-$ sudo teleport start --config=/path/to/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx!)
 
 ### Generate a token
 


### PR DESCRIPTION
Fixes #11337

Replace `teleport start` instructions with the `start-teleport.mdx` partial. Note that this change does not attempt to edit any other aspect of this guide, even though it will take substantial changes to make it consistent with the rest of our docs.