### PR TITLE
Try to fix TestAgentPoolConnectionCount

### DIFF
--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -383,7 +383,7 @@ func (p *AgentPool) isAgentRequired() bool {
 		return true
 	}
 
-	return p.active.len() < p.runtimeConfig.connectionCount
+	return p.active.len() < p.runtimeConfig.getConnectionCount()
 }
 
 // disconnectAgents handles disconnecting agents that are no longer required.
@@ -630,6 +630,12 @@ func (c *agentPoolRuntimeConfig) restrictConnectionCount() bool {
 		return false
 	}
 	return c.tunnelStrategyType == types.ProxyPeering
+}
+
+func (c *agentPoolRuntimeConfig) getConnectionCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return c.connectionCount
 }
 
 // useReverseTunnelV2 returns true if reverse tunnel should be used.

--- a/lib/reversetunnel/agentpool_test.go
+++ b/lib/reversetunnel/agentpool_test.go
@@ -117,8 +117,6 @@ func setupTestAgentPool(t *testing.T) (*AgentPool, *mockClient) {
 // TestAgentPoolConnectionCount ensures that an agent pool creates the desired
 // number of connections based on the runtime config.
 func TestAgentPoolConnectionCount(t *testing.T) {
-	// TODO: fix flaky test https://github.com/gravitational/teleport/issues/22984
-	t.Skip("flaky test - skip until it's fixed")
 	pool, client := setupTestAgentPool(t)
 	client.mockGetClusterNetworkingConfig = func(ctx context.Context) (types.ClusterNetworkingConfig, error) {
 		config := types.DefaultClusterNetworkingConfig()
@@ -134,13 +132,8 @@ func TestAgentPoolConnectionCount(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Eventually(t, func() bool {
-		select {
-		case <-pool.tracker.Acquire():
-			return true
-		default:
-			return false
-		}
-	}, time.Second*5, time.Millisecond*10, "expected a lease to be available")
+		return pool.active.len() == 1
+	}, time.Second*5, time.Millisecond*10, "wait for agent pool")
 
 	require.False(t, pool.isAgentRequired())
 	require.Equal(t, pool.Count(), 1)


### PR DESCRIPTION
## What 
- fix flakiness caused by  https://github.com/gravitational/teleport/blob/4f60292a6a2ee6c48b18ac50cd4aea943924979f/lib/reversetunnel/agentpool.go#L255 that is run in parallel and the `require.False(t, pool.isAgentRequired())` check depends of the `p.run()` timing. 
  The issue can be reproduce by adding time.Sleep call and delaying the `p.active.add(agent)`: 
```diff
diff --git a/lib/reversetunnel/agentpool.go b/lib/reversetunnel/agentpool.go
index 645f984e31..03ade0660f 100644
--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -272,6 +272,7 @@ func (p *AgentPool) run() error {
                if err != nil {
                        p.log.WithError(err).Debugf("Failed to connect agent.")
                } else {
+                       time.Sleep(time.Millisecond * 100)
                        p.wg.Add(1)
                        p.active.add(agent)
                        p.updateConnectedProxies()
```
 - fix `TestAgentPoolConnectionCount` test race condition

related: https://github.com/gravitational/teleport/issues/22984