### PR TITLE
Check Okta action transitions during update, allow failed -> pending.

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -378,6 +378,10 @@ func (o *OktaAssignmentActionV1) SetStatus(status string) error {
 		invalidTransition = true
 	case OktaAssignmentActionV1_CLEANUP_FAILED:
 		invalidTransition = true
+	case OktaAssignmentActionV1_UNKNOWN:
+		// All transitions are allowed from UNKNOWN.
+	default:
+		invalidTransition = true
 	}
 
 	if invalidTransition {

--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -283,7 +283,7 @@ type OktaAssignmentAction interface {
 	// * PENDING -> (PROCESSING, CLEANUP_PENDING)
 	// * PROCESSING -> (SUCCESSFUL, FAILED, CLEANUP_PENDING)
 	// * SUCCESSFUL -> (CLEANUP_PENDING, CLEANUP_PROCESSING)
-	// * FAILED -> (PROCESSING, CLEANUP_PENDING, CLEANUP_PROCESSING)
+	// * FAILED -> (PENDING, CLEANUP_PENDING, CLEANUP_PROCESSING)
 	// * CLEANUP_PENDING -> CLEANUP_PROCESSING
 	// * CLEANUP_PROCESSING -> (CLEANUP_FAILED, CLEANED_UP)
 	SetStatus(string) error
@@ -356,7 +356,7 @@ func (o *OktaAssignmentActionV1) SetStatus(status string) error {
 		}
 	case OktaAssignmentActionV1_FAILED:
 		switch status {
-		case constants.OktaAssignmentActionStatusProcessing:
+		case constants.OktaAssignmentActionStatusPending:
 		case constants.OktaAssignmentActionStatusCleanupPending:
 		default:
 			invalidTransition = true

--- a/api/types/okta_test.go
+++ b/api/types/okta_test.go
@@ -63,8 +63,8 @@ func TestOktaAssignments_SetStatus(t *testing.T) {
 		{startStatus: constants.OktaAssignmentActionStatusSuccessful, nextStatus: constants.OktaAssignmentActionStatusCleanupFailed, invalid: true},
 
 		// FAILED transitions
-		{startStatus: constants.OktaAssignmentActionStatusFailed, nextStatus: constants.OktaAssignmentActionStatusPending, invalid: true},
-		{startStatus: constants.OktaAssignmentActionStatusFailed, nextStatus: constants.OktaAssignmentActionStatusProcessing},
+		{startStatus: constants.OktaAssignmentActionStatusFailed, nextStatus: constants.OktaAssignmentActionStatusPending},
+		{startStatus: constants.OktaAssignmentActionStatusFailed, nextStatus: constants.OktaAssignmentActionStatusProcessing, invalid: true},
 		{startStatus: constants.OktaAssignmentActionStatusFailed, nextStatus: constants.OktaAssignmentActionStatusSuccessful, invalid: true},
 		{startStatus: constants.OktaAssignmentActionStatusFailed, nextStatus: constants.OktaAssignmentActionStatusFailed, invalid: true},
 		{startStatus: constants.OktaAssignmentActionStatusFailed, nextStatus: constants.OktaAssignmentActionStatusCleanupPending},

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -144,6 +144,33 @@ func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types
 			return trace.Wrap(err)
 		}
 
+		// Make a copy so that we don't modify the previous assignment.
+		previousCopy := previousAssignment.Copy()
+		previousActions := previousCopy.GetActions()
+
+		if len(previousActions) != len(assignment.GetActions()) {
+			return trace.BadParameter("Update to Okta assignment %s failed because the previous version has a different number of actions", assignment.GetName())
+		}
+
+		// Make sure that the status transitions of the updated assignment are valid.
+		for i, action := range assignment.GetActions() {
+			previousAction := previousActions[i]
+
+			// Ensure that the previous actions are equal
+			if !actionsMatch(previousAction, action) {
+				return trace.BadParameter("action mismatch when updating Okta assignment %s", assignment.GetName())
+			}
+
+			// Don't check the status transition if the statuses are equal.
+			if previousAction.GetStatus() == action.GetStatus() {
+				continue
+			}
+
+			if err := previousAction.SetStatus(action.GetStatus()); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+
 		return o.assignmentSvc.UpdateResource(ctx, assignment)
 	})
 	if err != nil {
@@ -189,4 +216,10 @@ func (o *OktaService) DeleteAllOktaAssignments(ctx context.Context) error {
 	return trace.Wrap(o.assignmentSvc.RunWhileLocked(ctx, oktaAssignmentModifyLock, oktaAssignmentModifyLockTTL, func(ctx context.Context, b backend.Backend) error {
 		return o.assignmentSvc.DeleteAllResources(ctx)
 	}))
+}
+
+// actionsMatch returns true if two actions match minus the status and last transition.
+func actionsMatch(a1, a2 types.OktaAssignmentAction) bool {
+	return a1.GetTargetType() == a2.GetTargetType() &&
+		a1.GetID() == a2.GetID()
 }

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -161,8 +161,9 @@ func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types
 				return trace.BadParameter("action mismatch when updating Okta assignment %s", assignment.GetName())
 			}
 
-			// Don't check the status transition if the statuses are equal.
-			if previousAction.GetStatus() == action.GetStatus() {
+			// Don't check the status transition if the statuses are equal and the last transitions are equal.
+			if previousAction.GetStatus() == action.GetStatus() &&
+				previousAction.GetLastTransition().Equal(action.GetLastTransition()) {
 				continue
 			}
 

--- a/lib/services/local/okta_test.go
+++ b/lib/services/local/okta_test.go
@@ -215,56 +215,14 @@ func TestOktaAssignmentCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	// Create a couple Okta assignments.
-	assignment1, err := types.NewOktaAssignment(
-		types.Metadata{
-			Name: "assignment1",
-		},
-		types.OktaAssignmentSpecV1{
-			User: "test-user@test.user",
-			Actions: []*types.OktaAssignmentActionV1{
-				{
-					Status: types.OktaAssignmentActionV1_PENDING,
-					Target: &types.OktaAssignmentActionTargetV1{
-						Type: types.OktaAssignmentActionTargetV1_APPLICATION,
-						Id:   "123456",
-					},
-				},
-				{
-					Status: types.OktaAssignmentActionV1_SUCCESSFUL,
-					Target: &types.OktaAssignmentActionTargetV1{
-						Type: types.OktaAssignmentActionTargetV1_GROUP,
-						Id:   "234567",
-					},
-				},
-			},
-		},
+	assignment1 := oktaAssignment(t, "assignment1", "test-user@test.user",
+		oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "123456", constants.OktaAssignmentActionStatusPending, clock.Now()),
+		oktaAction(t, types.OktaAssignmentActionTargetV1_GROUP, "234567", constants.OktaAssignmentActionStatusSuccessful, clock.Now()),
 	)
-	require.NoError(t, err)
-	assignment2, err := types.NewOktaAssignment(
-		types.Metadata{
-			Name: "assignment2",
-		},
-		types.OktaAssignmentSpecV1{
-			User: "test-user@test.user",
-			Actions: []*types.OktaAssignmentActionV1{
-				{
-					Status: types.OktaAssignmentActionV1_PENDING,
-					Target: &types.OktaAssignmentActionTargetV1{
-						Type: types.OktaAssignmentActionTargetV1_APPLICATION,
-						Id:   "123456",
-					},
-				},
-				{
-					Status: types.OktaAssignmentActionV1_SUCCESSFUL,
-					Target: &types.OktaAssignmentActionTargetV1{
-						Type: types.OktaAssignmentActionTargetV1_GROUP,
-						Id:   "234567",
-					},
-				},
-			},
-		},
+	assignment2 := oktaAssignment(t, "assignment2", "test-user@test.user",
+		oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "123456", constants.OktaAssignmentActionStatusPending, clock.Now()),
+		oktaAction(t, types.OktaAssignmentActionTargetV1_GROUP, "234567", constants.OktaAssignmentActionStatusSuccessful, clock.Now()),
 	)
-	require.NoError(t, err)
 
 	// Initially we expect no assignments.
 	out, nextToken, err := service.ListOktaAssignments(ctx, 200, "")
@@ -327,10 +285,37 @@ func TestOktaAssignmentCRUD(t *testing.T) {
 	_, err = service.CreateOktaAssignment(ctx, assignment1)
 	require.True(t, trace.IsAlreadyExists(err), "expected already exists error, got %v", err)
 
-	// Update an assignment.
-	assignment1.SetExpiry(clock.Now().Add(30 * time.Minute))
+	// Fail to update the assignment due to mismatching number of actions
+	assignment1 = oktaAssignment(t, "assignment1", "test-user@test.user",
+		oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "123456", constants.OktaAssignmentActionStatusPending, clock.Now()),
+	)
+	_, err = service.UpdateOktaAssignment(ctx, assignment1)
+	require.ErrorContains(t, err, "different number of actions")
+
+	// Fail to update the assignment due to actions with differing contents.
+	assignment1 = oktaAssignment(t, "assignment1", "test-user@test.user",
+		oktaAction(t, types.OktaAssignmentActionTargetV1_GROUP, "diff", constants.OktaAssignmentActionStatusPending, clock.Now()),
+		oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "diff", constants.OktaAssignmentActionStatusSuccessful, clock.Now()),
+	)
+	_, err = service.UpdateOktaAssignment(ctx, assignment1)
+	require.ErrorContains(t, err, "action mismatch")
+
+	// Fail to update the assignment due to bad transition.
+	assignment1 = oktaAssignment(t, "assignment1", "test-user@test.user",
+		oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "123456", constants.OktaAssignmentActionStatusFailed, clock.Now()),
+		oktaAction(t, types.OktaAssignmentActionTargetV1_GROUP, "234567", constants.OktaAssignmentActionStatusSuccessful, clock.Now()),
+	)
+	_, err = service.UpdateOktaAssignment(ctx, assignment1)
+	require.ErrorContains(t, err, "invalid transition")
+
+	// Update succeeds with a valid transition.
+	assignment1 = oktaAssignment(t, "assignment1", "test-user@test.user",
+		oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "123456", constants.OktaAssignmentActionStatusProcessing, clock.Now()),
+		oktaAction(t, types.OktaAssignmentActionTargetV1_GROUP, "234567", constants.OktaAssignmentActionStatusSuccessful, clock.Now()),
+	)
 	_, err = service.UpdateOktaAssignment(ctx, assignment1)
 	require.NoError(t, err)
