### PR TITLE
add golang.org/x/time/rate dep

### DIFF
--- a/e_imports.go
+++ b/e_imports.go
@@ -49,6 +49,7 @@ import (
 	_ "github.com/google/go-attestation/attest"
 	_ "github.com/gravitational/form"
 	_ "github.com/okta/okta-sdk-golang/v2/okta"
+	_ "golang.org/x/time/rate"
 	_ "google.golang.org/api/admin/directory/v1"
 	_ "google.golang.org/api/cloudidentity/v1"
 	_ "google.golang.org/genproto/googleapis/rpc/status"

--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	golang.org/x/sys v0.7.0
 	golang.org/x/term v0.7.0
 	golang.org/x/text v0.9.0
+	golang.org/x/time v0.3.0
 	google.golang.org/api v0.114.0
 	google.golang.org/genproto v0.0.0-20230330154414-c0448cd141ea
 	google.golang.org/grpc v1.54.0
@@ -352,7 +353,6 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.7.0 // indirect
 	go.uber.org/zap v1.24.0 // indirect
-	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect


### PR DESCRIPTION
This PR updates e_imports.go to include `golang.org/x/time/rate` dep introduced by https://github.com/gravitational/teleport.e/pull/1030