### PR TITLE
Headless Login explicit username

### DIFF
--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -209,7 +209,7 @@ func MustCreateUserIdentityFile(t *testing.T, tc *TeleInstance, username string,
 		Key:            key.MarshalSSHPublicKey(),
 		Username:       username,
 		TTL:            ttl,
-		Compatiblity:   constants.CertificateFormatStandard,
+		Compatibility:  constants.CertificateFormatStandard,
 		RouteToCluster: tc.Secrets.SiteName,
 	})
 	require.NoError(t, err)

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -205,11 +205,13 @@ func MustCreateUserIdentityFile(t *testing.T, tc *TeleInstance, username string,
 	require.NoError(t, err)
 	key.ClusterName = tc.Secrets.SiteName
 
-	sshCert, tlsCert, err := tc.Process.GetAuthServer().GenerateUserTestCerts(
-		key.MarshalSSHPublicKey(), username, ttl,
-		constants.CertificateFormatStandard,
-		tc.Secrets.SiteName, "",
-	)
+	sshCert, tlsCert, err := tc.Process.GetAuthServer().GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+		Key:            key.MarshalSSHPublicKey(),
+		Username:       username,
+		TTL:            ttl,
+		Compatiblity:   constants.CertificateFormatStandard,
+		RouteToCluster: tc.Secrets.SiteName,
+	})
 	require.NoError(t, err)
 
 	key.Cert = sshCert

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/service"
@@ -115,8 +116,14 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 	}
 	a := req.Process.GetAuthServer()
 	sshPub := ssh.MarshalAuthorizedKey(priv.SSHPublicKey())
