### PR TITLE
Rate limit all unauthenticated HTTP endpoints

### DIFF
--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -3167,7 +3167,7 @@ func TestCustomRateLimiting(t *testing.T) {
 		},
 		{
 			name:  "RPC CreateAuthenticateChallenge",
-			burst: defaults.LimiterPasswordlessBurst,
+			burst: defaults.LimiterBurst,
 			fn: func(clt *Client) error {
 				_, err := clt.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{})
 				return err

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -383,9 +383,9 @@ func getCustomRate(endpoint string) *ratelimit.RateSet {
 		return rates
 	// Passwordless RPCs (potential unauthenticated challenge generation).
 	case "/proto.AuthService/CreateAuthenticateChallenge":
-		const period = defaults.LimiterPasswordlessPeriod
-		const average = defaults.LimiterPasswordlessAverage
-		const burst = defaults.LimiterPasswordlessBurst
+		const period = defaults.LimiterPeriod
+		const average = defaults.LimiterAverage
+		const burst = defaults.LimiterBurst
 		rates := ratelimit.NewRateSet()
 		if err := rates.Add(period, average, burst); err != nil {
 			log.WithError(err).Debugf("Failed to define a custom rate for rpc method %q, using default rate", endpoint)

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -362,15 +362,14 @@ const (
 	LimiterMaxConcurrentSignatures = 10
 )
 
-// Default rate limits for unauthenticated passwordless endpoints.
+// Default rate limits for unauthenticated endpoints.
 const (
-	// LimiterPasswordlessPeriod is the default period for passwordless limiters.
-	LimiterPasswordlessPeriod = 1 * time.Minute
-	// LimiterPasswordlessAverage is the default average for passwordless
-	// limiters.
-	LimiterPasswordlessAverage = 10
-	// LimiterPasswordlessBurst is the default burst for passwordless limiters.
-	LimiterPasswordlessBurst = 20
+	// LimiterPeriod is the default period for unauthenticated limiters.
+	LimiterPeriod = 1 * time.Minute
+	// LimiterAverage is the default average for unauthenticated limiters.
+	LimiterAverage = 20
+	// LimiterBurst is the default burst for unauthenticated limiters.
+	LimiterBurst = 40
 )
 
 const (

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -372,6 +372,16 @@ const (
 	LimiterBurst = 40
 )
 
+// Default high rate limits for unauthenticated endpoints that are CPU constrained.
+const (
+	// LimiterHighPeriod is the default period for high rate unauthenticated limiters.
+	LimiterHighPeriod = 1 * time.Minute
+	// LimiterHighAverage is the default average for high rate unauthenticated limiters.
+	LimiterHighAverage = 120
+	// LimiterHighBurst is the default burst for high rate unauthenticated limiters.
+	LimiterHighBurst = 480
+)
+
 const (
 	// HostCertCacheSize is the number of host certificates to cache at any moment.
 	HostCertCacheSize = 4000

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -346,6 +346,9 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 		MaxConnections:   defaults.LimiterMaxConnections,
 		MaxNumberOfUsers: defaults.LimiterMaxConcurrentUsers,
 	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	// highLimiter is used for endpoints which are only CPU constrained and require high request rates
 	h.highLimiter, err = limiter.NewRateLimiter(limiter.Config{
 		Rates: []limiter.Rate{

--- a/lib/web/apiserver_login_test.go
+++ b/lib/web/apiserver_login_test.go
@@ -305,7 +305,7 @@ func TestAuthenticate_rateLimiting(t *testing.T) {
 	}{
 		{
 			name:  "/webapi/mfa/login/begin",
-			burst: defaults.LimiterPasswordlessBurst,
+			burst: defaults.LimiterBurst,
 			fn: func(clt *client.WebClient) error {
 				ep := clt.Endpoint("webapi", "mfa", "login", "begin")
 				_, err := clt.PostJSON(ctx, ep, &client.MFAChallengeRequest{})


### PR DESCRIPTION
This PR is an extension to what was done in PR #172. This PR is designed to fix https://github.com/gravitational/teleport/issues/4330 and also fix https://github.com/gravitational/teleport-private/issues/403.

Rather than audit endpoints and choose what endpoints should be rate limited, this commit proposes that for safety and reduced cognitive load, all unauthenticated endpoints become rate limited.

The primary concern in this type of change would be if our rate limit becomes too aggressive for general use.  There are two considered strategies to make sure this does not become impacting:
1. Adjust the rate limiter so the rate limit becomes endpoint specific.  This would avoid the need to consider how activity on one endpoint effects another.
2. Accept that rate limit interactions are possible and instead ensure rate limits are high enough to avoid this concern.

This commit chooses option 2.  While `opt 1` has advantages, particularly as endpoints and new use cases are added.  Option 2 provides the strictest and safest rate limits.

Our rate limits were configured to:
period: 1 min
avg rate: 10
burst rate: 20

In order to build a safety buffer with option #2 those allowed rates were doubled.