### PR TITLE
[v11] Revert "support readable enum values in database tls mode"

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -17,7 +17,6 @@ limitations under the License.
 package types
 
 import (
-	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -742,91 +741,3 @@ func (d Databases) Less(i, j int) bool { return d[i].GetName() < d[j].GetName() 
 
 // Swap swaps two databases.
 func (d Databases) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
-
-// MarshalJSON marshals DatabaseTLSMode to string.
-func (d DatabaseTLSMode) MarshalJSON() ([]byte, error) {
-	val, err := d.encode()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	out, err := json.Marshal(val)
-	return out, trace.Wrap(err)
-}
-
-// UnmarshalJSON supports parsing DatabaseTLSMode from number or string.
-func (d *DatabaseTLSMode) UnmarshalJSON(data []byte) error {
-	type loopBreaker DatabaseTLSMode
-	var val loopBreaker
-	// try as number first.
-	if err := json.Unmarshal(data, &val); err == nil {
-		*d = DatabaseTLSMode(val)
-		return nil
-	}
-
-	// fallback to string.
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return trace.Wrap(err)
-	}
-	return d.decodeName(s)
-}
-
-// MarshalYAML marshals DatabaseTLSMode to string.
-func (d DatabaseTLSMode) MarshalYAML() (interface{}, error) {
-	val, err := d.encode()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return val, nil
-}
-
-// UnmarshalYAML supports parsing DatabaseTLSMode from number or string.
-func (d *DatabaseTLSMode) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// try as number first.
-	type loopBreaker DatabaseTLSMode
-	var val loopBreaker
-	if err := unmarshal(&val); err == nil {
-		*d = DatabaseTLSMode(val)
-		return nil
-	}
-
-	// fallback to string.
-	var s string
-	if err := unmarshal(&s); err != nil {
-		return trace.Wrap(err)
-	}
-	return d.decodeName(s)
-}
-
-// decodeName decodes DatabaseTLSMode from a string. This is necessary for
-// allowing tctl commands to work with the same names as documented in Teleport
-// configuration, rather than requiring it be specified as an unreadable enum
-// number.
-func (d *DatabaseTLSMode) decodeName(name string) error {
-	switch name {
-	case "verify-full", "":
-		*d = DatabaseTLSMode_VERIFY_FULL
-		return nil
-	case "verify-ca":
-		*d = DatabaseTLSMode_VERIFY_CA
-		return nil
-	case "insecure":
-		*d = DatabaseTLSMode_INSECURE
-		return nil
-	}
-	return trace.BadParameter("DatabaseTLSMode invalid value %v", d)
-}
-
-// encode RequireMFAType into a string. This allows users to see a readable,
-// documented value for the setting using tsh db ls or tctl get db.
-func (d DatabaseTLSMode) encode() (string, error) {
-	switch d {
-	case DatabaseTLSMode_VERIFY_FULL:
-		return "verify-full", nil
-	case DatabaseTLSMode_VERIFY_CA:
-		return "verify-ca", nil
-	case DatabaseTLSMode_INSECURE:
-		return "insecure", nil
-	}
-	return "", trace.BadParameter("DatabaseTLSMode invalid value %v", d)
-}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3432,7 +3432,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		tsrv, err = reversetunnel.NewServer(
 			reversetunnel.Config{
-				Context:                       process.ExitContext(),
 				Component:                     teleport.Component(teleport.ComponentProxy, process.id),
 				ID:                            process.Config.HostUUID,
 				ClusterName:                   clusterName,

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/memorydb"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/redshift"
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -47,45 +46,21 @@ import (
 
 // TestDatabaseUnmarshal verifies a database resource can be unmarshaled.
 func TestDatabaseUnmarshal(t *testing.T) {
-	t.Parallel()
-	tlsModes := map[string]types.DatabaseTLSMode{
-		"":            types.DatabaseTLSMode_VERIFY_FULL,
-		"verify-full": types.DatabaseTLSMode_VERIFY_FULL,
-		"verify-ca":   types.DatabaseTLSMode_VERIFY_CA,
-		"insecure":    types.DatabaseTLSMode_INSECURE,
-	}
-	for tlsModeName, tlsModeValue := range tlsModes {
-		t.Run("tls mode "+tlsModeName, func(t *testing.T) {
-			expected, err := types.NewDatabaseV3(types.Metadata{
-				Name:        "test-database",
-				Description: "Test description",
-				Labels:      map[string]string{"env": "dev"},
-			}, types.DatabaseSpecV3{
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-				CACert:   fixtures.TLSCACertPEM,
-				TLS: types.DatabaseTLS{
-					Mode: tlsModeValue,
-				},
-			})
-			require.NoError(t, err)
-			caCert := indent(fixtures.TLSCACertPEM, 4)
-
-			// verify it works with string tls mode.
-			data, err := utils.ToJSON([]byte(fmt.Sprintf(databaseYAML, tlsModeName, caCert)))
-			require.NoError(t, err)
-			actual, err := UnmarshalDatabase(data)
-			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(expected, actual))
-
-			// verify it works with integer tls mode.
-			data, err = utils.ToJSON([]byte(fmt.Sprintf(databaseYAML, int32(tlsModeValue), caCert)))
-			require.NoError(t, err)
-			actual, err = UnmarshalDatabase(data)
-			require.NoError(t, err)
-			require.Empty(t, cmp.Diff(expected, actual))
-		})
-	}
+	expected, err := types.NewDatabaseV3(types.Metadata{
+		Name:        "test-database",
+		Description: "Test description",
+		Labels:      map[string]string{"env": "dev"},
+	}, types.DatabaseSpecV3{
+		Protocol: defaults.ProtocolPostgres,
+		URI:      "localhost:5432",
+		CACert:   fixtures.TLSCACertPEM,
+	})
+	require.NoError(t, err)
+	data, err := utils.ToJSON([]byte(fmt.Sprintf(databaseYAML, indent(fixtures.TLSCACertPEM, 4))))
+	require.NoError(t, err)
+	actual, err := UnmarshalDatabase(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
 }
 
 // TestDatabaseMarshal verifies a marshaled database resource can be unmarshaled back.
@@ -260,8 +235,7 @@ func indent(s string, spaces int) string {
 	return strings.Join(lines, "\n")
 }
 
-var databaseYAML = `---
-kind: db
+var databaseYAML = `kind: db
 version: v3
 metadata:
   name: test-database
@@ -271,9 +245,7 @@ metadata:
 spec:
   protocol: "postgres"
   uri: "localhost:5432"
-  tls:
-    mode: %v
-  ca_cert: |-
+  ca_cert: |
 %v`
 
 // TestDatabaseFromAzureDBServer tests converting an Azure DB Server to a database resource.

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -27,11 +27,12 @@ import (
 	"time"
 
 	"github.com/gravitational/kingpin"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 
 	"github.com/gravitational/teleport/api/breaker"
-	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -203,39 +204,7 @@ func makeAndRunTestAuthServer(t *testing.T, opts ...testServerOptionFunc) (auth 
 	// timeout here because this isn't the kind of problem that this test is meant to catch.
 	require.NoError(t, err, "auth server didn't start after 30s")
 
-	if cfg.Auth.Enabled && cfg.Databases.Enabled {
-		waitForDatabases(t, auth, cfg.Databases.Databases)
-	}
 	return auth
-}
-
-func waitForDatabases(t *testing.T, auth *service.TeleportProcess, dbs []service.Database) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	for {
-		select {
-		case <-time.After(500 * time.Millisecond):
-			all, err := auth.GetAuthServer().GetDatabaseServers(ctx, apidefaults.Namespace)
-			require.NoError(t, err)
-
-			// Count how many input "dbs" are registered.
-			var registered int
-			for _, db := range dbs {
-				for _, a := range all {
-					if a.GetName() == db.Name {
-						registered++
-						break
-					}
-				}
-			}
-
-			if registered == len(dbs) {
-				return
-			}
-		case <-ctx.Done():
-			t.Fatal("databases not registered after 10s")
-		}
-	}
 }
 
 func newDynamicServiceAddr(t *testing.T) *dynamicServiceAddr {
@@ -260,4 +229,25 @@ type dynamicServiceAddr struct {
 	tunnelAddr  string
 	authAddr    string
 	descriptors []service.FileDescriptor
+}
+
+func waitForBackendDatabaseResourcePropagation(t *testing.T, authServer *auth.Server) {
+	deadlineC := time.After(5 * time.Second)
+	for {
+		select {
+		case <-time.Tick(100 * time.Millisecond):
+			databases, err := authServer.GetDatabaseServers(context.Background(), defaults.Namespace)
+			if err != nil {
+				logrus.WithError(err).Debugf("GetDatabaseServer call failed")
+				continue
+			}
+			if len(databases) == 0 {
+				logrus.Debugf("Database servers not found")
+				continue
+			}
+			return
+		case <-deadlineC:
+			t.Fatal("Failed to fetch database servers")
+		}
+	}
 }

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2800,7 +2800,7 @@ func TestSerializeDatabases(t *testing.T) {
 	    "redis": {}
 	  },
       "tls": {
-        "mode": "verify-full"
+        "mode": 0
       },
       "ad": {
         "keytab_file": "",


### PR DESCRIPTION
Revert https://github.com/gravitational/teleport/pull/23601 from v11 

