### PR TITLE
Add the new access verb `use` to web user context

### DIFF
--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -29,6 +29,7 @@ type access struct {
 	Edit   bool `json:"edit"`
 	Create bool `json:"create"`
 	Delete bool `json:"remove"`
+	Use    bool `json:"use"`
 }
 
 type accessStrategy struct {
@@ -145,6 +146,7 @@ func newAccess(roleSet services.RoleSet, ctx *services.Context, kind string) acc
 		Edit:   hasAccess(roleSet, ctx, kind, types.VerbUpdate),
 		Create: hasAccess(roleSet, ctx, kind, types.VerbCreate),
 		Delete: hasAccess(roleSet, ctx, kind, types.VerbDelete),
+		Use:    hasAccess(roleSet, ctx, kind, types.VerbUse),
 	}
 }
 

--- a/lib/web/ui/usercontext_test.go
+++ b/lib/web/ui/usercontext_test.go
@@ -51,7 +51,7 @@ func TestNewUserContext(t *testing.T) {
 		},
 		{
 			Resources: []string{types.KindIntegration},
-			Verbs:     services.RW(),
+			Verbs:     append(services.RW(), types.VerbUse),
 		},
 	})
 
@@ -80,14 +80,13 @@ func TestNewUserContext(t *testing.T) {
 	userContext, err := NewUserContext(user, roleSet, proto.Features{}, true)
 	require.NoError(t, err)
 
-	allowed := access{true, true, true, true, true}
-	denied := access{false, false, false, false, false}
+	allowedRW := access{true, true, true, true, true, false}
+	denied := access{false, false, false, false, false, false}
 
 	// test user name and acl
 	require.Equal(t, userContext.Name, "root")
-	require.Empty(t, cmp.Diff(userContext.ACL.AuthConnectors, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.TrustedClusters, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.Integrations, allowed))
+	require.Empty(t, cmp.Diff(userContext.ACL.AuthConnectors, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.TrustedClusters, allowedRW))
 	require.Empty(t, cmp.Diff(userContext.ACL.AppServers, denied))
 	require.Empty(t, cmp.Diff(userContext.ACL.DBServers, denied))
 	require.Empty(t, cmp.Diff(userContext.ACL.KubeServers, denied))
@@ -99,7 +98,7 @@ func TestNewUserContext(t *testing.T) {
 	require.Empty(t, cmp.Diff(userContext.ACL.Nodes, denied))
 	require.Empty(t, cmp.Diff(userContext.ACL.AccessRequests, denied))
 	require.Empty(t, cmp.Diff(userContext.ACL.ConnectionDiagnostic, denied))
-	require.Empty(t, cmp.Diff(userContext.ACL.Desktops, allowed))
+	require.Empty(t, cmp.Diff(userContext.ACL.Desktops, allowedRW))
 	require.Empty(t, cmp.Diff(userContext.AccessStrategy, accessStrategy{
 		Type:   types.RequestStrategyOptional,
 		Prompt: "",
@@ -110,6 +109,9 @@ func TestNewUserContext(t *testing.T) {
 	require.Equal(t, userContext.ACL.DesktopSessionRecording, true)
 	require.Empty(t, cmp.Diff(userContext.ACL.License, denied))
 	require.Empty(t, cmp.Diff(userContext.ACL.Download, denied))
+
+	// test enabling of the 'Use' verb
+	require.Empty(t, cmp.Diff(userContext.ACL.Integrations, access{true, true, true, true, true, true}))
 
 	// test local auth type
 	require.Equal(t, userContext.AuthType, authLocal)
@@ -122,7 +124,7 @@ func TestNewUserContext(t *testing.T) {
 
 	userContext, err = NewUserContext(user, roleSet, proto.Features{Cloud: true}, true)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(userContext.ACL.Billing, access{true, true, false, false, false}))
+	require.Empty(t, cmp.Diff(userContext.ACL.Billing, access{true, true, false, false, false, false}))
 
 	// test that desktopRecordingEnabled being false overrides the roleSet.RecordDesktopSession() returning true
 	userContext, err = NewUserContext(user, roleSet, proto.Features{}, false)
@@ -153,24 +155,24 @@ func TestNewUserContextCloud(t *testing.T) {
 
 	roleSet := []types.Role{role}
 
-	allowed := access{true, true, true, true, true}
+	allowedRW := access{true, true, true, true, true, false}
 
 	userContext, err := NewUserContext(user, roleSet, proto.Features{Cloud: true}, true)
 	require.NoError(t, err)
 
 	require.Equal(t, userContext.Name, "root")
-	require.Empty(t, cmp.Diff(userContext.ACL.AuthConnectors, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.TrustedClusters, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.AppServers, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.DBServers, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.KubeServers, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.Events, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.RecordedSessions, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.Roles, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.Users, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.Tokens, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.Nodes, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.AccessRequests, allowed))
+	require.Empty(t, cmp.Diff(userContext.ACL.AuthConnectors, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.TrustedClusters, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.AppServers, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.DBServers, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.KubeServers, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.Events, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.RecordedSessions, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.Roles, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.Users, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.Tokens, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.Nodes, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.AccessRequests, allowedRW))
 	require.Empty(t, cmp.Diff(userContext.AccessStrategy, accessStrategy{
 		Type:   types.RequestStrategyOptional,
 		Prompt: "",
@@ -180,6 +182,6 @@ func TestNewUserContextCloud(t *testing.T) {
 	require.Equal(t, userContext.ACL.DesktopSessionRecording, true)
 
 	// cloud-specific asserts
-	require.Empty(t, cmp.Diff(userContext.ACL.Billing, allowed))
-	require.Empty(t, cmp.Diff(userContext.ACL.Desktops, allowed))
+	require.Empty(t, cmp.Diff(userContext.ACL.Billing, allowedRW))
+	require.Empty(t, cmp.Diff(userContext.ACL.Desktops, allowedRW))
 }

--- a/web/packages/teleport/src/mocks/contexts.ts
+++ b/web/packages/teleport/src/mocks/contexts.ts
@@ -60,7 +60,7 @@ const allAccessAcl: Acl = {
   license: fullAccess,
   download: fullAccess,
   plugins: fullAccess,
-  integrations: fullAccess,
+  integrations: { ...fullAccess, use: true },
   deviceTrust: fullAccess,
 };
 

--- a/web/packages/teleport/src/services/user/makeAcl.ts
+++ b/web/packages/teleport/src/services/user/makeAcl.ts
@@ -95,4 +95,5 @@ export const defaultAccess = {
   edit: false,
   create: false,
   remove: false,
+  use: false,
 };

--- a/web/packages/teleport/src/services/user/makeAcl.ts
+++ b/web/packages/teleport/src/services/user/makeAcl.ts
@@ -33,8 +33,8 @@ export function makeAcl(json): Acl {
   const plugins = json.plugins || defaultAccess;
   // TODO(lisa): requires backend changes to user context.
   // Feature is off until all TODO related to integrations is done.
-  // const integrations = json.integrations || defaultAccess;
-  const integrations = defaultAccess;
+  // const integrations = json.integrations || defaultAccessWithUse;
+  const integrations = defaultAccessWithUse;
   const dbServers = json.dbServers || defaultAccess;
   const db = json.db || defaultAccess;
   const desktops = json.desktops || defaultAccess;
@@ -95,5 +95,9 @@ export const defaultAccess = {
   edit: false,
   create: false,
   remove: false,
+};
+
+export const defaultAccessWithUse = {
+  ...defaultAccess,
   use: false,
 };

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -45,6 +45,7 @@ export interface Access {
   edit: boolean;
   create: boolean;
   remove: boolean;
+  use?: boolean;
 }
 
 export interface Acl {

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -45,7 +45,10 @@ export interface Access {
   edit: boolean;
   create: boolean;
   remove: boolean;
-  use?: boolean;
+}
+
+export interface AccessWithUse extends Access {
+  use: boolean;
 }
 
 export interface Acl {
@@ -72,7 +75,7 @@ export interface Acl {
   license: Access;
   download: Access;
   plugins: Access;
-  integrations: Access;
+  integrations: AccessWithUse;
   deviceTrust: Access;
 }
 

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -38,6 +38,7 @@ test('undefined values in context response gives proper default values', async (
         edit: true,
         create: true,
         remove: true,
+        use: true,
       },
     },
   };
@@ -55,6 +56,7 @@ test('undefined values in context response gives proper default values', async (
         edit: true,
         create: true,
         remove: true,
+        use: true,
       },
       // Test that undefined acl booleans are set to default false.
       trustedClusters: {
@@ -63,6 +65,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       nodes: {
         create: false,
@@ -70,6 +73,7 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
+        use: false,
       },
       plugins: {
         create: false,
@@ -77,6 +81,7 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
+        use: false,
       },
       integrations: {
         list: false,
@@ -84,6 +89,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       roles: {
         list: false,
@@ -91,6 +97,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       recordedSessions: {
         list: false,
@@ -98,6 +105,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       desktops: {
         create: false,
@@ -105,6 +113,7 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
+        use: false,
       },
       events: {
         list: false,
@@ -112,6 +121,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       users: {
         list: false,
@@ -119,6 +129,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       activeSessions: {
         create: false,
@@ -126,6 +137,7 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
+        use: false,
       },
       appServers: {
         list: false,
@@ -133,6 +145,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       kubeServers: {
         list: false,
@@ -140,6 +153,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       license: {
         list: false,
@@ -147,6 +161,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       download: {
         list: false,
@@ -154,6 +169,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       tokens: {
         list: false,
@@ -161,6 +177,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       accessRequests: {
         list: false,
@@ -168,6 +185,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       billing: {
         list: false,
@@ -175,6 +193,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       dbServers: {
         list: false,
@@ -182,6 +201,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       db: {
         list: false,
@@ -189,6 +209,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       connectionDiagnostic: {
         list: false,
@@ -196,6 +217,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       deviceTrust: {
         list: false,
@@ -203,6 +225,7 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
+        use: false,
       },
       clipboardSharingEnabled: true,
       desktopSessionRecordingEnabled: true,

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -38,7 +38,6 @@ test('undefined values in context response gives proper default values', async (
         edit: true,
         create: true,
         remove: true,
-        use: true,
       },
     },
   };
@@ -56,7 +55,6 @@ test('undefined values in context response gives proper default values', async (
         edit: true,
         create: true,
         remove: true,
-        use: true,
       },
       // Test that undefined acl booleans are set to default false.
       trustedClusters: {
@@ -65,7 +63,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       nodes: {
         create: false,
@@ -73,7 +70,6 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
-        use: false,
       },
       plugins: {
         create: false,
@@ -81,7 +77,6 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
-        use: false,
       },
       integrations: {
         list: false,
@@ -97,7 +92,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       recordedSessions: {
         list: false,
@@ -105,7 +99,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       desktops: {
         create: false,
@@ -113,7 +106,6 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
-        use: false,
       },
       events: {
         list: false,
@@ -121,7 +113,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       users: {
         list: false,
@@ -129,7 +120,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       activeSessions: {
         create: false,
@@ -137,7 +127,6 @@ test('undefined values in context response gives proper default values', async (
         list: false,
         read: false,
         remove: false,
-        use: false,
       },
       appServers: {
         list: false,
@@ -145,7 +134,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       kubeServers: {
         list: false,
@@ -153,7 +141,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       license: {
         list: false,
@@ -161,7 +148,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       download: {
         list: false,
@@ -169,7 +155,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       tokens: {
         list: false,
@@ -177,7 +162,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       accessRequests: {
         list: false,
@@ -185,7 +169,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       billing: {
         list: false,
@@ -193,7 +176,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       dbServers: {
         list: false,
@@ -201,7 +183,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       db: {
         list: false,
@@ -209,7 +190,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       connectionDiagnostic: {
         list: false,
@@ -217,7 +197,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       deviceTrust: {
         list: false,
@@ -225,7 +204,6 @@ test('undefined values in context response gives proper default values', async (
         edit: false,
         create: false,
         remove: false,
-        use: false,
       },
       clipboardSharingEnabled: true,
       desktopSessionRecordingEnabled: true,


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/22129

merged PR https://github.com/gravitational/teleport/pull/24133, adds a new access verb `use`