### PR TITLE
Docs: Bump Teleport 12.2.1

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1457,7 +1457,7 @@
     },
     "teleport": {
       "major_version": "12",
-      "version": "12.1.5",
+      "version": "12.2.1",
       "golang": "1.20",
       "plugin": {
         "version": "12.1.5"


### PR DESCRIPTION
Bumps Teleport version in docs config to `12.2.1`.