### PR TITLE
Fix panic when incoming request is nil

### DIFF
--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -565,6 +565,10 @@ func (s *Server) HandleConnection(conn net.Conn) {
 			for {
 				select {
 				case req := <-reqs:
+					if req == nil {
+						connClosed()
+						return
+					}
 					// wait for a request that wants a reply to send the error
 					if !req.WantReply {
 						continue

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -567,7 +567,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 				case req := <-reqs:
 					if req == nil {
 						connClosed()
-						return
+						break
 					}
 					// wait for a request that wants a reply to send the error
 					if !req.WantReply {


### PR DESCRIPTION
This PR prevents a panic when the SSH request channel is closed by [`mux.loop`](https://github.com/gravitational/crypto/blob/c3f983bc73dcf711908e49d91bda9cffbecb13cd/ssh/mux.go#L197-L199) if it encounters a connection error.

Fixes #24186