### PR TITLE
Add SSL Certificates to Usage Script

### DIFF
--- a/examples/teleport-usage/Dockerfile
+++ b/examples/teleport-usage/Dockerfile
@@ -3,6 +3,7 @@ WORKDIR /app
 COPY go.mod go.sum main.go /app/
 RUN go build -o teleport_usage
 FROM debian:buster-slim
+RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=0 /app/teleport_usage /app/
 ENTRYPOINT ["./teleport_usage"]

--- a/examples/teleport-usage/Dockerfile
+++ b/examples/teleport-usage/Dockerfile
@@ -3,7 +3,10 @@ WORKDIR /app
 COPY go.mod go.sum main.go /app/
 RUN go build -o teleport_usage
 FROM debian:stable-slim
-RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get -y update && \
+   apt-get install -y ca-certificates && \
+   apt-get -y clean && \
+   rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=0 /app/teleport_usage /app/
 ENTRYPOINT ["./teleport_usage"]

--- a/examples/teleport-usage/Dockerfile
+++ b/examples/teleport-usage/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.20-bullseye
 WORKDIR /app
 COPY go.mod go.sum main.go /app/
 RUN go build -o teleport_usage
-FROM debian:buster-slim
+FROM debian:stable-slim
 RUN apt update && apt install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY --from=0 /app/teleport_usage /app/


### PR DESCRIPTION
Currently, the usage script is failing because it does not have a CA to verify SSL certs.

```
2023/04/12 11:50:50 RequestError: send request failed
caused by: Post "https://dynamodb.us-west-2.amazonaws.com/": tls: failed to verify certificate: x509: certificate signed by unknown authority
```