### PR TITLE
Ensure that proxy services join by dialing auth

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -522,6 +522,10 @@ func applyAuthOrProxyAddress(fc *FileConfig, cfg *servicecfg.Config) error {
 		}
 
 		if haveProxyServer {
+			if fc.Proxy.Enabled() {
+				return trace.BadParameter("proxy_server can not be specified when proxy service is enabled")
+			}
+
 			addr, err := utils.ParseHostPortAddr(fc.ProxyServer, defaults.HTTPListenPort)
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -1138,6 +1138,17 @@ func TestProxyPeeringPublicAddr(t *testing.T) {
 	}
 }
 
+func TestProxyMustJoinViaAuth(t *testing.T) {
+	cfg := servicecfg.MakeDefaultConfig()
+
+	err := ApplyFileConfig(&FileConfig{
+		Version: defaults.TeleportConfigVersionV3,
+		Proxy:   Proxy{Service: Service{EnabledFlag: "yes"}},
+		Global:  Global{ProxyServer: "proxy.example.com:3080"},
+	}, cfg)
+	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+}
+
 func TestBackendDefaults(t *testing.T) {
 	read := func(val string) *servicecfg.Config {
 		// Default value is lite backend.


### PR DESCRIPTION
If you attempt to join a proxy service to a cluster via another proxy, Teleport will panic with an index out of bounds error.

This is an invalid configuration - proxies must have a direct connection to auth. Fix the panic in favor of a more actionable error.

Fixes #24618