### PR TITLE
Disable `build-macos` and `build-windows` on PR

### DIFF
--- a/.github/workflows/build-macos-bypass.yaml
+++ b/.github/workflows/build-macos-bypass.yaml
@@ -29,7 +29,7 @@ on:
 jobs:
   build:
     name: Build on Mac OS
-    runs-on: macos-12
+    runs-on: ubuntu-latest
 
     permissions:
       contents: none

--- a/.github/workflows/build-macos-bypass.yaml
+++ b/.github/workflows/build-macos-bypass.yaml
@@ -13,17 +13,6 @@ run-name: Skip Build on Mac OS
 
 on:
   pull_request:
-    paths-ignore:
-      - '.github/workflows/build-macos.yaml'
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '**.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'build.assets/Makefile'
-      - 'build.assets/Dockerfile*'
-      - 'Makefile'
   merge_group:
     paths-ignore:
       - '.github/workflows/build-macos.yaml'

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -2,18 +2,6 @@ name: Build on Mac OS
 run-name: Build on Mac OS
 
 on:
-  pull_request:
-    paths:
-      - '.github/workflows/build-macos.yaml'
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - '**.rs'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'build.assets/Makefile'
-      - 'build.assets/Dockerfile*'
-      - 'Makefile'
   merge_group:
     paths:
       - '.github/workflows/build-macos.yaml'

--- a/.github/workflows/build-windows-bypass.yaml
+++ b/.github/workflows/build-windows-bypass.yaml
@@ -13,16 +13,6 @@ run-name: Skip Build on Windows
 
 on:
   pull_request:
-    # We only build tsh on Windows so only consider Go code as tsh doesn't
-    # run any Rust.
-    paths-ignore:
-      - '.github/workflows/build-windows.yaml'
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'build.assets/Makefile'
-      - 'build.assets/Dockerfile*'
-      - 'Makefile'
   merge_group:
     # We only build tsh on Windows so only consider Go code as tsh doesn't
     # run any Rust.

--- a/.github/workflows/build-windows-bypass.yaml
+++ b/.github/workflows/build-windows-bypass.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   build:
     name: Build on Windows
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
 
     permissions:
       contents: none

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -2,17 +2,6 @@ name: Build on Windows
 run-name: Build on Windows
 
 on:
-  pull_request:
-    # We only build tsh on Windows so only consider Go code as tsh doesn't
-    # run any Rust.
-    paths:
-      - '.github/workflows/build-windows.yaml'
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'build.assets/Makefile'
-      - 'build.assets/Dockerfile*'
-      - 'Makefile'
   merge_group:
     # We only build tsh on Windows so only consider Go code as tsh doesn't
     # run any Rust.

--- a/.github/workflows/lint-ui-bypass.yaml
+++ b/.github/workflows/lint-ui-bypass.yaml
@@ -22,7 +22,7 @@ on:
 jobs:
   lint:
     name: Prettier, ESLint, & TSC
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: none

--- a/.github/workflows/unit-tests-ui-bypass.yaml
+++ b/.github/workflows/unit-tests-ui-bypass.yaml
@@ -24,7 +24,7 @@ on:
 jobs:
   lint:
     name: Test UI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     permissions:
       contents: none


### PR DESCRIPTION
This commit removes the `build-macos` and `build-windows` from the PR flow, instead delegating to the bypass job. These jobs still run before being accepted in the merge queue.

This means that failures in these two jobs may not be known until the merge queue. Although late issue discovery is not ideal, it is considered the most critical in ensuring that `master` remains stable.

After discussing with @r0mant and @russjones we believe this change is worth trying because:
* Currently MacOS builds are 31% of our Teleport Actions spend (~$3,400 / week)
* Windows builds are also significant at 13% (~$1,400 / week)
* There has been relatively few failures of these jobs (without other jobs also failing)
* Unlike unit tests, build failures are never intermittent so a failure is a clear sign of a fix needed
* We still will have verification that `master` remains healthy

As an additional minor optimization all bypass jobs were updated to run on `ubuntu-latest`.

2 to 4 weeks after this change is merged we plan to review our spend again to see if these changes are helping as expected, as well if any additional opportunities for savings present themselves.