### PR TITLE
Introduce an OktaAssignmentsGetter and use it in the watcher.

### DIFF
--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -56,7 +56,7 @@ type OktaImportRules interface {
 type OktaAssignmentsGetter interface {
 	// ListOktaAssignments returns a paginated list of all Okta assignment resources.
 	ListOktaAssignments(context.Context, int, string) ([]types.OktaAssignment, string, error)
-	// GetOktaAssignmen treturns the specified Okta assignment resources.
+	// GetOktaAssignment returns the specified Okta assignment resources.
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
 }
 

--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -52,7 +52,7 @@ type OktaImportRules interface {
 	DeleteAllOktaImportRules(context.Context) error
 }
 
-// OktaAssignmentGetter defines an interface for reading OktaAssignments.
+// OktaAssignmentsGetter defines an interface for reading OktaAssignments.
 type OktaAssignmentsGetter interface {
 	// ListOktaAssignments returns a paginated list of all Okta assignment resources.
 	ListOktaAssignments(context.Context, int, string) ([]types.OktaAssignment, string, error)

--- a/lib/services/okta.go
+++ b/lib/services/okta.go
@@ -52,12 +52,18 @@ type OktaImportRules interface {
 	DeleteAllOktaImportRules(context.Context) error
 }
 
-// OktaAssignments defines an interface for managing OktaAssignments.
-type OktaAssignments interface {
+// OktaAssignmentGetter defines an interface for reading OktaAssignments.
+type OktaAssignmentsGetter interface {
 	// ListOktaAssignments returns a paginated list of all Okta assignment resources.
 	ListOktaAssignments(context.Context, int, string) ([]types.OktaAssignment, string, error)
 	// GetOktaAssignmen treturns the specified Okta assignment resources.
 	GetOktaAssignment(ctx context.Context, name string) (types.OktaAssignment, error)
+}
+
+// OktaAssignments defines an interface for managing OktaAssignments.
+type OktaAssignments interface {
+	OktaAssignmentsGetter
+
 	// CreateOktaAssignment creates a new Okta assignment resource.
 	CreateOktaAssignment(context.Context, types.OktaAssignment) (types.OktaAssignment, error)
 	// UpdateOktaAssignment updates an existing Okta assignment resource.

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1751,7 +1751,7 @@ type OktaAssignmentWatcherConfig struct {
 	// RWCfg is the resource watcher configuration.
 	RWCfg ResourceWatcherConfig
 	// OktaAssignments is responsible for fetching Okta assignments.
-	OktaAssignments OktaAssignments
+	OktaAssignments OktaAssignmentsGetter
 	// PageSize is the number of Okta assignments to list at a time.
 	PageSize int
 	// OktaAssignmentsC receives up-to-date list of all Okta assignment resources.
@@ -1764,7 +1764,7 @@ func (cfg *OktaAssignmentWatcherConfig) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 	if cfg.OktaAssignments == nil {
-		assignments, ok := cfg.RWCfg.Client.(OktaAssignments)
+		assignments, ok := cfg.RWCfg.Client.(OktaAssignmentsGetter)
 		if !ok {
 			return trace.BadParameter("missing parameter OktaAssignments and Client not usable as OktaAssignments")
 		}


### PR DESCRIPTION
The `OktaAssignmentWatcher` has been adjusted to use an `OktaAssignmentsGetter` interface, which is a read only interface. This is due to the fact that the `OktaAccessPoint`, used by the Okta service, does not fully implement the `OktaAssignments` interface (it does not implement `DeleteAllOktaAssignments`). As the watcher only needs the read functions, this will allow us to prevent the Okta service from having access to the `DeleteAll` while still being able to use the `OktaAssignmentWatcher`.