### PR TITLE
[v12] Allow the Okta role to read the cluster name.

### DIFF
--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -816,6 +816,7 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					Namespaces: []string{types.Wildcard},
 					AppLabels:  types.Labels{types.Wildcard: []string{types.Wildcard}},
 					Rules: []types.Rule{
+						types.NewRule(types.KindClusterName, services.RO()),
 						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),
 						types.NewRule(types.KindSemaphore, services.RW()),
 						types.NewRule(types.KindEvent, services.RW()),

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -370,6 +370,7 @@ func ForDiscovery(cfg Config) Config {
 func ForOkta(cfg Config) Config {
 	cfg.target = "okta"
 	cfg.Watches = []types.WatchKind{
+		{Kind: types.KindClusterName},
 		{Kind: types.KindCertAuthority, LoadSecrets: false},
 		{Kind: types.KindUser},
 		{Kind: types.KindAppServer},


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/24538 to branch/v12