### PR TITLE
[v10] chore: Bump Buf from 1.16.0 to 1.17.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -260,7 +260,7 @@ RUN curl -fsSL https://github.com/golangci/golangci-lint/releases/download/v1.46
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.16.0" && \
+    VERSION="1.17.0" && \
       curl -fsSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Backport #24220 to branch/v10