### PR TITLE
operator: revert to old dockerfile and oci image build process

### DIFF
--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -1,5 +1,4 @@
 ARG BUILDBOX
-ARG BASE_IMAGE=gcr.io/distroless/static-debian11
 # BUILDPLATFORM is provided by Docker/buildx
 FROM --platform=$BUILDPLATFORM $BUILDBOX as builder
 
@@ -26,17 +25,20 @@ COPY integrations/operator/sidecar/ integrations/operator/sidecar/
 COPY integrations/operator/main.go integrations/operator/main.go
 COPY integrations/operator/namespace.go integrations/operator/namespace.go
 
-ARG TARGETOS
-ARG TARGETARCH
+# Compiler package should use host-triplet-agnostic name (i.e. "x86-64-linux-gnu-gcc" instead of "gcc")
+#  in most cases, to avoid issues on systems with multiple versions of gcc (i.e. buildboxes)
+# TARGETOS and TARGETARCH are provided by Docker/buildx, but must be explicitly listed here
+ARG COMPILER_NAME TARGETOS TARGETARCH
 
-# Build the program. We rely on golang's cross-compilation capabilities for multiarch building.
-RUN echo "Targeting $TARGETOS/$TARGETARCH" && \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+# Build the program
+# CGO is required for github.com/gravitational/teleport/lib/system
+RUN echo "Targeting $TARGETOS/$TARGETARCH with CC=$COMPILER_NAME" && \
+    CGO_ENABLED=1 CC=$COMPILER_NAME GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -a -o /go/bin/teleport-operator github.com/gravitational/teleport/integrations/operator
 
 # Create the image with the build operator on the $TARGETPLATFORM
 # TARGETPLATFORM is provided by Docker/buildx
-FROM --platform=$TARGETPLATFORM $BASE_IMAGE
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/cc
 WORKDIR /
 COPY --from=builder /go/bin/teleport-operator .
 

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -23,6 +23,21 @@ include ./envtest.mk
 # Configure which compiler and buildbox to use
 OS ?= $(shell go env GOOS)
 ARCH ?= $(shell go env GOARCH)
+ifeq ("$(OS)","linux")
+ifeq ("$(ARCH)","amd64")
+COMPILER ?= x86_64-linux-gnu-gcc
+PLATFORM_BUILDBOX ?= $(BUILDBOX)
+else ifeq ("$(ARCH)","386")
+COMPILER ?= x86_64-linux-gnu-gcc
+PLATFORM_BUILDBOX ?= $(BUILDBOX)
+else ifeq ("$(ARCH)","arm")
+COMPILER ?= arm-linux-gnueabihf-gcc
+PLATFORM_BUILDBOX ?= $(BUILDBOX_ARM)
+else ifeq ("$(ARCH)","arm64")
+COMPILER ?= aarch64-linux-gnu-gcc
+PLATFORM_BUILDBOX ?= $(BUILDBOX_ARM)
+endif
+endif
 
 .PHONY: all
 all: build
@@ -110,8 +125,8 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker buildx build --platform="$(OS)/$(ARCH)" --build-arg BUILDBOX=$(BUILDBOX) \
-		-t ${IMG} --load ../.. -f ./Dockerfile
+	docker buildx build --platform="$(OS)/$(ARCH)" --build-arg BUILDBOX=$(PLATFORM_BUILDBOX) \
+		--build-arg COMPILER_NAME=$(COMPILER) -t ${IMG} --load ../.. -f ./Dockerfile
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.


### PR DESCRIPTION
This PR fixes the operator OCI image build process.

I wrongly removed cgo in the operator build in https://github.com/gravitational/teleport/pull/23698. 
Somehow amd64 compilation still worked. However, this broke a bunch of arm64 dependencies and the drone builds.