### PR TITLE
docs: use teleport systemd include for start

### DIFF
--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -228,26 +228,7 @@ Application Service host.
 
 ### Run the Teleport Application Service
 
-On the host where you will run the Teleport Application Service, execute the
-following command, depending on whether you installed Teleport using a package
-manager or via a TAR archive:
-
-<Tabs>
-<TabItem label="Package Manager">
-
-```code
-$ sudo systemctl start teleport
-```
-</TabItem>
-<TabItem label="TAR archive">
-
-```code
-$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport; 
-$ sudo systemctl start teleport; 
-```
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Application Service"!)
 
 ## Step 3/4. Enable your user to access Azure CLIs
 

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -312,22 +312,7 @@ On the host where you will run the Teleport Application Service, execute the
 following command, depending on whether you installed Teleport using a package
 manager or via a TAR archive:
 
-<Tabs>
-<TabItem label="Package Manager">
-
-```code
-$ sudo systemctl start teleport
-```
-</TabItem>
-<TabItem label="TAR archive">
-
-```code
-$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport; 
-$ sudo systemctl start teleport; 
-```
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Application Service"!)
 
 ## Step 3/4. Enable your user to access Google Cloud CLIs
 

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -96,11 +96,7 @@ app_service:
 Note that the URI scheme must be `tcp://` in order for Teleport to recognize
 this as a TCP application.
 
-Start Teleport:
-
-```code
-$ teleport start
-```
+(!docs/pages/includes/start-teleport.mdx!)
 
 ## Step 3/4. Start app proxy
 

--- a/docs/pages/database-access/guides/aws-dynamodb.mdx
+++ b/docs/pages/database-access/guides/aws-dynamodb.mdx
@@ -217,26 +217,7 @@ Substitute `teleport.example.com` with the address of your Teleport Proxy Servic
 (For Teleport Cloud customers, this will be similar to `mytenant.teleport.sh`.)
 Replace the value of `auth_token` with the token generated in the previous step.
 
-Now start the Teleport Database Service:
-
-<Tabs>
-<TabItem label="Package Manager">
-
-```code
-$ sudo systemctl start teleport
-```
-
-</TabItem>
-<TabItem label="TAR archive">
-
-```code
-$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport
-$ sudo systemctl start teleport
-```
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 ## Step 4/4 Connect
 

--- a/docs/pages/database-access/guides/azure-redis.mdx
+++ b/docs/pages/database-access/guides/azure-redis.mdx
@@ -146,12 +146,7 @@ and replace the subscription in `assignableScopes` with your own subscription id
 
 ## Step 4/5. Start the Database Service
 
-Once the service principal is configured with the required IAM permissions,
-start the Teleport Database Service:
-
-```code
-$ teleport start --config=/etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 ## Step 5/5. Connect
 

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -218,11 +218,7 @@ Server auto-discovery enabled in the `eastus` region and place it at the
 
 ## Step 7/8. Start Teleport Database Service
 
-Start the Database Service:
-
-```code
-$ teleport start --config=/etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 <Admonition
   type="tip"

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -64,8 +64,8 @@ $ teleport db start \
 </TabItem>
 <TabItem label="Configuration file">
 
-On the node where you will run the Teleport Database Service, run
-with the following in `/etc/teleport.yaml`:
+On the node where you will run the Teleport Database Service, add the following
+in `/etc/teleport.yaml`:
 
 ```yaml
 version: v3

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -65,7 +65,7 @@ $ teleport db start \
 <TabItem label="Configuration file">
 
 On the node where you will run the Teleport Database Service, run
-`teleport start` with the following in `/etc/teleport.yaml`:
+with the following in `/etc/teleport.yaml`:
 
 ```yaml
 version: v3
