### PR TITLE
helm: fix `teleport-kube-agent` telemetry

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -121,7 +121,7 @@ spec:
         {{- end }}
         env:
         # This variable is set for telemetry purposes.
-        # Telemetry is opt-in and controlled at the auth level.
+        # Telemetry is opt-in for oss users and controlled at the auth level.
         - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
           value: "true"
         {{- if .Values.updater.enabled }}

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -119,8 +119,11 @@ spec:
         {{- if .Values.imagePullPolicy }}
         imagePullPolicy: {{ toYaml .Values.imagePullPolicy }}
         {{- end }}
-        {{- if or .Values.extraEnv .Values.tls.existingCASecretName .Values.updater.enabled }}
         env:
+        # This variable is set for telemetry purposes.
+        # Telemetry is opt-in and controlled at the auth level.
+        - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+          value: "true"
         {{- if .Values.updater.enabled }}
         - name: TELEPORT_EXT_UPGRADER
           value: kube
@@ -131,10 +134,6 @@ spec:
         {{- if .Values.tls.existingCASecretName }}
         - name: SSL_CERT_FILE
           value: /etc/teleport-tls-ca/ca.pem
-        # Used to track whether a Teleport agent was installed using this method.
-        - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
-          value: true
-        {{- end }}
         {{- end }}
         args:
         - "--diag-addr=0.0.0.0:3000"

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -122,6 +122,10 @@ spec:
         imagePullPolicy: {{ toYaml .Values.imagePullPolicy }}
         {{- end }}
         env:
+          # This variable is set for telemetry purposes.
+          # Telemetry is opt-in and controlled at the auth level.
+          - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+            value: "true"
           - name: TELEPORT_REPLICA_NAME
             valueFrom:
               fieldRef:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -27,6 +27,9 @@ sets Deployment annotations when specified if action is Upgrade:
           containers:
           - args:
             - --diag-addr=0.0.0.0:3000
+            env:
+            - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+              value: "true"
             image: public.ecr.aws/gravitational/teleport:13.0.0-dev
             imagePullPolicy: IfNotPresent
             livenessProbe:
@@ -95,6 +98,9 @@ sets Deployment labels when specified if action is Upgrade:
         containers:
         - args:
           - --diag-addr=0.0.0.0:3000
+          env:
+          - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+            value: "true"
           image: public.ecr.aws/gravitational/teleport:13.0.0-dev
           imagePullPolicy: IfNotPresent
           livenessProbe:
@@ -150,6 +156,9 @@ sets Pod annotations when specified if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -205,6 +214,9 @@ sets Pod labels when specified if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -277,6 +289,9 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -333,6 +348,9 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
     - args:
       - --diag-addr=0.0.0.0:3000
       - --insecure
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -388,6 +406,9 @@ should correctly configure existingDataVolume when set if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -441,6 +462,9 @@ should expose diag port if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -508,6 +532,9 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -575,6 +602,9 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -630,6 +660,9 @@ should have one replica when replicaCount is not set if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -685,6 +718,9 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -746,10 +782,10 @@ should mount tls.existingCASecretName and set environment when set in values if 
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
-        value: true
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -812,12 +848,12 @@ should mount tls.existingCASecretName and set extra environment when set in valu
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
-        value: true
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -879,6 +915,9 @@ should provision initContainer correctly when set in values if action is Upgrade
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -970,6 +1009,9 @@ should set SecurityContext if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1045,6 +1087,9 @@ should set affinity when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1100,6 +1145,9 @@ should set default serviceAccountName when not set in values if action is Upgrad
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1167,6 +1215,8 @@ should set environment when extraEnv set in values if action is Upgrade:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
@@ -1224,6 +1274,9 @@ should set image and tag correctly if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:8.3.4
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1279,6 +1332,9 @@ should set imagePullPolicy when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: Always
       livenessProbe:
