### PR TITLE
Update relcli to fix publishing of release notes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -755,7 +755,7 @@ kind: pipeline
 type: kubernetes
 name: clean-up-previous-build
 environment:
-  RELCLI_IMAGE: 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/relcli:v1.1.76-35e77b7-20221117T1411084
+  RELCLI_IMAGE: 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/relcli:master-57a5d42-20230412T1204687
 trigger:
   event:
     include:
@@ -20214,7 +20214,7 @@ kind: pipeline
 type: kubernetes
 name: publish-rlz
 environment:
-  RELCLI_IMAGE: 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/relcli:v1.1.76-35e77b7-20221117T1411084
+  RELCLI_IMAGE: 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/relcli:master-57a5d42-20230412T1204687
 trigger:
   event:
     include:
@@ -20343,6 +20343,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 500d6db4385acfd4f4614d962b87f67ff37f16f62c7a6c295d59c8b4611ac92d
+hmac: dcf10b332b4bc54f24baaaf73a8222d3e8148a85c6fbdd880ca92a0e62ad52a9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -838,7 +838,7 @@ steps:
   - |-
     docker run -i -v /tmpfs/creds:/tmpfs/creds \
       -e DRONE_REPO -e DRONE_TAG -e RELCLI_BASE_URL -e RELCLI_CERT -e RELCLI_KEY \
-      $RELCLI_IMAGE relcli auto_destroy -f -v 6
+      $RELCLI_IMAGE auto_destroy -f -v 6
   environment:
     RELCLI_BASE_URL: https://releases-prod.platform.teleport.sh
     RELCLI_CERT: /tmpfs/creds/releases.crt
@@ -20304,7 +20304,7 @@ steps:
   - |-
     docker run -i -v /tmpfs/creds:/tmpfs/creds \
       -e DRONE_REPO -e DRONE_TAG -e RELCLI_BASE_URL -e RELCLI_CERT -e RELCLI_KEY \
-      $RELCLI_IMAGE relcli auto_publish -f -v 6
+      $RELCLI_IMAGE auto_publish -f -v 6
   environment:
     RELCLI_BASE_URL: https://releases-prod.platform.teleport.sh
     RELCLI_CERT: /tmpfs/creds/releases.crt
@@ -20343,6 +20343,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: dcf10b332b4bc54f24baaaf73a8222d3e8148a85c6fbdd880ca92a0e62ad52a9
+hmac: c3ec624a7d78b178fb297fe3fc3b1b8ffb06d8028c1428c4b95ba0328b234ea1
 
 ...

--- a/dronegen/promote.go
+++ b/dronegen/promote.go
@@ -54,7 +54,7 @@ func promoteBuildPipelines() []pipeline {
 }
 
 func publishReleasePipeline() pipeline {
-	p := relcliPipeline(triggerPromote, "publish-rlz", "Publish in Release API", "relcli auto_publish -f -v 6")
+	p := relcliPipeline(triggerPromote, "publish-rlz", "Publish in Release API", "auto_publish -f -v 6")
 
 	p.DependsOn = []string{"promote-build"} // Manually written pipeline
 

--- a/dronegen/relcli.go
+++ b/dronegen/relcli.go
@@ -14,7 +14,7 @@
 
 package main
 
-const relcliImage = "146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/relcli:v1.1.76-35e77b7-20221117T1411084"
+const relcliImage = "146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/relcli:master-57a5d42-20230412T1204687"
 
 func relcliPipeline(trigger trigger, name string, stepName string, command string) pipeline {
 	p := newKubePipeline(name)

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -603,5 +603,5 @@ func tagPackagePipeline(packageType string, b buildType) pipeline {
 }
 
 func tagCleanupPipeline() pipeline {
-	return relcliPipeline(triggerTag, tagCleanupPipelineName, "Clean up previously built artifacts", "relcli auto_destroy -f -v 6")
+	return relcliPipeline(triggerTag, tagCleanupPipelineName, "Clean up previously built artifacts", "auto_destroy -f -v 6")
 }


### PR DESCRIPTION
Bumps relcli used to include https://github.com/gravitational/cloud/pull/4115 .