### PR TITLE
Update jonboulle/clockwork to 0.4.0

### DIFF
--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -292,7 +292,7 @@ func New(cfg Config) (*CircuitBreaker, error) {
 	}
 
 	cb := CircuitBreaker{cfg: cfg}
-	cb.nextGeneration(cfg.Clock.Now().UTC())
+	cb.nextGeneration(cfg.Clock.Now())
 
 	return &cb, nil
 }

--- a/api/breaker/breaker.go
+++ b/api/breaker/breaker.go
@@ -292,7 +292,7 @@ func New(cfg Config) (*CircuitBreaker, error) {
 	}
 
 	cb := CircuitBreaker{cfg: cfg}
-	cb.nextGeneration(cfg.Clock.Now())
+	cb.nextGeneration(cfg.Clock.Now().UTC())
 
 	return &cb, nil
 }

--- a/api/breaker/breaker_test.go
+++ b/api/breaker/breaker_test.go
@@ -39,30 +39,30 @@ func TestCircuitBreaker_generation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	generation, state := cb.currentState(clock.Now().UTC())
+	generation, state := cb.currentState(clock.Now())
 	require.Equal(t, uint64(1), generation)
 	require.Equal(t, StateStandby, state)
-	require.Equal(t, clock.Now().UTC().Add(time.Second), cb.expiry)
+	require.Equal(t, clock.Now().Add(time.Second), cb.expiry)
 
 	clock.Advance(500 * time.Millisecond)
-	generation, state = cb.currentState(clock.Now().UTC())
+	generation, state = cb.currentState(clock.Now())
 	require.Equal(t, uint64(1), generation)
 	require.Equal(t, StateStandby, state)
 	clock.Advance(501 * time.Millisecond)
-	generation, state = cb.currentState(clock.Now().UTC())
+	generation, state = cb.currentState(clock.Now())
 	require.Equal(t, uint64(2), generation)
 	require.Equal(t, StateStandby, state)
-	require.Equal(t, clock.Now().UTC().Add(time.Second), cb.expiry)
+	require.Equal(t, clock.Now().Add(time.Second), cb.expiry)
 
 	for i := 0; i < 1000; i++ {
-		prevGeneration, prevState := cb.currentState(clock.Now().UTC())
-		cb.nextGeneration(clock.Now().UTC())
-		generation, state := cb.currentState(clock.Now().UTC())
+		prevGeneration, prevState := cb.currentState(clock.Now())
+		cb.nextGeneration(clock.Now())
+		generation, state := cb.currentState(clock.Now())
 		require.NotEqual(t, prevGeneration, generation)
 		require.Equal(t, prevState, state)
 	}
 
-	generation, state = cb.currentState(clock.Now().UTC())
+	generation, state = cb.currentState(clock.Now())
 	require.Equal(t, uint64(1002), generation)
 	require.Equal(t, StateStandby, state)
 }
