### PR TITLE
Increase mTLS cert expiration to 2 years

### DIFF
--- a/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
+++ b/web/packages/teleport/src/Discover/Database/MutualTls/useMutualTls.ts
@@ -95,6 +95,7 @@ export function useMutualTls({ ctx, props }: Props) {
     canUpdateDatabase: access.edit,
     curlCmd: generateSignCertificateCurlCommand(
       clusterId,
+      '17520h',
       meta.db.hostname,
       joinToken?.id
     ),
@@ -104,13 +105,14 @@ export function useMutualTls({ ctx, props }: Props) {
 
 function generateSignCertificateCurlCommand(
   clusterId: string,
+  expiration: string,
   hostname: string,
   token: string
 ) {
   if (!token) return '';
 
   const requestUrl = cfg.getDatabaseSignUrl(clusterId);
-  const requestData = JSON.stringify({ hostname });
+  const requestData = JSON.stringify({ ttl: expiration, hostname });
 
   // curl flag -OJ  makes curl use the file name
   // defined from the response header.


### PR DESCRIPTION
In testing a self hosted database I noticed that the mTLS cert expiration was only 1 day.  This caused issues with my initial setup.

After investigation it looked like the TTL parameter was able to be read, but the default curl command did not provide any TTL (and thus the generated cert will default to expire in 24 hours).

This PR is primarily for discussion if a longer TTL should be provided as default in our curl commands when generating mTLS certificates.  It's unclear to me why we wanted such a short expiration for this certificate.

If we decide we do want to enable a longer default TTL, please point me to where I should configure this default.  Currently the value for 2 years is just hard coded.