### PR TITLE
[web] Add isModeratedSession flag to web ssh session

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -106,6 +106,8 @@ type Session struct {
 	AppName string `json:"app_name"`
 	// Owner is the name of the session owner, ie the one who created the session.
 	Owner string `json:"owner"`
+	// IsModeratedSession is true if the session requires moderation.
+	IsModeratedSession bool `json:"isModeratedSession"`
 }
 
 // Participants returns the usernames of the current session participants.

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -107,7 +107,7 @@ type Session struct {
 	// Owner is the name of the session owner, ie the one who created the session.
 	Owner string `json:"owner"`
 	// IsModeratedSession is true if the session requires moderation.
-	IsModeratedSession bool `json:"isModeratedSession"`
+	IsModeratedSession bool `json:"is_moderated_session"`
 }
 
 // Participants returns the usernames of the current session participants.

--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -106,8 +106,8 @@ type Session struct {
 	AppName string `json:"app_name"`
 	// Owner is the name of the session owner, ie the one who created the session.
 	Owner string `json:"owner"`
-	// IsModeratedSession is true if the session requires moderation.
-	IsModeratedSession bool `json:"is_moderated_session"`
+	// Moderated is true if the session requires moderation.
+	Moderated bool `json:"moderated"`
 }
 
 // Participants returns the usernames of the current session participants.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2704,17 +2704,17 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 	accessEvaluator := auth.NewSessionAccessEvaluator(policySets, types.SSHSessionKind, owner)
 
 	return session.Session{
-		Login:              req.Login,
-		ServerID:           id,
-		ClusterName:        clusterName,
-		ServerHostname:     host,
-		ServerHostPort:     port,
-		IsModeratedSession: accessEvaluator.IsModerated(),
-		ID:                 session.NewID(),
-		Created:            time.Now().UTC(),
-		LastActive:         time.Now().UTC(),
-		Namespace:          apidefaults.Namespace,
-		Owner:              owner,
+		Login:          req.Login,
+		ServerID:       id,
+		ClusterName:    clusterName,
+		ServerHostname: host,
+		ServerHostPort: port,
+		Moderated:      accessEvaluator.IsModerated(),
+		ID:             session.NewID(),
+		Created:        time.Now().UTC(),
+		LastActive:     time.Now().UTC(),
+		Namespace:      apidefaults.Namespace,
+		Owner:          owner,
 	}, nil
 }
 
@@ -2837,7 +2837,7 @@ func trackerToLegacySession(tracker types.SessionTracker, clusterName string) se
 		KubernetesClusterName: tracker.GetKubeCluster(),
 		DesktopName:           tracker.GetDesktopName(),
 		AppName:               tracker.GetAppName(),
-		IsModeratedSession:    accessEvaluator.IsModerated(),
+		Moderated:             accessEvaluator.IsModerated(),
 		DatabaseName:          tracker.GetDatabaseName(),
 		Owner:                 tracker.GetHostUser(),
 	}

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
@@ -99,4 +99,5 @@ const session: Session = {
   parties: [],
   addr: '1.1.1.1:1111',
   participantModes: ['observer', 'moderator', 'peer'],
+  isModeratedSession: false,
 };

--- a/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/DocumentSsh.story.tsx
@@ -99,5 +99,5 @@ const session: Session = {
   parties: [],
   addr: '1.1.1.1:1111',
   participantModes: ['observer', 'moderator', 'peer'],
-  isModeratedSession: false,
+  moderated: false,
 };

--- a/web/packages/teleport/src/Sessions/fixtures/index.ts
+++ b/web/packages/teleport/src/Sessions/fixtures/index.ts
@@ -34,6 +34,7 @@ export const sessions: Session[] = [
     clusterId: 'im-a-cluster-name',
     resourceName: 'minikube',
     participantModes: ['observer', 'moderator', 'peer'],
+    isModeratedSession: false,
   },
   {
     kind: 'ssh',
@@ -52,6 +53,7 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer', 'moderator'],
+    isModeratedSession: false,
   },
   {
     kind: 'desktop',
@@ -70,6 +72,7 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer', 'moderator', 'peer'],
+    isModeratedSession: false,
   },
   {
     kind: 'db',
@@ -88,6 +91,7 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer'],
+    isModeratedSession: false,
   },
   {
     kind: 'app',
@@ -106,5 +110,6 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer', 'moderator', 'peer'],
+    isModeratedSession: false,
   },
 ];