@@ -90,6 +90,8 @@ db_service:
       env: "dev"
 
 ```
+
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 See the full [YAML reference](../reference/configuration.mdx) for details.
 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -19,7 +19,7 @@ In this guide you will:
 
 ## Prerequisites
 
-(!docs/pages/includes/edition-prereqs-tabs.mdx)
+(!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - [MongoDB Atlas](https://www.mongodb.com/cloud/atlas) cluster.
 - A host, e.g., an Amazon EC2 instance, where you will run the Teleport Database

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -130,7 +130,7 @@ Install Teleport on the host where you will run the Teleport Database Service:
 ## Step 4/5. Set up the Teleport Database service
 
 Below is an example of a database service configuration file that proxies
-a single Cloud SQL MySQL database:
+a single Cloud SQL MySQL database. Store at `/etc/teleport.yaml`:
 
 <ScopedBlock scope={["oss", "enterprise"]}>
 
@@ -228,11 +228,7 @@ proxy_service:
   Service or Application Service.
 </Admonition>
 
-Start the Database Service:
-
-```code
-$ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 ### GCP credentials
 

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -130,7 +130,7 @@ Install Teleport on the host where you will run the Teleport Database Service:
 ## Step 4/5. Set up the Teleport Database service
 
 Below is an example of a database service configuration file that proxies
-a single Cloud SQL MySQL database. Store at `/etc/teleport.yaml`:
+a single Cloud SQL MySQL database. Save this file as `/etc/teleport.yaml`:
 
 <ScopedBlock scope={["oss", "enterprise"]}>
 

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -226,11 +226,7 @@ $ teleport db configure create \
   SSH Service or Application Service.
 </Admonition>
 
-Start the Database Service:
-
-```code
-$ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -194,14 +194,14 @@ Install Teleport on the host where you will run the Teleport Database Service:
 ## Step 6/7. Set up the Teleport Database service
 
 Below is an example of a Database Service configuration file that proxies
-a single Cloud SQL PostgreSQL database:
+a single Cloud SQL PostgreSQL database. Save this to `/etc/teleport.yaml`:
 
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```yaml
 version: v3
 teleport:
-  data_dir: /var/lib/teleport-db
+  data_dir: /var/lib/teleport
   nodename: test
   # Proxy address to connect to. Note that it has to be the proxy address
   # because the Database Service always connects to the cluster over a reverse
@@ -245,7 +245,7 @@ proxy_service:
 ```yaml
 version: v3
 teleport:
-  data_dir: /var/lib/teleport-db
+  data_dir: /var/lib/teleport
   nodename: test
   # Proxy address to connect to. Use your Teleport Cloud tenant address here.
   proxy_server: mytenant.teleport.sh:443
@@ -293,11 +293,7 @@ proxy_service:
 
 </Notice>
 
-Start the Database Service:
-
-```code
-$ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 ### GCP credentials
 

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -175,11 +175,7 @@ $ teleport db configure create \
   
 </Admonition>
 
-Start the database service:
-
-```code
-$ teleport start --config=/path/to/teleport-db.yaml --token=/tmp/token
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 </TabItem>
 </Tabs>

--- a/docs/pages/database-access/guides/redshift-serverless.mdx
+++ b/docs/pages/database-access/guides/redshift-serverless.mdx
@@ -275,27 +275,7 @@ for more information.
 
 ### Start the Database service
 
-Run the following command on the Database Service node, depending on how you
-installed Teleport:
-
-<Tabs>
-<TabItem label="Package Manager">
-
-```code
-$ sudo systemctl start teleport
-```
-
-</TabItem>
-<TabItem label="TAR archive">
-
-```code
-$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport
-$ sudo systemctl start teleport
-```
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 The Database Service will discover all Redshift databases according to the
 configuration and register them in the cluster. The Database Service will also

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -308,12 +308,8 @@ object typically resides under the AWS Reserved / RDS path:
 </Admonition>
 
 ## Step 5/7. Start the Database Service
-Start the Database Service:
 
-```code
-$ teleport start --config=/etc/teleport.yaml
-```
-
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 
 ## Step 6/7. Create SQL Server AD users
 

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -568,11 +568,7 @@ ssh_service:
 </TabItem>
 </Tabs>
 
-Start Teleport after updating `/etc/teleport.yaml`:
-
-```code
-sudo teleport start -c /etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Desktop Service"!)
 
 ## Step 7/7. Log in using Teleport
 

--- a/docs/pages/desktop-access/active-directory.mdx
+++ b/docs/pages/desktop-access/active-directory.mdx
@@ -119,26 +119,7 @@ Click **Next**.
 
 Once you've saved `/etc/teleport.yaml`, start Teleport:
 
-<Tabs>
-<TabItem label="System Service">
-
-This command assumes the `root` user. Prepend `sudo` otherwise.
-
-```code
-$ systemctl start teleport.service
-```
-
-</TabItem>
-<TabItem label="Standalone Binary">
-
-From the directory containing the Teleport binary:
-
-```code
-$ ./teleport start --config=/etc/teleport.yaml
-```
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Desktop Service"!)
 
 The access wizard will detect when the new Teleport instance has joined the
 cluster, and you can then click **Next**.

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -148,27 +148,7 @@ ssh_service:
 
 </Details>
 
