### PR TITLE
Kubernetes License check for Kubernetes Proxies

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -35,6 +35,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -274,7 +275,8 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 	}
 
 	closeCtx, close := context.WithCancel(cfg.Context)
-
+	var isKubeLicensed atomic.Bool
+	isKubeLicensed.Store(true)
 	fwd := &Forwarder{
 		log:               cfg.log,
 		cfg:               cfg,
@@ -287,9 +289,11 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 			ReadBufferSize:  1024,
 			WriteBufferSize: 1024,
 		},
-		clusterDetails:  make(map[string]*kubeDetails),
-		cachedTransport: transportClients,
+		clusterDetails:              make(map[string]*kubeDetails),
+		cachedTransport:             transportClients,
+		isClusterKubernetesLicensed: isKubeLicensed,
 	}
+
 	router := httprouter.New()
 
 	router.UseRawPath = true
@@ -339,7 +343,57 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 			return nil, trace.Wrap(err)
 		}
 	}
+
+	// Start the proxy license watcher only if it not a kube service.
+	// Kube service validation is performed by the auth server when it tries
+	// to heartbeat the cluster.
+	if fwd.cfg.KubeServiceType != KubeService {
+		go fwd.proxylicenseWatcher()
+	}
+
 	return fwd, nil
+}
+
+// proxylicenseWatcher periodically checks if the auth server is licensed for
+// kubernetes. This check is required after the introduction of the credentials
+// forwarding feature. When a root kube proxy is forwarding requests to a leaf
+// kube proxy, the root kube proxy must ensure that it is licensed for
+// kubernetes otherwise an enterprise root cluster will be able to forward
+// requests to an OSS leaf cluster and bypass the license check.
+// This check is only performed on Kubernetes proxies.
+func (f *Forwarder) proxylicenseWatcher() {
+	t := time.NewTicker(30 * time.Minute)
+	defer t.Stop()
+	for {
+		licensed, err := f.checkIfAuthIsLicensed()
+		if err != nil {
+			f.log.WithError(err).Warn("Failed to check if auth server is licensed for Kubernetes usage.")
+		} else {
+			f.isClusterKubernetesLicensed.Store(licensed)
+		}
+		select {
+		case <-t.C:
+		case <-f.ctx.Done():
+			return
+		}
+	}
+}
+
+// checkIfAuthIsLicensed checks if the auth server is licensed for kubernetes.
+// This check is required after the introduction of the credentials forwarding
+// feature. When a root kube proxy is forwarding requests to a leaf kube proxy,
+// the root kube proxy must ensure that it is licensed for kubernetes otherwise
+// an enterprise root cluster will be able to forward requests to an OSS leaf
+// cluster and bypass the license check.
+func (f *Forwarder) checkIfAuthIsLicensed() (bool, error) {
+	ctx, cancel := context.WithTimeout(f.ctx, defaults.HTTPRequestTimeout)
+	defer cancel()
+	// If this is a kube_service, we can just return the local kube servers.
+	ping, err := f.cfg.AuthClient.Ping(ctx)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	return ping.ServerFeatures.Kubernetes, nil
 }
 
 // Forwarder intercepts kubernetes requests, acting as Kubernetes API proxy.
@@ -384,6 +438,9 @@ type Forwarder struct {
 	cachedTransport *ttlmap.TTLMap
 	// cachedTransportMu is a mutex used to protect the cachedTransport.
 	cachedTransportMu sync.Mutex
+	// isClusterKubernetesLicensed is a pointer to a boolean that indicates
+	// whether the cluster is licensed for Kubernetes.
+	isClusterKubernetesLicensed atomic.Bool
 }
 
 // getKubeServersByNameFunc is a function that returns a list of
@@ -498,6 +555,12 @@ const accessDeniedMsg = "[00] access denied"
 
 // authenticate function authenticates request
 func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