--- a/web/packages/teleport/src/Sessions/fixtures/index.ts
+++ b/web/packages/teleport/src/Sessions/fixtures/index.ts
@@ -34,7 +34,7 @@ export const sessions: Session[] = [
     clusterId: 'im-a-cluster-name',
     resourceName: 'minikube',
     participantModes: ['observer', 'moderator', 'peer'],
-    isModeratedSession: false,
+    moderated: false,
   },
   {
     kind: 'ssh',
@@ -53,7 +53,7 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer', 'moderator'],
-    isModeratedSession: false,
+    moderated: false,
   },
   {
     kind: 'desktop',
@@ -72,7 +72,7 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer', 'moderator', 'peer'],
-    isModeratedSession: false,
+    moderated: false,
   },
   {
     kind: 'db',
@@ -91,7 +91,7 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer'],
-    isModeratedSession: false,
+    moderated: false,
   },
   {
     kind: 'app',
@@ -110,6 +110,6 @@ export const sessions: Session[] = [
     addr: 'd5d6d695-97c5-4bef-b052-0f5c6203d7a1',
     clusterId: 'im-a-cluster-name',
     participantModes: ['observer', 'moderator', 'peer'],
-    isModeratedSession: false,
+    moderated: false,
   },
 ];

--- a/web/packages/teleport/src/services/session/makeSession.ts
+++ b/web/packages/teleport/src/services/session/makeSession.ts
@@ -38,7 +38,7 @@ export default function makeSession(json): Session {
     server_addr,
     parties,
     participantModes,
-    is_moderated_session,
+    moderated,
   } = json;
 
   const createdDate = created ? new Date(created) : null;
@@ -59,7 +59,7 @@ export default function makeSession(json): Session {
     parties: parties ? parties.map(p => makeParticipant(p)) : [],
     addr: server_addr ? server_addr.replace(PORT_REGEX, '') : '',
     participantModes: participantModes ?? [],
-    isModeratedSession: is_moderated_session,
+    moderated,
   };
 }
 

--- a/web/packages/teleport/src/services/session/makeSession.ts
+++ b/web/packages/teleport/src/services/session/makeSession.ts
@@ -38,6 +38,7 @@ export default function makeSession(json): Session {
     server_addr,
     parties,
     participantModes,
+    isModeratedSession,
   } = json;
 
   const createdDate = created ? new Date(created) : null;
@@ -58,6 +59,7 @@ export default function makeSession(json): Session {
     parties: parties ? parties.map(p => makeParticipant(p)) : [],
     addr: server_addr ? server_addr.replace(PORT_REGEX, '') : '',
     participantModes: participantModes ?? [],
+    isModeratedSession,
   };
 }
 

--- a/web/packages/teleport/src/services/session/makeSession.ts
+++ b/web/packages/teleport/src/services/session/makeSession.ts
@@ -38,7 +38,7 @@ export default function makeSession(json): Session {
     server_addr,
     parties,
     participantModes,
-    isModeratedSession,
+    is_moderated_session,
   } = json;
 
   const createdDate = created ? new Date(created) : null;
@@ -59,7 +59,7 @@ export default function makeSession(json): Session {
     parties: parties ? parties.map(p => makeParticipant(p)) : [],
     addr: server_addr ? server_addr.replace(PORT_REGEX, '') : '',
     participantModes: participantModes ?? [],
-    isModeratedSession,
+    isModeratedSession: is_moderated_session,
   };
 }
 

--- a/web/packages/teleport/src/services/session/types.ts
+++ b/web/packages/teleport/src/services/session/types.ts
@@ -39,6 +39,8 @@ export interface Session {
   resourceName: string;
   // participantModes are the participant modes that are available to the user listing this session.
   participantModes: ParticipantMode[];
+  // whether this session requires moderation or not. this is NOT if the session is currently being actively moderated
+  isModeratedSession: boolean;
 }
 
 export type SessionMetadata = {

--- a/web/packages/teleport/src/services/session/types.ts
+++ b/web/packages/teleport/src/services/session/types.ts
@@ -40,7 +40,7 @@ export interface Session {
   // participantModes are the participant modes that are available to the user listing this session.
   participantModes: ParticipantMode[];
   // whether this session requires moderation or not. this is NOT if the session is currently being actively moderated
-  isModeratedSession: boolean;
+  moderated: boolean;
 }
 
 export type SessionMetadata = {


### PR DESCRIPTION
Part of: https://github.com/gravitational/teleport/pull/23546

This adds the `isModeratedSession` flag to new/fetched sessions in the web UI so we can make logic decisions around it (like starting a File Transfer Request).

I decided to name the flag `isModeratedSession` rather than `isModerated` because, to _me_, `isModerated` sounds like its currently being moderated but, I won't die on that hill and I'm fine to keep it in line with the access evaluator name.