### PR TITLE
helm: default to distroless images

### DIFF
--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -34,7 +34,7 @@ should add an operator side-car when operator is enabled:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -157,7 +157,7 @@ should set nodeSelector when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -244,7 +244,7 @@ should set resources when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -320,7 +320,7 @@ should set securityContext when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -406,7 +406,7 @@ should use OSS image and not mount license when enterprise is not set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --apply-on-startup=/etc/teleport/apply-on-startup.yaml
-      image: public.ecr.aws/gravitational/teleport:8.3.4
+      image: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -5,7 +5,7 @@ should provision initContainer correctly when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v12.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       name: wait-auth-update
     - args:
       - echo test
@@ -62,7 +62,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -123,7 +123,7 @@ should set nodeSelector when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v12.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       name: wait-auth-update
     nodeSelector:
       environment: security
@@ -164,7 +164,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -232,7 +232,7 @@ should set resources when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v12.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       name: wait-auth-update
     serviceAccountName: RELEASE-NAME-proxy
     terminationGracePeriodSeconds: 60
@@ -255,7 +255,7 @@ should set securityContext for initContainers when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -323,7 +323,7 @@ should set securityContext for initContainers when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v12.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false
@@ -353,7 +353,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       lifecycle:
         preStop:
@@ -421,7 +421,7 @@ should set securityContext when set in values:
       - wait
       - no-resolve
       - RELEASE-NAME-auth-v12.NAMESPACE.svc.cluster.local
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       name: wait-auth-update
       securityContext:
         allowPrivilegeEscalation: false

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -168,11 +168,11 @@ tests:
     set:
       clusterName: helm-lint.example.com
       enterprise: true
-      teleportVersionOverride: 8.3.4
+      teleportVersionOverride: 12.2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: public.ecr.aws/gravitational/teleport-ent:8.3.4
+          value: public.ecr.aws/gravitational/teleport-ent-distroless:12.2.1
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -190,11 +190,11 @@ tests:
     template: auth/deployment.yaml
     set:
       clusterName: helm-lint
-      teleportVersionOverride: 8.3.4
+      teleportVersionOverride: 12.2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: public.ecr.aws/gravitational/teleport:8.3.4
+          value: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -229,21 +229,21 @@ tests:
     set:
       clusterName: helm-lint.example.com
       enterprise: true
-      teleportVersionOverride: 8.3.4
+      teleportVersionOverride: 12.2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: public.ecr.aws/gravitational/teleport-ent:8.3.4
+          value: public.ecr.aws/gravitational/teleport-ent-distroless:12.2.1
 
   - it: should use OSS image when enterprise is not set in values
     template: proxy/deployment.yaml
     set:
       clusterName: helm-lint
