### PR TITLE
Make TestTeleportProcess_reconnectToAuth less flaky

### DIFF
--- a/lib/auth/authclient/authclient.go
+++ b/lib/auth/authclient/authclient.go
@@ -21,6 +21,7 @@ package authclient
 import (
 	"context"
 	"crypto/tls"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -28,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/utils"
@@ -45,6 +47,8 @@ type Config struct {
 	Log logrus.FieldLogger
 	// CircuitBreakerConfig is the configuration for the auth client circuit breaker.
 	CircuitBreakerConfig breaker.Config
+	// DialTimeout determines how long to wait for dialing to succeed before aborting.
+	DialTimeout time.Duration
 }
 
 // Connect creates a valid client connection to the auth service.  It may
@@ -60,6 +64,7 @@ func Connect(ctx context.Context, cfg *Config) (auth.ClientI, error) {
 		},
 		CircuitBreakerConfig:     cfg.CircuitBreakerConfig,
 		InsecureAddressDiscovery: cfg.TLS.InsecureSkipVerify,
+		DialTimeout:              cfg.DialTimeout,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err, "failed direct dial to auth server: %v", err)
@@ -82,7 +87,13 @@ func Connect(ctx context.Context, cfg *Config) (auth.ClientI, error) {
 		// TODO(nic): this logic should be implemented once and reused in IoT
 		// nodes.
 
-		resolver := reversetunnel.WebClientResolver(cfg.AuthServers, cfg.TLS.InsecureSkipVerify)
+		resolver := reversetunnel.WebClientResolver(&webclient.Config{
+			Context:   ctx,
+			ProxyAddr: cfg.AuthServers[0].String(),
+			Insecure:  cfg.TLS.InsecureSkipVerify,
+			Timeout:   cfg.DialTimeout,
+		})
+
 		resolver, err = reversetunnel.CachingResolver(ctx, resolver, nil /* clock */)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -17,7 +17,6 @@ limitations under the License.
 package service
 
 import (
-	"context"
 	"crypto/tls"
 	"path/filepath"
 	"strings"
@@ -35,6 +34,7 @@ import (
 	"github.com/gravitational/teleport"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib"
@@ -1108,7 +1108,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 		logger.Debug("Attempting to discover reverse tunnel address.")
 		logger.Debug("Attempting to connect to Auth Server through tunnel.")
 
-		tunnelClient, err := process.newClientThroughTunnel(authServers, tlsConfig, sshClientConfig)
+		tunnelClient, err := process.newClientThroughTunnel(authServers[0].String(), tlsConfig, sshClientConfig)
 		if err != nil {
 			process.log.Errorf("Node failed to establish connection to Teleport Proxy. We have tried the following endpoints:")
 			process.log.Errorf("- connecting to auth server directly: %v", directErr)
@@ -1134,7 +1134,7 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 			logger := process.log.WithField("proxy-server", proxyServer.String())
 			logger.Debug("Attempting to connect to Auth Server through tunnel.")
 
-			tunnelClient, err := process.newClientThroughTunnel([]utils.NetAddr{proxyServer}, tlsConfig, sshClientConfig)
+			tunnelClient, err := process.newClientThroughTunnel(proxyServer.String(), tlsConfig, sshClientConfig)
 			if err != nil {
 				return nil, trace.Errorf("Failed to connect to Proxy Server through tunnel: %v", err)
 			}
@@ -1153,8 +1153,13 @@ func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client
 	return nil, trace.NotImplemented("could not find connection strategy for config version %s", process.Config.Version)
 }
 
-func (process *TeleportProcess) newClientThroughTunnel(authServers []utils.NetAddr, tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
-	resolver := reversetunnel.WebClientResolver(authServers, lib.IsInsecureDevMode())
+func (process *TeleportProcess) newClientThroughTunnel(addr string, tlsConfig *tls.Config, sshConfig *ssh.ClientConfig) (*auth.Client, error) {
+	resolver := reversetunnel.WebClientResolver(&webclient.Config{
+		Context:   process.ExitContext(),
+		ProxyAddr: addr,
+		Insecure:  lib.IsInsecureDevMode(),
+		Timeout:   process.Config.ClientTimeout,
+	})
 
 	resolver, err := reversetunnel.CachingResolver(process.ExitContext(), resolver, process.Clock)
 	if err != nil {
@@ -1177,6 +1182,7 @@ func (process *TeleportProcess) newClientThroughTunnel(authServers []utils.NetAd
 			apiclient.LoadTLS(tlsConfig),
 		},
 		CircuitBreakerConfig: process.Config.CircuitBreakerConfig,
+		DialTimeout:          process.Config.ClientTimeout,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1184,7 +1190,7 @@ func (process *TeleportProcess) newClientThroughTunnel(authServers []utils.NetAd
 
 	// Check connectivity to cluster. If the request fails, unwrap the error to
 	// get the underlying error.
-	_, err = clt.GetDomainName(context.TODO())
+	_, err = clt.GetDomainName(process.ExitContext())
 	if err != nil {
 		if err2 := clt.Close(); err2 != nil {
 			process.log.WithError(err2).Warn("Failed to close Auth Server tunnel client.")
@@ -1222,6 +1228,7 @@ func (process *TeleportProcess) newClientDirect(authServers []utils.NetAddr, tls
 		Credentials: []apiclient.Credentials{
 			apiclient.LoadTLS(tlsConfig),
 		},
+		DialTimeout:          process.Config.ClientTimeout,
 		CircuitBreakerConfig: process.Config.CircuitBreakerConfig,
 		DialOpts:             dialOpts,
 	}, cltParams...)
@@ -1229,7 +1236,7 @@ func (process *TeleportProcess) newClientDirect(authServers []utils.NetAddr, tls
 		return nil, trace.Wrap(err)
 	}
 
-	if _, err := clt.GetDomainName(context.TODO()); err != nil {
+	if _, err := clt.GetDomainName(process.ExitContext()); err != nil {
 		if err2 := clt.Close(); err2 != nil {
 			process.log.WithError(err2).Warn("Failed to close direct Auth Server client.")
 		}

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
@@ -589,18 +590,20 @@ func TestSetupProxyTLSConfig(t *testing.T) {
 
 func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 	t.Parallel()
-	clock := clockwork.NewFakeClock()
 	// Create and configure a default Teleport configuration.
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.SetAuthServerAddress(utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"})
-	cfg.Clock = clock
+	cfg.Clock = clockwork.NewRealClock()
 	cfg.DataDir = t.TempDir()
 	cfg.Auth.Enabled = false
 	cfg.Proxy.Enabled = false
 	cfg.SSH.Enabled = true
-	cfg.MaxRetryPeriod = defaults.MaxWatcherBackoff
+	cfg.MaxRetryPeriod = 5 * time.Millisecond
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.ConnectFailureC = make(chan time.Duration, 5)
+	cfg.ClientTimeout = time.Millisecond
+	cfg.InstanceMetadataClient = cloud.NewDisabledIMDSClient()
+	cfg.Log = utils.NewLoggerForTests()
 	process, err := NewTeleport(cfg)
 	require.NoError(t, err)
 
@@ -613,6 +616,7 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 		require.Nil(t, c)
 	}()
 
+	timeout := time.After(10 * time.Second)
 	step := cfg.MaxRetryPeriod / 5.0
 	for i := 0; i < 5; i++ {
 		// wait for connection to fail
@@ -623,14 +627,8 @@ func TestTeleportProcess_reconnectToAuth(t *testing.T) {
 
 			require.GreaterOrEqual(t, duration, stepMin)
 			require.LessOrEqual(t, duration, stepMax)
-
-			// wait for connection to get to retry.After
-			clock.BlockUntil(1)
-
-			// add some extra to the duration to ensure the retry occurs
-			clock.Advance(cfg.MaxRetryPeriod)
-		case <-time.After(time.Minute):
-			t.Fatalf("timeout waiting for failure")
+		case <-timeout:
+			t.Fatalf("timeout waiting for failure %d", i)
 		}
 	}
 


### PR DESCRIPTION
1) Sets the process `ClientTimeout` and propagate to the appropriate clients so that connection attempts don't last 30s 
2) Lowers the `MaxRetryPeriod` and uses a real clock instead of using the default value and a fake clock to advance time 
3) Sets the process `Log` so that the test outputs more than just a single failure statement