### PR TITLE
fix protocol name for elasticsearch guide

### DIFF
--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -51,7 +51,7 @@ $ teleport db start \
   --token=/tmp/token \
   --auth-server=teleport.example.com:3080 \
   --name=myelastic \
-  --protocol=elastic \
+  --protocol=elasticsearch \
   --uri=elasticsearch.example.com:9200 \
   --labels=env=dev
 ```
@@ -64,7 +64,7 @@ $ teleport db start \
   --token=/tmp/token \
   --auth-server=mytennant.teleport.sh:443 \
   --name=myelastic \
-  --protocol=elastic \
+  --protocol=elasticsearch \
   --uri=elasticsearch.example.com:9200 \
   --labels=env=dev
 ```


### PR DESCRIPTION
This is a tiny docs only PR.

The correct protocol with `teleport db start/configure` is "elasticsearch".

The guide step's example command leads to this error:
```
$ teleport db start \
        --token=/tmp/token \
        --auth-server=teleport.example.com:3080 \
        --name=myelastic \
        --protocol=elastic \
        --uri=elasticsearch.example.com:9200 \
        --labels=env=dev
ERROR: unsupported database "myelastic" protocol "elastic", supported are: [postgres mysql mongodb oracle cockroachdb redis snowflake sqlserver cassandra elasticsearch dynamodb]
```