-      teleportVersionOverride: 8.3.4
+      teleportVersionOverride: 12.2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: public.ecr.aws/gravitational/teleport:8.3.4
+          value: public.ecr.aws/gravitational/teleport-distroless:12.2.1
 
   - it: should mount TLS certs when cert-manager is enabled
     template: proxy/deployment.yaml

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -607,12 +607,12 @@
         "image": {
             "$id": "#/properties/image",
             "type": "string",
-            "default": "public.ecr.aws/gravitational/teleport"
+            "default": "public.ecr.aws/gravitational/teleport-distroless"
         },
         "enterpriseImage": {
             "$id": "#/properties/enterpriseImage",
             "type": "string",
-            "default": "public.ecr.aws/gravitational/teleport-ent"
+            "default": "public.ecr.aws/gravitational/teleport-ent-distroless"
         },
         "imagePullSecrets": {
             "$id": "#/properties/imagePullSecrets",

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -431,9 +431,17 @@ tls:
 ##################################################
 
 # Container image for the cluster.
-image: public.ecr.aws/gravitational/teleport
+# Since version 13, hardened distroless images are used by default.
+# You can use the deprecated debian-based images by setting the value to
+# `public.ecr.aws/gravitational/teleport`. Those images will be
+# removed with teleport 14.
+image: public.ecr.aws/gravitational/teleport-distroless
 # Enterprise version of the image
-enterpriseImage: public.ecr.aws/gravitational/teleport-ent
+# Since version 13, hardened distroless images are used by default.
+# You can use the deprecated debian-based images by setting the value to
+# `public.ecr.aws/gravitational/teleport-ent`. Those images will be
+# removed with teleport 14.
+enterpriseImage: public.ecr.aws/gravitational/teleport-ent-distroless
 # Optional array of imagePullSecrets, to use when pulling from a private registry
 imagePullSecrets: []
 # Teleport logging configuration

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -30,7 +30,7 @@ sets Deployment annotations when specified if action is Upgrade:
             env:
             - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
               value: "true"
-            image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+            image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -101,7 +101,7 @@ sets Deployment labels when specified if action is Upgrade:
           env:
           - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
             value: "true"
-          image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+          image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -159,7 +159,7 @@ sets Pod annotations when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -217,7 +217,7 @@ sets Pod labels when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -292,7 +292,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -351,7 +351,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -409,7 +409,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -465,7 +465,7 @@ should expose diag port if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -535,7 +535,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -605,7 +605,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -663,7 +663,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -721,7 +721,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -786,7 +786,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -854,7 +854,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -918,7 +918,7 @@ should provision initContainer correctly when set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1012,7 +1012,7 @@ should set SecurityContext if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1090,7 +1090,7 @@ should set affinity when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1219,7 +1219,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: "true"
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1277,7 +1277,7 @@ should set image and tag correctly if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:8.3.4
+      image: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1335,7 +1335,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1393,7 +1393,7 @@ should set nodeSelector if set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1453,7 +1453,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1523,7 +1523,7 @@ should set preferred affinity when more than one replica is used if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1581,7 +1581,7 @@ should set priorityClassName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1640,7 +1640,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1708,7 +1708,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1766,7 +1766,7 @@ should set resources when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1831,7 +1831,7 @@ should set serviceAccountName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1889,7 +1889,7 @@ should set tolerations when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/job_test.yaml.snap
@@ -13,7 +13,7 @@ should set nodeSelector in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:
@@ -43,7 +43,7 @@ should set securityContext in post-delete hook:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       name: post-delete-job
       securityContext:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -16,7 +16,7 @@ sets Pod annotations when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -84,7 +84,7 @@ sets Pod labels when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -176,7 +176,7 @@ sets StatefulSet labels when specified:
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+            image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -272,7 +272,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -340,7 +340,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -428,7 +428,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+            image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -506,7 +506,7 @@ should add volumeMount for data volume when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -574,7 +574,7 @@ should expose diag port:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -642,7 +642,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -724,7 +724,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -804,7 +804,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -872,7 +872,7 @@ should have one replica when replicaCount is not set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -940,7 +940,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1010,7 +1010,7 @@ should mount extraVolumes and extraVolumeMounts:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1085,7 +1085,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: RELEASE-NAME
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1165,7 +1165,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1241,7 +1241,7 @@ should not add emptyDir for data when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1309,7 +1309,7 @@ should provision initContainer correctly when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1413,7 +1413,7 @@ should set SecurityContext:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1501,7 +1501,7 @@ should set affinity when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1569,7 +1569,7 @@ should set default serviceAccountName when not set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1650,7 +1650,7 @@ should set environment when extraEnv set in values:
         value: RELEASE-NAME
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1718,7 +1718,7 @@ should set image and tag correctly:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:8.3.4
+      image: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1786,7 +1786,7 @@ should set imagePullPolicy when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1854,7 +1854,7 @@ should set nodeSelector if set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1936,7 +1936,7 @@ should set preferred affinity when more than one replica is used:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2004,7 +2004,7 @@ should set probeTimeoutSeconds when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2082,7 +2082,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2150,7 +2150,7 @@ should set resources when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2225,7 +2225,7 @@ should set serviceAccountName when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2293,7 +2293,7 @@ should set storage.requests when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2361,7 +2361,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2429,7 +2429,7 @@ should set tolerations when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:13.0.0-dev
+      image: public.ecr.aws/gravitational/teleport-distroless:13.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -24,7 +24,7 @@ sets the affinity:
     - args:
       - --agent-name=RELEASE-NAME
       - --agent-namespace=NAMESPACE
-      - --base-image=public.ecr.aws/gravitational/teleport
+      - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --release-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:13.0.0-dev
@@ -68,7 +68,7 @@ sets the tolerations:
     - args:
       - --agent-name=RELEASE-NAME
       - --agent-namespace=NAMESPACE
-      - --base-image=public.ecr.aws/gravitational/teleport
+      - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
       - --release-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:13.0.0-dev

--- a/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/deployment_test.yaml
@@ -275,11 +275,11 @@ tests:
       # https://github.com/helm/helm/issues/8137
       unitTestUpgrade: true
 
-      teleportVersionOverride: 8.3.4
+      teleportVersionOverride: 12.2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: public.ecr.aws/gravitational/teleport:8.3.4
+          value: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       - matchSnapshot:
           path: spec.template.spec
 

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -209,11 +209,11 @@ tests:
     values:
       - ../.lint/stateful.yaml
     set:
-      teleportVersionOverride: 8.3.4
+      teleportVersionOverride: 12.2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: public.ecr.aws/gravitational/teleport:8.3.4
+          value: public.ecr.aws/gravitational/teleport-distroless:12.2.1
       - matchSnapshot:
           path: spec.template.spec
 

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -25,11 +25,11 @@ tests:
     values:
       - ../.lint/updater.yaml
     set:
-      image: repo.example.com/gravitaional/teleport
+      image: repo.example.com/gravitaional/teleport-distroless
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--base-image=repo.example.com/gravitaional/teleport"
+          content: "--base-image=repo.example.com/gravitaional/teleport-distroless"
   - it: sets the updater base entreprise image
     values:
       - ../.lint/updater.yaml
@@ -38,7 +38,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--base-image=public.ecr.aws/gravitational/teleport-ent"
+          content: "--base-image=public.ecr.aws/gravitational/teleport-ent-distroless"
   - it: sets the updater agent name
     values:
       - ../.lint/updater.yaml
@@ -135,11 +135,11 @@ tests:
     values:
       - ../.lint/updater.yaml
     set:
-      teleportVersionOverride: 8.3.4
+      teleportVersionOverride: 12.2.1
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: public.ecr.aws/gravitational/teleport-kube-agent-updater:8.3.4
+          value: public.ecr.aws/gravitational/teleport-kube-agent-updater:12.2.1
   - it: sets the updater container imagePullPolicy
     values:
       - ../.lint/updater.yaml

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -290,7 +290,12 @@
         "image": {
             "$id": "#/properties/image",
             "type": "string",
-            "default": "public.ecr.aws/gravitational/teleport"
+            "default": "public.ecr.aws/gravitational/teleport-distroless"
+        },
+        "entrepriseImage": {
+            "$id": "#/properties/entrepriseImage",
+            "type": "string",
+            "default": "public.ecr.aws/gravitational/teleport-ent-distroless"
         },
         "imagePullSecrets": {
             "$id": "#/properties/imagePullSecrets",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -201,9 +201,17 @@ storage:
 ################################################################
 
 # Container image for the cluster.
-image: public.ecr.aws/gravitational/teleport
+# Since version 13, hardened distroless images are used by default.
+# You can use the deprecated debian-based images by setting the value to
+# `public.ecr.aws/gravitational/teleport`. Those images will be
+# removed with teleport 14.
+image: public.ecr.aws/gravitational/teleport-distroless
 # Enterprise version of the image
-enterpriseImage: public.ecr.aws/gravitational/teleport-ent
+# Since version 13, hardened distroless images are used by default.
+# You can use the deprecated debian-based images by setting the value to
+# `public.ecr.aws/gravitational/teleport-ent`. Those images will be
+# removed with teleport 14.
+enterpriseImage: public.ecr.aws/gravitational/teleport-ent-distroless
 # Optional array of imagePullSecrets, to use when pulling from a private registry
 imagePullSecrets: []
 # - name: myRegistryKeySecretName


### PR DESCRIPTION
Makes Helm default to distroless images.

This can be reverted by setting `image` or `enterpriseImage`.

I'll send a separate docs PR tomorrow because we want to merge this quickly and bundling the docs changes would likely mean bypassing the docs folks.

I have not tested the change, in theory, images are supposed to behave the same way but we might find surprises during the v13 test plan. Especially some docs might be asking users to run `bash` for example.