### PR TITLE
[v10] Machine ID: log correct identity in post-renewal message

### DIFF
--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -549,7 +549,7 @@ func (b *Bot) renew(
 		return trace.Wrap(err)
 	}
 
-	identStr, err := describeTLSIdentity(b.ident())
+	identStr, err := describeTLSIdentity(newIdentity)
 	if err != nil {
 		return trace.Wrap(err, "Could not describe bot identity at %s", botDestination)
 	}


### PR DESCRIPTION
Backport #24240 to branch/v10