### PR TITLE
Added missing `mkdir` call when determining if a release is a pre-release.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6594,6 +6594,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -6660,6 +6661,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -6726,6 +6728,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -6792,6 +6795,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -20226,6 +20230,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 4cca363e389f871662adb53ffa9e0b8feedb6d8e213f4df135b827c31f6bf0f8
+hmac: 9e3e382cf1c954e55fbb663d8cf656600e28c81758e8c6700ae58180d30c1cb3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6594,7 +6594,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
+  - mkdir -pv "/go/vars"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -6661,7 +6661,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
+  - mkdir -pv "/go/vars"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -6728,7 +6728,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
+  - mkdir -pv "/go/vars"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -6795,7 +6795,7 @@ steps:
   image: golang:1.18-alpine
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - mkdir -pv "$(dirname "/go/vars/release-environment.txt")"
+  - mkdir -pv "/go/vars"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
     "promote") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
@@ -20230,6 +20230,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 9e3e382cf1c954e55fbb663d8cf656600e28c81758e8c6700ae58180d30c1cb3
+hmac: e5062da93026ddd6ccfa44929ed29e15faf53f07790f1ffad49dab0e062b4757
 
 ...

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -72,6 +72,7 @@ func buildPromoteOsPackagePipeline(repoType, versionChannel, packageNameFilter, 
 			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
 			Commands: []string{
 				fmt.Sprintf("cd %q", path.Join(clonePath, "build.assets", "tooling")),
+				fmt.Sprintf(`mkdir -pv "$(dirname %q)"`, releaseEnvironmentFilePath),
 				fmt.Sprintf(`(go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo "promote") > %q`, releaseEnvironmentFilePath),
 			},
 		},

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -72,7 +72,7 @@ func buildPromoteOsPackagePipeline(repoType, versionChannel, packageNameFilter, 
 			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
 			Commands: []string{
 				fmt.Sprintf("cd %q", path.Join(clonePath, "build.assets", "tooling")),
-				fmt.Sprintf(`mkdir -pv "$(dirname %q)"`, releaseEnvironmentFilePath),
+				fmt.Sprintf("mkdir -pv %q", path.Dir(releaseEnvironmentFilePath)),
 				fmt.Sprintf(`(go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo "promote") > %q`, releaseEnvironmentFilePath),
 			},
 		},


### PR DESCRIPTION
This PR fixes an issue where promotion fails due to a missing directory when determining if the promotion is for a pre-release.