### PR TITLE
helm: Add updater support to `teleport-kube-agent` chart

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -139,14 +139,21 @@ below:
 
 ### `updater.enabled`
 
+| Type   | Default value | Required? |
+|--------|---------------|-----------|
+| `bool` | false         | No        |
+
 Enables the Kube Agent Updater and deploys it alongside the Teleport Agent.
-You must enable this when:
+You can enable this when:
+
 - using Teleport Cloud and your tenant is enrolled into automatic updates.
-  (You can check this through the web UI, choose "add a new node" of type
-  Kubernetes, and check if the value is turned on.)
+  (You can check this through the web UI, choose `Add Kubernetes` and
+  `Enroll New Resource of type Kubernetes`, and check if the value is turned
+  on.)
 - using self-hosted Teleport and you maintain your own version server.
 
 You must not enable this if:
+
 - you are a Teleport Cloud customer not enrolled in automatic updates.
 - you are a self-hosted Teleport user and have not set up your Teleport cluster to 
   support automatic updates.
@@ -158,7 +165,9 @@ You must not enable this if:
 | `string` | "https://update.gravitational.io/v1/" | Yes if not using Teleport Cloud |
 
 `updater.versionServer` is the URL of the version server the agent fetches the
-target version from.
+target version from. The complete version endpoint is built by concatenating
+[`versionServer`](#updaterversionserver) and
+[`releaseChannel`](#updaterreleasechannel).
 
 You must set this if the updater is enabled, and you are not a Teleport Cloud user.
 
@@ -171,7 +180,9 @@ You must not change the default values if you are a Teleport Cloud user.
 | `string` | "stable/cloud"  | No        |
 
 `updater.releaseChannel` is the release channel the updater subscribes to.
-
+The complete version endpoint is built by concatenating
+[`versionServer`](#updaterversionserver) and
+[`releaseChannel`](#updaterreleasechannel).
 You must not change the default value if you are a Teleport Cloud user unless
 instructed by Teleport support.
 

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -106,6 +106,90 @@ This parameter is not mandatory to preserve backwards compatibility with older c
 
 If you specify a role here, you may also need to specify some other settings which are detailed in this reference.
 
+## `updater`
+
+`updater` controls whether the Kube Agent Updater should be deployed alongside
+the `teleport-kube-agent`. The updater fetches the target version, validates the
+image signature, and updates the teleport deployment.
+
+All kubernetes-specific fields such as `tolerations`, `affinity`, `nodeSelector`,
+... default to the agent values. However, they can be overridden from the
+`udpater` object. For example:
+
+```yaml
+# the agent pod requests 1cpu and 2 GiB of memory. It also has a memory limit.
+resources:
+  requests:
+    cpu: "1"
+    memory: "2Gi"
+  limits:
+    memory: "2Gi"
+
+# the updater pod requests 0.5 cpu and 512MiB of memory. The memory limit has also been unset.
+updater:
+  resources:
+    requests:
+      cpu: "0.5"
+      memory: "512Mi"
+    limits: ~
+```
+
+Other updater-specific values that can be defined in `updater` are described
+below:
+
+### `updater.enabled`
+
+Enables the Kube Agent Updater and deploys it alongside the Teleport Agent.
+You must enable this when:
+- using Teleport Cloud and you tenant is enrolled into automatic updates.
+  (You can check this through the web UI, choose "add a new node" of type
+  Kubernetes, and check if the value is turned on.)
+- using Teleport on-prem and you maintain your own version server.
+
+You must not enable this if:
+- you are a Teleport Cloud customer not enrolled in automatic updates.
+  you are a Teleport on-prem user and have not set up your Teleport cluster to 
+  support automatic updates.
+
+### `updater.versionServer`
+
+| Type     | Default value                         | Required?                       |
+|----------|---------------------------------------|---------------------------------|
+| `string` | "https://update.gravitational.io/v1/" | Yes if not using Teleport Cloud |
+
+`updater.versionServer` is the URL of the version server the agent fetches the
+target version from.
+
+You must set this if the updater is enabled, and you are not a Teleport Cloud user.
+
+You must not change the default values if you are a Teleport Cloud user.
+
+### `updater.releaseChannel`
+
+| Type     | Default value   | Required? |
+|----------|-----------------|-----------|
+| `string` | "stable/cloud"  | No        |
+
+`updater.releaseChannel` is the release channel the updater subscribes to.
+
+You must not change the default value if you are a Teleport Cloud user unless
+instructed by Teleport support.
+
+You can change this value if the updater is enabled, you are not a Teleport
+Cloud user, and manage your own version server.
+
+### `updater.image`
+
+| Type     | Default value                                              | Required? |
+|----------|------------------------------------------------------------|-----------|
+| `string` | "public.ecr.aws/gravitational/teleport-kube-agent-updater" | No        |
+
+`image` sets the container image used for Teleport updater pods run when
+`updater.enabled` is true.
+
+You can override this to use your own Teleport Kube Agent Updater image rather
+than a Teleport-published image.
+
 ## `roleBindingName`
 
 | Type     | Default value | Required? |
@@ -1044,9 +1128,18 @@ The size of persistent volume to create.
 |----------|-----------------------------------------|
 | `string` | `public.ecr.aws/gravitational/teleport` |
 
-`image` sets the container image used for Teleport pods run by the `teleport-kube-agent` chart.
+`image` sets the container image used for Teleport agent pods run by the `teleport-kube-agent` chart.
 
 You can override this to use your own Teleport image rather than a Teleport-published image.
+
+<Admonition type="warning" title="Interaction with Teleport Kube Agent Updater">
+When using the Teleport Kube Agent Updater you must ensure the image is
+available before the updater version target gets updated and Kubernetes tries
+to pull the image.
+
+For this reason, it is strongly discouraged to set a custom image when
+connecting to a Teleport Cloud instance enrolled in automatic updates.
+</Admonition>
 
 <Tabs>
   <TabItem label="values.yaml">

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -141,14 +141,14 @@ below:
 
 Enables the Kube Agent Updater and deploys it alongside the Teleport Agent.
 You must enable this when:
-- using Teleport Cloud and you tenant is enrolled into automatic updates.
+- using Teleport Cloud and your tenant is enrolled into automatic updates.
   (You can check this through the web UI, choose "add a new node" of type
   Kubernetes, and check if the value is turned on.)
-- using Teleport on-prem and you maintain your own version server.
+- using self-hosted Teleport and you maintain your own version server.
 
 You must not enable this if:
 - you are a Teleport Cloud customer not enrolled in automatic updates.
-  you are a Teleport on-prem user and have not set up your Teleport cluster to 
+- you are a self-hosted Teleport user and have not set up your Teleport cluster to 
   support automatic updates.
 
 ### `updater.versionServer`

--- a/examples/chart/teleport-kube-agent/.lint/updater.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/updater.yaml
@@ -1,5 +1,5 @@
 proxyAddr: proxy.example.com:3080
-roles: ""
+roles: "custom"
 updater:
   enabled: true
   versionServer: https://my-custom-version-server/v1

--- a/examples/chart/teleport-kube-agent/.lint/updater.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/updater.yaml
@@ -1,0 +1,6 @@
+proxyAddr: proxy.example.com:3080
+roles: ""
+updater:
+  enabled: true
+  versionServer: https://my-custom-version-server/v1
+  releaseChannel: cloud/preview

--- a/examples/chart/teleport-kube-agent/.lint/updater.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/updater.yaml
@@ -3,4 +3,4 @@ roles: ""
 updater:
   enabled: true
   versionServer: https://my-custom-version-server/v1
-  releaseChannel: cloud/preview
+  releaseChannel: custom/preview

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -1,18 +1,13 @@
 {{- define "teleport-kube-agent.config" -}}
 {{- $logLevel := (coalesce .Values.logLevel .Values.log.level "INFO") -}}
-{{- if .Values.teleportVersionOverride -}}
-  {{- $_ := set . "teleportVersion" .Values.teleportVersionOverride -}}
-{{- else -}}
-  {{- $_ := set . "teleportVersion" .Chart.Version -}}
-{{- end -}}
-{{- if (ge (semver .teleportVersion).Major 11) }}
+{{- if (ge (include "teleport-kube-agent.version" . | semver).Major 11) }}
 version: v3
 {{- end }}
 teleport:
   join_params:
     method: "{{ .Values.joinParams.method }}"
     token_name: "/etc/teleport-secrets/auth-token"
-  {{- if (ge (semver .teleportVersion).Major 11) }}
+  {{- if (ge (include "teleport-kube-agent.version" . | semver).Major 11) }}
   proxy_server: {{ required "proxyAddr is required in chart values" .Values.proxyAddr }}
   {{- else }}
   auth_servers: ["{{ required "proxyAddr is required in chart values" .Values.proxyAddr }}"]

--- a/examples/chart/teleport-kube-agent/templates/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_helpers.tpl
@@ -13,6 +13,26 @@ true
 Create the name of the service account to use
 if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name
 */}}
-{{- define "teleport.serviceAccountName" -}}
+{{- define "teleport-kube-agent.serviceAccountName" -}}
 {{- coalesce .Values.serviceAccount.name .Values.serviceAccountName .Release.Name -}}
+{{- end -}}
+
+{{- define "teleport-kube-agent.version" -}}
+{{- if .Values.teleportVersionOverride -}}
+  {{- .Values.teleportVersionOverride -}}
+{{- else -}}
+  {{- .Chart.Version -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "teleport-kube-agent.baseImage" -}}
+{{- if .Values.enterprise -}}
+  {{- .Values.enterpriseImage -}}
+{{- else -}}
+  {{- .Values.image -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "teleport-kube-agent.image" -}}
+{{ include "teleport-kube-agent.baseImage" . }}:{{ include "teleport-kube-agent.version" . }}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrolebinding.yaml
@@ -13,6 +13,6 @@ roleRef:
   name: {{ .Values.clusterRoleName | default .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "teleport.serviceAccountName" . }}
+  name: {{ template "teleport-kube-agent.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
+++ b/examples/chart/teleport-kube-agent/templates/delete_hook.yaml
@@ -80,7 +80,7 @@ spec:
                 fieldPath: metadata.namespace
           - name: RELEASE_NAME
             value: {{ .Release.Name }}
-        image: "{{ if .Values.enterprise }}{{ .Values.enterpriseImage }}{{ else }}{{ .Values.image }}{{ end }}:{{ .teleportVersion }}"
+        image: {{ include "teleport-kube-agent.image" . | quote }}
         {{- if .Values.imagePullPolicy }}
         imagePullPolicy: {{ toYaml .Values.imagePullPolicy }}
         {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -115,7 +115,7 @@ spec:
       {{- end }}
       containers:
       - name: "teleport"
-        image: "{{ if .Values.enterprise }}{{ .Values.enterpriseImage }}{{ else }}{{ .Values.image }}{{ end }}:{{ .teleportVersion }}"
+        image: {{ include "teleport-kube-agent.image" . | quote }}
         {{- if .Values.imagePullPolicy }}
         imagePullPolicy: {{ toYaml .Values.imagePullPolicy }}
         {{- end }}
@@ -206,5 +206,5 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-      serviceAccountName: {{ template "teleport.serviceAccountName" . }}
+      serviceAccountName: {{ template "teleport-kube-agent.serviceAccountName" . }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/psp.yaml
+++ b/examples/chart/teleport-kube-agent/templates/psp.yaml
@@ -66,5 +66,5 @@ roleRef:
   name: {{ .Release.Name }}-psp
 subjects:
 - kind: ServiceAccount
-  name: {{ template "teleport.serviceAccountName" . }}
+  name: {{ template "teleport-kube-agent.serviceAccountName" . }}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/rolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/rolebinding.yaml
@@ -13,5 +13,5 @@ roleRef:
   name: {{ .Values.roleName | default .Release.Name }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "teleport.serviceAccountName" . }}
+  name: {{ template "teleport-kube-agent.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "teleport.serviceAccountName" . }}
+  name: {{ template "teleport-kube-agent.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- if .Values.extraLabels.serviceAccount }}
   labels:

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -110,14 +110,14 @@ spec:
 {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
 {{- end }}
-      serviceAccountName: {{ template "teleport.serviceAccountName" . }}
+      serviceAccountName: {{ template "teleport-kube-agent.serviceAccountName" . }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}
       {{- end }}
       containers:
       - name: "teleport"
-        image: "{{ if .Values.enterprise }}{{ .Values.enterpriseImage }}{{ else }}{{ .Values.image }}{{ end }}:{{ .teleportVersion }}"
+        image: {{ include "teleport-kube-agent.image" . | quote }}
         {{- if .Values.imagePullPolicy }}
         imagePullPolicy: {{ toYaml .Values.imagePullPolicy }}
         {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/updater/_helpers.tpl
+++ b/examples/chart/teleport-kube-agent/templates/updater/_helpers.tpl
@@ -1,0 +1,7 @@
+{{/*
+Create the name of the service account to use
+if serviceAccount is not defined or serviceAccount.name is empty, use .Release.Name
+*/}}
+{{- define "teleport-kube-agent-updater.serviceAccountName" -}}
+{{- coalesce .Values.updater.serviceAccount.name (include "teleport-kube-agent.serviceAccountName" . | printf "%s-updater") -}}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -1,0 +1,113 @@
+{{- if .Values.updater.enabled -}}
+{{- $updater := mustMergeOverwrite (mustDeepCopy .Values) .Values.updater -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-updater
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-updater
+{{- if $updater.extraLabels.deployment }}
+    {{- toYaml $updater.extraLabels.deployment | nindent 4 }}
+{{- end }}
+{{- if $updater.annotations.deployment }}
+  annotations: {{- toYaml $updater.annotations.deployment | nindent 4 }}
+{{- end }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-updater
+  template:
+    metadata:
+      annotations:
+{{- if $updater.annotations.pod }}
+  {{- toYaml $updater.annotations.pod | nindent 8 }}
+{{- end }}
+      labels:
+        app: {{ .Release.Name }}
+{{- if $updater.extraLabels.pod }}
+  {{- toYaml $updater.extraLabels.pod | nindent 8 }}
+{{- end }}
+    spec:
+{{- if $updater.affinity }}
+      affinity: {{- toYaml $updater.affinity | nindent 8 }}
+{{- end }}
+{{- if $updater.tolerations }}
+      tolerations: {{- toYaml $updater.tolerations | nindent 8 }}
+{{- end }}
+{{- if $updater.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml $updater.imagePullSecrets | nindent 8 }}
+{{- end }}
+{{- if $updater.nodeSelector }}
+      nodeSelector: {{- toYaml $updater.nodeSelector | nindent 8 }}
+{{- end }}
+      containers:
+      - name: "kube-agent-updater"
+        image: "{{ $updater.image }}:{{ include "teleport-kube-agent.version" . }}"
+{{- if $updater.imagePullPolicy }}
+        imagePullPolicy: {{ toYaml $updater.imagePullPolicy }}
+{{- end }}
+{{- if or $updater.extraEnv $updater.tls.existingCASecretName }}
+        env:
+  {{- if (gt (len $updater.extraEnv) 0) }}
+    {{- toYaml $updater.extraEnv | nindent 8 }}
+  {{- end }}
+  {{- if $updater.tls.existingCASecretName }}
+        - name: SSL_CERT_FILE
+          value: /etc/teleport-tls-ca/ca.pem
+        # Used to track whether a Teleport agent was installed using this method.
+        - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+          value: true
+  {{- end }}
+{{- end }}
+        args:
+          - "--agent-name={{ .Release.Name }}"
+          - "--agent-namespace={{ .Release.Namespace }}"
+          - "--base-image={{ include "teleport-kube-agent.baseImage" . }}"
+          - "--version-server={{ $updater.versionServer }}"
+          - "--release-channel={{ $updater.releaseChannel }}"
+{{- if $updater.securityContext }}
+        securityContext: {{- toYaml $updater.securityContext | nindent 10 }}
+{{- end }}
+        ports:
+        - name: metrics
+          containerPort: 8080
+          protocol: TCP
+        - name: healthz
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 6 # consider agent unhealthy after 30s (6 * 5s)
+          timeoutSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: diag
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 6 # consider unready after 30s
+          timeoutSeconds: 5
+{{- if $updater.resources }}
+        resources: {{- toYaml $updater.resources | nindent 10 }}
+{{- end }}
+{{- if $updater.tls.existingCASecretName }}
+        volumeMounts:
+        - mountPath: /etc/teleport-tls-ca
+          name: "teleport-tls-ca"
+          readOnly: true
+      volumes:
+      - name: "teleport-tls-ca"
+        secret:
+          secretName: {{ $updater.tls.existingCASecretName }}
+{{- end }}
+{{- if $updater.priorityClassName }}
+      priorityClassName: {{ $updater.priorityClassName }}
+{{- end }}
+      serviceAccountName: {{ template "teleport-kube-agent-updater.serviceAccountName" . }}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/updater/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/role.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.updater.enabled -}}
+{{- $updater := mustMergeOverwrite (mustDeepCopy .Values) .Values.updater -}}
+{{- if $updater.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-updater
+  namespace: {{ .Release.Namespace }}
+{{- if $updater.extraLabels.role }}
+  labels: {{- toYaml $updater.extraLabels.role | nindent 4 }}
+{{- end }}
+rules:
+# the updater needs to list pods to check their health
+# it also needs to delete pods to unstuck Statefulset rollouts
+- apiGroups:
+    - ""
+  resources:
+    - pods
+  verbs:
+    - get
+    - watch
+    - list
+    - delete
+- apiGroups:
+    - ""
+  resources:
+    - pods/status
+  verbs:
+    - get
+    - watch
+    - list
+# the updater needs to get the secret created by the agent containing the
+# maintenance window
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
+    - watch
+    - list
+  resourceNames:
+    - {{ .Release.Name }}-shared-state
+# the controller in the updater must be able to watch deployments and
+# statefulsets and get the one it should reconcile
+- apiGroups:
+    - "apps"
+  resources:
+    - deployments
+    - statefulsets
+    - deployments/status
+    - statefulsets/status
+  verbs:
+    - get
+    - watch
+    - list
+# However the updater should only update the agent it is watching
+- apiGroups:
+    - "apps"
+  resources:
+    - deployments
+    - statefulsets
+  verbs:
+    - update
+  resourceNames:
+    - {{ .Release.Name }}
+{{- end -}}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/updater/rolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/rolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.updater.enabled -}}
+{{- $updater := mustMergeOverwrite (mustDeepCopy .Values) .Values.updater -}}
+{{- if $updater.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-updater
+  namespace: {{ .Release.Namespace }}
+{{- if $updater.extraLabels.roleBinding }}
+  labels:
+  {{- toYaml $updater.extraLabels.roleBinding | nindent 4 }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .Release.Name }}-updater
+subjects:
+- kind: ServiceAccount
+  name: {{ template "teleport-kube-agent-updater.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/templates/updater/serviceaccount.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.updater.enabled -}}
+{{- $updater := mustMergeOverwrite (mustDeepCopy .Values) .Values.updater -}}
+{{- if $updater.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "teleport-kube-agent-updater.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- if $updater.extraLabels.serviceAccount }}
+  labels: {{- toYaml $updater.extraLabels.serviceAccount | nindent 4 }}
+{{- end }}
+{{- if $updater.annotations.serviceAccount }}
+  annotations: {{- toYaml $updater.annotations.serviceAccount | nindent 4 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -13,7 +13,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: 'public.ecr.aws/gravitational/teleport:'
+      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -43,7 +43,7 @@ should set securityContext in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: 'public.ecr.aws/gravitational/teleport:'
+      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -26,7 +26,7 @@ sets the affinity:
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/teleport
       - --version-server=https://my-custom-version-server/v1
-      - --release-channel=cloud/preview
+      - --release-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -70,7 +70,7 @@ sets the tolerations:
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/teleport
       - --version-server=https://my-custom-version-server/v1
-      - --release-channel=cloud/preview
+      - --release-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -1,0 +1,117 @@
+sets the affinity:
+  1: |
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: gravitational.io/dedicated
+              operator: In
+              values:
+              - teleport
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+        - podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - teleport
+            topologyKey: kubernetes.io/hostname
+          weight: 1
+    containers:
+    - args:
+      - --agent-name=RELEASE-NAME
+      - --agent-namespace=NAMESPACE
+      - --base-image=public.ecr.aws/gravitational/teleport
+      - --version-server=https://my-custom-version-server/v1
+      - --release-channel=cloud/preview
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:13.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      name: kube-agent-updater
+      ports:
+      - containerPort: 8080
+        name: metrics
+        protocol: TCP
+      - containerPort: 8081
+        name: healthz
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - all
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 9807
+    serviceAccountName: RELEASE-NAME-updater
+sets the tolerations:
+  1: |
+    containers:
+    - args:
+      - --agent-name=RELEASE-NAME
+      - --agent-namespace=NAMESPACE
+      - --base-image=public.ecr.aws/gravitational/teleport
+      - --version-server=https://my-custom-version-server/v1
+      - --release-channel=cloud/preview
+      image: public.ecr.aws/gravitational/teleport-kube-agent-updater:13.0.0-dev
+      imagePullPolicy: IfNotPresent
+      livenessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /healthz
+          port: healthz
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      name: kube-agent-updater
+      ports:
+      - containerPort: 8080
+        name: metrics
+        protocol: TCP
+      - containerPort: 8081
+        name: healthz
+        protocol: TCP
+      readinessProbe:
+        failureThreshold: 6
+        httpGet:
+          path: /readyz
+          port: diag
+        initialDelaySeconds: 5
+        periodSeconds: 5
+        timeoutSeconds: 5
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+          - all
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 9807
+    serviceAccountName: RELEASE-NAME-updater
+    tolerations:
+    - effect: NoExecute
+      key: dedicated
+      operator: Equal
+      value: teleport
+    - effect: NoSchedule
+      key: dedicated
+      operator: Equal
+      value: teleport

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
@@ -1,0 +1,49 @@
+sets the correct role rules:
+  1: |
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+      - watch
+      - list
+      - delete
+    - apiGroups:
+      - ""
+      resources:
+      - pods/status
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - ""
+      resourceNames:
+      - RELEASE-NAME-shared-state
+      resources:
+      - secrets
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - apps
+      resources:
+      - deployments
+      - statefulsets
+      - deployments/status
+      - statefulsets/status
+      verbs:
+      - get
+      - watch
+      - list
+    - apiGroups:
+      - apps
+      resourceNames:
+      - RELEASE-NAME
+      resources:
+      - deployments
+      - statefulsets
+      verbs:
+      - update

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -96,8 +96,6 @@ tests:
       - equal:
           path: spec.template.metadata.annotations.kubernetes\.io/pod-different
           value: 4
-#  - it: sets the pod extra labels
-#  - it: sets the deployment extra labels
   - it: sets the affinity
     values:
       - ../.lint/updater.yaml

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -1,0 +1,229 @@
+suite: Updater Deployment
+templates:
+  - updater/deployment.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a Deployment when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a Deployment when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: Deployment
+          apiVersion: apps/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+  #
+  # Testing the agent configuration
+  #
+  - it: sets the updater base image
+    values:
+      - ../.lint/updater.yaml
+    set:
+      image: repo.example.com/gravitaional/teleport
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--base-image=repo.example.com/gravitaional/teleport"
+  - it: sets the updater base entreprise image
+    values:
+      - ../.lint/updater.yaml
+    set:
+      enterprise: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--base-image=public.ecr.aws/gravitational/teleport-ent"
+  - it: sets the updater agent name
+    values:
+      - ../.lint/updater.yaml
+    release:
+      name: my-release
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-name=my-release"
+  - it: sets the updater agent namespace
+    values:
+      - ../.lint/updater.yaml
+    release:
+      namespace: my-namespace
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--agent-namespace=my-namespace"
+  - it: sets the updater version server
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+    - contains:
+        path: spec.template.spec.containers[0].args
+        content: "--version-server=https://my-custom-version-server/v1"
+  - it: sets the updater release channel
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--release-channel=cloud/preview"
+  #
+  # Kubernetes-related tests
+  #
+  - it: sets the deployment annotations
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/annotations.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.kubernetes\.io/deployment
+          value: test-annotation
+      - equal:
+          path: metadata.annotations.kubernetes\.io/deployment-different
+          value: 3
+  - it: sets the pod annotations
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/annotations.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations.kubernetes\.io/pod
+          value: test-annotation
+      - equal:
+          path: spec.template.metadata.annotations.kubernetes\.io/pod-different
+          value: 4
+#  - it: sets the pod extra labels
+#  - it: sets the deployment extra labels
+  - it: sets the affinity
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/affinity.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.affinity
+      - matchSnapshot:
+          path: spec.template.spec
+  - it: sets the tolerations
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/tolerations.yaml
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.tolerations
+      - matchSnapshot:
+          path: spec.template.spec
+  - it: sets the imagePullSecrets
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/imagepullsecrets.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: myRegistryKeySecretName
+  - it: sets the nodeSelector
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/node-selector.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value:
+            gravitational.io/k8s-role: node
+  - it: sets the updater container image and version
+    values:
+      - ../.lint/updater.yaml
+    set:
+      teleportVersionOverride: 8.3.4
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: public.ecr.aws/gravitational/teleport-kube-agent-updater:8.3.4
+  - it: sets the updater container imagePullPolicy
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/image-pull-policy.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+  - it: mounts the tls CA if provided and set the env var
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/existing-tls-secret-with-ca.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: teleport-tls-ca
+            secret:
+              secretName: helm-lint-existing-tls-secret-ca
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /etc/teleport-tls-ca
+            name: teleport-tls-ca
+            readOnly: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: SSL_CERT_FILE
+            value: /etc/teleport-tls-ca/ca.pem
+  - it: sets the updater container extraEnv
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/extra-env.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+            value: http://username:password@my.proxy.host:3128
+  - it: sets the pod resources
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/resources.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: 2
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: 4Gi
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: 1
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: 2Gi
+  - it: sets the pod priorityClass
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/priority-class-name.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.priorityClassName
+          value: teleport-kube-agent
+  - it: sets the pod service-account
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/service-account-name.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: teleport-kube-agent-sa-updater
+  - it: sets the pod service-account (override)
+    values:
+      - ../.lint/updater.yaml
+      - ../.lint/service-account-name.yaml
+    set:
+      updater:
+        serviceAccount:
+          name: distinct-updater-sa
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: distinct-updater-sa

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -70,7 +70,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--release-channel=cloud/preview"
+          content: "--release-channel=custom/preview"
   #
   # Kubernetes-related tests
   #

--- a/examples/chart/teleport-kube-agent/tests/updater_role_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_role_test.yaml
@@ -1,0 +1,39 @@
+suite: Updater Role
+templates:
+  - updater/role.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a Role when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a Role when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: Role
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+  - it: does not create a Role when updater.enabled is true but rbac creation is disabled
+    values:
+      - ../.lint/updater.yaml
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  #
+  # Catch-all content test
+  #
+  - it: sets the correct role rules
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - matchSnapshot:
+          path: rules

--- a/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
@@ -1,0 +1,49 @@
+suite: Updater Role
+templates:
+  - updater/rolebinding.yaml
+tests:
+  #
+  # Basic tests
+  #
+  - it: does not create a RoleBinding when updater.enabled is false (default)
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: creates a RoleBinding when updater.enabled is true
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - containsDocument:
+          kind: RoleBinding
+          apiVersion: rbac.authorization.k8s.io/v1
+          name: RELEASE-NAME-updater
+          namespace: NAMESPACE
+  - it: does not create a RoleBinding when updater.enabled is true but rbac creation is disabled
+    values:
+      - ../.lint/updater.yaml
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  #
+  # Catch-all content test
+  #
+  - it: sets the correct rolebinding content
+    values:
+      - ../.lint/updater.yaml
+    asserts:
+      - equal:
+          path: roleRef
+          value:
+            apiGroup: rbac.authorization.k8s.io
+            kind: Role
+            name: RELEASE-NAME-updater
+      - equal:
+          path: subjects
+          value:
+            - kind: ServiceAccount
+              name: RELEASE-NAME-updater
+              namespace: NAMESPACE

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -139,7 +139,8 @@ tls:
 updater:
   enabled: false
   # `updater.versionServer` is the URL of the version server the agent fetches
-  # the target version from.
+  # the target version from. The complete version endpoint is built by
+  # concatenating `versionServer` and `releaseChannel`.
   versionServer: "https://update.gravitational.io/v1/"
   # Release channel the agent subscribes to.
   releaseChannel: "stable/cloud"

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -136,6 +136,18 @@ tls:
   # The filename inside the secret is important - it _must_ be ca.pem
   existingCASecretName: ""
 
+updater:
+  enabled: false
+  # `updater.versionServer` is the URL of the version server the agent fetches
+  # the target version from.
+  versionServer: "https://update.gravitational.io/v1/"
+  # Release channel the agent subscribes to.
+  releaseChannel: "stable/cloud"
+  image: public.ecr.aws/gravitational/teleport-kube-agent-updater
+  serviceAccount:
+    # service account name defaults to "<kube agent sa name>-updater"
+    name: ""
+
 # If set, will use an existing volume mounted via extraVolumes
 # as the Teleport data directory.
 # If anything is set under the "storage" key, this will be ignored.


### PR DESCRIPTION
This PR adds updater support to the `teleport-kube-agent` chart.

Cloud users will need to set

```yaml
updater:
  enabled: true
```

While on-prem users will also need to set their own version server

```yaml
updater:
  enabled: true
  versionServer: https://foo.example.com
```

By default the updater deployment will honour all applicable Kubernetes-related values like `resources`, `affinity`, `extraEnv`, ... but those can be overwritten like we do in `teleport-cluster`:


```yaml
updater:
  enabled: true
  resources:
    requests:
      cpu: "0.5"
      memory: 1Gi
```