### PR TITLE
Connect: Do not include staging feedback address in prod CSP

### DIFF
--- a/web/packages/teleterm/webpack.renderer.extend.js
+++ b/web/packages/teleterm/webpack.renderer.extend.js
@@ -42,9 +42,14 @@ function createHtmlPlugin({ isDev }) {
 }
 
 function getCsp({ isDev }) {
+  // feedbackAddress needs to be kept in sync with the same property in staticConfig.ts.
+  const feedbackAddress = isDev
+    ? 'https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod'
+    : 'https://usage.teleport.dev';
+
   let csp = `
 default-src 'self';
-connect-src 'self' https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod https://usage.teleport.dev;
+connect-src 'self' ${feedbackAddress};
 style-src 'self' 'unsafe-inline';
 img-src 'self' data: blob:;
 object-src 'none';


### PR DESCRIPTION
Staging environments are typically less secure than production ones. We should not include the staging feedback URL in the final packaged app in case it gets compromised.

Tested in dev and prod mode with dev tools enabled. The staging URL seems to not work (unrelated to this change) but I was able to submit a request from the packaged version.

We can't really load `staticConfig` inside webpack config file here because the static config is defined in a TypeScript file.

---

`staticConfig` exists only in v12+, v10 and v11 backports shouldn't mention it.