### PR TITLE
WebDiscover: Add open source integrations enrollment page

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -19,9 +19,10 @@ import { useLocation, useHistory } from 'react-router';
 
 import * as Icons from 'design/Icon';
 import styled from 'styled-components';
-import { Box, Flex, Text, Popover, Link } from 'design';
+import { Box, Flex, Text, Link } from 'design';
 
 import useTeleport from 'teleport/useTeleport';
+import { ToolTipNoPermBadge } from 'teleport/components/ToolTipNoPermBadge';
 import { Acl } from 'teleport/services/user';
 import {
   ResourceKind,
@@ -151,7 +152,7 @@ export function SelectResource(props: SelectResourceProps) {
                     <BadgeGuided>Guided</BadgeGuided>
                   )}
                   {!r.hasAccess && (
-                    <ToolTip
+                    <ToolTipNoPermBadge
                       children={
                         <PermissionsErrorMessage resourceKind={r.kind} />
                       }
@@ -225,59 +226,6 @@ const ClearSearch = ({ onClick }: { onClick(): void }) => {
       </Box>
       <Text>Clear search</Text>
     </Flex>
-  );
-};
-
-const ToolTip: React.FC = ({ children }) => {
-  const [anchorEl, setAnchorEl] = useState();
-  const open = Boolean(anchorEl);
-
-  function handlePopoverOpen(event) {
-    setAnchorEl(event.currentTarget);
-  }
-
-  function handlePopoverClose() {
-    setAnchorEl(null);
-  }
-
-  return (
-    <>
-      <div
-        aria-owns={open ? 'mouse-over-popover' : undefined}
-        onMouseEnter={handlePopoverOpen}
-        onMouseLeave={handlePopoverClose}
-        css={`
-          position: absolute;
-          background: red;
-          padding: 0px 6px;
-          border-top-right-radius: 8px;
-          border-bottom-left-radius: 8px;
-          top: 0px;
-          right: 0px;
-          font-size: 10px;
-        `}
-      >
-        Lacking Permissions
-      </div>
-      <Popover
-        modalCss={() => `pointer-events: none;`}
-        onClose={handlePopoverClose}
-        open={open}
-        anchorEl={anchorEl}
-        anchorOrigin={{
-          vertical: 'bottom',
-          horizontal: 'left',
-        }}
-        transformOrigin={{
-          vertical: 'top',
-          horizontal: 'left',
-        }}
-      >
-        <StyledOnHover px={3} py={2}>
-          {children}
-        </StyledOnHover>
-      </Popover>
-    </>
   );
 };
 
@@ -395,12 +343,6 @@ const BadgeGuided = styled.div`
   top: 0px;
   right: 0px;
   font-size: 10px;
-`;
-
-const StyledOnHover = styled(Text)`
-  background-color: white;
-  color: black;
-  max-width: 350px;
 `;
 
 const InputWrapper = styled.div`

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -2373,6 +2373,18 @@ exports[`render with no access 1`] = `
   justify-content: center;
 }
 
