### PR TITLE
docs: provider faq answer for configurable maintenance times for cloud

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -31,7 +31,7 @@ Yes, Teleport provides scheduled maintenance windows for upgrades, patches and o
 maintenance start window time of day that works best for your organization.
 
 To select the best maintenance time window select your username in the Web UI, then the Help & Support option from the drop-down.
-The Schedule Upgrade section within that page allows you to configure the start time. Updates for that tenant will not start 
+The Scheduled Upgrades section within that page allows you to configure the start time. Updates for that tenant will not start 
 earlier than that time of day. 
 
 Teleport recommends subscribing to the Teleport Enterprise Cloud updates at [status.teleport.sh](https://status.teleport.sh) to keep up to date on Scheduled Maintenance.

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -25,6 +25,17 @@ Yes. Customers can subscribe to Teleport Enterprise Cloud updates at [status.tel
 
 Please [reach out to sales](https://goteleport.com/signup/enterprise) to discuss pricing.
 
+## Are maintenance update times configurable? 
+
+Yes, Teleport provides scheduled maintenance windows for upgrades, patches and other required updates. You can select the
+maintenance start window time of day that works best for your organization.
+
+To select the best maintenance time window select your username in the Web UI, then the Help & Support option from the drop-down.
+The Schedule Upgrade section within that page allows you to configure the start time. Updates for that tenant will not start 
+earlier than that time of day. 
+
+Teleport recommends subscribing to the Teleport Enterprise Cloud updates at [status.teleport.sh](https://status.teleport.sh) to keep up to date on Scheduled Maintenance.
+
 ## If I start with Teleport Enterprise Cloud, can I move to Teleport Enterprise or Teleport Open Source, or do I need to start again?
 
 If you plan to use S3 and DynamoDB as storage backends, we can provide data for you to import. But you should reach out to us first. If you use a different backend, you will need to start over.

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -27,14 +27,18 @@ Please [reach out to sales](https://goteleport.com/signup/enterprise) to discuss
 
 ## Are upgrades times configurable for my Teleport Enterprise Cloud tenant?
 
-Yes, you can set the window start time that works best for your organization for upgrades. Teleport provides a scheduled maintenance
-time window for any upgrades, patches and other required updates for all tenants. An upgrade for your tenant will not start
-earlier than the window start time you set.
+Yes, you can set the window start time that works best for your organization
+for upgrades. Teleport provides a scheduled maintenance time window for any
+upgrades, patches and other required updates for all tenants. An upgrade for
+your tenant will not start earlier than the window start time you set.
 
-To set the window start time select your username in the Web UI, then the Help & Support option from the drop-down.
-The Scheduled Upgrades section within that page allows you to configure the window start time.
+To set the window start time select your username in the Web UI, then the Help
+& Support option from the drop-down. The Scheduled Upgrades section within that
+page allows you to configure the window start time.
 
-Teleport recommends subscribing to the Teleport Enterprise Cloud updates at [status.teleport.sh](https://status.teleport.sh) to keep up to date on scheduled maintenance.
+Teleport recommends subscribing to the Teleport Enterprise Cloud updates at
+[status.teleport.sh](https://status.teleport.sh) to keep up to date on
+scheduled maintenance.
 
 ## If I start with Teleport Enterprise Cloud, can I move to Teleport Enterprise or Teleport Open Source, or do I need to start again?
 

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -25,16 +25,16 @@ Yes. Customers can subscribe to Teleport Enterprise Cloud updates at [status.tel
 
 Please [reach out to sales](https://goteleport.com/signup/enterprise) to discuss pricing.
 
-## Are maintenance update times configurable? 
+## Are upgrades times configurable for my Teleport Enterprise Cloud tenant?
 
-Yes, Teleport provides scheduled maintenance windows for upgrades, patches and other required updates. You can select the
-maintenance start window time of day that works best for your organization.
+Yes, you can set the window start time that works best for your organization for upgrades. Teleport provides a scheduled maintenance
+time window for any upgrades, patches and other required updates for all tenants. An upgrade for your tenant will not start
+earlier than the window start time you set.
 
-To select the best maintenance time window select your username in the Web UI, then the Help & Support option from the drop-down.
-The Scheduled Upgrades section within that page allows you to configure the start time. Updates for that tenant will not start 
-earlier than that time of day. 
+To set the window start time select your username in the Web UI, then the Help & Support option from the drop-down.
+The Scheduled Upgrades section within that page allows you to configure the window start time.
 
-Teleport recommends subscribing to the Teleport Enterprise Cloud updates at [status.teleport.sh](https://status.teleport.sh) to keep up to date on Scheduled Maintenance.
+Teleport recommends subscribing to the Teleport Enterprise Cloud updates at [status.teleport.sh](https://status.teleport.sh) to keep up to date on scheduled maintenance.
 
 ## If I start with Teleport Enterprise Cloud, can I move to Teleport Enterprise or Teleport Open Source, or do I need to start again?
 


### PR DESCRIPTION
ONly backport to `branch/v12` since it's cloud.