### PR TITLE
v12 upcoming releases: Replace "Spotlight Search" with "Cross-Cluster Search"

### DIFF
--- a/docs/pages/preview/upcoming-releases.mdx
+++ b/docs/pages/preview/upcoming-releases.mdx
@@ -91,7 +91,7 @@ Teleport will include OpsGenie access plugin.
 
 Database Access will add support for connecting to AWS OpenSearch.
 
-#### Spotlight Search for Teleport Connect
+#### Cross-Cluster Search for Teleport Connect
 
 Teleport Connect will include a new search experience, allowing you to search for and connect to resources
 across all logged-in clusters.


### PR DESCRIPTION
Spotlight is [a term trademarked by Apple](https://www.apple.com/legal/intellectual-property/trademark/appletmlist.html) so we're probably better off not using "Spotlight search" when referring to the new feature.