+
 	assignment, err = service.GetOktaAssignment(ctx, assignment1.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(assignment1, assignment,
@@ -371,4 +356,82 @@ func TestOktaAssignmentCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, nextToken)
 	require.Empty(t, out)
+}
+
+func TestActionsMatch(t *testing.T) {
+	now := time.Now()
+
+	tests := []struct {
+		name     string
+		action1  types.OktaAssignmentAction
+		action2  types.OktaAssignmentAction
+		expected bool
+	}{
+		{
+			name:     "actions match",
+			action1:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusPending, now),
+			action2:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusPending, now),
+			expected: true,
+		},
+		{
+			name:     "target mismatch",
+			action1:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusPending, now),
+			action2:  oktaAction(t, types.OktaAssignmentActionTargetV1_GROUP, "1", constants.OktaAssignmentActionStatusPending, now),
+			expected: false,
+		},
+		{
+			name:     "id mismatch",
+			action1:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusPending, now),
+			action2:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "2", constants.OktaAssignmentActionStatusPending, now),
+			expected: false,
+		},
+		{
+			name:     "status ignored",
+			action1:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusPending, now),
+			action2:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusCleanupPending, now),
+			expected: true,
+		},
+		{
+			name:     "last transition ignored",
+			action1:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusPending, now),
+			action2:  oktaAction(t, types.OktaAssignmentActionTargetV1_APPLICATION, "1", constants.OktaAssignmentActionStatusPending, now.Add(time.Hour)),
+			expected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, actionsMatch(test.action1, test.action2))
+		})
+	}
+}
+
+func oktaAssignment(t *testing.T, name, username string, actions ...*types.OktaAssignmentActionV1) types.OktaAssignment {
+	assignment, err := types.NewOktaAssignment(
+		types.Metadata{
+			Name: name,
+		},
+		types.OktaAssignmentSpecV1{
+			User:    username,
+			Actions: actions,
+		},
+	)
+	require.NoError(t, err)
+
+	return assignment
+}
+
+func oktaAction(t *testing.T, targetType types.OktaAssignmentActionTargetV1_OktaAssignmentActionTargetType,
+	id string, status string, lastTransition time.Time) *types.OktaAssignmentActionV1 {
+
+	action := &types.OktaAssignmentActionV1{
+		Target: &types.OktaAssignmentActionTargetV1{
+			Type: targetType,
+			Id:   id,
+		},
+		LastTransition: lastTransition,
+	}
+	action.SetStatus(status)
+
+	return action
 }


### PR DESCRIPTION
Okta action transitions are now checked when performing an update. This will allow us to update individual statuses while avoiding concurrency issues. Statuses that are equal are allowed in this case.

Additionally, a FAILED status can now become a PENDING status rather than going directly to processing.