### PR TITLE
[v11] update aws configurator

### DIFF
--- a/lib/cloud/aws/identity.go
+++ b/lib/cloud/aws/identity.go
@@ -42,6 +42,15 @@ type Identity interface {
 	fmt.Stringer
 }
 
+const (
+	// ResourceTypeRole is the resource type for an AWS IAM role.
+	ResourceTypeRole = "role"
+	// ResourceTypeAssumedRole is the resource type for an AWS IAM assumed role.
+	ResourceTypeAssumedRole = "assumed-role"
+	// ResourceTypeUser is the resource type for an AWS IAM user.
+	ResourceTypeUser = "user"
+)
+
 // User represents an AWS IAM user identity.
 type User struct {
 	identityBase
@@ -66,12 +75,12 @@ func (i identityBase) GetName() string {
 	parts := strings.Split(i.arn.Resource, "/")
 	// EC2 instances running on AWS with attached IAM role will have
 	// assumed-role identity with ARN like:
-	// arn:aws:sts::1234567890:assumed-role/DatabaseAccess/i-1234567890
-	if parts[0] == "assumed-role" && len(parts) > 2 {
+	// arn:aws:sts::123456789012:assumed-role/DatabaseAccess/i-1234567890
+	if parts[0] == ResourceTypeAssumedRole && len(parts) > 2 {
 		return parts[1]
 	}
 	// Resource can include a path and the name is its last component e.g.
-	// arn:aws:iam::1234567890:role/path/to/customrole
+	// arn:aws:iam::123456789012:role/path/to/customrole
 	return parts[len(parts)-1]
 }
 
@@ -115,13 +124,13 @@ func IdentityFromArn(arnString string) (Identity, error) {
 
 	parts := strings.Split(parsedARN.Resource, "/")
 	switch parts[0] {
-	case "role", "assumed-role":
+	case ResourceTypeRole, ResourceTypeAssumedRole:
 		return Role{
 			identityBase: identityBase{
 				arn: parsedARN,
 			},
 		}, nil
-	case "user":
+	case ResourceTypeUser:
 		return User{
 			identityBase: identityBase{
 				arn: parsedARN,

--- a/lib/configurators/common.go
+++ b/lib/configurators/common.go
@@ -21,6 +21,7 @@ import (
 // BootstrapFlags flags provided by users to configure and define how the
 // configurators will work.
 type BootstrapFlags struct {
+	// DiscoveryService indicates the bootstrap is for the discovery service.
 	DiscoveryService bool
 	// ConfigPath database agent configuration path.
 	ConfigPath string

--- a/tool/teleport/common/configurator.go
+++ b/tool/teleport/common/configurator.go
@@ -289,6 +289,12 @@ func onConfigureDatabasesAWSCreate(flags configureDatabaseAWSCreateFlags) error 
 		return trace.Wrap(err)
 	}
 
+	// Check if configurator actions is empty.
+	if configurator.IsEmpty() {
+		fmt.Println("The agent doesn't require any extra configuration.")
+		return nil
+	}
+
 	actions := configurator.Actions()
 	printDiscoveryConfiguratorActions(actions)
 	fmt.Print("\n")
@@ -302,12 +308,6 @@ func onConfigureDatabasesAWSCreate(flags configureDatabaseAWSCreateFlags) error 
 		if !confirmed {
 			return nil
 		}
-	}
-
-	// Check if configurator actions is empty.
-	if configurator.IsEmpty() {
-		fmt.Println("The agent doesn't require any extra configuration.")
-		return nil
 	}
 
 	err = executeDiscoveryConfiguratorActions(ctx, configurator.Name(), actions)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -288,16 +288,17 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		Short('r').
 		StringVar(&configureDatabaseAWSCreateFlags.types)
 	dbConfigureAWSCreateIAM.Flag("name", "Created policy name. Defaults to empty. Will be auto-generated if not provided.").Default(awsconfigurators.DefaultPolicyName).StringVar(&configureDatabaseAWSCreateFlags.policyName)
-	dbConfigureAWSCreateIAM.Flag("attach", "Try to attach the policy to the IAM identity.").Default("true").BoolVar(&configureDatabaseAWSCreateFlags.attach)
+	// --attach flag is deprecated.
+	dbConfigureAWSCreateIAM.Flag("attach", "Try to attach the policy to the IAM identity.").Hidden().Default("true").BoolVar(&configureDatabaseAWSCreateFlags.attach)
 	dbConfigureAWSCreateIAM.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDatabaseAWSCreateFlags.confirm)
 	dbConfigureAWSCreateIAM.Flag("role", "IAM role name to attach policy to. Mutually exclusive with --user").StringVar(&configureDatabaseAWSCreateFlags.role)
 	dbConfigureAWSCreateIAM.Flag("user", "IAM user name to attach policy to. Mutually exclusive with --role").StringVar(&configureDatabaseAWSCreateFlags.user)
 
-	// "teleport discovery" bootstrap command and subcommnads.
+	// "teleport discovery" bootstrap command and subcommands.
 	discoveryCmd := app.Command("discovery", "Teleport discovery service commands")
 	discoveryBootstrapCmd := discoveryCmd.Command("bootstrap", "Bootstrap the necessary configuration for the database agent. It reads the provided agent configuration to determine what will be bootstrapped.")
 	discoveryBootstrapCmd.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').Default(defaults.ConfigFilePath).ExistingFileVar(&configureDiscoveryBootstrapFlags.config.ConfigPath)
-	discoveryBootstrapCmd.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDatabaseAWSCreateFlags.confirm)
+	discoveryBootstrapCmd.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDiscoveryBootstrapFlags.confirm)
 	discoveryBootstrapCmd.Flag("attach-to-role", "Role name to attach policy to. Mutually exclusive with --attach-to-user. If none of the attach-to flags is provided, the command will try to attach the policy to the current user/role based on the credentials.").StringVar(&configureDiscoveryBootstrapFlags.config.AttachToRole)
 	discoveryBootstrapCmd.Flag("attach-to-user", "User name to attach policy to. Mutually exclusive with --attach-to-role. If none of the attach-to flags is provided, the command will try to attach the policy to the current user/role based on the credentials.").StringVar(&configureDiscoveryBootstrapFlags.config.AttachToUser)
 	discoveryBootstrapCmd.Flag("policy-name", fmt.Sprintf("Name of the Teleport Discovery service policy. Default: %q", awsconfigurators.EC2DiscoveryPolicyName)).Default(awsconfigurators.EC2DiscoveryPolicyName).StringVar(&configureDiscoveryBootstrapFlags.config.PolicyName)


### PR DESCRIPTION
backports https://github.com/gravitational/teleport/pull/24362 to v11

I removed the keyspaces/dynamodb stuff since we didn't support those configurators in v11.