### PR TITLE
Close auth clients in tctl tests

### DIFF
--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -85,6 +85,13 @@ func getAuthClient(ctx context.Context, t *testing.T, fc *config.FileConfig, opt
 
 	client, err := authclient.Connect(ctx, clientConfig)
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		if closer, ok := client.(io.Closer); ok {
+			closer.Close()
+		}
+	})
+
 	return client
 }
 


### PR DESCRIPTION
Goroutine dumps from failed tests show a large number of goroutines blocked in GRPC client code. Our tctl tests create auth clients but only expose them via auth.ClientI, which doesn't have a close method.

Updates #19372 and #24005