### PR TITLE
helm: support setting proxyListenerMode to emptystring

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/proxy/_config.common.tpl
@@ -23,7 +23,7 @@ proxy_service:
 {{- else }}
   public_addr: '{{ required "clusterName is required in chart values" .Values.clusterName }}:443'
 {{- end }}
-{{- if eq .Values.proxyListenerMode "separate" }}
+{{- if ne .Values.proxyListenerMode "multiplex" }}
   listen_addr: 0.0.0.0:3023
   {{- if .Values.sshPublicAddr }}
   ssh_public_addr: {{- toYaml .Values.sshPublicAddr | nindent 8 }}

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -169,7 +169,7 @@ spec:
           containerPort: 3021
           protocol: TCP
         {{- end }}
-        {{- if eq $proxy.proxyListenerMode "separate" }}
+        {{- if ne $proxy.proxyListenerMode "multiplex" }}
         - name: sshproxy
           containerPort: 3023
           protocol: TCP

--- a/examples/chart/teleport-cluster/templates/proxy/service.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/service.yaml
@@ -33,7 +33,7 @@ spec:
     port: 443
     targetPort: 3080
     protocol: TCP
-{{- if eq $proxy.proxyListenerMode "separate" }}
+{{- if ne $proxy.proxyListenerMode "multiplex" }}
   - name: sshproxy
     port: 3023
     targetPort: 3023


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/24302

The user copied all our default values from v11 and applied them on v12. Some of them were not meant to be set by users, were not covered by our backward compatibility guarantee efforts, and it broke. This PR ensures we handle more gracefully when this happens.