### PR TITLE
Fix race in TestSSH/ssh_jump_host_access

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3857,12 +3857,25 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	}
 
 	tlscfg := serverTLSConfig.Clone()
-	setupTLSConfigClientCAsForCluster(tlscfg, accessPoint, clusterName)
 	tlscfg.ClientAuth = tls.RequireAndVerifyClientCert
 	if lib.IsInsecureDevMode() {
 		tlscfg.InsecureSkipVerify = true
 		tlscfg.ClientAuth = tls.RequireAnyClientCert
 	}
+	tlscfg.GetConfigForClient = func(*tls.ClientHelloInfo) (*tls.Config, error) {
+		tlsClone := tlscfg.Clone()
+
+		// Build the client CA pool containing the cluster's user CA in
+		// order to be able to validate certificates provided by users.
+		var err error
+		tlsClone.ClientCAs, _, err = auth.DefaultClientCertPool(accessPoint, clusterName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		return tlsClone, nil
+	}
+
 	creds, err := auth.NewTransportCredentials(auth.TransportCredentialsConfig{
 		TransportCredentials: credentials.NewTLS(tlscfg),
 		UserGetter:           authMiddleware,


### PR DESCRIPTION
Fixes a data race in the `proxyClusterGuesser` as seen in [`TestSSH/ssh_jump_host_access`](https://github.com/gravitational/teleport/actions/runs/4628998780/jobs/8188742086?pr=24188). The proxy ssh client `proxyClusterGuesser` now uses a similar [mechanism](https://github.com/gravitational/teleport/blob/master/api/client/proxy/client.go#L227-L241) as the proxy grpc client to protect the inferred cluster name from being updated concurrently.

In addition to prevent tests from falling back to using ssh instead of grpc the transport server tls config is no longer using `setupTLSConfigClientCAsForCluster`. Instead `GetConfigForClient` is set directly and it only updates the `tls.Config.ClientCAs`.