### PR TITLE
Remove deprecated web api routes

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -545,12 +545,6 @@ func (h *Handler) bindDefaultEndpoints() {
 	// App sessions
 	h.POST("/webapi/sessions/app", h.WithAuth(h.createAppSession))
 
-	// DELETE IN 13, deprecated/unused web sessions routes (avatus)
-	// https://github.com/gravitational/teleport/pull/19892
-	h.POST("/webapi/sessions", httplib.WithCSRFProtection(h.WithLimiterHandlerFunc(h.createWebSession)))
-	h.DELETE("/webapi/sessions", h.WithAuth(h.deleteWebSession))
-	h.POST("/webapi/sessions/renew", h.WithAuth(h.renewWebSession))
-
 	// Web sessions
 	h.POST("/webapi/sessions/web", httplib.WithCSRFProtection(h.WithLimiterHandlerFunc(h.createWebSession)))
 	h.DELETE("/webapi/sessions/web", h.WithAuth(h.deleteWebSession))


### PR DESCRIPTION
More info in conversation here: https://github.com/gravitational/teleport/pull/19892

Removing these routes that were deprecated in 12
- /webapi/sessions
- /webapi/sessions
- /webapi/sessions/renew