### PR TITLE
Use CompareAndSwap for OktaAssignments instead of lock.

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -177,6 +177,8 @@ func (o *OktaImportRuleMatchV1) CheckAndSetDefaults() error {
 type OktaAssignment interface {
 	ResourceWithLabels
 
+	// SetMetadata will set the metadata for the Okta assignment.
+	SetMetadata(metadata Metadata)
 	// GetUser will return the user that the Okta assignment actions applies to.
 	GetUser() string
 	// GetActions will return the list of actions that will be performed as part of this assignment.
@@ -199,6 +201,11 @@ func NewOktaAssignment(metadata Metadata, spec OktaAssignmentSpecV1) (OktaAssign
 		return nil, trace.Wrap(err)
 	}
 	return o, nil
+}
+
+// SetMetadata will set the metadata for the Okta assignment.
+func (o *OktaAssignmentV1) SetMetadata(metadata Metadata) {
+	o.Metadata = metadata
 }
 
 // GetUser returns the user that the actions will be applied to.

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -149,6 +149,7 @@ func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types
 			if err := currentAction.SetStatus(action.GetStatus()); err != nil {
 				return trace.Wrap(err)
 			}
+			currentAction.SetLastTransition(action.GetLastTransition())
 		}
 
 		return nil

--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -152,6 +152,8 @@ func (o *OktaService) UpdateOktaAssignment(ctx context.Context, assignment types
 			currentAction.SetLastTransition(action.GetLastTransition())
 		}
 
+		currentAssignment.SetMetadata(assignment.GetMetadata())
+
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
CompareAndSwap should be used for the OktaAssignment updates instead of a lock, as it's lighter wait and fits the intended problem better.