+	// If the cluster is not licensed for Kubernetes, return an error to the client.
+	if !f.isClusterKubernetesLicensed.Load() {
+		// If the cluster is not licensed for Kubernetes, return an error to the client
+		// but in a way that the code is translated to 500 error code.
+		return nil, trace.Errorf("Teleport cluster is not licensed for Kubernetes")
+	}
 	ctx, span := f.cfg.tracer.Start(
 		req.Context(),
 		"kube.Forwarder/authenticate",

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -511,9 +511,8 @@ const accessDeniedMsg = "[00] access denied"
 func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 	// If the cluster is not licensed for Kubernetes, return an error to the client.
 	if !f.cfg.ClusterFeatures().Kubernetes {
-		// If the cluster is not licensed for Kubernetes, return an error to the client
-		// but in a way that the code is translated to 500 error code.
-		return nil, trace.Errorf("Teleport cluster is not licensed for Kubernetes")
+		// If the cluster is not licensed for Kubernetes, return an error to the client.
+		return nil, trace.AccessDenied("Teleport cluster is not licensed for Kubernetes")
 	}
 	ctx, span := f.cfg.tracer.Start(
 		req.Context(),

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1862,8 +1862,8 @@ func TestKubernetesLicenseEnforcement(t *testing.T) {
 				require.Error(tt, err)
 				var kubeErr *kubeerrors.StatusError
 				require.ErrorAs(tt, err, &kubeErr)
-				require.Equal(tt, kubeErr.ErrStatus.Code, int32(500))
-				require.Equal(tt, kubeErr.ErrStatus.Reason, metav1.StatusReasonInternalError)
+				require.Equal(tt, kubeErr.ErrStatus.Code, int32(http.StatusForbidden))
+				require.Equal(tt, kubeErr.ErrStatus.Reason, metav1.StatusReasonForbidden)
 				require.Equal(tt, kubeErr.ErrStatus.Message, "Teleport cluster is not licensed for Kubernetes")
 			},
 		},

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -178,6 +178,7 @@ func TestAuthenticate(t *testing.T) {
 			return filtered, nil
 		},
 	}
+	f.isClusterKubernetesLicensed.Store(true)
 
 	const remoteAddr = "user.example.com"
 	activeAccessRequests := []string{uuid.NewString(), uuid.NewString()}

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -38,6 +38,7 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -202,7 +203,8 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 			CheckImpersonationPermissions: func(ctx context.Context, clusterName string, sarClient authztypes.SelfSubjectAccessReviewInterface) error {
 				return nil
 			},
-			Clock: clockwork.NewRealClock(),
+			Clock:           clockwork.NewRealClock(),
+			ClusterFeatures: func() proto.Features { return proto.Features{Kubernetes: true} },
 		},
 		DynamicLabels: nil,
 		TLS:           tlsConfig,

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -231,6 +231,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 			LockWatcher:                   lockWatcher,
 			CheckImpersonationPermissions: cfg.Kube.CheckImpersonationPermissions,
 			PublicAddr:                    publicAddr,
+			ClusterFeatures:               process.getClusterFeatures,
 		},
 		TLS:                  tlsConfig,
 		AccessPoint:          accessPoint,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4070,7 +4070,8 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				// using Impersonation headers. The upstream service will validate if
 				// the provided connection certificate is from a proxy server and
 				// will impersonate the identity of the user that is making the request.
-				ConnTLSConfig: tlsConfig.Clone(),
+				ConnTLSConfig:   tlsConfig.Clone(),
+				ClusterFeatures: process.getClusterFeatures,
 			},
 			TLS:             tlsConfig.Clone(),
 			LimiterConfig:   cfg.Proxy.Limiter,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7943,6 +7943,11 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 			},
 			ConnTLSConfig: tlsConfig,
 			Clock:         clockwork.NewRealClock(),
+			ClusterFeatures: func() clientproto.Features {
+				return clientproto.Features{
+					Kubernetes: true,
+				}
+			},
 		},
 		TLS:           tlsConfig,
 		AccessPoint:   client,


### PR DESCRIPTION
This PR ensures that a given Teleport root cluster is licensed for Kubernetes access when forwarding credentials to leaf clusters.

Previously, the root Kube proxy would call auth server to generate a new cert-key pair with the user identity and during the call Auth ensured that it was licensed for Kubernetes usage. Given the recent developments for #22533, the call mentioned was removed and it's now possible for a root enterprise cluster to forward requests to a OSS leaf cluster without validating its license.

Auth server already enforces Kubernetes license for Kubernetes service when it tries to heartbeat the cluster. If the cluster is not properly licensed, it's not possible to register kubernetes clusters.

Part of #22533