+.c9 {
+  box-sizing: border-box;
+  background-color: red;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  position: absolute;
+  padding: 0px 6px;
+  top: 0px;
+  right: 0px;
+  font-size: 10px;
+}
+
 .c6 {
   display: grid;
   grid-template-columns: repeat(auto-fill,320px);
@@ -2434,17 +2446,6 @@ exports[`render with no access 1`] = `
   opacity: 0.6;
 }
 
-.c9 {
-  position: absolute;
-  background: red;
-  padding: 0px 6px;
-  border-top-right-radius: 8px;
-  border-bottom-left-radius: 8px;
-  top: 0px;
-  right: 0px;
-  font-size: 10px;
-}
-
 <div
   class="c0"
 >
@@ -2487,6 +2488,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2523,6 +2525,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2558,6 +2561,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2599,6 +2603,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2640,6 +2645,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2681,6 +2687,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2722,6 +2729,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2763,6 +2771,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2803,6 +2812,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2844,6 +2854,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2885,6 +2896,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2926,6 +2938,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -2969,6 +2982,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3013,6 +3027,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3057,6 +3072,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3101,6 +3117,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3145,6 +3162,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3189,6 +3207,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3233,6 +3252,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3277,6 +3297,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3321,6 +3342,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3365,6 +3387,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3409,6 +3432,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3453,6 +3477,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3497,6 +3522,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3535,6 +3561,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3579,6 +3606,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3623,6 +3651,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3667,6 +3696,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3711,6 +3741,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3755,6 +3786,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3799,6 +3831,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3837,6 +3870,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3881,6 +3915,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -3925,6 +3960,7 @@ exports[`render with no access 1`] = `
     >
       <div
         class="c9"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4098,6 +4134,18 @@ exports[`render with partial access 1`] = `
   justify-content: center;
 }
 
+.c20 {
+  box-sizing: border-box;
+  background-color: red;
+  border-top-right-radius: 4px;
+  border-bottom-left-radius: 4px;
+  position: absolute;
+  padding: 0px 6px;
+  top: 0px;
+  right: 0px;
+  font-size: 10px;
+}
+
 .c6 {
   display: grid;
   grid-template-columns: repeat(auto-fill,320px);
@@ -4190,17 +4238,6 @@ exports[`render with partial access 1`] = `
 .c5:placeholder {
   color: white;
   opacity: 0.6;
-}
-
-.c20 {
-  position: absolute;
-  background: red;
-  padding: 0px 6px;
-  border-top-right-radius: 8px;
-  border-bottom-left-radius: 8px;
-  top: 0px;
-  right: 0px;
-  font-size: 10px;
 }
 
 <div
@@ -4557,6 +4594,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4598,6 +4636,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4639,6 +4678,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4680,6 +4720,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4723,6 +4764,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4767,6 +4809,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4811,6 +4854,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4855,6 +4899,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4899,6 +4944,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4943,6 +4989,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -4987,6 +5034,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5031,6 +5079,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5075,6 +5124,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5119,6 +5169,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5163,6 +5214,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5207,6 +5259,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5251,6 +5304,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5289,6 +5343,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5333,6 +5388,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5377,6 +5433,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5421,6 +5478,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5465,6 +5523,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5509,6 +5568,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5553,6 +5613,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5591,6 +5652,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5635,6 +5697,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>
@@ -5679,6 +5742,7 @@ exports[`render with partial access 1`] = `
     >
       <div
         class="c20"
+        data-testid="tooltip"
       >
         Lacking Permissions
       </div>

--- a/web/packages/teleport/src/IntegrationEnroll/IntegrationEnroll.story.tsx
+++ b/web/packages/teleport/src/IntegrationEnroll/IntegrationEnroll.story.tsx
@@ -1,0 +1,30 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+
+import { IntegrationEnroll } from './IntegrationEnroll';
+
+export default {
+  title: 'Teleport/Integrations',
+};
+
+export const Enroll = () => (
+  <MemoryRouter>
+    <IntegrationEnroll />
+  </MemoryRouter>
+);

--- a/web/packages/teleport/src/IntegrationEnroll/IntegrationEnroll.tsx
+++ b/web/packages/teleport/src/IntegrationEnroll/IntegrationEnroll.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Box } from 'design';
+
+import {
+  FeatureBox,
+  FeatureHeader,
+  FeatureHeaderTitle,
+} from 'teleport/components/Layout';
+
+import { IntegrationTiles } from './IntegrationTiles';
+import { NoCodeIntegrationDescription } from './common';
+
+export function IntegrationEnroll() {
+  return (
+    <FeatureBox>
+      <FeatureHeader>
+        <FeatureHeaderTitle>Select Integration Type</FeatureHeaderTitle>
+      </FeatureHeader>
+      <Box>
+        <NoCodeIntegrationDescription />
+        <IntegrationTiles />
+      </Box>
+    </FeatureBox>
+  );
+}

--- a/web/packages/teleport/src/IntegrationEnroll/IntegrationTiles.test.tsx
+++ b/web/packages/teleport/src/IntegrationEnroll/IntegrationTiles.test.tsx
@@ -18,8 +18,6 @@ import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { render, screen } from 'design/utils/testing';
 
-import cfg from 'teleport/config';
-
 import { IntegrationTiles } from './IntegrationTiles';
 
 test('render', async () => {
@@ -36,10 +34,7 @@ test('render', async () => {
 
   const tile = screen.getByTestId('tile');
   expect(tile).toBeEnabled();
-
-  // Want to loosely test the href value (not exact).
-  // eslint-disable-next-line jest-dom/prefer-to-have-attribute
-  expect(tile.getAttribute('href')).toContain(cfg.getIntegrationEnrollRoute());
+  expect(tile.getAttribute('href')).toBeTruthy();
 });
 
 test('render disabled', async () => {

--- a/web/packages/teleport/src/IntegrationEnroll/IntegrationTiles.test.tsx
+++ b/web/packages/teleport/src/IntegrationEnroll/IntegrationTiles.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { render, screen } from 'design/utils/testing';
+
+import cfg from 'teleport/config';
+
+import { IntegrationTiles } from './IntegrationTiles';
+
+test('render', async () => {
+  render(
+    <MemoryRouter>
+      <IntegrationTiles />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText(/amazon web services/i)).toBeInTheDocument();
+  expect(screen.queryByText(/no permission/i)).not.toBeInTheDocument();
+  expect(screen.getByRole('img')).toBeInTheDocument();
+  expect(screen.getByRole('link')).toBeInTheDocument();
+
+  const tile = screen.getByTestId('tile');
+  expect(tile).toBeEnabled();
+
+  // Want to loosely test the href value (not exact).
+  // eslint-disable-next-line jest-dom/prefer-to-have-attribute
+  expect(tile.getAttribute('href')).toContain(cfg.getIntegrationEnrollRoute());
+});
+
+test('render disabled', async () => {
+  render(
+    <MemoryRouter>
+      <IntegrationTiles hasAccess={false} />
+    </MemoryRouter>
+  );
+
+  expect(screen.getByText(/lacking permission/i)).toBeInTheDocument();
+  expect(screen.queryByRole('link')).not.toBeInTheDocument();
+
+  const tile = screen.getByTestId('tile');
+  expect(tile).not.toHaveAttribute('href');
+
+  // The element has disabled attribute, but it's in the format `disabled=""`
+  // so "toBeDisabled" interprets it as false.
+  // eslint-disable-next-line jest-dom/prefer-enabled-disabled
+  expect(tile).toHaveAttribute('disabled');
+});

--- a/web/packages/teleport/src/IntegrationEnroll/IntegrationTiles.tsx
+++ b/web/packages/teleport/src/IntegrationEnroll/IntegrationTiles.tsx
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Text, Image } from 'design';
+import awsIcon from 'design/assets/images/icons/aws.svg';
+
+import cfg from 'teleport/config';
+import { ToolTipNoPermBadge } from 'teleport/components/ToolTipNoPermBadge';
+
+import { IntegrationTile } from './common';
+
+// IntegrationTiles is plural but at the moment we only
+// support aws-oidc. Expecting this to grow.
+export function IntegrationTiles({
+  hasAccess = true,
+}: {
+  hasAccess?: boolean;
+}) {
+  return (
+    <IntegrationTile
+      disabled={!hasAccess}
+      as={hasAccess ? Link : null}
+      to={hasAccess ? cfg.getIntegrationEnrollRoute('aws-oidc') : null}
+    >
+      <Image mt={3} mb={2} src={awsIcon} width="80px" height="80px" />
+      <Text>
+        Amazon Web Services
+        <br />
+        OIDC
+      </Text>
+      {!hasAccess && (
+        <ToolTipNoPermBadge
+          children={`You do not have access to create integrations`}
+        />
+      )}
+    </IntegrationTile>
+  );
+}

--- a/web/packages/teleport/src/IntegrationEnroll/common.tsx
+++ b/web/packages/teleport/src/IntegrationEnroll/common.tsx
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { Flex, Text, Box } from 'design';
+import styled from 'styled-components';
+
+export type IntegrationTypes = 'aws-oidc';
+
+export const IntegrationTile = styled(Flex).attrs({
+  'data-testid': 'tile',
+})`
+  color: inherit;
+  text-decoration: none;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
+  border-radius: 4px;
+  height: 170px;
+  width: 170px;
+  background-color: ${({ theme }) => theme.colors.buttons.secondary.default};
+  text-align: center;
+  cursor: pointer;
+
+  ${props => {
+    const pointerEvents = props.disabled ? 'none' : null;
+    if (props.$exists) {
+      return { pointerEvents };
+    }
+
+    return `
+    opacity: ${props.disabled ? '0.45' : '1'};
+    &:hover {
+      background-color: ${props.theme.colors.buttons.secondary.hover};
+    }
+    `;
+  }}
+`;
+
+export const NoCodeIntegrationDescription = () => (
+  <Box mb={3}>
+    <Text fontWeight="bold" typography="h4">
+      No-Code Integrations
+    </Text>
+    <Text typography="body1">
+      Hosted Integrations eliminate the setup work so you can quickly connect
+      applications to Teleport for alerting and other useful functions. This
+      list is short for now, but it will grow with time!
+    </Text>
+  </Box>
+);

--- a/web/packages/teleport/src/IntegrationEnroll/index.ts
+++ b/web/packages/teleport/src/IntegrationEnroll/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// export as default for use with React.lazy
+export { IntegrationEnroll as default } from './IntegrationEnroll';
+export { IntegrationTiles } from './IntegrationTiles';
+
+export * from './common';

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.story.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.story.tsx
@@ -1,0 +1,51 @@
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React from 'react';
+import styled from 'styled-components';
+import { Box } from 'design';
+
+import { ToolTipNoPermBadge } from './ToolTipNoPermBadge';
+
+export default {
+  title: 'Teleport/ToolTip',
+};
+
+export const NoPermissionBadgeString = () => (
+  <SomeBox>
+    I'm a sample container
+    <ToolTipNoPermBadge children={'I am a string'} />
+  </SomeBox>
+);
+
+export const NoPermissionBadgeComp = () => (
+  <SomeBox>
+    I'm a sample container
+    <ToolTipNoPermBadge
+      children={<Box p={3}>I'm a box component with too much padding</Box>}
+    />
+  </SomeBox>
+);
+
+const SomeBox = styled.div`
+  width: 240px;
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  position: relative;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.05);
+`;

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.test.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+import { render, screen, userEvent } from 'design/utils/testing';
+
+import { ToolTipNoPermBadge } from './ToolTipNoPermBadge';
+
+test('hovering renders tooltip msg and unhovering makes it disappear', async () => {
+  render(
+    <SomeBox>
+      <ToolTipNoPermBadge children="test message" />
+    </SomeBox>
+  );
+
+  expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+
+  const badge = screen.getByTestId('tooltip');
+
+  await userEvent.hover(badge);
+  expect(screen.getByTestId('tooltip-msg')).toBeInTheDocument();
+
+  await userEvent.unhover(badge);
+  expect(screen.queryByTestId('tooltip-msg')).not.toBeInTheDocument();
+});
+
+const SomeBox = styled.div`
+  width: 240px;
+  padding: 16px;
+`;

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.tsx
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Text, Popover, Box } from 'design';
+
+type Props = {
+  borderRadius?: number;
+};
+
+export const ToolTipNoPermBadge: React.FC<Props> = ({
+  children,
+  borderRadius = 2,
+}) => {
+  const [anchorEl, setAnchorEl] = useState();
+  const open = Boolean(anchorEl);
+
+  function handlePopoverOpen(event) {
+    setAnchorEl(event.currentTarget);
+  }
+
+  function handlePopoverClose() {
+    setAnchorEl(null);
+  }
+
+  return (
+    <>
+      <Box
+        data-testid="tooltip"
+        aria-owns={open ? 'mouse-over-popover' : undefined}
+        onMouseEnter={handlePopoverOpen}
+        onMouseLeave={handlePopoverClose}
+        borderTopRightRadius={borderRadius}
+        borderBottomLeftRadius={borderRadius}
+        bg="red"
+        css={`
+          position: absolute;
+          padding: 0px 6px;
+          top: 0px;
+          right: 0px;
+          font-size: 10px;
+        `}
+      >
+        Lacking Permissions
+      </Box>
+      <Popover
+        modalCss={() => `pointer-events: none;`}
+        onClose={handlePopoverClose}
+        open={open}
+        anchorEl={anchorEl}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'left',
+        }}
+      >
+        <StyledOnHover px={3} py={2} data-testid="tooltip-msg">
+          {children}
+        </StyledOnHover>
+      </Popover>
+    </>
+  );
+};
+
+const StyledOnHover = styled(Text)`
+  background-color: white;
+  color: black;
+  max-width: 350px;
+`;

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/index.ts
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ToolTipNoPermBadge } from './ToolTipNoPermBadge';

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -86,7 +86,7 @@ const AuthConnectors = React.lazy(
   () => import(/* webpackChunkName: "auth-connectors" */ './AuthConnectors')
 );
 const Locks = React.lazy(
-  () => import(/* webpackChunkName: "lazy" */ './Locks')
+  () => import(/* webpackChunkName: "locks" */ './Locks')
 );
 const NewLock = React.lazy(
   () => import(/* webpackChunkName: "newLock" */ './Locks/NewLock')
@@ -102,6 +102,10 @@ const Discover = React.lazy(
 );
 const Integrations = React.lazy(
   () => import(/* webpackChunkName: "integrations" */ './Integrations')
+);
+const IntegrationEnroll = React.lazy(
+  () =>
+    import(/* webpackChunkName: "integration-enroll" */ './IntegrationEnroll')
 );
 
 // ****************************
@@ -425,6 +429,36 @@ export class FeatureIntegrations implements TeleportFeature {
   }
 }
 
+export class FeatureIntegrationEnroll implements TeleportFeature {
+  category = NavigationCategory.Management;
+  section = ManagementSection.Access;
+
+  route = {
+    title: 'Enroll New Integration',
+    path: cfg.routes.integrationEnroll,
+    exact: false,
+    component: () => <IntegrationEnroll />,
+  };
+
+  hasAccess(flags: FeatureFlags) {
+    return flags.enrollIntegrations;
+  }
+
+  navigationItem = {
+    title: 'Enroll New Integration',
+    icon: <AddIcon />,
+    getLink() {
+      return cfg.getIntegrationEnrollRoute(null);
+    },
+  };
+
+  // getRoute allows child class extending this
+  // parent class to refer to this parent's route.
+  getRoute() {
+    return this.route;
+  }
+}
+
 // - Activity
 
 export class FeatureRecordings implements TeleportFeature {
@@ -591,6 +625,7 @@ export function getOSSFeatures(): TeleportFeature[] {
     new FeatureNewLock(),
     new FeatureIntegrations(),
     new FeatureDiscover(),
+    new FeatureIntegrationEnroll(),
 
     // - Activity
     new FeatureRecordings(),

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -108,6 +108,7 @@ class TeleportContext implements types.Context {
         plugins: false,
         integrations: false,
         deviceTrust: false,
+        enrollIntegrationsOrPlugins: false,
         enrollIntegrations: false,
       };
     }
@@ -132,7 +133,8 @@ class TeleportContext implements types.Context {
       discover: userContext.hasDiscoverAccess(),
       plugins: userContext.getPluginsAccess().list,
       integrations: userContext.getIntegrationsAccess().list,
-      enrollIntegrations:
+      enrollIntegrations: userContext.getIntegrationsAccess().create,
+      enrollIntegrationsOrPlugins:
         userContext.getPluginsAccess().create ||
         userContext.getIntegrationsAccess().create,
       deviceTrust: userContext.getDeviceTrustAccess().list,

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -91,6 +91,7 @@ export interface FeatureFlags {
   discover: boolean;
   plugins: boolean;
   integrations: boolean;
+  enrollIntegrationsOrPlugins: boolean;
   enrollIntegrations: boolean;
   deviceTrust: boolean;
 }


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/22129
enterprise part: https://github.com/gravitational/teleport.e/pull/1113

- Adds open source version of integrations enrollment page (only lists resource type `integration`)
- Copied over some styling from enterprise
- Create a shareable component for `lacks permission` red colored badge, when on hover display tooltip message

#### Screenshot
doesn't do anything upon click, but this feature is also  manually disabled (menu tab will not render unless you change the code)

<img width="1488" alt="image" src="https://user-images.githubusercontent.com/43280172/231240005-493bb122-9337-4752-9530-179fb0fedab1.png">
