### PR TITLE
docs: oracle guide updates

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -992,6 +992,11 @@
                "slug": "/database-access/guides/mysql-self-hosted/"
             },
             {
+              "title": "Self-Hosted Oracle (Preview)",
+              "forScopes": ["enterprise", "cloud"],
+              "slug": "/database-access/guides/oracle-self-hosted/"
+            },
+            {
                "title": "Self-Hosted PostgreSQL",
                "slug": "/database-access/guides/postgres-self-hosted/"
             },
@@ -1002,11 +1007,6 @@
             {
                "title": "Self-Hosted Redis Cluster",
                "slug": "/database-access/guides/redis-cluster/"
-            },
-            {
-              "title": "Self-Hosted Oracle (Preview)",
-              "forScopes": ["enterprise", "cloud"],
-              "slug": "/database-access/guides/oracle-self-hosted/"
             },
             {
                "title": "Snowflake (Preview)",

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -87,7 +87,7 @@ $ tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h
 
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 
-If `tctl` finds the Orapki tool in your local environment, the `tctl auth sign --format=oracle --hostdb.example.com --out=server --ttl=2190h` command will produce an Oracle Wallet and
+If `tctl` finds the Orapki tool in your local environment, the `tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h` command will produce an Oracle Wallet and
 instructions how to configure the Oracle TCPS listener with Teleport Oracle Wallet. Otherwise the `tctl auth sign --format=oracle` command  will produce a `p12` certificate and instructions on how to create an Oracle Wallet on your Oracle Database instance.
 
 ## Step 6/7. Configure Oracle Database

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -7,6 +7,15 @@ description: How to configure Teleport Database Access with Oracle.
   Database Access for Oracle Database is currently in Preview mode.
 </Admonition>
 
+<Details
+  title="Version warning"
+  opened={true}
+  min="12.2"
+>
+Databae Access for Oracle Database is available starting from Teleport `v12.2`
+and is a Enterprise-only feature.
+</Details>
+
 This guide will help you to:
 
 - Install and configure Teleport.

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -80,7 +80,7 @@ $ teleport db configure create \
 Follow the instructions below to generate TLS credentials for your database.
 
 ```code
-# Export Teleport's certificate authority and a generate certificate/key pair
+# Export Teleport's certificate authority and a generated certificate/key pair
 # for host db.example.com with a 1-year validity period.
 $ tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h
 ```

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -36,19 +36,11 @@ This guide will help you to:
 - The `sqlcl` [Oracle client](https://www.oracle.com/pl/database/sqldeveloper/technologies/sqlcl/) installed and added to your system's `PATH` environment variable or any GUI client that supports JDBC
   Oracle thin client.
 
-## Step 1/7. Create a Teleport user
+## Step 1/6. Create a Teleport user
 
 (!docs/pages/includes/database-access/create-user.mdx!)
 
-## Step 2/7. Set up the Teleport Database Service
-
-(!docs/pages/includes/database-access/token.mdx!)
-
-Follow the instructions below to install Teleport on the host where you will run the Teleport Database Service.
-
-(!docs/pages/includes/install-linux.mdx!)
-
-## Step 2/7. Create a Database Service configuration
+## Step 2/6. Create a Database Service configuration
 
 (!docs/pages/includes/database-access/token.mdx!)
 
@@ -69,11 +61,11 @@ $ teleport db configure create \
    --labels=env=dev
 ```
 
-## Step 4/7. Start the Database Service
+## Step 3/6. Start the Database Service
 
 (!docs/pages/includes/start-teleport.mdx service="the Database Service"!)
 
-## Step 5/7. Create a certificate/key pair and Teleport Oracle Wallet
+## Step 4/6. Create a certificate/key pair and Teleport Oracle Wallet
 
 (!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
 
@@ -90,7 +82,7 @@ $ tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h
 If `tctl` finds the Orapki tool in your local environment, the `tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h` command will produce an Oracle Wallet and
 instructions how to configure the Oracle TCPS listener with Teleport Oracle Wallet. Otherwise the `tctl auth sign --format=oracle` command  will produce a `p12` certificate and instructions on how to create an Oracle Wallet on your Oracle Database instance.
 
-## Step 6/7. Configure Oracle Database
+## Step 5/6. Configure Oracle Database
 
 In order to enable the Teleport Oracle integration you will need to configure the TCPS Oracle listener and use the Teleport Oracle Wallet created in the previous step.
 
@@ -127,7 +119,7 @@ CREATE USER alice IDENTIFIED EXTERNALLY AS 'CN=alice';
 GRANT CREATE SESSION TO alice;
 ```
 
-## Step 7/7. Connect
+## Step 6/6. Connect
 
 Once the Database Service has joined the cluster, log in to see the available
 databases:

--- a/docs/pages/includes/database-access/guides.mdx
+++ b/docs/pages/includes/database-access/guides.mdx
@@ -3,26 +3,26 @@
 - [Active Directory SQL Server (Preview)](../../database-access/guides/sql-server-ad.mdx): Connect Microsoft SQL Server with Active Directory authentication.
 - [AWS DynamoDB](../../database-access/guides/aws-dynamodb.mdx): Connect AWS DynamoDB.
 - [AWS ElastiCache & MemoryDB](../../database-access/guides/redis-aws.mdx): Connect AWS ElastiCache or AWS MemoryDB for Redis database.
+- [AWS Keyspaces (Apache Cassandra)](../../database-access/guides/aws-cassandra-keyspaces.mdx): Connect to an AWS Keyspaces database.
 - [AWS RDS & Aurora](../../database-access/guides/rds.mdx): Connect AWS RDS or Aurora PostgreSQL, MariaDB or MySQL database.
 - [AWS RDS Proxy](../../database-access/guides/rds-proxy.mdx): Connect AWS RDS Proxy instances to Teleport.
 - [AWS Redshift](../../database-access/guides/postgres-redshift.mdx): Connect AWS Redshift database.
 - [AWS Redshift Serverless](../../database-access/guides/redshift-serverless.mdx): Connect to AWS Redshift serverless.
-- [AWS Keyspaces (Apache Cassandra)](../../database-access/guides/aws-cassandra-keyspaces.mdx): Connect to an AWS Keyspaces database.
-- [Azure PostgreSQL & MySQL](../../database-access/guides/azure-postgres-mysql.mdx): Connect Azure PostgreSQL or MySQL.
 - [Azure Cache for Redis](../../database-access/guides/azure-redis.mdx): Connect Azure Cache for Redis.
+- [Azure PostgreSQL & MySQL](../../database-access/guides/azure-postgres-mysql.mdx): Connect Azure PostgreSQL or MySQL.
 - [Azure SQL Server (Preview)](../../database-access/guides/azure-sql-server-ad.mdx): Connect Azure SQL Server with Azure Active Directory authentication.
 - [GCP Cloud SQL MySQL](../../database-access/guides/mysql-cloudsql.mdx): Connect GCP Cloud SQL MySQL database.
 - [GCP Cloud SQL PostgreSQL](../../database-access/guides/postgres-cloudsql.mdx): Connect GCP Cloud SQL PostgreSQL database.
 - [MongoDB Atlas](../../database-access/guides/mongodb-atlas.mdx): Connect MongoDB Atlas cluster.
+- [Self-Hosted Cassandra & ScyllaDB](../../database-access/guides/cassandra-self-hosted.mdx): Connect self-hosted Cassandra or ScyllaDB.
 - [Self-hosted CockroachDB](../../database-access/guides/cockroachdb-self-hosted.mdx): Connect self-hosted CockroachDB database.
 - [Self-hosted Elasticsearch](../../database-access/guides/elastic.mdx)
 - [Self-hosted MongoDB](../../database-access/guides/mongodb-self-hosted.mdx): Connect self-hosted MongoDB database.
 - [Self-hosted MySQL & MariaDB](../../database-access/guides/mysql-self-hosted.mdx): Connect self-hosted MySQL or MariaDB database.
+- [Self-Hosted Oracle (Preview)](../../database-access/guides/oracle-self-hosted.mdx): Connect self-hosted Oracle database.
 - [Self-hosted PostgreSQL](../../database-access/guides/postgres-self-hosted.mdx): Connect self-hosted PostgreSQL database.
 - [Self-hosted Redis Cluster](../../database-access/guides/redis-cluster.mdx): Connect a self-hosted Redis Cluster.
 - [Self-hosted Redis](../../database-access/guides/redis.mdx): Connect self-hosted Redis.
-- [Self-Hosted Cassandra & ScyllaDB](../../database-access/guides/cassandra-self-hosted.mdx): Connect self-hosted Cassandra or ScyllaDB.
-- [Self-Hosted Oracle](../../database-access/guides/oracle-self-hosted.mdx): Connect self-hosted Oracle database.
 - [Snowflake (Preview)](../../database-access/guides/snowflake.mdx): Connect Snowflake.
 
 ## Other guides


### PR DESCRIPTION
- guides list wasn't in alphabetical order
- oracle guide didn't mention version starting from or that it was enterprise only
- fix to `tctl` command
- steps were duplicated