### PR TITLE
Create a partial for Event Handler role/user

### DIFF
--- a/docs/pages/includes/plugins/event-handler-role-user.mdx
+++ b/docs/pages/includes/plugins/event-handler-role-user.mdx
@@ -1,0 +1,32 @@
+The `teleport-event-handler configure` command generated a file called
+`teleport-event-handler-role.yaml`. This file defines a `teleport-event-handler`
+role and a user with read-only access to the `event` API:
+
+```yaml
+kind: role
+metadata:
+  name: teleport-event-handler
+spec:
+  allow:
+    rules:
+      - resources: ['event', 'session']
+        verbs: ['list','read']
+version: v5
+---
+kind: user
+metadata:
+  name: teleport-event-handler
+spec:
+  roles: ['teleport-event-handler']
+version: v2
+```
+
+Move this file to your workstation (or recreate it by pasting the snippet above)
+and use `tctl` on your workstation to create the role and the user:
+
+```code
+$ tctl create -f teleport-event-handler-role.yaml
+# user "teleport-event-handler" has been created
+# role 'teleport-event-handler' has been created
+```
+

--- a/docs/pages/management/export-audit-events/datadog.mdx
+++ b/docs/pages/management/export-audit-events/datadog.mdx
@@ -78,36 +78,7 @@ from Teleport's events API, and forwards them to Fluentd.
 
 ## Step 3/6. Create a user and role for reading audit events
 
-The `configure` command generates a file called `teleport-event-handler-role.yaml`
-that defines a `teleport-event-handler` role and a user with read-only access
-to the `event` API:
-
-```yaml
-kind: role
-metadata:
-  name: teleport-event-handler
-spec:
-  allow:
-    rules:
-      - resources: ['event']
-        verbs: ['list','read']
-version: v5
----
-kind: user
-metadata:
-  name: teleport-event-handler
-spec:
-  roles: ['teleport-event-handler']
-version: v2
-```
-
-Use `tctl` to create the role and the user:
-
-```code
-$ tctl create -f teleport-event-handler-role.yaml
-# user "teleport-event-handler" has been created
-# role 'teleport-event-handler' has been created
-```
+(!docs/pages/includes/plugins/event-handler-role-user.mdx!)
 
 ## Step 4/6. Create teleport-event-handler credentials
 

--- a/docs/pages/management/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/management/export-audit-events/elastic-stack.mdx
@@ -57,36 +57,7 @@ We'll re-purpose the files generated for Fluentd in our Logstash configuration.
 
 ### Define RBAC resources
 
-The `teleport-event-handler configure` command generated a file called
-`teleport-event-handler-role.yaml`. This file defines a `teleport-event-handler`
-role and a user with read-only access to the `event` API:
-
-```yaml
-kind: role
-metadata:
-  name: teleport-event-handler
-spec:
-  allow:
-    rules:
-      - resources: ['event', 'session']
-        verbs: ['list','read']
-version: v5
----
-kind: user
-metadata:
-  name: teleport-event-handler
-spec:
-  roles: ['teleport-event-handler']
-version: v2
-```
-
-Use `tctl` to create the role and the user:
-
-```code
-$ tctl create -f teleport-event-handler-role.yaml
-# user "teleport-event-handler" has been created
-# role 'teleport-event-handler' has been created
-```
+(!docs/pages/includes/plugins/event-handler-role-user.mdx!)
 
 <Details title="Using tctl on the Logstash host?">
 

--- a/docs/pages/management/export-audit-events/fluentd.mdx
+++ b/docs/pages/management/export-audit-events/fluentd.mdx
@@ -72,36 +72,7 @@ key from the same certificate authority for the Teleport Event Handler to use.
 
 ## Step 3/6. Create a user and role for reading audit events
 
-The `configure` command generates a file called `teleport-event-handler-role.yaml`
-that defines a `teleport-event-handler` role and a user with read-only access to
-the `event` API:
-
-```yaml
-kind: user
-metadata:
-  name: teleport-event-handler
-spec:
-  roles: ['teleport-event-handler']
-version: v2
----
-kind: role
-metadata:
-  name: teleport-event-handler
-spec:
-  allow:
-    rules:
-      - resources: ['event']
-        verbs: ['list','read']
-version: v5
-```
-
-Use `tctl` to create the role and the user:
-
-```code
-$ tctl create -f teleport-event-handler-role.yaml
-user 'teleport-event-handler' has been created
-role 'teleport-event-handler' has been created
-```
+(!docs/pages/includes/plugins/event-handler-role-user.mdx!)
 
 ## Step 4/6. Create teleport-event-handler credentials
 

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -65,37 +65,7 @@ We'll re-purpose the files generated for Fluentd in our Universal Forwarder conf
 
 ### Define RBAC resources
 
-The `teleport-event-handler configure` command generated a file called
-`teleport-event-handler-role.yaml`. This file defines a `teleport-event-handler`
-role and a user with read-only access to the `event` API:
-
-```yaml
-kind: role
-metadata:
-  name: teleport-event-handler
-spec:
-  allow:
-    rules:
-      - resources: ['event', 'session']
-        verbs: ['list','read']
-version: v5
----
-kind: user
-metadata:
-  name: teleport-event-handler
-spec:
-  roles: ['teleport-event-handler']
-version: v2
-```
-
-Move this file to your workstation (or recreate it by pasting the snippet above)
-and use `tctl` on your workstation to create the role and the user:
-
-```code
-$ tctl create -f teleport-event-handler-role.yaml
-# user "teleport-event-handler" has been created
-# role 'teleport-event-handler' has been created
-```
+(!docs/pages/includes/plugins/event-handler-role-user.mdx!)
 
 ### Enable impersonation of the Teleport Event Handler plugin user
 


### PR DESCRIPTION
Fixes #22243

This way, we can include consistent instructions across the Event Handler guides, and users won't see `role not found` errors.