-Start or restart the Teleport service. For new Teleport nodes, the examples below
-depend on how you installed Teleport (from a system package or a TAR archive):
-
-<Tabs>
-<TabItem label="System Package">
-
-```code
-$ sudo systemctl start teleport.service
-```
-
-</TabItem>
-<TabItem label="Tar Archive">
-
-```code
-$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport;
-$ sudo systemctl start teleport;
-```
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Desktop Service"!)
 
 ## Step 3/4. Configure Windows access
 

--- a/docs/pages/kubernetes-access/discovery/google-cloud.mdx
+++ b/docs/pages/kubernetes-access/discovery/google-cloud.mdx
@@ -562,6 +562,7 @@ GOOGLE_APPLICATION_CREDENTIALS="/var/lib/teleport/google-cloud-credentials.json"
 Start the Teleport service:
 
 ```code
+$ sudo systemctl enable teleport
 $ sudo systemctl start teleport
 ```
 </TabItem>

--- a/docs/pages/kubernetes-access/register-clusters/dynamic-registration.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/dynamic-registration.mdx
@@ -150,28 +150,7 @@ will watch for them.
 
 ### Run the Teleport Kubernetes Service
 
-On the host where you will run the Teleport Kubernetes Service, execute the
-following command, depending on whether you installed Teleport using a package
-manager or via a TAR archive:
-
-<Tabs>
-<TabItem label="Package Manager">
-
-```code
-$ sudo systemctl start teleport
-```
-
-</TabItem>
-<TabItem label="TAR archive">
-
-```code
-$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport; 
-$ sudo systemctl start teleport; 
-```
-
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Kubernetes Service"!)
 
 ## Step 2/3. Authorize your user 
 

--- a/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -178,26 +178,7 @@ characters, `.`, `_`, and `-`. EKS typically includes `:` and `@` in their
 
 ### Start the Teleport Kubernetes Service
 
-On the host where you will run the Teleport Kubernetes Service, execute the
-following command, depending on whether you installed Teleport using a package
-manager or via a TAR archive:
-
-<Tabs>
-<TabItem label="Package Manager">
-
-```code
-$ sudo systemctl start teleport
-```
-</TabItem>
-<TabItem label="TAR archive">
-
-```code
-$ sudo teleport install systemd --output=/etc/systemd/system/teleport.service;
-$ sudo systemctl enable teleport; 
-$ sudo systemctl start teleport; 
-```
-</TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Kubernetes Service"!)
 
 ## Step 3/4. Grant access to your Teleport user
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -125,10 +125,7 @@ The `teleport node configure` command above placed a configuration file at
 `/etc/teleport.yaml`. The last step is to start Teleport, pointing it at this
 configuration:
 
-```
-# Start Teleport
-$ sudo teleport start --config=/etc/teleport.yaml
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport SSH Service"!)
 
 ### Access the Web UI
 

--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -149,31 +149,7 @@ app_service:
 
 ### Start Teleport
 
-On your Linux machine, run the necessary commands to start the `teleport` daemon
-(this depends on how you installed Teleport earlier).
-
-<Tabs>
-  <TabItem label="Package manager RPM/DEB">
-
-    ```code
-    $ sudo systemctl start teleport
-    ```
-  </TabItem>
-
-  <TabItem label="Source or custom install">
-  Create a systemd unit file using the `teleport install systemd` command and the unit file path you'd
-  like to use for your configuration. We recommend the path `/etc/systemd/system/teleport.service` for most use cases:
-
-    ```code
-    $ sudo teleport install systemd -o /etc/systemd/system/teleport.service
-    ```
-  Enable and start the new `teleport` daemon:
-
-    ```code
-    $ sudo systemctl enable teleport && sudo systemctl start teleport
-    ```
-  </TabItem>
-</Tabs>
+(!docs/pages/includes/start-teleport.mdx service="the Teleport SSH Service"!)
 
 You can access Teleport's Web UI via HTTPS at the domain you created earlier
 (e.g., `https://teleport.example.com`). You should see a welcome screen similar


### PR DESCRIPTION
Use include to make `systemctl` instructions consistent.