### PR TITLE
Flaky Test detector: skip slow tests

### DIFF
--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
 )
 
 var (
@@ -41,6 +43,15 @@ var (
 	excludeUpdates   = testCmd.Flag("exclude-updates", "Exclude updated test methods").Short('u').Bool()
 	onlyRunFlag      = testCmd.Flag("only-run-flag", "Show only -run flag").Short('r').Bool()
 	escapeDollarSign = testCmd.Flag("escape-dollar-sign", "Output $ as $$").Short('d').Bool()
+
+	// testsToSkip contains a list of tests that are excluded from running.
+	testsToSkip = []string{
+		// TestCompletenessReset and TestCompletenessInit take around 8s and 17s respectively to run.
+		// The script for Flaky Tests is running 100x, which gives us a total of 800s and 1700s.
+		// The timeout for running all the tests (`go test ... -count=100`) is 600s, which is not enough.
+		// These tests are now skipped and should be added back when they take less time to run.
+		"TestCompletenessReset", "TestCompletenessInit",
+	}
 )
 
 func main() {
@@ -153,6 +164,10 @@ func test(repoPath string, ref string, changedFiles []string) {
 		}
 
 		for _, n := range r.Changed {
+			if slices.Contains(testsToSkip, n.RefName) {
+				log.Printf("-skipping %q (%s)\n", n.RefName, dir)
+				continue
+			}
 			methods = append(methods, "^"+n.RefName+dollarSign)
 			dirs[dir] = struct{}{}
 		}

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -602,7 +602,7 @@ func TestCompletenessInit(t *testing.T) {
 
 	// put lots of CAs in the backend
 	for i := 0; i < caCount; i++ {
-		ca := suite.NewTestCA(types.UserCA, fmt.Sprintf("%d.example.org", i))
+		ca := suite.NewTestCA(types.UserCA, fmt.Sprintf("%d.example.com", i))
 		require.NoError(t, p.trustS.UpsertCertAuthority(ctx, ca))
 	}
 

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -602,7 +602,7 @@ func TestCompletenessInit(t *testing.T) {
 
 	// put lots of CAs in the backend
 	for i := 0; i < caCount; i++ {
-		ca := suite.NewTestCA(types.UserCA, fmt.Sprintf("%d.example.com", i))
+		ca := suite.NewTestCA(types.UserCA, fmt.Sprintf("%d.example.org", i))
 		require.NoError(t, p.trustS.UpsertCertAuthority(ctx, ca))
 	}
 


### PR DESCRIPTION
Some tests can now be skipped when running the Flaky Tests Detector.
It also adds two tests that are slow enough to hit the timeout: TestCompletenessReset and TestCompletenessInit

Demo:
![image](https://user-images.githubusercontent.com/689271/231393051-f28cdb19-7d76-44d4-aaa3-013418e75c2a.png)
