### PR TITLE
User friendly error messages on config and bootstrap files that don't exist

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1805,7 +1805,7 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 
 	if clf.BootstrapFile != "" {
 		if !utils.FileExists(clf.BootstrapFile) {
-			return trace.NotFound("failed to bootstrap cluster configuration: bootstrap file specified '%s' does not exist", clf.BootstrapFile)
+			return trace.NotFound("failed to bootstrap cluster configuration: file %q does not exist", clf.BootstrapFile)
 		}
 		resources, err := ReadResources(clf.BootstrapFile)
 		if err != nil {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -209,9 +209,6 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 
 // ReadResources loads a set of resources from a file.
 func ReadResources(filePath string) ([]types.Resource, error) {
-	if !utils.FileExists(filePath) {
-		return nil, trace.NotFound("failed to bootstrap cluster configuration: bootstrap file specified '%s' does not exist", filePath)
-	}
 	reader, err := utils.OpenFile(filePath)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1807,6 +1804,9 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 	}
 
 	if clf.BootstrapFile != "" {
+		if !utils.FileExists(clf.BootstrapFile) {
+			return trace.NotFound("failed to bootstrap cluster configuration: bootstrap file specified '%s' does not exist", clf.BootstrapFile)
+		}
 		resources, err := ReadResources(clf.BootstrapFile)
 		if err != nil {
 			return trace.Wrap(err)
@@ -1818,6 +1818,9 @@ func Configure(clf *CommandLineFlags, cfg *servicecfg.Config, legacyAppFlags boo
 	}
 
 	if clf.ApplyOnStartupFile != "" {
+		if !utils.FileExists(clf.ApplyOnStartupFile) {
+			return trace.NotFound("failed to bootstrap cluster configuration: apply on startup file specified '%s' does not exist", clf.ApplyOnStartupFile)
+		}
 		resources, err := ReadResources(clf.ApplyOnStartupFile)
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -195,7 +195,7 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 	if cliConfigPath != "" {
 		configFilePath = cliConfigPath
 		if !utils.FileExists(configFilePath) {
-			return nil, trace.BadParameter("failed to load configuration: configuration file specified '%s' does not exist", configFilePath)
+			return nil, trace.NotFound("failed to load configuration: configuration file specified '%s' does not exist", configFilePath)
 		}
 	}
 	// default config doesn't exist? quietly return:
@@ -210,7 +210,7 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 // ReadResources loads a set of resources from a file.
 func ReadResources(filePath string) ([]types.Resource, error) {
 	if !utils.FileExists(filePath) {
-		return nil, trace.BadParameter("failed to bootstrap cluster configuration: bootstrap file specified '%s' does not exist", filePath)
+		return nil, trace.NotFound("failed to bootstrap cluster configuration: bootstrap file specified '%s' does not exist", filePath)
 	}
 	reader, err := utils.OpenFile(filePath)
 	if err != nil {

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -195,7 +195,7 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 	if cliConfigPath != "" {
 		configFilePath = cliConfigPath
 		if !utils.FileExists(configFilePath) {
-			return nil, trace.NotFound("file %s is not found", configFilePath)
+			return nil, trace.BadParameter("failed to load configuration: configuration file specified '%s' does not exist", configFilePath)
 		}
 	}
 	// default config doesn't exist? quietly return:
@@ -209,6 +209,9 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 
 // ReadResources loads a set of resources from a file.
 func ReadResources(filePath string) ([]types.Resource, error) {
+	if !utils.FileExists(filePath) {
+		return nil, trace.BadParameter("failed to bootstrap cluster configuration: bootstrap file specified '%s' does not exist", filePath)
+	}
 	reader, err := utils.OpenFile(filePath)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -195,7 +195,7 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 	if cliConfigPath != "" {
 		configFilePath = cliConfigPath
 		if !utils.FileExists(configFilePath) {
-			return nil, trace.NotFound("failed to load configuration: configuration file specified '%s' does not exist", configFilePath)
+			return nil, trace.NotFound("failed to load configuration: file %q does not exist", configFilePath)
 		}
 	}
 	// default config doesn't exist? quietly return:

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -142,12 +142,12 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		StringVar(&ccf.NodeName)
 	start.Flag("config",
 		fmt.Sprintf("Path to a configuration file [%v]", defaults.ConfigFilePath)).
-		Short('c').ExistingFileVar(&ccf.ConfigFile)
+		Short('c').StringVar(&ccf.ConfigFile)
 	start.Flag("apply-on-startup",
 		fmt.Sprintf("Path to a non-empty YAML file containing resources to apply on startup. Works on initialized clusters, unlike --bootstrap. Only supports the following types: %s.", types.KindToken)).
-		ExistingFileVar(&ccf.ApplyOnStartupFile)
+		StringVar(&ccf.ApplyOnStartupFile)
 	start.Flag("bootstrap",
-		"Path to a non-empty YAML file containing bootstrap resources (ignored if already initialized)").ExistingFileVar(&ccf.BootstrapFile)
+		"Path to a non-empty YAML file containing bootstrap resources (ignored if already initialized)").StringVar(&ccf.BootstrapFile)
 	start.Flag("config-string",
 		"Base64 encoded configuration string").Hidden().Envar(defaults.ConfigEnvar).
 		StringVar(&ccf.ConfigString)


### PR DESCRIPTION
Addresses #6477. Provides non-generic error messages when config or bootstrap files specified do not exist.

From

```bash
$ teleport start -c config
# full teleport help ....
ERROR: path 'config' does not exist

$ teleport start --bootstrap file
# full teleport help...
ERROR: path 'file' does not exist
```

to

```bash
$ teleport start -c config
ERROR: failed to load configuration: configuration file specified 'config' does not exist

$ teleport start --bootstrap file
ERROR: failed to bootstrap cluster configuration: bootstrap file specified 'file' does not exist
```



