### PR TITLE
Satisfy the messaging linter

### DIFF
--- a/docs/pages/changelog.mdx
+++ b/docs/pages/changelog.mdx
@@ -2,5 +2,5 @@
 title: Teleport Changelog
 description: The Changelog provides a comprehensive description of the changes introduced by each Teleport release.
 ---
-
+{/*lint disable messaging*/}
 (!CHANGELOG.md!)

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -19,7 +19,7 @@ following [Getting Started with Windows Access](getting-started.mdx).
 Continue with this guide if:
 
 - You're running an older version of Teleport and can't upgrade.
-- You want to install Desktop Access using the same instance of `teleport`
+- You want to install the Desktop Service using the same instance of `teleport`
   running the Proxy/Auth Services.
 
 </Admonition>
@@ -495,7 +495,7 @@ the filepath to the `der_ca_file` configuration variable.
 
 <Admonition type="note" title="Teleport CA">
 Prior to v8.0, the Teleport CA was not compatible with Windows logins. If
-you're setting up Desktop Access in an existing cluster created before v8.0,
+you're setting up the Desktop Service in an existing cluster created before v8.0,
 you must first perform a [CA rotation](../management/operations/ca-rotation.mdx) in
 order to resolve this.
 </Admonition>


### PR DESCRIPTION
- Ignore the messaging linter in the changelog. The changelog uses a different heading convention than the rest of the docs (title case instead of sentence case), so it's difficult to apply the same standards consistently.

- Minor edits to the Manual AD guide