### PR TITLE
Add info to the Directory Sharing guide

### DIFF
--- a/docs/pages/desktop-access/directory-sharing.mdx
+++ b/docs/pages/desktop-access/directory-sharing.mdx
@@ -49,17 +49,27 @@ and click "Share Directory":
 
 ![The "Share Desktop" button](../../img/desktop-access/share.png)
 
-<Notice type="warning">
-For security reasons the web browser's filesystem access API prohibits you from sharing certain directories,
-including the standard locations for commonly used user directories such as "Desktop"
-and "Documents", as well as critical directories more typically used by the operating
-system itself.
+### Limitations on directories you can share
 
-For a full list of the blocked user directories, see [here](https://wicg.github.io/file-system-access/#enumdef-wellknowndirectory).
+#### Prohibited directories
+
+For security reasons the web browser's filesystem access API prohibits you from
+sharing certain directories, including the standard locations for commonly used
+user directories such as "Desktop" and "Documents", as well as critical
+directories more typically used by the operating system itself.
+
+For a full list of the blocked user directories, see the [File System Access
+Specification](https://wicg.github.io/file-system-access/#enumdef-wellknowndirectory).
 
 Subdirectories *within* these blocked user directories may still be shared.
 
-</Notice>
+#### Long directory names
+
+Based on testing, we have determined that directory sharing leads to unexpected
+errors if you share directories whose names (including all path segments) have
+640 characters or more.
+
+### After you share a directory
 
 When you first share a directory, your browser will prompt you to allow it to
 make changes in the directory, and you will need to grant these permissions to


### PR DESCRIPTION
Closes #14950

Indicate the effects of using long directory names. Edit a `Notice` component with warnings about prohibited directories in order to make room for this.