### PR TITLE
reduce log spam when AWS DB engine name is not recognized

### DIFF
--- a/lib/srv/discovery/fetchers/db/aws_rds.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds.go
@@ -340,7 +340,7 @@ func retryWithIndividualEngineFilters(log logrus.FieldLogger, engines []string, 
 	if !isUnrecognizedAWSEngineNameError(err) {
 		return trace.Wrap(err)
 	}
-	log.WithError(err).Warn("Teleport supports an engine which is unrecognized in this AWS region. Querying engines individually.")
+	log.WithError(trace.Unwrap(err)).Debug("Teleport supports an engine which is unrecognized in this AWS region. Querying engine names individually.")
 	for _, engine := range engines {
 		err := fn(rdsEngineFilter([]string{engine}))
 		if err == nil {


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/17533

The error message was a warning and included a trace wrapped error in the log, which created a scary looking stacktrace warning and spammed up the logs every few minutes.

This PR reduces the log message to `Debug` log-level, and unwraps the error as well. The stack trace is not important here, it just might be useful to get the unwrapped error message and see which engine was problematic. For whatever reason, it's intermittently `aurora` ( and seems to happen more frequently now), even though AWS documents that as a supported engine.