### PR TITLE
[v12] Make the OpenSSH guide more prominent

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -96,7 +96,8 @@ infrastructure.
 
 Read about how to enable access to:
 
-- [Servers](./server-access/getting-started.mdx)
+- [Servers](./server-access/getting-started.mdx), including OpenSSH servers that
+  [do not have Teleport installed](./server-access/guides/openssh.mdx)
 - [Kubernetes clusters](./kubernetes-access/introduction.mdx)
 - [Databases](./database-access/introduction.mdx)
 - [Applications](./application-access/introduction.mdx)

--- a/docs/pages/server-access/introduction.mdx
+++ b/docs/pages/server-access/introduction.mdx
@@ -15,8 +15,11 @@ Teleport Server Access is designed for the following kinds of scenarios:
 
 ## Getting started
 
-- [Get started](getting-started.mdx): Get started using Teleport Server Access in 10 minutes. Server access for most common SSH use-cases.
-- [Integrate with OpenSSH](guides/openssh.mdx): SSO and short-lived certificates for OpenSSH.
+- [Get started](getting-started.mdx): Get started using Teleport server access
+  in 10 minutes. Server access for most common SSH use-cases.
+- [Integrate with OpenSSH](guides/openssh.mdx): You can use Teleport-issued
+  certificates to access legacy OpenSSH servers on hosts where there is no
+  Teleport installation.
 
 ## Guides
 


### PR DESCRIPTION
Backports #24340

Closes #13365

- Clarify the nature of the guide in the server-access.mdx index page
- Add a more prominent link in the docs landing page.