### PR TITLE
Fix `TestService_ProxySSH_Errors` flakiness

### DIFF
--- a/lib/srv/transport/transportv1/transport_test.go
+++ b/lib/srv/transport/transportv1/transport_test.go
@@ -361,10 +361,18 @@ func TestService_ProxySSH_Errors(t *testing.T) {
 				return nil, trace.AccessDenied("no access checker")
 			},
 			fn: func(t *testing.T, stream transportv1pb.TransportService_ProxySSHClient, conn *echoConn) {
-				require.NoError(t, stream.Send(&transportv1pb.ProxySSHRequest{DialTarget: &transportv1pb.TargetHost{
+				err := stream.Send(&transportv1pb.ProxySSHRequest{DialTarget: &transportv1pb.TargetHost{
 					HostPort: "1234",
 					Cluster:  "test",
-				}}))
+				}})
+				switch {
+				// The server will attempt to get the authz context prior to receiving the first
+				// message from the client which may terminate the stream and result in an EOF.
+				case errors.Is(err, io.EOF):
+					return
+				default:
+					require.NoError(t, err)
+				}
 
 				resp, err := stream.Recv()
 				require.Nil(t, resp)
@@ -380,7 +388,6 @@ func TestService_ProxySSH_Errors(t *testing.T) {
 				default:
 					t.Fatalf("expected either EOF or Access Denied, got %v", err)
 				}
-
 			},
 		},
 		{


### PR DESCRIPTION
The server may kill the stream prior to sending or receiving a message so the test now checks whether an io.EOF was received in response interacting with the server. We expect that an io.EOF should be received either when sending or receiving a message. If both complete successfully then we expect to receive the actual access denied error.


Closes #22551