### PR TITLE
Move docs builds down in GitHub Actions test

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -38,11 +38,11 @@ jobs:
         # single version of the docs.
         run: 'echo "{\"versions\": [{\"name\": \"docs\", \"branch\": \"$GITHUB_REF_NAME\", \"deprecated\": false}]}" > /src/config.json'
 
-      - name: Test the docs build
-        run: cd /src && yarn install && yarn build
-
       - name: Check spelling
         run: cd /src && yarn spellcheck /src/content/docs
 
       - name: Lint the docs
         run: cd /src && yarn markdown-lint
+
+      - name: Test the docs build
+        run: cd /src && yarn install && yarn build


### PR DESCRIPTION
The docs build takes the longest so best to get a failure from the faster steps first (spelling, lint).