### PR TITLE
Add missing continue and handle error in the test echo SSH server

### DIFF
--- a/lib/multiplexer/multiplexer_test.go
+++ b/lib/multiplexer/multiplexer_test.go
@@ -1113,7 +1113,9 @@ func startSSHServer(t *testing.T, listener net.Listener) {
 	go func() {
 		for newReq := range reqs {
 			if newReq.Type == "echo" {
-				newReq.Reply(true, newReq.Payload)
+				err := newReq.Reply(true, newReq.Payload)
+				assert.NoError(t, err)
+				continue
 			}
 			err := newReq.Reply(false, nil)
 			assert.NoError(t, err)

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -368,7 +368,9 @@ func startSSHServer(t *testing.T, listener net.Listener) {
 	go func() {
 		for newReq := range reqs {
 			if newReq.Type == "echo" {
-				newReq.Reply(true, newReq.Payload)
+				err := newReq.Reply(true, newReq.Payload)
+				assert.NoError(t, err)
+				continue
 			}
 			err := newReq.Reply(false, nil)
 			assert.NoError(t, err)


### PR DESCRIPTION
Test echo SSH server didn't go to the next iteration after processing echo request which could cause test flakiness.

Fixes #23480 