### PR TITLE
Docs: purge extra newlines

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -173,7 +173,6 @@ run the Jira plugin on the same server as the Teleport Proxy, so you can use the
 
 You should be able to run the Teleport plugin now!
 
-
 <Tabs>
 <TabItem label="Executable" scopes={["oss", "enterprise", "cloud"]}>
 ```code

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -272,7 +272,6 @@ severity = "INFO" # Logger severity. Could be "INFO", "ERROR", "DEBUG" or "WARN"
 
 ## Step 7/8. Test your Mattermost bot
 
-
 <Tabs>
 <TabItem label="Executable" scope={["oss", "enterprise"]}>
 After modifying your configuration, run the bot with the following command:

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -471,7 +471,6 @@ flag when you run the plugin binary later in this guide.
 
 </Details>
 
-
 Edit the configuration file in `/etc/teleport-pagerduty.toml` as explained
 below:
 
@@ -582,7 +581,6 @@ Access Request:
 
 ![PagerDuty dashboard showing an Access
 Request](../../../img/enterprise/plugins/pagerduty/new-access-req-incident.png)
-
 
 ### Resolve the request
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -146,7 +146,6 @@ To request access to these resources, run
     --reason <request reason>
 ```
 
-
 ## Step 5/8. Request access to a resource
 
 Copy the command output by `tsh request search` in the previous step, optionally filling in a request reason.

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -209,7 +209,6 @@ Bob can also assume granted Access Request roles using Web UI:
 
 ![Teleport Assume](../../../img/access-controls/dual-authz/teleport-7-bob-assume.png)
 
-
 {/* TODO: This H2 will show up in the table of contents when this section is invisible.
 We need a way to hide invisible H2s from the TOC. */}
 <ScopedBlock scope={["oss", "enterprise"]}>

--- a/docs/pages/access-controls/guides/headless.mdx
+++ b/docs/pages/access-controls/guides/headless.mdx
@@ -35,7 +35,6 @@ For example:
 - A Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/).
 
-
 ## Step 1/3. Configuration
 
 A v12.2+ Teleport cluster capable of WebAuthn is automatically capable of

--- a/docs/pages/access-controls/guides/ip-pinning.mdx
+++ b/docs/pages/access-controls/guides/ip-pinning.mdx
@@ -62,7 +62,6 @@ spec:
     ...
 ```
 
-
 ## Role example
 
 Let's walk through an example of setting up IP pinning for a role.
@@ -79,6 +78,7 @@ spec:
   options:
     pin_source_ip: true
 ```
+
 The admin assigns this role to the user Alice, who then logs into Teleport using the 'tsh' command and tries 
 to access a node from the same IP address she logged in with:
 

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -4,7 +4,6 @@ description: Moderated Sessions
 h1: Moderated Sessions
 ---
 
-
 ## Introduction
 
 Moderated Sessions allows Teleport administrators to define requirements for
@@ -167,7 +166,6 @@ A participant joining a session will always have one of three modes:
 - `observer`: Allows read-only access to the session. You can view output but cannot control the session in any way nor send any input.
 - `moderator`: Allows you to watch the session. You can view output and forcefully terminate or pause the session at any time, but can't send input.
 - `peer`: Allows you to collaborate in the session. You can view output and send input.
-
 
 When joining a session with `tsh join` or `tsh kube join`, a user can specify a
 participant mode with the `--mode <mode>` flag , where the mode is one of `peer`,

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -185,7 +185,6 @@ $ tsh login --proxy=mytenant.teleport.sh --user=alice
 
 </ScopedBlock>
 
-
 ## SSO users
 
 Identity provider admins can assign metadata to a user such as group membership

--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -46,7 +46,6 @@ information about the temporary user.
 You can inspect a temporary `user` resource created via your SSO integration
 by using the `tctl` command:
 
-
 <ScopedBlock scope={["oss", "enterprise"]}>
 
 ```code
@@ -559,7 +558,6 @@ must be able to:
 If something is not working, we recommend to:
 
 - Double-check the host names, tokens and TCP ports in a connector definition.
-
 
 ### Using the Web UI
 

--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -123,7 +123,6 @@ spec:
 
 Replace the `acs` field with your Teleport address, update the group IDs in the `attributes_to_roles` field with the actual Azure AD group ID values, and insert the downloaded Federation Metadata XML into the `entity_descriptor` field.
 
-
 Create the connector using `tctl`:
 
 ```code
@@ -176,8 +175,6 @@ $ tctl create dev.yaml
 ## Testing
 
 ![Login with Microsoft](../../../img/azuread/azure-11-loginwithmsft.png)
