### PR TITLE
Remove Role `v6`->`v5` downgrade logic

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -3194,21 +3194,3 @@ func MarshalRole(role types.Role, opts ...MarshalOption) ([]byte, error) {
 		return nil, trace.BadParameter("unrecognized role version %T", role)
 	}
 }
-
-// DowngradeToV5 converts a V6 role to V5 so that it will be compatible with
-// older instances. Makes a shallow copy if the conversion is necessary. The
-// passed in role will not be mutated.
-// DELETE IN 13.0.0
-func DowngradeRoleToV5(r *types.RoleV6) (*types.RoleV6, error) {
-	switch r.Version {
-	case types.V3, types.V4, types.V5:
-		return r, nil
-	case types.V6:
-		var downgraded types.RoleV6
-		downgraded = *r
-		downgraded.Version = types.V5
-		return &downgraded, nil
-	default:
-		return nil, trace.BadParameter("unrecognized role version %T", r.Version)
-	}
-}


### PR DESCRIPTION
Teleport 13 supports clients running `>=12.0.0 && <=13.x.x` and all of them already support Role `v6`, thus the downgrade logic can be removed without impact.