@@ -1334,6 +1390,9 @@ should set nodeSelector if set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1391,6 +1450,9 @@ should set not set priorityClassName when not set in values if action is Upgrade
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1458,6 +1520,9 @@ should set preferred affinity when more than one replica is used if action is Up
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1513,6 +1578,9 @@ should set priorityClassName when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1569,6 +1637,9 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1634,6 +1705,9 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1689,6 +1763,9 @@ should set resources when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1751,6 +1828,9 @@ should set serviceAccountName when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -1806,6 +1886,9 @@ should set tolerations when set in values if action is Upgrade:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
+      env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       image: public.ecr.aws/gravitational/teleport:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -4,6 +4,8 @@ sets Pod annotations when specified:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -70,6 +72,8 @@ sets Pod labels when specified:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -160,6 +164,8 @@ sets StatefulSet labels when specified:
           - args:
             - --diag-addr=0.0.0.0:3000
             env:
+            - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+              value: "true"
             - name: TELEPORT_REPLICA_NAME
               valueFrom:
                 fieldRef:
@@ -254,6 +260,8 @@ should add insecureSkipProxyTLSVerify to args when set in values:
       - --diag-addr=0.0.0.0:3000
       - --insecure
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -320,6 +328,8 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -406,6 +416,8 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
           - args:
             - --diag-addr=0.0.0.0:3000
             env:
+            - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+              value: "true"
             - name: TELEPORT_REPLICA_NAME
               valueFrom:
                 fieldRef:
@@ -482,6 +494,8 @@ should add volumeMount for data volume when using StatefulSet:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -548,6 +562,8 @@ should expose diag port:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -614,6 +630,8 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -694,6 +712,8 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -772,6 +792,8 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -838,6 +860,8 @@ should have one replica when replicaCount is not set:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -904,6 +928,8 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -972,6 +998,8 @@ should mount extraVolumes and extraVolumeMounts:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1043,6 +1071,8 @@ should mount tls.existingCASecretName and set environment when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1119,6 +1149,8 @@ should mount tls.existingCASecretName and set extra environment when set in valu
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1197,6 +1229,8 @@ should not add emptyDir for data when using StatefulSet:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1263,6 +1297,8 @@ should provision initContainer correctly when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1365,6 +1401,8 @@ should set SecurityContext:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1451,6 +1489,8 @@ should set affinity when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1517,6 +1557,8 @@ should set default serviceAccountName when not set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1594,6 +1636,8 @@ should set environment when extraEnv set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1662,6 +1706,8 @@ should set image and tag correctly:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1728,6 +1774,8 @@ should set imagePullPolicy when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1794,6 +1842,8 @@ should set nodeSelector if set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1874,6 +1924,8 @@ should set preferred affinity when more than one replica is used:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -1940,6 +1992,8 @@ should set probeTimeoutSeconds when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -2016,6 +2070,8 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -2082,6 +2138,8 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -2155,6 +2213,8 @@ should set serviceAccountName when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -2221,6 +2281,8 @@ should set storage.requests when set in values and action is an Upgrade:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -2287,6 +2349,8 @@ should set storage.storageClassName when set in values and action is an Upgrade:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:
@@ -2353,6 +2417,8 @@ should set tolerations when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       env:
+      - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+        value: "true"
       - name: TELEPORT_REPLICA_NAME
         valueFrom:
           fieldRef:

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -690,3 +690,14 @@ tests:
           content:
             name: TELEPORT_EXT_UPGRADER
             value: kube
+
+  - it: should set the installation method environment variable
+    template: statefulset.yaml
+    values:
+      - ../.lint/stateful.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
+            value: "true"


### PR DESCRIPTION
Fixes the teleport-kube-agent telemetry. It was broken for 3 reasons:

- the variable was set only on Deployments and not Statefulsets
- the variable value was interpreted as a boolean which would not pass Kubernetes schema validation
- the variable was set only when `tls.existingCASecretName` value was not not empty