### PR TITLE
Deprecate custom implementation of renderHook

### DIFF
--- a/web/packages/design/src/utils/renderHook.tsx
+++ b/web/packages/design/src/utils/renderHook.tsx
@@ -17,6 +17,9 @@
 import React from 'react';
 import { act, render } from '@testing-library/react';
 
+/**
+ * @deprecated Use renderHook provided by @testing-library/react-hooks instead.
+ */
 export default function renderHook<T extends (...args: any) => any>(
   hooks: T,
   options?: Options


### PR DESCRIPTION
The implementation provided by `@testing-library/react-hooks` has docs, examples online and is likely to be actively maintained for future React upgrades.