### PR TITLE
Remove unnecessary sudo from Connect uninstall docs

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -329,7 +329,7 @@ $ sudo rm -f /Applications/Teleport\ Connect.app
 To remove the local user data directory:
 
 ```code
-$ sudo rm -rf ~/Library/Application\ Support/Teleport\ Connect
+$ rm -rf ~/Library/Application\ Support/Teleport\ Connect
 ``` 
 
 </TabItem>


### PR DESCRIPTION
`sudo` is not necessary to remove a folder that's in the home directory.