### PR TITLE
docs: correct mongodb atlas example config

### DIFF
--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -85,7 +85,8 @@ db_service:
   - name: "mongodb-atlas"
     protocol: "mongodb"
     uri: "mongodb+srv://cluster0.abcde.mongodb.net"
-    ca_cert_file: "/path/to/letsencrypt/isrgrootx1.pem"
+    tls:
+      ca_cert_file: "/path/to/letsencrypt/isrgrootx1.pem"
     static_labels:
       env: "dev"
 
@@ -133,7 +134,8 @@ db_service:
   - name: "mongodb-atlas"
     protocol: "mongodb"
     uri: "mongodb+srv://cluster0.abcde.mongodb.net"
-    ca_cert_file: "/path/to/letsencrypt/isrgrootx1.pem"
+    tls:
+      ca_cert_file: "/path/to/letsencrypt/isrgrootx1.pem"
     static_labels:
       env: "dev"
 ```


### PR DESCRIPTION
tls cert was in the wrong location