### PR TITLE
Fix `TestCheckAccessToRegisteredResource` flaky test

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1920,7 +1920,6 @@ func TestWebAgentForward(t *testing.T) {
 }
 
 func TestActiveSessions(t *testing.T) {
-	t.Parallel()
 	s := newWebSuite(t)
 	pack := s.authPack(t, "foo")
 


### PR DESCRIPTION
When multiple tests run in parallel and one of them replaces the module's features, it affects all the running tests.

A test was changing the modules while running in parallel and it resulted in the flakiness of `TestCheckAccessToRegisteredResource` because, since #23755, we enforce that the server has the Kubernetes feature enabled in order to upsert the server.

Fixes #24115