### PR TITLE
[v12] Attempt ssh connections with and without mfa at the same time

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/proxy"
+	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/teleagent"
 	"github.com/gravitational/teleport/lib/utils"
@@ -488,7 +489,7 @@ func (t *TerminalHandler) makeClient(ctx context.Context, ws *websocket.Conn) (*
 // used to access nodes which require per-session mfa. The ceremony is performed directly
 // to make use of the authProvider already established for the session instead of leveraging
 // the TeleportClient which would require dialing the auth server a second time.
-func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.TeleportClient) error {
+func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.TeleportClient) ([]ssh.AuthMethod, error) {
 	ctx, span := t.tracer.Start(ctx, "terminal/issueSessionMFACerts")
 	defer span.End()
 
@@ -497,7 +498,7 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 	log.Debug("Attempting to issue a single-use user certificate with an MFA check.")
 	stream, err := t.ctx.cfg.RootClient.GenerateUserSingleUseCerts(ctx)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	defer func() {
 		stream.CloseSend()
@@ -506,7 +507,7 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 
 	pk, err := keys.ParsePrivateKey(t.ctx.cfg.Session.GetPriv())
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	key := &client.Key{
@@ -517,7 +518,7 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 
 	tlsCert, err := key.TeleportTLSCertificate()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	if err := stream.Send(
@@ -534,58 +535,56 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 				},
 			},
 		}); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	resp, err := stream.Recv()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	challenge := resp.GetMFAChallenge()
 	if challenge == nil {
-		return trace.BadParameter("server sent a %T on GenerateUserSingleUseCerts, expected MFAChallenge", resp.Response)
+		return nil, trace.BadParameter("server sent a %T on GenerateUserSingleUseCerts, expected MFAChallenge", resp.Response)
 	}
 
 	span.AddEvent("prompting user with mfa challenge")
 	assertion, err := promptMFAChallenge(t.stream, protobufMFACodec{})(ctx, tc.WebProxyAddr, challenge)
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 	span.AddEvent("user completed mfa challenge")
 
 	err = stream.Send(&authproto.UserSingleUseCertsRequest{Request: &authproto.UserSingleUseCertsRequest_MFAResponse{MFAResponse: assertion}})
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	resp, err = stream.Recv()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	certResp := resp.GetCert()
 	if certResp == nil {
-		return trace.BadParameter("server sent a %T on GenerateUserSingleUseCerts, expected SingleUseUserCert", resp.Response)
+		return nil, trace.BadParameter("server sent a %T on GenerateUserSingleUseCerts, expected SingleUseUserCert", resp.Response)
 	}
 
 	switch crt := certResp.Cert.(type) {
 	case *authproto.SingleUseUserCert_SSH:
 		key.Cert = crt.SSH
 	default:
-		return trace.BadParameter("server sent a %T SingleUseUserCert in response", certResp.Cert)
+		return nil, trace.BadParameter("server sent a %T SingleUseUserCert in response", certResp.Cert)
 	}
 
 	key.ClusterName = t.sessionData.ClusterName
 
 	am, err := key.AsAuthMethod()
 	if err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
-	tc.AuthMethods = []ssh.AuthMethod{am}
-
-	return nil
+	return []ssh.AuthMethod{am}, nil
 }
 
 func promptMFAChallenge(
@@ -614,6 +613,89 @@ func promptMFAChallenge(
 	}
 }
 
