### PR TITLE
Fixes roles list/read dependency for listing desktops

### DIFF
--- a/lib/web/resources.go
+++ b/lib/web/resources.go
@@ -571,11 +571,7 @@ func handleClusterAppsGet(clt resourcesAPIGetter, r *http.Request, cfg ui.MakeAp
 	}, nil
 }
 
-func handleClusterDesktopsGet(clt resourcesAPIGetter, r *http.Request) (*listResourcesGetResponse, error) {
-	roles, err := clt.GetRoles(r.Context())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+func handleClusterDesktopsGet(clt resourcesAPIGetter, roles []types.Role, r *http.Request) (*listResourcesGetResponse, error) {
 	resp, err := attemptListResources(clt, r, types.KindWindowsDesktop)
 	if err == nil {
 		windowsDesktops, err := types.ResourcesWithLabels(resp.Resources).AsWindowsDesktops()

--- a/lib/web/resources_test.go
+++ b/lib/web/resources_test.go
@@ -865,14 +865,10 @@ func TestHandleClusterWindowsGetFallback(t *testing.T) {
 		return proto.PingResponse{ServerVersion: "9.1"}, nil
 	}
 
-	m.mockGetRoles = func(ctx context.Context) ([]types.Role, error) {
-		return []types.Role{}, nil
-	}
-
 	mockHTTPReq, err := http.NewRequest("", "", nil)
 	require.NoError(t, err)
 
-	res, err := handleClusterDesktopsGet(m, mockHTTPReq)
+	res, err := handleClusterDesktopsGet(m, []types.Role{}, mockHTTPReq)
 	require.NoError(t, err)
 	require.Nil(t, res.StartKey)
 	require.Nil(t, res.TotalCount)

--- a/lib/web/servers.go
+++ b/lib/web/servers.go
@@ -67,7 +67,12 @@ func (h *Handler) clusterDesktopsGet(w http.ResponseWriter, r *http.Request, p h
 		return nil, trace.Wrap(err)
 	}
 
-	res, err := handleClusterDesktopsGet(clt, r)
+	accessChecker, err := sctx.GetUserAccessChecker()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	res, err := handleClusterDesktopsGet(clt, accessChecker.Roles(), r)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Changes in #22118 were backported incorrectly to v10 in #22344, which caused the roles list/read dependency to be enforced for listing desktops.

These changes fix that issue by using the SessionContext's AccessChecker to get the Roles of the current user, rather than requesting them with the auth.ClientI which is authenticated as the user themselves.