### PR TITLE
allow redundant security release alert suppression

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -980,7 +980,7 @@ func (a *Server) doReleaseAlertSync(ctx context.Context, current vc.Target, visi
 		}
 	}
 
-	if sp := visitor.NewestSecurityPatch(); sp.Ok() && sp.NewerThan(current) {
+	if sp := visitor.NewestSecurityPatch(); sp.Ok() && sp.NewerThan(current) && !sp.SecurityPatchAltOf(current) {
 		// explicit security patch alerts have a more limited audience, so we generate
 		// them as their own separate alert.
 		log.Warnf("A newer security patch has been detected. current=%s, patch=%s", current.Version(), sp.Version())

--- a/lib/versioncontrol/github/github_test.go
+++ b/lib/versioncontrol/github/github_test.go
@@ -307,6 +307,14 @@ func TestLabelParse(t *testing.T) {
 			desc: "normalize caps and spaces",
 		},
 		{
+			notes: "labels: security-patch=yes, security-patch-alts=v1.2.3|v1.2.4",
+			expect: map[string]string{
+				vc.LabelSecurityPatch:     "yes",
+				vc.LabelSecurityPatchAlts: "v1.2.3|v1.2.4",
+			},
+			desc: "real-world label set",
+		},
+		{
 			notes: "labels: hello=world, greeting='Hey there! how are you?', , count=7",
 			expect: map[string]string{
 				"hello": "world",

--- a/lib/versioncontrol/versioncontrol_test.go
+++ b/lib/versioncontrol/versioncontrol_test.go
@@ -22,6 +22,46 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestSecurityPatchAlts(t *testing.T) {
+	tts := []struct {
+		desc string
+		a, b Target
+		alt  bool
+	}{
+		{
+			desc: "basic alt case",
+			a:    NewTarget("v1.2.3", SecurityPatch(true), SecurityPatchAlts("v1.2.2", "v1.2.1")),
+			b:    NewTarget("v1.2.1"),
+			alt:  true,
+		},
+		{
+			desc: "minimal alt case",
+			a:    NewTarget("v1.2.3", SecurityPatchAlts("v1.2.1")),
+			b:    NewTarget("v1.2.1"),
+			alt:  true,
+		},
+		{
+			desc: "trivial non-alt case",
+			a:    NewTarget("v1.2.3"),
+			b:    NewTarget("v1.2.1"),
+			alt:  false,
+		},
+		{
+			desc: "non-matching non-alt case case",
+			a:    NewTarget("v1.2.3", SecurityPatchAlts("v1.2.2")),
+			b:    NewTarget("v1.2.1"),
+			alt:  false,
+		},
+	}
+
+	for _, tt := range tts {
+		// check alt status is expected
+		require.Equal(t, tt.alt, tt.a.SecurityPatchAltOf(tt.b), "desc=%q", tt.desc)
+		// check alt status is bidirectional
+		require.Equal(t, tt.alt, tt.b.SecurityPatchAltOf(tt.a), "desc=%q", tt.desc)
+	}
+}
+
 func TestVisitorBasics(t *testing.T) {
 	tts := []struct {
 		versions         []string


### PR DESCRIPTION
Sometimes we release the same security patch under multiple versions, which results in confusing alerts telling users to upgrade to a security patch that they already effectively hold.

This PR adds support for a new label that allows a release to list other releases that are alternates of the same security patch (and therefore can safely ignore the new releases' security patch status).  Ex:

```
labels: security-patch=yes, security-patch-alts=v1.2.3|v1.2.2
```