### PR TITLE
Fix tsh proxy aws --endpoint-url error

### DIFF
--- a/tool/tsh/app_aws.go
+++ b/tool/tsh/app_aws.go
@@ -93,6 +93,11 @@ func newAWSApp(cf *CLIConf, profile *client.ProfileStatus, appName string) (*aws
 	}, nil
 }
 
+// GetAppName returns the app name.
+func (a *awsApp) GetAppName() string {
+	return a.appName
+}
+
 // StartLocalProxies sets up local proxies for serving AWS clients.
 //
 // There are two ways clients can connect to the local proxies.

--- a/tool/tsh/proxy.go
+++ b/tool/tsh/proxy.go
@@ -612,6 +612,10 @@ func onProxyCommandApp(cf *CLIConf) error {
 
 // onProxyCommandAWS creates local proxes for AWS apps.
 func onProxyCommandAWS(cf *CLIConf) error {
+	if err := checkProxyAWSFormatCompatibility(cf); err != nil {
+		return trace.Wrap(err)
+	}
+
 	awsApp, err := pickActiveAWSApp(cf)
 	if err != nil {
 		return trace.Wrap(err)
@@ -628,64 +632,77 @@ func onProxyCommandAWS(cf *CLIConf) error {
 		}
 	}()
 
-	envVars, err := awsApp.GetEnvVars()
-	if err != nil {
+	if err := printProxyAWSTemplate(cf, awsApp); err != nil {
 		return trace.Wrap(err)
 	}
+	<-cf.Context.Done()
+	return nil
+}
 
-	proxyHost, proxyPort, err := net.SplitHostPort(awsApp.GetForwardProxyAddr())
+type awsAppInfo interface {
+	GetAppName() string
+	GetEnvVars() (map[string]string, error)
+	GetEndpointURL() string
+	GetForwardProxyAddr() string
+}
+
+func printProxyAWSTemplate(cf *CLIConf, awsApp awsAppInfo) error {
+	envVars, err := awsApp.GetEnvVars()
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	templateData := map[string]interface{}{
 		"envVars":     envVars,
-		"address":     awsApp.GetForwardProxyAddr(),
 		"endpointURL": awsApp.GetEndpointURL(),
 		"format":      cf.Format,
 		"randomPort":  cf.LocalProxyPort == "",
-		"appName":     awsApp.appName,
-		"proxyScheme": "http",
-		"proxyHost":   proxyHost,
-		"proxyPort":   proxyPort,
+		"appName":     awsApp.GetAppName(),
 		"region":      getEnvOrDefault(awsRegionEnvVar, "<region>"),
 		"keystore":    getEnvOrDefault(awsKeystoreEnvVar, "<keystore>"),
 		"workgroup":   getEnvOrDefault(awsWorkgroupEnvVar, "<workgroup>"),
 	}
 
+	if proxyAddr := awsApp.GetForwardProxyAddr(); proxyAddr != "" {
+		proxyHost, proxyPort, err := net.SplitHostPort(proxyAddr)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		templateData["proxyScheme"] = "http"
+		templateData["proxyHost"] = proxyHost
+		templateData["proxyPort"] = proxyPort
+	}
+
 	templates := []string{awsProxyHeaderTemplate}
 	switch {
 	case cf.Format == awsProxyFormatAthenaODBC:
-		if cf.AWSEndpointURLMode {
-			return trace.BadParameter("format %q is not supported in --endpoint-url mode", cf.Format)
-		}
 		templates = append(templates, awsProxyAthenaODBCTemplate)
-
 	case cf.Format == awsProxyFormatAthenaJDBC:
-		if cf.AWSEndpointURLMode {
-			return trace.BadParameter("format %q is not supported in --endpoint-url mode", cf.Format)
-		}
 		templates = append(templates, awsProxyJDBCHeaderFooterTemplate, awsProxyAthenaJDBCTemplate)
-
 	case cf.AWSEndpointURLMode:
 		templates = append(templates, awsEndpointURLProxyTemplate)
 	default:
 		templates = append(templates, awsHTTPSProxyTemplate)
 	}
 
-	template := template.New("").Funcs(cloudTemplateFuncs)
+	combined := template.New("").Funcs(cloudTemplateFuncs)
 	for _, text := range templates {
-		template, err = template.Parse(text)
+		combined, err = combined.Parse(text)
 		if err != nil {
 			return trace.Wrap(err)
 		}
 	}
 
-	if err = template.Execute(cf.Stdout(), templateData); err != nil {
-		return trace.Wrap(err)
-	}
+	return trace.Wrap(combined.Execute(cf.Stdout(), templateData))
+}
 
-	<-cf.Context.Done()
+func checkProxyAWSFormatCompatibility(cf *CLIConf) error {
+	switch cf.Format {
+	case awsProxyFormatAthenaODBC, awsProxyFormatAthenaJDBC:
+		if cf.AWSEndpointURLMode {
+			return trace.BadParameter("format %q is not supported in --endpoint-url mode", cf.Format)
+		}
+	}
 	return nil
 }
 

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -1015,3 +1015,163 @@ Use one of the following commands to connect to the database or to the address a
 		})
 	}
 }
