### PR TITLE
[v11] Tweak messaging to anticipate a new linter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ The connection attempt would show up in the audit log as a "port" audit event
 
 ### [High] Teleport authorization bypass in Kubernetes Access
 
-When authorizing a Kubernetes Access request, Teleport did not adequately
+When authorizing a Kubernetes access request, Teleport did not adequately
 validate the target Kubernetes cluster.
 
 This could allow an attacker in possession of valid Kubernetes agent credentials
@@ -29,7 +29,7 @@ audit event (code T3009I) and include the Kubernetes cluster metadata.
 
 ### Other improvements and fixes
 
-* Application Access
+* Application access
   * Reduced log noise. [#23366](https://github.com/gravitational/teleport/pull/23366)
   * Fixed app access requests being redirected to leaf's public address in some cases. [#23221](https://github.com/gravitational/teleport/pull/23221)
 * AMIs
@@ -120,7 +120,7 @@ This release of Teleport contains a security fix as well as multiple improvement
 * Fixed issue with orphaned child processes after session ends. [#22224](https://github.com/gravitational/teleport/pull/22224)
 * Fixed issue with internal logins periodically appearing in Teleport Connect. [#22188](https://github.com/gravitational/teleport/pull/22188)
 * Fixed issue with remote cluster connection status sometimes not being updated properly. [#22089](https://github.com/gravitational/teleport/pull/22089)
-* Fixed heartbeat failures from database service. [#22084](https://github.com/gravitational/teleport/pull/22084)
+* Fixed heartbeat failures from the Database Service. [#22084](https://github.com/gravitational/teleport/pull/22084)
 * Fixed issue with missing `--request-id=` flag in UI for Kubernetes login instructions. [#21443](https://github.com/gravitational/teleport/pull/21443)
 * Fixed access denied issues when using full role ARN when connecting to databases. [#21254](https://github.com/gravitational/teleport/pull/21254)
 * Added `--client` flag to `tsh version` command flag to show client-only version. [#22168](https://github.com/gravitational/teleport/pull/22168)
@@ -142,11 +142,11 @@ This release of Teleport contains a low severity security fix and multiple impro
 ### Other improvements and fixes
 
 * Fixed issue with readyz endpoint not recovering from degraded state. [#21827](https://github.com/gravitational/teleport/pull/21827)
-* Fixed issue with applications temporarily disappearing during app service restart. [#21808](https://github.com/gravitational/teleport/pull/21808)
+* Fixed issue with applications temporarily disappearing during Application Service restart. [#21808](https://github.com/gravitational/teleport/pull/21808)
 * Fixed desktop access discovery errors in access management UI. [#21757](https://github.com/gravitational/teleport/pull/21757)
 * Fixed "handshake failed" and "access denied" Teleport Connect errors on Windows. [#21721](https://github.com/gravitational/teleport/pull/21721)
 * Fixed issue with access management UI not accepting valid port numbers. [#21652](https://github.com/gravitational/teleport/pull/21652)
-* Fixed database connection issues during database service restarts. [#21636](https://github.com/gravitational/teleport/pull/21636)
+* Fixed database connection issues during Database Service restarts. [#21636](https://github.com/gravitational/teleport/pull/21636)
 * Fixed Kubernetes connection issues during Kubernetes service restarts. [#21616](https://github.com/gravitational/teleport/pull/21616)
 * Fixed issue with application access going into redirect loop sometimes. [#21614](https://github.com/gravitational/teleport/pull/21614)
 * Fixed issue with moderated sessions not working on leaf clusters. [#21611](https://github.com/gravitational/teleport/pull/21611)
@@ -166,11 +166,11 @@ This release of Teleport contains multiple improvements and bug fixes.
 * Fixed panic when terminating moderated session with Ctrl-D. [#21350](https://github.com/gravitational/teleport/pull/21350)
 * Fixed issue with Teleport installer script failing with 404. [#21242](https://github.com/gravitational/teleport/pull/21242)
 * Fixed issue with Teleport Connect installation on some Debian systems. [#21221](https://github.com/gravitational/teleport/pull/21221)
-* Fixed issue with Kubernetes Access impersonation via `--as` flag. [#21148](https://github.com/gravitational/teleport/pull/21148)
+* Fixed issue with Kubernetes access impersonation via `--as` flag. [#21148](https://github.com/gravitational/teleport/pull/21148)
 * Fixed issue with Teleport generating audit events for preset roles after each restart. [#21142](https://github.com/gravitational/teleport/pull/21142)
-* Fixed issue with Desktop Access losing connections to desktops when LDAP discovery is disabled. [#21083](https://github.com/gravitational/teleport/pull/21083)
+* Fixed issue with the Desktop Service losing connections to desktops when LDAP discovery is disabled. [#21083](https://github.com/gravitational/teleport/pull/21083)
 * Fixed `tsh db connect` when using hardware-backed private keys. [#21042](https://github.com/gravitational/teleport/pull/21042)
-* Fixed issue with Desktop Access sessions being recorded on disk with disabled recording. [#21011](https://github.com/gravitational/teleport/pull/21011)
+* Fixed issue with desktop access sessions being recorded on disk with disabled recording. [#21011](https://github.com/gravitational/teleport/pull/21011)
 * Fixed issue with web UI sessions not being accounted for during graceful shutdown. [#20914](https://github.com/gravitational/teleport/pull/20914)
 * Reduced CPU usage when using enhanced session recording. [#21438](https://github.com/gravitational/teleport/pull/21438)
 * Updated OpenSSL to the latest security patch `1.1.1t`. [#21426](https://github.com/gravitational/teleport/pull/21426)
@@ -216,7 +216,7 @@ This release of Teleport contains a security fix, as well as multiple improvemen
 * Added PodMonitor support in `teleport-cluster` Helm chart. [#20564](https://github.com/gravitational/teleport/pull/20564)
 * Added support for passing raw config in `teleport-kube-agent` Helm chart. [#20449](https://github.com/gravitational/teleport/pull/20449)
 * Added nodeSelector field to `teleport-cluster` Helm chart. [#20441](https://github.com/gravitational/teleport/pull/20441)
-* Improved Kubernetes Access stability for slow clients. [#20517](https://github.com/gravitational/teleport/pull/20517)
+* Improved Kubernetes access stability for slow clients. [#20517](https://github.com/gravitational/teleport/pull/20517)
 * Updated `teleport-cluster` Helm chart to reload proxy certificate daily. [#20503](https://github.com/gravitational/teleport/pull/20503)
 
 ## 11.2.3
@@ -299,12 +299,12 @@ Get-AdUser -Identity svc-teleport | Select SID
 * Added an improved database joining flow in the web UI [#1487](https://github.com/gravitational/webapps/pull/1487)
 * Added support for secure certificate mapping for Windows desktop certificates [#19737](https://github.com/gravitational/teleport/pull/19737)
 * Fixed an issue with desktop directory sharing where large files could be corrupted [#1472](https://github.com/gravitational/webapps/pull/1472)
-* Fixed an issue where Desktop Access users may see a an error after ending a session [#1470](https://github.com/gravitational/webapps/pull/1470)
+* Fixed an issue where desktop access users may see a an error after ending a session [#1470](https://github.com/gravitational/webapps/pull/1470)
 * Fixed an issue preventing database agents from joining due to improperly formatted YAML [#19958](https://github.com/gravitational/teleport/pull/19958)
 * Updated the web UI to use session storage instead of local storage for Teleport's bearer token [#1470](https://github.com/gravitational/webapps/pull/1470)
 * Added rate limiting to SAML/OIDC routes [#19950](https://github.com/gravitational/teleport/pull/19950)
 * Fixed an issue connecting to leaf cluster desktops via reverse tunnel [#19945](https://github.com/gravitational/teleport/pull/19945)
-* Fixed a backwards compability issue with Database Access in 11.1.4 [#19940](https://github.com/gravitational/teleport/pull/19940)
+* Fixed a backwards compability issue with database access in 11.1.4 [#19940](https://github.com/gravitational/teleport/pull/19940)
 * Fixed an issue where access requests for Kubernetes clusters used improperly cached credentials [#19912](https://github.com/gravitational/teleport/pull/19912)
 * Added support for CentOS 7 in ARM64 builds [#19895](https://github.com/gravitational/teleport/pull/19895)
 * Added rate limiting to unauthenticated routes [#19869](https://github.com/gravitational/teleport/pull/19869)
@@ -314,7 +314,7 @@ Get-AdUser -Identity svc-teleport | Select SID
 * Fixed an issue preventing audit events that exceed the maximum size limit from being logged [#19736](https://github.com/gravitational/teleport/pull/19736)
 * Fixed an issue preventing some users from being able to play desktop recordings [#19709](https://github.com/gravitational/teleport/pull/19709)
 * Added validation of AWS Account IDs when adding databases (#19638) [#19702](https://github.com/gravitational/teleport/pull/19702)
-* Added a new audit event for DynamoDB requests via Application Access [#19667](https://github.com/gravitational/teleport/pull/19667)
+* Added a new audit event for DynamoDB requests via application access [#19667](https://github.com/gravitational/teleport/pull/19667)
 * Added the ability to export `tsh` traces even when the Auth Server is not configured for tracing [#19583](https://github.com/gravitational/teleport/pull/19583)
 * Added support for linking Teleport Connect's embedded `tsh` binary for use outside of Teleport Connect [#1488](https://github.com/gravitational/webapps/pull/1488)
 
@@ -323,7 +323,7 @@ Get-AdUser -Identity svc-teleport | Select SID
 This release of Teleport contains multiple security fixes, improvements and bug fixes.
 
 *Note:* This release of Teleport contains an issue that affects backwards compatibility
-with Database Access agents. If you are a Database Access user we recommend skipping
+with database access agents. If you are a database access user we recommend skipping
 straight to version 11.2.0.
 
 ### [Critical] RBAC bypass in SSH TCP tunneling
@@ -337,9 +337,9 @@ establish a TCP tunnel to a node they didn’t have access to.
 The connection attempt would show up in the audit log as a “port” audit event
 (code T3003I) and include Teleport username in the “user” field.
 
-### [High] Application Access session hijack
+### [High] Application access session hijack
 
-When accepting Application Access requests, Teleport did not sufficiently
+When accepting application access requests, Teleport did not sufficiently
 validate client credentials.
 
 This could allow an attacker in possession of a valid active application session
@@ -432,11 +432,11 @@ This release of Teleport contains multiple improvements and bug fixes.
 * Added support for self-hosted Github Enterprise SSO connectors in Teleport Enterprise edition. [#18521](https://github.com/gravitational/teleport/pull/18521), [#18687](https://github.com/gravitational/teleport/pull/18687)
 * Added audit events for DynamoDB via AWS CLI access. [#18035](https://github.com/gravitational/teleport/pull/18035)
 * Added auth connectors support in Kubernetes Operator. [#18350](https://github.com/gravitational/teleport/pull/18350)
-* Added audit events for Desktop Access directory sharing. [#18398](https://github.com/gravitational/teleport/pull/18398)
-* Added trusted clusters support for Desktop Access. [#18666](https://github.com/gravitational/teleport/pull/18666)
+* Added audit events for desktop access directory sharing. [#18398](https://github.com/gravitational/teleport/pull/18398)
+* Added trusted clusters support for desktop access. [#18666](https://github.com/gravitational/teleport/pull/18666)
 * Added support for `user.spec` syntax in moderated session filters. [#18455](https://github.com/gravitational/teleport/pull/18455)
-* Added support for GKE auto-discovery to Kubernetes Access. [#18396](https://github.com/gravitational/teleport/pull/18396)
-* Added FIPS support to Desktop Access. [#18743](https://github.com/gravitational/teleport/pull/18743)
+* Added support for GKE auto-discovery to Kubernetes access. [#18396](https://github.com/gravitational/teleport/pull/18396)
+* Added FIPS support to desktop access. [#18743](https://github.com/gravitational/teleport/pull/18743)
 * Added `teleport discovery bootstrap` command. [#18641](https://github.com/gravitational/teleport/pull/18641)
 * Added `windows_desktops` as the correct resource for `tctl` commands. [#18816](https://github.com/gravitational/teleport/pull/18816)
 * Updated `tsh db ls` JSON and YAML output to include allowed users. [#18543](https://github.com/gravitational/teleport/pull/18543)
@@ -446,7 +446,7 @@ This release of Teleport contains multiple improvements and bug fixes.
 * Fixed issue with RDS auto-discovery failing to start in some cases. [#18590](https://github.com/gravitational/teleport/pull/18590)
 * Fixed "cannot read properties of null" error when trying to add a new server using web UI. [webapps#1356](https://github.com/gravitational/webapps/pull/1356)
 * Fixed issue with applications list pagination in web UI. [#18601](https://github.com/gravitational/teleport/pull/18601)
-* Fixed issue with MongoDB commands sometimes failing through Database Access. [#18738](https://github.com/gravitational/teleport/pull/18738)
+* Fixed issue with MongoDB commands sometimes failing through database access. [#18738](https://github.com/gravitational/teleport/pull/18738)
 * Fixed issue with automatically imported cloud labels not being used in RBAC in App Access. [#18642](https://github.com/gravitational/teleport/pull/18642)
 * Fixed issue with Kubernetes sessions lingering after all participants have disconnected. [#18684](https://github.com/gravitational/teleport/pull/18684)
 * Fixed issue with auth server being down affecting ability to establish new non-moderated SSH sessions. [#18441](https://github.com/gravitational/teleport/pull/18441)
@@ -500,7 +500,7 @@ Teleport did not block SFTP protocol in Moderated Sessions.
 ### Other fixes
 
 * Fixed issue with agent forwarding not working for auto-created users. [#17586](https://github.com/gravitational/teleport/pull/17586)
-* Fixed "traits missing" error in Application Access. [#17737](https://github.com/gravitational/teleport/pull/17737)
+* Fixed "traits missing" error in application access. [#17737](https://github.com/gravitational/teleport/pull/17737)
 * Fixed connection leak issue in IAM joining. [#17737](https://github.com/gravitational/teleport/pull/17737)
 * Fixed panic in "tsh db ls". [#17780](https://github.com/gravitational/teleport/pull/17780)
 * Fixed issue with "tsh mfa add" not displaying OTP QR code image on Windows. [#17703](https://github.com/gravitational/teleport/pull/17703)
@@ -514,12 +514,12 @@ Teleport did not block SFTP protocol in Moderated Sessions.
 
 Teleport 11 brings the following new major features and improvements:
 
-- Hardware-backed private keys support for Server Access (Enterprise only).
-- Replacement of obsolete SCP protocol with SFTP for Server Access.
+- Hardware-backed private keys support for server access (Enterprise only).
+- Replacement of obsolete SCP protocol with SFTP for server access.
 - Removal of persistent storage requirement for Helm charts.
-- Automatic discovery and enrollment of EKS/AKS clusters for Kubernetes Access.
-- Richer Azure integrations for Server and Database Access.
-- Cassandra and Scylla support for Database Access, including AWS Keyspaces.
+- Automatic discovery and enrollment of EKS/AKS clusters for Kubernetes access.
+- Richer Azure integrations for server and database access.
+- Cassandra and Scylla support for database access, including AWS Keyspaces.
 - GitHub Actions and Terraform support for Machine ID.
 - Access Requests and file upload/download support for Teleport Connect.
 
@@ -534,7 +534,7 @@ See how to enable it in this guide:
 https://goteleport.com/docs/access-controls/guides/hardware-key-support/
 
 Hardware-backed private keys is an enterprise only feature, and is currently
-supported for Server Access only.
+supported for server access only.
 
 ### SFTP protocol
 
@@ -574,11 +574,11 @@ Teleport 11 improves Azure support in multiple areas.
 Teleport agents running on Azure VMs will now automatically import Azure tags to
 label resources.
 
-Teleport Database Access now supports auto-discovery for Azure-hosted PostgreSQL
+Teleport database access now supports auto-discovery for Azure-hosted PostgreSQL
 and MySQL databases. See the updated Azure guide for more details:
 https://goteleport.com/docs/ver/11.0/database-access/guides/azure-postgres-mysql/.
 
-In addition, Teleport Database Access will now use Azure AD managed identity
+In addition, Teleport database access will now use Azure AD managed identity
 authentication for Azure-hosted SQL Server databases.
 
 ### Cassandra/ScyllaDB
@@ -667,9 +667,9 @@ Teleport 11 Helm upgrade.
 The preview PostgreSQL backend was deleted due to performance and scalability
 concerns.
 
-#### Removed Desktop Access support for 32-bit ARM and 386 architectures
+#### Removed desktop access support for 32-bit ARM and 386 architectures
 
-32-bit support for Desktop Access on ARM and 386 architectures has been removed
+32-bit support for desktop access on ARM and 386 architectures has been removed
 due to performance issues on these devices.
 
 This also reduces the binary size for these builds, making them slightly more
@@ -685,24 +685,24 @@ Platform:
 * Resource Access Requests (Preview)
 * Proxy Peering (Preview)
 
-Server Access:
+Server access:
 
 * IP-Based Restrictions (Preview)
 * Automatic User Provisioning (Preview)
 
-Database Access:
+Database access:
 
-* Audit Logging for Microsoft SQL Server Database Access
-* Snowflake Database Access (Preview)
-* ElastiCache/MemoryDB Database Access (Preview)
+* Audit Logging for Microsoft SQL Server database access
+* Snowflake database access (Preview)
+* ElastiCache/MemoryDB database access (Preview)
 
 Teleport Connect:
 
-* Teleport Connect for Server and Database Access (Preview)
+* Teleport Connect for server and database access (Preview)
 
 Machine ID:
 
-* Machine ID Database Access Support (Preview)
+* Machine ID database access support (Preview)
 
 ### Passwordless (Preview)
 
@@ -765,32 +765,32 @@ Linux groups and assigned appropriate “sudoer” privileges.
 To learn more about configuring automatic user provisioning read the guide:
 https://goteleport.com/docs/server-access/guides/host-user-creation/.
 
-### Audit Logging for Microsoft SQL Server Database Access
+### Audit Logging for Microsoft SQL Server database access
 
-Teleport 9 introduced a preview of Database Access support for Microsoft SQL
+Teleport 9 introduced a preview of database access support for Microsoft SQL
 Server which didn’t include audit logging of user queries. Teleport 10 captures
 users' queries and prepared statements and sends them to the audit log, similarly
 to other supported database protocols.
 
-Teleport Database Access for SQL Server remains in Preview mode with more UX
+Teleport database access for SQL Server remains in Preview mode with more UX
 improvements coming in future releases.
 
 Refer to the guide to set up access to a SQL Server with Active Directory
 authentication: https://goteleport.com/docs/database-access/guides/sql-server-ad/.
 
-### Snowflake Database Access (Preview)
+### Snowflake database access (Preview)
 
-Teleport 10 brings support for Snowflake to Database Access. Administrators can
+Teleport 10 brings support for Snowflake to database access. Administrators can
 set up access to Snowflake databases through Teleport for their users with
-standard Database Access features like role-based access control and audit
+standard database access features like role-based access control and audit
 logging, including query activity.
 
 Connect your Snowflake database to Teleport following this guide:
 https://goteleport.com/docs/database-access/guides/snowflake/.
 
-### Elasticache/MemoryDB Database Access (Preview)
+### Elasticache/MemoryDB database access (Preview)
 
-Teleport 9 added Redis protocol support to Database Access. Teleport 10 improves
+Teleport 9 added Redis protocol support to database access. Teleport 10 improves
 this integration by adding native support for AWS-hosted Elasticache and
 MemoryDB, including auto-discovery and automatic credential management in some
 deployment configurations.
@@ -798,18 +798,18 @@ deployment configurations.
 Learn more about it in this guide:
 https://goteleport.com/docs/database-access/guides/redis-aws/.
 
-### Teleport Connect for Server and Database Access (Preview)
+### Teleport Connect for server and database access (Preview)
 
 Teleport Connect is a graphical macOS application that simplifies access to your
-Teleport resources. Teleport Connect 10 supports Server Access and Database Access.
+Teleport resources. Teleport Connect 10 supports server access and database access.
 Other protocols and Windows support are coming in a future release.
 
 Get Teleport Connect installer from the macOS tab on the downloads page:
 https://goteleport.com/download/.
 
-### Machine ID Database Access Support (Preview)
+### Machine ID database access support (Preview)
 
-In Teleport 10 we’ve added Database Access support to Machine ID. Applications
+In Teleport 10 we’ve added database access support to Machine ID. Applications
 can use Machine ID to access databases protected by Teleport.
 
 You can find Machine ID guide for database access in the documentation:
@@ -921,16 +921,16 @@ This release of Teleport contains multiple improvements and bug fixes.
 * Fixed two potential panics. [#13590](https://github.com/gravitational/teleport/pull/13590), [#13655](https://github.com/gravitational/teleport/pull/13655)
 * Fixed issue with enhanced session recording not working on recent Ubuntu versions. [#13650](https://github.com/gravitational/teleport/pull/13650)
 * Fixed issue with CA rotation when Database Service does not contain any databases. [#13517](https://github.com/gravitational/teleport/pull/13517)
-* Fixed issue with Desktop Access connection failing with "invalid channel name rdpsnd" error. [#13450](https://github.com/gravitational/teleport/issues/13450)
+* Fixed issue with desktop access connection failing with "invalid channel name rdpsnd" error. [#13450](https://github.com/gravitational/teleport/issues/13450)
 * Fixed issue with invalid Teleport config when enabling IMDSv2 in Terraform config. [#13537](https://github.com/gravitational/teleport/pull/13537)
 
 ## 9.3.6
 
 This release of Teleport contains multiple improvements and bug fixes.
 
-* Added Unicode clipboard support to Desktop Access. [#13391](https://github.com/gravitational/teleport/pull/13391)
+* Added Unicode clipboard support to desktop access. [#13391](https://github.com/gravitational/teleport/pull/13391)
 * Fixed backwards compatibility issue with fetch access requests from older servers. [#13490](https://github.com/gravitational/teleport/pull/13490)
-* Fixed issue with Application Access requests periodically failing with 500 errors. [#13469](https://github.com/gravitational/teleport/pull/13469)
+* Fixed issue with application access requests periodically failing with 500 errors. [#13469](https://github.com/gravitational/teleport/pull/13469)
 * Fixed issues with pagination when displaying applications. [#13451](https://github.com/gravitational/teleport/pull/13451)
 * Fixed file descriptor leak in Machine ID. [#13386](https://github.com/gravitational/teleport/pull/13386)
 
@@ -939,10 +939,10 @@ This release of Teleport contains multiple improvements and bug fixes.
 This release of Teleport contains multiple improvements and bug fixes.
 
 * Fixed backwards compatibility issue with fetching access requests from older servers. [#13428](https://github.com/gravitational/teleport/pull/13428)
-* Fixed issue with using Microsoft SQL Server Management Studio with Database Access. [#13337](https://github.com/gravitational/teleport/pull/13337)
+* Fixed issue with using Microsoft SQL Server Management Studio with database access. [#13337](https://github.com/gravitational/teleport/pull/13337)
 * Added support for `tsh proxy ssh -J` to improve interoperability with OpenSSH clients. [#13311](https://github.com/gravitational/teleport/pull/13311)
 * Added ability to provide security context in Helm charts. [#13286](https://github.com/gravitational/teleport/pull/13286)
-* Added Application and Database Access support to reference AWS Terraform deployment. [#13383](https://github.com/gravitational/teleport/pull/13383)
+* Added Application and database access support to reference AWS Terraform deployment. [#13383](https://github.com/gravitational/teleport/pull/13383)
 * Improved reliability of dialing Auth Server through the Proxy. [#13399](https://github.com/gravitational/teleport/pull/13399)
 * Improved `kubectl exec` auditing by logging access denied attempts. [#12831](https://github.com/gravitational/teleport/pull/12831), [#13400](https://github.com/gravitational/teleport/pull/13400)
 
@@ -1031,9 +1031,9 @@ This release of Teleport contains multiple improvements and bug fixes.
 * Improved compatibility with PuTTY. [#12662](https://github.com/gravitational/teleport/pull/12662)
 * Added support for global tsh config file `/etc/tsh.yaml`. [#12626](https://github.com/gravitational/teleport/pull/12626)
 * Added `tbot configure` command. [#12576](https://github.com/gravitational/teleport/pull/12576)
-* Fixed issue with Desktop Access not working in Teleport Cloud. [#12781](https://github.com/gravitational/teleport/pull/12781)
+* Fixed issue with desktop access not working in Teleport Cloud. [#12781](https://github.com/gravitational/teleport/pull/12781)
 * Improved Web UI performance in large clusters. [#12637](https://github.com/gravitational/teleport/pull/12637)
-* Fixed issue with running MySQL stored procedures via Database Access. [#12734](https://github.com/gravitational/teleport/pull/12734)
+* Fixed issue with running MySQL stored procedures via database access. [#12734](https://github.com/gravitational/teleport/pull/12734)
 
 ## 9.2.3
 
@@ -1044,14 +1044,14 @@ This release of Teleport contains multiple improvements and bug fixes.
 * Fixed backwards compatibility issues with session upload. [#12535](https://github.com/gravitational/teleport/pull/12535)
 * Added support for persistency in custom mode in Helm charts. [#12218](https://github.com/gravitational/teleport/pull/12218)
 * Fixed issue with PostgreSQL backend not respecting username from certificate. [#12553](https://github.com/gravitational/teleport/pull/12553)
-* Fixed issues with `kubectl cp` and `kubectl exec` not working through Kubernetes Access. [#12541](https://github.com/gravitational/teleport/pull/12541)
+* Fixed issues with `kubectl cp` and `kubectl exec` not working through Kubernetes access. [#12541](https://github.com/gravitational/teleport/pull/12541)
 * Fixed issues with dynamic registration logic for cloud databases. [#12451](https://github.com/gravitational/teleport/pull/12451)
 * Fixed issue with automatic Add Application script failing to join the cluster. [#12539](https://github.com/gravitational/teleport/pull/12539)
 * Fixed issue with `tctl` crashing when PAM is enabled. [#12572](https://github.com/gravitational/teleport/pull/12572)
 * Added support for setting priority class and extra labels in Helm charts. [#12568](https://github.com/gravitational/teleport/pull/12568)
 * Fixed issue with App Access JWT tokens not including `iat` claim. [#12589](https://github.com/gravitational/teleport/pull/12589)
 * Added ability to inject App Access JWT tokens in rewritten headers. [#12589](https://github.com/gravitational/teleport/pull/12589)
-* Desktop Access automatically adds a `teleport.dev/ou` label for desktops discovered via LDAP. [#12502](https://github.com/gravitational/teleport/pull/12502)
+* Desktop access automatically adds a `teleport.dev/ou` label for desktops discovered via LDAP. [#12502](https://github.com/gravitational/teleport/pull/12502)
 * Updated Machine ID to generates identity files compatible with `tctl` and `tsh`. [#12500](https://github.com/gravitational/teleport/pull/12500)
 * Updated internal build infrastructure to Go 1.17.10. [#12607](https://github.com/gravitational/teleport/pull/12607)
 * Improved proxy memory usage in clusters with large number of nodes. [#12573](https://github.com/gravitational/teleport/pull/12573)
@@ -1088,7 +1088,7 @@ This release of Teleport contains multiple improvements and bug fixes.
 * Fixed multiple conditions that could lead to SSH sessions freezing. [#12286](https://github.com/gravitational/teleport/pull/12286)
 * Fixed issue with `tsh db ls` failing for leaf clusters. [#12320](https://github.com/gravitational/teleport/pull/12320)
 * Fixed a scenario in which Teleport's internal cache could potentially become unhealthy. [#12251](https://github.com/gravitational/teleport/pull/12251), [#12002](https://github.com/gravitational/teleport/pull/12002)
-* Improved performance when opening new Application Access sessions. [#12300](https://github.com/gravitational/teleport/pull/12300)
+* Improved performance when opening new application access sessions. [#12300](https://github.com/gravitational/teleport/pull/12300)
 * Added flags to the `teleport configure` command. [#12267](https://github.com/gravitational/teleport/pull/12267)
 * Improved CA rotation stability. [#12333](https://github.com/gravitational/teleport/pull/12333)
 * Fixed issue with `mongosh` certificate verification when using TLS routing. [#12363](https://github.com/gravitational/teleport/pull/12363)
@@ -1161,7 +1161,7 @@ the URL.
 This release of Teleport contains multiple improvements and fixes.
 
 * Fixed issue with `:` not being allowed in label keys. [#11563](https://github.com/gravitational/teleport/pull/11563)
-* Fixed potential panic in Kubernetes Access. [#11614](https://github.com/gravitational/teleport/pull/11614)
+* Fixed potential panic in Kubernetes access. [#11614](https://github.com/gravitational/teleport/pull/11614)
 * Added `teleport_connect_to_node_attempts_total` Prometheus metric. [#11629](https://github.com/gravitational/teleport/pull/11629)
 * Multiple CA rotation stability improvements. [#11658](https://github.com/gravitational/teleport/pull/11658)
 * Fixed console player Ctrl-C and Ctrl-D functionality. [#11559](https://github.com/gravitational/teleport/pull/11559)
@@ -1214,12 +1214,12 @@ This release of Teleport contains multiple improvements and bug fixes.
 
 Teleport 9.0 is a major release that brings:
 
-- Teleport Desktop Access GA
+- Teleport desktop access GA
 - Teleport Machine ID Preview
-- Various additions to Teleport Database Access
-- Moderated Sessions for Server and Kubernetes Access
+- Various additions to Teleport database access
+- Moderated Sessions for server and Kubernetes access
 
-Desktop Access adds support for clipboard sharing, session recording, and
+Desktop access adds support for clipboard sharing, session recording, and
 per-session MFA.
 
 Teleport Machine ID Preview extends identity-based access to machines. It's the
@@ -1227,7 +1227,7 @@ easiest way to issue, renew, and manage SSH and X.509 certificates for service
 accounts, microservices, CI/CD automation and all other forms of
 machine-to-machine access.
 
-Database Access brings self-hosted Redis support, RDS MariaDB (10.6 and higher)
+Database access brings self-hosted Redis support, RDS MariaDB (10.6 and higher)
 support, auto-discovery for Redshift clusters, and auto-IAM configuration
 improvements to GA. Additionally, this release also brings Microsoft SQL Server
 with AD authentication to Preview.
@@ -1236,11 +1236,11 @@ Moderated Sessions enables the creation of sessions where a moderator has to
 be present. This feature can be selectively enabled for specific sessions via
 RBAC and can be used in conjunction with per-session MFA.
 
-### Desktop Access
+### Desktop access
 
 #### Clipboard Support
 
-Desktop Access now supports copying and pasting text between your local
+Desktop access now supports copying and pasting text between your local
 workstation and a remote Windows Desktop. This feature requires a Chromium-based
 browser and can be disabled via RBAC.
 
@@ -1277,11 +1277,11 @@ Some of the things you can do with Machine ID:
 
 [Machine ID getting started guide](docs/pages/machine-id/getting-started.mdx)
 
-### Database Access
+### Database access
 
 #### Redis
 
-You can now use Database Access to connect to a self-hosted Redis instance or
+You can now use database access to connect to a self-hosted Redis instance or
 Redis cluster and view Redis commands in the Teleport audit log. We will be
 adding support for AWS Elasticache in the coming weeks.
 
@@ -1290,7 +1290,7 @@ adding support for AWS Elasticache in the coming weeks.
 #### SQL Server (Preview)
 
 Teleport 9 includes a preview release of Microsoft SQL Server with Active
-Directory authentication support for Database Access. Audit logging of query
+Directory authentication support for database access. Audit logging of query
 activity is not included in the preview release and will be implemented in a
 later 9.x release.
 
@@ -1307,7 +1307,7 @@ supports IAM authentication is 10.6.
 #### Other Improvements
 
 In addition, Teleport 9 expands auto-discovery to support Redshift databases and
-2 new commands which simplify the Database Access getting started experience:
+2 new commands which simplify the database access getting started experience:
 "teleport db configure create", which generates Database Service configuration,
 and "teleport db configure bootstrap", which configures IAM permissions for the
 Database Service when running on AWS.
@@ -1331,9 +1331,9 @@ observers, moderators or peers.
 
 CentOS 6 support was deprecated in Teleport 8 and has now been removed.
 
-#### Desktop Access
+#### Desktop access
 
-Desktop Access now authenticates to LDAP using X.509 client certificates.
+desktop access now authenticates to LDAP using X.509 client certificates.
 Support for the `password_file` configuration option has been removed.
 
 ## 8.0.0
@@ -1342,9 +1342,9 @@ Teleport 8.0 is a major release of Teleport that contains new features, improvem
 
 ### New Features
 
-#### Windows Desktop Access Preview
+#### Windows desktop access Preview
 
-Teleport 8.0 includes a preview of the Windows Desktop Access feature, allowing
+Teleport 8.0 includes a preview of the Windows desktop access feature, allowing
 users passwordless login to Windows Desktops via any modern web browser.
 
 Teleport users can connect to Active Directory enrolled Windows hosts running
@@ -1353,7 +1353,7 @@ Windows 10, Windows Server 2012 R2 and newer Windows versions.
 To try this feature yourself, check out our
 [Getting Started Guide](docs/pages/desktop-access/getting-started.mdx).
 
-Review the Desktop Access design in:
+Review the desktop access design in:
 
 - [RFD #33](https://github.com/gravitational/teleport/blob/master/rfd/0033-desktop-access.md)
 - [RFD #34](https://github.com/gravitational/teleport/blob/master/rfd/0034-desktop-access-windows.md)
@@ -1437,7 +1437,7 @@ confirmation, for example).
   [#8491](https://github.com/gravitational/teleport/pull/8491)
 * Added support for account recovery and cancellation.
   [#6769](https://github.com/gravitational/teleport/pull/6769)
-* Added per-session MFA support to Database Access.
+* Added per-session MFA support to database access.
   [#8270](https://github.com/gravitational/teleport/pull/8270)
 * Added support for profile specific `kubeconfig`.
   [#7840](https://github.com/gravitational/teleport/pull/7840)
@@ -1446,7 +1446,7 @@ confirmation, for example).
 
 * Fixed issues with web applications that utilized
   [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource)
-  with Application Access.
+  with application access.
   [#8359](https://github.com/gravitational/teleport/pull/8359)
 * Fixed issue were interactive sessions would always return exit code 0.
   [#8081](https://github.com/gravitational/teleport/pull/8081)
@@ -1485,9 +1485,9 @@ glibc compatibility layer they have already been using.
 apk --update --no-cache add libgcc
 ```
 
-#### Database Access Certificates
+#### Database access Certificates
 
-With the `GODEBUG=x509ignoreCN=0` flag removed in Go 1.17, Database Access users
+With the `GODEBUG=x509ignoreCN=0` flag removed in Go 1.17, database access users
 will no longer be able to connect to databases that include their hostname in
 the `CommonName` field of the presented certificate. Users are recommended to
 update their database certificates to include hostname in the
@@ -1510,21 +1510,21 @@ Teleport 7.0 is a major release of Teleport that contains new features, improvem
 
 #### MongoDB
 
-Added support for [MongoDB](https://www.mongodb.com) to Teleport Database Access. [#6600](https://github.com/gravitational/teleport/issues/6600).
+Added support for [MongoDB](https://www.mongodb.com) to Teleport database access. [#6600](https://github.com/gravitational/teleport/issues/6600).
 
-View the [Database Access with MongoDB](docs/pages/database-access/guides/mongodb-self-hosted.mdx) for more details.
+View the [database access with MongoDB](docs/pages/database-access/guides/mongodb-self-hosted.mdx) for more details.
 
 #### Cloud SQL MySQL
 
-Added support for [GCP Cloud SQL MySQL](https://cloud.google.com/sql/docs/mysql) to Teleport Database Access. [#7302](https://github.com/gravitational/teleport/pull/7302)
+Added support for [GCP Cloud SQL MySQL](https://cloud.google.com/sql/docs/mysql) to Teleport database access. [#7302](https://github.com/gravitational/teleport/pull/7302)
 
 View the Cloud SQL MySQL [guide](docs/pages/database-access/guides/mysql-cloudsql.mdx) for more details.
 
 #### AWS Console
 
-Added support for [AWS Console](https://aws.amazon.com/console) to Teleport Application Access. [#7590](https://github.com/gravitational/teleport/pull/7590)
+Added support for [AWS Console](https://aws.amazon.com/console) to Teleport application access. [#7590](https://github.com/gravitational/teleport/pull/7590)
 
-Teleport Application Access can now automatically sign users into the AWS Management Console using [Identity federation](https://aws.amazon.com/identity/federation). View AWS Management Console [guide](docs/pages/application-access/guides/aws-console.mdx) for more details.
+Teleport application access can now automatically sign users into the AWS Management Console using [Identity federation](https://aws.amazon.com/identity/federation). View AWS Management Console [guide](docs/pages/application-access/guides/aws-console.mdx) for more details.
 
 #### Restricted Sessions
 
@@ -1536,7 +1536,7 @@ Updated Enhanced Session Recording to no longer require the installation of exte
 
 ### Improvements
 
-* Added the ability to terminate Database Access certificates when the certificate expires. [#5476](https://github.com/gravitational/teleport/issues/5476)
+* Added the ability to terminate database access certificates when the certificate expires. [#5476](https://github.com/gravitational/teleport/issues/5476)
 * Added additional FedRAMP compliance controls, such as custom disconnect and MOTD messages. [#6091](https://github.com/gravitational/teleport/issues/6091) [#7396](https://github.com/gravitational/teleport/pull/7396)
 * Added the ability to export Audit Log and session recordings using the Teleport API. [#6731](https://github.com/gravitational/teleport/pull/6731) [#7360](https://github.com/gravitational/teleport/pull/7360)
 * Added the ability to partially configure a cluster. [#5857](https://github.com/gravitational/teleport/issues/5857) [RFD #28](https://github.com/gravitational/teleport/blob/master/rfd/0028-cluster-config-resources.md)
@@ -1557,9 +1557,9 @@ Updated Enhanced Session Recording to no longer require the installation of exte
 
 Enhanced Session Recording has been updated to use CO-RE BPF executables. This makes deployment much simpler, you no longer have to install `bcc-tools`, but comes with a higher minimum kernel version of 5.8 and above. [#6027](https://github.com/gravitational/teleport/pull/6027)
 
-#### Kubernetes Access
+#### Kubernetes access
 
-Kubernetes Access will no longer automatically register a cluster named after the Teleport cluster if the proxy is running within a Kubernetes cluster. Users wishing to retain this functionality now have to explicitly set `kube_cluster_name`. [#6786](https://github.com/gravitational/teleport/pull/6786)
+Kubernetes access will no longer automatically register a cluster named after the Teleport cluster if the proxy is running within a Kubernetes cluster. Users wishing to retain this functionality now have to explicitly set `kube_cluster_name`. [#6786](https://github.com/gravitational/teleport/pull/6786)
 
 #### `tsh`
 
@@ -1579,16 +1579,16 @@ before upgrading.
 
 #### Added Amazon Redshift Support
 
-Added support for [Amazon Redshift](https://aws.amazon.com/redshift) to Teleport Database Access.[#6479](https://github.com/gravitational/teleport/pull/6479).
+Added support for [Amazon Redshift](https://aws.amazon.com/redshift) to Teleport database access.[#6479](https://github.com/gravitational/teleport/pull/6479).
 
-View the [Database Access with Redshift on AWS Guide](docs/pages/database-access/guides/postgres-redshift.mdx) for more details.
+View the [database access with Redshift on AWS guide](docs/pages/database-access/guides/postgres-redshift.mdx) for more details.
 
 ### Improvements
 
-* Added pass-through header support for Teleport Application Access. [#6601](https://github.com/gravitational/teleport/pull/6601)
+* Added pass-through header support for Teleport application access. [#6601](https://github.com/gravitational/teleport/pull/6601)
 * Added ability to propagate claim information from root to leaf clusters. [#6540](https://github.com/gravitational/teleport/pull/6540)
-* Added Proxy Protocol for MySQL Database Access. [#6594](https://github.com/gravitational/teleport/pull/6594)
-* Added prepared statement support for Postgres Database Access. [#6303](https://github.com/gravitational/teleport/pull/6303)
+* Added Proxy Protocol for MySQL database access. [#6594](https://github.com/gravitational/teleport/pull/6594)
+* Added prepared statement support for Postgres database access. [#6303](https://github.com/gravitational/teleport/pull/6303)
 * Added `GetSessionEventsRequest` RPC endpoint for Audit Log pagination. [RFD 19](https://github.com/gravitational/teleport/blob/master/rfd/0019-event-iteration-api.md) [#6731](https://github.com/gravitational/teleport/pull/6731)
 * Changed DynamoDB indexing strategy for events. [RFD 24](https://github.com/gravitational/teleport/blob/master/rfd/0024-dynamo-event-overflow.md) [#6583](https://github.com/gravitational/teleport/pull/6583)
 
@@ -1638,7 +1638,7 @@ This release of Teleport contains multiple bug fixes.
 
 This release of Teleport contains a bug fix.
 
-* Added support for PROXY protocol to Database Access (MySQL). [#6517](https://github.com/gravitational/teleport/issues/6517)
+* Added support for PROXY protocol to database access (MySQL). [#6517](https://github.com/gravitational/teleport/issues/6517)
 
 ## 6.1.2
 
@@ -1674,15 +1674,15 @@ See [#5071](https://github.com/gravitational/teleport/pull/5071) for technical d
 
 * Added the ability to propagate SSO claims to PAM modules. [#6158](https://github.com/gravitational/teleport/pull/6158)
 * Added support for cluster routing to reduce latency to leaf clusters. [RFD 21](https://github.com/gravitational/teleport/blob/master/rfd/0021-cluster-routing.md)
-* Added support for Google Cloud SQL to Database Access. [#6090](https://github.com/gravitational/teleport/pull/6090)
-* Added support CLI credential issuance for Application Access. [#5918](https://github.com/gravitational/teleport/pull/5918)
+* Added support for Google Cloud SQL to database access. [#6090](https://github.com/gravitational/teleport/pull/6090)
+* Added support CLI credential issuance for application access. [#5918](https://github.com/gravitational/teleport/pull/5918)
 * Added support for Encrypted SAML Assertions. [#5598](https://github.com/gravitational/teleport/pull/5598)
 * Added support for user impersonation. [#6073](https://github.com/gravitational/teleport/pull/6073)
 
 ### Fixes
 
 * Fixed interoperability issues with `gpg-agent`. [RFD 18](http://github.com/gravitational/teleport/blob/master/rfd/0018-agent-loading.md)
-* Fixed websocket support in Application Access. [#6028](https://github.com/gravitational/teleport/pull/6028)
+* Fixed websocket support in application access. [#6028](https://github.com/gravitational/teleport/pull/6028)
 * Fixed file argument issues with `tsh play`. [#1580](https://github.com/gravitational/teleport/issues/1580)
 * Fixed `utmp` regressions that caused issues in LXC containers. [#6256](https://github.com/gravitational/teleport/pull/6256)
 
@@ -1711,22 +1711,23 @@ This release of Teleport contains multiple bug fixes.
 
 Teleport 6.0 is a major release with new features, functionality, and bug fixes.
 
-We have implemented [Database Access](https://goteleport.com/teleport/docs/database-access/),
-open sourced role-based access control (RBAC), and added official API and a Go client library.
+We have implemented [database
+access](./docs/pages/database-access/introduction.mdx), open sourced role-based
+access control (RBAC), and added official API and a Go client library.
 
 Users can review the [6.0 milestone](https://github.com/gravitational/teleport/milestone/33?closed=1) on Github for more details.
 
 ### New Features
 
-#### Database Access
+#### Database access
 
-Review the Database Access design in [RFD #11](https://github.com/gravitational/teleport/blob/master/rfd/0011-database-access.md).
+Review the database access design in [RFD #11](https://github.com/gravitational/teleport/blob/master/rfd/0011-database-access.md).
 
-With Database Access users can connect to PostgreSQL and MySQL databases using short-lived certificates, configure SSO authentication and role-based access controls for databases, and capture SQL query activity in the audit log.
+With database access users can connect to PostgreSQL and MySQL databases using short-lived certificates, configure SSO authentication and role-based access controls for databases, and capture SQL query activity in the audit log.
 
 ##### Getting Started
 
-Configure Database Access following the [Getting Started](https://goteleport.com/teleport/docs/database-access/getting-started/) guide.
+Configure database access following the [Getting Started](./docs/pages/database-access/introduction.mdx#getting-started/) guide.
 
 ##### Guides
 
@@ -1738,11 +1739,11 @@ Configure Database Access following the [Getting Started](https://goteleport.com
 
 ##### Resources
 
-To learn more about configuring role-based access control for Database Access, check out [RBAC](https://goteleport.com/teleport/docs/database-access/rbac/) section.
+To learn more about configuring role-based access control for database access, check out the [RBAC](./docs/pages/database-access/introduction.mdx/) section.
 
-[Architecture](https://goteleport.com/teleport/docs/database-access/architecture/) provides a more in-depth look at Database Access internals such as networking and security.
+[Architecture](./docs/pages/database-access/introduction.mdx/) provides a more in-depth look at database access internals such as networking and security.
 
-See [Reference](https://goteleport.com/teleport/docs/database-access/reference/) for an overview of Database Access related configuration and CLI commands.
+See [Reference](./docs/pages/database-access/reference.mdx) for an overview of database access related configuration and CLI commands.
 
 Finally, check out [Frequently Asked Questions](docs/pages/database-access/faq.mdx).
 
@@ -1794,7 +1795,7 @@ if err = clt.CreateAccessRequest(ctx, accessRequest); err != nil {
 
 * Added `utmp`/`wtmp` support for SSH in [#5491](https://github.com/gravitational/teleport/pull/5491).
 * Added the ability to set a Kubernetes specific public address in [#5611](https://github.com/gravitational/teleport/pull/5611).
-* Added Proxy Protocol support to Kubernetes Access in [#5299](https://github.com/gravitational/teleport/pull/5299).
+* Added Proxy Protocol support to Kubernetes access in [#5299](https://github.com/gravitational/teleport/pull/5299).
 * Added ACME ([Let's Encrypt](https://letsencrypt.org/)) support to make getting and using TLS certificates easier. [#5177](https://github.com/gravitational/teleport/issues/5177).
 * Added the ability to manage local users to the Web UI in [#2945](https://github.com/gravitational/teleport/issues/2945).
 * Added the ability to preserve timestamps when using `tsh scp` in [#2889](https://github.com/gravitational/teleport/issues/2889).
@@ -1860,13 +1861,13 @@ Teleport 5.0 is a major release with new features, functionality, and bug fixes.
 
 #### New Features
 
-Teleport 5.0 introduces two distinct features: Teleport Application Access and significant Kubernetes Access improvements - multi-cluster support.
+Teleport 5.0 introduces two distinct features: Teleport application access and significant Kubernetes access improvements - multi-cluster support.
 
-##### Teleport Application Access
+##### Teleport application access
 
-Teleport can now be used to provide secure access to web applications. This new feature was built with the express intention of securing internal apps which might have once lived on a VPN or had a simple authorization and authentication mechanism with little to no audit trail. Application Access works with everything from dashboards to single page Javascript applications (SPA).
+Teleport can now be used to provide secure access to web applications. This new feature was built with the express intention of securing internal apps which might have once lived on a VPN or had a simple authorization and authentication mechanism with little to no audit trail. application access works with everything from dashboards to single page Javascript applications (SPA).
 
-Application Access uses mutually authenticated reverse tunnels to establish a secure connection with the Teleport unified Access Plane which can then becomes the single ingress point for all traffic to an internal application.
+application access uses mutually authenticated reverse tunnels to establish a secure connection with the Teleport unified Access Plane which can then becomes the single ingress point for all traffic to an internal application.
 
 Adding an application follows the same UX as adding SSH servers or Kubernetes clusters, starting with creating a static or dynamic invite token.
 
@@ -1888,15 +1889,15 @@ Applications can also be configured using the new `app_service` section in `tele
 
 ```yaml
 app_service:
-   # Teleport Application Access is enabled.
+   # Teleport application access is enabled.
    enabled: yes
    # We've added a default sample app that will check
-   # that Teleport Application Access is working
+   # that Teleport application access is working
    # and output JWT tokens.
    # https://dumper.teleport.example.com:3080/
    debug_app: true
    apps:
-   # Application Access can be used to proxy any HTTP endpoint.
+   # application access can be used to proxy any HTTP endpoint.
    # Note: Name can't include any spaces and should be DNS-compatible A-Za-z0-9-._
    - name: "internal-dashboard"
      uri: "http://10.0.1.27:8000"
@@ -1919,7 +1920,7 @@ app_service:
      - name: "os"
        command: ["/usr/bin/uname"]
        period: "5s"
-     # A proxy can support multiple applications. Application Access
+     # A proxy can support multiple applications. application access
      # can also be deployed with a Teleport node.
      - name: "arris"
        uri: "http://localhost:3001"
@@ -1946,7 +1947,7 @@ proxy_service:
 
 You can learn more at [https://goteleport.com/teleport/docs/application-access/](https://goteleport.com/teleport/docs/application-access/)
 
-##### Teleport Kubernetes Access
+##### Teleport Kubernetes access
 
 Teleport 5.0 also introduces two highly requested features for Kubernetes.
 
@@ -2072,7 +2073,7 @@ See https://rpm.releases.teleport.dev/ for more details.
 * Added `--format=json` playback option for `tsh play`. For example `tsh play --format=json ~/play/0c0b81ed-91a9-4a2a-8d7c-7495891a6ca0.tar | jq '.event` can be used to show all events within an a local archive. [#4578](https://github.com/gravitational/teleport/issues/4578)
 * Added support for continuous backups and auto scaling for DynamoDB. [#4780](https://github.com/gravitational/teleport/issues/4780)
 * Added a Linux ARM64/ARMv8 (64-bit) Release. [#3383](https://github.com/gravitational/teleport/issues/3383)
-* Added `https_keypairs` field which replaces `https_key_file` and `https_cert_file`. This allows administrators to load multiple HTTPS certs for Teleport Application Access. Teleport 5.0 is backwards compatible with the old format, but we recommend updating your configuration to use `https_keypairs`.
+* Added `https_keypairs` field which replaces `https_key_file` and `https_cert_file`. This allows administrators to load multiple HTTPS certs for Teleport application access. Teleport 5.0 is backwards compatible with the old format, but we recommend updating your configuration to use `https_keypairs`.
 
 Enterprise Only:
 
@@ -2096,7 +2097,7 @@ We've added an [API Reference](https://goteleport.com/docs/api-reference/) to si
 Please follow our [standard upgrade procedure](https://goteleport.com/teleport/docs/admin-guide/#upgrading-teleport).
 
 * Optional: Consider updating `https_key_file` & `https_cert_file` to our new `https_keypairs:` format.
-* Optional: Consider migrating Kubernetes Access from `proxy_service` to `kubernetes_service` after the upgrade.
+* Optional: Consider migrating Kubernetes access from `proxy_service` to `kubernetes_service` after the upgrade.
 
 ### 4.4.6
 

--- a/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/fedramp.mdx
@@ -99,12 +99,12 @@ version: v3
 teleport:
   auth_token: xxxx-token-xxxx
 
-  # Specify either the proxy address
+  # Specify either the Proxy Service address...
   proxy_server: teleport.example.com:3080
-  # or the auth server address
+  # or the Auth Service address
   auth_server: 10.1.1.10:3025
 
-# Enable ssh service and disable auth and proxy:
+# Enable the SSH Service and disable the Auth and Proxy Services:
 ssh_service:
   enabled: true
 auth_service:

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -29,22 +29,22 @@ Additionally, this feature can be configured to require touch for every Teleport
   Supported (`tsh`, `tctl`, and Teleport Connect):
     
     - Standard Teleport API requests (`tsh ls`, `tctl create`, etc.)
-    - Server Access
-    - Database Access
+    - Server access
+    - Database access
       - Must use `tsh proxy db` instead of `tsh db connect`
   
   Not yet supported:
 
     - Teleport WebUI (except for user registration / reset password)
     - Agent forwarding functionality such as `tsh ssh -A`, Proxy Recording mode, and OpenSSH integration
-    - Kubernetes Access
-    - Desktop Access
-    - Application Access
+    - Kubernetes access
+    - Desktop access
+    - Application access
 
   The unsupported features above will not function for users that have have hardware key support
   enforced. This is either because the user's hardware key can't be accessed within that feature
   (WebUI) or because the protocol only supports raw private keys currently (Agent forwarding,
-  Kubernetes Access, Desktop Access). 
+  Kubernetes access, desktop access). 
 
   To navigate these incompatibilities, we recommend enabling hardware key support only when
   necessary, such as for roles with access to critical infrastructure. These roles can be accessed

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -8,9 +8,9 @@ h1: Moderated Sessions
 ## Introduction
 
 Moderated Sessions allows Teleport administrators to define requirements for
-other users to be present in a Server or Kubernetes Access session. Depending on
-the requirements, these users can observe the session in real time, participate
-in the session, and terminate the session at will.
+other users to be present in a server or Kubernetes session. Depending on the
+requirements, these users can observe the session in real time, participate in
+the session, and terminate the session at will.
 
 In addition, Teleport administrators can [define rules](#join_sessions) that allow users to join each other's
 sessions from `tsh` and the Web UI.
@@ -203,7 +203,7 @@ but the session will remain open. This discards all input from session participa
 
 Moderated Session RBAC controls were added to the role specification in version 5
 (`version: v5` in the YAML definition).
-Previously, Server Access did not include controls over which users can join a
+Previously, the Teleport SSH Service did not include controls over which users can join a
 session.
 To avoid breaking functionality for users with only roles on v4 or older, RBAC
 access checks will only be enforced if the user has at least one v5 role.

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -35,7 +35,7 @@ their on-disk Teleport certificates.
   enforced. Additionally, only v6.1 or newer `tsh` binaries implement
   per-session MFA checks.
 
-  Per-session MFA for Desktop Access was introduced in Teleport 9.
+  Per-session MFA for desktop access was introduced in Teleport 9.
 </Details>
 
 
@@ -261,9 +261,9 @@ even when logging into `dev1.example.com`.
 
 <Admonition title="Per-session MFA for Database Access" type="tip">
 
-Database Access supports per-connection MFA. When Jerry connects to the database
-`prod-mysql-instance` (with label `env: prod`), he gets prompted for an MFA check
-for each `tsh db connect` or `tsh proxy db` call:
+The Teleport Database Service supports per-connection MFA. When Jerry connects
+to the database `prod-mysql-instance` (with label `env: prod`), he gets prompted
+for an MFA check for each `tsh db connect` or `tsh proxy db` call:
 
 ```code
 $ tsh db connect prod-mysql-instance
@@ -300,4 +300,4 @@ Current limitations for this feature are:
   If you enable per-session MFA checks cluster-wide, you will not be able to
   use Application access. We're working on integrating per-session
   MFA checks for these clients.
-- For Desktop Access, only WebAuthn devices are supported.
+- For desktop access, only WebAuthn devices are supported.

--- a/docs/pages/application-access/controls.mdx
+++ b/docs/pages/application-access/controls.mdx
@@ -1,15 +1,14 @@
 ---
 title: Application Access Role-Based Access Control
-description: Role-Based Access Control (RBAC) for Teleport Application Access.
+description: Role-Based Access Control (RBAC) for Teleport application access.
 ---
 
-# Application Access Role-Based Access Control
-
-This article describes Access Control concepts particularly relevant to Teleport Application Access.
+This article describes access control concepts particularly relevant to the
+Teleport Application Service.
 
 ## Assigning labels to applications
 
-Teleport Application Access uses labels to control access to the proxied
+The Teleport Application Service uses labels to control access to the proxied
 web applications.
 
 Teleport administrators can assign static and dynamic labels to apps using

--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -1,10 +1,10 @@
 ---
 title: Getting Started with Teleport Application Access
-description: Getting started with Teleport Application Access.
+description: Getting started with Teleport application access.
 videoBanner: 5Uwhp3IQMHY
 ---
 
-Let's connect to Grafana using Teleport Application Access in three steps:
+Let's connect to Grafana using Teleport in three steps:
 
 - Launch Grafana in a Docker container.
 - Install the Teleport Application Service on a node and configure it to proxy Grafana.
@@ -23,7 +23,7 @@ Let's connect to Grafana using Teleport Application Access in three steps:
 
 (!docs/pages/includes/tctl.mdx!)
 
-- A Docker installation, which we will use to launch Grafana in a container. Alternatively, if you have another web application you'd like to protect with Application Access, you can use that instead.
+- A Docker installation, which we will use to launch Grafana in a container. Alternatively, if you have another web application you'd like to protect with Teleport, you can use that instead.
 - A host where you will run the Teleport Application Service.
 
 <Admonition type="tip" title="Not yet a Teleport user?">

--- a/docs/pages/application-access/guides.mdx
+++ b/docs/pages/application-access/guides.mdx
@@ -1,13 +1,15 @@
 ---
 title: Application Access Guides
-description: Guides for configuring Teleport Application Access.
+description: Guides for configuring Teleport application access.
 layout: tocless-doc
 ---
 
-These guides explain basic Teleport Application Access usage.
+These guides explain how to use Teleport to enable secure access to
+applications.
 
-- [Web App Access](./guides/connecting-apps.mdx): How to access web apps with Teleport Application Access.
-- [TCP App Access (Preview)](./guides/tcp.mdx): How to access plain TCP apps with Teleport Application Access.
-- [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport Application Access.
-- [AWS Access](./guides/aws-console.mdx): How to access AWS Management Console, AWS CLI, and AWS SDKs with Teleport Application Access.
+- [Web App Access](./guides/connecting-apps.mdx): How to access web apps with Teleport.
+- [TCP App Access (Preview)](./guides/tcp.mdx): How to access plain TCP apps with Teleport.
+- [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport.
+- [AWS Access](./guides/aws-console.mdx): How to access AWS Management Console, AWS CLI, and AWS SDKs with Teleport. 
 - [Dynamic Registration](./guides/dynamic-registration.mdx): Register/unregister apps without restarting Teleport.
+

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -1,10 +1,15 @@
 ---
 title: Access REST APIs With Teleport Application Access
-description: How to access REST APIs with Teleport Application Access.
+description: How to access REST APIs with Teleport application access.
 ---
 
-Teleport Application Access can be used to access applications' (REST or Teleport's own gRPC) APIs with
-tools like [curl](https://man7.org/linux/man-pages/man1/curl.1.html) or Postman.
+The Teleport Application Service can be used to access applications' (REST or
+Teleport's own gRPC) APIs with tools like
+[curl](https://man7.org/linux/man-pages/man1/curl.1.html) or Postman.
+
+<Admonition type="note" title="Non-HTTP API Support">
+Use [TCP application access](./tcp.mdx) for non-HTTP APIs (like gRPC).
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/application-access/guides/aws-console.mdx
+++ b/docs/pages/application-access/guides/aws-console.mdx
@@ -1,6 +1,6 @@
 ---
 title: Access AWS With Teleport Application Access
-description: How to access AWS with Teleport Application Access.
+description: How to access AWS with Teleport application access.
 videoBanner: GVcy_rffxQw
 ---
 
@@ -18,13 +18,15 @@ This guide will explain how to:
 ## Prerequisites
 
 - A running Teleport cluster, either self hosted or in Teleport Cloud.
-- A host running the `teleport` daemon with Application Access enabled. Follow
-  the [Getting Started](../getting-started.mdx) or
-  [Connecting Apps](./connecting-apps.mdx) guides to get it running.
+- A host running the `teleport` daemon with the Teleport Application Service
+  enabled. Follow the [Getting Started](../getting-started.mdx) or [Connecting
+  Apps](../guides/connecting-apps.mdx) guides to get it running.
 - IAM permissions in the AWS account you want to connect.
-- AWS EC2 or other instance where you can assign a IAM Security Role for the Teleport Agent.
-- `aws` command line interface (CLI) tool in PATH. [Installing or updating the latest version of the AWS CLI
-](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+- AWS EC2 or other instance where you can assign a IAM Security Role for the
+  Teleport Agent.
+- `aws` command line interface (CLI) tool in PATH. [Installing or updating the
+  latest version of the AWS CLI
+  ](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 
 <Admonition type="note">
 If using Teleport deployed in AWS EKS, you cannot use Helm chart
@@ -128,7 +130,7 @@ You can make the policy more strict by providing specific IAM role resource
 ARNs in the Resource field instead of using a wildcard.
 </Admonition>
 
-Attach this policy to the IAM role/user your Teleport application service agent
+Attach this policy to the IAM role/user your Teleport Application Service agent
 is using.
 
 ![AWS Attach Security Role](../../../img/application-access/attach-security-role.png)
@@ -162,7 +164,7 @@ Templates](../../access-controls/guides/role-templates.mdx) for details.
 
 ## Step 5/9. Register AWS console application in Teleport
 
-Add AWS management console to your application service configuration:
+Add AWS management console to your Application Service configuration:
 
 ```yaml
 version: v3

--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -9,7 +9,7 @@ and follow the installation [instructions](../../installation.mdx).
 ## Start Auth/Proxy service
 
 Create a configuration file for a Teleport service that will be running
-auth and proxy servers:
+the Auth and Proxy Services:
 
 ```yaml
 teleport:
@@ -72,7 +72,7 @@ comes with a built-in `access` role that grants access to all apps:
 $ tctl --config=/path/to/teleport.yaml users add --roles=access appuser
 ```
 
-## Start application service with CLI flags
+## Start the Application Service with CLI flags
 
 Install Teleport:
 
@@ -151,7 +151,7 @@ proxy_service:
   enabled: "no"
 ```
 
-Start the application service:
+Start the Application Service:
 
 ```code
 $ sudo teleport start --config=/path/to/teleport.yaml

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -5,7 +5,8 @@ description: How to configure Teleport for accessing plain TCP apps
 
 Teleport can provide access to any TCP-based application. This allows users to
 connect to applications which Teleport doesn't natively support such as SMTP
-servers or databases not yet natively supported in Database Access.
+servers or databases not yet natively supported by the Teleport Database
+Service.
 
 ## Prerequisites
 

--- a/docs/pages/application-access/introduction.mdx
+++ b/docs/pages/application-access/introduction.mdx
@@ -3,10 +3,8 @@ title: Application Access Guide
 description: How to set up and configure Teleport for Application access with SSO and RBAC
 ---
 
-# Application Access
-
-Teleport Application Access is designed to provide secure access to
-internal dashboards and applications, such as:
+Teleport is designed to provide secure access to cloud provider APIs and
+internal applications. Examples include: 
 
 - Internal control panels.
 - Tools, such as wikis, that are available only when connected to a VPN.
@@ -37,26 +35,26 @@ internal dashboards and applications, such as:
 
 ## Getting started
 
-Get started with Application Access in a 10 minute [guide](./getting-started.mdx).
+Get started with application access in a 10 minute [guide](./getting-started.mdx).
 
 ## Access guides
 
-These guides explain basic Teleport Application Access usage.
+These guides explain how to use Teleport to enable secure access to
+applications:
 
-- [Web App Access](./guides/connecting-apps.mdx): How to access web apps with Teleport Application Access.
-- [TCP App Access (Preview)](./guides/tcp.mdx): How to access plain TCP apps with Teleport Application Access.
-- [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport Application Access.
-- [AWS Access](./guides/aws-console.mdx): How to access AWS Management Console, AWS CLI, and AWS SDKs with Teleport Application Access.
+- [Web App Access](./guides/connecting-apps.mdx): How to access web apps with Teleport.
+- [TCP App Access (Preview)](./guides/tcp.mdx): How to access plain TCP apps with Teleport.
+- [API Access](./guides/api-access.mdx): How to access REST APIs with Teleport.
+- [AWS Access](./guides/aws-console.mdx): How to access AWS Management Console, AWS CLI, and AWS SDKs with Teleport.
 - [Dynamic Registration](./guides/dynamic-registration.mdx): Register/unregister apps without restarting Teleport.
-- [Interactive Lab](https://play.instruqt.com/teleport/invite/rgvuva4gzkon): Try Teleport using our guided Teleport Application Access lab.
+- [Interactive Lab](https://play.instruqt.com/teleport/invite/rgvuva4gzkon): Try Teleport using our guided Teleport application access lab.
 
 ## JWT guides
 
-These guides explain how web apps behind Teleport Application Access can
-leverage Teleport-signed JWT tokens to implement authentication and
-authorization.
+These guides explain how web apps protected by Teleport can leverage
+Teleport-signed JWT tokens to implement authentication and authorization.
 
-- [Introduction](./jwt/introduction.mdx): Introduction to JWT tokens with Application Access.
+- [Introduction](./jwt/introduction.mdx): Introduction to JWT tokens with application access.
 - [Elasticsearch](./jwt/elasticsearch.mdx): How to use JWT authentication with Elasticsearch.
 
 ## Example legacy apps
@@ -79,8 +77,8 @@ Other common legacy app scenarios:
 
 ## Example modern apps
 
-Teleport Application Access also supports modern web applications such as internal web
-tools and infrastructure software:
+Teleport also supports modern web applications such as internal web tools and
+infrastructure software:
 
 - Kubernetes Dashboard.
 - Grafana.

--- a/docs/pages/application-access/jwt.mdx
+++ b/docs/pages/application-access/jwt.mdx
@@ -1,12 +1,12 @@
 ---
 title: Application Access JWT Authentication
-description: Guides for using Teleport Application Access JWT authentication.
+description: Guides for using Teleport application access JWT authentication.
 layout: tocless-doc
 ---
 
-These guides explain how web apps behind Teleport Application Access can
+These guides explain how web apps behind the Teleport Application Service can
 leverage Teleport-signed JWT tokens to implement authentication and
 authorization.
 
-- [Introduction](./jwt/introduction.mdx): Introduction to JWT tokens with Application Access.
+- [Introduction](./jwt/introduction.mdx): Introduction to JWT tokens with application access.
 - [Elasticsearch](./jwt/elasticsearch.mdx): How to use JWT authentication with Elasticsearch.

--- a/docs/pages/application-access/jwt/elasticsearch.mdx
+++ b/docs/pages/application-access/jwt/elasticsearch.mdx
@@ -4,7 +4,7 @@ description: How to use JWT authentication with Elasticsearch
 ---
 
 This guide will help you configure Elasticsearch [JWT authentication](https://www.elastic.co/guide/en/elasticsearch/reference/current/jwt-realm.html)
-with Teleport Application Access.
+with Teleport.
 
 <Details title="Version warning" opened={true}>
   Elasticsearch supports JWT authentication starting from version `8.2.0`.
@@ -110,5 +110,6 @@ $ curl \
 ## Next steps
 
 - Get more information about integrating with [Teleport JWT tokens](./introduction.mdx).
-- Learn more about [accessing APIs](../guides/api-access.mdx) with Application Access.
-- Take a look at [Access Controls](../controls.mdx) with Application Access.
+- Learn more about [accessing APIs](../guides/api-access.mdx) with the Teleport
+  Application Service.
+- Take a look at application-related [Access Controls](../controls.mdx).

--- a/docs/pages/application-access/jwt/introduction.mdx
+++ b/docs/pages/application-access/jwt/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Use JWT Tokens With Application Access
-description: How to use JWT tokens for authentication with Teleport Application Access.
+description: How to use JWT tokens for authentication with Teleport application access.
 ---
 
 Teleport sends a JWT token signed with Teleport's authority with each request

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Application Access Reference Documentation
-description: Configuration and CLI reference documentation for Teleport Application Access.
+description: Configuration and CLI reference documentation for Teleport application access.
 ---
 
 ## Configuration
@@ -126,7 +126,7 @@ $ tctl create -f app.yaml
 
 ## CLI
 
-This section shows CLI commands relevant for Application Access.
+This section shows CLI commands relevant for application access.
 
 ### tsh apps ls
 

--- a/docs/pages/architecture/session-recording.mdx
+++ b/docs/pages/architecture/session-recording.mdx
@@ -49,9 +49,10 @@ Windows, database, and Kubernetes sessions are always recorded at the host runni
 the Teleport service for this session type, since there is no Teleport software
 running on the "node" (desktop, database, or Kubernetes cluster).
 
-For this reason, Teleport Windows, Database, and Kubernetes Access treats `node`
-and `proxy` identically (perform asynchronous recording) and `node-sync` and
-`proxy-sync` identically (perform synchronous recording).
+For this reason, the Teleport Windows, Database, and Kubernetes Services treat
+`node` and `proxy` identically (perform asynchronous recording) and `node-sync`
+and `proxy-sync` identically (perform synchronous recording).
+
 </Admonition>
 
 ### Record at Node

--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -2,5 +2,5 @@
 title: Teleport Changelog
 description: The Changelog provides a comprehensive description of the changes introduced by each Teleport release.
 ---
-
+{/*lint disable messaging*/}
 (!CHANGELOG.md!)

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -1,10 +1,10 @@
 ---
 title: Database Access GUI Clients
-description: How to configure graphical database clients for Teleport Database Access.
+description: How to configure graphical database clients for Teleport database access.
 ---
 
 This guide describes how to configure popular graphical database clients to
-work with Teleport Database Access.
+work with Teleport.
 
 ## Setting up your Teleport environment
 
@@ -62,8 +62,8 @@ Ensure that your environment includes the following:
 </Tabs>
 
 - The Teleport Database Service configured to access a database. See one of our
-  [guides](../database-access/guides.mdx) for how to set up Teleport Database Access for your
-  database.
+  [guides](../database-access/guides.mdx) for how to set up the Teleport
+  Database Service for your database.
 
 
 ### Get connection information

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -62,7 +62,7 @@ required for your particular use case.
 The Teleport Connect app provides all the same access to resources as `tsh` in
 a friendly graphic user interface. After [downloading](https://goteleport.com/download/)
 and installing Teleport Connect, you can log in and initiate sessions for
-Server and Database Access within a single window.
+server and database access within a single window.
 
 1. Click **CONNECT** to connect to the Teleport cluster:
 
@@ -94,12 +94,12 @@ Activity logs for users with the right permissions.
 
 ## Protocols
 
-### Server Access (`ssh`)
+### Server access (`ssh`)
 
 <Tabs>
 <TabItem label="tsh">
 
-`tsh ls` lists the servers you have access to through Server Access (SSH):
+`tsh ls` lists the servers you have access to through Teleport:
 
 ```code
 $ tsh ls
@@ -144,7 +144,7 @@ $ tsh scp some-file.ext server.example.com:
 some-file.ext   7% |███████                | (25/342 MB, 2.9 MB/s) [9s:1m48s]
 ```
 
-### Kubernetes Access (`kubectl`)
+### Kubernetes access (`kubectl`)
 
 <Tabs>
 <TabItem label="tsh">
@@ -286,7 +286,7 @@ list those that are accessible to your user under <Icon name="database" size="sm
 
 ### Desktop Access
 
-Desktop Access is available through the Teleport Web UI. In your browser,
+Desktop access is available through the Teleport Web UI. In your browser,
 navigate to your Teleport cluster (e.g. 
 <ScopedBlock scope={["oss", "enterprise"]}>`https://teleport.example.com`</ScopedBlock>
 <ScopedBlock scope={["cloud"]}>`https://mytennant.teleport.sh`</ScopedBlock>
@@ -310,8 +310,9 @@ either directly or through proxy tunnels.
   Learn more about it from [Using the tsh Command Line Tool](./tsh.mdx).
 
 - Teleport Connect is a graphic utility for connecting to resources through
-Teleport. You can initiate Server Access, connect to databases, and start
-Desktop Access sessions. See [Using Teleport Connect](./teleport-connect.mdx).
+  Teleport. You use it to connect to servers, databases, and Kubernetes
+  clusters. See [Using Teleport Connect](./teleport-connect.mdx).
 
+{/*lint ignore messaging for page title*/}
 - [Database Access GUI Clients](./gui-clients.mdx) details
 how to connect many popular database GUI clients through Teleport.

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -840,8 +840,8 @@ DEBU [TSH]       Self re-exec command: tsh [status --format=json]. tsh/aliases.g
 
 ## Interactive Recording
 
-Within the Teleport cluster the Server and Kubernetes recorded sessions are available for listing and replay for authorized users via `tsh`.
-The same listings, including Desktop Access sessions, are available in the Web Console under Session Recordings in the Activity section.
+Within the Teleport cluster, server and Kubernetes recorded sessions are available for listing and replay for authorized users via `tsh`.
+The same listings, including Windows desktop sessions, are available in the Web Console under Session Recordings in the Activity section.
 
 ### List and Play Recordings
 

--- a/docs/pages/contributing/documentation/style-guide.mdx
+++ b/docs/pages/contributing/documentation/style-guide.mdx
@@ -47,7 +47,7 @@ Teleport and want to set up Teleport for a specific scenario.
 
 #### Example outline
 
-- Guide title: "Kubernetes Access on GKE"
+- Guide title: "Access Kubernetes on GKE"
 - The purpose of the guide
 - Prerequisites
 - Setup steps

--- a/docs/pages/database-access/architecture.mdx
+++ b/docs/pages/database-access/architecture.mdx
@@ -1,13 +1,15 @@
 ---
 title: Database Access Architecture
-description: How Teleport Database Access works.
+description: How Teleport enables secure access to databases.
 ---
 
-This section provides an overview of Teleport Database Access inner workings.
+This section provides an overview of how Teleport enables secure access to
+databases.
 
 ## How it works
 
-Let's take a look at a sample Database Access deployment:
+Let's take a look at a sample Teleport deployment that enables access to
+databases:
 
 ![Teleport Database Access Diagram](../../img/database-access/diagram.png)
 
@@ -29,11 +31,11 @@ In it, we have the following Teleport components:
 
 </ScopedBlock>
 
-- [Teleport Auth](../architecture/authentication.mdx). Serves as
+- [Teleport Auth Service](../architecture/authentication.mdx). Serves as
   cluster's certificate authority, handles user authentication/authorization
   and issues short-lived client certificates.
-- Teleport Database Service. The Database Access' "brain" that connects
-  to the databases, performs database authentication and protocol parsing.
+- Teleport Database Service. The "brain" that connects to the databases,
+  performs database authentication and protocol parsing.
 
 Database Service establishes an SSH reverse tunnel to the Proxy. As such, users
 do not need to have direct connectivity to the Database Service, or the databases
@@ -48,7 +50,7 @@ can be located behind a firewall.
   Database Service can be also connected to multiple databases.
 </Admonition>
 
-Let's take a look at the typical flow Database Access users go through to
+Let's take a look at the typical flow that Teleport users go through to
 connect to a database.
 
 1. A user logs into the cluster with `tsh login` command and retrieves
@@ -102,7 +104,7 @@ For configuring graphical clients, use the `tsh proxy db` command, which prints
 detailed information about the connection such as the host, port, and location
 of the secrets. See [GUI Clients](../connect-your-client/gui-clients.mdx) for details.
 
-### Proxy to Database service
+### Proxy to the Database Service
 
 The connection between the Proxy and the Database Service is also authenticated
 with mutual TLS.
@@ -111,7 +113,7 @@ The Proxy generates a short-lived X.509 certificate signed by the
 cluster's host authority, with the client's identity and database routing
 information encoded in it, and uses it to authenticate with the Database Service.
 
-### Database service to database
+### Database Service to database
 
 Database authentication is handled differently for self-hosted databases and
 databases hosted by AWS.

--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -1,11 +1,11 @@
 ---
 title: Database Access FAQ
-description: Frequently asked questions about Teleport Database Access.
+description: Frequently asked questions about Teleport database access.
 ---
 
-## Which database protocols does Teleport Database Access support?
+## Which database protocols does Teleport the Database Service support?
 
-Teleport Database Access currently supports the following protocols:
+The Teleport Database Service currently supports the following protocols:
 
 - MariaDB
 - Microsoft SQL Server
@@ -55,7 +55,7 @@ on a plain TCP load balancer (e.g. NLB in AWS).
 <TabItem scope={["cloud"]} label="Teleport Cloud">
 
 In Teleport Cloud, the Proxy Service uses the following ports for
-Database Access client traffic:
+Database Service client traffic:
 
 |Configuration setting|Port|
 |---|---|

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -1,10 +1,10 @@
 ---
 title: Database Access Getting Started Guide
-description: Getting started with Teleport Database Access and AWS Aurora PostgreSQL.
+description: Getting started with Teleport database access and AWS Aurora PostgreSQL.
 ---
 
-In this getting started guide we will use Teleport Database Access to connect
-to a PostgreSQL AWS Aurora database.
+In this getting started guide we will use Teleport to connect to a PostgreSQL
+AWS Aurora database.
 
 Here's an overview of what we will do:
 
@@ -23,7 +23,7 @@ Here's an overview of what we will do:
 
 <Admonition type="note" title="Supported versions">
 
-Teleport Database Access is available starting from the `6.0.0` Teleport
+Teleport database access is available starting from the `6.0.0` Teleport
 release.
 
 </Admonition>

--- a/docs/pages/database-access/guides.mdx
+++ b/docs/pages/database-access/guides.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access Guides
-description: Guides for configuring Teleport Database Access with self-hosted or cloud-hosted databases.
+description: Guides for configuring Teleport database access with self-hosted or cloud-hosted databases.
 layout: tocless-doc
 ---
 

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with AWS Keyspaces (Apache Cassandra)
-description: How to configure Teleport Database Access with AWS Keyspaces (Apache Cassandra)
+description: How to configure Teleport database access with AWS Keyspaces (Apache Cassandra)
 ---
 
 <Details
@@ -10,7 +10,7 @@ description: How to configure Teleport Database Access with AWS Keyspaces (Apach
   scopeOnly={true}
   min="11.0"
 >
-  Database Access for AWS Keyspaces (Apache Cassandra) is available starting from Teleport `v11.0`.
+  Database access for AWS Keyspaces (Apache Cassandra) is available starting from Teleport `v11.0`.
 </Details>
 
 

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Azure PostgreSQL and MySQL
-description: How to configure Teleport Database Access with Azure Database for PostgreSQL and MySQL.
+description: How to configure Teleport database access with Azure Database for PostgreSQL and MySQL.
 ---
 
 <Details

--- a/docs/pages/database-access/guides/azure-redis.mdx
+++ b/docs/pages/database-access/guides/azure-redis.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Azure Cache for Redis
-description: How to configure Teleport Database Access with Azure Cache for Redis
+description: How to configure Teleport database access with Azure Cache for Redis
 ---
 
 This guide will help you to:

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with SQL Server on Azure (Preview)
-description: How to configure Teleport Database Access with Azure SQL Server using Azure Active Directory authentication.
+description: How to configure Teleport database access with Azure SQL Server using Azure Active Directory authentication.
 ---
 
 <Details
@@ -10,12 +10,12 @@ description: How to configure Teleport Database Access with Azure SQL Server usi
   scopeOnly={true}
   min="11.0"
 >
-  Database Access for Azure SQL Server with Azure Active Directory authentication
+  Database access for Azure SQL Server with Azure Active Directory authentication
   is available starting from Teleport `11.0`.
 </Details>
 
 <Admonition type="warning" title="Preview">
-  Database Access for Azure SQL Server with Azure Active Directory authentication is
+  Database access for Azure SQL Server with Azure Active Directory authentication is
   currently in Preview mode.
 </Admonition>
 

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Cassandra and ScyllaDB
-description: How to configure Teleport Database Access with Cassandra and ScyllaDB.
+description: How to configure Teleport database access with Cassandra and ScyllaDB.
 ---
 
 <Details

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Self-Hosted CockroachDB
-description: How to configure Teleport Database Access with self-hosted CockroachDB.
+description: How to configure Teleport database access with self-hosted CockroachDB.
 ---
 
 <Details

--- a/docs/pages/database-access/guides/dynamodb.mdx
+++ b/docs/pages/database-access/guides/dynamodb.mdx
@@ -32,7 +32,7 @@ This guide will help you to:
 (!docs/pages/includes/tctl.mdx!)
 
 <Admonition type="tip" title="Not yet a Teleport user?">
-If you have not yet deployed the Auth Service and Proxy Service, you should follow one of our [getting started guides](../getting-started.mdx) or try our Teleport Application Access [interactive learning track](https://play.instruqt.com/teleport/invite/rgvuva4gzkon).
+If you have not yet deployed the Auth Service and Proxy Service, you should follow one of our [getting started guides](../getting-started.mdx) or try our Teleport application access [interactive learning track](https://play.instruqt.com/teleport/invite/rgvuva4gzkon).
 </Admonition>
 
 We will assume your Teleport cluster is accessible at `teleport.example.com` and `*.teleport.example.com`. You can substitute the address of your Teleport Proxy Service. (For Teleport Cloud customers, this will be similar to `mytenant.teleport.sh`.)

--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Elasticsearch
-description: How to configure Teleport Database Access with Elasticsearch.
+description: How to configure Teleport database access with Elasticsearch.
 ---
 
 <Details
@@ -13,13 +13,13 @@ description: How to configure Teleport Database Access with Elasticsearch.
   Database access for Elasticsearch is available starting from Teleport `10.3`.
 </Details>
 
-This guide will help you to configure secured access to an Elasticsearch database using Teleport Database Access.
+This guide will help you to configure secured access to an Elasticsearch database using the Teleport Database Service.
 
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- A self-hosted Elasticsearch database. Elastic Cloud [does not support client certificates](https://www.elastic.co/guide/en/cloud/current/ec-restrictions.html#ec-restrictions-security), which are required for setting up Database Access.
+- A self-hosted Elasticsearch database. Elastic Cloud [does not support client certificates](https://www.elastic.co/guide/en/cloud/current/ec-restrictions.html#ec-restrictions-security), which are required for setting up the Database Service.
 
 - A host where you will run the Teleport Database Service. If you are already running the Teleport
   Database Service, you must ensure that it uses Teleport version 10.3 or newer in order to connect

--- a/docs/pages/database-access/guides/ha.mdx
+++ b/docs/pages/database-access/guides/ha.mdx
@@ -1,12 +1,12 @@
 ---
 title: Database Access High Availability (HA)
-description: How to configure Teleport Database Access in a Highly Available (HA) configuration.
+description: How to configure Teleport database access in a Highly Available (HA) configuration.
 ---
 
-You can deploy Database Access in a Highly Available (HA) configuration in a
-couple of common ways: combined replicas and separate replicas. Both of those
-revolve around pointing multiple Database Services to the same database
-instance.
+You can deploy the Teleport Database Service in a Highly Available (HA)
+configuration in a couple of common ways: combined replicas and separate
+replicas. Both of those revolve around pointing multiple Database Services to
+the same database instance.
 
 ## Combined replicas
 
@@ -89,4 +89,5 @@ you're using to connect.
 ## Next steps
 
 - Get started by [connecting](../guides.mdx) your database.
-- Review Database Access [architecture](../architecture.mdx).
+- Review the [architecture](../architecture.mdx) of the Teleport Database
+  Service.

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with MongoDB Atlas
-description: How to configure Teleport Database Access with MongoDB Atlas.
+description: How to configure Teleport database access with MongoDB Atlas.
 videoBanner: mu_ZKTjnFJ8
 ---
 

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -1,12 +1,12 @@
 ---
 title: Database Access with Self-Hosted MongoDB
-description: How to configure Teleport Database Access with self-hosted MongoDB.
+description: How to configure Teleport database access with self-hosted MongoDB.
 videoBanner: 6lgVObxoLkc
 ---
 
 In this guide you will:
 
-1. Install and configure Teleport for Database Access.
+1. Install and configure Teleport for database access.
 2. Configure mutual TLS authentication between Teleport and your MongoDB cluster.
 3. Connect to your MongoDB instance via Teleport.
 
@@ -25,7 +25,7 @@ In this guide you will:
 - MongoDB cluster (standalone or replica set) version `(=mongodb.min_version=)` or newer.
 
 <Admonition type="note">
-  Teleport Database Access supports MongoDB `(=mongodb.min_version=)` and newer.
+  Teleport database access supports MongoDB `(=mongodb.min_version=)` and newer.
   Older versions have not been tested and are not guaranteed to work. MongoDB
   `(=mongodb.min_version=)` was released in November 2017 and reached EOL in
   April 2021 so if you're still using an older version, consider upgrading.

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with MySQL on GCP Cloud SQL
-description: How to configure Teleport Database Access with GCP Cloud SQL MySQL.
+description: How to configure Teleport database access with GCP Cloud SQL MySQL.
 ---
 
 This guide will help you to:
@@ -22,7 +22,7 @@ This guide will help you to:
 
 <Notice type="warning">
 
-Teleport Database Access for Cloud SQL MySQL is available starting from the
+Teleport database access for Cloud SQL MySQL is available starting from the
 `7.0` release.
 
 </Notice>
@@ -225,7 +225,7 @@ proxy_service:
   title="Tip"
 >
   A single Teleport process can run multiple different services, for example
-  multiple Database Access instances as well as other services such the SSH
+  multiple Database Service instances as well as other services such the SSH
   Service or Application Service.
 </Admonition>
 

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Self-Hosted MySQL/MariaDB
-description: How to configure Teleport Database Access with self-hosted MySQL/MariaDB.
+description: How to configure Teleport database access with self-hosted MySQL/MariaDB.
 ---
 
 This guide will help you to:

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with PostgreSQL on GCP Cloud SQL
-description: How to configure Teleport Database Access with GCP Cloud SQL PostgreSQL.
+description: How to configure Teleport database access with GCP Cloud SQL PostgreSQL.
 videoBanner: br9LZ3ZXqCk
 ---
 
@@ -289,7 +289,7 @@ proxy_service:
 >
 
   A single Teleport process can run multiple different services, for example
-  multiple Database Access instances as well as other services such the SSH
+  multiple Database Services instances as well as other services such the SSH
   Service or Application Service.
 
 </Notice>
@@ -359,7 +359,7 @@ $ tsh db connect --db-user=teleport@<project-id>.iam --db-name=postgres cloudsql
   title="What database user name to use?"
 >
 
-  When connecting to the database, use the name of the database service account
+  When connecting to the database, use the name of the database's service account
   that you added as an IAM database user
   [above](#step-27-create-a-service-account-for-the-database), minus the
   `.gserviceaccount.com` suffix. The database user name is shown on the Users

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Redshift on AWS
-description: How to configure Teleport Database Access with AWS Redshift PostgreSQL.
+description: How to configure Teleport database access with AWS Redshift PostgreSQL.
 videoBanner: UFhT52d5bYg
 ---
 

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Self-Hosted PostgreSQL
-description: How to configure Teleport Database Access with self-hosted PostgreSQL.
+description: How to configure Teleport database access with self-hosted PostgreSQL.
 ---
 
 This guide will help you to:

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -1,7 +1,7 @@
 ---
 title: Database Access with AWS RDS and Aurora
 h1: Database Access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB
-description: How to configure Teleport Database Access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB.
+description: How to configure Teleport database access with AWS RDS and Aurora for PostgreSQL, MySQL and MariaDB.
 ---
 
 This guide will help you to:
@@ -18,7 +18,7 @@ This guide will help you to:
 </ScopedBlock>
 
 <Admonition type="note" title="Supported versions">
-    The following products are not compatible with Database Access as they don't support IAM authentication:
+    The following products are not compatible with database access as they don't support IAM authentication:
     - Aurora Serverless v1.
     - RDS MariaDB versions lower than 10.6.
 

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with AWS ElastiCache and AWS MemoryDB for Redis
-description: How to configure Teleport Database Access with AWS ElastiCache and AWS MemoryDB for Redis.
+description: How to configure Teleport database access with AWS ElastiCache and AWS MemoryDB for Redis.
 ---
 
 This guide will help you to:

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Redis Cluster
-description: How to configure Teleport Database Access with Redis Cluster.
+description: How to configure Teleport database access with Redis Cluster.
 ---
 
 <Details
@@ -10,7 +10,7 @@ description: How to configure Teleport Database Access with Redis Cluster.
   scopeOnly={true}
   min="9.0"
 >
-  Database Access for Redis is available starting from Teleport `9.0`.
+  Database access for Redis is available starting from Teleport `9.0`.
 </Details>
 
 If you want to configure Redis Standalone, please read [Database Access with Redis](redis.mdx).

--- a/docs/pages/database-access/guides/redis.mdx
+++ b/docs/pages/database-access/guides/redis.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Redis
-description: How to configure Teleport Database Access with Redis.
+description: How to configure Teleport database access with Redis.
 ---
 
 <Details

--- a/docs/pages/database-access/guides/snowflake.mdx
+++ b/docs/pages/database-access/guides/snowflake.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Snowflake
-description: How to configure Teleport Database Access with Snowflake.
+description: How to configure Teleport database access with Snowflake.
 ---
 
 <Details

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access with Microsoft SQL Server with Active Directory authentication (Preview)
-description: How to configure Teleport Database Access with Microsoft SQL Server with Active Directory authentication.
+description: How to configure Teleport database access with Microsoft SQL Server with Active Directory authentication.
 videoBanner: k2wz79XCexY
 ---
 
@@ -11,12 +11,12 @@ videoBanner: k2wz79XCexY
   scopeOnly={true}
   min="9.0"
 >
-  Database Access for Microsoft SQL Server with Active Directory authentication
+  Database access for Microsoft SQL Server with Active Directory authentication
   is available starting from Teleport `9.0`.
 </Details>
 
 <Admonition type="warning" title="Preview">
-  Database Access for Microsoft SQL Server is currently in Preview mode.
+  Database access for Microsoft SQL Server is currently in Preview mode.
 </Admonition>
 
 This guide will help you to:

--- a/docs/pages/database-access/introduction.mdx
+++ b/docs/pages/database-access/introduction.mdx
@@ -1,12 +1,12 @@
 ---
 title: Database Access
-description: Teleport Database Access introduction, demo and resources.
+description: Teleport database access introduction, demo and resources.
 ---
 
 Teleport can provide secure connections to your databases while improving both
 access control and visibility.
 
-Some of the things you can do with Database Access:
+Some of the things you can do with database access:
 
 - Enable users to retrieve short-lived database certificates using a Single Sign-On
   flow, thus maintaining their organization-wide identity.
@@ -48,14 +48,14 @@ with GitHub, execute a few SQL queries and observe them in the audit log:
 
 ## Resources
 
-To learn more about configuring role-based access control for Database Access,
+To learn more about configuring role-based access control for database access,
 check out the [RBAC](./rbac.mdx) section.
 
 The [Architecture](./architecture.mdx) section provides a more in-depth look at
-Database Access internals such as networking and security.
+Teleport Database Service internals such as networking and security.
 
 See [Reference](./reference.mdx) for an overview of
-Database Access-related configuration and CLI commands.
+database access-related configuration and CLI commands.
 
 If you hit any issues, check out the [Troubleshooting
 documentation](./troubleshooting.mdx) for common problems and solutions.

--- a/docs/pages/database-access/rbac.mdx
+++ b/docs/pages/database-access/rbac.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Role-Based Access Controls
-description: Role-based access control (RBAC) for Teleport Database Access.
+description: Role-based access control (RBAC) for Teleport database access.
 ---
 
 Role-based access control (or RBAC, for short) allows administrators to set up
@@ -12,7 +12,7 @@ engineers can gain temporary access to the production database in case of
 emergency"*.
 
 For a more general description of Teleport roles and examples see [RBAC](../access-controls/introduction.mdx), as
-this section focuses on configuring RBAC for Database Access.
+this section focuses on configuring RBAC for database access.
 
 ## Role configuration
 

--- a/docs/pages/database-access/reference.mdx
+++ b/docs/pages/database-access/reference.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access Reference
-description: Configuration and CLI reference for Teleport Database Access.
+description: Configuration and CLI reference for the Teleport Database Service.
 ---
 
 - [Configuration](./reference/configuration.mdx)

--- a/docs/pages/database-access/reference/audit.mdx
+++ b/docs/pages/database-access/reference/audit.mdx
@@ -1,9 +1,7 @@
 ---
 title: Database Access Audit Events Reference
-description: Audit events reference for Teleport Database Access.
+description: Audit events reference for Teleport database access.
 ---
-
-# Database Access Audit Events Reference
 
 ## db.session.start (TDB00I/W)
 

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -1,10 +1,10 @@
 ---
 title: Database Access CLI Reference
-description: CLI reference for Teleport Database Access.
+description: CLI reference for Teleport database access.
 ---
 
 This reference shows you how to run common commands for managing Teleport
-Database Access, including:
+the Database Service, including:
 
 - The `teleport` daemon command, which is executed on the host where you
   will run the Teleport Database Service.
@@ -143,7 +143,7 @@ $ teleport db configure bootstrap -c /etc/teleport.yaml --manual
 
 When invoked with a `--format=db` (or `--format=mongodb` for MongoDB) flag,
 produces a CA certificate, a client certificate and a private key file used for
-configuring Database Access with self-hosted database instances.
+configuring the Database Service with self-hosted database instances.
 
 <Admonition type="note" title="Note">
   For database formats, `tctl` must be run on an Auth Service host or the remote

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: Database Access Configuration Reference
-description: Configuration reference for Teleport Database Access.
+description: Configuration reference for Teleport database access.
 ---
 
 ## Database service configuration
@@ -17,7 +17,7 @@ appearing in `teleport.yaml` configuration file:
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
-The following Proxy service configuration is relevant for Database Access:
+The following Proxy service configuration is relevant for database access:
 
 <Admonition
   type="warning"
@@ -58,7 +58,7 @@ proxy_service:
 <TabItem scope={["cloud"]} label="Teleport Cloud">
 
 Teleport Cloud automatically configures the Teleport Proxy Service with the
-following settings that are relevant to Database Access. This reference
+following settings that are relevant to database access. This reference
 configuration uses `mytenant.teleport.sh` in place of your Teleport Cloud tenant
 address.
 

--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -226,7 +226,7 @@ This must be a subdomain of the domain you chose for [`route53_zone`](#route53\_
 
 Setting `export TF_VAR_add_wildcard_route53_record="true"`
 
-Used to enable Application Access for subdomains of the Teleport Proxy Service's public web address. A wildcard entry for the public-facing 
+Used to enable the Teleport Application Service for subdomains of the Teleport Proxy Service's public web address. A wildcard entry for the public-facing 
 domain will be set in Route 53, e.g., `*.teleport.example.com`, to point to the Teleport load balancer. For ACM a wildcard 
 certificate is included if this is set to `true`. Let's Encrypt automatically includes a wildcard subdomain in certificates that it issues.
 

--- a/docs/pages/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/gcp.mdx
@@ -344,10 +344,11 @@ Save the following configuration file as `/etc/teleport.yaml` on the Node:
 version: v3
 teleport:
   auth_token: (= presets.tokens.second =)
-  # Nodes and other agents can be joined to the cluster via the proxy's public address.
-  # This will establish a reverse tunnel between the proxy and the node which is used for all traffic.
+  # Teleport agents can be joined to the cluster via the Proxy Service's 
+  # public address. This will establish a reverse tunnel between the Proxy 
+  # Service and the agent that is used for all traffic.
   proxy_server: teleport.example.com:443
-# enable ssh service and disable auth and proxy
+# enable the SSH Service and disable the Auth and Proxy Services
 ssh_service:
   enabled: true
 auth_service:

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -129,7 +129,7 @@ these options:
 You can use `cert-manager` to provision and automatically renew TLS credentials
 by completing ACME challenges via Let's Encrypt. We recommend this approach if
 you require CLI access to web applications using client certificates via
-Teleport Application Access.
+the Teleport Application Service.
 
 #### Using AWS Certificate Manager
 
@@ -139,10 +139,10 @@ certificates.
 You should be aware of the limitations for using AWS Certificate Manager to
 provision TLS credentials for Teleport:
 
-- This will prevent Teleport Application Access from working via CLI using
-  client certificates. Application Access will still work via a browser.
-- Command-line Application Access does not work with ACM. Using ACM will prevent
-  Teleport from facilitating Application Access via CLI (using client
+- This will prevent the Teleport Application Service from working via CLI using
+  client certificates. Application access will still work via a browser.
+- Command-line application access does not work with ACM. Using ACM will prevent
+  Teleport from facilitating application access via CLI (using client
   certificates), as Teleport will not be handling its own TLS termination.
 - Using ACM through a AWS Load Balancer prevents the required traffic for
   Postgres or MongoDB through Teleport's web port. If you choose to use the ACM

--- a/docs/pages/desktop-access/directory-sharing.mdx
+++ b/docs/pages/desktop-access/directory-sharing.mdx
@@ -1,11 +1,11 @@
 ---
 title: Desktop Access Directory Sharing
-description: Teleport Desktop Access Directory Sharing lets you easily send files to a remote desktop.
+description: Teleport desktop Directory Sharing lets you easily send files to a remote desktop.
 ---
 
-Directory Sharing is a feature of Teleport Desktop Access that makes it easy to
-move files between a local machine and a remote desktop—and apply changes to
-those files—without compromising security.
+Directory Sharing is a Teleport feature of that makes it easy to move files
+between a local machine and a remote desktop—and apply changes to those
+files—without compromising security.
 
 During a remote desktop session, you can select a folder on your local
 workstation to share with the remote desktop. Changes to the folder on either
@@ -22,9 +22,11 @@ after the session ends.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- Teleport Desktop Access with at least one remote desktop registered in your
-  cluster. If you have not yet configured Desktop Access, read [Getting Started
-  with Desktop Access](./getting-started.mdx) before beginning this guide.
+{/*lint ignore messaging to ignore the page title linked here*/}
+- The Teleport Desktop Service with at least one remote desktop registered in
+  your cluster. If you have not yet configured Desktop Access, read [Getting
+  Started with Desktop Access](./getting-started.mdx) before beginning this
+  guide.
 - A browser on your local machine that supports the File System Access API,
   which Teleport uses for Directory Sharing. We support the latest versions of
   Chromium-based browsers like Google Chrome, Brave, and Microsoft Edge.
@@ -176,11 +178,11 @@ $ tctl create -f role.yaml
 Directory Sharing is a powerful tool for editing files on remote desktops, and
 you'll want to make sure you have a comprehensive audit trail so you can conduct
 a post-incident retrospective or investigate unintended usage. Learn how to set
-up [session recording for Desktop Access](./reference/sessions.mdx).
+up [session recording for desktop access](./reference/sessions.mdx).
 
-Aside from Directory Sharing, Desktop Access also enables you to share the
-contents of your clipboard with a remote desktop. Learn how to use [Clipboard
-Sharing](./reference/clipboard.mdx).
+Aside from Directory Sharing, the Teleport Desktop Service also enables you to
+share the contents of your clipboard with a remote desktop. Learn how to use
+[Clipboard Sharing](./reference/clipboard.mdx).
 
 ### How Directory Sharing works
 

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -1,6 +1,6 @@
 ---
 title: Getting Started with Desktop Access
-description: Automatically add Teleport Desktop Access to your infrastructure
+description: Automatically add Teleport desktop access to your infrastructure
 videoBanner: v36tlB8D5kk
 ---
 
@@ -21,12 +21,12 @@ provide secure, passwordless access to Windows desktops.
 
 <Details title="Compare Desktop Access to other RDP clients">
 
-Teleport Desktop Access is designed to be a secure access solution for Windows
-environments. Teleport implements a minimal feature set of the RDP protocol with
-security as a priority, and may not be as performant as standard RDP clients.
-Consider Desktop Access to manage access to your most sensitive Windows
-environments, not as a drop-in replacement for other tools to provide general
-access to Windows desktops.
+The Teleport Desktop Service is designed to be a secure access solution for
+Windows environments. Teleport implements a minimal feature set of the RDP
+protocol with security as a priority, and may not be as performant as standard
+RDP clients. Consider the Desktop Service to manage access to your most sensitive
+Windows environments, not as a drop-in replacement for other tools to provide
+general access to Windows desktops.
 
 </Details>
 
@@ -74,9 +74,9 @@ Click **NEXT**.
 The PowerShell script will output a Teleport configuration block. Copy this
 block to a temporary location. Click **Next**.
 
-On the Linux host you installed Teleport to run as the Desktop Access connector,
-edit `/etc/teleport.yaml` and paste the configuration provided by the output of
-the previous step. Review and edit the addition as necessarily for your environment:
+On the Linux host where you installed Teleport to run the Desktop Service, edit
+`/etc/teleport.yaml` and paste the configuration provided by the output of the
+previous step. Review and edit the addition as necessarily for your environment:
 
 ```yaml
 version: v3
@@ -205,3 +205,4 @@ under **Desktops**. Click **Finish** then **BROWSE EXISTING RESOURCES** to see t
 If you hit any issues, check out the
 [Troubleshooting documentation](./troubleshooting.mdx) for common problems and
 solutions.
+

--- a/docs/pages/desktop-access/introduction.mdx
+++ b/docs/pages/desktop-access/introduction.mdx
@@ -1,13 +1,11 @@
 ---
 title: Desktop Access
-description: Teleport Desktop Access introduction and resources.
+description: Teleport desktop access introduction and resources.
 videoBanner: n2h0GisWdss
 ---
 
-# Desktop Access
-
-Teleport manages graphical desktop access to remote hosts. With Teleport
-Desktop Access, you get:
+Teleport manages graphical desktop access to remote hosts. With Teleport, you
+get:
 
 - A password-less login experience backed by strong cryptographic
   authentication.

--- a/docs/pages/desktop-access/manual-setup.mdx
+++ b/docs/pages/desktop-access/manual-setup.mdx
@@ -4,17 +4,18 @@ description: Manually Connect Teleport to Active Directory and log into a Window
 videoBanner: YvMqgcq0MTQ
 ---
 
-In this guide we will connect an Active Directory domain to Teleport using
-Desktop Access and log into a Windows desktop from that domain.
+In this guide we will connect an Active Directory domain to Teleport using the
+Teleport Desktop Service and log into a Windows desktop from that domain.
 
 <Admonition type="tip" title="Use The Wizard">
 
-Starting with Teleport 10.2.6, you can install Active Directory and configure Teleport Desktop Access through the web UI. See [Getting Started](getting-started.mdx) for more information.
+Starting with Teleport 10.2.6, you can install Active Directory and configure Teleport desktop access through the web UI. See [Getting Started](getting-started.mdx) for more information.
 
 Continue with this guide if:
 
 - You're running an older version of Teleport and can't upgrade.
-- You want to install Desktop Access using the same instance of `teleport` running the proxy/auth services.
+- You want to install the Teleport Desktop Service using the same instance of
+  `teleport` running the Proxy/Auth services.
 
 </Admonition>
 
@@ -36,7 +37,7 @@ This guide requires you to have:
 
   See [Teleport Getting Started](../try-out-teleport/introduction.mdx) if you're new to Teleport.
 
-- A Linux server to run the Teleport Desktop Access service on.
+- A Linux server to run the Teleport Desktop Service on.
 
   You can reuse an existing server running any other Teleport instance.
 
@@ -466,7 +467,7 @@ the filepath to the `der_ca_file` configuration variable.
 
 <Admonition type="note" title="Teleport CA">
   Prior to v8.0, the Teleport CA was not compatible with Windows logins. If
-  you're setting up Desktop Access in an existing cluster created before v8.0,
+  you're setting up desktop access in an existing cluster created before v8.0,
   you must first perform a [CA rotation](../management/operations/ca-rotation.mdx) in
   order to resolve this.
 </Admonition>
@@ -475,7 +476,7 @@ Install Teleport on the host where you will run the Teleport Desktop Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-In order to enable Desktop Access in Teleport, add the following section in
+In order to enable desktop access in Teleport, add the following section in
 `/etc/teleport.yaml` on your Linux server. For a detailed description of these
 configuration fields, see the
 [configuration reference](./reference/configuration.mdx) page.
@@ -611,7 +612,7 @@ $ tctl create -f windows-desktop-admins.yaml
 
 ### Connect to your Windows desktop
 
-At this point everything is ready for Desktop Access connections. Open
+At this point everything is ready for Desktop Service connections. Open
 the Teleport web UI and log in with a user with the role created above.
 
 On the left pane, select `Desktops (preview)`. You should see the list of all

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -1,6 +1,6 @@
 ---
 title: Role-Based Access Control for Desktop Access
-description: Role-based access control (RBAC) for Teleport Desktop Access
+description: Role-based access control (RBAC) for Teleport desktop access
 ---
 
 Teleport's RBAC allows administrators to set up granular access policies for
@@ -77,9 +77,9 @@ host_labels:
 
 ### Using LDAP
 
-Teleport Desktop Access can automatically discover Windows Desktops and register
-them with the Teleport Cluster by periodically querying an LDAP server. There
-are several ways that these desktops can be labeled:
+The Teleport Desktop Service can automatically discover Windows Desktops and
+register them with the Teleport Cluster by periodically querying an LDAP server.
+There are several ways that these desktops can be labeled:
 
 Teleport applies the following labels automatically to all desktops discovered
 via LDAP:
@@ -97,7 +97,7 @@ via LDAP:
 Additionally, users can configure
 [LDAP attributes](https://docs.microsoft.com/en-us/windows/win32/adschema/attributes-all)
 which will be converted into Teleport labels. For example, consider the
-following Desktop Access configuration:
+following Desktop Service configuration:
 
 ```yaml
 discovery:

--- a/docs/pages/desktop-access/reference.mdx
+++ b/docs/pages/desktop-access/reference.mdx
@@ -1,10 +1,10 @@
 ---
 title: Desktop Access Reference
-description: Comprehensive guides to configuring and auditing Desktop Access.
+description: Comprehensive guides to configuring and auditing desktop access.
 layout: tocless-doc
 ---
 
-- [Configuration](./reference/configuration.mdx): Configure Teleport Desktop Access.
-- [Audit](./reference/audit.mdx): Desktop Access audit events.
+- [Configuration](./reference/configuration.mdx): Configure Teleport desktop access.
+- [Audit](./reference/audit.mdx): Desktop access audit events.
 - [Clipboard](./reference/clipboard.mdx): Share your clipboard with a remote desktop.
 - [Session Recording](./reference/sessions.mdx): Desktop session recording and playback

--- a/docs/pages/desktop-access/reference/audit.mdx
+++ b/docs/pages/desktop-access/reference/audit.mdx
@@ -1,6 +1,6 @@
 ---
 title: Desktop Access Audit Events Reference
-description: Audit events reference for Teleport Desktop Access.
+description: Audit events reference for Teleport desktop access.
 ---
 
 ## windows.desktop.session.start (TDP00I/W)

--- a/docs/pages/desktop-access/reference/cli.mdx
+++ b/docs/pages/desktop-access/reference/cli.mdx
@@ -1,9 +1,10 @@
 ---
 title: Desktop Access CLI Reference
-description: CLI reference for Teleport Desktop Access.
+description: CLI reference for Teleport desktop access.
 ---
 
-The following `tctl` commands are used to manage Teleport Desktop Access.
+The following `tctl` commands are used to manage the Teleport Windows Desktop
+Service.
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/desktop-access/reference/clipboard.mdx
+++ b/docs/pages/desktop-access/reference/clipboard.mdx
@@ -1,10 +1,10 @@
 ---
 title: Clipboard Sharing
-description: Using Clipboard Sharing with Teleport Desktop Access.
+description: Using Clipboard Sharing with Teleport desktop access.
 ---
 
-Teleport Desktop Access supports copying and pasting text between your browser
-and a remote Windows Desktop.
+Teleport supports copying and pasting text between your browser and a remote
+Windows Desktop.
 
 <Admonition type="note">
 This feature requires a Chromium-based browser such as Google Chrome, Brave,

--- a/docs/pages/desktop-access/reference/configuration.mdx
+++ b/docs/pages/desktop-access/reference/configuration.mdx
@@ -1,16 +1,14 @@
 ---
 title: Desktop Access Configuration Reference
-description: Configuration reference for Teleport Desktop Access.
+description: Configuration reference for Teleport desktop access.
 ---
 
-## Windows Desktop Service configuration
-
-`teleport.yaml` fields related to Desktop Access:
+`teleport.yaml` fields related to desktop access:
 
 ```yaml
-# Main service responsible for Desktop Access.
+# Main service responsible for desktop access.
 #
-# You can have multiple Desktop Access services in your cluster (but not in the
+# You can have multiple Desktop Service instances in your cluster (but not in the
 # same teleport.yaml), connected to the same or different Active Directory
 # domains.
 (!docs/pages/includes/desktop-access/desktop-config.yaml!)

--- a/docs/pages/desktop-access/reference/sessions.mdx
+++ b/docs/pages/desktop-access/reference/sessions.mdx
@@ -1,9 +1,9 @@
 ---
 title: Session Recording and Playback
-description: Recording and Playing Back Teleport Desktop Access Sessions.
+description: Recording and playing back Teleport desktop access sessions.
 ---
 
-Teleport Desktop Access supports recording and playback of desktop sessions.
+The Teleport Database Service supports recording and playback of desktop sessions.
 
 ## Disabling session recording
 
@@ -78,12 +78,14 @@ of the stream is reached. To replay a session, refresh the page.
 
 ## Storage
 
-Be aware, Desktop Access session recordings save PNGs of changing sections of the
-screen, which means they take up significantly more disk space than SSH or Kubernetes
-session recordings. When using async recording modes, ensure that the host running
-Teleport's desktop service has sufficient disk space to store recordings that are
-in progress. As a point of reference, when a full 1080p screen is redrawn (for example 
-when opening a new full-sized application window), you can expect about 250kb to be
+Be aware, desktop session recordings save PNGs of changing sections of the
+screen, which means they take up significantly more disk space than SSH or
+Kubernetes session recordings. When using async recording modes, ensure that the
+host running Teleport's Desktop Service has sufficient disk space to store
+recordings that are in progress. 
+
+As a point of reference, when a full 1080p screen is redrawn (for example when
+opening a new full-sized application window), you can expect about 250kb to be
 saved to disk. If disk space is a concern, we recommend using sync recording and
 configuring a cloud storage solution such as S3.
 

--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting Desktop Access
-description: Common issues and resolutions for Teleport's Desktop Access
+description: Common issues and resolutions for Teleport's desktop access
 ---
 
 Common issues and resolution steps.

--- a/docs/pages/includes/cloud/cloudmanagedadvisory.mdx
+++ b/docs/pages/includes/cloud/cloudmanagedadvisory.mdx
@@ -1,9 +1,9 @@
 <Details scopeOnly={true} scope={["cloud"]} title="Teleport Cloud">
 This guide deploys the Teleport Auth Service and Proxy Service, which are fully managed in Teleport Cloud. If you are a Teleport Cloud customer, we recommend following our guides for accessing specific resources within your infrastructure:
 
-- [Server Access](/docs/server-access/getting-started.mdx)
-- [Kubernetes Access](/docs/kubernetes-access/getting-started.mdx)
-- [Database Access](/docs/database-access/getting-started.mdx)
-- [Desktop Access](/docs/desktop-access/getting-started.mdx)
-- [Application Access](/docs/application-access/getting-started.mdx)
+- [Servers](/docs/server-access/getting-started.mdx)
+- [Kubernetes clusters](/docs/kubernetes-access/getting-started.mdx)
+- [Databases](/docs/database-access/getting-started.mdx)
+- [Windows Desktops](/docs/desktop-access/getting-started.mdx)
+- [Applications](/docs/application-access/getting-started.mdx)
 </Details>

--- a/docs/pages/includes/database-access/aws-troubleshooting-max-policy-size.mdx
+++ b/docs/pages/includes/database-access/aws-troubleshooting-max-policy-size.mdx
@@ -56,7 +56,7 @@ policy.
 
 </Details>
 
-Another option is to deploy [Database Access in a Highly Available (HA)
+Another option is to deploy [the Database Service in a highly available (HA)
 configuration](../../database-access/guides/ha.mdx) where databases can be
 sharded to separate Database Services with different IAM roles.
 

--- a/docs/pages/includes/database-access/create-user.mdx
+++ b/docs/pages/includes/database-access/create-user.mdx
@@ -1,6 +1,6 @@
 <Admonition type="tip">
 
-To modify an existing user to provide access to the Database Access service, see [Database Access Access Controls](../../database-access/rbac.mdx)
+To modify an existing user to provide access to the Database Service, see [Database Access Access Controls](../../database-access/rbac.mdx)
 
 </Admonition>
 

--- a/docs/pages/includes/database-access/rotation-note.mdx
+++ b/docs/pages/includes/database-access/rotation-note.mdx
@@ -1,8 +1,8 @@
 <Admonition type="note" title="Certificate Rotation">
-  Teleport 10.0 introduced a new certificate authority that is only used by Database Access.
-  Older Teleport versions use a host certificate to sign Database Access certificates.
+  Teleport 10.0 introduced a new certificate authority that is only used by the Teleport Database Service.
+  Older Teleport versions use a host certificate to sign Database Service certificates.
 
-After upgrading to Teleport 10.0, the host certificate authority will still be used by Database Access to maintain compatibility.
+After upgrading to Teleport 10.0, the host certificate authority will still be used by the Database Service to maintain compatibility.
   The first [certificate rotation](../../management/operations/ca-rotation.mdx) will rotate host and database certificates.
 
 New Teleport 10.0+ installations generate the database certificate authority when they first start, and are not affected

--- a/docs/pages/includes/dns.mdx
+++ b/docs/pages/includes/dns.mdx
@@ -1,9 +1,9 @@
 Set up two `A` DNS records: `tele.example.com` for all traffic and
-`*.tele.example.com` for web apps using Application Access. We are assuming
+`*.tele.example.com` for web apps using application access. We are assuming
 that your domain name is `example.com`. Use your own subdomain instead of
 `tele`.
 
-<Details opened={false} title="Why are we using wildcard subdomains for Application Access?">
+<Details opened={false} title="Why are we using wildcard subdomains for application access?">
 (!docs/pages/includes/dns-app-access.mdx!)
 </Details>
 

--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -11,11 +11,11 @@
 
 ||Open Source|Enterprise|Cloud|
 |---|---|---|---|
-|[Application Access](../application-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
-|[Server Access](../server-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
-|[Database Access](../database-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
-|[Desktop Access](../desktop-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
-|[Kubernetes Access](../kubernetes-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
+|[Application access](../application-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
+|[Server access](../server-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
+|[Database access](../database-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
+|[Desktop access](../desktop-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
+|[Kubernetes access](../kubernetes-access/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
 |[Machine ID](../machine-id/getting-started.mdx)|&#10004;|&#10004;|&#10004;|
 |Agentless integration with [OpenSSH servers](../server-access/guides/openssh.mdx)|&#10004;|&#10004;|&#10004;|
 

--- a/docs/pages/kubernetes-access/guides.mdx
+++ b/docs/pages/kubernetes-access/guides.mdx
@@ -1,13 +1,14 @@
 ---
 title: Kubernetes Access Guides
-description: Detailed guides for configuring Teleport Kubernetes Access.
+description: Detailed guides for configuring Teleport Kubernetes access.
 layout: tocless-doc
 ---
 
 - [Teleport Kubernetes Access and Trusted Clusters](./guides/federation.mdx):
   Federated Access using Teleport Trusted Clusters.
+{/*lint ignore messaging*/}
 - [Kubernetes Access Multiple Clusters](./guides/multiple-clusters.mdx):
-  Connect Multiple Clusters with Teleport Kubernetes Access.
+  Connect Multiple Clusters with Teleport.
 - [Kubernetes Access from a Standalone Teleport
   Cluster](./guides/standalone-teleport.mdx): Connect a Teleport cluster to a
   Kubernetes cluster running in a separate network.

--- a/docs/pages/kubernetes-access/introduction.mdx
+++ b/docs/pages/kubernetes-access/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Kubernetes Access
-description: Teleport Kubernetes Access introduction, demo, and resources.
+description: Teleport Kubernetes access introduction, demo, and resources.
 ---
 
 Teleport provides secure access to Kubernetes clusters.
@@ -33,10 +33,14 @@ Set up SSO, capture audit events, and sessions with Teleport running in a Kubern
 
 ## Get started
 
-- [Teleport Kubernetes Access](./getting-started.mdx): Get started with Teleport Kubernetes Access.
+{/*lint ignore messaging*/}
+- [Teleport Kubernetes Access](./getting-started.mdx): Get started with Teleport Kubernetes access.
 
 ## Guides
 
-- [Teleport Kubernetes Access and Trusted Clusters](./guides/federation.mdx): Federated Access using Teleport Trusted Clusters.
-- [Kubernetes Access Multiple Clusters](./guides/multiple-clusters.mdx): Connecting Multiple Clusters with Teleport Kubernetes Access.
+{/*lint ignore messaging*/}
+- [Teleport Kubernetes Access and Trusted Clusters](./guides/federation.mdx): Federated access using Teleport Trusted Clusters.
+{/*lint ignore messaging*/}
+- [Kubernetes Access Multiple Clusters](./guides/multiple-clusters.mdx): Connecting Multiple Clusters with Teleport.
+{/*lint ignore messaging*/}
 - [Kubernetes Access from a Standalone Teleport Cluster](./guides/standalone-teleport.mdx): Connecting standalone Teleport installations to Kubernetes clusters

--- a/docs/pages/machine-id/faq.mdx
+++ b/docs/pages/machine-id/faq.mdx
@@ -30,8 +30,8 @@ We hope to introduce support for generating a `ssh_config` that is compatible
 with leaf clusters for use with OpenSSH. You can track support for this on the 
 [GitHub Machine ID Trusted Cluster Support issue](https://github.com/gravitational/teleport/issues/13792).
 
-We currently do not support Application Access, Database Access or Kubernetes
-Access to resources in leaf clusters.
+We currently do not support access to applications, databases, or Kubernetes
+clusters in Trusted Clusters configured as leaf clusters.
 
 ## Should I define allowed logins as user traits or within roles?
 

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -24,14 +24,14 @@ You will need to be running the Teleport Proxy and Auth Services, version 9.3.0 
 later.
 </ScopedBlock>
 
-If you have not already put your database behind Teleport Database Access,
-follow the [Database Access Getting Started Guide](../../database-access/getting-started.mdx).
-Database Access supports databases like PostgreSQL, MongoDB, Redis, and much
-more. See our [Database Access Guides](../../database-access/guides.mdx) for
-a complete list.
+If you have not already put your database behind the Teleport Database Service,
+follow the [database access getting started guide](../../database-access/getting-started.mdx).
+The Teleport Database Service supports databases like PostgreSQL, MongoDB,
+Redis, and much more. See our [database access
+guides](../../database-access/guides.mdx) for a complete list.
 
-If you have not already set up Machine ID, follow the [Machine ID Getting
-Started Guide](../getting-started.mdx) to familiarize yourself with Machine ID.
+If you have not already set up Machine ID, follow the [Machine ID getting
+started guide](../getting-started.mdx) to familiarize yourself with Machine ID.
 You'll need `tctl` access to initially configure the bot.
 
 (!docs/pages/includes/tctl.mdx!)

--- a/docs/pages/machine-id/guides/github-actions-kubernetes.mdx
+++ b/docs/pages/machine-id/guides/github-actions-kubernetes.mdx
@@ -16,9 +16,9 @@ description: A tutorial for using Machine ID with GitHub Actions and Kubernetes
 GitHub Actions is a popular CI/CD platform that works as a part of the larger
 GitHub ecosystem.
 
-In this guide, you will use Teleport Machine ID and Kubernetes Access to allow a
-GitHub Actions workflow to securely connect to a Kubernetes cluster without the
-need for long-lived secrets.
+In this guide, you will use Machine ID and the Teleport Kubernetes Service to
+allow a GitHub Actions workflow to securely connect to a Kubernetes cluster
+without the need for long-lived secrets.
 
 Teleport supports secure joining on both GitHub-hosted and self-hosted GitHub
 Actions runners as well as GitHub Enterprise Server.

--- a/docs/pages/management/guides/ec2-tags.mdx
+++ b/docs/pages/management/guides/ec2-tags.mdx
@@ -20,7 +20,7 @@ fakehost.example.com 127.0.0.1:3022 env=example,hostname=ip-172-31-53-70,aws/Nam
 ```
 
 <Notice type="note">
-  For services that manage multiple resources (such as the database service), each resource will receive the
+  For services that manage multiple resources (such as the Database Service), each resource will receive the
   same labels from EC2.
 </Notice>
 

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -535,7 +535,7 @@ $ ssh myuser@node1.example.com
 
 ### tsh proxy app
 
-Starts a local TLS proxy for Application Access connections.
+Starts a local TLS proxy for Application Service connections.
 You can use this proxy to connect to an application repeatedly after a single login to your Teleport cluster,
 which is especially useful for interacting with an application via a CLI.
 
@@ -1692,7 +1692,7 @@ $ tctl auth sign -o <filepath> [--user <user> | --host <host>][--format] [<flags
 | `--leaf-cluster` | `""` | The name of a leaf cluster. | |
 | `--kube-cluster-name` | `""` | Kubernetes Cluster Name | |
 | `--app-name` | `""` | application name | Generate a certificate for accessing the specified web application |
-| `--db-service` | `""` | database service name | Generate a certificate for accessing the specified database service |
+| `--db-service` | `""` | Database Service name | Generate a certificate for accessing the specified Database Service instance |
 | `--db-user` | `""` | database user | When `--db-service` is specified, encode this database user in the certificate |
 | `--db-name` | `""` | database name | When `--db-service` is specified, encode this database name in the certificate |
 

--- a/docs/pages/reference/config.mdx
+++ b/docs/pages/reference/config.mdx
@@ -162,7 +162,7 @@ teleport:
 
     # Only use one of auth_server or proxy_server.
     #
-    # When you have either the application service or database service enabled,
+    # When you have either the Application Service or Database Service enabled,
     # only tunneling through the proxy is supported, so you should specify proxy_server.
     # All other services support both tunneling through the proxy and directly connecting
     # to the auth server, so you can specify either auth_server or proxy_server.
@@ -771,7 +771,7 @@ proxy_service:
     #  enabled: yes
     #  email: user@example.com
 
-# This section configures the 'application service'
+# This section configures the Application Service
 app_service:
     # Turns 'app' role on. Default is 'no'
     enabled: yes
@@ -809,15 +809,15 @@ app_service:
         #   For example:
         #   - "Host: jenkins.example.com"
 
-## This section configures the 'kubernetes service'
+## This section configures the Kubernetes Service
 (!docs/pages/includes/kubernetes-access/kubernetes-config.yaml!)
 
-# This section configures the 'discovery service'
+# This section configures the Discovery Service
 (!docs/pages/includes/discovery/discovery-config.yaml!)
 
-# This section configures the 'database service'.
+# This section configures the Database Service.
 (!docs/pages/includes/database-access/database-config.yaml!)
 
-# This section configures the windows desktop service
+# This section configures the Windows Desktop Service
 (!docs/pages/includes/desktop-access/desktop-config.yaml!)
 ```

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -203,8 +203,9 @@ For possible values, [see the Teleport Configuration Reference](../../reference/
 | - | - | - | - | - |
 | `bool` | `false` | no | `proxy_service.postgres_listen_addr` | ❌ |
 
-`separatePostgresListener` controls whether Teleport will multiplex PostgreSQL traffic for Teleport Database Access
-over a separate TLS listener to Teleport's web UI.
+`separatePostgresListener` controls whether Teleport will multiplex PostgreSQL
+traffic for the Teleport Database Service over a separate TLS listener to
+Teleport's web UI.
 
 When `separatePostgresListener` is `false` (the default), PostgreSQL traffic will be directed to port 443 (the default Teleport web
 UI port). This works in situations when Teleport is terminating its own TLS traffic, i.e. when using certificates from LetsEncrypt
@@ -235,7 +236,7 @@ These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is se
 | - | - | - | - | - |
 | `bool` | `false` | no | `proxy_service.mongo_listen_addr` | ❌ |
 
-`separateMongoListener` controls whether Teleport will multiplex PostgreSQL traffic for Teleport Database Access
+`separateMongoListener` controls whether Teleport will multiplex PostgreSQL traffic for the Teleport Database Service
 over a separate TLS listener to Teleport's web UI.
 
 When `separateMongoListener` is `false` (the default), MongoDB traffic will be directed to port 443 (the default Teleport web

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -377,7 +377,7 @@ You can specify multiple apps by adding additional list elements.
 |--------|---------------|--------------------------------------------------------------------------------------|
 | `list` | `[]`          | When `app` chart role is used at least one of `apps` and `appResources` is required. |
 
-`appResources` is a YAML list object detailing the resource selectors of the applications that should be proxied by Teleport Application Access.
+`appResources` is a YAML list object detailing the resource selectors of the applications that should be proxied by the Teleport Application Service.
 
 You can specify multiple selectors by including additional list elements.
 
@@ -644,7 +644,7 @@ You can specify multiple databases by adding additional list elements.
 |--------|---------------|---------------------------------------------------------------------------------------------------------------------------------------|
 | `list` | `[]`          | When the `db` chart role is used at least one of `databases`, `awsDatabases`,<br/> `azureDatabases`, `databaseResources` is required. |
 
-`databaseResources` is a YAML list object detailing the resource selectors of the databases that should be proxied by Teleport Database Access.
+`databaseResources` is a YAML list object detailing the resource selectors of the databases that should be proxied by the Teleport Database Service.
 
 You can specify multiple selectors by adding elements to the list.
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -1,10 +1,11 @@
 ---
 title: Server Access Getting Started Guide
-description: Getting started with Teleport Server Access.
+description: Getting started with Teleport server access.
 videoBanner: 8aiVin0LvmE
 ---
 
-Server Access involves managing your resources, configuring new clusters, and issuing commands through a CLI or programmatically to an API.
+Server access involves managing your resources, configuring new clusters, and
+issuing commands through a CLI or programmatically to an API.
 
 This guide introduces some of these common scenarios and how to interact with Teleport to accomplish them:
 

--- a/docs/pages/server-access/guides.mdx
+++ b/docs/pages/server-access/guides.mdx
@@ -1,6 +1,6 @@
 ---
 title: Server Access Guides
-description: Teleport Server Access guides.
+description: Teleport server access guides.
 layout: tocless-doc
 ---
 

--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -79,10 +79,10 @@ of the Linux distribution being used. See [User/Group Name Syntax](https://syste
 
 <Admonition type="warning">
 
-When a Teleport user accesses a Node, Teleport Server Access checks each of the
-user's roles that match the Node. If at least one role matches the Node but does not
-include `create_host_user: true`, automatic user creation will be disabled. Roles that
-do not match the Node will not be checked.
+When a Teleport user accesses an SSH Service instance, Teleport checks each of
+the user's roles that match the instance. If at least one role matches the
+instance but does not include `create_host_user: true`, automatic user creation
+will be disabled. Roles that do not match the Node will not be checked.
 
 </Admonition>
 

--- a/docs/pages/server-access/guides/jetbrains-sftp.mdx
+++ b/docs/pages/server-access/guides/jetbrains-sftp.mdx
@@ -5,7 +5,7 @@ h1: SFTP with JetBrains IDE
 ---
 
 JetBrain's IDEs, like PyCharm, GoLand, and IntelliJ, allow browsing, copying, and editing files on a remote server
-using the SFTP protocol. You can integrate Teleport Server Access with your IDE, so you can copy files to and from a remote
+using the SFTP protocol. You can integrate Teleport with your IDE so you can copy files to and from a remote
 machine without using a third-party client.
 
 This guide explains how to use Teleport and a JetBrains IDE to access files with SFTP.
@@ -15,8 +15,9 @@ This guide explains how to use Teleport and a JetBrains IDE to access files with
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - JetBrains IDE like PyCharm, IntelliJ, GoLand etc. See [Products](https://www.jetbrains.com/products/#type=ide) for a full list of JetBrains IDEs.
-- One or more Teleport Nodes with Server Access enabled. If you have not yet
-done this, read the [Server Access Getting Started Guide](../getting-started.mdx) to learn how.
+- One or more Teleport SSH Service instances. If you have not yet done this,
+  read the [Server Access Getting Started Guide](../getting-started.mdx) to
+  learn how.
 
 ## Step 1/3. First-time setup
 

--- a/docs/pages/server-access/introduction.mdx
+++ b/docs/pages/server-access/introduction.mdx
@@ -1,12 +1,14 @@
 ---
 title: Teleport Server Access Features and Introduction
-description: Teleport Server Access features and introduction.
+description: Teleport server access features and introduction.
 videoBanner: EsEvO5ndNDI
 ---
 
-Teleport Server Access consolidates SSH access across all environments, decreases configuration complexity, supports industry best practices and compliance while giving complete visibility over all sessions and events.
+Teleport consolidates SSH access across all environments, decreases
+configuration complexity, supports industry best practices and compliance while
+giving complete visibility over all sessions and events.
 
-Teleport Server Access is designed for the following kinds of scenarios:
+Teleport server access is designed for the following kinds of scenarios:
 
 1. When up to a vast number of clusters must be managed using the command-line (`tsh`) or programmatically (through the Teleport API) and you want to simplify your stack, security, and configuration complexity.
 2. When security team members must track and audit every user session. 
@@ -15,7 +17,7 @@ Teleport Server Access is designed for the following kinds of scenarios:
 
 ## Getting started
 
-- [Get started](getting-started.mdx): Get started using Teleport Server Access in 10 minutes. Server access for most common SSH use-cases.
+- [Get started](getting-started.mdx): Get started using Teleport server access in 10 minutes.
 - [Integrate with OpenSSH](guides/openssh.mdx): SSO and short-lived certificates for OpenSSH.
 
 ## Guides

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -1,6 +1,6 @@
 ---
 title: Access Controls for Servers
-description: Role-based access control (RBAC) for Teleport Server Access.
+description: Role-based access control (RBAC) for Teleport server access.
 ---
 
 

--- a/docs/pages/try-out-teleport/browser-labs.mdx
+++ b/docs/pages/try-out-teleport/browser-labs.mdx
@@ -8,7 +8,7 @@ You can quickly try out some of Teleport's key features from your browser.
 
 Choose one of our [interactive learning tracks](https://play.instruqt.com/teleport/invite/imz8g1n1xzru), which are hosted by Instruqt. These labs cover:
 
-- Teleport Server Access, which makes it easier to configure onboarding, RBAC, and auditing for SSH connections to remote hosts.
-- Teleport Application Access, which gives you secure access to your internal web applications.
-- Teleport Database Access, to learn how to securely access and configure a remote MySQL database.
-- Teleport Kubernetes Access, which provides advanced RBAC controls and auditing for `kubectl` commands.
+- Teleport server access, which makes it easier to configure onboarding, RBAC, and auditing for SSH connections to remote hosts.
+- Teleport application access, which gives you secure access to your internal web applications.
+- Teleport database access, to learn how to securely access and configure a remote MySQL database.
+- Teleport Kubernetes access, which provides advanced RBAC controls and auditing for `kubectl` commands.

--- a/docs/pages/try-out-teleport/local-kubernetes.mdx
+++ b/docs/pages/try-out-teleport/local-kubernetes.mdx
@@ -251,8 +251,8 @@ kubernetes-dashboard        ClusterIP   10.100.80.65   <none>        443/TCP    
 ```
 
 The `kubernetes-dashboard` service has an open HTTPS port but is not accessible
-outside the cluster (i.e., it has no external IP). By enabling Teleport
-Application Access, we will alow users to securely access the dashboard.
+outside the cluster (i.e., it has no external IP). By enabling the Teleport
+Application Service, we will alow users to securely access the dashboard.
 
 <Notice type="tip">
 


### PR DESCRIPTION
Backports #22270

In gravitational/docs#238, we will add a linter that lints for incorrect usage of Teleport terms. This change fixes linter violations to anticipate this new linter.

Changes include:

- Ensuring that Teleport service names are capitalized
- No longer using the "[Resource] Access" terminology. Instead, talk about adding resources, using Teleport services, etc.