### PR TITLE
dronegen: Fix spelling of GHA workflow in kube pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -8981,7 +8981,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 1h0m0s -workflow release-teleport-kube-agent-udpater-oci.yml
+    -tag-workflow -timeout 1h0m0s -workflow release-teleport-kube-agent-updater-oci.yml
     -workflow-ref=${DRONE_TAG} -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} '
   environment:
     GHA_APP_KEY:
@@ -20343,6 +20343,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: c3ec624a7d78b178fb297fe3fc3b1b8ffb06d8028c1428c4b95ba0328b234ea1
+hmac: 2b0baa890b89809154cbdae3134c92f8ad3d221bf4b205c6ce858eed78e536ab
 
 ...

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -220,7 +220,7 @@ func tagPipelines() []pipeline {
 		buildType:    buildType{os: "linux", fips: false},
 		trigger:      triggerTag,
 		pipelineName: "build-teleport-kube-agent-updater-oci-images",
-		ghaWorkflow:  "release-teleport-kube-agent-udpater-oci.yml",
+		ghaWorkflow:  "release-teleport-kube-agent-updater-oci.yml",
 		srcRefVar:    "DRONE_TAG",
 		workflowRef:  "${DRONE_TAG}",
 		timeout:      60 * time.Minute,


### PR DESCRIPTION
Fix the spelling of "updater" (from "udpater") so that the pipeline for
releasing the kube agent actually gets called and not emit the error:

    2023/04/12 09:01:40 Failed to fetch initial task list:
      Failed to fetch runs
      GET https://api.github.com/repos/gravitational/teleport.e/actions/workflows/release-teleport-kube-agent-udpater-oci.yml/runs?branch=v13.0.0-camh.mac.9&created=%3E2023-04-12T08%3A59%3A40Z&per_page=100:
      404 Not Found []