### PR TITLE
skip flaky test TestAgentPoolConnectionCount

### DIFF
--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -117,6 +117,8 @@ func setupTestAgentPool(t *testing.T) (*AgentPool, *mockClient) {
 // TestAgentPoolConnectionCount ensures that an agent pool creates the desired
 // number of connections based on the runtime config.
 func TestAgentPoolConnectionCount(t *testing.T) {
+	// TODO: fix flaky test https://github.com/gravitational/teleport/issues/22984
+	t.Skip("flaky test - skip until it's fixed")
 	pool, client := setupTestAgentPool(t)
 	client.mockGetClusterNetworkingConfig = func(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 		config := types.DefaultClusterNetworkingConfig()


### PR DESCRIPTION
Skipping this test temporarily. Flaky test issue: https://github.com/gravitational/teleport/issues/22984