### PR TITLE
Improve Kubernetes proxy memory usage

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -165,6 +165,14 @@ type TLSServer struct {
 	// reconcileCh triggers reconciliation of proxied kube_clusters.
 	reconcileCh chan struct{}
 	log         *logrus.Entry
+
+	// kubeServerWatcher is used by the kube proxy to watch for changes in the
+	// kubernetes servers of a cluster. Proxy requires it to update the kubeServersMap
+	// which holds the list of kubernetes_services connected to the proxy for a given
+	// kubernetes cluster name. Proxy uses this map to route requests to the correct
+	// kubernetes_service. The servers are kept in memory to avoid making unnecessary
+	// unmarshal calls followed by filtering and to improve memory usage.
+	kubeServerWatcher *services.KubeServerWatcher
 }
 
 // NewTLSServer returns new unstarted TLS server
@@ -299,8 +307,27 @@ func (t *TLSServer) Serve(listener net.Listener) error {
 	// proxied clusters based on the kube_cluster resources.
 	// This watcher is only started for the kube_service if a resource watcher
 	// is configured.
-	if t.kubeClusterWatcher, err = t.startKubeClusterResourceWatcher(t.closeContext); err != nil {
+	kubeClusterWatcher, err := t.startKubeClusterResourceWatcher(t.closeContext)
+	if err != nil {
 		return trace.Wrap(err)
+	}
+	t.mu.Lock()
+	t.kubeClusterWatcher = kubeClusterWatcher
+	t.mu.Unlock()
+
+	// kubeServerWatcher is used by the kube proxy to watch for changes in the
+	// kubernetes servers of a cluster. Proxy requires it to update the kubeServersMap
+	// which holds the list of kubernetes_services connected to the proxy for a given
+	// kubernetes cluster name. Proxy uses this map to route requests to the correct
+	// kubernetes_service. The servers are kept in memory to avoid making unnecessary
+	// unmarshal calls followed by filtering to improve memory usage.
+	if t.kubeServerWatcher != nil {
+		// Wait for the watcher to initialize before starting the server so that the
+		// proxy can start routing requests to the kubernetes_service instead of
+		// returning an error because the cache is not initialized.
+		if err := t.kubeServerWatcher.WaitInitialization(); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	return t.Server.Serve(tls.NewListener(mux.TLS(), t.TLS))
@@ -330,10 +357,19 @@ func (t *TLSServer) close(ctx context.Context) error {
 
 	t.closeFunc()
 
+	t.mu.Lock()
+	kubeClusterWatcher := t.kubeClusterWatcher
+	t.mu.Unlock()
 	// Stop the kube_cluster resource watcher.
-	if t.kubeClusterWatcher != nil {
-		t.kubeClusterWatcher.Close()
+	if kubeClusterWatcher != nil {
+		kubeClusterWatcher.Close()
 	}
+
+	// Stop the kube_server resource watcher.
+	if t.kubeServerWatcher != nil {
+		t.kubeServerWatcher.Close()
+	}
+
 	t.mu.Lock()
 	listClose := t.listener.Close()
 	t.mu.Unlock()
@@ -560,12 +596,31 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 			return []types.KubeServer{srv}, nil
 		}, nil
 	case ProxyService:
-		return t.getAuthKubeServers, nil
+		// If not a kube_service, we need to watch the kube_server objects.
+		var err error
+		// Start watching the kube_server objects.
+		t.kubeServerWatcher, err = t.startKubeServerResourceWatcher(t.fwd.ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return func(_ context.Context, name string) ([]types.KubeServer, error) {
+			servers, err := t.kubeServerWatcher.GetKubeServersByClusterName(name)
+			return servers, trace.Wrap(err)
+		}, nil
 	case LegacyProxyService:
+		// If this is a legacy kube proxy, then we need to return the local kube servers if
+		// the local server is proxying the target cluster, otherwise act like a proxy_service.
+		// and forward the request to the next proxy.
+		var err error
+		// Start watching the kube_server objects.
+		t.kubeServerWatcher, err = t.startKubeServerResourceWatcher(t.fwd.ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		return func(ctx context.Context, name string) ([]types.KubeServer, error) {
 			kube, err := t.getKubeClusterWithServiceLabels(name)
 			if err != nil {
-				servers, err := t.getAuthKubeServers(ctx, name)
+				servers, err := t.kubeServerWatcher.GetKubeServersByClusterName(name)
 				return servers, trace.Wrap(err)
 			}
 			srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)
@@ -577,23 +632,4 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 	default:
 		return nil, trace.BadParameter("unknown kubernetes service type %q", t.KubeServiceType)
 	}
-}
-
-// getAuthKubeServers returns the kubernetes servers for a given kube cluster
-// using the Auth server client.
-func (t *TLSServer) getAuthKubeServers(ctx context.Context, name string) ([]types.KubeServer, error) {
-	servers, err := t.CachingAuthClient.GetKubernetesServers(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	var returnServers []types.KubeServer
-	for _, server := range servers {
-		if server.GetCluster().GetName() == name {
-			returnServers = append(returnServers, server)
-		}
-	}
-	if len(returnServers) == 0 {
-		return nil, trace.NotFound("no kubernetes servers found for cluster %q", name)
-	}
-	return returnServers, nil
 }

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -603,8 +603,8 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return func(_ context.Context, name string) ([]types.KubeServer, error) {
-			servers, err := t.kubeServerWatcher.GetKubeServersByClusterName(name)
+		return func(ctx context.Context, name string) ([]types.KubeServer, error) {
+			servers, err := t.kubeServerWatcher.GetKubeServersByClusterName(ctx, name)
 			return servers, trace.Wrap(err)
 		}, nil
 	case LegacyProxyService:
@@ -620,7 +620,7 @@ func (t *TLSServer) getKubernetesServersForKubeClusterFunc() (getKubeServersByNa
 		return func(ctx context.Context, name string) ([]types.KubeServer, error) {
 			kube, err := t.getKubeClusterWithServiceLabels(name)
 			if err != nil {
-				servers, err := t.kubeServerWatcher.GetKubeServersByClusterName(name)
+				servers, err := t.kubeServerWatcher.GetKubeServersByClusterName(ctx, name)
 				return servers, trace.Wrap(err)
 			}
 			srv, err := types.NewKubernetesServerV3FromCluster(kube, "", t.HostID)

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -248,17 +248,3 @@ func (s *TLSServer) deleteKubernetesServer(ctx context.Context, name string) err
 	}
 	return nil
 }
-
-// startKubeServerResourceWatcher starts watching changes to Kube servers resources.
-func (s *TLSServer) startKubeServerResourceWatcher(ctx context.Context) (*services.KubeServerWatcher, error) {
-	s.log.Debug("Initializing Kube Server resource watcher.")
-	watcher, err := services.NewKubeServerWatcher(ctx, services.KubeServerWatcherConfig{
-		ResourceWatcherConfig: services.ResourceWatcherConfig{
-			Component: s.Component,
-			Log:       s.log,
-			Client:    s.AccessPoint,
-			Clock:     s.Clock,
-		},
-	})
-	return watcher, trace.Wrap(err)
-}

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -248,3 +248,16 @@ func (s *TLSServer) deleteKubernetesServer(ctx context.Context, name string) err
 	}
 	return nil
 }
+
+// startKubeServerResourceWatcher starts watching changes to Kube servers resources.
+func (s *TLSServer) startKubeServerResourceWatcher(ctx context.Context) (*services.KubeServerWatcher, error) {
+	s.log.Debug("Initializing Kube Server resource watcher.")
+	watcher, err := services.NewKubeServerWatcher(ctx, services.KubeServerWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: s.Component,
+			Log:       s.log,
+			Client:    s.AccessPoint,
+		},
+	})
+	return watcher, trace.Wrap(err)
+}

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -257,6 +257,7 @@ func (s *TLSServer) startKubeServerResourceWatcher(ctx context.Context) (*servic
 			Component: s.Component,
 			Log:       s.log,
 			Client:    s.AccessPoint,
+			Clock:     s.Clock,
 		},
 	})
 	return watcher, trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4062,6 +4062,20 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if cfg.Proxy.Kube.LegacyKubeProxy {
 			kubeServiceType = kubeproxy.LegacyProxyService
 		}
