### PR TITLE
Connect: Create dedicated functions for connecting to resources

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/useDatabases.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/useDatabases.ts
@@ -32,9 +32,10 @@ export function useDatabases() {
     );
 
   function connect(db: ReturnType<typeof makeDatabase>, dbUser: string): void {
+    const { uri, name, protocol } = db;
     connectToDatabase(
       appContext,
-      { ...db, dbUser },
+      { uri, name, protocol, dbUser },
       { origin: 'resource_table' }
     );
   }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/useDatabases.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Databases/useDatabases.ts
@@ -15,13 +15,9 @@ limitations under the License.
 */
 
 import { useAppContext } from 'teleterm/ui/appContextProvider';
-import {
-  Database,
-  GatewayProtocol,
-  GetResourcesParams,
-} from 'teleterm/services/tshd/types';
-import { routing } from 'teleterm/ui/uri';
+import { Database, GetResourcesParams } from 'teleterm/services/tshd/types';
 import { makeDatabase } from 'teleterm/ui/services/clusters';
+import { connectToDatabase } from 'teleterm/ui/services/workspacesService';
 
 import { useServerSideResources } from '../useServerSideResources';
 
@@ -36,44 +32,11 @@ export function useDatabases() {
     );
 
   function connect(db: ReturnType<typeof makeDatabase>, dbUser: string): void {
-    const rootClusterUri = routing.ensureRootClusterUri(db.uri);
-    const documentsService =
-      appContext.workspacesService.getWorkspaceDocumentService(rootClusterUri);
-
-    const doc = documentsService.createGatewayDocument({
-      // Not passing the `gatewayUri` field here, as at this point the gateway doesn't exist yet.
-      // `port` is not passed as well, we'll let the tsh daemon pick a random one.
-      targetUri: db.uri,
-      targetName: db.name,
-      targetUser: getTargetUser(db.protocol as GatewayProtocol, dbUser),
-      origin: 'resource_table',
-    });
-
-    const connectionToReuse =
-      appContext.connectionTracker.findConnectionByDocument(doc);
-
-    if (connectionToReuse) {
-      appContext.connectionTracker.activateItem(connectionToReuse.id, {
-        origin: 'resource_table',
-      });
-    } else {
-      documentsService.add(doc);
-      documentsService.open(doc.uri);
-    }
-  }
-
-  function getTargetUser(
-    protocol: GatewayProtocol,
-    providedDbUser: string
-  ): string {
-    // we are replicating tsh behavior (user can be omitted for Redis)
-    // https://github.com/gravitational/teleport/blob/796e37bdbc1cb6e0a93b07115ffefa0e6922c529/tool/tsh/db.go#L240-L244
-    // but unlike tsh, Connect has to provide a user that is then used in a gateway document
-    if (protocol === 'redis') {
-      return providedDbUser || 'default';
-    }
-
-    return providedDbUser;
+    connectToDatabase(
+      appContext,
+      { ...db, dbUser },
+      { origin: 'resource_table' }
+    );
   }
 
   return {

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
@@ -38,9 +38,10 @@ export function useServers() {
   }
 
   function connect(server: ReturnType<typeof makeServer>, login: string): void {
+    const { uri, hostname } = server;
     connectToNode(
       appContext,
-      { ...server, login },
+      { uri, hostname, login },
       {
         origin: 'resource_table',
       }

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
@@ -16,7 +16,7 @@ limitations under the License.
 import { Server, GetResourcesParams } from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { makeServer } from 'teleterm/ui/services/clusters';
-import { connectToNode } from 'teleterm/ui/services/workspacesService';
+import { connectToServer } from 'teleterm/ui/services/workspacesService';
 
 import { useServerSideResources } from '../useServerSideResources';
 
@@ -39,7 +39,7 @@ export function useServers() {
 
   function connect(server: ReturnType<typeof makeServer>, login: string): void {
     const { uri, hostname } = server;
-    connectToNode(
+    connectToServer(
       appContext,
       { uri, hostname, login },
       {

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/Servers/useServers.ts
@@ -16,6 +16,7 @@ limitations under the License.
 import { Server, GetResourcesParams } from 'teleterm/services/tshd/types';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { makeServer } from 'teleterm/ui/services/clusters';
+import { connectToNode } from 'teleterm/ui/services/workspacesService';
 
 import { useServerSideResources } from '../useServerSideResources';
 
@@ -37,19 +38,13 @@ export function useServers() {
   }
 
   function connect(server: ReturnType<typeof makeServer>, login: string): void {
-    const rootCluster = appContext.clustersService.findRootClusterByResource(
-      server.uri
+    connectToNode(
+      appContext,
+      { ...server, login },
+      {
+        origin: 'resource_table',
+      }
     );
-    const documentsService =
-      appContext.workspacesService.getWorkspaceDocumentService(rootCluster.uri);
-    const doc = documentsService.createTshNodeDocument(server.uri, {
-      origin: 'resource_table',
-    });
-    doc.title = `${login}@${server.hostname}`;
-    doc.login = login;
-
-    documentsService.add(doc);
-    documentsService.setLocation(doc.uri);
   }
 
   return {

--- a/web/packages/teleterm/src/ui/DocumentCluster/clusterContext.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/clusterContext.tsx
@@ -20,7 +20,10 @@ import { useStore, Store } from 'shared/libs/stores';
 
 import { IAppContext } from 'teleterm/ui/types';
 import { ClusterUri, DocumentUri, KubeUri, routing } from 'teleterm/ui/uri';
-import { DocumentOrigin } from 'teleterm/ui/services/workspacesService';
+import {
+  connectToKube,
+  DocumentOrigin,
+} from 'teleterm/ui/services/workspacesService';
 
 import type * as tsh from 'teleterm/services/tshd/types';
 
@@ -73,10 +76,7 @@ class ClusterContext extends Store<State> {
   };
 
   connectKube = (kubeUri: KubeUri, params: { origin: DocumentOrigin }) => {
-    this.appCtx.commandLauncher.executeCommand('kube-connect', {
-      kubeUri,
-      origin: params.origin,
-    });
+    connectToKube(this.appCtx, { uri: kubeUri }, { origin: params.origin });
   };
 
   refresh = () => {

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -61,24 +61,32 @@ export function mapToActions(
               ?.loggedInUser?.sshLoginsList,
           placeholder: 'Provide login',
         },
-        perform: login =>
-          connectToNode(
+        perform: login => {
+          const { uri, hostname } = result.resource;
+          return connectToNode(
             ctx,
-            { ...result.resource, login },
+            { uri, hostname, login },
             {
               origin: 'search_bar',
             }
-          ),
+          );
+        },
       };
     }
     if (result.kind === 'kube') {
       return {
         type: 'simple-action',
         searchResult: result,
-        perform: () =>
-          connectToKube(ctx, result.resource, {
-            origin: 'search_bar',
-          }),
+        perform: () => {
+          const { uri } = result.resource;
+          return connectToKube(
+            ctx,
+            { uri },
+            {
+              origin: 'search_bar',
+            }
+          );
+        },
       };
     }
     if (result.kind === 'database') {
@@ -90,17 +98,21 @@ export function mapToActions(
             ctx.resourcesService.getDbUsers(result.resource.uri),
           placeholder: 'Provide db username',
         },
-        perform: dbUser =>
-          connectToDatabase(
+        perform: dbUser => {
+          const { uri, name, protocol } = result.resource;
+          return connectToDatabase(
             ctx,
             {
-              ...result.resource,
+              uri,
+              name,
+              protocol,
               dbUser,
             },
             {
               origin: 'search_bar',
             }
-          ),
+          );
+        },
       };
     }
     if (result.kind === 'resource-type-filter') {

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -20,7 +20,7 @@ import { SearchContext } from 'teleterm/ui/Search/SearchContext';
 import {
   connectToDatabase,
   connectToKube,
-  connectToNode,
+  connectToServer,
 } from 'teleterm/ui/services/workspacesService';
 
 export interface SimpleAction {
@@ -63,7 +63,7 @@ export function mapToActions(
         },
         perform: login => {
           const { uri, hostname } = result.resource;
-          return connectToNode(
+          return connectToServer(
             ctx,
             { uri, hostname, login },
             {

--- a/web/packages/teleterm/src/ui/commandLauncher.ts
+++ b/web/packages/teleterm/src/ui/commandLauncher.ts
@@ -95,35 +95,6 @@ const commands = {
     },
   },
 
-  'kube-connect': {
-    displayName: '',
-    description: '',
-    async run(
-      ctx: IAppContext,
-      args: { kubeUri: KubeUri; origin: DocumentOrigin }
-    ) {
-      const rootClusterUri = routing.ensureRootClusterUri(args.kubeUri);
-      const documentsService =
-        ctx.workspacesService.getWorkspaceDocumentService(rootClusterUri);
-      const kubeDoc = documentsService.createTshKubeDocument({
-        kubeUri: args.kubeUri,
-        origin: args.origin,
-      });
-      const connection = ctx.connectionTracker.findConnectionByDocument(
-        kubeDoc
-      ) as TrackedKubeConnection;
-
-      await ctx.workspacesService.setActiveWorkspace(rootClusterUri);
-
-      documentsService.add({
-        ...kubeDoc,
-        kubeConfigRelativePath:
-          connection?.kubeConfigRelativePath || kubeDoc.kubeConfigRelativePath,
-      });
-      documentsService.open(kubeDoc.uri);
-    },
-  },
-
   'cluster-connect': {
     displayName: '',
     description: '',

--- a/web/packages/teleterm/src/ui/commandLauncher.ts
+++ b/web/packages/teleterm/src/ui/commandLauncher.ts
@@ -15,8 +15,7 @@ limitations under the License.
 */
 
 import { IAppContext } from 'teleterm/ui/types';
-import { ClusterUri, KubeUri, RootClusterUri, routing } from 'teleterm/ui/uri';
-import { TrackedKubeConnection } from 'teleterm/ui/services/connectionTracker';
+import { ClusterUri, RootClusterUri, routing } from 'teleterm/ui/uri';
 import { Platform } from 'teleterm/mainProcess/types';
 import { DocumentOrigin } from 'teleterm/ui/services/workspacesService';
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToDatabase.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToDatabase.ts
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { IAppContext } from 'teleterm/ui/types';
+import { DatabaseUri, routing } from 'teleterm/ui/uri';
+import { GatewayProtocol } from 'teleterm/services/tshd/types';
+
+import { DocumentOrigin } from './types';
+
+export async function connectToDatabase(
+  ctx: IAppContext,
+  target: {
+    uri: DatabaseUri;
+    name: string;
+    protocol: string;
+    dbUser: string;
+  },
+  params: {
+    origin: DocumentOrigin;
+  }
+): Promise<void> {
+  const rootClusterUri = routing.ensureRootClusterUri(target.uri);
+  const documentsService =
+    ctx.workspacesService.getWorkspaceDocumentService(rootClusterUri);
+
+  const doc = documentsService.createGatewayDocument({
+    // Not passing the `gatewayUri` field here, as at this point the gateway doesn't exist yet.
+    // `port` is not passed as well, we'll let the tsh daemon pick a random one.
+    targetUri: target.uri,
+    targetName: target.name,
+    targetUser: getTargetUser(
+      target.protocol as GatewayProtocol,
+      target.dbUser
+    ),
+    origin: params.origin,
+  });
+
+  const connectionToReuse = ctx.connectionTracker.findConnectionByDocument(doc);
+
+  if (connectionToReuse) {
+    await ctx.connectionTracker.activateItem(connectionToReuse.id, {
+      origin: params.origin,
+    });
+  } else {
+    await ctx.workspacesService.setActiveWorkspace(rootClusterUri);
+    documentsService.add(doc);
+    documentsService.open(doc.uri);
+  }
+}
+
+function getTargetUser(
+  protocol: GatewayProtocol,
+  providedDbUser: string
+): string {
+  // we are replicating tsh behavior (user can be omitted for Redis)
+  // https://github.com/gravitational/teleport/blob/796e37bdbc1cb6e0a93b07115ffefa0e6922c529/tool/tsh/db.go#L240-L244
+  // but unlike tsh, Connect has to provide a user that is then used in a gateway document
+  if (protocol === 'redis') {
+    return providedDbUser || 'default';
+  }
+
+  return providedDbUser;
+}

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToDatabase.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToDatabase.ts
@@ -28,7 +28,7 @@ export async function connectToDatabase(
     protocol: string;
     dbUser: string;
   },
-  params: {
+  telemetry: {
     origin: DocumentOrigin;
   }
 ): Promise<void> {
@@ -45,14 +45,14 @@ export async function connectToDatabase(
       target.protocol as GatewayProtocol,
       target.dbUser
     ),
-    origin: params.origin,
+    origin: telemetry.origin,
   });
 
   const connectionToReuse = ctx.connectionTracker.findConnectionByDocument(doc);
 
   if (connectionToReuse) {
     await ctx.connectionTracker.activateItem(connectionToReuse.id, {
-      origin: params.origin,
+      origin: telemetry.origin,
     });
   } else {
     await ctx.workspacesService.setActiveWorkspace(rootClusterUri);

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToKube.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToKube.ts
@@ -23,14 +23,14 @@ import { DocumentOrigin } from './types';
 export async function connectToKube(
   ctx: IAppContext,
   target: { uri: KubeUri },
-  params: { origin: DocumentOrigin }
+  telemetry: { origin: DocumentOrigin }
 ): Promise<void> {
   const rootClusterUri = routing.ensureRootClusterUri(target.uri);
   const documentsService =
     ctx.workspacesService.getWorkspaceDocumentService(rootClusterUri);
   const kubeDoc = documentsService.createTshKubeDocument({
     kubeUri: target.uri,
-    origin: params.origin,
+    origin: telemetry.origin,
   });
   const connection = ctx.connectionTracker.findConnectionByDocument(
     kubeDoc

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToKube.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToKube.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { KubeUri, routing } from 'teleterm/ui/uri';
+import { IAppContext } from 'teleterm/ui/types';
+import { TrackedKubeConnection } from 'teleterm/ui/services/connectionTracker';
+
+import { DocumentOrigin } from './types';
+
+export async function connectToKube(
+  ctx: IAppContext,
+  target: { uri: KubeUri },
+  params: { origin: DocumentOrigin }
+): Promise<void> {
+  const rootClusterUri = routing.ensureRootClusterUri(target.uri);
+  const documentsService =
+    ctx.workspacesService.getWorkspaceDocumentService(rootClusterUri);
+  const kubeDoc = documentsService.createTshKubeDocument({
+    kubeUri: target.uri,
+    origin: params.origin,
+  });
+  const connection = ctx.connectionTracker.findConnectionByDocument(
+    kubeDoc
+  ) as TrackedKubeConnection;
+
+  await ctx.workspacesService.setActiveWorkspace(rootClusterUri);
+
+  documentsService.add({
+    ...kubeDoc,
+    kubeConfigRelativePath:
+      connection?.kubeConfigRelativePath || kubeDoc.kubeConfigRelativePath,
+  });
+  documentsService.open(kubeDoc.uri);
+}

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToNode.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToNode.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { routing, ServerUri } from 'teleterm/ui/uri';
+import { IAppContext } from 'teleterm/ui/types';
+
+import { DocumentOrigin } from './types';
+
+export async function connectToNode(
+  ctx: IAppContext,
+  target: {
+    uri: ServerUri;
+    hostname: string;
+    login: string;
+  },
+  params: {
+    origin: DocumentOrigin;
+  }
+): Promise<void> {
+  const rootClusterUri = routing.ensureRootClusterUri(target.uri);
+  const documentsService = ctx.workspacesService.getWorkspaceDocumentService(
+    routing.ensureRootClusterUri(target.uri)
+  );
+  const doc = documentsService.createTshNodeDocument(target.uri, {
+    origin: params.origin,
+  });
+  doc.title = `${target.login}@${target.hostname}`;
+  doc.login = target.login;
+
+  await ctx.workspacesService.setActiveWorkspace(rootClusterUri);
+  documentsService.add(doc);
+  documentsService.open(doc.uri);
+}

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToNode.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToNode.ts
@@ -26,7 +26,7 @@ export async function connectToNode(
     hostname: string;
     login: string;
   },
-  params: {
+  telemetry: {
     origin: DocumentOrigin;
   }
 ): Promise<void> {
@@ -35,7 +35,7 @@ export async function connectToNode(
     routing.ensureRootClusterUri(target.uri)
   );
   const doc = documentsService.createTshNodeDocument(target.uri, {
-    origin: params.origin,
+    origin: telemetry.origin,
   });
   doc.title = `${target.login}@${target.hostname}`;
   doc.login = target.login;

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToServer.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/connectToServer.ts
@@ -19,7 +19,7 @@ import { IAppContext } from 'teleterm/ui/types';
 
 import { DocumentOrigin } from './types';
 
-export async function connectToNode(
+export async function connectToServer(
   ctx: IAppContext,
   target: {
     uri: ServerUri;

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/index.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/index.ts
@@ -17,3 +17,6 @@ limitations under the License.
 export * from './documentsService';
 export * from './types';
 export * from './documentsUtils';
+export * from './connectToDatabase';
+export * from './connectToNode';
+export * from './connectToKube';

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/index.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/index.ts
@@ -18,5 +18,5 @@ export * from './documentsService';
 export * from './types';
 export * from './documentsUtils';
 export * from './connectToDatabase';
-export * from './connectToNode';
+export * from './connectToServer';
 export * from './connectToKube';


### PR DESCRIPTION
This PR makes connecting to the node faster (without using `commandLauncher`), since we know all the details needed to establish an SSH connection.   
I also created functions for dbs and kubes, so we can share the same code between resource tables/search bar.

I'm only unsure about the naming - I wanted to avoid names like `createDatabaseDocument` as we already have such functions in `DocumentsService`. They only create documents objects, but here we do more (we change the workspace, create a document and set it as active). It seems to me that all these operations can live in a function `connectToX`.

------
For now I left `ssh-ssh` command as it is used by QuickInput.