### PR TITLE
update aws configurator

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -784,6 +784,9 @@ func (d *DatabaseV3) SetManagedUsers(users []string) {
 
 // RequireAWSIAMRolesAsUsers returns true for database types that require AWS
 // IAM roles as database users.
+// IMPORTANT: if you add a database that requires AWS IAM Roles as users,
+// and that database supports discovery, be sure to update RequireAWSIAMRolesAsUsersMatchers
+// in lib/services as well.
 func (d *DatabaseV3) RequireAWSIAMRolesAsUsers() bool {
 	awsType, ok := d.getAWSType()
 	if !ok {

--- a/lib/cloud/aws/identity.go
+++ b/lib/cloud/aws/identity.go
@@ -42,6 +42,15 @@ type Identity interface {
 	fmt.Stringer
 }
 
+const (
+	// ResourceTypeRole is the resource type for an AWS IAM role.
+	ResourceTypeRole = "role"
+	// ResourceTypeAssumedRole is the resource type for an AWS IAM assumed role.
+	ResourceTypeAssumedRole = "assumed-role"
+	// ResourceTypeUser is the resource type for an AWS IAM user.
+	ResourceTypeUser = "user"
+)
+
 // User represents an AWS IAM user identity.
 type User struct {
 	identityBase
@@ -66,12 +75,12 @@ func (i identityBase) GetName() string {
 	parts := strings.Split(i.arn.Resource, "/")
 	// EC2 instances running on AWS with attached IAM role will have
 	// assumed-role identity with ARN like:
-	// arn:aws:sts::1234567890:assumed-role/DatabaseAccess/i-1234567890
-	if parts[0] == "assumed-role" && len(parts) > 2 {
+	// arn:aws:sts::123456789012:assumed-role/DatabaseAccess/i-1234567890
+	if parts[0] == ResourceTypeAssumedRole && len(parts) > 2 {
 		return parts[1]
 	}
 	// Resource can include a path and the name is its last component e.g.
-	// arn:aws:iam::1234567890:role/path/to/customrole
+	// arn:aws:iam::123456789012:role/path/to/customrole
 	return parts[len(parts)-1]
 }
 
@@ -115,13 +124,13 @@ func IdentityFromArn(arnString string) (Identity, error) {
 
 	parts := strings.Split(parsedARN.Resource, "/")
 	switch parts[0] {
-	case "role", "assumed-role":
+	case ResourceTypeRole, ResourceTypeAssumedRole:
 		return Role{
 			identityBase: identityBase{
 				arn: parsedARN,
 			},
 		}, nil
-	case "user":
+	case ResourceTypeUser:
 		return User{
 			identityBase: identityBase{
 				arn: parsedARN,

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -521,8 +521,12 @@ func checkAndSetDefaultsForAWSMatchers(matcherInput []AWSMatcher) error {
 				return trace.Wrap(err, "discovery service AWS matcher assume_role_arn is invalid")
 			}
 		} else if matcher.ExternalID != "" {
-			return trace.BadParameter("discovery service AWS matcher assume_role_arn is empty, but has external_id %q",
-				matcher.ExternalID)
+			for _, t := range matcher.Types {
+				if !slices.Contains(services.RequireAWSIAMRolesAsUsersMatchers, t) {
+					return trace.BadParameter("discovery service AWS matcher assume_role_arn is empty, but has external_id %q",
+						matcher.ExternalID)
+				}
+			}
 		}
 
 		if matcher.Tags == nil || len(matcher.Tags) == 0 {

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 	"github.com/aws/aws-sdk-go/service/ssm"
@@ -224,6 +225,8 @@ type ConfiguratorConfig struct {
 	AWSSession *awssession.Session
 	// AWSSTSClient AWS STS client.
 	AWSSTSClient stsiface.STSAPI
+	// AWSIAMClient AWS IAM client.
+	AWSIAMClient iamiface.IAMAPI
 	// AWSSSMClient AWS SSM Client
 	AWSSSMClient ssmiface.SSMAPI
 	// Policies instance of the `Policies` that the actions use.
@@ -254,11 +257,13 @@ func (c *ConfiguratorConfig) CheckAndSetDefaults() error {
 			}
 		}
 
+		if c.AWSSTSClient == nil {
+			c.AWSSTSClient = sts.New(c.AWSSession)
+		}
+		if c.AWSIAMClient == nil {
+			c.AWSIAMClient = iam.New(c.AWSSession)
+		}
 		if c.Identity == nil {
-			if c.AWSSTSClient == nil {
-				c.AWSSTSClient = sts.New(c.AWSSession)
-			}
-
 			c.Identity, err = awslib.GetIdentityWithClient(context.Background(), c.AWSSTSClient)
 			if err != nil {
 				return trace.Wrap(err)
@@ -473,7 +478,7 @@ func buildActions(config ConfiguratorConfig) ([]configurators.ConfiguratorAction
 	}
 
 	// Define the target and target type.
-	target, err := policiesTarget(config.Flags, accountID, partitionID, config.Identity)
+	target, err := policiesTarget(config.Flags, accountID, partitionID, config.Identity, config.AWSIAMClient)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -486,11 +491,11 @@ func buildActions(config ConfiguratorConfig) ([]configurators.ConfiguratorAction
 
 // policiesTarget defines which target and its type the policies will be
 // attached to.
-func policiesTarget(flags configurators.BootstrapFlags, accountID string, partitionID string, identity awslib.Identity) (awslib.Identity, error) {
+func policiesTarget(flags configurators.BootstrapFlags, accountID string, partitionID string, identity awslib.Identity, iamClient iamiface.IAMAPI) (awslib.Identity, error) {
 	if flags.AttachToUser != "" {
 		userArn := flags.AttachToUser
 		if !arn.IsARN(flags.AttachToUser) {
-			userArn = fmt.Sprintf("arn:%s:iam::%s:user/%s", partitionID, accountID, flags.AttachToUser)
+			userArn = buildIAMARN(partitionID, accountID, "user", flags.AttachToUser)
 		}
 
 		return awslib.IdentityFromArn(userArn)
@@ -499,17 +504,63 @@ func policiesTarget(flags configurators.BootstrapFlags, accountID string, partit
 	if flags.AttachToRole != "" {
 		roleArn := flags.AttachToRole
 		if !arn.IsARN(flags.AttachToRole) {
-			roleArn = fmt.Sprintf("arn:%s:iam::%s:role/%s", partitionID, accountID, flags.AttachToRole)
+			roleArn = buildIAMARN(partitionID, accountID, "role", flags.AttachToRole)
 		}
 
 		return awslib.IdentityFromArn(roleArn)
 	}
 
 	if identity == nil {
-		return awslib.IdentityFromArn(fmt.Sprintf("arn:%s:iam::%s:user/%s", partitionID, accountID, defaultAttachUser))
+		return awslib.IdentityFromArn(buildIAMARN(partitionID, accountID, "user", defaultAttachUser))
+	}
+
+	if identity.GetType() == awslib.ResourceTypeAssumedRole {
+		roleIdentity, err := getRoleARNForAssumedRole(iamClient, identity)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return roleIdentity, nil
 	}
 
 	return identity, nil
+}
+
+// buildIAMARN constructs an AWS IAM ARN string from the given partition,
+// account, resource type, and resource.
+// If the resource starts with the "/" prefix, this function takes care not to
+// add an additional "/" prefix to the constructed ARN.
+// This handles resource names that include a path correctly. Example:
+// resource input: "/some/path/to/rolename"
+// arn output: "arn:aws:iam::123456789012:role/some/path/to/rolename"
+func buildIAMARN(partitionID, accountID, resourceType, resource string) string {
+	if strings.HasPrefix(resource, "/") {
+		return fmt.Sprintf("arn:%s:iam::%s:%s%s", partitionID, accountID, resourceType, resource)
+	} else {
+		return fmt.Sprintf("arn:%s:iam::%s:%s/%s", partitionID, accountID, resourceType, resource)
+	}
+}
+
+// failedToResolveAssumeRoleARN is an error message returned when an
+// assumed-role identity cannot be resolved to the role ARN that it assumes,
+// which is necessary to attach policies to the identity.
+// Rather than returning errors about why it failed, this message suggests a
+// simple fix for the user to specify a role or user to attach policies to.
+const failedToResolveAssumeRoleARN = "Running with assumed-role credentials. Policies cannot be attached to an assumed-role. Provide the name or ARN of the IAM user or role to attach policies to."
+
+// getRoleARNForAssumedRole attempts to resolve assumed-role credentials to
+// the underlying role ARN using IAM API.
+// This is necessary since the assumed-role ARN does not include the role path,
+// so we cannot reliably reconstruct the role ARN from the assumed-role ARN.
+func getRoleARNForAssumedRole(iamClient iamiface.IAMAPI, identity awslib.Identity) (awslib.Identity, error) {
+	roleOutput, err := iamClient.GetRole(&iam.GetRoleInput{RoleName: aws.String(identity.GetName())})
+	if err != nil || roleOutput == nil || roleOutput.Role == nil || roleOutput.Role.Arn == nil {
+		return nil, trace.BadParameter(failedToResolveAssumeRoleARN)
+	}
+	roleIdentity, err := awslib.IdentityFromArn(*roleOutput.Role.Arn)
+	if err != nil {
+		return nil, trace.BadParameter(failedToResolveAssumeRoleARN)
+	}
+	return roleIdentity, nil
 }
 
 // buildPolicyDocument builds the policy document.
@@ -726,6 +777,10 @@ func hasMemoryDBDatabases(flags configurators.BootstrapFlags, fileConfig *config
 
 // hasAWSKeyspacesDatabases checks if the agent needs permission for AWS Keyspaces.
 func hasAWSKeyspacesDatabases(flags configurators.BootstrapFlags, fileConfig *config.FileConfig) bool {
+	if flags.ForceAWSKeyspacesPermissions {
+		return true
+	}
+
 	// There is no auto discovery for AWS Keyspaces.
 	if flags.DiscoveryService {
 		return false
@@ -738,6 +793,10 @@ func hasAWSKeyspacesDatabases(flags configurators.BootstrapFlags, fileConfig *co
 
 // hasDynamoDBDatabases checks if the agent needs permission for AWS DynamoDB.
 func hasDynamoDBDatabases(flags configurators.BootstrapFlags, fileConfig *config.FileConfig) bool {
+	if flags.ForceDynamoDBPermissions {
+		return true
+	}
+
 	// There is no auto discovery for AWS DynamoDB.
 	if flags.DiscoveryService {
 		return false

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	awssession "github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/ssm/ssmiface"
 	"github.com/aws/aws-sdk-go/service/sts"
@@ -44,7 +46,8 @@ func TestAWSIAMDocuments(t *testing.T) {
 	userTarget, err := awslib.IdentityFromArn("arn:aws:iam::123456789012:user/example-user")
 	require.NoError(t, err)
 
-	roleTarget, err := awslib.IdentityFromArn("arn:aws:iam::123456789012:role/example-role")
+	roleARN := "arn:aws:iam::123456789012:role/example-role"
+	roleTarget, err := awslib.IdentityFromArn(roleARN)
 	require.NoError(t, err)
 
 	unknownIdentity, err := awslib.IdentityFromArn("arn:aws:iam::123456789012:ec2/example-ec2")
@@ -140,7 +143,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					"rds:DescribeDBInstances", "rds:ModifyDBInstance",
 					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+				{Effect: awslib.EffectAllow, Resources: []string{roleARN}, Actions: []string{
 					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
 				}},
 			},
@@ -150,7 +153,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					"rds:DescribeDBClusters", "rds:ModifyDBCluster",
 					"rds-db:connect",
 				}},
-				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+				{Effect: awslib.EffectAllow, Resources: []string{roleARN}, Actions: []string{
 					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
 				}},
 			},
@@ -1006,10 +1009,13 @@ func TestAWSPoliciesAttacher(t *testing.T) {
 }
 
 func TestAWSPoliciesTarget(t *testing.T) {
-	userIdentity, err := awslib.IdentityFromArn("arn:aws:iam::1234567:user/example-user")
+	userIdentity, err := awslib.IdentityFromArn("arn:aws:iam::123456789012:user/example-user")
 	require.NoError(t, err)
 
-	roleIdentity, err := awslib.IdentityFromArn("arn:aws:iam::1234567:role/example-role")
+	roleIdentity, err := awslib.IdentityFromArn("arn:aws:iam::123456789012:role/example-role")
+	require.NoError(t, err)
+
+	assumedRoleIdentity, err := awslib.IdentityFromArn("arn:aws:sts::123456789012:assumed-role/example-role/i-12345")
 	require.NoError(t, err)
 
 	tests := map[string]struct {
@@ -1021,6 +1027,9 @@ func TestAWSPoliciesTarget(t *testing.T) {
 		targetName        string
 		targetAccountID   string
 		targetPartitionID string
+		targetString      string
+		iamClient         iamiface.IAMAPI
+		wantErrContains   string
 	}{
 		"UserNameFromFlags": {
 			flags:             configurators.BootstrapFlags{AttachToUser: "example-user"},
@@ -1030,6 +1039,17 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetName:        "example-user",
 			targetAccountID:   "123456",
 			targetPartitionID: "aws",
+			targetString:      "arn:aws:iam::123456:user/example-user",
+		},
+		"UserNameWithPathFromFlags": {
+			flags:             configurators.BootstrapFlags{AttachToUser: "/some/path/example-user"},
+			accountID:         "123456",
+			partitionID:       "aws",
+			targetType:        awslib.User{},
+			targetName:        "example-user",
+			targetAccountID:   "123456",
+			targetPartitionID: "aws",
+			targetString:      "arn:aws:iam::123456:user/some/path/example-user",
 		},
 		"UserARNFromFlags": {
 			flags:             configurators.BootstrapFlags{AttachToUser: "arn:aws:iam::123456789012:user/example-user"},
@@ -1037,6 +1057,7 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetName:        "example-user",
 			targetAccountID:   "123456789012",
 			targetPartitionID: "aws",
+			targetString:      "arn:aws:iam::123456789012:user/example-user",
 		},
 		"RoleNameFromFlags": {
 			flags:             configurators.BootstrapFlags{AttachToRole: "example-role"},
@@ -1046,6 +1067,17 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetName:        "example-role",
 			targetAccountID:   "123456789012",
 			targetPartitionID: "aws",
+			targetString:      "arn:aws:iam::123456789012:role/example-role",
+		},
+		"RoleNameWithPathFromFlags": {
+			flags:             configurators.BootstrapFlags{AttachToRole: "/some/path/example-role"},
+			accountID:         "123456789012",
+			partitionID:       "aws",
+			targetType:        awslib.Role{},
+			targetName:        "example-role",
+			targetAccountID:   "123456789012",
+			targetPartitionID: "aws",
+			targetString:      "arn:aws:iam::123456789012:role/some/path/example-role",
 		},
 		"RoleARNFromFlags": {
 			flags:             configurators.BootstrapFlags{AttachToRole: "arn:aws:iam::123456789012:role/example-role"},
@@ -1053,6 +1085,7 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetName:        "example-role",
 			targetAccountID:   "123456789012",
 			targetPartitionID: "aws",
+			targetString:      "arn:aws:iam::123456789012:role/example-role",
 		},
 		"UserFromIdentity": {
 			flags:             configurators.BootstrapFlags{},
@@ -1061,6 +1094,7 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetName:        userIdentity.GetName(),
 			targetAccountID:   userIdentity.GetAccountID(),
 			targetPartitionID: userIdentity.GetPartition(),
+			targetString:      "arn:aws:iam::123456789012:user/example-user",
 		},
 		"RoleFromIdentity": {
 			flags:             configurators.BootstrapFlags{},
@@ -1069,6 +1103,7 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetName:        roleIdentity.GetName(),
 			targetAccountID:   roleIdentity.GetAccountID(),
 			targetPartitionID: roleIdentity.GetPartition(),
+			targetString:      "arn:aws:iam::123456789012:role/example-role",
 		},
 		"DefaultTarget": {
 			flags:             configurators.BootstrapFlags{},
@@ -1078,17 +1113,64 @@ func TestAWSPoliciesTarget(t *testing.T) {
 			targetName:        defaultAttachUser,
 			targetAccountID:   "*",
 			targetPartitionID: "*",
+			targetString:      "arn:*:iam::*:user/username",
+		},
+		"AssumedRoleIdentity": {
+			flags:             configurators.BootstrapFlags{},
+			identity:          assumedRoleIdentity,
+			targetType:        awslib.Role{},
+			targetName:        assumedRoleIdentity.GetName(),
+			targetAccountID:   assumedRoleIdentity.GetAccountID(),
+			targetPartitionID: assumedRoleIdentity.GetPartition(),
+			targetString:      "arn:aws:iam::123456789012:role/example-role",
+			iamClient:         &iamMock{partition: "aws", account: "123456789012"},
+		},
+		"AssumedRoleIdentityForRoleWithPath": {
+			flags:             configurators.BootstrapFlags{},
+			identity:          assumedRoleIdentity,
+			targetType:        awslib.Role{},
+			targetName:        assumedRoleIdentity.GetName(),
+			targetAccountID:   assumedRoleIdentity.GetAccountID(),
+			targetPartitionID: assumedRoleIdentity.GetPartition(),
+			targetString:      "arn:aws:iam::123456789012:role/some/path/example-role",
+			iamClient:         &iamMock{partition: "aws", account: "123456789012", addPath: "/some/path/"},
+		},
+		"AssumedRoleIdentityWithoutIAMPermissions": {
+			flags:             configurators.BootstrapFlags{},
+			identity:          assumedRoleIdentity,
+			targetType:        awslib.Role{},
+			targetName:        assumedRoleIdentity.GetName(),
+			targetAccountID:   assumedRoleIdentity.GetAccountID(),
+			targetPartitionID: assumedRoleIdentity.GetPartition(),
+			targetString:      "arn:aws:iam::123456789012:role/example-role",
+			iamClient:         &iamMock{unauthorized: true},
+			wantErrContains:   "Policies cannot be attached to an assumed-role",
+		},
+		"AssumedRoleIdentityWithRoleFromFlags": {
+			flags:             configurators.BootstrapFlags{AttachToRole: "arn:aws:iam::123456789012:role/some/path/example-role"},
+			identity:          assumedRoleIdentity,
+			targetType:        awslib.Role{},
+			targetName:        "example-role",
+			targetAccountID:   "123456789012",
+			targetPartitionID: "aws",
+			targetString:      "arn:aws:iam::123456789012:role/some/path/example-role",
+			iamClient:         &iamMock{unauthorized: true},
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			target, err := policiesTarget(test.flags, test.accountID, test.partitionID, test.identity)
+			target, err := policiesTarget(test.flags, test.accountID, test.partitionID, test.identity, test.iamClient)
+			if test.wantErrContains != "" {
+				require.ErrorContains(t, err, test.wantErrContains)
+				return
+			}
 			require.NoError(t, err)
 			require.IsType(t, test.targetType, target)
 			require.Equal(t, test.targetName, target.GetName())
 			require.Equal(t, test.targetAccountID, target.GetAccountID())
 			require.Equal(t, test.targetPartitionID, target.GetPartition())
+			require.Equal(t, test.targetString, target.String())
 		})
 	}
 }
@@ -1099,6 +1181,7 @@ func TestAWSDocumentConfigurator(t *testing.T) {
 
 	config := ConfiguratorConfig{
 		AWSSession:   &awssession.Session{},
+		AWSIAMClient: &iamMock{},
 		AWSSTSClient: &STSMock{ARN: "arn:aws:iam::1234567:role/example-role"},
 		AWSSSMClient: &SSMMock{
 			t: t,
@@ -1151,6 +1234,7 @@ func TestAWSConfigurator(t *testing.T) {
 
 	config := ConfiguratorConfig{
 		AWSSession:   &awssession.Session{},
+		AWSIAMClient: &iamMock{},
 		AWSSTSClient: &STSMock{ARN: "arn:aws:iam::1234567:role/example-role"},
 		AWSSSMClient: &SSMMock{},
 		FileConfig:   &config.FileConfig{},
@@ -1236,4 +1320,25 @@ func (m *SSMMock) CreateDocumentWithContext(ctx aws.Context, input *ssm.CreateDo
 	require.Equal(m.t, m.expectedInput, input)
 
 	return nil, nil
+}
+
+type iamMock struct {
+	iamiface.IAMAPI
+	unauthorized bool
+	partition    string
+	account      string
+	addPath      string
+}
+
+func (m *iamMock) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	if m.unauthorized {
+		return nil, trace.AccessDenied("unauthorized")
+	}
+	roleName := aws.StringValue(input.RoleName)
+	path := m.addPath
+	if path == "" {
+		path = "/"
+	}
+	arn := fmt.Sprintf("arn:%s:iam::%s:role%s%s", m.partition, m.account, path, roleName)
+	return &iam.GetRoleOutput{Role: &iam.Role{Arn: &arn}}, nil
 }

--- a/lib/configurators/common.go
+++ b/lib/configurators/common.go
@@ -21,6 +21,7 @@ import (
 // BootstrapFlags flags provided by users to configure and define how the
 // configurators will work.
 type BootstrapFlags struct {
+	// DiscoveryService indicates the bootstrap is for the discovery service.
 	DiscoveryService bool
 	// ConfigPath database agent configuration path.
 	ConfigPath string
@@ -47,6 +48,10 @@ type BootstrapFlags struct {
 	ForceMemoryDBPermissions bool
 	// ForceEC2Permissions forces the presence of EC2 permissions.
 	ForceEC2Permissions bool
+	// ForceAWSKeyspacesPermissions forces the presence of AWS Keyspaces permissions.
+	ForceAWSKeyspacesPermissions bool
+	// ForceDynamoDBPermissions forces the presence of DynamoDB permissions.
+	ForceDynamoDBPermissions bool
 }
 
 // ConfiguratorActionContext context passed across configurator actions. It is

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -358,15 +358,29 @@ const (
 
 // SupportedAWSMatchers is list of AWS services currently supported by the
 // Teleport discovery service.
-var SupportedAWSMatchers = []string{
+var SupportedAWSMatchers = append([]string{
 	AWSMatcherEC2,
 	AWSMatcherEKS,
+}, SupportedAWSDatabaseMatchers...)
+
+// SupportedAWSDatabaseMatchers is a list of the AWS databases currently
+// supported by the Teleport discovery service.
+var SupportedAWSDatabaseMatchers = []string{
 	AWSMatcherRDS,
 	AWSMatcherRDSProxy,
 	AWSMatcherRedshift,
 	AWSMatcherRedshiftServerless,
 	AWSMatcherElastiCache,
 	AWSMatcherMemoryDB,
+}
+
+// RequireAWSIAMRolesAsUsersMatchers is a list of the AWS databases that
+// require AWS IAM roles as database users.
+// IMPORTANT: if you add database matchers for AWS keyspaces, OpenSearch, or
+// DynamoDB discovery, add them here and in RequireAWSIAMRolesAsUsers in
+// api/types.
+var RequireAWSIAMRolesAsUsersMatchers = []string{
+	AWSMatcherRedshiftServerless,
 }
 
 const (

--- a/tool/teleport/common/configurator.go
+++ b/tool/teleport/common/configurator.go
@@ -40,6 +40,8 @@ var awsDatabaseTypes = []string{
 	types.DatabaseTypeRedshiftServerless,
 	types.DatabaseTypeElastiCache,
 	types.DatabaseTypeMemoryDB,
+	types.DatabaseTypeAWSKeyspaces,
+	types.DatabaseTypeDynamoDB,
 }
 
 type installSystemdFlags struct {
@@ -230,6 +232,10 @@ func buildAWSConfigurator(manual bool, flags configureDatabaseAWSFlags) (configu
 			configuratorFlags.ForceElastiCachePermissions = true
 		case types.DatabaseTypeMemoryDB:
 			configuratorFlags.ForceMemoryDBPermissions = true
+		case types.DatabaseTypeAWSKeyspaces:
+			configuratorFlags.ForceAWSKeyspacesPermissions = true
+		case types.DatabaseTypeDynamoDB:
+			configuratorFlags.ForceDynamoDBPermissions = true
 		}
 	}
 
@@ -292,6 +298,12 @@ func onConfigureDatabasesAWSCreate(flags configureDatabaseAWSCreateFlags) error 
 		return trace.Wrap(err)
 	}
 
+	// Check if configurator actions is empty.
+	if configurator.IsEmpty() {
+		fmt.Println("The agent doesn't require any extra configuration.")
+		return nil
+	}
+
 	actions := configurator.Actions()
 	printDiscoveryConfiguratorActions(actions)
 	fmt.Print("\n")
@@ -305,12 +317,6 @@ func onConfigureDatabasesAWSCreate(flags configureDatabaseAWSCreateFlags) error 
 		if !confirmed {
 			return nil
 		}
-	}
-
-	// Check if configurator actions is empty.
-	if configurator.IsEmpty() {
-		fmt.Println("The agent doesn't require any extra configuration.")
-		return nil
 	}
 
 	err = executeDiscoveryConfiguratorActions(ctx, configurator.Name(), actions)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -325,16 +325,17 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		Short('r').
 		StringVar(&configureDatabaseAWSCreateFlags.types)
 	dbConfigureAWSCreateIAM.Flag("name", "Created policy name. Defaults to empty. Will be auto-generated if not provided.").Default(awsconfigurators.DefaultPolicyName).StringVar(&configureDatabaseAWSCreateFlags.policyName)
-	dbConfigureAWSCreateIAM.Flag("attach", "Try to attach the policy to the IAM identity.").Default("true").BoolVar(&configureDatabaseAWSCreateFlags.attach)
+	// --attach flag is deprecated.
+	dbConfigureAWSCreateIAM.Flag("attach", "Try to attach the policy to the IAM identity.").Hidden().Default("true").BoolVar(&configureDatabaseAWSCreateFlags.attach)
 	dbConfigureAWSCreateIAM.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDatabaseAWSCreateFlags.confirm)
 	dbConfigureAWSCreateIAM.Flag("role", "IAM role name to attach policy to. Mutually exclusive with --user").StringVar(&configureDatabaseAWSCreateFlags.role)
 	dbConfigureAWSCreateIAM.Flag("user", "IAM user name to attach policy to. Mutually exclusive with --role").StringVar(&configureDatabaseAWSCreateFlags.user)
 
-	// "teleport discovery" bootstrap command and subcommnads.
+	// "teleport discovery" bootstrap command and subcommands.
 	discoveryCmd := app.Command("discovery", "Teleport discovery service commands")
 	discoveryBootstrapCmd := discoveryCmd.Command("bootstrap", "Bootstrap the necessary configuration for the database agent. It reads the provided agent configuration to determine what will be bootstrapped.")
 	discoveryBootstrapCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').Default(defaults.ConfigFilePath).ExistingFileVar(&configureDiscoveryBootstrapFlags.config.ConfigPath)
-	discoveryBootstrapCmd.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDatabaseAWSCreateFlags.confirm)
+	discoveryBootstrapCmd.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDiscoveryBootstrapFlags.confirm)
 	discoveryBootstrapCmd.Flag("attach-to-role", "Role name to attach policy to. Mutually exclusive with --attach-to-user. If none of the attach-to flags is provided, the command will try to attach the policy to the current user/role based on the credentials.").StringVar(&configureDiscoveryBootstrapFlags.config.AttachToRole)
 	discoveryBootstrapCmd.Flag("attach-to-user", "User name to attach policy to. Mutually exclusive with --attach-to-role. If none of the attach-to flags is provided, the command will try to attach the policy to the current user/role based on the credentials.").StringVar(&configureDiscoveryBootstrapFlags.config.AttachToUser)
 	discoveryBootstrapCmd.Flag("policy-name", fmt.Sprintf("Name of the Teleport Discovery service policy. Default: %q.", awsconfigurators.EC2DiscoveryPolicyName)).Default(awsconfigurators.EC2DiscoveryPolicyName).StringVar(&configureDiscoveryBootstrapFlags.config.PolicyName)


### PR DESCRIPTION
This PR does several things that I'd like to backport as well:
- fixes `teleport discovery bootstrap --confirm`
  - `--confirm` had no effect before, because we passed the wrong variable to kingpin
- checks if the configurator is "empty" before prompting to confirm with `teleport db configure aws create-iam`
  - fixes issue where the user is prompted to confirm 0 actions
- changes discovery fileconfig AWS matcher checking to not error if `external_id` is set and `assume_role_arn` is not set when discovering database that use AWS IAM roles as db_users
  - matches check we do for databases themselves
 - includes AWS Keyspaces (Cassandra) and DynamoDB in configurator command `--types`, since we already supported them in the bootstrap command.
- fixes permissions policy and semaphore acquisition case where AWS identity target is an assumed-role arn
  - prior behavior was using the assumed-role ARN in IAM policy statements, which doesn't make sense, and acquiring a semaphore with the assumed-role arn which also doesn't make sense (because the point of the semaphore is to prevent multiple agents from updating IAM permissions for a given identity at the same time).

Fixes https://github.com/gravitational/teleport/issues/23462

Couldn't find any other issues for these changes, just things I noticed while working on this area of code.