### PR TITLE
Plugins: do not retry CAS for deleted requests that were resolved

### DIFF
--- a/integrations/access/common/app.go
+++ b/integrations/access/common/app.go
@@ -419,7 +419,7 @@ func (a *BaseApp) updateMessages(ctx context.Context, reqID string, tag pd.Resol
 
 		// If resolution field is not empty then we already resolved the incident before. In this case we just quit.
 		if existing.AccessRequestData.ResolutionTag != pd.Unresolved {
-			return GenericPluginData{}, trace.CompareFailed("request is already resolved")
+			return existing, nil
 		}
 
 		// Mark plugin data as resolved.


### PR DESCRIPTION
Currently when processing a deleted access request, if it already has a resolution set (e.g. approved/denied), we return `trace.CompareFailed`, which makes the CAS logic needlessly retry the operation, when in reality we don't have to update anything. This is evident from the logs:

```
{
  "caller": "common/app.go:164",
  "component": null,
  "error": "request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, request is already resolved, context deadline exceeded",
  "level": "error",
  "message": "Failed to process deleted request",
  "request_id": "74f66b6a-553c-4ff5-9efa-d6245b03dcad",
  "request_op": "delete",
  "timestamp": "2023-04-07T07:21:46Z"
}
```

This changes it to "update" the object with the same content instead (no-op). Judging from the comment ("In this case we just quit."), it was always the intention to not retry in this case.