+
+type fakeAWSAppInfo struct {
+	forwardProxyAddr string
+}
+
+func (f fakeAWSAppInfo) GetAppName() string {
+	return "fake-aws-app"
+}
+func (f fakeAWSAppInfo) GetEnvVars() (map[string]string, error) {
+	envVars := map[string]string{
+		"AWS_ACCESS_KEY_ID":     "FAKE_ID",
+		"AWS_SECRET_ACCESS_KEY": "FAKE_KEY",
+		"AWS_CA_BUNDLE":         "FAKE_CA_BUNDLE_PATH",
+	}
+	if f.forwardProxyAddr != "" {
+		envVars["HTTPS_PROXY"] = "http://" + f.forwardProxyAddr
+	}
+	return envVars, nil
+}
+func (f fakeAWSAppInfo) GetEndpointURL() string {
+	return "https://127.0.0.1:12345"
+}
+func (f fakeAWSAppInfo) GetForwardProxyAddr() string {
+	return f.forwardProxyAddr
+}
+
+func TestPrintProxyAWSTemplate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		inputCLIConf *CLIConf
+		inputAWSApp  awsAppInfo
+		wantSnippets []string
+	}{
+		{
+			name: "HTTPS_PROXY mode",
+			inputCLIConf: &CLIConf{
+				Format: envVarDefaultFormat(),
+			},
+			inputAWSApp: fakeAWSAppInfo{
+				forwardProxyAddr: "127.0.0.1:8888",
+			},
+			wantSnippets: []string{
+				"127.0.0.1:8888",
+				"Use the following credentials and HTTPS proxy setting to connect to the proxy",
+			},
+		},
+		{
+			name: "endpoint URL mode",
+			inputCLIConf: &CLIConf{
+				Format:             envVarDefaultFormat(),
+				AWSEndpointURLMode: true,
+			},
+			inputAWSApp: fakeAWSAppInfo{},
+			wantSnippets: []string{
+				"AWS endpoint URL at https://127.0.0.1:12345",
+			},
+		},
+		{
+			name: "athena-odbc",
+			inputCLIConf: &CLIConf{
+				Format: awsProxyFormatAthenaODBC,
+			},
+			inputAWSApp: fakeAWSAppInfo{
+				forwardProxyAddr: "127.0.0.1:8888",
+			},
+			wantSnippets: []string{
+				"DRIVER=Simba Amazon Athena ODBC Connector;",
+				"UseProxy=1;ProxyScheme=http;ProxyHost=127.0.0.1;ProxyPort=8888;",
+			},
+		},
+		{
+			name: "athena-jdbc",
+			inputCLIConf: &CLIConf{
+				Format: awsProxyFormatAthenaJDBC,
+			},
+			inputAWSApp: fakeAWSAppInfo{
+				forwardProxyAddr: "127.0.0.1:8888",
+			},
+			wantSnippets: []string{
+				"jdbc:awsathena:",
+				"ProxyHost=127.0.0.1;ProxyPort=8888;",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			buf := new(bytes.Buffer)
+			test.inputCLIConf.overrideStdout = buf
+			require.NoError(t, printProxyAWSTemplate(test.inputCLIConf, test.inputAWSApp))
+			for _, wantSnippet := range test.wantSnippets {
+				require.Contains(t, buf.String(), wantSnippet)
+			}
+		})
+	}
+}
+
+func TestCheckProxyAWSFormatCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		input      *CLIConf
+		checkError require.ErrorAssertionFunc
+	}{
+		{
+			name: "default format is supported in HTTPS_PROXY mode",
+			input: &CLIConf{
+				Format: envVarDefaultFormat(),
+			},
+			checkError: require.NoError,
+		},
+		{
+			name: "default format is supported in endpoint URL mode",
+			input: &CLIConf{
+				Format:             envVarDefaultFormat(),
+				AWSEndpointURLMode: true,
+			},
+			checkError: require.NoError,
+		},
+		{
+			name: "athena-odbc is supported in HTTPS_PROXY mode",
+			input: &CLIConf{
+				Format: awsProxyFormatAthenaODBC,
+			},
+			checkError: require.NoError,
+		},
+		{
+			name: "athena-odbc is not supported in endpoint URL mode",
+			input: &CLIConf{
+				Format:             awsProxyFormatAthenaODBC,
+				AWSEndpointURLMode: true,
+			},
+			checkError: require.Error,
+		},
+		{
+			name: "athena-jdbc is supported in HTTPS_PROXY mode",
+			input: &CLIConf{
+				Format: awsProxyFormatAthenaJDBC,
+			},
+			checkError: require.NoError,
+		},
+		{
+			name: "athena-jdbc is not supported in endpoint URL mode",
+			input: &CLIConf{
+				Format:             awsProxyFormatAthenaJDBC,
+				AWSEndpointURLMode: true,
+			},
+			checkError: require.Error,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.checkError(t, checkProxyAWSFormatCompatibility(test.input))
+		})
+	}
+}


### PR DESCRIPTION
Fix an issue `tsh proxy aws --endpoint-url` always gives an error (`master` only)

```
$ tsh proxy aws  --endpoint-url
ERROR: missing port in address
```
The error is caused when try to parse forward proxy's address which is empty with `--endpoint-url` mode.

Decided to split the current function to smaller functions and added some unit tests.