### PR TITLE
Fix flaky tests

### DIFF
--- a/lib/auth/keystore/keystore_test.go
+++ b/lib/auth/keystore/keystore_test.go
@@ -127,16 +127,15 @@ JhuTMEqUaAOZBoQLn+txjl3nu9WwTThJzlY0L4w=
 )
 
 func TestKeyStore(t *testing.T) {
-	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
 	modules.SetTestModules(t, &modules.TestModules{
 		TestBuildType: modules.BuildEnterprise,
 		TestFeatures: modules.Features{
 			HSM: true,
 		},
 	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
 
 	skipSoftHSM := os.Getenv("SOFTHSM2_PATH") == ""
 	var softHSMConfig Config

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -209,8 +209,6 @@ func TestGetClientUserIsSSO(t *testing.T) {
 }
 
 func TestAuthorizer_Authorize_deviceTrust(t *testing.T) {
-	t.Parallel()
-
 	client, watcher, _ := newTestResources(t)
 
 	ctx := context.Background()

--- a/lib/modules/test.go
+++ b/lib/modules/test.go
@@ -62,6 +62,7 @@ type TestModules struct {
 func SetTestModules(t *testing.T, testModules *TestModules) {
 	defaultModules := GetModules()
 	t.Cleanup(func() { SetModules(defaultModules) })
+	t.Setenv("TELEPORT_TEST_NOT_SAFE_FOR_PARALLEL", "true")
 	SetModules(testModules)
 }
 

--- a/lib/srv/session_control_test.go
+++ b/lib/srv/session_control_test.go
@@ -104,8 +104,6 @@ func (m mockAccessChecker) RoleNames() []string {
 }
 
 func TestSessionController_AcquireSessionContext(t *testing.T) {
-	t.Parallel()
-
 	clock := clockwork.NewFakeClock()
 	emitter := &eventstest.MockEmitter{}
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1920,12 +1920,11 @@ func TestWebAgentForward(t *testing.T) {
 }
 
 func TestActiveSessions(t *testing.T) {
-	t.Parallel()
-	s := newWebSuite(t)
-	pack := s.authPack(t, "foo")
-
 	// Use enterprise license (required for moderated sessions).
 	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+
+	s := newWebSuite(t)
+	pack := s.authPack(t, "foo")
 
 	start := time.Now()
 	kinds := []types.SessionKind{


### PR DESCRIPTION
Fixes flaky tests caused by updating a test module while using `t.Parallel()` with `modules.SetTestModules()`

Closes #24115
Closes #24105