-
-
 
 The CLI is the same as before:
 ```code
@@ -388,7 +385,6 @@ The error above is caused by a Name ID format that is not compatible with Telepo
 Change the Name ID format to use email instead:
 
 ![Change NameID format to use email](../../../img/azuread/azuread-nameid.png)
-
 
 ## Further reading
 - [Teleport Configuration Resources Reference](../../reference/resources.mdx)

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -219,7 +219,6 @@ After logging in successfully, you will see the following:
 
 ![Login success view](../../../img/login-success.jpg)
 
-
 You will receive the details of your user session within the CLI. 
 
 <ScopedBlock scope={["oss", "enterprise"]}>

--- a/docs/pages/access-controls/sso/google-workspace.mdx
+++ b/docs/pages/access-controls/sso/google-workspace.mdx
@@ -212,7 +212,6 @@ Configure [domain-wide
     The scope granted to the service account will determine if Teleport will
     fetch both direct and indirect groups or just direct groups, respectively.
 
-
 ## Step 3/4. Create an OIDC connector
 
 Create the following OIDC connector [resource spec](../../reference/resources.mdx) as `gworkspace-connector.yaml`. We will explain how to choose values for fields within the resource spec below.
@@ -232,7 +231,6 @@ Create the following OIDC connector [resource spec](../../reference/resources.md
 </Tabs>
 
 The email that you set for `google_admin_email` **must** be the email address of a user that has permission to list all groups, users, and group membership in your Google Workspace account. This user will generally need super admin or group admin privileges.
-
 
 Do not use the email of the service account for `google_admin_email`. The configuration display will look the same, but the service account will not have the required domain-wide delegation.
 

--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -975,4 +975,3 @@ short-lived credentials via Machine ID, which reduces the risk of these
 credentials becoming stolen. View our [Machine ID
 documentation](../machine-id/introduction.mdx) to learn more.
 
-

--- a/docs/pages/application-access/cloud-apis/aws-console.mdx
+++ b/docs/pages/application-access/cloud-apis/aws-console.mdx
@@ -62,11 +62,9 @@ Enter a role name and press create role.
 
 ![Create Role Step 3](../../../img/application-access/create-role-example-readonly-3.png)
 
-
 ### Repeat for Power User
 
 Follow the same steps and select `PowerUserAccess` IAM Policy to create a `ExamplePowerUser` role.
-
 
 ## Step 2/9. Update IAM role trust relationships
 

--- a/docs/pages/application-access/cloud-apis/azure.mdx
+++ b/docs/pages/application-access/cloud-apis/azure.mdx
@@ -240,7 +240,6 @@ Azure managed identities (if any) they can access.
 There are two approaches you can take to authorize users to access Azure
 identities.
 
-
 |Approach|Description|Supported User Types|
 |---|---|---|
 |**Dynamic**|A Teleport role includes a template variable that grants a user access to all Azure identities assigned directly to them.|Local users, OIDC, SAML|

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -69,7 +69,6 @@ $ tctl tokens add \
 
 ### Start Teleport
 
-
 Install Teleport on the host where you will run the Teleport Application Service. See our [Installation](../installation.mdx) page for options besides Linux servers.
 
 (!docs/pages/includes/install-linux.mdx!)

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -103,7 +103,6 @@ $ tctl create app.yaml
 
 </ScopedBlock>
 
-
 After the resource has been created, it will appear among the list of available
 apps (in `tsh apps ls` or UI) as long as at least one Application Service
 instance picks it up according to its label selectors.

--- a/docs/pages/architecture/authorization.mdx
+++ b/docs/pages/architecture/authorization.mdx
@@ -208,7 +208,6 @@ The same applies to Kubernetes:
 - Alice can access kubernetes cluster as `system:masters` if it's labeled as `test` or `stage`.
 - Alice can access kubernetes clusters only as a `view` role if it's labeled as `prod`.
 
-
 ### Role templates
 
 Roles support template variables. Here is a role snippet that explains

--- a/docs/pages/architecture/nodes.mdx
+++ b/docs/pages/architecture/nodes.mdx
@@ -147,8 +147,6 @@ See the [reference](../reference/audit.mdx#recorded-sessions) to learn how to tu
 on the recording proxy mode. Note that the recording mode is configured on the
 Auth Service.
 
-
-
 ## More concepts
 
 - [Architecture Overview](../core-concepts.mdx)

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -295,8 +295,6 @@ more information.)
 
 ![DynamoDB local connection in NoSQL Workbench](../../img/database-access/nosql-workbench-connection.png)
 
-
-
 ## SQL Server DBeaver
 
 In the DBeaver connection configuration menu, use your proxy's endpoint. This is
@@ -356,9 +354,7 @@ Congratulations! You have just connected to your Redis instance.
 
 ![Redis Insight Connected](../../img/database-access/guides/redis/redisinsight-connected.png)
 
-
 ## Snowflake: JetBrains (IntelliJ, Goland, DataGrip, PyCharm, etc.)
-
 
 The Snowflake integration works only in the authenticated proxy mode. Start a local proxy for connections to your Snowflake database by using the command below:
 ```

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -139,7 +139,6 @@ a custom home location through [the `TELEPORT_HOME` environment
 variable](../reference/cli.mdx#tsh-environment-variables). For example, logging in to a new cluster
 through tsh will not make that cluster show up in Teleport Connect.
 
-
 <Tabs>
 <TabItem label="macOS">
 To add tsh to `PATH`, execute `tsh install` from the command bar in Teleport Connect. This will
@@ -172,7 +171,6 @@ The file will open in your default editor.
 </Admonition>
 
 Below is the list of the supported config properties.
-
 
 | Property                      | Default                                                                                                              | Description                                                            |
 |-------------------------------|----------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|
@@ -214,7 +212,6 @@ Available key codes:
 - `F1` to `F24`
 - `,`, `.`, `/`, `\`, `` ` ``, `-`, `=`, `;`, `'`, `[`, `]`
 - `Space`, `Tab`, `CapsLock`, `NumLock`, `ScrollLock`, `Backspace`, `Delete`, `Insert`, `Enter`, `Up`, `Down`, `Left`, `Right`, `Home`, `End`, `PageUp`, `PageDown`, `Escape`, `IntlBackslash`
-
 
 ## Telemetry
 

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -874,7 +874,6 @@ tmpfs            1982720       0   1982720   0% /sys/firmware
 root@ubuntu:/# exit
 exit
 
-
 end of session playback
 ```
 

--- a/docs/pages/contributing/documentation/style-guide.mdx
+++ b/docs/pages/contributing/documentation/style-guide.mdx
@@ -53,7 +53,6 @@ Teleport and want to set up Teleport for a specific scenario.
 - Setup steps
 - Next steps
 
-
 ### Getting started articles
 
 **Getting started guides** are designed to get a user up and running in the
@@ -95,7 +94,6 @@ Specific kinds of architecture guides include:
 1. **Networking**: Readers are interested in learning about specific ports, components, and protocols that are or can be used.
 2. **Security**: Lists security protocols and primitives. SecOps will look for an attack vector tree diagram.
 3. **Deployment**: Should include a deployment diagram which in turn explains components and how they interact with databases and each other.
-
 
 ### Conceptual guides
 

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -13,7 +13,6 @@ description: How to configure Teleport Database Access with AWS Keyspaces (Apach
   Database Access for AWS Keyspaces (Apache Cassandra) is available starting from Teleport `v11.0`.
 </Details>
 
-
 This guide will help you to:
 
 - Install and configure Teleport.
@@ -109,7 +108,6 @@ You can choose `AmazonKeyspacesReadOnlyAccess` for read-only access to AWS Keysp
 Enter a role name and press "Create role".
 ![Create Role Step 1](../../../img/database-access/guides/keyspaces/create-role-step3.png)
 
-
 ## Step 4/5. Give Teleport permissions to assume roles
 
 Next, attach the following policy to the IAM role or IAM user the Teleport
@@ -133,7 +131,6 @@ assume the IAM roles:
   You can make the policy more strict by providing specific IAM role resource
   ARNs in the "Resource" field instead of using a wildcard.
 </Admonition>
-
 
 ## Step 5/5. Connect
 

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -13,7 +13,6 @@ description: How to configure Teleport Database Access with Cassandra and Scylla
   Database access for Cassandra & ScyllaDB is available starting from Teleport `v11.0`.
 </Details>
 
-
 This guide will help you to:
 
 - Install and configure Teleport.
@@ -93,7 +92,6 @@ $ teleport db start \
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
-
 ## Step 3/5. Set up mutual TLS
 
 (!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
@@ -168,8 +166,6 @@ Follow the instructions for your database to enable TLS communication with your 
   </TabItem>
 </Tabs>
 
-
-
 ## Step 5/5. Connect
 
 Once the Database Service has joined the cluster, log in to see the available
@@ -216,7 +212,6 @@ $ tsh db logout example
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
-
 
 ## Next steps
 

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -43,7 +43,6 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-
 <Tabs>
 <TabItem label="Self-Hosted" scope={["enterprise","oss"]}>
 Start the Teleport Database Service, pointing the `--auth-server` flag to the address of your Teleport Proxy Service:
@@ -81,7 +80,6 @@ $ teleport db start \
 
 </TabItem>
 </Tabs>
-
 
 <Admonition type="tip">
   You can start the Database Service using a configuration file instead of CLI flags.

--- a/docs/pages/database-access/guides/dynamic-registration.mdx
+++ b/docs/pages/database-access/guides/dynamic-registration.mdx
@@ -58,7 +58,6 @@ spec:
   uri: "localhost:5432"
 ```
 
-
 The user creating the dynamic registration needs to have a role with access to the 
 database labels and the `db` resource.  In this example role the user can only
 create and maintain database services labeled `env: prod` and `engine: postgres`.

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -10,7 +10,6 @@ In this guide you will:
 2. Configure mutual TLS authentication between Teleport and your MongoDB cluster.
 3. Connect to your MongoDB instance via Teleport.
 
-
 <ScopedBlock scope={["oss", "enterprise"]}>
 ![Teleport Database Access MongoDB Self-Hosted](../../../img/database-access/guides/mongodb_selfhosted.png)
 </ScopedBlock>

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -231,7 +231,6 @@ $ teleport db configure create \
 </TabItem>
 </Tabs>
 
-
 ## Step 4/4. Connect
 
 Once the Database Service has joined the cluster, log in to see the available

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -31,7 +31,6 @@ This guide will help you to:
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
-
 ## Step 2/7. Set up the Teleport Database Service
 
 (!docs/pages/includes/database-access/token.mdx!)
@@ -64,7 +63,6 @@ $ teleport db configure create \
 ## Step 4/7. Start the Database Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Database Service"!)
-
 
 ## Step 5/7. Create a certificate/key pair and Teleport Oracle Wallet
 
@@ -157,7 +155,6 @@ $ tsh db logout oracle
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
-
 
 ## Next steps
 

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -90,7 +90,6 @@ in Google Cloud documentation for more info.
 The final part of GCP configuration is to create a service account for the
 Teleport Database Service.
 
-
 ### Create a service account
 
 Go to the [Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts)

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -275,8 +275,6 @@ Provide Active Directory parameters:
 | `--ad-domain` | Active Directory domain (Kerberos realm) that SQL Server is joined. |
 | `--ad-spn` | Service Principal Name for SQL Server to fetch Kerberos tickets for. |
 
-
-
 ### Service Principal Name
 
 You can use `ldapsearch` command to see the SPNs registered for your SQL

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -18,7 +18,6 @@ cluster:
 
 </ScopedBlock>
 
-
 This guide will show you how to get started with Teleport on DigitalOcean
 Kubernetes.
 
@@ -41,7 +40,6 @@ While the Kubernetes cluster is being provisioned, follow the "Getting Started" 
 <Figure align="left" bordered caption="Set up DigitalOcean Kubernetes client">
   ![Set up DigitalOcean Kubernetes client](../../../img/helm/digitalocean/setup-k8s.png)
 </Figure>
-
 
 ## Step 2/4. Install Teleport 
 
@@ -149,7 +147,6 @@ Copy the link shown after executing the above command and open the link in a web
   ![Set up user](../../../img/helm/digitalocean/setup-user.png)
 </Figure>
 
-
 After you complete the registration process by setting up a password and enrolling in two-factor authentication, you will be logged in to Teleport Web UI. 
 
 In this step, we created a user **tadmin** with roles `access, edit`. These are the default roles available in Teleport. However, to allow this user to access the Kubernetes cluster, we will need to assign **tadmin** a role authorized to access the Kubernetes cluster. So first, let's create a role named **member** with the Kubernetes privilege `system:master`.
@@ -249,7 +246,6 @@ Teleport keeps an audit log of access to a Kubernetes cluster. In the screenshot
 <Figure align="left" bordered caption="View audit log">
   ![View audit log](../../../img/helm/digitalocean/view-activity.png)
 </Figure>
-
 
 ## Next steps
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -180,7 +180,6 @@ Go back to the "Service Accounts" view in Google Cloud IAM & Admin.
   ![Private key saved](../../../img/helm/gcp/12-privatekey@1.5x.png)
 </Figure>
 
-
 #### Create the Kubernetes secret containing the JSON private key for the service account
 
 Find the path where the JSON private key was just saved (likely your browser's default "Downloads" directory).

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -188,7 +188,6 @@ Started](../try-out-teleport/introduction.mdx) guide.
 These steps will need to be repeated if Teleport's user certificate authority is rotated.
 </Admonition>
 
-
 Get the Teleport user CA certificate by running the following in the Windows machine where you can manage your group policy, assigning <Var name="proxy" /> to the address of your Teleport Proxy Service:
 
 ```code
@@ -378,7 +377,6 @@ to use the newly created template to issue certificates used for Remote Desktop 
 
 In this section, we will create a certificate template that uses elliptic curve P-384 and uses SHA384 as the signature algorithm.
 
-
 1. Open the Microsoft Management Console (MMC)
 
 ```text
@@ -416,7 +414,6 @@ Right-click on `Server authentication certificate template`, `Edit`, then select
   ![RDP Certificate Template](../../img/desktop-access/rdp-certificate-template.png)
 </Figure>
 
-
 ### Configure server certificate auto-enrollment
 
 In the group policy editor for `Teleport Access Policy`, select:
@@ -426,7 +423,6 @@ Computer Configuration > Policies > Windows Settings > Public Key Policies
 ```
 
 Double-click on `Certificate Services Client - Auto-Enrollment`, then select `Enabled` in the `Configuration Model`.
-
 
 ### Ensure your GPO is updated
 

--- a/docs/pages/includes/aws-credentials.mdx
+++ b/docs/pages/includes/aws-credentials.mdx
@@ -54,4 +54,3 @@ description of credential loading behavior.
 
 </Details>
 
-

--- a/docs/pages/includes/config-reference/instance-wide.yaml
+++ b/docs/pages/includes/config-reference/instance-wide.yaml
@@ -66,13 +66,11 @@ teleport:
     # This value can be specified as FQDN e.g. host.example.com
     advertise_ip: 10.1.0.5
 
-
     # Teleport provides HTTP endpoints for monitoring purposes. They are
     # disabled by default but you can enable them using the diagnosis address.
     # See the Teleport metrics reference:
     # https://goteleport.com/docs/management/diagnostics/metrics/
     diag_addr: "127.0.0.1:3000"
-
 
     # Only use one of auth_server or proxy_server.
     #

--- a/docs/pages/includes/dns.mdx
+++ b/docs/pages/includes/dns.mdx
@@ -53,7 +53,6 @@ Service:
     ```
   </TabItem>
 
-
 </Tabs>
 
 </Details>

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -50,7 +50,6 @@ files in partials, this partial uses relative URL paths instead.
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
   To download these tools, visit the [Downloads](../choose-an-edition/teleport-cloud/downloads.mdx) page.
 
-
   ```code
   $ tctl version
   # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -115,7 +115,6 @@
 | `teleport_cache_stale_events` | counter | Teleport | Number of stale events received by a Teleport service cache. A high percentage of stale events can indicate a degraded backend. |
 | `tx` | counter | Teleport | Number of bytes transmitted during an SSH connection. |
 
-
 ## Golang runtime metrics
 
 | Name | Type | Component | Description |

--- a/docs/pages/includes/sso/loginerrortroubleshooting.mdx
+++ b/docs/pages/includes/sso/loginerrortroubleshooting.mdx
@@ -44,7 +44,6 @@ traits correctly. For a user to see a Node in Teleport, the result of populating
  template variable in a role's `allow.logins` must match at least one of a user's
  `traits.logins`.
 
-
 In this example a user will have usernames `ubuntu`, `debian` and usernames from the SSO trait `logins` for Nodes that have a `env: dev` label.  If the SSO trait username is `bob` then the usernames would include `ubuntu`, `debian`, and `bob`.
 
 ```yaml

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -101,7 +101,6 @@ chart.
 |`teleport-cluster`|Auth Service<br/>Proxy Service<br/>Other Teleport services if using a custom configuration|[Reference](reference/helm-reference/teleport-cluster.mdx)
 |`teleport-kube-agent`|Kubernetes Service<br/>Application Service<br/>Database Service|[Reference](reference/helm-reference/teleport-kube-agent.mdx)|
 
-
 ## macOS
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
@@ -186,7 +185,6 @@ against `tsh version` and `tctl version`.
 Teleport is written in Go, and currently requires **go v(=teleport.golang=)** or
 newer. Detailed instructions for building from source are available in the
 [README](https://github.com/gravitational/teleport#building-teleport).
-
 
 ## Checksums
 

--- a/docs/pages/kubernetes-access/discovery/azure.mdx
+++ b/docs/pages/kubernetes-access/discovery/azure.mdx
@@ -181,7 +181,6 @@ associated with Teleport identity.
 
 </Details>
 
-
   </TabItem>
     <TabItem label="Local Accounts">
       In this case, Teleport will use the user credentials generated during the 
@@ -206,7 +205,6 @@ associated with Teleport identity.
 
   </TabItem>
 </Tabs>
-
 
 ## Step 2/2. Configure Teleport to discover AKS clusters
 

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -29,7 +29,6 @@ to automatically join the cluster on subsequent restarts.
 
 - (!docs/pages/includes/tctl.mdx!)
 
-
 ## Step 1/3. Create a Kubernetes service account with an IAM identity
 
 Teleport supports a mode where agents running in AWS can join the cluster using the

--- a/docs/pages/machine-id/architecture.mdx
+++ b/docs/pages/machine-id/architecture.mdx
@@ -106,7 +106,6 @@ differences.
 - The certificates exchanged for the token are 
   renewable, as we will explain in the next section.
 
-
 ### Dynamic join tokens (e.g AWS IAM)
 
 - These tokens rely on an external authority that allows the bot to prove it is 

--- a/docs/pages/machine-id/guides/host-certificate.mdx
+++ b/docs/pages/machine-id/guides/host-certificate.mdx
@@ -80,7 +80,6 @@ Once complete, create your role to apply to the `tbot` configuration in the next
 $ tctl create tbotrole.yaml
 ```
 
-
 ## Step 3/5 Create Your `tbot` Configuration
 
 Before you create a bot user, you need to determine which role(s) you want to
@@ -361,7 +360,6 @@ Your output will resemble the following:
                 x-teleport-authority UNKNOWN OPTION (len 55)
                 x-teleport-role UNKNOWN OPTION (len 8)
 ```
-
 
 ## Step 5/5 Configuring SSHD and connecting to the Teleport Cluster
 

--- a/docs/pages/machine-id/reference.mdx
+++ b/docs/pages/machine-id/reference.mdx
@@ -3,7 +3,6 @@ title: Machine ID Reference
 description: Configuration and CLI reference for Teleport Machine ID.
 ---
 
-
 - [Configuration](./reference/configuration.mdx)
 - [GitHub Actions](./reference/github-actions.mdx)
 - [GitLab CI](./reference/gitlab.mdx)

--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -67,7 +67,6 @@ destinations:
           # artifacts.
           path: /opt/machine-id
 
-
           # Configure symlink attack prevention. Requires Linux 5.6+.
           # Possible values:
           #   * try-secure (default): Attempt to securely read and write certificates

--- a/docs/pages/machine-id/reference/gitlab.mdx
+++ b/docs/pages/machine-id/reference/gitlab.mdx
@@ -25,7 +25,6 @@ The following constraints exist:
 - `sub`: a string uniquely identifying the CI run's source. It follows the
   following format:
 
-
 ```yaml
 kind: token
 version: v2

--- a/docs/pages/management/admin/daemon.mdx
+++ b/docs/pages/management/admin/daemon.mdx
@@ -153,12 +153,10 @@ To upgrade a host to a newer version of Teleport, you must:
 
 </Admonition>
 
-
 ## Understanding Teleport daemon command line options for unit file configuration
 
 The `teleport install systemd` command includes a number of optional flags that you can use to strictly define parameters of the generated unit file and set where that output will be written.
 The following table includes all command line options available with the `teleport install systemd` command, a brief description of what they do, and their default settings:
-
 
 | Flag | Description | Default |
 | --- | ----------- | ---- |

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -379,7 +379,6 @@ If this doesn't work, delete the directory your Node uses to maintain its state,
 
 </Details>
 
-
 ## Next steps: Using labels
 
 Once you have labeled your resources, you can refer to your labels when running

--- a/docs/pages/management/diagnostics/tracing.mdx
+++ b/docs/pages/management/diagnostics/tracing.mdx
@@ -14,7 +14,6 @@ to a format that your telemetry backend accepts.
 In order to enable tracing for a `teleport` instance, add the following section to that instance's configuration file (`/etc/teleport.yaml`).
 For a detailed description of these configuration fields, see the [configuration reference](./reference/configuration.mdx) page.
 
-
 ```yaml
 tracing_service:
    enabled: yes

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -226,7 +226,6 @@ In the **Input Settings** view (above), next to the **Source type** field, click
 then **_json**. Splunk will index incoming logs as JSON, which is the format the
 Event Handler uses to send logs to the Universal Forwarder.
 
-
 In the **Index** section, select the `teleport-audit-logs` index you created
 earlier. Click **Review** then view the summary and click **Submit**. Copy the
 **Token Value** field and keep it somewhere safe so you can use it later in this
@@ -252,7 +251,6 @@ $ sudo chown splunk:splunk server.pem
 ```
 
 ### Configure the HTTP Event Collector
-
 
 On your Universal Forwarder host, create a file at
 `/opt/splunkforwarder/etc/system/local/inputs.conf` with the following content:

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -218,7 +218,6 @@ proxy_service:
   number>-<instance id>`) and will not be allowed to join.
 </Admonition>
 
-
 Start Teleport on the Node and confirm that it is able to connect to and join
 your cluster. You're all set!
 

--- a/docs/pages/management/security/reduce-blast-radius.mdx
+++ b/docs/pages/management/security/reduce-blast-radius.mdx
@@ -84,7 +84,6 @@ If your `second_factor` configuration is set to `off` and a user creates an acco
 - Run the `tctl users reset <account>` command to force a user to enter new credentials, including any required MFA device.
 </Admonition>
 
-
 ## Present an MFA challenge for every attempt to access a resource
 After a user logs into a Teleport cluster, they can request access to a particular resource, e.g., a node, database, application, or Kubernetes cluster. In this case, the Teleport Auth Service issues a single-use certificate for accessing that resource. You can prevent attackers from doing damage with a compromised certificate by enabling per-session MFA. With this setting, whenever a user requests a one-time certificate to access a resource, the Teleport Auth Service will issue an MFA challenge, even if the user has already begun a Teleport session via `tsh login`.
 
@@ -161,7 +160,6 @@ spec:
 
 The `spec.allow.request.roles` field lists the names of other roles that a user with the `reviewee` role can request. When a reviewee requests access to one of these roles, Teleport notifies reviewers via your access plugins. The `spec.allow.requests.roles.thresholds` field indicates how many reviews are required to approve or deny the request.
 
-
 ## Automatically prevent some roles from requesting others
 A malicious Teleport user could request a more privileged role and trick a reviewer into granting access. You can prevent such a scenario by defining roles that prohibit users from even requesting access to particular roles.
 
@@ -192,7 +190,6 @@ However, the Auth Service denies the request.
 Creating request...
 ERROR: user "myuser" can not request role "admin"
 ```
-
 
 ## Restrict role requests based on user traits
 Teleport's `role` resource lets you take precautions against accidental privilege escalation by ensuring that any user with particular attributes will have restricted access to certain roles. You can assign a list of `traits` to a user, then define a `role` resource that prevents any user whose traits match a regular expression from requesting elevated privileges.
@@ -240,7 +237,6 @@ spec:
 ```
 
 The `claims_to_roles` field within an `allow` or `deny` rule maps a user's `traits` to `roles` that they are either permitted or forbidden to request. In this case, we use the `{{regexp.not_match(\"admin\")}}` template function to prevent any user  from requesting the `db-writer` role unless they have a `groups` trait with a value like `administrator` or `admins`. Users who *do* have such a trait can request the role with two approvals.
-
 
 ## Set up your RBAC without admin roles
 You can design your Teleport RBAC so that there is no all-powerful administrator in the system, or even a `reviewer` role with elevated privileges. This way, you can reduce the blast radius if an attacker successfully impersonates a Teleport user and requests a more privileged role.

--- a/docs/pages/preview/upcoming-releases.mdx
+++ b/docs/pages/preview/upcoming-releases.mdx
@@ -56,7 +56,6 @@ The key areas of focus for Teleport cloud in early 2022 are:
 | Q2 2022 | Offer more data retention options |
 | Q3 2022 | Option to store data in alternate regions around the world |
 
-
 ## Semantic Versioning
 
 Teleport follows [semantic versioning](https://semver.org/) for pre-releases and releases.

--- a/docs/pages/reference/audit.mdx
+++ b/docs/pages/reference/audit.mdx
@@ -9,7 +9,6 @@ There are two components of the audit log:
 <Tabs>
 <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
-
 1. **Cluster Events:** Teleport logs events like successful user logins along
    with metadata like remote IP address, time, and the session ID.
 2. **Recorded Sessions:** Every SSH, desktop, or Kubernetes shell session is recorded and
@@ -18,7 +17,6 @@ There are two components of the audit log:
 
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Cloud">
-
 
 1. **Cluster Events:** Teleport logs events like successful user logins along
    with metadata like remote IP address, time, and the session ID.
@@ -147,7 +145,6 @@ The possible event types are:
 In addition to logging start and end events, Teleport can also record the entire session.
 For SSH or Kubernetes sessions this captures the entire stream of bytes from the PTY.
 For desktop sessions the recording includes the contents of the screen.
-
 
 <Tabs>
 <TabItem scope={["enterprise", "oss"]} label="Self-Hosted">

--- a/docs/pages/reference/authentication.mdx
+++ b/docs/pages/reference/authentication.mdx
@@ -49,7 +49,6 @@ Add the following to your Teleport configuration file, which is stored in
       second_factor: off
   ```
 
-
 ### Dynamic resource
 
 Obtain your existing `cluster_auth_preference` resource:
@@ -121,7 +120,6 @@ $ tctl create -f cap.yaml
 ```
 </TabItem>
 </Tabs>
-
 
 ## Authentication connectors
 

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -446,6 +446,7 @@ Downloaded recorded session are directly playable as a file.
 ```code
 $ tsh play c8e1b2c5-322a-4095-89e3-391edfd2da9b.tar
 ```
+
 </Admonition>
 
 ### tsh recordings export
@@ -1389,7 +1390,6 @@ DEBU [TSH]       Self re-exec command: tsh [status --format=json]. tsh/aliases.g
 ...
 ```
 
-
 ## tctl
 
 `tctl` is a CLI tool that allows a cluster administrator to manage all resources
@@ -1488,8 +1488,6 @@ which could result in the error,
 
   </TabItem>
 </Tabs>
-
-
 
 **Example**
 
@@ -2017,7 +2015,6 @@ The test process is safe from side effects in that:
 ```
 </Admonition>
 
-
 #### Arguments
 
 - `[<filename>]` Connector resource definition file. Optional. Empty for stdin.
@@ -2198,7 +2195,6 @@ The following flags are specific to Google Workspace:
 | `--google-legacy`  | Flag to select groups with direct membership filtered by domain (legacy behavior). <br/>Disabled by default. [More info](https://goteleport.com/docs/enterprise/sso/google-workspace/#how-teleport-uses-google-workspace-apis) |
 | `--google-id`      | Shorthand for setting the `--id` flag to `<GOOGLE_WORKSPACE_CLIENT_ID>.apps.googleusercontent.com`     |
 
-
 #### Global flags
 
 These flags are available for all commands: `--debug, --config`. Run
@@ -2241,7 +2237,6 @@ $ tctl sso configure oidc --preset google -r groups,mygroup@mydomain.example.com
 $ tctl sso configure oidc ... | tctl sso test
 ```
 
-
 ### tctl sso configure saml
 
 Configure the SAML auth connector, optionally using a preset.
@@ -2282,7 +2277,6 @@ Mandatory flags: `--name`, `--attributes-to-roles`, `--entity-descriptor`. These
 | `--provider`                |                                                                       | Sets the external identity provider type, enabling workarounds. Examples: ping, adfs.                                                                            |
 | `--ignore-missing-roles`    |                                                                       | Ignore missing roles referenced in `--attributes-to-roles`.                                                                                                      |
 
-
 Supported presets:
 
 | Name       | Description                          | Display   |
@@ -2291,7 +2285,6 @@ Supported presets:
 | `onelogin` | OneLogin                             | OneLogin  |
 | `ad`       | Azure Active Directory               | Microsoft |
 | `adfs`     | Active Directory Federation Services | ADFS      |
-
 
 #### Global flags
 
@@ -2535,7 +2528,6 @@ $ tctl edit role/sre
 $ TELEPORT_EDITOR=nano tctl edit user/alice
 ```
 
-
 ### tctl status
 
 Report cluster status:
@@ -2598,7 +2590,6 @@ $ tctl alerts create \
 
 Register a device.
 
-
 ```code
 $ tctl devices add --os=OS --asset-tag=SERIAL_NUMBER
 ```
@@ -2655,7 +2646,6 @@ tsh device enroll --token=(=devicetrust.enroll_token=)
 ### tctl devices ls
 
 List registered devices.
-
 
 ```code
 $ tctl devices ls
@@ -2878,7 +2868,6 @@ $ tbot init \
     --reader-user=jenkins
 ```
 
-
 ### tbot db
 
 Connects to databases using native clients and queries database information. This is best used for testing and validation purposes;
@@ -2985,7 +2974,6 @@ Note that this decreases security:
 
 Refer to the [database guide](../machine-id/guides/databases.mdx) for more information on
 using database proxies.
-
 
 #### Flags
 

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -346,7 +346,6 @@ For possible values, [see the Teleport Configuration Reference](../../reference/
   </TabItem>
 </Tabs>
 
-
 ## `separatePostgresListener`
 
 | Type   | Default value | Required? | `teleport.yaml` equivalent           |
@@ -527,7 +526,6 @@ else [`clusterName`](#clusterName) is used. Default port is 3036.
   ```
   </TabItem>
 </Tabs>
-
 
 ## `postgresPublicAddr`
 
@@ -1876,7 +1874,6 @@ A list of extra environment variables to be set on the main Teleport container.
   ```
   </TabItem>
 </Tabs>
-
 
 ## `extraVolumes`
 

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -1345,7 +1345,6 @@ Ensures that this number of replicas is available during voluntary disruptions, 
 |----------|---------------|
 | `string` | `nil`         |
 
-
 `clusterRoleBindingName` can be optionally used to override the name of the Kubernetes `ClusterRoleBinding` used by the `teleport-kube-agent` chart's `ServiceAccount`.
 
 <Tabs>
@@ -1774,7 +1773,6 @@ the Teleport pod.
   </Admonition>
   </TabItem>
 </Tabs>
-
 
 ## `extraLabels.roleBinding`
 

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -45,7 +45,6 @@ following use cases:
 </TabItem>
 </Tabs>
 
-
 ## HTTP CONNECT proxies
 
 Some networks funnel all connections through a proxy server where they can be

--- a/docs/pages/reference/predicate-language.mdx
+++ b/docs/pages/reference/predicate-language.mdx
@@ -35,7 +35,6 @@ The language also supports the following functions:
 | `equals(<field>, <field2>)`    | checks if the value from `<field2>` is equal to the value from `<field>`              |
 | `equals(<field>, "<value>")`   | checks if `<value>` is equal to the value from `<field>`                              |
 
-
 ## Resource filtering
 
 Both the [`tsh`](cli.mdx#tsh) and [`tctl`](cli.mdx#tctl) CLI tools allow you to filter nodes, 
@@ -67,6 +66,5 @@ The language also supports the following functions:
 | `exists(labels["env"])`               | resources with a label key `env`; label value unchecked    |
 | `!exists(labels["env"])`              | resources without a label key `env`; label value unchecked |
 | `search("foo", "bar", "some phrase")` | fuzzy match against common resource fields                 |
-
 
 See some [examples](cli.mdx#filter-examples) of the different ways you can filter resources.

--- a/docs/pages/reference/terraform-provider.mdx
+++ b/docs/pages/reference/terraform-provider.mdx
@@ -19,7 +19,6 @@ Supported resources:
 - [teleport_trusted_cluster](#teleport_trusted_cluster)
 - [teleport_user](#teleport_user)
 
-
 ## Provider configuration
 
 Add the following configuration section to your `terraform` configuration block:
@@ -37,7 +36,6 @@ terraform {
 
 The provider supports the following options:
 
-
 | Name                   | Type   | Description                                                                    | Environment Variable               |
 | ---------------------- | ------ | ------------------------------------------------------------------------------ | ---------------------------------- |
 | `addr`                 | string | Teleport auth or proxy address in "host:port" format.                          | `TF_TELEPORT_ADDR`                 |
@@ -54,7 +52,6 @@ The provider supports the following options:
 | `retry_base_duration`  | string | Base duration between retries. [Format](https://pkg.go.dev/time#ParseDuration) | `TF_TELEPORT_RETRY_BASE_DURATION`  |
 | `retry_cap_duration`   | string | Max duration between retries. [Format](https://pkg.go.dev/time#ParseDuration)  | `TF_TELEPORT_RETRY_CAP_DURATION`   |
 | `retry_max_tries`      | string | Max number of retries.                                                         | `TF_TELEPORT_RETRY_MAX_TRIES`      |
-
 
 You need to specify at least one of:
 
@@ -87,7 +84,6 @@ provider "teleport" {
 | sub_kind | string |          | SubKind is an optional resource subkind. |
 | version  | string |          | Version is the resource version.         |
 
-
 ### metadata
 
 Metadata is the app resource metadata.
@@ -99,7 +95,6 @@ Metadata is the app resource metadata.
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -115,7 +110,6 @@ Spec is the app resource spec.
 | rewrite              | object |          | Rewrite is a list of rewriting rules to apply to requests and responses. |
 | uri                  | string |          | URI is the web app endpoint.                                             |
 
-
 #### spec.aws
 
 AWS contains additional options for AWS applications.
@@ -123,7 +117,6 @@ AWS contains additional options for AWS applications.
 |    Name     |  Type  | Required |                               Description                               |
 |-------------|--------|----------|-------------------------------------------------------------------------|
 | external_id | string |          | ExternalID is the AWS External ID used when assuming roles in this app. |
-
 
 #### spec.dynamic_labels
 
@@ -135,7 +128,6 @@ DynamicLabels are the app's command labels.
 | period  | duration         |          | Period is a time between command runs |
 | result  | string           |          | Result captures standard output       |
 
-
 #### spec.rewrite
 
 Rewrite is a list of rewriting rules to apply to requests and responses.
@@ -145,7 +137,6 @@ Rewrite is a list of rewriting rules to apply to requests and responses.
 | headers  | object           |          | Headers is a list of headers to inject when passing the request over to the application.                                                          |
 | redirect | array of strings |          | Redirect defines a list of hosts which will be rewritten to the public address of the application if they occur in the &#34;Location&#34; header. |
 
-
 ##### spec.rewrite.headers
 
 Headers is a list of headers to inject when passing the request over to the application.
@@ -154,7 +145,6 @@ Headers is a list of headers to inject when passing the request over to the appl
 |-------|--------|----------|---------------------------------|
 | name  | string |          | Name is the http header name.   |
 | value | string |          | Value is the http header value. |
-
 
 Example:
 
@@ -185,7 +175,6 @@ resource "teleport_app" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources |
 | version  | string |          | Version is a resource version                                    |
 
-
 ### metadata
 
 Metadata is resource metadata
@@ -196,7 +185,6 @@ Metadata is resource metadata
 | expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -218,7 +206,6 @@ Spec is an AuthPreference specification
 | u2f                     | object |          | U2F are the settings for the U2F device.                                                                                           |
 | webauthn                | object |          | Webauthn are the settings for server-side Web Authentication support.                                                              |
 
-
 #### spec.device_trust
 
 DeviceTrust holds settings related to trusted device verification. Requires Teleport Enterprise.
@@ -226,7 +213,6 @@ DeviceTrust holds settings related to trusted device verification. Requires Tele
 | Name |  Type  | Required |                                                                                                                                                                                                                                             Description                                                                                                                                                                                                                                              |
 |------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | mode | string |          | Mode of verification for trusted devices.  The following modes are supported:  - &#34;off&#34;: disables both device authentication and authorization. - &#34;optional&#34;: allows both device authentication and authorization, but doesn&#39;t enforce the presence of device extensions for sensitive endpoints. - &#34;required&#34;: enforces the presence of device extensions for sensitive endpoints.  Mode is always &#34;off&#34; for OSS. Defaults to &#34;optional&#34; for Enterprise. |
-
 
 #### spec.idp
 
@@ -236,7 +222,6 @@ IDP is a set of options related to accessing IdPs within Teleport. Requires Tele
 |------|--------|----------|----------------------------------------------------|
 | saml | object |          | SAML are options related to the Teleport SAML IdP. |
 
-
 ##### spec.idp.saml
 
 SAML are options related to the Teleport SAML IdP.
@@ -244,7 +229,6 @@ SAML are options related to the Teleport SAML IdP.
 |  Name   | Type | Required | Description |
 |---------|------|----------|-------------|
 | enabled | bool |          |             |
-
 
 #### spec.u2f
 
@@ -256,7 +240,6 @@ U2F are the settings for the U2F device.
 | device_attestation_cas | array of strings |          | DeviceAttestationCAs contains the trusted attestation CAs for U2F devices.                                                                                                                                |
 | facets                 | array of strings |          | Facets returns the facets for universal second factor. Deprecated: Kept for backwards compatibility reasons, but Facets have no effect since Teleport v10, when Webauthn replaced the U2F implementation. |
 
-
 #### spec.webauthn
 
 Webauthn are the settings for server-side Web Authentication support.
@@ -266,7 +249,6 @@ Webauthn are the settings for server-side Web Authentication support.
 | attestation_allowed_cas | array of strings |          | Allow list of device attestation CAs in PEM format. If present, only devices whose attestation certificates match the certificates specified here may be registered (existing registrations are unchanged). If supplied in conjunction with AttestationDeniedCAs, then both conditions need to be true for registration to be allowed (the device MUST match an allowed CA and MUST NOT match a denied CA). By default all devices are allowed.         |
 | attestation_denied_cas  | array of strings |          | Deny list of device attestation CAs in PEM format. If present, only devices whose attestation certificates don&#39;t match the certificates specified here may be registered (existing registrations are unchanged). If supplied in conjunction with AttestationAllowedCAs, then both conditions need to be true for registration to be allowed (the device MUST match an allowed CA and MUST NOT match a denied CA). By default no devices are denied. |
 | rp_id                   | string           |          | RPID is the ID of the Relying Party. It should be set to the domain name of the Teleport installation.  IMPORTANT: RPID must never change in the lifetime of the cluster, because it&#39;s recorded in the registration data on the WebAuthn device. If the RPID changes, all existing WebAuthn key registrations will become invalid and all users who use WebAuthn as the second factor will need to re-register.                                     |
-
 
 Example:
 
@@ -300,7 +282,6 @@ resource "teleport_auth_preference" "example" {
 | token_ttl | string               |          | The desired TTL for the token if one is created. If unset, a server default is used                                                                           |
 | traits    | map of string arrays |          |                                                                                                                                                               |
 | user_name | string               |          | The name of the generated bot user                                                                                                                            |
-
 
 Example:
 
@@ -352,7 +333,6 @@ resource "teleport_bot" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources |
 | version  | string |          | Version is a resource version                                    |
 
-
 ### metadata
 
 Metadata is resource metadata
@@ -363,7 +343,6 @@ Metadata is resource metadata
 | expires     | RFC3339 time   |          | Expires is a global expiry time header can be set on any resource in the system.                               |
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -382,7 +361,6 @@ Spec is a ClusterNetworkingConfig specification
 | tunnel_strategy         | object   |          | TunnelStrategyV1 determines the tunnel strategy used in the cluster.                                                                                                                                    |
 | web_idle_timeout        | duration |          | WebIdleTimeout sets global cluster default setting for the web UI idle timeouts.                                                                                                                        |
 
-
 #### spec.tunnel_strategy
 
 TunnelStrategyV1 determines the tunnel strategy used in the cluster.
@@ -392,24 +370,17 @@ TunnelStrategyV1 determines the tunnel strategy used in the cluster.
 | agent_mesh    | object |          |             |
 | proxy_peering | object |          |             |
 
-
 ##### spec.tunnel_strategy.agent_mesh
-
-
 
 |  Name  | Type | Required |                          Description                          |
 |--------|------|----------|---------------------------------------------------------------|
 | active | bool |          | Automatically generated field preventing empty message errors |
 
-
 ##### spec.tunnel_strategy.proxy_peering
-
-
 
 |          Name          |  Type  | Required | Description |
 |------------------------|--------|----------|-------------|
 | agent_connection_count | number |          |             |
-
 
 Example:
 
@@ -440,7 +411,6 @@ resource "teleport_cluster_networking_config" "example" {
 | sub_kind | string |          | SubKind is an optional resource subkind. |
 | version  | string |          | Version is the resource version.         |
 
-
 ### metadata
 
 Metadata is the database metadata.
@@ -452,7 +422,6 @@ Metadata is the database metadata.
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -471,7 +440,6 @@ Spec is the database spec.
 | tls            | object |          | TLS is the TLS configuration used when establishing connection to target database. Allows to provide custom CA cert or override server name. |
 | uri            | string | *        | URI is the database connection endpoint.                                                                                                     |
 
-
 #### spec.ad
 
 AD is the Active Directory configuration for the database.
@@ -484,7 +452,6 @@ AD is the Active Directory configuration for the database.
 | krb5_file     | string |          | Krb5File is the path to the Kerberos configuration file. Defaults to /etc/krb5.conf.    |
 | ldap_cert     | string |          | LDAPCert is a certificate from Windows LDAP/AD, optional; only for x509 Authentication. |
 | spn           | string |          | SPN is the service principal name for the database.                                     |
-
 
 #### spec.aws
 
@@ -503,7 +470,6 @@ AWS contains AWS specific settings for RDS/Aurora/Redshift databases.
 | region              | string |          | Region is a AWS cloud region.                                                                  |
 | secret_store        | object |          | SecretStore contains secret store configurations.                                              |
 
-
 ##### spec.aws.elasticache
 
 ElastiCache contains AWS ElastiCache Redis specific metadata.
@@ -514,7 +480,6 @@ ElastiCache contains AWS ElastiCache Redis specific metadata.
 | replication_group_id       | string           |          | ReplicationGroupID is the Redis replication group ID.                              |
 | transit_encryption_enabled | bool             |          | TransitEncryptionEnabled indicates whether in-transit encryption (TLS) is enabled. |
 | user_group_ids             | array of strings |          | UserGroupIDs is a list of user group IDs.                                          |
-
 
 ##### spec.aws.memorydb
 
@@ -527,7 +492,6 @@ MemoryDB contains AWS MemoryDB specific metadata.
 | endpoint_type | string |          | EndpointType is the type of the endpoint.                            |
 | tls_enabled   | bool   |          | TLSEnabled indicates whether in-transit encryption (TLS) is enabled. |
 
-
 ##### spec.aws.rds
 
 RDS contains RDS specific metadata.
@@ -539,7 +503,6 @@ RDS contains RDS specific metadata.
 | instance_id | string |          | InstanceID is the RDS instance identifier.                        |
 | resource_id | string |          | ResourceID is the RDS instance resource identifier (db-xxx).      |
 
-
 ##### spec.aws.rdsproxy
 
 RDSProxy contains AWS Proxy specific metadata.
@@ -550,7 +513,6 @@ RDSProxy contains AWS Proxy specific metadata.
 | name                 | string |          | Name is the identifier of an RDS Proxy.                               |
 | resource_id          | string |          | ResourceID is the RDS instance resource identifier (prx-xxx).         |
 
-
 ##### spec.aws.redshift
 
 Redshift contains Redshift specific metadata.
@@ -558,7 +520,6 @@ Redshift contains Redshift specific metadata.
 |    Name    |  Type  | Required |                  Description                  |
 |------------|--------|----------|-----------------------------------------------|
 | cluster_id | string |          | ClusterID is the Redshift cluster identifier. |
-
 
 ##### spec.aws.redshift_serverless
 
@@ -570,7 +531,6 @@ RedshiftServerless contains AWS Redshift Serverless specific metadata.
 | workgroup_id   | string |          | WorkgroupID is the workgroup ID.       |
 | workgroup_name | string |          | WorkgroupName is the workgroup name.   |
 
-
 ##### spec.aws.secret_store
 
 SecretStore contains secret store configurations.
@@ -579,7 +539,6 @@ SecretStore contains secret store configurations.
 |------------|--------|----------|----------------------------------------------------|
 | key_prefix | string |          | KeyPrefix specifies the secret key prefix.         |
 | kms_key_id | string |          | KMSKeyID specifies the AWS KMS key for encryption. |
-
 
 #### spec.azure
 
@@ -592,7 +551,6 @@ Azure contains Azure specific database metadata.
 | redis           | object |          | Redis contains Azure Cache for Redis specific database metadata.   |
 | resource_id     | string |          | ResourceID is the Azure fully qualified ID for the resource.       |
 
-
 ##### spec.azure.redis
 
 Redis contains Azure Cache for Redis specific database metadata.
@@ -600,7 +558,6 @@ Redis contains Azure Cache for Redis specific database metadata.
 |       Name        |  Type  | Required |                           Description                           |
 |-------------------|--------|----------|-----------------------------------------------------------------|
 | clustering_policy | string |          | ClusteringPolicy is the clustering policy for Redis Enterprise. |
-
 
 #### spec.dynamic_labels
 
@@ -612,7 +569,6 @@ DynamicLabels is the database dynamic labels.
 | period  | duration         |          | Period is a time between command runs |
 | result  | string           |          | Result captures standard output       |
 
-
 #### spec.gcp
 
 GCP contains parameters specific to GCP Cloud SQL databases.
@@ -622,7 +578,6 @@ GCP contains parameters specific to GCP Cloud SQL databases.
 | instance_id | string |          | InstanceID is the Cloud SQL instance ID.                           |
 | project_id  | string |          | ProjectID is the GCP project ID the Cloud SQL instance resides in. |
 
-
 #### spec.mysql
 
 MySQL is an additional section with MySQL database options.
@@ -630,7 +585,6 @@ MySQL is an additional section with MySQL database options.
 |      Name      |  Type  | Required |                                              Description                                              |
 |----------------|--------|----------|-------------------------------------------------------------------------------------------------------|
 | server_version | string |          | ServerVersion is the server version reported by DB proxy if the runtime information is not available. |
-
 
 #### spec.tls
 
@@ -641,7 +595,6 @@ TLS is the TLS configuration used when establishing connection to target databas
 | ca_cert     | string |          | CACert is an optional user provided CA certificate used for verifying database TLS connection.                                     |
 | mode        | number |          | Mode is a TLS connection mode. See DatabaseTLSMode for details.                                                                    |
 | server_name | string |          | ServerName allows to provide custom hostname. This value will override the servername/hostname on a certificate during validation. |
-
 
 Example:
 
@@ -673,7 +626,6 @@ resource "teleport_database" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources. |
 | version  | string |          | Version is a resource version.                                    |
 
-
 ### metadata
 
 Metadata holds resource metadata.
@@ -685,7 +637,6 @@ Metadata holds resource metadata.
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -701,7 +652,6 @@ Spec is an Github connector specification.
 | teams_to_logins | object |          | TeamsToLogins maps Github team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead. |
 | teams_to_roles  | object |          | TeamsToRoles maps Github team memberships onto allowed roles.                                                                       |
 
-
 #### spec.teams_to_logins
 
 TeamsToLogins maps Github team memberships onto allowed logins/roles.  DELETE IN 11.0.0 Deprecated: use GithubTeamsToRoles instead.
@@ -714,7 +664,6 @@ TeamsToLogins maps Github team memberships onto allowed logins/roles.  DELETE IN
 | organization      | string           |          | Organization is a Github organization a user belongs to.                          |
 | team              | string           |          | Team is a team within the organization a user belongs to.                         |
 
-
 #### spec.teams_to_roles
 
 TeamsToRoles maps Github team memberships onto allowed roles.
@@ -724,7 +673,6 @@ TeamsToRoles maps Github team memberships onto allowed roles.
 | organization | string           |          | Organization is a Github organization a user belongs to.  |
 | roles        | array of strings |          | Roles is a list of allowed logins for this org/team.      |
 | team         | string           |          | Team is a team within the organization a user belongs to. |
-
 
 Example:
 
@@ -769,7 +717,6 @@ resource "teleport_github_connector" "github" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources. |
 | version  | string |          | Version is a resource version.                                    |
 
-
 ### metadata
 
 Metadata holds resource metadata.
@@ -781,7 +728,6 @@ Metadata holds resource metadata.
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -805,7 +751,6 @@ Spec is an OIDC connector specification.
 | scope                      | array of strings |          | Scope specifies additional scopes set by provider.                                                                                            |
 | username_claim             | string           |          | UsernameClaim specifies the name of the claim from the OIDC connector to be used as the user&#39;s username.                                  |
 
-
 #### spec.claims_to_roles
 
 ClaimsToRoles specifies a dynamic mapping from claims to roles.
@@ -815,7 +760,6 @@ ClaimsToRoles specifies a dynamic mapping from claims to roles.
 | claim | string           |          | Claim is a claim name.                             |
 | roles | array of strings |          | Roles is a list of static teleport roles to match. |
 | value | string           |          | Value is a claim value to match.                   |
-
 
 Example:
 
@@ -859,7 +803,6 @@ resource "teleport_oidc_connector" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources |
 | version  | string |          | Version is version                                               |
 
-
 ### metadata
 
 Metadata is resource metadata
@@ -871,7 +814,6 @@ Metadata is resource metadata
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         |          | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -891,7 +833,6 @@ Spec is a provisioning token V2 spec
 | suggested_agent_matcher_labels | map of string arrays |          |                                                                                                                                                            |
 | suggested_labels               | map of string arrays |          |                                                                                                                                                            |
 
-
 #### spec.allow
 
 Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.
@@ -903,7 +844,6 @@ Allow is a list of TokenRules, nodes using this token must match one allow rule 
 | aws_regions | array of strings |          | AWSRegions is used for the EC2 join method and is a list of AWS regions a node is allowed to join from.                                        |
 | aws_role    | string           |          | AWSRole is used for the EC2 join method and is the the ARN of the AWS role that the auth server will assume in order to call the ec2 API.      |
 
-
 #### spec.azure
 
 Azure allows the configuration of options specific to the "azure" join method.
@@ -911,7 +851,6 @@ Azure allows the configuration of options specific to the "azure" join method.
 | Name  |  Type  | Required |                                          Description                                          |
 |-------|--------|----------|-----------------------------------------------------------------------------------------------|
 | allow | object |          | Allow is a list of Rules, nodes using this token must match one allow rule to use this token. |
-
 
 ##### spec.azure.allow
 
@@ -922,7 +861,6 @@ Allow is a list of Rules, nodes using this token must match one allow rule to us
 | resource_groups | array of strings |          | ResourceGroups is a list of Azure resource groups the node is allowed to join from. |
 | subscription    | string           |          | Subscription is the Azure subscription.                                             |
 
-
 #### spec.circleci
 
 CircleCI allows the configuration of options specific to the "circleci" join method.
@@ -931,7 +869,6 @@ CircleCI allows the configuration of options specific to the "circleci" join met
 |-----------------|--------|----------|----------------------------------------------------------------------------------------------------|
 | allow           | object |          | Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token. |
 | organization_id | string |          |                                                                                                    |
-
 
 ##### spec.circleci.allow
 
@@ -942,7 +879,6 @@ Allow is a list of TokenRules, nodes using this token must match one allow rule 
 | context_id | string |          |             |
 | project_id | string |          |             |
 
-
 #### spec.github
 
 GitHub allows the configuration of options specific to the "github" join method.
@@ -951,7 +887,6 @@ GitHub allows the configuration of options specific to the "github" join method.
 |------------------------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | allow                  | object |          | Allow is a list of TokenRules, nodes using this token must match one allow rule to use this token.                                                                                                                                                                                                                                                                                                                                                                                                  |
 | enterprise_server_host | string |          | EnterpriseServerHost allows joining from runners associated with a GitHub Enterprise Server instance. When unconfigured, tokens will be validated against github.com, but when configured to the host of a GHES instance, then the tokens will be validated against host.  This value should be the hostname of the GHES instance, and should not include the scheme or a path. The instance must be accessible over HTTPS at this hostname and the certificate must be trusted by the Auth Server. |
-
 
 ##### spec.github.allow
 
@@ -968,7 +903,6 @@ Allow is a list of TokenRules, nodes using this token must match one allow rule 
 | sub              | string |          | Sub also known as Subject is a string that roughly uniquely indentifies the workload. The format of this varies depending on the type of github action run. |
 | workflow         | string |          | The name of the workflow.                                                                                                                                   |
 
-
 #### spec.kubernetes
 
 Kubernetes allows the configuration of options specific to the "kubernetes" join method.
@@ -977,7 +911,6 @@ Kubernetes allows the configuration of options specific to the "kubernetes" join
 |-------|--------|----------|-----------------------------------------------------------------------------------------------|
 | allow | object |          | Allow is a list of Rules, nodes using this token must match one allow rule to use this token. |
 
-
 ##### spec.kubernetes.allow
 
 Allow is a list of Rules, nodes using this token must match one allow rule to use this token.
@@ -985,7 +918,6 @@ Allow is a list of Rules, nodes using this token must match one allow rule to us
 |      Name       |  Type  | Required |                                                         Description                                                         |
 |-----------------|--------|----------|-----------------------------------------------------------------------------------------------------------------------------|
 | service_account | string |          | ServiceAccount is the namespaced name of the Kubernetes service account. Its format is &#34;namespace:service-account&#34;. |
-
 
 Example:
 
@@ -1019,7 +951,6 @@ resource "teleport_provision_token" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources |
 | version  | string |          | Version is version                                               |
 
-
 ### metadata
 
 Metadata is resource metadata
@@ -1032,7 +963,6 @@ Metadata is resource metadata
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
 
-
 ### spec
 
 Spec is a role specification
@@ -1042,7 +972,6 @@ Spec is a role specification
 | allow   | object |          | Allow is the set of conditions evaluated to grant access.                               |
 | deny    | object |          | Deny is the set of conditions evaluated to deny access. Deny takes priority over allow. |
 | options | object |          | Options is for OpenSSH options like agent forwarding.                                   |
-
 
 #### spec.allow
 
@@ -1076,7 +1005,6 @@ Allow is the set of conditions evaluated to grant access.
 | windows_desktop_labels | map of string arrays |          |                                                                                                                                 |
 | windows_desktop_logins | array of strings     |          | WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.                                      |
 
-
 ##### spec.allow.impersonate
 
 Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.
@@ -1086,7 +1014,6 @@ Impersonate specifies what users and roles this role is allowed to impersonate b
 | roles | array of strings |          | Roles is a list of resources this role is allowed to impersonate                                               |
 | users | array of strings |          | Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern |
 | where | string           |          | Where specifies optional advanced matcher                                                                      |
-
 
 ##### spec.allow.join_sessions
 
@@ -1099,7 +1026,6 @@ JoinSessions specifies policies to allow users to join other sessions.
 | name  | string           |          | Name is the name of the policy.                                 |
 | roles | array of strings |          | Roles is a list of roles that you can join the session of.      |
 
-
 ##### spec.allow.kubernetes_resources
 
 KubernetesResources is the Kubernetes Resources this Role grants access to.
@@ -1110,10 +1036,7 @@ KubernetesResources is the Kubernetes Resources this Role grants access to.
 | name      | string |          | Name is the resource name. It supports wildcards.                                           |
 | namespace | string |          | Namespace is the resource namespace. It supports wildcards.                                 |
 
-
 ##### spec.allow.request
-
-
 
 |        Name         |         Type         | Required |                                                                                                                    Description                                                                                                                    |
 |---------------------|----------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1123,7 +1046,6 @@ KubernetesResources is the Kubernetes Resources this Role grants access to.
 | search_as_roles     | array of strings     |          | SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request. |
 | suggested_reviewers | array of strings     |          | SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.                                                                                                                            |
 | thresholds          | object               |          | Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.                                        |
-
 
 ###### spec.allow.request.claims_to_roles
 
@@ -1135,7 +1057,6 @@ ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.
 | roles | array of strings |          | Roles is a list of static teleport roles to match. |
 | value | string           |          | Value is a claim value to match.                   |
 
-
 ###### spec.allow.request.thresholds
 
 Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.
@@ -1146,7 +1067,6 @@ Thresholds is a list of thresholds, one of which must be met in order for review
 | deny    | number |          | Deny is the number of denials needed for state-transition.                                   |
 | filter  | string |          | Filter is an optional predicate used to determine which reviews count toward this threshold. |
 | name    | string |          | Name is the optional human-readable name of the threshold.                                   |
-
 
 ##### spec.allow.require_session_join
 
@@ -1161,7 +1081,6 @@ RequireSessionJoin specifies policies for required users to start a session.
 | name     | string           |          | Name is the name of the policy.                                                                     |
 | on_leave | string           |          | OnLeave is the behaviour that&#39;s used when the policy is no longer fulfilled for a live session. |
 
-
 ##### spec.allow.review_requests
 
 ReviewRequests defines conditions for submitting access reviews.
@@ -1173,7 +1092,6 @@ ReviewRequests defines conditions for submitting access reviews.
 | roles            | array of strings |          | Roles is the name of roles which may be reviewed.                                                                                                                                                                     |
 | where            | string           |          | Where is an optional predicate which further limits which requests are reviewable.                                                                                                                                    |
 
-
 ###### spec.allow.review_requests.claims_to_roles
 
 ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.
@@ -1183,7 +1101,6 @@ ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.
 | claim | string           |          | Claim is a claim name.                             |
 | roles | array of strings |          | Roles is a list of static teleport roles to match. |
 | value | string           |          | Value is a claim value to match.                   |
-
 
 ##### spec.allow.rules
 
@@ -1195,7 +1112,6 @@ Rules is a list of rules and their access levels. Rules are a high level constru
 | resources | array of strings |          | Resources is a list of resources                                |
 | verbs     | array of strings |          | Verbs is a list of verbs                                        |
 | where     | string           |          | Where specifies optional advanced matcher                       |
-
 
 #### spec.deny
 
@@ -1229,7 +1145,6 @@ Deny is the set of conditions evaluated to deny access. Deny takes priority over
 | windows_desktop_labels | map of string arrays |          |                                                                                                                                 |
 | windows_desktop_logins | array of strings     |          | WindowsDesktopLogins is a list of desktop login names allowed/denied for Windows desktops.                                      |
 
-
 ##### spec.deny.impersonate
 
 Impersonate specifies what users and roles this role is allowed to impersonate by issuing certificates or other possible means.
@@ -1239,7 +1154,6 @@ Impersonate specifies what users and roles this role is allowed to impersonate b
 | roles | array of strings |          | Roles is a list of resources this role is allowed to impersonate                                               |
 | users | array of strings |          | Users is a list of resources this role is allowed to impersonate, could be an empty list or a Wildcard pattern |
 | where | string           |          | Where specifies optional advanced matcher                                                                      |
-
 
 ##### spec.deny.join_sessions
 
@@ -1252,7 +1166,6 @@ JoinSessions specifies policies to allow users to join other sessions.
 | name  | string           |          | Name is the name of the policy.                                 |
 | roles | array of strings |          | Roles is a list of roles that you can join the session of.      |
 
-
 ##### spec.deny.kubernetes_resources
 
 KubernetesResources is the Kubernetes Resources this Role grants access to.
@@ -1263,10 +1176,7 @@ KubernetesResources is the Kubernetes Resources this Role grants access to.
 | name      | string |          | Name is the resource name. It supports wildcards.                                           |
 | namespace | string |          | Namespace is the resource namespace. It supports wildcards.                                 |
 
-
 ##### spec.deny.request
-
-
 
 |        Name         |         Type         | Required |                                                                                                                    Description                                                                                                                    |
 |---------------------|----------------------|----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -1276,7 +1186,6 @@ KubernetesResources is the Kubernetes Resources this Role grants access to.
 | search_as_roles     | array of strings     |          | SearchAsRoles is a list of extra roles which should apply to a user while they are searching for resources as part of a Resource Access Request, and defines the underlying roles which will be requested as part of any Resource Access Request. |
 | suggested_reviewers | array of strings     |          | SuggestedReviewers is a list of reviewer suggestions.  These can be teleport usernames, but that is not a requirement.                                                                                                                            |
 | thresholds          | object               |          | Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.                                        |
-
 
 ###### spec.deny.request.claims_to_roles
 
@@ -1288,7 +1197,6 @@ ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.
 | roles | array of strings |          | Roles is a list of static teleport roles to match. |
 | value | string           |          | Value is a claim value to match.                   |
 
-
 ###### spec.deny.request.thresholds
 
 Thresholds is a list of thresholds, one of which must be met in order for reviews to trigger a state-transition.  If no thresholds are provided, a default threshold of 1 for approval and denial is used.
@@ -1299,7 +1207,6 @@ Thresholds is a list of thresholds, one of which must be met in order for review
 | deny    | number |          | Deny is the number of denials needed for state-transition.                                   |
 | filter  | string |          | Filter is an optional predicate used to determine which reviews count toward this threshold. |
 | name    | string |          | Name is the optional human-readable name of the threshold.                                   |
-
 
 ##### spec.deny.require_session_join
 
@@ -1314,7 +1221,6 @@ RequireSessionJoin specifies policies for required users to start a session.
 | name     | string           |          | Name is the name of the policy.                                                                     |
 | on_leave | string           |          | OnLeave is the behaviour that&#39;s used when the policy is no longer fulfilled for a live session. |
 
-
 ##### spec.deny.review_requests
 
 ReviewRequests defines conditions for submitting access reviews.
@@ -1326,7 +1232,6 @@ ReviewRequests defines conditions for submitting access reviews.
 | roles            | array of strings |          | Roles is the name of roles which may be reviewed.                                                                                                                                                                     |
 | where            | string           |          | Where is an optional predicate which further limits which requests are reviewable.                                                                                                                                    |
 
-
 ###### spec.deny.review_requests.claims_to_roles
 
 ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.
@@ -1336,7 +1241,6 @@ ClaimsToRoles specifies a mapping from claims (traits) to teleport roles.
 | claim | string           |          | Claim is a claim name.                             |
 | roles | array of strings |          | Roles is a list of static teleport roles to match. |
 | value | string           |          | Value is a claim value to match.                   |
-
 
 ##### spec.deny.rules
 
@@ -1348,7 +1252,6 @@ Rules is a list of rules and their access levels. Rules are a high level constru
 | resources | array of strings |          | Resources is a list of resources                                |
 | verbs     | array of strings |          | Verbs is a list of verbs                                        |
 | where     | string           |          | Where specifies optional advanced matcher                       |
-
 
 #### spec.options
 
@@ -1381,7 +1284,6 @@ Options is for OpenSSH options like agent forwarding.
 | require_mfa_type           | number           |          | RequireMFAType is the type of MFA requirement enforced for this user.                                                                                                      |
 | ssh_file_copy              | bool             |          |                                                                                                                                                                            |
 
-
 ##### spec.options.cert_extensions
 
 CertExtensions specifies the key/values
@@ -1393,7 +1295,6 @@ CertExtensions specifies the key/values
 | type  | number |          | Type represents the certificate type being extended, only ssh is supported at this time. |
 | value | string |          | Value specifies the valueg to be used in the cert extension.                             |
 
-
 ##### spec.options.idp
 
 IDP is a set of options related to accessing IdPs within Teleport. Requires Teleport Enterprise.
@@ -1402,7 +1303,6 @@ IDP is a set of options related to accessing IdPs within Teleport. Requires Tele
 |------|--------|----------|----------------------------------------------------|
 | saml | object |          | SAML are options related to the Teleport SAML IdP. |
 
-
 ###### spec.options.idp.saml
 
 SAML are options related to the Teleport SAML IdP.
@@ -1410,7 +1310,6 @@ SAML are options related to the Teleport SAML IdP.
 |  Name   | Type | Required | Description |
 |---------|------|----------|-------------|
 | enabled | bool |          |             |
-
 
 ##### spec.options.record_session
 
@@ -1421,7 +1320,6 @@ RecordDesktopSession indicates whether desktop access sessions should be recorde
 | default | string |          | Default indicates the default value for the services. |
 | desktop | bool   |          |                                                       |
 | ssh     | string |          | SSH indicates the session mode used on SSH sessions.  |
-
 
 Example:
 
@@ -1487,7 +1385,6 @@ resource "teleport_role" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources. |
 | version  | string |          | Version is a resource version.                                    |
 
-
 ### metadata
 
 Metadata holds resource metadata.
@@ -1499,7 +1396,6 @@ Metadata holds resource metadata.
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -1522,7 +1418,6 @@ Spec is an SAML connector specification.
 | signing_key_pair        | object |          | SigningKeyPair is an x509 key pair used to sign AuthnRequest.                                                                                                     |
 | sso                     | string |          | SSO is the URL of the identity provider&#39;s SSO service.                                                                                                        |
 
-
 #### spec.assertion_key_pair
 
 EncryptionKeyPair is a key pair used for decrypting SAML assertions.
@@ -1531,7 +1426,6 @@ EncryptionKeyPair is a key pair used for decrypting SAML assertions.
 |-------------|--------|----------|-----------------------------------------------|
 | cert        | string |          | Cert is a PEM-encoded x509 certificate.       |
 | private_key | string |          | PrivateKey is a PEM encoded x509 private key. |
-
 
 #### spec.attributes_to_roles
 
@@ -1543,7 +1437,6 @@ AttributesToRoles is a list of mappings of attribute statements to roles.
 | roles | array of strings |          | Roles is a list of static teleport roles to map to. |
 | value | string           |          | Value is an attribute statement value to match.     |
 
-
 #### spec.signing_key_pair
 
 SigningKeyPair is an x509 key pair used to sign AuthnRequest.
@@ -1552,7 +1445,6 @@ SigningKeyPair is an x509 key pair used to sign AuthnRequest.
 |-------------|--------|----------|-----------------------------------------------|
 | cert        | string |          | Cert is a PEM-encoded x509 certificate.       |
 | private_key | string |          | PrivateKey is a PEM encoded x509 private key. |
-
 
 Example:
 
@@ -1611,7 +1503,6 @@ resource "teleport_saml_connector" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources |
 | version  | string |          | Version is a resource version                                    |
 
-
 ### metadata
 
 Metadata is resource metadata
@@ -1623,7 +1514,6 @@ Metadata is resource metadata
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
 
-
 ### spec
 
 Spec is a SessionRecordingConfig specification
@@ -1632,7 +1522,6 @@ Spec is a SessionRecordingConfig specification
 |------------------------|--------|----------|------------------------------------------------------|
 | mode                   | string |          | Mode controls where (or if) the session is recorded. |
 | proxy_checks_host_keys | bool   |          |                                                      |
-
 
 Example:
 
@@ -1663,7 +1552,6 @@ resource "teleport_session_recording_config" "example" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources. |
 | version  | string |          | Version is a resource version.                                    |
 
-
 ### metadata
 
 Metadata holds resource metadata.
@@ -1675,7 +1563,6 @@ Metadata holds resource metadata.
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -1690,7 +1577,6 @@ Spec is a Trusted Cluster specification.
 | tunnel_addr    | string           |          | ReverseTunnelAddress is the address of the SSH proxy server of the cluster to join. If not set, it is derived from &lt;metadata.name&gt;:&lt;default reverse tunnel port&gt;.       |
 | web_proxy_addr | string           |          | ProxyAddress is the address of the web proxy server of the cluster to join. If not set, it is derived from &lt;metadata.name&gt;:&lt;default web proxy server port&gt;.             |
 
-
 #### spec.role_map
 
 RoleMap specifies role mappings to remote roles.
@@ -1699,7 +1585,6 @@ RoleMap specifies role mappings to remote roles.
 |--------|------------------|----------|-----------------------------------------------|
 | local  | array of strings |          | Local specifies local roles to map to         |
 | remote | string           |          | Remote specifies remote role name to map from |
-
 
 Example:
 
@@ -1738,7 +1623,6 @@ resource "teleport_trusted_cluster" "cluster" {
 | sub_kind | string |          | SubKind is an optional resource sub kind, used in some resources |
 | version  | string |          | Version is version                                               |
 
-
 ### metadata
 
 Metadata is resource metadata
@@ -1750,7 +1634,6 @@ Metadata is resource metadata
 | labels      | map of strings |          | Labels is a set of labels                                                                                      |
 | name        | string         | *        | Name is an object name                                                                                         |
 | namespace   | string         |          | Namespace is object namespace. The field should be called &#34;namespace&#34; when it returns in Teleport 2.4. |
-
 
 ### spec
 
@@ -1764,7 +1647,6 @@ Spec is a user specification
 | saml_identities   | object               |          | SAMLIdentities lists associated SAML identities that let user log in using externally verified identity           |
 | traits            | map of string arrays |          |                                                                                                                   |
 
-
 #### spec.github_identities
 
 GithubIdentities list associated Github OAuth2 identities that let user log in using externally verified identity
@@ -1773,7 +1655,6 @@ GithubIdentities list associated Github OAuth2 identities that let user log in u
 |--------------|--------|----------|-----------------------------------------------------------------------------------|
 | connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. &#39;google-example.com&#39; |
 | username     | string |          | Username is username supplied by external identity provider                       |
-
 
 #### spec.oidc_identities
 
@@ -1784,7 +1665,6 @@ OIDCIdentities lists associated OpenID Connect identities that let user log in u
 | connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. &#39;google-example.com&#39; |
 | username     | string |          | Username is username supplied by external identity provider                       |
 
-
 #### spec.saml_identities
 
 SAMLIdentities lists associated SAML identities that let user log in using externally verified identity
@@ -1793,7 +1673,6 @@ SAMLIdentities lists associated SAML identities that let user log in using exter
 |--------------|--------|----------|-----------------------------------------------------------------------------------|
 | connector_id | string |          | ConnectorID is id of registered OIDC connector, e.g. &#39;google-example.com&#39; |
 | username     | string |          | Username is username supplied by external identity provider                       |
-
 
 Example:
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -207,7 +207,6 @@ Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 In this example, `tele-admin` is now logged into the `tele.example.com` cluster
 through Teleport SSH.
 
-
 </ScopedBlock>
 <ScopedBlock scope={["cloud"]}>
 

--- a/docs/pages/server-access/guides/ec2-discovery.mdx
+++ b/docs/pages/server-access/guides/ec2-discovery.mdx
@@ -220,7 +220,6 @@ mainSteps:
     runCommand:
       - /bin/sh /tmp/installTeleport.sh "{{ token }}"
 
-
 4. Attach IAM policies to "yourUser-discovery-role".
 
 Confirm? [y/N]: y

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -15,7 +15,6 @@ when gradually transitioning large server fleets to Teleport.
   ![Teleport OpenSSH Recording Proxy](../../../img/server-access/openssh-proxy.svg)
 </Figure>
 
-
 <ScopedBlock scope={["cloud"]}>
 
 Teleport Cloud only supports session recording at the Node level. If you are

--- a/docs/pages/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/server-access/guides/ssh-pam.mdx
@@ -175,7 +175,6 @@ $ cat /etc/motd
   ![Teleport SSH with updated MOTD](../../../img/motd/teleport-with-updated-MOTD.png)
 </Figure>
 
-
 ## Create local Unix users on login
 
 Teleport has the ability to create local Unix users on login. This is
@@ -239,7 +238,6 @@ identity information.
   ```
 
 </Admonition>
-
 
 Next, update `/etc/teleport.yaml` to call the above PAM stack by both enabling PAM and
 setting the service_name.

--- a/docs/pages/server-access/guides/vscode.mdx
+++ b/docs/pages/server-access/guides/vscode.mdx
@@ -24,7 +24,6 @@ older clients can use `ssh.exe` from either [Git for Windows][git] or
 Microsoft's [Win32-OpenSSH project][win32-openssh].
 </Admonition>
 
-
 ## Step 1/3. First-time setup
 
 Configure your local SSH client to access Teleport Nodes, assigning the `--proxy` flag to the address of your Teleport Proxy Service (e.g., `mytenant.teleport.sh` for Teleport Cloud users).
@@ -36,7 +35,6 @@ $ tsh login --proxy proxy.foo.example.com --user alice
 # generate the OpenSSH config for the proxy:
 $ tsh config --proxy proxy.foo.example.com
 ```
-
 
 Append the resulting configuration snippet into your SSH config file located
 in the path below:

--- a/docs/pages/try-out-teleport/digitalocean.mdx
+++ b/docs/pages/try-out-teleport/digitalocean.mdx
@@ -29,7 +29,6 @@ Head over to the Teleport page on [DigitalOcean Marketplace](https://marketplace
   ![Teleport 1-Click droplet page](../../img/quickstart/digitalocean/1click-droplet-page.png)
 </Figure>
 
-
 Once you click the button, DigitalOcean redirects you to the control panel to configure resources for the Teleport droplet. This step is similar to how you create a regular [droplet in DigitalOcean](https://docs.digitalocean.com/products/droplets/how-to/create/). Teleport is very lightweight, and if you are just trying out Teleport, you can select the $5 droplet. Make sure you select "SSH keys" as the SSH authentication method as it is more secure than a password.
 <Figure align="left" bordered caption="Create a droplet">
   ![Create a droplet](../../img/quickstart/digitalocean/create-droplet.png)
@@ -88,13 +87,11 @@ Open the link copied in the previous step in the browser to complete the setup p
   ![Set up user](../../img/quickstart/digitalocean/setup-user.png)
 </Figure>
 
-
 Once you set up a password and provide a valid TOTP code, the user setup process will be complete, and you will be redirected to Teleport Web UI:
 
 <Figure align="left" bordered caption="Teleport Web UI">
   ![Teleport Web UI](../../img/quickstart/digitalocean/webui.png)
 </Figure>
-
 
 Congrats! You've completed setting up Teleport.
 


### PR DESCRIPTION
This is a cleanup PR for the docs. It removes every instance of multiple newlines in the docs, which is never necessary. 