-	sshCert, x509Cert, err := a.GenerateUserTestCerts(
-		sshPub, req.Username, ttl, constants.CertificateFormatStandard, req.RouteToCluster, req.SourceIP)
+	sshCert, x509Cert, err := a.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+		Key:            sshPub,
+		Username:       req.Username,
+		TTL:            ttl,
+		Compatiblity:   constants.CertificateFormatStandard,
+		RouteToCluster: req.RouteToCluster,
+		PinnedIP:       req.SourceIP,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integration/helpers/usercreds.go
+++ b/integration/helpers/usercreds.go
@@ -120,7 +120,7 @@ func GenerateUserCreds(req UserCredsRequest) (*UserCreds, error) {
 		Key:            sshPub,
 		Username:       req.Username,
 		TTL:            ttl,
-		Compatiblity:   constants.CertificateFormatStandard,
+		Compatibility:  constants.CertificateFormatStandard,
 		RouteToCluster: req.RouteToCluster,
 		PinnedIP:       req.SourceIP,
 	})

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1454,7 +1454,7 @@ type GenerateUserTestCertsRequest struct {
 	Key            []byte
 	Username       string
 	TTL            time.Duration
-	Compatiblity   string
+	Compatibility  string
 	RouteToCluster string
 	PinnedIP       string
 	MFAVerified    string
@@ -1478,7 +1478,7 @@ func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte
 	certs, err := a.generateUserCert(certRequest{
 		user:           user,
 		ttl:            req.TTL,
-		compatibility:  req.Compatiblity,
+		compatibility:  req.Compatibility,
 		publicKey:      req.Key,
 		routeToCluster: req.RouteToCluster,
 		checker:        checker,

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1449,9 +1449,19 @@ func certRequestPinIP(pinIP bool) certRequestOption {
 	return func(r *certRequest) { r.pinIP = pinIP }
 }
 
+type GenerateUserTestCertsRequest struct {
+	Key            []byte
+	Username       string
+	TTL            time.Duration
+	Compatiblity   string
+	RouteToCluster string
+	PinnedIP       string
+	MFAVerified    bool
+}
+
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
-func (a *Server) GenerateUserTestCerts(key []byte, username string, ttl time.Duration, compatibility, routeToCluster, pinnedIP string) ([]byte, []byte, error) {
-	user, err := a.GetUser(username, false)
+func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte, []byte, error) {
+	user, err := a.GetUser(req.Username, false)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -1466,14 +1476,15 @@ func (a *Server) GenerateUserTestCerts(key []byte, username string, ttl time.Dur
 	}
 	certs, err := a.generateUserCert(certRequest{
 		user:           user,
-		ttl:            ttl,
-		compatibility:  compatibility,
-		publicKey:      key,
-		routeToCluster: routeToCluster,
+		ttl:            req.TTL,
+		compatibility:  req.Compatiblity,
+		publicKey:      req.Key,
+		routeToCluster: req.RouteToCluster,
 		checker:        checker,
 		traits:         user.GetTraits(),
-		loginIP:        pinnedIP,
-		pinIP:          pinnedIP != "",
+		loginIP:        req.PinnedIP,
+		pinIP:          req.PinnedIP != "",
+		mfaVerified:    "mfa-verified",
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1449,6 +1449,7 @@ func certRequestPinIP(pinIP bool) certRequestOption {
 	return func(r *certRequest) { r.pinIP = pinIP }
 }
 
+// GenerateUserTestCertsRequest is a request to generate test certificates.
 type GenerateUserTestCertsRequest struct {
 	Key            []byte
 	Username       string
@@ -1456,7 +1457,7 @@ type GenerateUserTestCertsRequest struct {
 	Compatiblity   string
 	RouteToCluster string
 	PinnedIP       string
-	MFAVerified    bool
+	MFAVerified    string
 }
 
 // GenerateUserTestCerts is used to generate user certificate, used internally for tests
@@ -1484,7 +1485,7 @@ func (a *Server) GenerateUserTestCerts(req GenerateUserTestCertsRequest) ([]byte
 		traits:         user.GetTraits(),
 		loginIP:        req.PinnedIP,
 		pinIP:          req.PinnedIP != "",
-		mfaVerified:    "mfa-verified",
+		mfaVerified:    req.MFAVerified,
 	})
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -368,6 +368,9 @@ type Config struct {
 	// MockSSOLogin is used in tests for mocking the SSO login response.
 	MockSSOLogin SSOLoginFunc
 
+	// MockHeadlessLogin is used in tests for mocking the Headless login response.
+	MockHeadlessLogin HeadlessLoginFunc
+
 	// HomePath is where tsh stores profiles
 	HomePath string
 
@@ -3672,7 +3675,14 @@ func (tc *TeleportClient) mfaLocalLogin(ctx context.Context, priv *keys.PrivateK
 	return response, trace.Wrap(err)
 }
 
+// HeadlessLoginFunc is a function used in tests to mock Headless logins.
+type HeadlessLoginFunc func(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error)
+
 func (tc *TeleportClient) headlessLogin(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error) {
+	if tc.MockHeadlessLogin != nil {
+		return tc.MockHeadlessLogin(ctx, priv)
+	}
+
 	headlessAuthenticationID := services.NewHeadlessAuthenticationID(priv.MarshalSSHPublicKey())
 
 	webUILink, err := url.JoinPath("https://"+tc.WebProxyAddr, "web", "headless", headlessAuthenticationID)

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -369,7 +369,7 @@ type Config struct {
 	MockSSOLogin SSOLoginFunc
 
 	// MockHeadlessLogin is used in tests for mocking the Headless login response.
-	MockHeadlessLogin HeadlessLoginFunc
+	MockHeadlessLogin SSHLoginFunc
 
 	// HomePath is where tsh stores profiles
 	HomePath string
@@ -3674,9 +3674,6 @@ func (tc *TeleportClient) mfaLocalLogin(ctx context.Context, priv *keys.PrivateK
 
 	return response, trace.Wrap(err)
 }
-
-// HeadlessLoginFunc is a function used in tests to mock Headless logins.
-type HeadlessLoginFunc func(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error)
 
 func (tc *TeleportClient) headlessLogin(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error) {
 	if tc.MockHeadlessLogin != nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -3342,6 +3342,9 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 			return nil, trace.BadParameter("either --headless or --auth can be specified, not both")
 		}
 		cf.AuthConnector = constants.HeadlessConnector
+		if !cf.ExplicitUsername {
+			return nil, trace.BadParameter("user must be set explicity for headless login with the --user flag or $TELEPORT_USER env variable")
+		}
 	}
 
 	if err := tryLockMemory(cf); err != nil {

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -332,7 +332,7 @@ type CLIConf struct {
 	mockSSOLogin client.SSOLoginFunc
 
 	// mockHeadlessLogin used in tests to override Headless login handler in teleport client.
-	mockHeadlessLogin client.HeadlessLoginFunc
+	mockHeadlessLogin client.SSHLoginFunc
 
 	// HomePath is where tsh stores profiles
 	HomePath string

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -331,6 +331,9 @@ type CLIConf struct {
 	// mockSSOLogin used in tests to override sso login handler in teleport client.
 	mockSSOLogin client.SSOLoginFunc
 
+	// mockHeadlessLogin used in tests to override Headless login handler in teleport client.
+	mockHeadlessLogin client.HeadlessLoginFunc
+
 	// HomePath is where tsh stores profiles
 	HomePath string
 
@@ -3343,7 +3346,7 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 		}
 		cf.AuthConnector = constants.HeadlessConnector
 		if !cf.ExplicitUsername {
-			return nil, trace.BadParameter("user must be set explicity for headless login with the --user flag or $TELEPORT_USER env variable")
+			return nil, trace.BadParameter("user must be set explicitly for headless login with the --user flag or $TELEPORT_USER env variable")
 		}
 	}
 
@@ -3495,6 +3498,7 @@ func makeClientForProxy(cf *CLIConf, proxy string, useProfileLogin bool) (*clien
 
 	// pass along mock sso login if provided (only used in tests)
 	c.MockSSOLogin = cf.mockSSOLogin
+	c.MockHeadlessLogin = cf.mockHeadlessLogin
 
 	// Set tsh home directory
 	c.HomePath = cf.HomePath

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2713,7 +2713,7 @@ func mockSSOLogin(t *testing.T, authServer *auth.Server, user types.User) client
 			Key:            priv.MarshalSSHPublicKey(),
 			Username:       user.GetName(),
 			TTL:            time.Hour,
-			Compatiblity:   constants.CertificateFormatStandard,
+			Compatibility:  constants.CertificateFormatStandard,
 			RouteToCluster: clusterName.GetClusterName(),
 		})
 		require.NoError(t, err)
@@ -2744,7 +2744,7 @@ func mockHeadlessLogin(t *testing.T, authServer *auth.Server, user types.User) c
 			Key:            priv.MarshalSSHPublicKey(),
 			Username:       user.GetName(),
 			TTL:            time.Hour,
-			Compatiblity:   constants.CertificateFormatStandard,
+			Compatibility:  constants.CertificateFormatStandard,
 			RouteToCluster: clusterName.GetClusterName(),
 			MFAVerified:    "mfa-verified",
 		})

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2735,7 +2735,7 @@ func mockSSOLogin(t *testing.T, authServer *auth.Server, user types.User) client
 	}
 }
 
-func mockHeadlessLogin(t *testing.T, authServer *auth.Server, user types.User) client.HeadlessLoginFunc {
+func mockHeadlessLogin(t *testing.T, authServer *auth.Server, user types.User) client.SSHLoginFunc {
 	return func(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error) {
 		// generate certificates for our user
 		clusterName, err := authServer.GetClusterName()
@@ -2746,7 +2746,7 @@ func mockHeadlessLogin(t *testing.T, authServer *auth.Server, user types.User) c
 			TTL:            time.Hour,
 			Compatiblity:   constants.CertificateFormatStandard,
 			RouteToCluster: clusterName.GetClusterName(),
-			MFAVerified:    true,
+			MFAVerified:    "mfa-verified",
 		})
 		require.NoError(t, err)
 

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -1745,6 +1745,114 @@ func tryCreateTrustedCluster(t *testing.T, authServer *auth.Server, trustedClust
 	require.FailNow(t, "Timeout creating trusted cluster")
 }
 
+func TestSSHHeadless(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	user, err := user.Current()
+	require.NoError(t, err)
+
+	// Headless ssh should pass session mfa requirements
+	sshLoginRole, err := types.NewRole("ssh-login", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			RequireMFAType: types.RequireMFAType_SESSION,
+		},
+		Allow: types.RoleConditions{
+			Logins:     []string{user.Username},
+			NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+	})
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"ssh-login"})
+
+	rootAuth, rootProxy := makeTestServers(t, withBootstrap(sshLoginRole, alice))
+
+	authAddr, err := rootAuth.AuthAddr()
+	require.NoError(t, err)
+
+	proxyAddr, err := rootProxy.ProxyWebAddr()
+	require.NoError(t, err)
+
+	require.NoError(t, rootAuth.GetAuthServer().SetAuthPreference(ctx, &types.AuthPreferenceV2{
+		Spec: types.AuthPreferenceSpecV2{
+			Type:         constants.Local,
+			SecondFactor: constants.SecondFactorOptional,
+			Webauthn: &types.Webauthn{
+				RPID: "127.0.0.1",
+			},
+		},
+	}))
+
+	sshHostname := "test-ssh-server"
+	node := makeTestSSHNode(t, authAddr, withHostname(sshHostname), withSSHLabel("access", "true"))
+	sshHostID := node.Config.HostUUID
+
+	hasNodes := func(hostIDs ...string) func() bool {
+		return func() bool {
+			nodes, err := rootAuth.GetAuthServer().GetNodes(ctx, apidefaults.Namespace)
+			require.NoError(t, err)
+			foundCount := 0
+			for _, node := range nodes {
+				if slices.Contains(hostIDs, node.GetName()) {
+					foundCount++
+				}
+			}
+			return foundCount == len(hostIDs)
+		}
+	}
+
+	// wait for auth to see nodes
+	require.Eventually(t, hasNodes(sshHostID), 10*time.Second, 100*time.Millisecond, "nodes never showed up")
+
+	// perform "tsh --headless ssh"
+	err = Run(ctx, []string{
+		"ssh",
+		"--insecure",
+		"--headless",
+		"--proxy", proxyAddr.String(),
+		"--user", "alice",
+		fmt.Sprintf("%s@%s", user.Username, sshHostname),
+		"echo", "test",
+	}, cliOption(func(cf *CLIConf) error {
+		cf.mockHeadlessLogin = mockHeadlessLogin(t, rootAuth.GetAuthServer(), alice)
+		return nil
+	}))
+	require.NoError(t, err)
+
+	// "tsh --auth headless ssh" should also perform headless ssh
+	err = Run(ctx, []string{
+		"ssh",
+		"--insecure",
+		"--auth", constants.HeadlessConnector,
+		"--proxy", proxyAddr.String(),
+		"--user", "alice",
+		fmt.Sprintf("%s@%s", user.Username, sshHostname),
+		"echo", "test",
+	}, cliOption(func(cf *CLIConf) error {
+		cf.mockHeadlessLogin = mockHeadlessLogin(t, rootAuth.GetAuthServer(), alice)
+		return nil
+	}))
+	require.NoError(t, err)
+
+	// headless ssh should fail if user is not set.
+	err = Run(ctx, []string{
+		"ssh",
+		"--insecure",
+		"--headless",
+		"--proxy", proxyAddr.String(),
+		fmt.Sprintf("%s@%s", user.Username, sshHostname),
+		"echo", "test",
+	}, cliOption(func(cf *CLIConf) error {
+		cf.mockHeadlessLogin = mockHeadlessLogin(t, rootAuth.GetAuthServer(), alice)
+		return nil
+	}))
+	require.Error(t, err)
+	require.ErrorIs(t, err, trace.BadParameter("user must be set explicitly for headless login with the --user flag or $TELEPORT_USER env variable"))
+}
+
 func TestFormatConnectCommand(t *testing.T) {
 	t.Parallel()
 
@@ -2601,11 +2709,45 @@ func mockSSOLogin(t *testing.T, authServer *auth.Server, user types.User) client
 		// generate certificates for our user
 		clusterName, err := authServer.GetClusterName()
 		require.NoError(t, err)
-		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(
-			priv.MarshalSSHPublicKey(), user.GetName(), time.Hour,
-			constants.CertificateFormatStandard,
-			clusterName.GetClusterName(), "",
-		)
+		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+			Key:            priv.MarshalSSHPublicKey(),
+			Username:       user.GetName(),
+			TTL:            time.Hour,
+			Compatiblity:   constants.CertificateFormatStandard,
+			RouteToCluster: clusterName.GetClusterName(),
+		})
+		require.NoError(t, err)
+
+		// load CA cert
+		authority, err := authServer.GetCertAuthority(ctx, types.CertAuthID{
+			Type:       types.HostCA,
+			DomainName: clusterName.GetClusterName(),
+		}, false)
+		require.NoError(t, err)
+
+		// build login response
+		return &auth.SSHLoginResponse{
+			Username:    user.GetName(),
+			Cert:        sshCert,
+			TLSCert:     tlsCert,
+			HostSigners: auth.AuthoritiesToTrustedCerts([]types.CertAuthority{authority}),
+		}, nil
+	}
+}
+
+func mockHeadlessLogin(t *testing.T, authServer *auth.Server, user types.User) client.HeadlessLoginFunc {
+	return func(ctx context.Context, priv *keys.PrivateKey) (*auth.SSHLoginResponse, error) {
+		// generate certificates for our user
+		clusterName, err := authServer.GetClusterName()
+		require.NoError(t, err)
+		sshCert, tlsCert, err := authServer.GenerateUserTestCerts(auth.GenerateUserTestCertsRequest{
+			Key:            priv.MarshalSSHPublicKey(),
+			Username:       user.GetName(),
+			TTL:            time.Hour,
+			Compatiblity:   constants.CertificateFormatStandard,
+			RouteToCluster: clusterName.GetClusterName(),
+			MFAVerified:    true,
+		})
 		require.NoError(t, err)
 
 		// load CA cert


### PR DESCRIPTION
Return an error if user is not explicitly set for headless login. This should help prevent users from hitting https://github.com/gravitational/teleport/issues/23436 due to their OS user being used for login by default.