### PR TITLE
Convert `tsh ls` to use cluster client

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2172,30 +2172,38 @@ func isRemoteDest(name string) bool {
 	return strings.ContainsRune(name, ':')
 }
 
-// ListNodesWithFilters returns a list of nodes connected to a proxy
+// ListNodesWithFilters returns all nodes that match the filters in the current cluster
+// that the logged in user has access to.
 func (tc *TeleportClient) ListNodesWithFilters(ctx context.Context) ([]types.Server, error) {
+	req := tc.DefaultResourceFilter()
+	req.ResourceType = types.KindNode
+
 	ctx, span := tc.Tracer.Start(
 		ctx,
 		"teleportClient/ListNodesWithFilters",
 		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
+		oteltrace.WithAttributes(
+			attribute.String("resource", req.ResourceType),
+			attribute.Int("limit", int(req.Limit)),
+			attribute.String("predicate", req.PredicateExpression),
+			attribute.StringSlice("keywords", req.SearchKeywords),
+		),
 	)
 	defer span.End()
 
-	// connect to the proxy and ask it to return a full list of servers
-	proxyClient, err := tc.ConnectToProxy(ctx)
+	clt, err := tc.ConnectToCluster(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer proxyClient.Close()
+	defer clt.Close()
 
-	filter := tc.DefaultResourceFilter()
-	filter.ResourceType = types.KindNode
-	servers, err := proxyClient.FindNodesByFilters(ctx, *filter)
+	resources, err := client.GetResourcesWithFilters(ctx, clt.AuthClient, *req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return servers, nil
+	servers, err := types.ResourcesWithLabels(resources).AsServers()
+	return servers, trace.Wrap(err)
 }
 
 // GetClusterAlerts returns a list of matching alerts from the current cluster.
@@ -2495,15 +2503,22 @@ func (tc *TeleportClient) ListAllNodes(ctx context.Context) ([]types.Server, err
 	)
 	defer span.End()
 
-	proxyClient, err := tc.ConnectToProxy(ctx)
+	clt, err := tc.ConnectToCluster(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	defer proxyClient.Close()
+	defer clt.Close()
 
-	return proxyClient.FindNodesByFilters(ctx, proto.ListResourcesRequest{
-		Namespace: tc.Namespace,
+	resources, err := client.GetResourcesWithFilters(ctx, clt.AuthClient, proto.ListResourcesRequest{
+		Namespace:    tc.Namespace,
+		ResourceType: types.KindNode,
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	servers, err := types.ResourcesWithLabels(resources).AsServers()
+	return servers, trace.Wrap(err)
 }
 
 // ListKubernetesClustersWithFiltersAllClusters returns a map of all kube clusters in all clusters connected to a proxy.
@@ -2796,7 +2811,14 @@ func (tc *TeleportClient) ConnectToCluster(ctx context.Context) (*ClusterClient,
 		return nil, trace.Wrap(err)
 	}
 
-	aclt, err := auth.NewClient(pclt.ClientConfig(ctx, pclt.ClusterName()))
+	cluster := tc.SiteName
+	connected := pclt.ClusterName()
+	root, err := tc.rootClusterName()
+	if err == nil && len(tc.JumpHosts) > 0 && connected != root {
+		cluster = connected
+	}
+
+	aclt, err := auth.NewClient(pclt.ClientConfig(ctx, cluster))
 	if err != nil {
 		return nil, trace.NewAggregate(err, pclt.Close())
 	}
@@ -2806,6 +2828,7 @@ func (tc *TeleportClient) ConnectToCluster(ctx context.Context) (*ClusterClient,
 		ProxyClient: pclt,
 		AuthClient:  aclt,
 		Tracer:      tc.Tracer,
+		cluster:     cluster,
 	}, nil
 }
 

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -748,25 +748,6 @@ func (proxy *ProxyClient) NewWatcher(ctx context.Context, watch types.Watch) (ty
 	return watcher, nil
 }
 
-// FindNodesByFilters returns list of the nodes which have filters matched.
-func (proxy *ProxyClient) FindNodesByFilters(ctx context.Context, req proto.ListResourcesRequest) ([]types.Server, error) {
-	ctx, span := proxy.Tracer.Start(
-		ctx,
-		"proxyClient/FindNodesByFilters",
-		oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-		oteltrace.WithAttributes(
-			attribute.String("resource", req.ResourceType),
-			attribute.Int("limit", int(req.Limit)),
-			attribute.String("predicate", req.PredicateExpression),
-			attribute.StringSlice("keywords", req.SearchKeywords),
-		),
-	)
-	defer span.End()
-
-	servers, err := proxy.FindNodesByFiltersForCluster(ctx, req, proxy.siteName)
-	return servers, trace.Wrap(err)
-}
-
 func (proxy *ProxyClient) GetClusterAlerts(ctx context.Context, req types.GetClusterAlertsRequest) ([]types.ClusterAlert, error) {
 	ctx, span := proxy.Tracer.Start(
 		ctx,

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -34,17 +34,13 @@ type ClusterClient struct {
 	ProxyClient *proxyclient.Client
 	AuthClient  auth.ClientI
 	Tracer      oteltrace.Tracer
+	cluster     string
 }
 
 // ClusterName returns the name of the cluster that the client
 // is connected to.
 func (c *ClusterClient) ClusterName() string {
-	cluster := c.ProxyClient.ClusterName()
-	if len(c.tc.JumpHosts) > 0 && cluster != "" {
-		return cluster
-	}
-
-	return c.tc.SiteName
+	return c.cluster
 }
 
 // Close terminates the connections to Auth and Proxy.


### PR DESCRIPTION
Migrates `tsh ls` to connect to the cluster via the new `client.ClusterClient` to help reduce latency caused by geolocation. Doing so resulted in some tests failing due to the cluster name of the client not being set correctly. The `ClusterClient` now only uses the guessed client if jump hosts were provided and the inferred cluster name is not the root cluster.