### PR TITLE
Clarify how to decide undocumented style questions

### DIFF
--- a/docs/pages/contributing/documentation/style-guide.mdx
+++ b/docs/pages/contributing/documentation/style-guide.mdx
@@ -111,13 +111,20 @@ Specific kinds of architecture guides include:
 - Should be easy to navigate with a browser's search functionality. List all content on the same page.
 - Should avoid prose and be expressed with brevity.
 
-
 ## General style rules
 
 Please refer to this style guide when determining how address questions about
 English grammar, usage, and so on. Since many of these rules have equally
 justifiable alternatives, a style guide prevents debates over these questions
 from getting in the way of documenting Teleport.
+
+<Notice type="tip">
+
+If a commonly debated style question does not have a resolution in this guide
+(e.g., the Oxford comma), all we ask is that you keep your style consistent
+within a particular page to maintain a professional polish.
+
+</Notice>
 
 ### Voice
 


### PR DESCRIPTION
Fixes #10716

There are too many style rules for us to have a style guide entry for everything. We could use a professional style guide, e.g., the AP manual, but these usually require subscriptions, which isn't great for an open source documentation site. Instead, we can side with consistency within a single page.