### PR TITLE
Removed "workflow-tag" argument from OPRT GHA call

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6603,7 +6603,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
+    -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
     -input "package-name-filter=$($DRONE_REPO_PRIVATE && echo "*ent*" || echo "")"
     -input "release-channel=stable" -input "repo-type=apt" -input "version-channel=${DRONE_TAG}" '
@@ -6670,7 +6670,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
+    -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
     -input "package-name-filter=$($DRONE_REPO_PRIVATE && echo "*ent*" || echo "")"
     -input "release-channel=stable" -input "repo-type=yum" -input "version-channel=${DRONE_TAG}" '
@@ -6737,7 +6737,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
+    -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
     -input "package-name-filter=teleport-ent-updater*" -input "release-channel=stable"
     -input "repo-type=apt" -input "version-channel=cloud" '
@@ -6804,7 +6804,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
+    -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
     -input "package-name-filter=teleport-ent-updater*" -input "release-channel=stable"
     -input "repo-type=yum" -input "version-channel=cloud" '
@@ -20230,6 +20230,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: e5062da93026ddd6ccfa44929ed29e15faf53f07790f1ffad49dab0e062b4757
+hmac: 94573da39023b1a7033fdc927e5d306102f5b348a823cd3b7f0b6ea67ac9bccb
 
 ...

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -26,14 +26,15 @@ import (
 type ghaBuildType struct {
 	buildType
 	trigger
-	pipelineName string
-	ghaWorkflow  string
-	srcRefVar    string
-	workflowRef  string
-	timeout      time.Duration
-	slackOnError bool
-	dependsOn    []string
-	inputs       map[string]string
+	pipelineName      string
+	ghaWorkflow       string
+	srcRefVar         string
+	workflowRef       string
+	timeout           time.Duration
+	slackOnError      bool
+	dependsOn         []string
+	shouldTagWorkflow bool
+	inputs            map[string]string
 }
 
 func ghaBuildPipeline(b ghaBuildType) pipeline {
@@ -46,7 +47,11 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 	cmd.WriteString(`go run ./cmd/gh-trigger-workflow `)
 	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
 	cmd.WriteString(`-repo teleport.e `)
-	cmd.WriteString(`-tag-workflow `)
+
+	if b.shouldTagWorkflow {
+		cmd.WriteString(`-tag-workflow `)
+	}
+
 	fmt.Fprintf(&cmd, `-timeout %s `, b.timeout.String())
 	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
 	fmt.Fprintf(&cmd, `-workflow-ref=%s `, b.workflowRef)

--- a/dronegen/mac_gha.go
+++ b/dronegen/mac_gha.go
@@ -25,14 +25,15 @@ import "time"
 // These build assets are signed and notarized.
 func darwinTagPipelineGHA() pipeline {
 	bt := ghaBuildType{
-		buildType:    buildType{os: "darwin", arch: "amd64"},
-		trigger:      triggerTag,
-		pipelineName: "build-darwin-amd64",
-		ghaWorkflow:  "release-mac-amd64.yaml",
-		srcRefVar:    "DRONE_TAG",
-		workflowRef:  "${DRONE_TAG}",
-		timeout:      60 * time.Minute,
-		slackOnError: true,
+		buildType:         buildType{os: "darwin", arch: "amd64"},
+		trigger:           triggerTag,
+		pipelineName:      "build-darwin-amd64",
+		ghaWorkflow:       "release-mac-amd64.yaml",
+		srcRefVar:         "DRONE_TAG",
+		workflowRef:       "${DRONE_TAG}",
+		timeout:           60 * time.Minute,
+		slackOnError:      true,
+		shouldTagWorkflow: true,
 		inputs: map[string]string{
 			"release-artifacts": "true",
 			"build-packages":    "true",
@@ -48,14 +49,15 @@ func darwinTagPipelineGHA() pipeline {
 // release time to discover breakage.
 func darwinPushPipelineGHA() pipeline {
 	bt := ghaBuildType{
-		buildType:    buildType{os: "darwin", arch: "amd64"},
-		trigger:      triggerPush,
-		pipelineName: "push-build-darwin-amd64",
-		ghaWorkflow:  "release-mac-amd64.yaml",
-		srcRefVar:    "DRONE_COMMIT",
-		workflowRef:  "${DRONE_BRANCH}",
-		timeout:      60 * time.Minute,
-		slackOnError: true,
+		buildType:         buildType{os: "darwin", arch: "amd64"},
+		trigger:           triggerPush,
+		pipelineName:      "push-build-darwin-amd64",
+		ghaWorkflow:       "release-mac-amd64.yaml",
+		srcRefVar:         "DRONE_COMMIT",
+		workflowRef:       "${DRONE_BRANCH}",
+		timeout:           60 * time.Minute,
+		slackOnError:      true,
+		shouldTagWorkflow: true,
 		inputs: map[string]string{
 			"release-artifacts": "false",
 			"build-packages":    "false",

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -50,11 +50,12 @@ func buildPromoteOsPackagePipeline(repoType, versionChannel, packageNameFilter, 
 	clonePath := "/go/src/github.com/gravitational/teleport"
 
 	pipeline := ghaBuildPipeline(ghaBuildType{
-		trigger:      triggerPromote,
-		pipelineName: fmt.Sprintf("publish-%s-%s-new-repos", pipelineNameSuffix, repoType),
-		ghaWorkflow:  "deploy-packages.yaml",
-		timeout:      12 * time.Hour, // DR takes a long time
-		workflowRef:  "refs/heads/master",
+		trigger:           triggerPromote,
+		pipelineName:      fmt.Sprintf("publish-%s-%s-new-repos", pipelineNameSuffix, repoType),
+		ghaWorkflow:       "deploy-packages.yaml",
+		timeout:           12 * time.Hour, // DR takes a long time
+		workflowRef:       "refs/heads/master",
+		shouldTagWorkflow: false,
 		inputs: map[string]string{
 			"repo-type":           repoType,
 			"environment":         fmt.Sprintf("$(cat %q)", releaseEnvironmentFilePath),

--- a/dronegen/promote.go
+++ b/dronegen/promote.go
@@ -21,12 +21,13 @@ func promoteBuildPipelines() []pipeline {
 	promotePipelines = append(promotePipelines, promoteBuildOsRepoPipelines()...)
 
 	ociPipeline := ghaBuildPipeline(ghaBuildType{
-		buildType:    buildType{os: "linux", fips: false},
-		trigger:      triggerPromote,
-		pipelineName: "promote-teleport-oci-distroless-images",
-		ghaWorkflow:  "promote-teleport-oci-distroless.yml",
-		timeout:      60 * time.Minute,
-		workflowRef:  "${DRONE_TAG}",
+		buildType:         buildType{os: "linux", fips: false},
+		trigger:           triggerPromote,
+		pipelineName:      "promote-teleport-oci-distroless-images",
+		ghaWorkflow:       "promote-teleport-oci-distroless.yml",
+		timeout:           60 * time.Minute,
+		workflowRef:       "${DRONE_TAG}",
+		shouldTagWorkflow: true,
 		inputs: map[string]string{
 			"release-source-tag": "${DRONE_TAG}",
 		},
@@ -36,12 +37,13 @@ func promoteBuildPipelines() []pipeline {
 	promotePipelines = append(promotePipelines, ociPipeline)
 
 	updaterPipeline := ghaBuildPipeline(ghaBuildType{
-		buildType:    buildType{os: "linux", fips: false},
-		trigger:      triggerPromote,
-		pipelineName: "promote-teleport-kube-agent-updater-oci-images",
-		ghaWorkflow:  "promote-teleport-kube-agent-updater-oci.yml",
-		timeout:      60 * time.Minute,
-		workflowRef:  "${DRONE_TAG}",
+		buildType:         buildType{os: "linux", fips: false},
+		trigger:           triggerPromote,
+		pipelineName:      "promote-teleport-kube-agent-updater-oci-images",
+		ghaWorkflow:       "promote-teleport-kube-agent-updater-oci.yml",
+		timeout:           60 * time.Minute,
+		workflowRef:       "${DRONE_TAG}",
+		shouldTagWorkflow: true,
 		inputs: map[string]string{
 			"release-source-tag": "${DRONE_TAG}",
 		},

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -75,15 +75,16 @@ func pushPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:    buildType{os: "linux", arch: "arm64"},
-		trigger:      triggerPush,
-		pipelineName: "push-build-linux-arm64",
-		ghaWorkflow:  "release-linux-arm64.yml",
-		timeout:      60 * time.Minute,
-		slackOnError: true,
-		srcRefVar:    "DRONE_COMMIT",
-		workflowRef:  "${DRONE_BRANCH}",
-		inputs:       map[string]string{"upload-artifacts": "false"},
+		buildType:         buildType{os: "linux", arch: "arm64"},
+		trigger:           triggerPush,
+		pipelineName:      "push-build-linux-arm64",
+		ghaWorkflow:       "release-linux-arm64.yml",
+		timeout:           60 * time.Minute,
+		slackOnError:      true,
+		srcRefVar:         "DRONE_COMMIT",
+		workflowRef:       "${DRONE_BRANCH}",
+		shouldTagWorkflow: true,
+		inputs:            map[string]string{"upload-artifacts": "false"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -190,25 +190,27 @@ func tagPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:    buildType{os: "linux", arch: "arm64", fips: false},
-		trigger:      triggerTag,
-		pipelineName: "build-linux-arm64",
-		ghaWorkflow:  "release-linux-arm64.yml",
-		srcRefVar:    "DRONE_TAG",
-		workflowRef:  "${DRONE_TAG}",
-		timeout:      60 * time.Minute,
-		dependsOn:    []string{tagCleanupPipelineName},
-		inputs:       map[string]string{"upload-artifacts": "true"},
+		buildType:         buildType{os: "linux", arch: "arm64", fips: false},
+		trigger:           triggerTag,
+		pipelineName:      "build-linux-arm64",
+		ghaWorkflow:       "release-linux-arm64.yml",
+		srcRefVar:         "DRONE_TAG",
+		workflowRef:       "${DRONE_TAG}",
+		timeout:           60 * time.Minute,
+		dependsOn:         []string{tagCleanupPipelineName},
+		shouldTagWorkflow: true,
+		inputs:            map[string]string{"upload-artifacts": "true"},
 	}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:    buildType{os: "linux", fips: false},
-		trigger:      triggerTag,
-		pipelineName: "build-teleport-oci-distroless-images",
-		ghaWorkflow:  "release-teleport-oci-distroless.yml",
-		srcRefVar:    "DRONE_TAG",
-		workflowRef:  "${DRONE_TAG}",
-		timeout:      60 * time.Minute,
+		buildType:         buildType{os: "linux", fips: false},
+		trigger:           triggerTag,
+		pipelineName:      "build-teleport-oci-distroless-images",
+		ghaWorkflow:       "release-teleport-oci-distroless.yml",
+		srcRefVar:         "DRONE_TAG",
+		workflowRef:       "${DRONE_TAG}",
+		timeout:           60 * time.Minute,
+		shouldTagWorkflow: true,
 		dependsOn: []string{
 			tagCleanupPipelineName,
 			"build-linux-amd64-deb",
@@ -217,13 +219,14 @@ func tagPipelines() []pipeline {
 	}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:    buildType{os: "linux", fips: false},
-		trigger:      triggerTag,
-		pipelineName: "build-teleport-kube-agent-updater-oci-images",
-		ghaWorkflow:  "release-teleport-kube-agent-updater-oci.yml",
-		srcRefVar:    "DRONE_TAG",
-		workflowRef:  "${DRONE_TAG}",
-		timeout:      60 * time.Minute,
+		buildType:         buildType{os: "linux", fips: false},
+		trigger:           triggerTag,
+		pipelineName:      "build-teleport-kube-agent-updater-oci-images",
+		ghaWorkflow:       "release-teleport-kube-agent-updater-oci.yml",
+		srcRefVar:         "DRONE_TAG",
+		workflowRef:       "${DRONE_TAG}",
+		timeout:           60 * time.Minute,
+		shouldTagWorkflow: true,
 	}))
 
 	// Only amd64 Windows is supported for now.


### PR DESCRIPTION
This PR fixes an issue where the "workflow-tag" input is set when calling the OS package repo tool Github action from Drone.