### PR TITLE
Split PingConn to PingConn and PingTLSConn

### DIFF
--- a/api/utils/pingconn/pingconn.go
+++ b/api/utils/pingconn/pingconn.go
@@ -17,20 +17,20 @@ limitations under the License.
 package pingconn
 
 import (
-	"crypto/tls"
 	"encoding/binary"
 	"math"
+	"net"
 	"sync"
 
 	"github.com/gravitational/trace"
 )
 
 // New returns a ping connection wrapping the provided net.Conn.
-func New(conn *tls.Conn) *PingConn {
+func New(conn net.Conn) *PingConn {
 	return &PingConn{Conn: conn}
 }
 
-// PingConn wraps a *tls.Conn and add ping capabilities to it, including the
+// PingConn wraps a net.Conn and add ping capabilities to it, including the
 // `WritePing` function and `Read` (which excludes ping packets).
 //
 // When using this connection, the packets written will contain an initial data:
@@ -40,8 +40,7 @@ func New(conn *tls.Conn) *PingConn {
 // Ping messages have a packet size of zero and are produced only when
 // `WritePing` is called. On `Read`, any Ping packet is discarded.
 type PingConn struct {
-	//net.Conn
-	*tls.Conn
+	net.Conn
 
 	muRead  sync.Mutex
 	muWrite sync.Mutex

--- a/api/utils/pingconn/pingconn.go
+++ b/api/utils/pingconn/pingconn.go
@@ -49,7 +49,7 @@ type PingConn struct {
 	currentSize uint32
 }
 
-// Read reads content from the underlaying connection, discarding any ping
+// Read reads content from the underlying connection, discarding any ping
 // messages it finds.
 func (c *PingConn) Read(p []byte) (int, error) {
 	c.muRead.Lock()

--- a/api/utils/pingconn/pingconn_test.go
+++ b/api/utils/pingconn/pingconn_test.go
@@ -30,252 +30,283 @@ import (
 	"github.com/gravitational/teleport/api/fixtures"
 )
 
+type pingConn interface {
+	net.Conn
+	WritePing() error
+}
+
 func TestPingConnection(t *testing.T) {
-	t.Run("BufferSize", func(t *testing.T) {
-		nWrites := 10
-		dataWritten := []byte("message")
+	connTypes := []struct {
+		name     string
+		makeFunc func(t *testing.T) (pingConn, pingConn)
+	}{
+		{
+			name:     "PingConn",
+			makeFunc: makePingConn,
+		},
+		{
+			name:     "PingTLSConn",
+			makeFunc: makePingTLSConn,
+		},
+	}
 
-		for _, tt := range []struct {
-			desc    string
-			bufSize int
-		}{
-			{desc: "Same", bufSize: len(dataWritten)},
-			{desc: "Large", bufSize: len(dataWritten) * 2},
-			{desc: "Short", bufSize: len(dataWritten) / 2},
-		} {
-			t.Run(tt.desc, func(t *testing.T) {
-				r, w := makePingConn(t)
+	for _, connType := range connTypes {
+		t.Run(connType.name, func(t *testing.T) {
+			t.Run("BufferSize", func(t *testing.T) {
+				nWrites := 10
+				dataWritten := []byte("message")
 
-				// Write routine
-				errChan := make(chan error, 2)
-				go func() {
-					defer w.Close()
+				for _, tt := range []struct {
+					desc    string
+					bufSize int
+				}{
+					{desc: "Same", bufSize: len(dataWritten)},
+					{desc: "Large", bufSize: len(dataWritten) * 2},
+					{desc: "Short", bufSize: len(dataWritten) / 2},
+				} {
+					t.Run(tt.desc, func(t *testing.T) {
+						r, w := makePingConn(t)
 
-					for i := 0; i < nWrites; i++ {
-						// Eventually write some pings.
-						if i%2 == 0 {
-							err := w.WritePing()
-							if err != nil {
-								errChan <- err
-								return
-							}
-						}
+						// Write routine
+						errChan := make(chan error, 2)
+						go func() {
+							defer w.Close()
 
-						_, err := w.Write(dataWritten)
-						if err != nil {
-							errChan <- err
-							return
-						}
-					}
+							for i := 0; i < nWrites; i++ {
+								// Eventually write some pings.
+								if i%2 == 0 {
+									err := w.WritePing()
+									if err != nil {
+										errChan <- err
+										return
+									}
+								}
 
-					errChan <- nil
-				}()
-
-				// Read routine.
-				go func() {
-					defer r.Close()
-
-					buf := make([]byte, tt.bufSize)
-
-					for i := 0; i < nWrites; i++ {
-						var (
-							aggregator []byte
-							n          int
-							err        error
-						)
-
-						for n < len(dataWritten) {
-							n, err = r.Read(buf)
-							if err != nil {
-								errChan <- err
-								return
+								_, err := w.Write(dataWritten)
+								if err != nil {
+									errChan <- err
+									return
+								}
 							}
 
-							aggregator = append(aggregator, buf[:n]...)
+							errChan <- nil
+						}()
+
+						// Read routine.
+						go func() {
+							defer r.Close()
+
+							buf := make([]byte, tt.bufSize)
+
+							for i := 0; i < nWrites; i++ {
+								var (
+									aggregator []byte
+									n          int
+									err        error
+								)
+
+								for n < len(dataWritten) {
+									n, err = r.Read(buf)
+									if err != nil {
+										errChan <- err
+										return
+									}
+
+									aggregator = append(aggregator, buf[:n]...)
+								}
+
+								if !bytes.Equal(dataWritten, aggregator) {
+									errChan <- fmt.Errorf("wrong content read, expected '%s', got '%s'", string(dataWritten), string(buf[:n]))
+									return
+								}
+							}
+
+							errChan <- nil
+						}()
+
+						// Expect routines to finish.
+						timer := time.NewTimer(10 * time.Second)
+						defer timer.Stop()
+						for i := 0; i < 1; i++ {
+							select {
+							case err := <-errChan:
+								require.NoError(t, err)
+							case <-timer.C:
+								require.Fail(t, "routing didn't finished in time")
+							}
 						}
-
-						if !bytes.Equal(dataWritten, aggregator) {
-							errChan <- fmt.Errorf("wrong content read, expected '%s', got '%s'", string(dataWritten), string(buf[:n]))
-							return
-						}
-					}
-
-					errChan <- nil
-				}()
-
-				// Expect routines to finish.
-				timer := time.NewTimer(10 * time.Second)
-				defer timer.Stop()
-				for i := 0; i < 1; i++ {
-					select {
-					case err := <-errChan:
-						require.NoError(t, err)
-					case <-timer.C:
-						require.Fail(t, "routing didn't finished in time")
-					}
+					})
 				}
 			})
-		}
-	})
 
-	// Given a connection, read from it concurrently, asserting all content
-	// written is read.
-	//
-	// Messages can be out of order due to concurrent reads. Other tests must
-	// guarantee message ordering.
-	t.Run("ConcurrentReads", func(t *testing.T) {
-		// Number of writes performed.
-		nWrites := 10
-		// Data that is going to be written/read on the connection.
-		dataWritten := []byte("message")
-		// Size of each read call.
-		readSize := 2
-		// Number of reads necessary to read the full message
-		readNum := int(math.Ceil(float64(len(dataWritten)) / float64(readSize)))
+			// Given a connection, read from it concurrently, asserting all content
+			// written is read.
+			//
+			// Messages can be out of order due to concurrent reads. Other tests must
+			// guarantee message ordering.
+			t.Run("ConcurrentReads", func(t *testing.T) {
+				// Number of writes performed.
+				nWrites := 10
+				// Data that is going to be written/read on the connection.
+				dataWritten := []byte("message")
+				// Size of each read call.
+				readSize := 2
+				// Number of reads necessary to read the full message
+				readNum := int(math.Ceil(float64(len(dataWritten)) / float64(readSize)))
 
-		r, w := makePingConn(t)
-		defer r.Close()
-		defer w.Close() // This call may be a noop, but it's here just in case.
+				r, w := makePingConn(t)
+				defer r.Close()
+				defer w.Close() // This call may be a noop, but it's here just in case.
 
-		// readResult struct is used to store the result of a read.
-		type readResult struct {
-			data []byte
-			err  error
-		}
-
-		// Channel is used to store the result of a read.
-		resChan := make(chan readResult)
-
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		// Write routine
-		go func() {
-			for i := 0; i < nWrites; i++ {
-				_, err := w.Write(dataWritten)
-				if err != nil {
-					return
+				// readResult struct is used to store the result of a read.
+				type readResult struct {
+					data []byte
+					err  error
 				}
-			}
-		}()
 
-		// Read routines.
-		for i := 0; i < nWrites/2; i++ {
-			go func() {
-				buf := make([]byte, readSize)
-				for {
-					n, err := r.Read(buf)
-					if err != nil {
-						switch err {
-						// Since we're partially reading the message, the last
-						// read will return an EOF. In this case, do nothing
-						// and send the remaining bytes.
-						case io.EOF:
-						// The connection will be closed only if the test is
-						// completed. The read result will be empty, so return
-						// the function to complete the goroutine.
-						case io.ErrClosedPipe:
-							return
-						// Any other error should fail the test and complete the
-						// goroutine.
-						default:
-							resChan <- readResult{err: err}
+				// Channel is used to store the result of a read.
+				resChan := make(chan readResult)
+
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				// Write routine
+				go func() {
+					for i := 0; i < nWrites; i++ {
+						_, err := w.Write(dataWritten)
+						if err != nil {
 							return
 						}
 					}
+				}()
 
-					chanBytes := make([]byte, n)
-					copy(chanBytes, buf[:n])
-					resChan <- readResult{data: chanBytes}
+				// Read routines.
+				for i := 0; i < nWrites/2; i++ {
+					go func() {
+						buf := make([]byte, readSize)
+						for {
+							n, err := r.Read(buf)
+							if err != nil {
+								switch err {
+								// Since we're partially reading the message, the last
+								// read will return an EOF. In this case, do nothing
+								// and send the remaining bytes.
+								case io.EOF:
+								// The connection will be closed only if the test is
+								// completed. The read result will be empty, so return
+								// the function to complete the goroutine.
+								case io.ErrClosedPipe:
+									return
+								// Any other error should fail the test and complete the
+								// goroutine.
+								default:
+									resChan <- readResult{err: err}
+									return
+								}
+							}
+
+							chanBytes := make([]byte, n)
+							copy(chanBytes, buf[:n])
+							resChan <- readResult{data: chanBytes}
+						}
+					}()
 				}
-			}()
-		}
 
-		var aggregator []byte
-		for i := 0; i < nWrites; i++ {
-			for j := 0; j < readNum; j++ {
-				select {
-				case <-ctx.Done():
-					require.Fail(t, "Failed to read message (context timeout)")
-				case res := <-resChan:
-					require.NoError(t, res.err, "Failed to read message")
-					aggregator = append(aggregator, res.data...)
-				}
-			}
-		}
-
-		require.Len(t, aggregator, len(dataWritten)*nWrites, "Wrong messages written")
-
-		require.NoError(t, w.Close())
-
-		res := <-resChan
-		// If there's an error here, it means the error was not io.EOF or io.ErrPipeClosed, as those should have been discarded
-		// by the goroutine above. This likely means that the errors in PingConn were wrapped with trace.Wrap, which can break
-		// callers of net.Conn.
-		require.NoError(t, res.err, "there should be no error on close, check if the errors have been wrapped with trace.Wrap")
-	})
-
-	t.Run("ConcurrentWrites", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-
-		w, r := makeBufferedPingConn(t)
-		defer w.Close()
-		defer r.Close()
-
-		nWrites := 10
-		dataWritten := []byte("message")
-		writeChan := make(chan error)
-
-		// Start write routines.
-		for i := 0; i < nWrites/2; i++ {
-			go func() {
-				for writes := 0; writes < 2; writes++ {
-					err := w.WritePing()
-					if err != nil {
-						writeChan <- err
-						return
-					}
-
-					_, err = w.Write(dataWritten)
-					if err != nil {
-						writeChan <- err
-						return
+				var aggregator []byte
+				for i := 0; i < nWrites; i++ {
+					for j := 0; j < readNum; j++ {
+						select {
+						case <-ctx.Done():
+							require.Fail(t, "Failed to read message (context timeout)")
+						case res := <-resChan:
+							require.NoError(t, res.err, "Failed to read message")
+							aggregator = append(aggregator, res.data...)
+						}
 					}
 				}
 
-				writeChan <- nil
-			}()
-		}
+				require.Len(t, aggregator, len(dataWritten)*nWrites, "Wrong messages written")
 
-		// Expect all writes to succeed.
-		for i := 0; i < nWrites/2; i++ {
-			select {
-			case <-ctx.Done():
-				require.Fail(t, "timeout write")
-			case err := <-writeChan:
-				require.NoError(t, err)
-			}
-		}
+				require.NoError(t, w.Close())
 
-		// Read all messages.
-		buf := make([]byte, len(dataWritten))
-		for i := 0; i < nWrites; i++ {
-			n, err := r.Read(buf)
-			require.NoError(t, err)
-			require.Equal(t, dataWritten, buf[:n])
-		}
-	})
+				res := <-resChan
+				// If there's an error here, it means the error was not io.EOF or io.ErrPipeClosed, as those should have been discarded
+				// by the goroutine above. This likely means that the errors in PingConn were wrapped with trace.Wrap, which can break
+				// callers of net.Conn.
+				require.NoError(t, res.err, "there should be no error on close, check if the errors have been wrapped with trace.Wrap")
+			})
+
+			t.Run("ConcurrentWrites", func(t *testing.T) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				w, r := makeBufferedPingConn(t)
+				defer w.Close()
+				defer r.Close()
+
+				nWrites := 10
+				dataWritten := []byte("message")
+				writeChan := make(chan error)
+
+				// Start write routines.
+				for i := 0; i < nWrites/2; i++ {
+					go func() {
+						for writes := 0; writes < 2; writes++ {
+							err := w.WritePing()
+							if err != nil {
+								writeChan <- err
+								return
+							}
+
+							_, err = w.Write(dataWritten)
+							if err != nil {
+								writeChan <- err
+								return
+							}
+						}
+
+						writeChan <- nil
+					}()
+				}
+
+				// Expect all writes to succeed.
+				for i := 0; i < nWrites/2; i++ {
+					select {
+					case <-ctx.Done():
+						require.Fail(t, "timeout write")
+					case err := <-writeChan:
+						require.NoError(t, err)
+					}
+				}
+
+				// Read all messages.
+				buf := make([]byte, len(dataWritten))
+				for i := 0; i < nWrites; i++ {
+					n, err := r.Read(buf)
+					require.NoError(t, err)
+					require.Equal(t, dataWritten, buf[:n])
+				}
+			})
+		})
+	}
 }
 
 // makePingConn creates a piped ping connection.
-func makePingConn(t *testing.T) (*PingConn, *PingConn) {
+func makePingConn(t *testing.T) (pingConn, pingConn) {
+	t.Helper()
+
+	writer, reader := net.Pipe()
+	return New(writer), New(reader)
+}
+
+// makePingTLSConn creates a piped ping connection.
+func makePingTLSConn(t *testing.T) (pingConn, pingConn) {
 	t.Helper()
 
 	writer, reader := net.Pipe()
 	tlsWriter, tlsReader := makeTLSConn(t, writer, reader)
 
-	return New(tlsWriter), New(tlsReader)
+	return NewTLS(tlsWriter), NewTLS(tlsReader)
 }
 
 // makeBufferedPingConn creates connections to have asynchronous writes.

--- a/api/utils/pingconn/pingconn_test.go
+++ b/api/utils/pingconn/pingconn_test.go
@@ -299,7 +299,7 @@ func makePingConn(t *testing.T) (pingConn, pingConn) {
 	return New(writer), New(reader)
 }
 
-// makePingTLSConn creates a piped ping connection.
+// makePingTLSConn creates a piped TLS ping connection.
 func makePingTLSConn(t *testing.T) (pingConn, pingConn) {
 	t.Helper()
 

--- a/api/utils/pingconn/tls.go
+++ b/api/utils/pingconn/tls.go
@@ -37,7 +37,7 @@ type PingTLSConn struct {
 	ping *PingConn
 }
 
-// Read reads content from the underlaying connection, discarding any ping
+// Read reads content from the underlying connection, discarding any ping
 // messages it finds.
 func (c *PingTLSConn) Read(p []byte) (int, error) {
 	n, err := c.ping.Read(p)

--- a/api/utils/pingconn/tls.go
+++ b/api/utils/pingconn/tls.go
@@ -26,7 +26,7 @@ import (
 func NewTLS(conn *tls.Conn) *PingTLSConn {
 	return &PingTLSConn{
 		Conn: conn,
-		base: New(conn),
+		ping: New(conn),
 	}
 }
 
@@ -34,24 +34,24 @@ func NewTLS(conn *tls.Conn) *PingTLSConn {
 type PingTLSConn struct {
 	*tls.Conn
 
-	base *PingConn
+	ping *PingConn
 }
 
 // Read reads content from the underlaying connection, discarding any ping
 // messages it finds.
 func (c *PingTLSConn) Read(p []byte) (int, error) {
-	n, err := c.base.Read(p)
+	n, err := c.ping.Read(p)
 	return n, trace.Wrap(err)
 }
 
 // WritePing writes the ping packet to the connection.
 func (c *PingTLSConn) WritePing() error {
-	return trace.Wrap(c.base.WritePing())
+	return trace.Wrap(c.ping.WritePing())
 }
 
 // Write writes provided content to the underlying connection with proper
 // protocol fields.
 func (c *PingTLSConn) Write(p []byte) (int, error) {
-	n, err := c.base.Write(p)
+	n, err := c.ping.Write(p)
 	return n, trace.Wrap(err)
 }

--- a/api/utils/pingconn/tls.go
+++ b/api/utils/pingconn/tls.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pingconn
+
+import (
+	"crypto/tls"
+
+	"github.com/gravitational/trace"
+)
+
+// NewTLS returns a ping connection wrapping the provided tls.Conn.
+func NewTLS(conn *tls.Conn) *PingTLSConn {
+	return &PingTLSConn{
+		Conn: conn,
+		base: New(conn),
+	}
+}
+
+// PingTLSConn wraps a tls.Conn and adds ping capabilities to it.
+type PingTLSConn struct {
+	*tls.Conn
+
+	base *PingConn
+}
+
+// Read reads content from the underlaying connection, discarding any ping
+// messages it finds.
+func (c *PingTLSConn) Read(p []byte) (int, error) {
+	n, err := c.base.Read(p)
+	return n, trace.Wrap(err)
+}
+
+// WritePing writes the ping packet to the connection.
+func (c *PingTLSConn) WritePing() error {
+	return trace.Wrap(c.base.WritePing())
+}
+
+// Write writes provided content to the underlying connection with proper
+// protocol fields.
+func (c *PingTLSConn) Write(p []byte) (int, error) {
+	n, err := c.base.Write(p)
+	return n, trace.Wrap(err)
+}

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -229,7 +229,7 @@ func (l *LocalProxy) handleDownstreamConnection(ctx context.Context, downstreamC
 	var upstreamConn net.Conn = tlsConn
 	if common.IsPingProtocol(common.Protocol(tlsConn.ConnectionState().NegotiatedProtocol)) {
 		l.cfg.Log.Debug("Using ping connection")
-		upstreamConn = pingconn.New(tlsConn)
+		upstreamConn = pingconn.NewTLS(tlsConn)
 	}
 
 	return trace.Wrap(utils.ProxyConn(ctx, downstreamConn, upstreamConn))

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -410,7 +410,7 @@ func (p *Proxy) handleConn(ctx context.Context, clientConn net.Conn, defaultOver
 }
 
 // handlePingConnection starts the server ping routine and returns `pingConn`.
-func (p *Proxy) handlePingConnection(ctx context.Context, conn *tls.Conn) net.Conn {
+func (p *Proxy) handlePingConnection(ctx context.Context, conn *tls.Conn) utils.TLSConn {
 	pingConn := pingconn.NewTLS(conn)
 
 	// Start ping routine. It will continuously send pings in a defined

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -411,7 +411,7 @@ func (p *Proxy) handleConn(ctx context.Context, clientConn net.Conn, defaultOver
 
 // handlePingConnection starts the server ping routine and returns `pingConn`.
 func (p *Proxy) handlePingConnection(ctx context.Context, conn *tls.Conn) net.Conn {
-	pingConn := pingconn.New(conn)
+	pingConn := pingconn.NewTLS(conn)
 
 	// Start ping routine. It will continuously send pings in a defined
 	// interval.

--- a/lib/srv/alpnproxy/proxy_test.go
+++ b/lib/srv/alpnproxy/proxy_test.go
@@ -192,7 +192,7 @@ func TestProxyTLSDatabaseHandler(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		conn := pingconn.New(baseConn)
+		conn := pingconn.NewTLS(baseConn)
 		tlsConn := tls.Client(conn, &tls.Config{
 			Certificates: []tls.Certificate{
 				clientCert,


### PR DESCRIPTION
Part of
- #21870

Currently `pingconn.PingConn` wraps a `*tls.Conn`, as ALPN proxy server requires TLS functionalities from the wrapped connection.

Splitting `PingConn` into two types so we can wrap a regular `net.Conn` with ping protocol, without the TLS functionalities.