+// connectToHost establishes a connection to the target host. To reduce connection
+// latency if per session mfa is required, connections are tried with the existing
+// certs and with single use certs after completing the mfa ceremony. Only one of
+// the operations will succeed, and if per session mfa will not gain access to the
+// target it will abort before prompting a user to perform the ceremony.
+func (t *TerminalHandler) connectToHost(ctx context.Context, ws *websocket.Conn, tc *client.TeleportClient) (*client.NodeClient, error) {
+	ctx, span := t.tracer.Start(ctx, "terminal/connectToHost")
+	defer span.End()
+
+	accessChecker, err := t.ctx.GetUserAccessChecker()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	getAgent := func() (teleagent.Agent, error) {
+		return teleagent.NopCloser(tc.LocalAgent()), nil
+	}
+
+	type clientRes struct {
+		clt *client.NodeClient
+		err error
+	}
+
+	directResultC := make(chan clientRes, 1)
+	mfaResultC := make(chan clientRes, 1)
+
+	// use a child context so the goroutines can terminate the other if they succeed
+
+	directCtx, directCancel := context.WithCancel(ctx)
+	mfaCtx, mfaCancel := context.WithCancel(ctx)
+	go func() {
+		// try connecting to the node with the certs we already have
+		clt, err := t.connectToNode(directCtx, ws, tc, accessChecker, getAgent)
+		directResultC <- clientRes{clt: clt, err: err}
+	}()
+
+	// use a child context so the goroutine ends if this
+	// function returns early
+	go func() {
+		// try performing mfa and then connecting with the single use certs
+		clt, err := t.connectToNodeWithMFA(mfaCtx, ws, tc, accessChecker, getAgent)
+		mfaResultC <- clientRes{clt: clt, err: err}
+	}()
+
+	var directErr, mfaErr error
+	for i := 0; i < 2; i++ {
+		select {
+		case <-ctx.Done():
+			mfaCancel()
+			directCancel()
+			return nil, ctx.Err()
+		case res := <-directResultC:
+			if res.clt != nil {
+				mfaCancel()
+				res.clt.AddCancel(directCancel)
+				return res.clt, nil
+			}
+
+			directErr = res.err
+		case res := <-mfaResultC:
+			if res.clt != nil {
+				directCancel()
+				res.clt.AddCancel(mfaCancel)
+				return res.clt, nil
+			}
+
+			mfaErr = res.err
+		}
+	}
+
+	mfaCancel()
+	directCancel()
+
+	// Only return the error from connecting with mfa if the error
+	// originates from the mfa ceremony. If mfa is not required then
+	// the error from the direct connection to the node must be returned.
+	if mfaErr != nil && !errors.Is(mfaErr, client.MFARequiredUnknownErr{}) {
+		return nil, trace.Wrap(mfaErr)
+	}
+
+	return nil, trace.Wrap(directErr)
+}
+
 // streamTerminal opens a SSH connection to the remote host and streams
 // events back to the web client.
 func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.TeleportClient) {
@@ -622,107 +704,14 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 
 	defer t.terminalCancel()
 
-	accessChecker, err := t.ctx.GetUserAccessChecker()
+	nc, err := t.connectToHost(ctx, ws, tc)
 	if err != nil {
-		t.log.WithError(err).Warn("Unable to stream terminal - failed to get access checker")
+		t.log.WithError(err).Warn("Unable to stream terminal - failure connecting to host")
 		t.writeError(err)
 		return
 	}
 
-	agentGetter := func() (teleagent.Agent, error) {
-		return teleagent.NopCloser(tc.LocalAgent()), nil
-	}
-
-	conn, _, err := t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker, agentGetter)
-	if err != nil {
-		t.log.WithError(err).Warn("Unable to stream terminal - failed to dial host.")
-
-		if errors.Is(err, trace.NotFound(teleport.NodeIsAmbiguous)) {
-			const message = "error: ambiguous host could match multiple nodes\n\nHint: try addressing the node by unique id (ex: user@node-id)\n"
-			t.writeError(trace.NotFound(message))
-			return
-		}
-
-		t.writeError(err)
-		return
-	}
-
-	defer func() {
-		if conn == nil {
-			return
-		}
-
-		if err := conn.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
-			t.log.WithError(err).Warn("Failed to close connection to host")
-		}
-	}()
-
-	sshConfig := &ssh.ClientConfig{
-		User:            tc.HostLogin,
-		Auth:            tc.AuthMethods,
-		HostKeyCallback: tc.HostKeyCallback,
-	}
-
-	nc, connectErr := client.NewNodeClient(ctx, sshConfig, conn,
-		net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),
-		t.sessionData.ServerHostname,
-		tc, modules.GetModules().IsBoringBinary())
-	switch {
-	case connectErr != nil && !trace.IsAccessDenied(connectErr): // catastrophic error, return it
-		t.log.WithError(connectErr).Warn("Unable to stream terminal - failed to create node client")
-		t.writeError(connectErr)
-		return
-	case connectErr != nil && trace.IsAccessDenied(connectErr): // see if per session mfa would allow access
-		mfaRequiredResp, err := t.authProvider.IsMFARequired(ctx, &authproto.IsMFARequiredRequest{
-			Target: &authproto.IsMFARequiredRequest_Node{
-				Node: &authproto.NodeLogin{
-					Node:  t.sessionData.ServerID,
-					Login: tc.HostLogin,
-				},
-			},
-		})
-		if err != nil {
-			t.log.WithError(err).Warn("Unable to stream terminal - failed to determine if per session mfa is required")
-			// write the original connect error
-			t.writeError(connectErr)
-			return
-		}
-
-		if !mfaRequiredResp.Required {
-			t.log.WithError(connectErr).Warn("Unable to stream terminal - user does not have access to host")
-			// write the original connect error
-			t.writeError(connectErr)
-			return
-		}
-
-		// perform mfa ceremony and retrieve new certs
-		if err := t.issueSessionMFACerts(ctx, tc); err != nil {
-			t.log.WithError(err).Warn("Unable to stream terminal - failed to perform mfa ceremony")
-			t.writeError(err)
-			return
-		}
-
-		// update auth methods
-		sshConfig.Auth = tc.AuthMethods
-
-		// connect to the node again with the new certs
-		conn, _, err = t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker, agentGetter)
-		if err != nil {
-			t.log.WithError(err).Warn("Unable to stream terminal - failed to dial host")
-			t.writeError(err)
-			return
-		}
-
-		nc, err = client.NewNodeClient(ctx, sshConfig, conn,
-			net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),
-			t.sessionData.ServerHostname,
-			tc, modules.GetModules().IsBoringBinary())
-		if err != nil {
-			t.log.WithError(err).Warn("Unable to stream terminal - failed to create node client")
-			t.writeError(err)
-			return
-		}
-	}
+	defer nc.Close()
 
 	// Establish SSH connection to the server. This function will block until
 	// either an error occurs or it completes successfully.
