### PR TITLE
Rename the web test plan issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/webtestplan.md
+++ b/.github/ISSUE_TEMPLATE/webtestplan.md
@@ -1,7 +1,7 @@
 ---
-name: Test Plan
-about: Manual test plan for Teleport major releases
-title: "Teleport X Web Test Plan"
+name: Web Test Plan
+about: Web UI manual test plan for Teleport major releases
+title: "Teleport Web Test Plan"
 labels: testplan
 ---
 


### PR DESCRIPTION
This was copied from the original test plan template, but the name was never changed. As a result, the GitHub UI shows an error: "There is a problem with this template"