### PR TITLE
Add Okta assignment update statuses to Okta access point.

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -797,6 +797,11 @@ type OktaAccessPoint interface {
 	// UpdateOktaAssignment updates an existing Okta assignment resource.
 	UpdateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
 
+	// UpdateOktaAssignmentActionStatuses will update the statuses for all actions in an Okta assignment if the
+	// status is a valid transition. If a transition is invalid, it will be logged and the rest of the action statuses
+	// will be updated if possible.
+	UpdateOktaAssignmentActionStatuses(ctx context.Context, name, status string) (types.OktaAssignment, error)
+
 	// DeleteOktaAssignment removes the specified Okta assignment resource.
 	DeleteOktaAssignment(ctx context.Context, name string) error
 
@@ -1247,6 +1252,13 @@ func (w *OktaWrapper) CreateOktaAssignment(ctx context.Context, assignment types
 // UpdateOktaAssignment updates an existing Okta assignment resource.
 func (w *OktaWrapper) UpdateOktaAssignment(ctx context.Context, assignment types.OktaAssignment) (types.OktaAssignment, error) {
 	return w.NoCache.UpdateOktaAssignment(ctx, assignment)
+}
+
+// UpdateOktaAssignmentActionStatuses will update the statuses for all actions in an Okta assignment if the
+// status is a valid transition. If a transition is invalid, it will be logged and the rest of the action statuses
+// will be updated if possible.
+func (w *OktaWrapper) UpdateOktaAssignmentActionStatuses(ctx context.Context, name, status string) (types.OktaAssignment, error) {
+	return w.NoCache.UpdateOktaAssignmentActionStatuses(ctx, name, status)
 }
 
 // DeleteOktaAssignment removes the specified Okta assignment resource.


### PR DESCRIPTION
The Okta assignment update statuses function has been added to the Okta access point for use by the Okta enterprise service.