### PR TITLE
Flipped environment logic for OS package promotion

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6595,8 +6595,8 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
-    "promote") > "/go/vars/release-environment.txt"
+  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
+    "build") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
   pull: if-not-exists
@@ -6662,8 +6662,8 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
-    "promote") > "/go/vars/release-environment.txt"
+  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
+    "build") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
   pull: if-not-exists
@@ -6729,8 +6729,8 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
-    "promote") > "/go/vars/release-environment.txt"
+  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
+    "build") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
   pull: if-not-exists
@@ -6796,8 +6796,8 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo
-    "promote") > "/go/vars/release-environment.txt"
+  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
+    "build") > "/go/vars/release-environment.txt"
 - name: Delegate build to GitHub
   image: golang:1.18-alpine
   pull: if-not-exists
@@ -20230,6 +20230,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 94573da39023b1a7033fdc927e5d306102f5b348a823cd3b7f0b6ea67ac9bccb
+hmac: f050e1682c1fbe155664724f7308ec69f7520672dd0abeb7df1deb59e7e99ac1
 
 ...

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -74,7 +74,7 @@ func buildPromoteOsPackagePipeline(repoType, versionChannel, packageNameFilter, 
 			Commands: []string{
 				fmt.Sprintf("cd %q", path.Join(clonePath, "build.assets", "tooling")),
 				fmt.Sprintf("mkdir -pv %q", path.Dir(releaseEnvironmentFilePath)),
-				fmt.Sprintf(`(go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "build" || echo "promote") > %q`, releaseEnvironmentFilePath),
+				fmt.Sprintf(`(go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo "build") > %q`, releaseEnvironmentFilePath),
 			},
 		},
 		pipeline.Steps[1],


### PR DESCRIPTION
This PR fixes an issue where the logic for determining if a build should target production or development environments is inverted.