### PR TITLE
[v12] Add missing `join_method` in azure joining docs

### DIFF
--- a/docs/pages/management/guides/joining-nodes-azure.mdx
+++ b/docs/pages/management/guides/joining-nodes-azure.mdx
@@ -350,6 +350,7 @@ metadata:
 spec:
   # use the minimal set of roles required
   roles: [Node]
+  join_method: azure
   azure:
     allow:
       # specify the Azure subscription which Nodes may join from


### PR DESCRIPTION
Backport #24013 to branch/v12