### PR TITLE
fix: stop handling SIGINT, SIGTERM in tctl

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -22,9 +22,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
@@ -193,10 +191,7 @@ func TryRun(commands []CLICommand, args []string) error {
 		return trace.Wrap(err)
 	}
 
-	ctx, cancel := signal.NotifyContext(
-		context.Background(), syscall.SIGTERM, syscall.SIGINT,
-	)
-	defer cancel()
+	ctx := context.Background()
 
 	client, err := authclient.Connect(ctx, clientConfig)
 	if err != nil {


### PR DESCRIPTION
As far as I can tell, there is not a good reason to handle SIGINT and SIGTERM in `tctl`. The default action when these signals are unhandled is to immediately terminate the process, which I believe is the correct behavior for `tctl`.

What `tctl` currently does when these signals are received is cancel the root `context.Context` passed to all command handlers. This sounds like it should sufficient to quickly finish up and exit the program, but in practice there are many blocking operations that cannot be cancelled via a `context.Context`, including file read/writes.

I came across this when a user couldn't figure out how to kill an invocation of the `tctl login_rule test` command, `ctrl-c` didn't work. The reason was that the command reads from standard input by default, and the context cancellation could not interrupt the blocked read. We have at least two other commands that read from stdin by default, including `tctl create` and `tctl sso test`. The purpose of this PR is to make it easy to kill `tctl` with the familiar `ctrl-c` shortcut in these cases and any others.

The current signal handling was introduced here https://github.com/gravitational/teleport/pull/13029, it seems the reason was to create a way to cancel the root context, but IMO cancelling the context is unnecessary if the program is terminated.