### PR TITLE
Vite fixes (default exports, circular dependency)

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -26,7 +26,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { htmlPlugin, transformPlugin } from './html';
 import { getStyledComponentsConfig } from './styled';
 
-import type { UserConfig } from 'vite';
+import type { RollupCommonJSOptions, UserConfig } from 'vite';
 
 export function createViteConfig(
   rootDirectory: string,
@@ -62,6 +62,23 @@ export function createViteConfig(
         outDir: outputDirectory,
         assetsDir: 'app',
         emptyOutDir: true,
+        commonjsOptions: {
+          // this fixes an issue with react-day-picker in production builds - https://github.com/vitejs/vite/issues/2139
+          defaultIsModuleExports(id) {
+            try {
+              const module = require(id);
+
+              if (module?.default) {
+                return false;
+              }
+
+              return 'auto';
+            } catch {
+              return 'auto';
+            }
+          },
+          transformMixedEsModules: true,
+        } as RollupCommonJSOptions,
       },
       plugins: [
         react({

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -26,7 +26,7 @@ import tsconfigPaths from 'vite-tsconfig-paths';
 import { htmlPlugin, transformPlugin } from './html';
 import { getStyledComponentsConfig } from './styled';
 
-import type { RollupCommonJSOptions, UserConfig } from 'vite';
+import type { UserConfig } from 'vite';
 
 export function createViteConfig(
   rootDirectory: string,
@@ -78,7 +78,7 @@ export function createViteConfig(
             }
           },
           transformMixedEsModules: true,
-        } as RollupCommonJSOptions,
+        },
       },
       plugins: [
         react({

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -62,23 +62,6 @@ export function createViteConfig(
         outDir: outputDirectory,
         assetsDir: 'app',
         emptyOutDir: true,
-        commonjsOptions: {
-          // this fixes an issue with react-day-picker in production builds - https://github.com/vitejs/vite/issues/2139
-          defaultIsModuleExports(id) {
-            try {
-              const module = require(id);
-
-              if (module?.default) {
-                return false;
-              }
-
-              return 'auto';
-            } catch {
-              return 'auto';
-            }
-          },
-          transformMixedEsModules: true,
-        },
       },
       plugins: [
         react({

--- a/web/packages/teleport/src/Discover/Discover.tsx
+++ b/web/packages/teleport/src/Discover/Discover.tsx
@@ -22,7 +22,7 @@ import { Box } from 'design';
 import { FeatureBox } from 'teleport/components/Layout';
 
 import { Navigation } from 'teleport/Discover/Navigation/Navigation';
-import { SelectResource } from 'teleport/Discover/SelectResource';
+import { SelectResource } from 'teleport/Discover/SelectResource/SelectResource';
 import cfg from 'teleport/config';
 
 import { findViewAtIndex } from './flow';

--- a/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
+++ b/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
@@ -17,10 +17,16 @@ limitations under the License.
 import React from 'react';
 import { isAfter, endOfDay, startOfDay, isSameDay, subMonths } from 'date-fns';
 import styled from 'styled-components';
-import DayPicker, { DateUtils } from 'react-day-picker';
+import dayPicker from 'react-day-picker/DayPicker';
 import 'react-day-picker/lib/style.css';
 import { Flex } from 'design';
 import { Close as CloseIcon } from 'design/Icon';
+
+// There is a vite issue with react-day-picker in production builds
+// https://github.com/vitejs/vite/issues/2139
+// TODO(ryan): After node v18 upgrade, swap to the Vite config approach instead of this one
+// also, we should look into upgrading react-day-picker
+const DayPicker = dayPicker.default || dayPicker;
 
 export default class CustomRange extends React.Component {
   constructor(props) {
@@ -51,7 +57,7 @@ export default class CustomRange extends React.Component {
       this.startSelecting = true;
     }
 
-    const range = DateUtils.addDayToRange(day, { from, end });
+    const range = dayPicker.DateUtils.addDayToRange(day, { from, end });
 
     if (range.from) {
       range.from = startOfDay(range.from);


### PR DESCRIPTION
This fixes an issue with Vite production builds where certain libraries that export things a bit differently don't work (https://github.com/vitejs/vite/issues/2139).

To do this, we're using the ESModule interop (checking for `.default`) instead of the Vite config change as it doesn't work with node v16

Also this removes a circular dependency that Vite has been detecting in production builds

> Export "SelectResource" of module "../../../web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx" was reexported through module "../../../web/packages/teleport/src/Discover/SelectResource/index.ts" while both modules are dependencies of each other and will end up in different chunks by current Rollup settings. This scenario is not well supported at the moment as it will produce a circular dependency between chunks and will likely lead to broken execution order.
> Either change the import in "../../../web/packages/teleport/src/Discover/Discover.tsx" to point directly to the exporting module or reconfigure "output.manualChunks" to ensure these modules end up in the same chunk.