### PR TITLE
docs: remove ignored user parameter in tsh login example

### DIFF
--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -195,8 +195,8 @@ $ tctl create dev.yaml
 ## Testing
 
 The Web UI now contains a new "Okta" button at the login screen. The CLI
-behaves the same as before, but now you provide the email associated with an
-Okta account:
+allows you to just specify the Proxy address and it will automatically
+use the default SSO type.
 
 ```code
 $ tsh login --proxy=proxy.example.com

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -194,9 +194,9 @@ $ tctl create dev.yaml
 
 ## Testing
 
-The Web UI now contains a new "Okta" button at the login screen. The CLI
-allows you to just specify the Proxy address and it will automatically
-use the default SSO type.
+The Web UI now contains a new "Okta" button at the login screen. To 
+authenticate via the `tsh` CLI, specify the Proxy Service address and `tsh` will 
+automatically use the default authentication type:
 
 ```code
 $ tsh login --proxy=proxy.example.com

--- a/docs/pages/access-controls/sso/okta.mdx
+++ b/docs/pages/access-controls/sso/okta.mdx
@@ -199,7 +199,7 @@ behaves the same as before, but now you provide the email associated with an
 Okta account:
 
 ```code
-$ tsh login --proxy=proxy.example.com --user=alice@example.com
+$ tsh login --proxy=proxy.example.com
 ```
 
 This command prints the SSO login URL (and will try to open it automatically
@@ -210,7 +210,7 @@ Teleport can use multiple SAML connectors. In this case a connector name
 can be passed via the `--auth` flag. For the connector we created above:
 
 ```code
-$ tsh login --proxy=proxy.example.com --user=alice@example.com --auth=okta
+$ tsh login --proxy=proxy.example.com --auth=okta
 ```
 
 </Admonition>


### PR DESCRIPTION
The `--user` parameter has no impact when using a SSO auth connector with `tsh login`.