@@ -258,8 +258,8 @@ func TestCircuitBreaker_success(t *testing.T) {
 			require.NoError(t, err)
 			cb.state = tt.initialState
 
-			generation, state := cb.currentState(clock.Now().UTC())
-			cb.success(tt.successState, clock.Now().UTC())
+			generation, state := cb.currentState(clock.Now())
+			cb.success(tt.successState, clock.Now())
 			require.Equal(t, tt.expectedState, cb.state)
 			if tt.expectedState != state {
 				require.NotEqual(t, generation, cb.generation)
@@ -340,8 +340,8 @@ func TestCircuitBreaker_failure(t *testing.T) {
 			require.NoError(t, err)
 			cb.state = tt.initialState
 
-			generation, state := cb.currentState(clock.Now().UTC())
-			cb.failure(tt.failureState, clock.Now().UTC())
+			generation, state := cb.currentState(clock.Now())
+			cb.failure(tt.failureState, clock.Now())
 			require.Equal(t, tt.expectedState, cb.state)
 			if tt.expectedState != state {
 				require.NotEqual(t, generation, cb.generation)
@@ -492,7 +492,7 @@ func TestCircuitBreaker_Execute(t *testing.T) {
 			clock.Advance(tt.advance)
 			_, err := cb.Execute(tt.exec)
 			tt.errorAssertion(t, err)
-			generation, state := cb.currentState(clock.Now().UTC())
+			generation, state := cb.currentState(clock.Now())
 			require.Equal(t, tt.expectedGeneration, generation, "incorrect generation")
 			require.Equal(t, tt.expectedState, state, "incorrect state")
 

--- a/api/go.mod
+++ b/api/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/google/uuid v1.3.0
 	github.com/gravitational/trace v1.2.1
-	github.com/jonboulle/clockwork v0.3.0
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/russellhaering/gosaml2 v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.2

--- a/api/go.sum
+++ b/api/go.sum
@@ -154,6 +154,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
 github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/api/go.sum
+++ b/api/go.sum
@@ -152,7 +152,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
-github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
 github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/jackc/pgx/v4 v4.18.1
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97
-	github.com/jonboulle/clockwork v0.3.0
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/joshlf/go-acl v0.0.0-20200411065538-eae00ae38531
 	github.com/json-iterator/go v1.1.12
 	github.com/julienschmidt/httprouter v1.3.0 // replaced

--- a/go.sum
+++ b/go.sum
@@ -794,8 +794,9 @@ github.com/johannesboyne/gofakes3 v0.0.0-20210217223559-02ffa763be97/go.mod h1:J
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.2.2/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
-github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
 github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/josharian/native v1.0.0 h1:Ts/E8zCSEsG17dUqv7joXJFybuMLjQfWE04tsBODTxk=

--- a/lib/auth/test/suite.go
+++ b/lib/auth/test/suite.go
@@ -194,7 +194,7 @@ func (s *AuthSuite) GenerateUserCert(t *testing.T) {
 	require.Contains(t, parsedCert.Extensions, teleport.CertExtensionPreviousIdentityExpires)
 	prevIDExpires, err := time.Parse(time.RFC3339, parsedCert.Extensions[teleport.CertExtensionPreviousIdentityExpires])
 	require.NoError(t, err)
-	require.Equal(t, clock.Now().Add(time.Hour), prevIDExpires)
+	require.WithinDuration(t, clock.Now().Add(time.Hour), prevIDExpires, time.Second)
 
 	t.Run("device extensions", func(t *testing.T) {
 		const devID = "deviceid1"

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1579,8 +1579,8 @@ func TestWebSessionWithApprovedAccessRequestAndSwitchback(t *testing.T) {
 		AccessRequestID: accessReq.GetMetadata().Name,
 	})
 	require.NoError(t, err)
-	require.Equal(t, sess1.Expiry(), tt.clock.Now().Add(time.Minute*10))
-	require.Equal(t, sess1.GetLoginTime(), initialSession.GetLoginTime())
+	require.WithinDuration(t, tt.clock.Now().Add(time.Minute*10), sess1.Expiry(), time.Second)
+	require.WithinDuration(t, sess1.GetLoginTime(), initialSession.GetLoginTime(), time.Second)
 
 	sshcert, err := sshutils.ParseCertificate(sess1.GetPub())
 	require.NoError(t, err)
@@ -2151,7 +2151,7 @@ func TestGenerateCerts(t *testing.T) {
 		require.NoError(t, err)
 		identity, err := tlsca.FromSubject(tlsCert.Subject, tlsCert.NotAfter)
 		require.NoError(t, err)
-		require.True(t, identity.Expires.Before(clock.Now().Add(testUser2.TTL)))
+		require.WithinDuration(t, clock.Now().Add(testUser2.TTL), identity.Expires, time.Second)
 		require.Equal(t, identity.RouteToCluster, rc1.GetName())
 	})
 
@@ -4071,7 +4071,7 @@ func verifyJWT(clock clockwork.Clock, clusterName string, pairs []*types.JWTKeyP
 func newTestTLSServer(t testing.TB) *TestTLSServer {
 	as, err := NewTestAuthServer(TestAuthServerConfig{
 		Dir:   t.TempDir(),
-		Clock: clockwork.NewFakeClock(),
+		Clock: clockwork.NewFakeClockAt(time.Now().Round(time.Second).UTC()),
 	})
 	require.NoError(t, err)
 

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 
@@ -306,7 +307,7 @@ func TestEnforcesClusterNameDefault(t *testing.T) {
 				Time:        clock.Now(),
 				ClusterName: "cluster",
 			},
-		}))
+		}, cmpopts.EquateApproxTime(time.Second)))
 	})
 	t.Run("CheckingStreamer.CreateAuditStream", func(t *testing.T) {
 		streamer := &CheckingStreamer{
@@ -335,7 +336,7 @@ func TestEnforcesClusterNameDefault(t *testing.T) {
 				Time:        clock.Now(),
 				ClusterName: "cluster",
 			},
-		}))
+		}, cmpopts.EquateApproxTime(time.Second)))
 	})
 	t.Run("CheckingStreamer.ResumeAuditStream", func(t *testing.T) {
 		streamer := &CheckingStreamer{
@@ -364,6 +365,6 @@ func TestEnforcesClusterNameDefault(t *testing.T) {
 				Time:        clock.Now(),
 				ClusterName: "cluster",
 			},
-		}))
+		}, cmpopts.EquateApproxTime(time.Second)))
 	})
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -259,7 +259,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	clientCredentials, err := ttlmap.New(defaults.ClientCacheSize)
+	clientCredentials, err := ttlmap.New(defaults.ClientCacheSize, ttlmap.Clock(cfg.Clock))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -268,7 +268,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 	// deleting expired entried clusters and kube_servers entries.
 	// In the meantime, we need to make sure that the cache is cleaned
 	// from time to time.
