### PR TITLE
Consistent role impersonation expiry between normal join & delegated joining bots

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2401,7 +2401,7 @@ func (a *ServerWithRoles) NewKeepAliver(ctx context.Context) (types.KeepAliver, 
 // access request expirations.
 func (a *ServerWithRoles) desiredAccessInfo(ctx context.Context, req *proto.UserCertsRequest, user types.User) (*services.AccessInfo, error) {
 	if req.Username != a.context.User.GetName() {
-		if req.UseRoleRequests || len(req.RoleRequests) > 0 {
+		if isRoleImpersonation(*req) {
 			err := trace.AccessDenied("User %v tried to issue a cert for %v and added role requests. This is not supported.", a.context.User.GetName(), req.Username)
 			log.WithError(err).Warn()
 			return nil, err
@@ -2413,7 +2413,7 @@ func (a *ServerWithRoles) desiredAccessInfo(ctx context.Context, req *proto.User
 		}
 		return a.desiredAccessInfoForImpersonation(req, user)
 	}
-	if req.UseRoleRequests || len(req.RoleRequests) > 0 {
+	if isRoleImpersonation(*req) {
 		if len(req.AccessRequests) > 0 {
 			err := trace.AccessDenied("User %v tried to issue a cert with both role and access requests. This is not supported.", a.context.User.GetName())
 			log.WithError(err).Warn()
@@ -2437,9 +2437,7 @@ func (a *ServerWithRoles) desiredAccessInfoForImpersonation(req *proto.UserCerts
 func (a *ServerWithRoles) desiredAccessInfoForRoleRequest(req *proto.UserCertsRequest, traits wrappers.Traits) (*services.AccessInfo, error) {
 	// If UseRoleRequests is set, make sure we don't return unusable certs: an
 	// identity without roles can't be parsed.
-	// DEPRECATED: consider making role requests without UseRoleRequests set an
-	// error in V11.
-	if req.UseRoleRequests && len(req.RoleRequests) == 0 {
+	if len(req.RoleRequests) == 0 {
 		return nil, trace.BadParameter("at least one role request is required")
 	}
 
@@ -2546,6 +2544,16 @@ func (a *ServerWithRoles) GenerateUserCerts(ctx context.Context, req proto.UserC
 	)
 }
 
+func isRoleImpersonation(req proto.UserCertsRequest) bool {
+	// For now, either req.UseRoleRequests or len(req.RoleRequests) > 0
+	// indicates that role impersonation is being used.
+	// In Teleport 14.0.0, make using len(req.RoleRequests) > 0 without
+	// req.UseRoleRequests an error. This will simplify logic throughout
+	// by having a clear indicator of whether role impersonation is in use
+	// and make this helper redundant.
+	return req.UseRoleRequests || len(req.RoleRequests) > 0
+}
+
 func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserCertsRequest, opts ...certRequestOption) (*proto.Certs, error) {
 	// Device trust: authorize device before issuing certificates.
 	authPref, err := a.authServer.GetAuthPreference(ctx)
@@ -2595,7 +2603,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 		if len(req.AccessRequests) > 0 {
 			return nil, trace.AccessDenied("access denied: impersonated user can not request new roles")
 		}
-		if req.UseRoleRequests || len(req.RoleRequests) > 0 {
+		if isRoleImpersonation(req) {
 			// Note: technically this should never be needed as all role
 			// impersonated certs should have the DisallowReissue set.
 			return nil, trace.AccessDenied("access denied: impersonated roles can not request other roles")
@@ -2636,13 +2644,18 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 			return nil, trace.AccessDenied("access denied: client credentials have expired, please relogin.")
 		}
 
-		// if these credentials are not renewable, we limit the TTL to the duration of the session
-		// (this prevents users renewing their certificates forever)
-		if req.Expires.After(sessionExpires) {
-			if !identity.Renewable {
-				req.Expires = sessionExpires
-			} else if max := a.authServer.GetClock().Now().Add(defaults.MaxRenewableCertTTL); req.Expires.After(max) {
+		if identity.Renewable || isRoleImpersonation(req) {
+			// Bot self-renewal or role impersonation can request certs with an
+			// expiry up to the global maximum allowed value.
+			if max := a.authServer.GetClock().Now().Add(defaults.MaxRenewableCertTTL); req.Expires.After(max) {
 				req.Expires = max
+			}
+		} else {
+			// Standard user impersonation has an expiry limited to the expiry
+			// of the current session. This prevents a user renewing their
+			// own certificates indefinitely to avoid re-authenticating.
+			if req.Expires.After(sessionExpires) {
+				req.Expires = sessionExpires
 			}
 		}
 	}
@@ -2679,8 +2692,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	case req.Username == a.context.User.GetName():
 		// users can impersonate themselves, but role impersonation requests
 		// must be checked.
-
-		if len(req.RoleRequests) > 0 {
+		if isRoleImpersonation(req) {
 			// Note: CheckImpersonateRoles() checks against the _stored_
 			// impersonate roles for the user rather than the set available
 			// to the current identity. If not explicitly denied (as above),
@@ -2769,7 +2781,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	}
 	if user.GetName() != a.context.User.GetName() {
 		certReq.impersonator = a.context.User.GetName()
-	} else if req.UseRoleRequests || len(req.RoleRequests) > 0 {
+	} else if isRoleImpersonation(req) {
 		// Role impersonation uses the user's own name as the impersonator value.
 		certReq.impersonator = a.context.User.GetName()
 
@@ -2807,8 +2819,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// requests, or when the disallow-reissue flag has already been set.
 	if a.context.Identity.GetIdentity().Renewable &&
 		req.Username == a.context.User.GetName() &&
-		len(req.RoleRequests) == 0 &&
-		!req.UseRoleRequests &&
+		!isRoleImpersonation(req) &&
 		!certReq.disallowReissue {
 		certReq.renewable = true
 	}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -175,7 +175,6 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 		{
 			desc:      "renewable",
 			renewable: true,
-			// expiration is allowed to be pushed out into the future
 			reqTTL:    4 * time.Hour,
 			expiresIn: 4 * time.Hour,
 		},
@@ -193,6 +192,13 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 			// but no more than the maximum renewable cert TTL
 			reqTTL:    2 * libdefaults.MaxRenewableCertTTL,
 			expiresIn: libdefaults.MaxRenewableCertTTL,
+		},
+		{
+			desc:         "not-renewable-role-requests-max-renew",
+			renewable:    false,
+			roleRequests: true,
+			reqTTL:       2 * libdefaults.MaxRenewableCertTTL,
+			expiresIn:    libdefaults.MaxRenewableCertTTL,
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -151,10 +151,11 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 	start := srv.AuthServer.Clock().Now()
 
 	for _, test := range []struct {
-		desc      string
-		renewable bool
-		reqTTL    time.Duration
-		expiresIn time.Duration
+		desc         string
+		renewable    bool
+		roleRequests bool
+		reqTTL       time.Duration
+		expiresIn    time.Duration
 	}{
 		{
 			desc:      "not-renewable",
@@ -164,11 +165,26 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 			expiresIn: 1 * time.Hour,
 		},
 		{
+			desc:         "not-renewable-role-requests",
+			renewable:    false,
+			roleRequests: true,
+			// expiration is allowed to be pushed out into the future
+			reqTTL:    4 * time.Hour,
+			expiresIn: 4 * time.Hour,
+		},
+		{
 			desc:      "renewable",
 			renewable: true,
 			// expiration is allowed to be pushed out into the future
 			reqTTL:    4 * time.Hour,
 			expiresIn: 4 * time.Hour,
+		},
+		{
+			desc:         "renewable-role-requests",
+			renewable:    true,
+			roleRequests: true,
+			reqTTL:       4 * time.Hour,
+			expiresIn:    4 * time.Hour,
 		},
 		{
 			desc:      "max-renew",
@@ -180,7 +196,8 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
-			user, _, err := CreateUserAndRole(srv.Auth(), test.desc, []string{"role"}, nil)
+			ctx := context.Background()
+			user, role, err := CreateUserAndRole(srv.Auth(), test.desc, []string{"role"}, nil)
 			require.NoError(t, err)
 
 			var id TestIdentity
@@ -201,11 +218,23 @@ func TestLocalUserCanReissueCerts(t *testing.T) {
 			client, err := srv.NewClient(id)
 			require.NoError(t, err)
 
-			certs, err := client.GenerateUserCerts(context.Background(), proto.UserCertsRequest{
+			req := proto.UserCertsRequest{
 				PublicKey: pub,
 				Username:  user.GetName(),
 				Expires:   start.Add(test.reqTTL),
-			})
+			}
+			if test.roleRequests {
+				// Reconfigure role to allow impersonation of its own role.
+				role.SetImpersonateConditions(types.Allow, types.ImpersonateConditions{
+					Roles: []string{role.GetName()},
+				})
+				require.NoError(t, srv.Auth().UpsertRole(ctx, role))
+
+				req.UseRoleRequests = true
+				req.RoleRequests = []string{role.GetName()}
+			}
+
+			certs, err := client.GenerateUserCerts(ctx, req)
 			require.NoError(t, err)
 
 			x509, err := tlsca.ParseCertificatePEM(certs.TLS)

--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -148,7 +148,6 @@ type identityConfigurator = func(req *proto.UserCertsRequest)
 func (b *Bot) generateIdentity(
 	ctx context.Context,
 	currentIdentity *identity.Identity,
-	expires time.Time,
 	destCfg *config.DestinationConfig,
 	defaultRoles []string,
 	configurator identityConfigurator,
@@ -176,7 +175,7 @@ func (b *Bot) generateIdentity(
 	req := proto.UserCertsRequest{
 		PublicKey:      publicKey,
 		Username:       currentIdentity.X509Cert.Subject.CommonName,
-		Expires:        expires,
+		Expires:        time.Now().Add(b.cfg.CertificateTTL),
 		RoleRequests:   roleRequests,
 		RouteToCluster: currentIdentity.ClusterName,
 
@@ -359,12 +358,11 @@ func (b *Bot) getRouteToApp(ctx context.Context, client auth.ClientI, appCfg *co
 
 func (b *Bot) generateImpersonatedIdentity(
 	ctx context.Context,
-	expires time.Time,
 	destCfg *config.DestinationConfig,
 	defaultRoles []string,
 ) (*identity.Identity, error) {
 	ident, err := b.generateIdentity(
-		ctx, b.ident(), expires, destCfg, defaultRoles, nil,
+		ctx, b.ident(), destCfg, defaultRoles, nil,
 	)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -389,7 +387,7 @@ func (b *Bot) generateImpersonatedIdentity(
 		// so we'll request the database access identity using the main bot
 		// identity (having gathered the necessary info for RouteToDatabase
 		// using the correct impersonated ident.)
-		newIdent, err := b.generateIdentity(ctx, ident, expires, destCfg, defaultRoles, func(req *proto.UserCertsRequest) {
+		newIdent, err := b.generateIdentity(ctx, ident, destCfg, defaultRoles, func(req *proto.UserCertsRequest) {
 			req.RouteToDatabase = route
 		})
 
@@ -400,7 +398,7 @@ func (b *Bot) generateImpersonatedIdentity(
 		// Note: the Teleport server does attempt to verify k8s cluster names
 		// and will fail to generate certs if the cluster doesn't exist or is
 		// offline.
-		newIdent, err := b.generateIdentity(ctx, ident, expires, destCfg, defaultRoles, func(req *proto.UserCertsRequest) {
+		newIdent, err := b.generateIdentity(ctx, ident, destCfg, defaultRoles, func(req *proto.UserCertsRequest) {
 			req.KubernetesCluster = destCfg.KubernetesCluster.ClusterName
 		})
 
@@ -420,7 +418,7 @@ func (b *Bot) generateImpersonatedIdentity(
 			return nil, trace.Wrap(err)
 		}
 
-		newIdent, err := b.generateIdentity(ctx, ident, expires, destCfg, defaultRoles, func(req *proto.UserCertsRequest) {
+		newIdent, err := b.generateIdentity(ctx, ident, destCfg, defaultRoles, func(req *proto.UserCertsRequest) {
 			req.RouteToApp = routeToApp
 		})
 		if err != nil {
@@ -606,7 +604,6 @@ func (b *Bot) renew(
 	}
 
 	// Next, generate impersonated certs
-	expires := newIdentity.X509Cert.NotAfter
 	for _, dest := range b.cfg.Destinations {
 		destImpl, err := dest.GetDestination()
 		if err != nil {
@@ -628,7 +625,7 @@ func (b *Bot) renew(
 			return trace.Wrap(err, "Could not write to destination %s, aborting.", destImpl)
 		}
 
-		impersonatedIdent, err := b.generateImpersonatedIdentity(ctx, expires, dest, defaultRoles)
+		impersonatedIdent, err := b.generateImpersonatedIdentity(ctx, dest, defaultRoles)
 		if err != nil {
 			return trace.Wrap(err, "Failed to generate impersonated certs for %s: %+v", destImpl, err)
 		}

--- a/lib/tbot/renew_test.go
+++ b/lib/tbot/renew_test.go
@@ -149,7 +149,7 @@ func TestDatabaseRequest(t *testing.T) {
 	b._ident = ident
 
 	impersonatedIdent, err := b.generateImpersonatedIdentity(
-		context.Background(), ident.X509Cert.NotAfter, dest, []string{roleName},
+		context.Background(), dest, []string{roleName},
 	)
 	require.NoError(t, err)
 
@@ -226,7 +226,7 @@ func TestAppRequest(t *testing.T) {
 	b._ident = ident
 
 	impersonatedIdent, err := b.generateImpersonatedIdentity(
-		ctx, ident.X509Cert.NotAfter, dest, []string{roleName},
+		ctx, dest, []string{roleName},
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Some upcoming work will be separating the bot's own identity renewal from impersonated credential renewal in `tbot` to improve stability and performance of tbot, especially in degraded conditions.

This means the bot can no longer rely on the bot's own identity having been renewed moments before the impersonated credentials are renewed. In some circumstances, the current method of requesting an expiry that matches the bot's current identity expiry, could lead to an impersonated credential being output with an extremely small expiry that falls before the next renewal. 

The existing auth side constraints already allowed a bot using a renewable join type (e.g `token`) to request a role impersonated certificate with an expiry beyond the bot's own expiry time, this PR modifies this to allow any role impersonation to be requested with an expiry beyond the bot's own expiry time.

I've also created a small helper `isRoleImpersonation` to make logic within `generateUserCerts` easier to read. 