### PR TITLE
Add architectural clarity to the AD guide

### DIFF
--- a/docs/pages/desktop-access/active-directory.mdx
+++ b/docs/pages/desktop-access/active-directory.mdx
@@ -84,7 +84,17 @@ block to a temporary location. Click **Next**.
 
 On the Linux host where you will run the Teleport Desktop Service, create a file
 called `/etc/teleport.yaml` and paste the configuration provided by the output
-of the previous step. The configuration file will resemble the following:
+of the previous step. 
+
+<Notice type="tip">
+
+If you would like to run the Teleport Desktop Service from a Teleport process
+that is already running other services, copy and paste only the
+`windows_desktop_service` section.
+
+</Notice>
+
+The configuration file will resemble the following:
 
 ```yaml
 version: v3

--- a/docs/pages/desktop-access/active-directory.mdx
+++ b/docs/pages/desktop-access/active-directory.mdx
@@ -39,25 +39,32 @@ access to Windows desktops.
   to support passwordless logins with Teleport to the Windows desktops
   in the Active Directory domain.
 - A Linux host where you will run the Teleport Desktop Service.
-  <ScopedBlock scope={["oss", "enterprise"]}> This guide assumes that you will
-  run Teleport's Windows Desktop Service on a dedicated host. To install Desktop
-  Access into an existing Teleport instance running other services, see the
-  [Manual Setup](active-directory-manual.mdx) guide for Desktop Access.</ScopedBlock>
 - An Active Directory domain, configured for LDAPS (Teleport requires an
   encrypted LDAP connection). Typically this means installing
   [AD CS](https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/).
 
 ## Step 1/2. Run the discovery wizard
 
-In your web browser, access the teleport Web UI at <ScopedBlock scope={["oss", "enterprise"]}>
+In this step, you will use the Teleport Web UI to download and run two scripts:
+
+- An Active Directory installation script to run on your Windows Server host
+- An installation script for the Teleport Desktop Service, which you will run on
+  your Linux host
+
+### Install Active Directory
+
+In your web browser, access the Teleport Web UI at the address of your Proxy
+Service host, e.g., <ScopedBlock scope={["oss", "enterprise"]}>
 `teleport.example.com`</ScopedBlock><ScopedBlock scope={["cloud"]}>
 `mytennant.teleport.sh`</ScopedBlock>. Click on your user name at the top right
-and select **Manage Access**, Select "Desktop" from the main menu, then **NEXT**.
+and select **Manage Access**. Select "Desktop" from the main menu, then
+**NEXT**.
 
-If you already have Active Directory installed, skip to the next step. Otherwise,
-copy and paste the first command provided into a Windows PowerShell window. If
-you aren't already running AD Certificate services, copy and paste the second
-command after the first one completes and the server restarts:
+If you already have Active Directory installed on your Windows Server host, skip
+to the next step. Otherwise, copy and paste the first command provided into a
+Windows PowerShell window on your Windows Server host. If you aren't already
+running AD Certificate services, copy and paste the second command after the
+first one completes and the server restarts:
 
 ![Install Active Directory](../../img/desktop-access/install-active-directory.png)
 
@@ -73,9 +80,11 @@ Click **NEXT**.
 The PowerShell script will output a Teleport configuration block. Copy this
 block to a temporary location. Click **Next**.
 
-On the Linux host you installed Teleport to run as the Desktop Service connector,
-edit `/etc/teleport.yaml` and paste the configuration provided by the output of
-the previous step. Review and edit the addition as necessarily for your environment:
+### Install the Teleport Desktop Service
+
+On the Linux host where you will run the Teleport Desktop Service, create a file
+called `/etc/teleport.yaml` and paste the configuration provided by the output
+of the previous step. The configuration file will resemble the following:
 
 ```yaml
 version: v3
@@ -113,7 +122,11 @@ windows_desktop_service:
     teleport.internal/resource-id: 42d8859c-60d0-4d7f-9767-bdd66b63fce6
 ```
 
-Click **Next**.
+Install the Teleport Desktop Service on your Linux host.
+
+(!docs/pages/includes/install-linux.mdx!)
+
+In the Teleport Web UI, click **Next**.
 
 ## Step 2/2. Start Teleport
 


### PR DESCRIPTION
Closes #22558
Closes #24074 

Add more explicit signposting for where to run the different installation scripts provided by the AD guide.

Also include explicit instructions to install Teleport on the Desktop Service host. The existing instructions weren't as explicit as they could be about whether to install Teleport, and required wading through the manual desktop access getting started guide.