-	transportClients, err := ttlmap.New(defaults.ClientCacheSize)
+	transportClients, err := ttlmap.New(defaults.ClientCacheSize, ttlmap.Clock(cfg.Clock))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -80,7 +80,8 @@ var (
 )
 
 func TestRequestCertificate(t *testing.T) {
-	cl, err := newMockCSRClient()
+	clock := clockwork.NewFakeClock()
+	cl, err := newMockCSRClient(clock)
 	require.NoError(t, err)
 	f := &Forwarder{
 		cfg: ForwarderConfig{
@@ -1246,11 +1247,12 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 }
 
 func newMockForwader(ctx context.Context, t *testing.T) *Forwarder {
-	clientCreds, err := ttlmap.New(defaults.ClientCacheSize)
+	clock := clockwork.NewFakeClock()
+	clientCreds, err := ttlmap.New(defaults.ClientCacheSize, ttlmap.Clock(clock))
 	require.NoError(t, err)
-	cachedTransport, err := ttlmap.New(defaults.ClientCacheSize)
+	cachedTransport, err := ttlmap.New(defaults.ClientCacheSize, ttlmap.Clock(clock))
 	require.NoError(t, err)
-	csrClient, err := newMockCSRClient()
+	csrClient, err := newMockCSRClient(clock)
 	require.NoError(t, err)
 
 	return &Forwarder{
@@ -1260,7 +1262,7 @@ func newMockForwader(ctx context.Context, t *testing.T) *Forwarder {
 			Keygen:            testauthority.New(),
 			AuthClient:        csrClient,
 			CachingAuthClient: mockAccessPoint{},
-			Clock:             clockwork.NewFakeClock(),
+			Clock:             clock,
 			Context:           ctx,
 			TracerProvider:    otel.GetTracerProvider(),
 			tracer:            otel.Tracer(teleport.ComponentKube),
@@ -1277,17 +1279,18 @@ func newMockForwader(ctx context.Context, t *testing.T) *Forwarder {
 type mockCSRClient struct {
 	auth.ClientI
 
+	clock    clockwork.Clock
 	ca       *tlsca.CertAuthority
 	gotCSR   auth.KubeCSR
 	lastCert *x509.Certificate
 }
 
-func newMockCSRClient() (*mockCSRClient, error) {
+func newMockCSRClient(clock clockwork.Clock) (*mockCSRClient, error) {
 	ca, err := tlsca.FromKeys([]byte(fixtures.TLSCACertPEM), []byte(fixtures.TLSCAKeyPEM))
 	if err != nil {
 		return nil, err
 	}
-	return &mockCSRClient{ca: ca}, nil
+	return &mockCSRClient{ca: ca, clock: clock}, nil
 }
 
 func (c *mockCSRClient) ProcessKubeCSR(csr auth.KubeCSR) (*auth.KubeCSRResponse, error) {
@@ -1298,11 +1301,11 @@ func (c *mockCSRClient) ProcessKubeCSR(csr auth.KubeCSR) (*auth.KubeCSRResponse,
 		return nil, err
 	}
 	caCSR := tlsca.CertificateRequest{
-		Clock:     clockwork.NewFakeClock(),
+		Clock:     c.clock,
 		PublicKey: x509CSR.PublicKey.(crypto.PublicKey),
 		Subject:   x509CSR.Subject,
 		// getClientCreds requires sessions to be valid for at least 1 minute
-		NotAfter: time.Now().Add(2 * time.Minute),
+		NotAfter: c.clock.Now().Add(2 * time.Minute),
 		DNSNames: x509CSR.DNSNames,
 	}
 	cert, err := c.ca.GenerateCertificate(caCSR)
@@ -1564,17 +1567,19 @@ func newKubeServersFromKubeClusters(t *testing.T, kubeClusters ...*types.Kuberne
 func TestForwarder_clientCreds_cache(t *testing.T) {
 	now := time.Now()
 
-	cache, err := ttlmap.New(10)
+	clock := clockwork.NewFakeClockAt(now.Add(-2 * time.Minute))
+
+	cache, err := ttlmap.New(10, ttlmap.Clock(clock))
 	require.NoError(t, err)
 
-	cl, err := newMockCSRClient()
+	cl, err := newMockCSRClient(clock)
 	require.NoError(t, err)
 
 	f := &Forwarder{
 		cfg: ForwarderConfig{
 			Keygen:         testauthority.New(),
 			AuthClient:     cl,
-			Clock:          clockwork.NewFakeClockAt(time.Now().Add(-2 * time.Minute)),
+			Clock:          clock,
 			TracerProvider: otel.GetTracerProvider(),
 			tracer:         otel.Tracer(teleport.ComponentKube),
 		},

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -971,7 +971,8 @@ func mockAuthCtx(ctx context.Context, t *testing.T, kubeCluster string, isRemote
 			isRemote: isRemote,
 		},
 		kubeClusterName: "kube-cluster",
-		sessionTTL:      time.Minute,
+		// getClientCreds requires sessions to be valid for at least 1 minute
+		sessionTTL: 2 * time.Minute,
 	}
 }
 
@@ -1300,8 +1301,9 @@ func (c *mockCSRClient) ProcessKubeCSR(csr auth.KubeCSR) (*auth.KubeCSRResponse,
 		Clock:     clockwork.NewFakeClock(),
 		PublicKey: x509CSR.PublicKey.(crypto.PublicKey),
 		Subject:   x509CSR.Subject,
-		NotAfter:  time.Now().Add(time.Minute),
-		DNSNames:  x509CSR.DNSNames,
+		// getClientCreds requires sessions to be valid for at least 1 minute
+		NotAfter: time.Now().Add(2 * time.Minute),
+		DNSNames: x509CSR.DNSNames,
 	}
 	cert, err := c.ca.GenerateCertificate(caCSR)
 	if err != nil {

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -230,9 +230,9 @@ func TestRecoveryAttemptsCRUD(t *testing.T) {
 		attempts, err := identity.GetUserRecoveryAttempts(ctx, username)
 		require.NoError(t, err)
 		require.Len(t, attempts, 3)
-		require.Equal(t, time1, attempts[0].Time)
-		require.Equal(t, time2, attempts[1].Time)
-		require.Equal(t, time3, attempts[2].Time)
+		require.WithinDuration(t, time1, attempts[0].Time, time.Second)
+		require.WithinDuration(t, time2, attempts[1].Time, time.Second)
+		require.WithinDuration(t, time3, attempts[2].Time, time.Second)
 
 		// Test delete all recovery attempts.
 		err = identity.DeleteUserRecoveryAttempts(ctx, username)

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -277,7 +277,7 @@ func TestHeartbeatAnnounce(t *testing.T) {
 			require.Equal(t, hb.state, HeartbeatStateAnnounceWait)
 
 			// advance time, and heartbeat will move to announce
-			clock.Advance(hb.AnnouncePeriod * time.Second)
+			clock.Advance(hb.AnnouncePeriod + time.Second)
 			err = hb.fetch()
 			require.NoError(t, err)
 			require.Equal(t, hb.state, HeartbeatStateAnnounce)

--- a/lib/srv/sessiontracker.go
+++ b/lib/srv/sessiontracker.go
@@ -79,15 +79,17 @@ const sessionTrackerExpirationUpdateInterval = apidefaults.SessionTrackerTTL / 3
 // SessionTracker to the backend, the write is retried with exponential backoff up until the original
 // SessionTracker expiry.
 func (s *SessionTracker) UpdateExpirationLoop(ctx context.Context, clock clockwork.Clock) error {
-	ticker := clock.NewTicker(sessionTrackerExpirationUpdateInterval)
-	defer func() {
-		// ensure the correct ticker is stopped due to reassignment below
-		ticker.Stop()
-	}()
+	// Use a timer and reset every loop (instead of a ticker) for two reasons:
+	// 1. We always want to wait the full interval after a successful update,
+	//    whether or not a retry was necessary.
+	// 2. It's easier for tests to wait for the timer to be reset, tickers
+	//    always count as a blocker.
+	timer := clock.NewTimer(sessionTrackerExpirationUpdateInterval)
+	defer timer.Stop()
 
 	for {
 		select {
-		case t := <-ticker.Chan():
+		case t := <-timer.Chan():
 			expiry := t.Add(apidefaults.SessionTrackerTTL)
 			if err := s.UpdateExpiration(ctx, expiry); err != nil {
 				// If the tracker doesn't exist in the backend then
@@ -96,20 +98,13 @@ func (s *SessionTracker) UpdateExpirationLoop(ctx context.Context, clock clockwo
 					return trace.Wrap(err)
 				}
 
-				// Stop the ticker so that it doesn't
-				// keep accumulating ticks while we are retrying.
-				ticker.Stop()
-
 				if err := s.retryUpdate(ctx, clock); err != nil {
 					return trace.Wrap(err)
 				}
-
-				// Tracker was updated, create a new ticker and proceed with the update
-				// loop.
-				// Note: clockwork.Ticker doesn't support Reset, if and when it does
-				// we should use that instead of creating a new ticker.
-				ticker = clock.NewTicker(sessionTrackerExpirationUpdateInterval)
 			}
+			// Tracker was updated, reset the timer to wait another full
+			// update interval and proceed with the update loop.
+			timer.Reset(sessionTrackerExpirationUpdateInterval)
 		case <-ctx.Done():
 			return nil
 		case <-s.closeC:
@@ -123,6 +118,7 @@ func (s *SessionTracker) retryUpdate(ctx context.Context, clock clockwork.Clock)
 	retry, err := retryutils.NewLinear(retryutils.LinearConfig{
 		Clock:  clock,
 		Max:    3 * time.Minute,
+		First:  time.Minute,
 		Step:   time.Minute,
 		Jitter: retryutils.NewHalfJitter(),
 	})

--- a/lib/srv/sessiontracker_test.go
+++ b/lib/srv/sessiontracker_test.go
@@ -88,15 +88,8 @@ func TestSessionTracker_UpdateRetry(t *testing.T) {
 	// will fail and force the retry mechanism to kick in. Odd iterations update
 	// session trackers successfully on first attempt.
 	for i := 0; i < 4; i++ {
-		// Wait for the ticker to be ready. On odd iterations we have to block on 2 instead of 1
-		// because clockwork.fakeTicker.Stop() doesn't result in removal of the ticker from the clockwork.FakeClock
-		// sleepers list. When the ticker is recreated after the retry finishes, the clock ends up with a sleeper
-		// for both the original ticker and the new ticker.
-		if i%2 == 1 {
-			clock.BlockUntil(2)
-		} else {
-			clock.BlockUntil(1)
-		}
+		// Wait for the ticker to be ready.
+		clock.BlockUntil(1)
 
 		// advance the clock to fire the ticker
 		clock.Advance(sessionTrackerExpirationUpdateInterval)

--- a/lib/srv/sessiontracker_test.go
+++ b/lib/srv/sessiontracker_test.go
@@ -85,8 +85,8 @@ func TestSessionTracker_UpdateRetry(t *testing.T) {
 	}()
 
 	// Walk through a few attempts to update the session tracker. Even iterations
-	// will fail and force the retry mechanism to kick in *twice*. Odd
-	// iterations update session trackers successfully on first attempt.
+	// will fail and force the retry mechanism to kick in. Odd iterations update
+	// session trackers successfully on first attempt.
 	for i := 0; i < 4; i++ {
 		clock.BlockUntil(1)
 
@@ -100,20 +100,13 @@ func TestSessionTracker_UpdateRetry(t *testing.T) {
 		if i%2 == 0 {
 			svc.updateError <- updateError
 
-			// the first retry is instant, wait for the update to be called
-			// again without advancing the clock
-			waitForUpdate(t, svc, done)
-
-			// send another error
-			svc.updateError <- updateError
-
-			// wait for the second retry to be engaged
+			// wait for the retry to be engaged
 			clock.BlockUntil(1)
 
 			// advance far enough for the retry to fire
 			clock.Advance(65 * time.Second)
 
-			// wait for the update to be called a third time
+			// wait for the update to be called again
 			waitForUpdate(t, svc, done)
 		}
 
@@ -129,7 +122,9 @@ func TestSessionTracker_UpdateRetry(t *testing.T) {
 	waitForUpdate(t, svc, done)
 	svc.updateError <- updateError
 
-	// the retry fires instantly
+	// advance far enough for the retry to fire
+	clock.BlockUntil(1)
+	clock.Advance(65 * time.Second)
 
 	// wait for update to be called from the retry loop and return an error
 	waitForUpdate(t, svc, done)

--- a/lib/tlsca/ca_test.go
+++ b/lib/tlsca/ca_test.go
@@ -198,7 +198,7 @@ func TestKubeExtensions(t *testing.T) {
 	out, err := FromSubject(cert.Subject, cert.NotAfter)
 	require.NoError(t, err)
 	require.False(t, out.Renewable)
-	require.Empty(t, cmp.Diff(out, &identity))
+	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
 }
 
 func TestAzureExtensions(t *testing.T) {
@@ -241,7 +241,7 @@ func TestAzureExtensions(t *testing.T) {
 	require.NoError(t, err)
 	out, err := FromSubject(cert.Subject, cert.NotAfter)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(out, &identity))
+	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
 	require.Equal(t, "43de4ffa8509aff3e3990e941400a403a12a6024d59897167b780ec0d03a1f15", out.RouteToApp.SessionID)
 }
 
@@ -347,7 +347,7 @@ func TestGCPExtensions(t *testing.T) {
 	require.NoError(t, err)
 	out, err := FromSubject(cert.Subject, cert.NotAfter)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(out, &identity))
+	require.Empty(t, cmp.Diff(out, &identity, cmpopts.EquateApproxTime(time.Second)))
 }
 
 func TestIdentity_GetUserMetadata(t *testing.T) {

--- a/lib/usagereporter/usagereporter_test.go
+++ b/lib/usagereporter/usagereporter_test.go
@@ -279,7 +279,6 @@ func TestUsageReporterDiscard(t *testing.T) {
 
 	// Wait the regular submit delay (to ensure submit finishes), as we have
 	// enough events to fill two batches.
-	fakeClock.BlockUntil(1)
 	fakeSubmitClock.BlockUntil(1)
 	advanceClocks(testSubmitDelay, fakeClock, fakeSubmitClock)
 

--- a/tool/tbot/kube_test.go
+++ b/tool/tbot/kube_test.go
@@ -65,7 +65,7 @@ func TestGetKubeCredentialData(t *testing.T) {
 		},
 	}
 
-	data, err := getCredentialData(idFile, clock)
+	data, err := getCredentialData(idFile, clock.Now())
 	require.NoError(t, err)
 
 	var parsed map[string]interface{}

--- a/tool/tbot/kube_test.go
+++ b/tool/tbot/kube_test.go
@@ -65,7 +65,7 @@ func TestGetKubeCredentialData(t *testing.T) {
 		},
 	}
 
-	data, err := getCredentialData(idFile)
+	data, err := getCredentialData(idFile, clock)
 	require.NoError(t, err)
 
 	var parsed map[string]interface{}
@@ -76,10 +76,9 @@ func TestGetKubeCredentialData(t *testing.T) {
 	require.Equal(t, string(certBytes), status["clientCertificateData"])
 	require.Equal(t, string(privateKeyBytes), status["clientKeyData"])
 
-	// Note: We'll usually subtract a minute from the expiration time, but
-	// since clockwerk's testing clock is set to 1984 we don't take that
-	// conditional.
+	// Note: We usually subtract a minute from the expiration time in
+	// getCredentialData to avoid the cert expiring mid-request.
 	ts, err := time.Parse(time.RFC3339, status["expirationTimestamp"].(string))
 	require.NoError(t, err)
-	require.Equal(t, notAfter, ts)
+	require.WithinDuration(t, notAfter.Add(-1*time.Minute), ts, time.Second)
 }


### PR DESCRIPTION
Creating this PR since CI doesn't seem to run on [the dependabot one](https://github.com/gravitational/teleport/pull/23968), and I want to make sure I caught all the tests that need to be fixed.

In this version, the default/starting time for `clockwork.NewFakeClock()` has been updated to `time.Now()` instead of the previous static date. This has multiple consequences:
- times are usually not at an even second, this breaks most equality checks
- times are not necessarily in UTC by default, this breaks equality checks too
- times are not way in the past anymore, breaking a bunch of buggy diff checks that were actually looking at negative numbers