### PR TITLE
Update Teleport Usage README container image badge

### DIFF
--- a/examples/teleport-usage/README.md
+++ b/examples/teleport-usage/README.md
@@ -1,4 +1,8 @@
 # Teleport Usage Gathering Script
+<a href="https://gallery.ecr.aws/gravitational/teleport-usage">
+<img src="https://img.shields.io/github/v/release/gravitational/teleport?sort=semver&label=Container Image&color=621FFF" />
+</a>
+
 
 This script retrieves the number of unique users accessing each of the five
 Teleport supported protocols over a 30 day period.


### PR DESCRIPTION
This PR adds a Container Image badge to allow users to check out the latest published image for the teleport usages script.

Because this script only publishes on releases it should match the teleport releases and allow us to use the badge link used in the root README.md

CC: @yjperez