### PR TITLE
patches up desktop tsh export

### DIFF
--- a/tool/tsh/recording_export_test.go
+++ b/tool/tsh/recording_export_test.go
@@ -87,7 +87,7 @@ func TestWriteMovieMultipleScreenSpecs(t *testing.T) {
 }
 
 func TestWriteMovieWritesOneFrame(t *testing.T) {
-	oneFrame := float64(frameDelayMs)
+	oneFrame := frameDelayMs
 	// need a PNG that will actually decode
 	events := []apievents.AuditEvent{
 		tdpEventMillis(t, tdp.ClientScreenSpec{Width: 128, Height: 128}, 0),


### PR DESCRIPTION
Patches up logic to account for delay between the last apievents.DesktopRecording event and the final apievents.WindowsDesktopSessionEnd event. Also adds handling for apievents.WindowsDesktopSessionStart events.