### PR TITLE
Add longer meta descriptions to high-traffic pages

### DIFF
--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teleport Role Templates
-description: Mapping SSO and Local Users Traits to Roles with Template.
+description: This guide explains templating in Teleport roles. Templates allow you to enable access to resources depending on the traits of a local or single sign-on user.
 ---
 
 As organizations grow, infrastructure teams have to figure out how to define

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Access Controls Reference Documentation
-description: Access Controls reference documentation for role options and properties.
+description: This reference shows you the configuration settings that you can include in a Teleport role, which enables you to apply access controls for your infrastructure.
 h1: Teleport Access Controls Reference
 ---
 

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Web Application Access
-description: How to configure Teleport for Application Access.
+description: In this getting started guide, learn how to connect an application to your Teleport cluster by running the Teleport Application Service.
 ---
 
 Download the latest version of Teleport for your platform from our [downloads page](https://goteleport.com/download)

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -1,6 +1,6 @@
 ---
 title: Teleport Changelog
-description: Learn about what's new, improved and fixed in Teleport.
+description: The Changelog provides a comprehensive description of the changes introduced by each Teleport release.
 ---
 
 (!CHANGELOG.md!)

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using the tsh Command Line Tool
-description: Using the tsh command line tool
+description: This reference shows you how to use Teleport's tsh tool to authenticate to a cluster, explore your infrastructure, and connect to a resource.
 ---
 
 This guide will show you how to use the Teleport client tool, `tsh`.

--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Introduction to Teleport
-description: How to install and quickly get up and running with Teleport.
+description: Teleport is an identity-aware, multi-protocol access proxy with native support for SSH, RDP, Kubernetes, and more. Get started with the Teleport documentation.
 layout: tocless-doc
 videoBanner: ki-uVTSocGE
 ---

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installing Teleport
-description: The guide for installing Teleport on servers and into Kubernetes clusters.
+description: How to install Teleport and Teleport's client tools on your platform, including binaries and instructions for Docker and Helm.
 h1: Installation
 videoBanner: VifXROQFjwg
 ---

--- a/docs/pages/management/admin/adding-nodes.mdx
+++ b/docs/pages/management/admin/adding-nodes.mdx
@@ -1,6 +1,6 @@
 ---
 title: Adding Nodes to your Cluster
-description: How to add Nodes to your Teleport cluster
+description: This guide shows you how to join a Teleport instance to your cluster in order to proxy access to resources in your infrastructure.
 ---
 
 This guide explains how to add Teleport Nodes to your cluster.

--- a/docs/pages/management/admin/self-signed-certs.mdx
+++ b/docs/pages/management/admin/self-signed-certs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Running Teleport with Self-Signed Certificates
-description: How run Teleport using self-certificates
+description: This guide shows you how to run Teleport using self-signed certificates, which is helpful for testing or demo environments.
 ---
 
 This guide explains how to evaluate Teleport in a

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -1,6 +1,6 @@
 ---
 title: Local Users
-description: Adding and deleting local users
+description: Learn how to manage local users in Teleport. Local users are stored on the Auth Service instead of a third-party identity provider.
 ---
 
 In Teleport, **local users** are users managed directly via Teleport, rather

--- a/docs/pages/management/guides/docker.mdx
+++ b/docs/pages/management/guides/docker.mdx
@@ -1,6 +1,6 @@
 ---
 title: How to Run Teleport Using Docker
-description: How to run Teleport using Docker.
+description: This guide shows you how to run Teleport as a Docker image, including a description of our available images and how to access a Teleport container.
 h1: Run Teleport using Docker
 ---
 

--- a/docs/pages/management/operations/upgrading.mdx
+++ b/docs/pages/management/operations/upgrading.mdx
@@ -1,6 +1,6 @@
 ---
 title: Upgrading a Teleport Cluster
-description: How to upgrade Teleport components
+description: This guide shows you the correct order in which to upgrade Teleport components when rolling out a new Teleport release in your cluster.
 ---
 
 In this guide, we will show you how to upgrade all of the components in your

--- a/docs/pages/reference/networking.mdx
+++ b/docs/pages/reference/networking.mdx
@@ -1,6 +1,6 @@
 ---
 title: Networking
-description: Teleport ports and networking requirements
+description: This reference explains the networking requirements of a Teleport cluster, including its public address, ports, and support for HTTP CONNECT proxies.
 ---
 
 ## Public address

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using Teleport with OpenSSH
-description: How to use Teleport on legacy systems with OpenSSH and sshd.
+description: This guide shows you how to set up Teleport to enable secure access to OpenSSH servers so you can protect legacy systems that do not run a Teleport binary.
 videoBanner: x0eYFUEIOrM
 ---
 


### PR DESCRIPTION
Longer meta descriptions lessen the likelihood that Google will automatically determine the description of a page within search results.