### PR TITLE
Fix panic for when `/web/launch` is requested

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -421,7 +421,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 			httplib.SetNoCacheHeaders(w.Header())
 
 			// app access needs to make a CORS fetch request, so we only set the default CSP on that page
-			if strings.HasPrefix(r.URL.Path, "/web/launch") {
+			if strings.HasPrefix(r.URL.Path, "/web/launch/") {
 				parts := strings.Split(r.URL.Path, "/")
 				// grab the FQDN from the URL to allow in the connect-src CSP
 				applicationURL := "https://" + parts[3] + ":*"


### PR DESCRIPTION
When this path is requested a panic occurs due to the assumption 3 lines down of how many parts are done after the `Split`.  Without a trailing `/` there will only be 2 parts leading to an array bounds panic.

This does not appear to be a significantly impacting issue, but this one line fix seems trivial and safe to me.

I am unsure who should review this PR, so please add whoever is most appropriate