### PR TITLE
Fixes for teleport-kube-agent-updater

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -25,7 +25,7 @@ spec:
   {{- toYaml $updater.annotations.pod | nindent 8 }}
 {{- end }}
       labels:
-        app: {{ .Release.Name }}
+        app: {{ .Release.Name }}-updater
 {{- if $updater.extraLabels.pod }}
   {{- toYaml $updater.extraLabels.pod | nindent 8 }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -66,7 +66,7 @@ spec:
           - "--agent-namespace={{ .Release.Namespace }}"
           - "--base-image={{ include "teleport-kube-agent.baseImage" . }}"
           - "--version-server={{ $updater.versionServer }}"
-          - "--release-channel={{ $updater.releaseChannel }}"
+          - "--version-channel={{ $updater.releaseChannel }}"
 {{- if $updater.securityContext }}
         securityContext: {{- toYaml $updater.securityContext | nindent 10 }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/updater/role.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/role.yaml
@@ -36,11 +36,23 @@ rules:
   resources:
     - secrets
   verbs:
-    - get
     - watch
     - list
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+  verbs:
+    - get
   resourceNames:
     - {{ .Release.Name }}-shared-state
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
 # the controller in the updater must be able to watch deployments and
 # statefulsets and get the one it should reconcile
 - apiGroups:
@@ -64,5 +76,20 @@ rules:
     - update
   resourceNames:
     - {{ .Release.Name }}
+- apiGroups:
+    - coordination.k8s.io
+  resources:
+    - leases
+  verbs:
+    - create
+- apiGroups:
+    - coordination.k8s.io
+  resourceNames:
+    - {{ .Release.Name }}
+  resources:
+    - leases
+  verbs:
+    - get
+    - update
 {{- end -}}
 {{- end -}}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -26,7 +26,7 @@ sets the affinity:
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
-      - --release-channel=custom/preview
+      - --version-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:14.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:
@@ -70,7 +70,7 @@ sets the tolerations:
       - --agent-namespace=NAMESPACE
       - --base-image=public.ecr.aws/gravitational/teleport-distroless
       - --version-server=https://my-custom-version-server/v1
-      - --release-channel=custom/preview
+      - --version-channel=custom/preview
       image: public.ecr.aws/gravitational/teleport-kube-agent-updater:14.0.0-dev
       imagePullPolicy: IfNotPresent
       livenessProbe:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_role_test.yaml.snap
@@ -19,14 +19,26 @@ sets the correct role rules:
       - list
     - apiGroups:
       - ""
+      resources:
+      - secrets
+      verbs:
+      - watch
+      - list
+    - apiGroups:
+      - ""
       resourceNames:
       - RELEASE-NAME-shared-state
       resources:
       - secrets
       verbs:
       - get
-      - watch
-      - list
+    - apiGroups:
+      - ""
+      resources:
+      - events
+      verbs:
+      - create
+      - patch
     - apiGroups:
       - apps
       resources:
@@ -46,4 +58,19 @@ sets the correct role rules:
       - deployments
       - statefulsets
       verbs:
+      - update
+    - apiGroups:
+      - coordination.k8s.io
+      resources:
+      - leases
+      verbs:
+      - create
+    - apiGroups:
+      - coordination.k8s.io
+      resourceNames:
+      - RELEASE-NAME
+      resources:
+      - leases
+      verbs:
+      - get
       - update

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -70,7 +70,7 @@ tests:
     asserts:
       - contains:
           path: spec.template.spec.containers[0].args
-          content: "--release-channel=custom/preview"
+          content: "--version-channel=custom/preview"
   #
   # Kubernetes-related tests
   #

--- a/integrations/kube-agent-updater/DEBUG.md
+++ b/integrations/kube-agent-updater/DEBUG.md
@@ -16,7 +16,7 @@ specific cases.
   ```
 - open a new terminal, create a new temporary directory and create your new kubeconfig
   ```shell
-  export kubeconfig="$(mktemp)"
+  export KUBECONFIG="$(mktemp)"
   kubectl config set-credentials myself --username=foo
   kubectl config set-cluster local-server --server=http://localhost:8001
   kubectl config set-context default-context --cluster=local-server --user=myself

--- a/integrations/kube-agent-updater/Dockerfile
+++ b/integrations/kube-agent-updater/Dockerfile
@@ -22,7 +22,7 @@ ARG TARGETARCH
 
 # Build the program. We rely on golang's cross-compilation capabilities for multiarch building.
 RUN echo "Targeting $TARGETOS/$TARGETARCH" && \
-    GOOS=$TARGETOS GOARCH=$TARGETARCH \
+    GOOS=$TARGETOS GOARCH=$TARGETARCH CGO_ENABLED=0 \
     go build -a -o /go/bin/teleport-kube-agent-updater github.com/gravitational/teleport/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater
 
 # Create the image with the build operator on the $TARGETPLATFORM

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -32,6 +32,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	"github.com/gravitational/teleport/integrations/kube-agent-updater/pkg/controller"
@@ -169,6 +170,15 @@ func main() {
 
 	if err := statefulsetController.SetupWithManager(mgr); err != nil {
 		ctrl.Log.Error(err, "failed to setup statefulset controller, exiting")
+		os.Exit(1)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		ctrl.Log.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		ctrl.Log.Error(err, "unable to set up ready check")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Fixes issues detected during test-plan:
- `teleport-kube-agent` chart updater deployment had an invalid selector and flags
- `teleport-kube-agent-updater` was not statically built on `linux/amd64`
- the updater was lacking a bunch of RBAC rules to perform leader election, watch secrets, and send events
- the updater was answering 404 to its healthz and ready routes