### PR TITLE
Edit the SSH Key Extensions guide prereqs

### DIFF
--- a/docs/pages/management/guides/ssh-key-extensions.mdx
+++ b/docs/pages/management/guides/ssh-key-extensions.mdx
@@ -9,8 +9,8 @@ Teleport supports exporting user SSH certificates with configurable key extensio
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- The GitHub SSO authentication connector. For more information, see [GitHub SSO](../../access-controls/sso/github-sso.mdx).
 - Access to GitHub Enterprise and permissions to modify GitHub's SSH Certificate Authorities.
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Import the Teleport CA into GitHub
 


### PR DESCRIPTION
Closes #22594

- Remove the requirement for GitHub SSO
- Use the standard prerequisites partial