### PR TITLE
Fix log output in `aggregating.Reporter`

### DIFF
--- a/lib/usagereporter/teleport/aggregating/reporter.go
+++ b/lib/usagereporter/teleport/aggregating/reporter.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -310,8 +311,9 @@ func (r *Reporter) persistUserActivity(ctx context.Context, startTime time.Time,
 			continue
 		}
 
+		reportUUID, _ := uuid.FromBytes(report.ReportUuid)
 		r.log.WithFields(logrus.Fields{
-			"report_uuid": report.ReportUuid,
+			"report_uuid": reportUUID,
 			"start_time":  startTime,
 			"records":     len(report.Records),
 		}).Debug("Persisted user activity report.")


### PR DESCRIPTION
Before this change, the UUID was written to the log in base64.