### PR TITLE
[v12] Docs: Remove Details block from tctl partial.

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -17,7 +17,7 @@ compromising productivity.
   "manager server" permission.
 - Either a Linux host or Kubernetes cluster where you will run the Discord plugin.
 
-(!/docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Define RBAC resources
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -16,7 +16,6 @@ compromising productivity.
 - Admin account on your Discord server. Installing a bot requires at least the
   "manager server" permission.
 - Either a Linux host or Kubernetes cluster where you will run the Discord plugin.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Define RBAC resources

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
@@ -25,7 +25,7 @@ regularly.
 
 </Admonition>
 
-(!/docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Define RBAC resources
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -14,7 +14,7 @@ Jira tickets.
 - Jira Server or Jira Cloud installation with an owner privileges, specifically
   to set up webhooks, issue types, and workflows
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Create a user and role for access
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -17,7 +17,7 @@ compromising productivity.
   Mattermost v7.0.1.
 - Either a Linux host or Kubernetes cluster where you will run the Mattermost plugin.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Define RBAC resources
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -16,7 +16,6 @@ compromising productivity.
 - A Mattermost account with admin privileges. This plugin has been tested with
   Mattermost v7.0.1.
 - Either a Linux host or Kubernetes cluster where you will run the Mattermost plugin.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Define RBAC resources

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -45,7 +45,7 @@ Teleport Cloud tenant and PagerDuty.
 
 </ScopedBlock>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Create services
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -28,7 +28,7 @@ available in Teleport Enterprise.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 <Admonition type="warning">
 All `teleport` instances in the cluster must be running Teleport `v10.0.0` or

--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -12,7 +12,7 @@ via ChatOps or anywhere else via our flexible Authorization Workflow API.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## RBAC Setup
 

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -14,9 +14,9 @@ wrap up with creating your own role.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/permission-warning.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/permission-warning.mdx!)
 
 ## Step 1/3. Add local users with preset roles
 

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -41,7 +41,7 @@ of two team members for a privileged role `dbadmin`.
 
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Set up a Teleport bot
 

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -62,7 +62,7 @@ Additionally, this feature can be configured to require touch for every Teleport
   Teleport clients use PIV slot 9a for the `hardware_key` option and 9c for the `hardware_key_touch` option, and will overwrite other keys and certs in these slots as needed. This may interfere with other PIV applications, like `yubikey-agent`, so we recommend only using one PIV application at a time.
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Enforce Hardware Key Support
 

--- a/docs/pages/access-controls/guides/impersonation.mdx
+++ b/docs/pages/access-controls/guides/impersonation.mdx
@@ -15,7 +15,7 @@ non-interactive CI/CD user Jenkins and a security scanner.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3: Create a CI/CD user and corresponding role
 

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -39,7 +39,7 @@ A lock can target the following objects or attributes:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Create a lock
 

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -38,13 +38,11 @@ their on-disk Teleport certificates.
   Per-session MFA for Desktop Access was introduced in Teleport 9.
 </Details>
 
-
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - [WebAuthn configured](webauthn.mdx) on this cluster
 - Second factor hardware device, such as YubiKey or SoloKey
 - A Web browser with [WebAuthn support](
@@ -64,6 +62,7 @@ teleport:
     webauthn:
       rp_id: teleport.example.com
 ```
+
 </Admonition>
 
 ## Configure per-session MFA

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -43,7 +43,7 @@ their on-disk Teleport certificates.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - [WebAuthn configured](webauthn.mdx) on this cluster
 - Second factor hardware device, such as YubiKey or SoloKey

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -20,7 +20,7 @@ other policies.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Local users
 

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -21,7 +21,7 @@ UI).
 - A Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Enable WebAuthn support
 

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -20,7 +20,6 @@ UI).
 - WebAuthn hardware device, such as YubiKey or SoloKey
 - A Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/)
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Enable WebAuthn support

--- a/docs/pages/access-controls/idps/saml-grafana.mdx
+++ b/docs/pages/access-controls/idps/saml-grafana.mdx
@@ -21,7 +21,7 @@ not just those running behind the Teleport App Service.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Configure a Teleport role with access to SAML service provider objects
 

--- a/docs/pages/access-controls/idps/saml-guide.mdx
+++ b/docs/pages/access-controls/idps/saml-guide.mdx
@@ -18,9 +18,9 @@ authenticate to external services.
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - If you're new to SAML, consider reviewing our [SAML Identity Provider
 Reference](./saml-reference.mdx) before proceeding.
+
 ## Example external application
 
 We'll be using [samltest.id](https://samltest.id/) to create a test consumer of

--- a/docs/pages/access-controls/idps/saml-guide.mdx
+++ b/docs/pages/access-controls/idps/saml-guide.mdx
@@ -17,7 +17,7 @@ authenticate to external services.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - If you're new to SAML, consider reviewing our [SAML Identity Provider
 Reference](./saml-reference.mdx) before proceeding.

--- a/docs/pages/access-controls/login-rules/guide.mdx
+++ b/docs/pages/access-controls/login-rules/guide.mdx
@@ -14,7 +14,7 @@ first Login Rule to your Teleport cluster.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 Before you get started you’ll need a running Teleport Enterprise or Cloud
 cluster on version `11.3.1` or greater.

--- a/docs/pages/access-controls/sso/adfs.mdx
+++ b/docs/pages/access-controls/sso/adfs.mdx
@@ -21,7 +21,7 @@ like:
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 

--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -23,7 +23,7 @@ Before you get started you’ll need:
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -17,7 +17,7 @@ from either GitHub Cloud or GitHub Enterprise Server.</ScopedBlock>
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Create a GitHub OAuth app
 

--- a/docs/pages/access-controls/sso/gitlab.mdx
+++ b/docs/pages/access-controls/sso/gitlab.mdx
@@ -22,7 +22,7 @@ like:
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Enable default OIDC authentication
 

--- a/docs/pages/access-controls/sso/google-workspace.mdx
+++ b/docs/pages/access-controls/sso/google-workspace.mdx
@@ -24,7 +24,7 @@ Before you get started you’ll need:
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Enable default OIDC authentication
 

--- a/docs/pages/access-controls/sso/oidc.mdx
+++ b/docs/pages/access-controls/sso/oidc.mdx
@@ -19,7 +19,7 @@ administrators to define policies like:
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Enable default OIDC authentication
 

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -24,7 +24,7 @@ Teleport administrators to define policies like:
 - A Teleport role with access to edit and maintain `saml` resources. This is
   available in the default `editor` role.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -23,7 +23,6 @@ Teleport administrators to define policies like:
 
 - A Teleport role with access to edit and maintain `saml` resources. This is
   available in the default `editor` role.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)

--- a/docs/pages/access-controls/sso/one-login.mdx
+++ b/docs/pages/access-controls/sso/one-login.mdx
@@ -20,7 +20,7 @@ like:
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/enterprise/samlauthentication.mdx!)
 

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -59,7 +59,7 @@ Teleport roles based on an external RBAC system.
 
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up your Kubernetes cluster
 

--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -48,7 +48,7 @@ prevent unauthorized access to your organization's Azure identities.
 
   </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Grant an identity to your VM
 

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -55,7 +55,7 @@ guide.
 
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Configure Google Cloud
 

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -21,7 +21,7 @@ Let's connect to Grafana using Teleport Application Access in three steps:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - A Docker installation, which we will use to launch Grafana in a container. Alternatively, if you have another web application you'd like to protect with Application Access, you can use that instead.
 - A host where you will run the Teleport Application Service.

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -22,7 +22,6 @@ Let's connect to Grafana using Teleport Application Access in three steps:
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - A Docker installation, which we will use to launch Grafana in a container. Alternatively, if you have another web application you'd like to protect with Application Access, you can use that instead.
 - A host where you will run the Teleport Application Service.
 

--- a/docs/pages/application-access/guides/dynamodb.mdx
+++ b/docs/pages/application-access/guides/dynamodb.mdx
@@ -37,7 +37,7 @@ This guide will help you to:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 <Admonition type="tip" title="Not yet a Teleport user?">
 If you have not yet deployed the Auth Service and Proxy Service, you should follow one of our [getting started guides](../getting-started.mdx) or try our Teleport Application Access [interactive learning track](https://play.instruqt.com/teleport/invite/rgvuva4gzkon).

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -12,7 +12,6 @@ servers or databases not yet natively supported in Database Access.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - TCP application to connect to. In this guide we'll use a PostgreSQL running
   in Docker as an example. You can also use any TCP-based application you may
   already have.

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -11,7 +11,7 @@ servers or databases not yet natively supported in Database Access.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - TCP application to connect to. In this guide we'll use a PostgreSQL running
   in Docker as an example. You can also use any TCP-based application you may

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -35,7 +35,7 @@ release.
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up Aurora
 

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -35,7 +35,7 @@ This guide will help you to:
 - The `cqlsh` Cassandra client installed and added to your system's `PATH` environment variable.
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/aws-dynamodb.mdx
+++ b/docs/pages/database-access/guides/aws-dynamodb.mdx
@@ -32,7 +32,7 @@ This guide will help you to:
   This guide assumes an EC2 instance when creating and applying IAM roles, and
   must be adjusted accordingly for custom configurations.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 <Admonition type="note" title="Example Access Control">
 This guide provides an example configuration of IAM access roles as a model,

--- a/docs/pages/database-access/guides/azure-redis.mdx
+++ b/docs/pages/database-access/guides/azure-redis.mdx
@@ -28,7 +28,6 @@ This guide will help you to:
   Service.
 - `redis-cli` version `6.2` or newer installed and added to your system's
   `PATH` environment variable.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a Teleport user

--- a/docs/pages/database-access/guides/azure-redis.mdx
+++ b/docs/pages/database-access/guides/azure-redis.mdx
@@ -29,7 +29,7 @@ This guide will help you to:
 - `redis-cli` version `6.2` or newer installed and added to your system's
   `PATH` environment variable.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a Teleport user
 

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -38,7 +38,6 @@ This guide will help you to:
 
 - SQL Server running on Azure.
 - The Teleport Database Service running on an Azure virtual instance.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Create a Teleport user

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -39,7 +39,7 @@ This guide will help you to:
 - SQL Server running on Azure.
 - The Teleport Database Service running on an Azure virtual instance.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/8. Create a Teleport user
 

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -33,7 +33,6 @@ This guide will help you to:
 
 - Self-hosted Cassandra or ScyllaDB instance.
 - The `cqlsh` Cassandra client installed and added to your system's `PATH` environment variable.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -34,7 +34,7 @@ This guide will help you to:
 - Self-hosted Cassandra or ScyllaDB instance.
 - The `cqlsh` Cassandra client installed and added to your system's `PATH` environment variable.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -35,7 +35,7 @@ This guide will help you to:
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -19,7 +19,6 @@ This guide will help you to:
 2. Configure mutual TLS authentication between Teleport and your CockroachDB cluster.
 3. Connect to your CockroachDB cluster via Teleport.
 
-
 <ScopedBlock scope={["oss", "enterprise"]}>
 ![Teleport Database Access CockroachDB Self-Hosted](../../../img/database-access/guides/cockroachdb_selfhosted.png)
 </ScopedBlock>
@@ -34,7 +33,6 @@ This guide will help you to:
 - CockroachDB cluster.
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up the Teleport Database Service

--- a/docs/pages/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/database-access/guides/dynamic-registration.mdx
@@ -91,7 +91,7 @@ To create a database resource, run:
 $ tctl create database.yaml
 ```
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 After the resource has been created, it will appear among the list of available
 databases (in `tsh db ls` or UI) as long as at least one Database Service

--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -28,7 +28,7 @@ This guide will help you to configure secured access to an Elasticsearch databas
 
   See [Installation](../../installation.mdx) for details.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -25,7 +25,7 @@ In this guide you will:
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -24,7 +24,6 @@ In this guide you will:
 - [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) cluster.
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up the Teleport Database Service

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -31,7 +31,7 @@ In this guide you will:
   April 2021 so if you're still using an older version, consider upgrading.
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Install and configure Teleport
 

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -31,7 +31,7 @@ Teleport Database Access for Cloud SQL MySQL is available starting from the
 - A host, e.g., a Compute Engine instance, where you will run the Teleport Database
   Service
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a service account for the Teleport Database Service
 

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -30,7 +30,6 @@ Teleport Database Access for Cloud SQL MySQL is available starting from the
 - Google Cloud account
 - A host, e.g., a Compute Engine instance, where you will run the Teleport Database
   Service
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a service account for the Teleport Database Service

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -23,7 +23,6 @@ This guide will help you to:
 - A self-hosted MySQL or MariaDB instance.
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up the Teleport Database Service

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -24,7 +24,7 @@ This guide will help you to:
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -26,7 +26,7 @@ This guide will help you to:
 - A host, e.g., a Compute Engine instance, where you will run the Teleport Database
   Service
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Enable Cloud SQL IAM authentication
 

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -25,7 +25,6 @@ This guide will help you to:
 - Command-line client `psql` installed and added to your system's `PATH` environment variable.
 - A host, e.g., a Compute Engine instance, where you will run the Teleport Database
   Service
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Enable Cloud SQL IAM authentication

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -27,7 +27,7 @@ This guide will help you to:
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a Teleport user
 

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -26,7 +26,6 @@ This guide will help you to:
 - Command-line client `psql` installed and added to your system's `PATH` environment variable.
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a Teleport user

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -24,7 +24,6 @@ This guide will help you to:
 - Command-line client `psql` installed and added to your system's `PATH` environment variable.
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -25,7 +25,7 @@ This guide will help you to:
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/rds-proxy.mdx
+++ b/docs/pages/database-access/guides/rds-proxy.mdx
@@ -25,7 +25,6 @@ Teleport currently supports RDS Proxy instances with engine family
 - Any RDS Proxy instances intended for connection through Teleport must have TLS enabled.
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a Database Service configuration

--- a/docs/pages/database-access/guides/rds-proxy.mdx
+++ b/docs/pages/database-access/guides/rds-proxy.mdx
@@ -26,7 +26,7 @@ Teleport currently supports RDS Proxy instances with engine family
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create a Database Service configuration
 

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -35,7 +35,6 @@ This guide will help you to:
   IAM policies.
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Create a Teleport user

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -36,7 +36,7 @@ This guide will help you to:
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Create a Teleport user
 

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -27,7 +27,7 @@ This guide will help you to:
 - A host, e.g., an EC2 instance, where you will run the Teleport Database
   Service.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Create a Teleport user
 

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -40,7 +40,7 @@ This guide will help you to:
   Redis `7.0` and RESP3 (REdis Serialization Protocol) are currently not supported.
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/redis.mdx
+++ b/docs/pages/database-access/guides/redis.mdx
@@ -45,7 +45,7 @@ This guide will help you to:
   Redis `7.0` and RESP3 (REdis Serialization Protocol) are currently not supported.
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/snowflake.mdx
+++ b/docs/pages/database-access/guides/snowflake.mdx
@@ -38,7 +38,7 @@ This guide will help you to:
 
   See [Installation](../../installation.mdx) for details.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Set up the Teleport Database Service
 

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -45,7 +45,7 @@ Directory authentication.
 - A Linux node joined to the same Active Directory domain as the database. This
   guide will walk you through the joining steps if you don't have one.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Create a Teleport user
 

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -44,7 +44,6 @@ Directory authentication.
 - A Windows machine joined to the same Active Directory domain as the database.
 - A Linux node joined to the same Active Directory domain as the database. This
   guide will walk you through the joining steps if you don't have one.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Create a Teleport user

--- a/docs/pages/desktop-access/directory-sharing.mdx
+++ b/docs/pages/desktop-access/directory-sharing.mdx
@@ -36,7 +36,7 @@ after the session ends.
   You can see a full compatibility table in the [Mozilla Developer Network
   documentation](https://developer.mozilla.org/en-US/docs/Web/API/File_System_Access_API#browser_compatibility).
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Share a directory
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -38,7 +38,7 @@ an [Active Directory domain](./active-directory.mdx).
 - A server or virtual machine running a Windows operating system with
   Remote Desktop enabled and the RDP port available to the Linux server.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Prepare Windows
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -37,7 +37,6 @@ an [Active Directory domain](./active-directory.mdx).
   You can reuse an existing server running any other Teleport instance.
 - A server or virtual machine running a Windows operating system with
   Remote Desktop enabled and the RDP port available to the Linux server.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Prepare Windows

--- a/docs/pages/desktop-access/reference/cli.mdx
+++ b/docs/pages/desktop-access/reference/cli.mdx
@@ -5,7 +5,7 @@ description: CLI reference for Teleport Desktop Access.
 
 The following `tctl` commands are used to manage Teleport Desktop Access.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 Generate a join token for a Windows Desktop Service:
 

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,9 +1,4 @@
-<Details 
-title="Make sure you can connect to Teleport" 
-scope={["oss", "enterprise"]} 
-scopeOnly={true}
-opened={true}
->
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
 remotely:
@@ -20,13 +15,8 @@ You can run subsequent `tctl` commands in this guide on your local machine.
 
 For full privileges, you can also run `tctl` commands on your Auth Service host.
 
-</Details>
-<Details 
-title="Make sure you can connect to Teleport" 
-scope={["cloud"]}
-scopeOnly={true}
-opened={true}
->
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
 
 To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
 remotely:
@@ -41,4 +31,4 @@ $ tctl status
 
 You must run subsequent `tctl` commands in this guide on your local machine.
 
-</Details>
+</ScopedBlock>

--- a/docs/pages/kubernetes-access/discovery/google-cloud.mdx
+++ b/docs/pages/kubernetes-access/discovery/google-cloud.mdx
@@ -31,7 +31,7 @@ Auto-Discovery for GKE.
   services. You can run this host on any cloud provider or even use a local
   machine.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Obtain Google Cloud credentials
 

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -27,7 +27,7 @@ Standalone Teleport Cluster](./register-clusters/static-kubeconfig.mdx).
 
 (!docs/pages/includes/kubernetes-access/helm-k8s.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Deployment overview
 

--- a/docs/pages/kubernetes-access/manage-access/rbac.mdx
+++ b/docs/pages/kubernetes-access/manage-access/rbac.mdx
@@ -20,7 +20,7 @@ Kubernetes clusers, groups, users, and resources.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 To run the local demo environment, ensure that you have the following tools
 installed on your workstation:

--- a/docs/pages/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -32,7 +32,7 @@ registration, then create, list, update, and delete Kubernetes clusters via
   permissions to create namespaces, secrets, service accounts, cluster roles,
   and cluster role bindings in the cluster.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Set up the Teleport Kubernetes Service
 

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -27,7 +27,7 @@ to automatically join the cluster on subsequent restarts.
 
 (!docs/pages/includes/helm.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 
 ## Step 1/3. Create a Kubernetes service account with an IAM identity

--- a/docs/pages/kubernetes-access/register-clusters/register-via-deployment.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/register-via-deployment.mdx
@@ -27,7 +27,7 @@ Teleport Kubernetes Service on each cluster you want to register.
 
 (!docs/pages/includes/helm.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Connecting clusters
 

--- a/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -23,7 +23,6 @@ authenticate to the API server of your chosen Kubernetes cluster.
   Kubernetes Service. This can run outside of your Kubernetes cluster. 
 - The [`kubectl`](https://kubernetes.io/docs/reference/kubectl/) command line
   tool installed on your workstation.
-  
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Generate a kubeconfig file

--- a/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -24,7 +24,7 @@ authenticate to the API server of your chosen Kubernetes cluster.
 - The [`kubectl`](https://kubernetes.io/docs/reference/kubectl/) command line
   tool installed on your workstation.
   
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Generate a kubeconfig file
 

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -26,7 +26,7 @@ If you're not already familiar with Machine ID, follow the
 [Getting Started Guide](../getting-started.mdx) to familiarize yourself with
 Machine ID. You'll also need `tctl` access to initially configure the bot.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 Lastly, ensure the `tbot` binary is installed on your Machine ID client system.
 The client system is any system from which you want to access your Teleport

--- a/docs/pages/machine-id/guides/circleci.mdx
+++ b/docs/pages/machine-id/guides/circleci.mdx
@@ -26,7 +26,6 @@ control.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - A running instance of the Teleport SSH Service that you have registered with
 your Teleport cluster. For instructions on setting this up, see the
 [Getting Started Guide](../../server-access/introduction.mdx). The SSH node must

--- a/docs/pages/machine-id/guides/circleci.mdx
+++ b/docs/pages/machine-id/guides/circleci.mdx
@@ -25,7 +25,7 @@ control.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - A running instance of the Teleport SSH Service that you have registered with
 your Teleport cluster. For instructions on setting this up, see the

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -34,7 +34,7 @@ If you have not already set up Machine ID, follow the [Machine ID Getting
 Started Guide](../getting-started.mdx) to familiarize yourself with Machine ID.
 You'll need `tctl` access to initially configure the bot.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 Lastly, ensure both the `tbot` and `tsh` executables are available on your
 application host. See [Installation](../../installation.mdx) for details.

--- a/docs/pages/machine-id/guides/github-actions-kubernetes.mdx
+++ b/docs/pages/machine-id/guides/github-actions-kubernetes.mdx
@@ -27,7 +27,7 @@ Actions runners as well as GitHub Enterprise Server.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - A Kubernetes cluster connected to your Teleport cluster. If you do not already
 have one configured, try our

--- a/docs/pages/machine-id/guides/github-actions.mdx
+++ b/docs/pages/machine-id/guides/github-actions.mdx
@@ -27,7 +27,7 @@ Actions runners as well as GitHub Enterprise Server.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - A node that is a part of the Teleport cluster with [Server Access](https://goteleport.com/docs/server-access/introduction/).
 - Your user should have the privileges to create token resources.

--- a/docs/pages/machine-id/guides/github-actions.mdx
+++ b/docs/pages/machine-id/guides/github-actions.mdx
@@ -28,7 +28,6 @@ Actions runners as well as GitHub Enterprise Server.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - A node that is a part of the Teleport cluster with [Server Access](https://goteleport.com/docs/server-access/introduction/).
 - Your user should have the privileges to create token resources.
 - A GitHub repository with GitHub Actions enabled. This guide uses the example `gravitational/example`

--- a/docs/pages/machine-id/guides/gitlab.mdx
+++ b/docs/pages/machine-id/guides/gitlab.mdx
@@ -29,7 +29,7 @@ control.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - A running instance of the Teleport SSH Service registered with your Teleport
 cluster. For instructions on setting this up, see the [Getting Started

--- a/docs/pages/machine-id/guides/gitlab.mdx
+++ b/docs/pages/machine-id/guides/gitlab.mdx
@@ -30,7 +30,6 @@ control.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - A running instance of the Teleport SSH Service registered with your Teleport
 cluster. For instructions on setting this up, see the [Getting Started
 Guide](../../server-access/introduction.mdx). The SSH node must include a user

--- a/docs/pages/machine-id/guides/jenkins.mdx
+++ b/docs/pages/machine-id/guides/jenkins.mdx
@@ -34,7 +34,7 @@ proxy_service:
 ```
 </Admonition>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Architecture
 

--- a/docs/pages/machine-id/guides/kubernetes.mdx
+++ b/docs/pages/machine-id/guides/kubernetes.mdx
@@ -28,7 +28,7 @@ If you're not already familiar with Machine ID, follow the
 [Getting Started Guide](../getting-started.mdx) to familiarize yourself with
 Machine ID. You'll also need `tctl` access to initially configure the bot.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 Next, ensure the `tbot` binary is installed on your Machine ID client system.
 The client system is any system from which you want to access your Teleport

--- a/docs/pages/management/admin/adding-nodes.mdx
+++ b/docs/pages/management/admin/adding-nodes.mdx
@@ -10,7 +10,6 @@ This guide explains how to add Teleport Nodes to your cluster.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - A Linux server that you will use to host your Teleport Node.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Install Teleport on your Node
@@ -45,7 +44,7 @@ print a warning message.
 
 The CA pin becomes invalid if a Teleport administrator performs the CA rotation
 by executing [`tctl auth rotate`](../../reference/cli.mdx#tctl-auth-rotate).
-    
+
 </Notice>
 
 On you local machine, retrieve the CA pin of the Auth Service <ScopedBlock

--- a/docs/pages/management/admin/adding-nodes.mdx
+++ b/docs/pages/management/admin/adding-nodes.mdx
@@ -11,7 +11,7 @@ This guide explains how to add Teleport Nodes to your cluster.
 
 - A Linux server that you will use to host your Teleport Node.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Install Teleport on your Node
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -38,7 +38,6 @@ region.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - A host where you will run a Teleport Node. In this guide, we will apply labels
   to this Node.
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -37,7 +37,7 @@ region.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - A host where you will run a Teleport Node. In this guide, we will apply labels
   to this Node.

--- a/docs/pages/management/admin/troubleshooting.mdx
+++ b/docs/pages/management/admin/troubleshooting.mdx
@@ -19,7 +19,7 @@ the Application Service and Database Service.
 - A host where you have installed and configured the `teleport` binary.
 </ScopedBlock>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Enable verbose logging
 

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -20,7 +20,7 @@ This guide shows you how to:
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Adding local users
 

--- a/docs/pages/management/export-audit-events/datadog.mdx
+++ b/docs/pages/management/export-audit-events/datadog.mdx
@@ -63,7 +63,7 @@ d-->h(Datadog)
 The instructions below demonstrate a local test of the Event Handler plugin on your
 workstation. You will need to adjust paths, ports, and domains for other environments.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/6. Install the Event Handler plugin
 

--- a/docs/pages/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/management/export-audit-events/fluentd.mdx
@@ -46,7 +46,7 @@ to integrate with your infrastructure.
 - Fluentd version v(=fluentd.version=) or greater.
 - Docker version v(=docker.version=).
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 - On your workstation, create a folder called `event-handler`, to hold configuration files and plugin state:
 

--- a/docs/pages/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/management/export-audit-events/fluentd.mdx
@@ -44,6 +44,7 @@ to integrate with your infrastructure.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - Fluentd version v(=fluentd.version=) or greater.
+
 - Docker version v(=docker.version=).
 
 - (!docs/pages/includes/tctl.mdx!)

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -38,7 +38,7 @@ visualization and alerting.
 - On Splunk Enterprise, port `8088` should be open to traffic from the host
   running the Teleport Event Handler and Universal Forwarder.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up the Teleport Event Handler plugin
 

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -89,7 +89,7 @@ more in the following guide:
 </TabItem>
 </Tabs>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up AWS IAM credentials
 

--- a/docs/pages/management/guides/joining-nodes-aws-iam.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-iam.mdx
@@ -64,10 +64,10 @@ connecting directly to the Auth Service.
 
 - An AWS EC2 instance to act as a Teleport Node, with the Teleport binary
   installed.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up AWS IAM credentials
+
 Every Node or Proxy using the IAM method to join your Teleport cluster needs AWS
 IAM credentials in order to call the `sts:GetCallerIdentity` API. No specific
 IAM policy or permissions are needed. Any IAM user or role can call this API.

--- a/docs/pages/management/guides/joining-nodes-aws-iam.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-iam.mdx
@@ -65,7 +65,7 @@ connecting directly to the Auth Service.
 - An AWS EC2 instance to act as a Teleport Node, with the Teleport binary
   installed.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up AWS IAM credentials
 Every Node or Proxy using the IAM method to join your Teleport cluster needs AWS

--- a/docs/pages/management/guides/joining-nodes-azure.mdx
+++ b/docs/pages/management/guides/joining-nodes-azure.mdx
@@ -41,7 +41,7 @@ connecting directly to the Auth Service.
   [Managed Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
   assigned to it with permission to read virtual machine info.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up a Managed Identity
 Every virtual machine hosting a Node or Proxy using the Azure method to join

--- a/docs/pages/management/guides/joining-nodes-azure.mdx
+++ b/docs/pages/management/guides/joining-nodes-azure.mdx
@@ -40,10 +40,10 @@ connecting directly to the Auth Service.
   installed. The Virtual Machine must have a
   [Managed Identity](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview)
   assigned to it with permission to read virtual machine info.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Set up a Managed Identity
+
 Every virtual machine hosting a Node or Proxy using the Azure method to join
 your Teleport cluster needs a Managed Identity assigned to it. The identity 
 requires the `Microsoft.Compute/virtualMachines/read` permission so Teleport

--- a/docs/pages/management/guides/terraform-provider.mdx
+++ b/docs/pages/management/guides/terraform-provider.mdx
@@ -20,7 +20,7 @@ This guide will explain how to:
   # Terraform v(=terraform.version=)
   ```
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 Create a folder called `teleport-terraform` to hold some temporary files:
 

--- a/docs/pages/management/operations/ca-rotation.mdx
+++ b/docs/pages/management/operations/ca-rotation.mdx
@@ -7,7 +7,7 @@ description: How to rotate Teleport's certificate authority
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Certificate Authority rotation
 

--- a/docs/pages/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/management/security/reduce-blast-radius.mdx
@@ -12,7 +12,7 @@ Teleport encourages users to practice defense in depth so that every component o
 - [Restrict role requests based on user traits](#restrict-role-requests-based-on-user-traits)
 - [Set up your RBAC without admin roles](#set-up-your-rbac-without-admin-roles)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Make MFA mandatory for `tsh login`
 If a user sets up an account to authenticate to their Teleport cluster with only a password, an adversary can gain access to the password using brute-force attacks, person-in-the-middle attacks, or phishing. But even if a user's password is compromised, you can stop an attacker from authenticating with it when they run `tsh login`.

--- a/docs/pages/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/management/security/reduce-blast-radius.mdx
@@ -11,10 +11,10 @@ Teleport encourages users to practice defense in depth so that every component o
 - [Automatically prevent some roles from requesting others](#automatically-prevent-some-roles-from-requesting-others)
 - [Restrict role requests based on user traits](#restrict-role-requests-based-on-user-traits)
 - [Set up your RBAC without admin roles](#set-up-your-rbac-without-admin-roles)
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Make MFA mandatory for `tsh login`
+
 If a user sets up an account to authenticate to their Teleport cluster with only a password, an adversary can gain access to the password using brute-force attacks, person-in-the-middle attacks, or phishing. But even if a user's password is compromised, you can stop an attacker from authenticating with it when they run `tsh login`.
 
 Teleport lets you make it mandatory for a user to enroll an MFA device when they create an account, and to authenticate using that device when they begin a new Teleport session.

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -26,7 +26,7 @@ users.
 </TabItem>
 </Tabs>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ### `tctl` concepts
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -30,7 +30,7 @@ This guide introduces some of these common scenarios and how to interact with Te
 - One host running a Linux environment (such as Ubuntu 20.04, CentOS
   8.0, or Debian 10). This will serve as a Teleport Node.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/permission-warning.mdx!)
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -27,9 +27,8 @@ This guide introduces some of these common scenarios and how to interact with Te
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- One host running a Linux environment (such as Ubuntu 20.04, CentOS
-  8.0, or Debian 10). This will serve as a Teleport Node.
-
+- One host running a Linux environment (such as Ubuntu 20.04, CentOS 8.0, or
+  Debian 10). This will serve as a Teleport Node.
 - (!docs/pages/includes/tctl.mdx!)
 
 (!docs/pages/includes/permission-warning.mdx!)

--- a/docs/pages/server-access/guides/auditd.mdx
+++ b/docs/pages/server-access/guides/auditd.mdx
@@ -13,7 +13,6 @@ You can configure Teleport's SSH Service to integrate with the Linux Auditing Sy
 - A running Teleport Node. See the [Server Access Getting Started Guide](../getting-started.mdx) for  how to add a Node to your Teleport cluster. On the Node, `teleport` must be running as a systemd service with root permissions.
 - Linux kernel 2.6.6+ compiled with `CONFIG_AUDIT`. Most Linux distributions have this option enabled by default.
 - `auditctl` to check auditd status (optional).
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Check system configuration
@@ -36,6 +35,7 @@ backlog_wait_time 60000
 backlog_wait_time_actual 0
 loginuid_immutable 0 unlocked
 ```
+
 The first line `enabled 1` indicates that auditd is enabled, and Teleport will send events.
 
 All events are generated on a Teleport Node.

--- a/docs/pages/server-access/guides/auditd.mdx
+++ b/docs/pages/server-access/guides/auditd.mdx
@@ -14,7 +14,7 @@ You can configure Teleport's SSH Service to integrate with the Linux Auditing Sy
 - Linux kernel 2.6.6+ compiled with `CONFIG_AUDIT`. Most Linux distributions have this option enabled by default.
 - `auditctl` to check auditd status (optional).
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Check system configuration
 

--- a/docs/pages/server-access/guides/azure-discovery.mdx
+++ b/docs/pages/server-access/guides/azure-discovery.mdx
@@ -17,7 +17,6 @@ managed identities.
 - Azure virtual machines to join the Teleport cluster, running
 Ubuntu/Debian/RHEL if making use of the default Teleport install script. (For
 other Linux distributions, you can install Teleport manually.)
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create an Azure invite token

--- a/docs/pages/server-access/guides/azure-discovery.mdx
+++ b/docs/pages/server-access/guides/azure-discovery.mdx
@@ -18,7 +18,7 @@ managed identities.
 Ubuntu/Debian/RHEL if making use of the default Teleport install script. (For
 other Linux distributions, you can install Teleport manually.)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/5. Create an Azure invite token
 

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -93,7 +93,7 @@ library preloading, and environment variables may not be captured in session rec
 </tbody>
 </table>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Configure a Teleport Node
 

--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -22,7 +22,7 @@ policies.
 default Teleport install script. (For other Linux distributions, you can
 install Teleport manually.)
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Create an EC2 invite token
 

--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -21,7 +21,6 @@ policies.
 - EC2 instances running Ubuntu/Debian/RHEL/Amazon Linux 2 and SSM agent version 3.1 or greater if making use of the
 default Teleport install script. (For other Linux distributions, you can
 install Teleport manually.)
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/7. Create an EC2 invite token

--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -29,7 +29,7 @@ since it must execute these commands in order to create transient users:
   - `getent`
   - `visudo`
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/2. Configure a role
 

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -27,7 +27,7 @@ We've outlined these reasons in [OpenSSH vs Teleport SSH for Servers?](https://g
   SSH port on this host must be open to traffic from the Teleport Proxy Service
   host.
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Configure `sshd` to trust the Teleport CA
 

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -26,7 +26,6 @@ We've outlined these reasons in [OpenSSH vs Teleport SSH for Servers?](https://g
 - A Linux host with the OpenSSH server `sshd` installed, but not Teleport. The
   SSH port on this host must be open to traffic from the Teleport Proxy Service
   host.
-
 - (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/4. Configure `sshd` to trust the Teleport CA

--- a/docs/pages/server-access/guides/restricted-session.mdx
+++ b/docs/pages/server-access/guides/restricted-session.mdx
@@ -37,7 +37,7 @@ Teleport supports network restrictions with more types coming in the future.
 </tbody>
 </table>
 
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Network Restrictions
 


### PR DESCRIPTION
Backports #24000 to `branch/v12`.

I'm also hoping to use this branch to backport further, since this has merge conflict resolutions.