### PR TITLE
Update missing color in Connect, reorder More Options menu items

### DIFF
--- a/web/packages/teleterm/src/ui/TopBar/MoreOptions.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/MoreOptions.tsx
@@ -65,6 +65,13 @@ function useMenuItems(): MenuItem[] {
 
   const menuItems: MenuItem[] = [
     {
+      title: 'Open new terminal',
+      isVisible: isSearchBarEnabled,
+      Icon: icons.Terminal,
+      keyboardShortcutAction: 'newTerminalTab',
+      onNavigate: openTerminalTab,
+    },
+    {
       title: 'Open config file',
       isVisible: true,
       Icon: icons.Config,
@@ -72,13 +79,6 @@ function useMenuItems(): MenuItem[] {
         const path = await mainProcessClient.openConfigFile();
         notificationsService.notifyInfo(`Opened the config file at ${path}.`);
       },
-    },
-    {
-      title: 'Open new terminal',
-      isVisible: isSearchBarEnabled,
-      Icon: icons.Terminal,
-      keyboardShortcutAction: 'newTerminalTab',
-      onNavigate: openTerminalTab,
     },
     {
       title: 'Install tsh in PATH',
@@ -222,7 +222,7 @@ function MenuItem({
               padding: ${props => props.theme.space[1]}px
                 ${props => props.theme.space[1]}px;
             `}
-            bg="primary.main"
+            bg="levels.surfaceSecondary"
           >
             {getAccelerator(item.keyboardShortcutAction)}
           </Text>


### PR DESCRIPTION
The "Open new terminal" item was introduced in the search bar PR, before the theme got updated in #23539. When rebasing the original search bar PR on top of theme changes, I forgot to update colors outside of the search bar directory.

Additionally, this PR moves "Open new terminal" to the top of the list because it's likely to be used more often than opening the config file.