### PR TITLE
Docs: add Datadog to audit events index

### DIFF
--- a/docs/pages/management/export-audit-events.mdx
+++ b/docs/pages/management/export-audit-events.mdx
@@ -18,6 +18,10 @@ messages via HTTP.
 Next, read our guides to setting up the Event Handler plugin to export audit
 events to your solution of choice:
 
+- [Export Teleport Audit Events with
+  Datadog](./export-audit-events/datadog.mdx): Learn how to configure the Event
+  Handler plugin and Fluentd (with the Datadog plugin) to export audit events to
+  Datadog.
 - [Monitor Teleport Audit Events with the Elastic
   Stack](./export-audit-events/elastic-stack.mdx): How to configure the Event
   Handler plugin to forward Teleport audit logs to Logstash for ingestion in


### PR DESCRIPTION
Updates the "Exporting Teleport Audit Events" index page with the new Datadog guide.