### PR TITLE
[v11] revert db tls mode backend marshal

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -743,16 +743,6 @@ func (d Databases) Less(i, j int) bool { return d[i].GetName() < d[j].GetName() 
 // Swap swaps two databases.
 func (d Databases) Swap(i, j int) { d[i], d[j] = d[j], d[i] }
 
-// MarshalJSON marshals DatabaseTLSMode to string.
-func (d DatabaseTLSMode) MarshalJSON() ([]byte, error) {
-	val, err := d.encode()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	out, err := json.Marshal(val)
-	return out, trace.Wrap(err)
-}
-
 // UnmarshalJSON supports parsing DatabaseTLSMode from number or string.
 func (d *DatabaseTLSMode) UnmarshalJSON(data []byte) error {
 	type loopBreaker DatabaseTLSMode
@@ -769,15 +759,6 @@ func (d *DatabaseTLSMode) UnmarshalJSON(data []byte) error {
 		return trace.Wrap(err)
 	}
 	return d.decodeName(s)
-}
-
-// MarshalYAML marshals DatabaseTLSMode to string.
-func (d DatabaseTLSMode) MarshalYAML() (interface{}, error) {
-	val, err := d.encode()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return val, nil
 }
 
 // UnmarshalYAML supports parsing DatabaseTLSMode from number or string.
@@ -815,18 +796,4 @@ func (d *DatabaseTLSMode) decodeName(name string) error {
 		return nil
 	}
 	return trace.BadParameter("DatabaseTLSMode invalid value %v", d)
-}
-
-// encode RequireMFAType into a string. This allows users to see a readable,
-// documented value for the setting using tsh db ls or tctl get db.
-func (d DatabaseTLSMode) encode() (string, error) {
-	switch d {
-	case DatabaseTLSMode_VERIFY_FULL:
-		return "verify-full", nil
-	case DatabaseTLSMode_VERIFY_CA:
-		return "verify-ca", nil
-	case DatabaseTLSMode_INSECURE:
-		return "insecure", nil
-	}
-	return "", trace.BadParameter("DatabaseTLSMode invalid value %v", d)
 }

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2800,7 +2800,7 @@ func TestSerializeDatabases(t *testing.T) {
 	    "redis": {}
 	  },
       "tls": {
-        "mode": "verify-full"
+        "mode": 0
       },
       "ad": {
         "keytab_file": "",


### PR DESCRIPTION
This reverts the custom marshal function for database TLS mode from https://github.com/gravitational/teleport/pull/23601