+
+		// kubeServerWatcher is used to watch for changes in the Kubernetes servers
+		// and feed them to the kube proxy server so it can route the requests to
+		// the correct kubernetes server.
+		kubeServerWatcher, err := services.NewKubeServerWatcher(process.ExitContext(), services.KubeServerWatcherConfig{
+			ResourceWatcherConfig: services.ResourceWatcherConfig{
+				Component: component,
+				Log:       log,
+				Client:    accessPoint,
+			},
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		kubeServer, err = kubeproxy.NewTLSServer(kubeproxy.TLSServerConfig{
 			ForwarderConfig: kubeproxy.ForwarderConfig{
 				Namespace:                     apidefaults.Namespace,
@@ -4089,13 +4103,14 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ConnTLSConfig:   tlsConfig.Clone(),
 				ClusterFeatures: process.getClusterFeatures,
 			},
-			TLS:             tlsConfig.Clone(),
-			LimiterConfig:   cfg.Proxy.Limiter,
-			AccessPoint:     accessPoint,
-			GetRotation:     process.GetRotation,
-			OnHeartbeat:     process.OnHeartbeat(component),
-			Log:             log,
-			IngressReporter: ingressReporter,
+			TLS:                      tlsConfig.Clone(),
+			LimiterConfig:            cfg.Proxy.Limiter,
+			AccessPoint:              accessPoint,
+			GetRotation:              process.GetRotation,
+			OnHeartbeat:              process.OnHeartbeat(component),
+			Log:                      log,
+			IngressReporter:          ingressReporter,
+			KubernetesServersWatcher: kubeServerWatcher,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -48,7 +48,6 @@ type KubernetesServerGetter interface {
 	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
 }
 
-
 // Kubernetes defines an interface for managing kubernetes clusters resources.
 type Kubernetes interface {
 	// KubernetesGetter provides methods for fetching kubernetes resources.

--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -42,6 +42,14 @@ type KubernetesClusterGetter interface {
 	GetKubernetesCluster(ctx context.Context, name string) (types.KubeCluster, error)
 }
 
+// KubernetesServerGetter defines interface for fetching kubernetes server resources.
+type KubernetesServerGetter interface {
+	// GetKubernetesServers returns all kubernetes server resources.
+	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
+}
+
+// Kubernet
+
 // Kubernetes defines an interface for managing kubernetes clusters resources.
 type Kubernetes interface {
 	// KubernetesGetter provides methods for fetching kubernetes resources.

--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -48,7 +48,6 @@ type KubernetesServerGetter interface {
 	GetKubernetesServers(context.Context) ([]types.KubeServer, error)
 }
 
-// Kubernet
 
 // Kubernetes defines an interface for managing kubernetes clusters resources.
 type Kubernetes interface {

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1259,7 +1259,7 @@ type kubeServerCollector struct {
 	// refreshed.
 	stale atomic.Bool
 	// cache is a helper for temporarily storing the results of GetKubernetesServers.
-	// It's used to limit the ammount of calls to the backend.
+	// It's used to limit the amount of calls to the backend.
 	cache *utils.FnCache
 }
 

--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -1362,8 +1362,8 @@ func (k *kubeServerCollector) notifyStale() {
 }
 
 // refreshStaleKubeServers attempts to reload kube servers from the cache if
-// the collecter is stale. This ensures that no matter the health of
-// the collecter callers will be returned the most up to date node
+// the collector is stale. This ensures that no matter the health of
+// the collector callers will be returned the most up to date node
 // set as possible.
 func (k *kubeServerCollector) refreshStaleKubeServers(ctx context.Context) error {
 	if !k.stale.Load() {

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -995,6 +996,110 @@ func newNodeServer(t *testing.T, name, addr string, tunnel bool) types.Server {
 	})
 	require.NoError(t, err)
 	return s
+}
+
+func TestKubeServerWatcher(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	bk, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	type client struct {
+		services.Presence
+		types.Events
+	}
+
+	presence := local.NewPresenceService(bk)
+	w, err := services.NewKubeServerWatcher(ctx, services.KubeServerWatcherConfig{
+		ResourceWatcherConfig: services.ResourceWatcherConfig{
+			Component: "test",
+			Client: &client{
+				Presence: presence,
+				Events:   local.NewEventsService(bk),
+			},
+			MaxStaleness: time.Minute,
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(w.Close)
+
+	newKubeServer := func(t *testing.T, name, addr, hostID string) types.KubeServer {
+		kube, err := types.NewKubernetesClusterV3(
+			types.Metadata{
+				Name: name,
+			},
+			types.KubernetesClusterSpecV3{})
+		require.NoError(t, err)
+		server, err := types.NewKubernetesServerV3FromCluster(kube, addr, hostID)
+		require.NoError(t, err)
+		return server
+	}
+
+	// Add some kube servers.
+	kubeServers := make([]types.KubeServer, 0, 5)
+	for i := 0; i < 5; i++ {
+		kubeServer := newKubeServer(t, fmt.Sprintf("kube_cluster-%d", i), "addr", fmt.Sprintf("host-%d", i))
+		_, err = presence.UpsertKubernetesServer(ctx, kubeServer)
+		require.NoError(t, err)
+		kubeServers = append(kubeServers, kubeServer)
+	}
+
+	require.Eventually(t, func() bool {
+		filtered, err := w.GetKubernetesServers()
+		assert.NoError(t, err)
+		return len(filtered) == len(kubeServers)
+	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive kube servers.")
+
+	// Test filtering by cluster name.
+	filtered, err := w.GetKubeServersByClusterName(kubeServers[0].GetName())
+	require.NoError(t, err)
+	require.Len(t, filtered, 1)
+
+	// Test Deleting a kube server.
+	require.NoError(t, presence.DeleteKubernetesServer(ctx, kubeServers[0].GetHostID(), kubeServers[0].GetName()))
+	require.Eventually(t, func() bool {
+		kube, err := w.GetKubernetesServers()
+		assert.NoError(t, err)
+		return len(kube) == len(kubeServers)-1
+	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive the delete event.")
+
+	filtered, err = w.GetKubeServersByClusterName(kubeServers[0].GetName())
+	require.Error(t, err)
+	require.Empty(t, filtered)
+
+	// Test adding a kube server with the same name as an existing one.
+	kubeServer := newKubeServer(t, kubeServers[1].GetName(), "addr", uuid.NewString())
+	_, err = presence.UpsertKubernetesServer(ctx, kubeServer)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		filtered, err := w.GetKubeServersByClusterName(kubeServers[1].GetName())
+		assert.NoError(t, err)
+		return len(filtered) == 2
+	}, time.Second, time.Millisecond, "Timeout waiting for watcher to the new registered kube server.")
+
+	// Test deleting all kube servers with the same name.
+	filtered, err = w.GetKubeServersByClusterName(kubeServers[1].GetName())
+	assert.NoError(t, err)
+	for _, server := range filtered {
+		require.NoError(t, presence.DeleteKubernetesServer(ctx, server.GetHostID(), server.GetName()))
+	}
+	require.Eventually(t, func() bool {
+		filtered, err := w.GetKubeServersByClusterName(kubeServers[1].GetName())
+		return len(filtered) == 0 && err != nil
+	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive the two delete events.")
+
+	require.NoError(t, presence.DeleteAllKubernetesServers(ctx))
+	require.Eventually(t, func() bool {
+		filtered, err := w.GetKubernetesServers()
+		assert.NoError(t, err)
+		return len(filtered) == 0
+	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive all delete events.")
 }
 
 // TestAccessRequestWatcher tests that access request resource watcher properly receives

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1051,25 +1051,25 @@ func TestKubeServerWatcher(t *testing.T) {
 	}
 
 	require.Eventually(t, func() bool {
-		filtered, err := w.GetKubernetesServers()
+		filtered, err := w.GetKubernetesServers(context.Background())
 		assert.NoError(t, err)
 		return len(filtered) == len(kubeServers)
 	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive kube servers.")
 
 	// Test filtering by cluster name.
-	filtered, err := w.GetKubeServersByClusterName(kubeServers[0].GetName())
+	filtered, err := w.GetKubeServersByClusterName(context.Background(), kubeServers[0].GetName())
 	require.NoError(t, err)
 	require.Len(t, filtered, 1)
 
 	// Test Deleting a kube server.
 	require.NoError(t, presence.DeleteKubernetesServer(ctx, kubeServers[0].GetHostID(), kubeServers[0].GetName()))
 	require.Eventually(t, func() bool {
-		kube, err := w.GetKubernetesServers()
+		kube, err := w.GetKubernetesServers(context.Background())
 		assert.NoError(t, err)
 		return len(kube) == len(kubeServers)-1
 	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive the delete event.")
 
-	filtered, err = w.GetKubeServersByClusterName(kubeServers[0].GetName())
+	filtered, err = w.GetKubeServersByClusterName(context.Background(), kubeServers[0].GetName())
 	require.Error(t, err)
 	require.Empty(t, filtered)
 
@@ -1078,25 +1078,25 @@ func TestKubeServerWatcher(t *testing.T) {
 	_, err = presence.UpsertKubernetesServer(ctx, kubeServer)
 	require.NoError(t, err)
 	require.Eventually(t, func() bool {
-		filtered, err := w.GetKubeServersByClusterName(kubeServers[1].GetName())
+		filtered, err := w.GetKubeServersByClusterName(context.Background(), kubeServers[1].GetName())
 		assert.NoError(t, err)
 		return len(filtered) == 2
 	}, time.Second, time.Millisecond, "Timeout waiting for watcher to the new registered kube server.")
 
 	// Test deleting all kube servers with the same name.
-	filtered, err = w.GetKubeServersByClusterName(kubeServers[1].GetName())
+	filtered, err = w.GetKubeServersByClusterName(context.Background(), kubeServers[1].GetName())
 	assert.NoError(t, err)
 	for _, server := range filtered {
 		require.NoError(t, presence.DeleteKubernetesServer(ctx, server.GetHostID(), server.GetName()))
 	}
 	require.Eventually(t, func() bool {
-		filtered, err := w.GetKubeServersByClusterName(kubeServers[1].GetName())
+		filtered, err := w.GetKubeServersByClusterName(context.Background(), kubeServers[1].GetName())
 		return len(filtered) == 0 && err != nil
 	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive the two delete events.")
 
 	require.NoError(t, presence.DeleteAllKubernetesServers(ctx))
 	require.Eventually(t, func() bool {
-		filtered, err := w.GetKubernetesServers()
+		filtered, err := w.GetKubernetesServers(context.Background())
 		assert.NoError(t, err)
 		return len(filtered) == 0
 	}, time.Second, time.Millisecond, "Timeout waiting for watcher to receive all delete events.")


### PR DESCRIPTION
Previously, the Kube proxy would load - per request - all servers from the in-memory cache, unmarshal them, and after applying a filter that excluded the unwanted clusters.

This PR keeps kube servers in memory and ensures they are re-used for every request hitting a Kubernetes proxy.

Closes #22598