@@ -738,6 +727,86 @@ func (t *TerminalHandler) streamTerminal(ws *websocket.Conn, tc *client.Teleport
 	}
 
 	t.log.Debug("Sent close event to web client.")
+}
+
+// connectToNode attempts to connect to the host with the already
+// provisioned certs for the user.
+func (t *TerminalHandler) connectToNode(ctx context.Context, ws *websocket.Conn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent teleagent.Getter) (*client.NodeClient, error) {
+	conn, _, err := t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker, getAgent)
+	if err != nil {
+		t.log.WithError(err).Warn("Unable to stream terminal - failed to dial host.")
+
+		if errors.Is(err, trace.NotFound(teleport.NodeIsAmbiguous)) {
+			const message = "error: ambiguous host could match multiple nodes\n\nHint: try addressing the node by unique id (ex: user@node-id)\n"
+			return nil, trace.NotFound(message)
+		}
+
+		return nil, trace.Wrap(err)
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            tc.HostLogin,
+		Auth:            tc.AuthMethods,
+		HostKeyCallback: tc.HostKeyCallback,
+	}
+
+	clt, err := client.NewNodeClient(ctx, sshConfig, conn,
+		net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),
+		t.sessionData.ServerHostname,
+		tc, modules.GetModules().IsBoringBinary())
+	if err != nil {
+		return nil, trace.NewAggregate(err, conn.Close())
+	}
+
+	return clt, nil
+}
+
+// connectToNodeWithMFA attempts to perform the mfa ceremony and then dial the
+// host with the retrieved single use certs.
+func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, ws *websocket.Conn, tc *client.TeleportClient, accessChecker services.AccessChecker, getAgent teleagent.Getter) (*client.NodeClient, error) {
+	mfaRequiredResp, err := t.authProvider.IsMFARequired(ctx, &authproto.IsMFARequiredRequest{
+		Target: &authproto.IsMFARequiredRequest_Node{
+			Node: &authproto.NodeLogin{
+				Node:  t.sessionData.ServerID,
+				Login: tc.HostLogin,
+			},
+		},
+	})
+	if err != nil {
+		return nil, trace.Wrap(client.MFARequiredUnknown(err))
+	}
+
+	if !mfaRequiredResp.Required {
+		return nil, trace.Wrap(client.MFARequiredUnknown(trace.AccessDenied("no access to %s", t.sessionData.ServerHostname)))
+	}
+
+	// perform mfa ceremony and retrieve new certs
+	authMethods, err := t.issueSessionMFACerts(ctx, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	sshConfig := &ssh.ClientConfig{
+		User:            tc.HostLogin,
+		Auth:            authMethods,
+		HostKeyCallback: tc.HostKeyCallback,
+	}
+
+	// connect to the node again with the new certs
+	conn, _, err := t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker, getAgent)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	nc, err := client.NewNodeClient(ctx, sshConfig, conn,
+		net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),
+		t.sessionData.ServerHostname,
+		tc, modules.GetModules().IsBoringBinary())
+	if err != nil {
+		return nil, trace.NewAggregate(err, conn.Close())
+	}
+
+	return nc, nil
 }
 
 // streamEvents receives events over the SSH connection and forwards them to


### PR DESCRIPTION
Backport #23865 to branch/v12


Also backports #24400 and part of #24195 to prevent races during tests caused by the simultaneous connection attempts. 