### PR TITLE
Ensure the Okta service can connect through the reverse tunnel.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5093,7 +5093,16 @@ func WithClusterCAs(tlsConfig *tls.Config, ap AccessCache, currentClusterName st
 
 // DefaultDNSNamesForRole returns default DNS names for the specified role.
 func DefaultDNSNamesForRole(role types.SystemRole) []string {
-	if (types.SystemRoles{role}).IncludeAny(types.RoleAuth, types.RoleAdmin, types.RoleProxy, types.RoleKube, types.RoleApp, types.RoleDatabase, types.RoleWindowsDesktop) {
+	if (types.SystemRoles{role}).IncludeAny(
+		types.RoleAuth,
+		types.RoleAdmin,
+		types.RoleProxy,
+		types.RoleKube,
+		types.RoleApp,
+		types.RoleDatabase,
+		types.RoleWindowsDesktop,
+		types.RoleOkta,
+	) {
 		return []string{
 			"*." + constants.APIDomain,
 			constants.APIDomain,

--- a/lib/reversetunnel/api.go
+++ b/lib/reversetunnel/api.go
@@ -198,4 +198,10 @@ const (
 	// It usually happens when a database agent has shut down (or crashed) but
 	// hasn't expired from the backend yet.
 	NoDatabaseTunnel = "could not find reverse tunnel, check that Database Service agent proxying this database is up and running"
+	// NoOktaTunnel is the error message returned when an Okta
+	// reverse tunnel cannot be found.
+	//
+	// It usually happens when an Okta service has shut down (or crashed) but
+	// hasn't expired from the backend yet.
+	NoOktaTunnel = "could not find reverse tunnel, check that Okta Service agent proxying this application is up and running"
 )

--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -454,7 +454,7 @@ func (s *localSite) skipDirectDial(params DialParams) (bool, error) {
 	// over a direct dial.
 	switch params.ConnType {
 	case types.KubeTunnel, types.NodeTunnel, types.ProxyTunnel, types.WindowsDesktopTunnel:
-	case types.AppTunnel, types.DatabaseTunnel:
+	case types.AppTunnel, types.DatabaseTunnel, types.OktaTunnel:
 		return true, nil
 	default:
 		return true, trace.BadParameter("unknown tunnel type: %s", params.ConnType)

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -431,6 +431,8 @@ func (p *transport) getConn(addr string, r *sshutils.DialReq) (net.Conn, bool, e
 		switch r.ConnType {
 		case types.AppTunnel:
 			return nil, false, trace.ConnectionProblem(err, NoApplicationTunnel)
+		case types.OktaTunnel:
+			return nil, false, trace.ConnectionProblem(err, NoOktaTunnel)
 		case types.DatabaseTunnel:
 			return nil, false, trace.ConnectionProblem(err, NoDatabaseTunnel)
 		}

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -426,7 +426,7 @@ func (p *transport) getConn(addr string, r *sshutils.DialReq) (net.Conn, bool, e
 			return nil, false, trace.Wrap(err)
 		}
 
-		// Connections to applications and databases should never occur over
+		// Connections to applications (including Okta applications) and databases should never occur over
 		// a direct dial, return right away.
 		switch r.ConnType {
 		case types.AppTunnel:

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2939,7 +2939,7 @@ func (process *TeleportProcess) getAdditionalPrincipals(role types.SystemRole) (
 			utils.NetAddr{Addr: reversetunnel.LocalKubernetes},
 		)
 		addrs = append(addrs, process.Config.Kube.PublicAddrs...)
-	case types.RoleApp:
+	case types.RoleApp, types.RoleOkta:
 		principals = append(principals, process.Config.HostUUID)
 	case types.RoleWindowsDesktop:
 		addrs = append(addrs,

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -424,6 +424,17 @@ func TestGetAdditionalPrincipals(t *testing.T) {
 			},
 		},
 		{
+			role: types.RoleOkta,
+			wantPrincipals: []string{
+				"global-hostname",
+				"global-uuid",
+			},
+			wantDNS: []string{
+				"*.teleport.cluster.local",
+				"teleport.cluster.local",
+			},
+		},
+		{
 			role: types.SystemRole("unknown"),
 			wantPrincipals: []string{
 				"global-hostname",


### PR DESCRIPTION
A few additional spots were not updated when enabling tunneling for the new enterprise Okta service. Those spots are:

* `auth.DefaultDNSNamesForRole` needed to be updated to ensure that wildcard certs for the API domain are generated.
* `reversetunnel` updates to ensure the `OktaTunnel` is handled in a similar fashion to the `AppTunnel`.
* `process.getAdditionalPrincipals` needed to be updated to account for the `HostUUID` as part of the principals supported for certificates.

With these, the Okta service is able to handle connections over the reverse tunnel properly.