### PR TITLE
[v10] docs: include Amazon Linux in BPF-supported distributions

### DIFF
--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -90,6 +90,7 @@ library preloading, and environment variables may not be captured in session rec
   <tr><td>Fedora</td><td>33</td><td>5.8+</td></tr>
   <tr><td>Archlinux</td><td>2020.09.01</td><td>5.8.5+</td></tr>
   <tr><td>Flatcar</td><td>2765.2.2</td><td>5.10.25+</td></tr>
+  <tr><td>Amazon Linux</td><td>2</td><td>5.10+</td></tr>
 </tbody>
 </table>
 

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -81,18 +81,13 @@ library preloading, and environment variables may not be captured in session rec
 
 ### Linux distributions and supported kernels
 
-<table>
-<thead>
-  <tr><td>Distro name</td><td>Distro version</td><td>Kernel version</td></tr>
-</thead>
-<tbody>
-  <tr><td>Ubuntu "Groovy Gorilla"</td><td>20.10</td><td>5.8+</td></tr>
-  <tr><td>Fedora</td><td>33</td><td>5.8+</td></tr>
-  <tr><td>Archlinux</td><td>2020.09.01</td><td>5.8.5+</td></tr>
-  <tr><td>Flatcar</td><td>2765.2.2</td><td>5.10.25+</td></tr>
-  <tr><td>Amazon Linux</td><td>2</td><td>5.10+</td></tr>
-</tbody>
-</table>
+| Distro name             | Distro version | Kernel Version |
+|:------------------------|:---------------|:---------------|
+| Ubuntu "Groovy Gorilla" | 20.10          | 5.8+           |
+| Fedora                  | 33             | 5.8+           |
+| Archlinux               | 2020.09.01     | 5.8.5+         |
+| Flatcar                 | 2765.2.2       | 5.10.25+       |
+| Amazon Linux            | 2              | 5.10+          |
 
 (!docs/pages/includes/tctl.mdx!)
 


### PR DESCRIPTION
Backport #24427 to branch/v10