### PR TITLE
docs: update audit results faq for cloud

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -130,7 +130,8 @@ $ tctl nodes add --ttl=5m --roles=node,proxy --token=$(uuid)
 
 ## Is an independent security audit available?
 
-Security audits by independent third-parties are performed at least annually, with the results made available on our [Audit Reports](https://goteleport.com/resources/audits/) page.
+Security audits by independent third-parties are performed at least annually. You can request audit results and other
+related information on the [Teleport Trust Portal](https://trust.goteleport.com).
 
 ## Where does Teleport Enterprise Cloud run?
 


### PR DESCRIPTION
Only backport to `branch/v12` since its cloud.