### PR TITLE
docs: update service description to default

### DIFF
--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -149,7 +149,7 @@ app_service:
 
 ### Start Teleport
 
-(!docs/pages/includes/start-teleport.mdx service="the Teleport SSH Service"!)
+(!docs/pages/includes/start-teleport.mdx!)
 
 You can access Teleport's Web UI via HTTPS at the domain you created earlier
 (e.g., `https://teleport.example.com`). You should see a welcome screen similar


### PR DESCRIPTION
the description should be the default, not specific to SSH. will apply to backports for #24248