### PR TITLE
Connect: Enable search bar feature flag by default

### DIFF
--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -37,7 +37,7 @@ export const createAppConfigSchema = (platform: Platform) => {
       .describe('Enables collecting of anonymous usage data.'),
     'feature.searchBar': z
       .boolean()
-      .default(false)
+      .default(true)
       .describe('Replaces the command bar with the new search bar'),
     'keymap.tab1': shortcutSchema
       .default(defaultKeymap['tab1'])


### PR DESCRIPTION
The feature flag is not necessary anymore but we can do the cleanup after the v13 cutoff. Until then, we just want to enable it by default in the v13 alpha.