### PR TITLE
Fixed OPRT migration issues

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6741,8 +6741,8 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
-    -input "package-name-filter=teleport-ent-updater*" -input "package-to-test=teleport-ent"
-    -input "release-channel=stable" -input "repo-type=apt" -input "version-channel=cloud" '
+    -input "package-name-filter=teleport-ent-updater*" -input "release-channel=stable"
+    -input "repo-type=apt" -input "version-channel=cloud" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -6808,8 +6808,8 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
-    -input "package-name-filter=teleport-ent-updater*" -input "package-to-test=teleport-ent"
-    -input "release-channel=stable" -input "repo-type=yum" -input "version-channel=cloud" '
+    -input "package-name-filter=teleport-ent-updater*" -input "release-channel=stable"
+    -input "repo-type=yum" -input "version-channel=cloud" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -20232,6 +20232,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 5d1f0f71d2fd80c34bdb564f5756145b73122b2c81ab4693c1b22f622ec93cd6
+hmac: 2d735b23ccff9dfe334b4defcfcd95a03e2a6ccec8d40b4aa0b1a9b3d2a94b25
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6606,7 +6606,8 @@ steps:
     -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
     -input "package-name-filter=$($DRONE_REPO_PRIVATE && echo "*ent*" || echo "")"
-    -input "release-channel=stable" -input "repo-type=apt" -input "version-channel=${DRONE_TAG}" '
+    -input "package-to-test=teleport-ent" -input "release-channel=stable" -input "repo-type=apt"
+    -input "version-channel=${DRONE_TAG}" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -6673,7 +6674,8 @@ steps:
     -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
     -input "package-name-filter=$($DRONE_REPO_PRIVATE && echo "*ent*" || echo "")"
-    -input "release-channel=stable" -input "repo-type=yum" -input "version-channel=${DRONE_TAG}" '
+    -input "package-to-test=teleport-ent" -input "release-channel=stable" -input "repo-type=yum"
+    -input "version-channel=${DRONE_TAG}" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -6739,8 +6741,8 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
-    -input "package-name-filter=teleport-ent-updater*" -input "release-channel=stable"
-    -input "repo-type=apt" -input "version-channel=cloud" '
+    -input "package-name-filter=teleport-ent-updater*" -input "package-to-test=teleport-ent"
+    -input "release-channel=stable" -input "repo-type=apt" -input "version-channel=cloud" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -6806,8 +6808,8 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -timeout 12h0m0s -workflow deploy-packages.yaml -workflow-ref=refs/heads/master
     -input "artifact-tag=${DRONE_TAG}" -input "environment=$(cat "/go/vars/release-environment.txt")"
-    -input "package-name-filter=teleport-ent-updater*" -input "release-channel=stable"
-    -input "repo-type=yum" -input "version-channel=cloud" '
+    -input "package-name-filter=teleport-ent-updater*" -input "package-to-test=teleport-ent"
+    -input "release-channel=stable" -input "repo-type=yum" -input "version-channel=cloud" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -20230,6 +20232,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: f050e1682c1fbe155664724f7308ec69f7520672dd0abeb7df1deb59e7e99ac1
+hmac: 5d1f0f71d2fd80c34bdb564f5756145b73122b2c81ab4693c1b22f622ec93cd6
 
 ...

--- a/build.assets/tooling/cmd/gh-trigger-workflow/main.go
+++ b/build.assets/tooling/cmd/gh-trigger-workflow/main.go
@@ -50,6 +50,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	ghinst "github.com/bradleyfalzon/ghinstallation/v2"
@@ -98,7 +99,7 @@ func main() {
 	// our dispatch event. Note that we pick a time slightly in the past to handle
 	// any clock skew.
 	baselineTime := time.Now().Add(-2 * time.Minute)
-	oldRuns, err := github.ListWorkflowRuns(dispatchCtx, gh.Actions, args.owner, args.repo, args.workflow, args.workflowRef, baselineTime)
+	oldRuns, err := github.ListWorkflowRuns(dispatchCtx, gh.Actions, args.owner, args.repo, args.workflow, getBranchForRef(args.workflowRef), baselineTime)
 	if err != nil {
 		log.Fatalf("Failed to fetch initial task list: %s", err)
 	}
@@ -141,6 +142,16 @@ func main() {
 	log.Printf("Workflow succeeded")
 }
 
+// Returns either the branch name for the provided reference (if it refers to a branch), or an empty string.
+func getBranchForRef(ref string) string {
+	branchRefPrefix := "refs/heads/"
+	if strings.HasPrefix(ref, branchRefPrefix) {
+		return strings.TrimPrefix(ref, branchRefPrefix)
+	}
+
+	return ""
+}
+
 // lookupInstallationID attempts to find an installation of the interface app
 // we're using to authenticate.
 func lookupInstallationID(ctx context.Context, args args) (int64, error) {
@@ -172,7 +183,7 @@ func waitForNewWorkflowRun(ctx context.Context, gh *ghapi.Client, args args, tag
 			log.Fatal("Timed out waiting for workflow run to start")
 
 		case <-ticker.C:
-			newRuns, err := github.ListWorkflowRuns(ctx, gh.Actions, args.owner, args.repo, args.workflow, args.workflowRef, baselineTime)
+			newRuns, err := github.ListWorkflowRuns(ctx, gh.Actions, args.owner, args.repo, args.workflow, getBranchForRef(args.workflowRef), baselineTime)
 			if err != nil {
 				return nil, trace.Wrap(err, "Failed polling for new workflow runs")
 			}

--- a/build.assets/tooling/lib/github/workflows.go
+++ b/build.assets/tooling/lib/github/workflows.go
@@ -64,12 +64,12 @@ type WorkflowRuns interface {
 
 // ListWorkflowRuns returns a set of RunIDs, representing the set of all for
 // workflow runs created since the supplied start time.
-func ListWorkflowRuns(ctx context.Context, actions WorkflowRuns, owner, repo, path, ref string, since time.Time) (RunIDSet, error) {
+func ListWorkflowRuns(ctx context.Context, actions WorkflowRuns, owner, repo, path, branch string, since time.Time) (RunIDSet, error) {
 	listOptions := github.ListWorkflowRunsOptions{
 		ListOptions: github.ListOptions{
 			PerPage: 100,
 		},
-		Branch:  ref,
+		Branch:  branch,
 		Created: ">" + since.Format(time.RFC3339),
 	}
 

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -63,6 +63,7 @@ func buildPromoteOsPackagePipeline(repoType, versionChannel, packageNameFilter, 
 			"release-channel":     "stable",
 			"version-channel":     versionChannel,
 			"package-name-filter": packageNameFilter,
+			"package-to-test":     "teleport-ent",
 		},
 	})
 


### PR DESCRIPTION
This PR fixes the following issues affecting the OS package repo tool migration:
* Enabled smoke tests using the teleport-ent package
* Fixed a bug with the gravitational-maintained github library where refs to branches were passed to a function instead of branch names, causing the function call to list no results. This prevented Drone from detecting when a workflow had succeeded or failed.