### PR TITLE
Updated promotion pipelines to publish OS packages in series

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -512,7 +512,7 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -1250,7 +1250,7 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -4355,7 +4355,7 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -4636,7 +4636,7 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -6550,12 +6550,12 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
-name: publish-normal-apt-new-repos
+name: publish-os-package-repos
 trigger:
   event:
     include:
@@ -6597,7 +6597,7 @@ steps:
   - mkdir -pv "/go/vars"
   - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
     "build") > "/go/vars/release-environment.txt"
-- name: Delegate build to GitHub
+- name: Publish Teleport to stable/${DRONE_TAG} apt repo
   image: golang:1.18-alpine
   pull: if-not-exists
   commands:
@@ -6611,61 +6611,7 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: publish-normal-yum-new-repos
-trigger:
-  event:
-    include:
-    - promote
-  target:
-    include:
-    - production
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Check out code
-  image: docker:git
-  pull: if-not-exists
-  commands:
-  - mkdir -pv "/go/src/github.com/gravitational/teleport"
-  - cd "/go/src/github.com/gravitational/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "${DRONE_COMMIT_SHA}"
-  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
-    chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - mkdir -pv /go/cache
-  - rm -f /root/.ssh/id_rsa
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Determine if release should go to development or production
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
-    "build") > "/go/vars/release-environment.txt"
-- name: Delegate build to GitHub
+- name: Publish Teleport to stable/${DRONE_TAG} yum repo
   image: golang:1.18-alpine
   pull: if-not-exists
   commands:
@@ -6679,61 +6625,7 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: publish-teleport-ent-updater-apt-new-repos
-trigger:
-  event:
-    include:
-    - promote
-  target:
-    include:
-    - production
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Check out code
-  image: docker:git
-  pull: if-not-exists
-  commands:
-  - mkdir -pv "/go/src/github.com/gravitational/teleport"
-  - cd "/go/src/github.com/gravitational/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "${DRONE_COMMIT_SHA}"
-  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
-    chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - mkdir -pv /go/cache
-  - rm -f /root/.ssh/id_rsa
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Determine if release should go to development or production
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
-    "build") > "/go/vars/release-environment.txt"
-- name: Delegate build to GitHub
+- name: Publish teleport-ent-updater to stable/cloud apt repo
   image: golang:1.18-alpine
   pull: if-not-exists
   commands:
@@ -6746,61 +6638,7 @@ steps:
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: publish-teleport-ent-updater-yum-new-repos
-trigger:
-  event:
-    include:
-    - promote
-  target:
-    include:
-    - production
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Check out code
-  image: docker:git
-  pull: if-not-exists
-  commands:
-  - mkdir -pv "/go/src/github.com/gravitational/teleport"
-  - cd "/go/src/github.com/gravitational/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "${DRONE_COMMIT_SHA}"
-  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
-    chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - mkdir -pv /go/cache
-  - rm -f /root/.ssh/id_rsa
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Determine if release should go to development or production
-  image: golang:1.18-alpine
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
-    "build") > "/go/vars/release-environment.txt"
-- name: Delegate build to GitHub
+- name: Publish teleport-ent-updater to stable/cloud yum repo
   image: golang:1.18-alpine
   pull: if-not-exists
   commands:
@@ -7352,7 +7190,7 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -7411,7 +7249,7 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -8760,7 +8598,7 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -8822,7 +8660,7 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaBuildPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
@@ -20117,10 +19955,7 @@ clone:
 depends_on:
 - promote-build
 - teleport-container-images-branch-promote
-- publish-normal-apt-new-repos
-- publish-normal-yum-new-repos
-- publish-teleport-ent-updater-apt-new-repos
-- publish-teleport-ent-updater-yum-new-repos
+- publish-os-package-repos
 - promote-teleport-oci-distroless-images
 - promote-teleport-kube-agent-updater-oci-images
 steps:
@@ -20232,6 +20067,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 88c1a612809e190c5b9ebfe10e6df274532105a408af9d6583823a530598fddd
+hmac: b21082aec9ef11b00b44457d459a8f6a6d60e21cb347a6b7853ae3dfa6619cc9
 
 ...

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -23,56 +24,41 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-type ghaBuildType struct {
-	buildType
-	trigger
-	pipelineName      string
-	ghaWorkflow       string
+type ghaWorkflow struct {
+	name              string
+	stepName          string
 	srcRefVar         string
-	workflowRef       string
+	ref               string
 	timeout           time.Duration
 	slackOnError      bool
-	dependsOn         []string
 	shouldTagWorkflow bool
 	seriesRun         bool
 	inputs            map[string]string
 }
 
-func ghaBuildPipeline(b ghaBuildType) pipeline {
-	p := newKubePipeline(b.pipelineName)
-	p.Trigger = b.trigger
+type ghaBuildType struct {
+	buildType
+	trigger
+	pipelineName string
+	checkoutPath string
+	dependsOn    []string
+	workflows    []ghaWorkflow
+}
+
+func ghaBuildPipeline(ghaBuild ghaBuildType) pipeline {
+	return ghaMultiBuildPipeline(nil, ghaBuild)
+}
+
+// ghaMultiBuildPipeline returns a pipeline with multiple supported workflow call steps
+func ghaMultiBuildPipeline(setupSteps []step, ghaBuild ghaBuildType) pipeline {
+	p := newKubePipeline(ghaBuild.pipelineName)
+	p.Trigger = ghaBuild.trigger
 	p.Workspace = workspace{Path: "/go"}
-	p.DependsOn = append(p.DependsOn, b.dependsOn...)
+	p.DependsOn = append(p.DependsOn, ghaBuild.dependsOn...)
 
-	var cmd strings.Builder
-	cmd.WriteString(`go run ./cmd/gh-trigger-workflow `)
-	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
-	cmd.WriteString(`-repo teleport.e `)
-
-	if b.shouldTagWorkflow {
-		cmd.WriteString(`-tag-workflow `)
-	}
-
-	if b.seriesRun {
-		cmd.WriteString(`-series-run `)
-	}
-
-	fmt.Fprintf(&cmd, `-timeout %s `, b.timeout.String())
-	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
-	fmt.Fprintf(&cmd, `-workflow-ref=%s `, b.workflowRef)
-
-	// If we don't need to build teleport...
-	if b.srcRefVar != "" {
-		cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
-		fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
-	}
-
-	// Sort inputs so the are output in a consistent order to avoid
-	// spurious changes in the generated drone config.
-	keys := maps.Keys(b.inputs)
-	sort.Strings(keys)
-	for _, k := range keys {
-		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, b.inputs[k])
+	checkoutPath := ghaBuild.checkoutPath
+	if checkoutPath == "" {
+		checkoutPath = "/go/src/github.com/gravitational/teleport"
 	}
 
 	p.Steps = []step{
@@ -83,25 +69,70 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 			Environment: map[string]value{
 				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
 			},
-			Commands: pushCheckoutCommands(b.buildType),
-		},
-		{
-			Name:  "Delegate build to GitHub",
-			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
-			Pull:  "if-not-exists",
-			Environment: map[string]value{
-				"GHA_APP_KEY": {fromSecret: "GITHUB_WORKFLOW_APP_PRIVATE_KEY"},
-			},
-			Commands: []string{
-				`cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"`,
-				cmd.String(),
-			},
+			Commands: pushCheckoutCommandsWithPath(ghaBuild.buildType, checkoutPath),
 		},
 	}
 
-	if b.slackOnError {
-		p.Steps = append(p.Steps, sendErrorToSlackStep())
+	p.Steps = append(p.Steps, setupSteps...)
+
+	for _, workflow := range ghaBuild.workflows {
+		p.Steps = append(p.Steps, buildGHAWorkflowCallStep(workflow, checkoutPath))
+
+		if workflow.slackOnError {
+			p.Steps = append(p.Steps, sendErrorToSlackStep())
+		}
 	}
 
 	return p
+}
+
+func buildGHAWorkflowCallStep(workflow ghaWorkflow, checkoutPath string) step {
+	var cmd strings.Builder
+	cmd.WriteString(`go run ./cmd/gh-trigger-workflow `)
+	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
+	cmd.WriteString(`-repo teleport.e `)
+
+	if workflow.shouldTagWorkflow {
+		cmd.WriteString(`-tag-workflow `)
+	}
+
+	if workflow.seriesRun {
+		cmd.WriteString(`-series-run `)
+	}
+
+	fmt.Fprintf(&cmd, `-timeout %s `, workflow.timeout.String())
+	fmt.Fprintf(&cmd, `-workflow %s `, workflow.name)
+	fmt.Fprintf(&cmd, `-workflow-ref=%s `, workflow.ref)
+
+	// If we don't need to build teleport...
+	if workflow.srcRefVar != "" {
+		cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
+		fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, workflow.srcRefVar)
+	}
+
+	// Sort inputs so the are output in a consistent order to avoid
+	// spurious changes in the generated drone config.
+	keys := maps.Keys(workflow.inputs)
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, workflow.inputs[k])
+	}
+
+	stepName := workflow.stepName
+	if stepName == "" {
+		stepName = "Delegate build to GitHub"
+	}
+
+	return step{
+		Name:  stepName,
+		Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
+		Pull:  "if-not-exists",
+		Environment: map[string]value{
+			"GHA_APP_KEY": {fromSecret: "GITHUB_WORKFLOW_APP_PRIVATE_KEY"},
+		},
+		Commands: []string{
+			fmt.Sprintf(`cd %q`, path.Join(checkoutPath, "build.assets", "tooling")),
+			cmd.String(),
+		},
+	}
 }

--- a/dronegen/mac_gha.go
+++ b/dronegen/mac_gha.go
@@ -25,18 +25,22 @@ import "time"
 // These build assets are signed and notarized.
 func darwinTagPipelineGHA() pipeline {
 	bt := ghaBuildType{
-		buildType:         buildType{os: "darwin", arch: "amd64"},
-		trigger:           triggerTag,
-		pipelineName:      "build-darwin-amd64",
-		ghaWorkflow:       "release-mac-amd64.yaml",
-		srcRefVar:         "DRONE_TAG",
-		workflowRef:       "${DRONE_TAG}",
-		timeout:           60 * time.Minute,
-		slackOnError:      true,
-		shouldTagWorkflow: true,
-		inputs: map[string]string{
-			"release-artifacts": "true",
-			"build-packages":    "true",
+		buildType:    buildType{os: "darwin", arch: "amd64"},
+		trigger:      triggerTag,
+		pipelineName: "build-darwin-amd64",
+		workflows: []ghaWorkflow{
+			{
+				name:              "release-mac-amd64.yaml",
+				srcRefVar:         "DRONE_TAG",
+				ref:               "${DRONE_TAG}",
+				timeout:           60 * time.Minute,
+				slackOnError:      true,
+				shouldTagWorkflow: true,
+				inputs: map[string]string{
+					"release-artifacts": "true",
+					"build-packages":    "true",
+				},
+			},
 		},
 	}
 	return ghaBuildPipeline(bt)
@@ -49,18 +53,22 @@ func darwinTagPipelineGHA() pipeline {
 // release time to discover breakage.
 func darwinPushPipelineGHA() pipeline {
 	bt := ghaBuildType{
-		buildType:         buildType{os: "darwin", arch: "amd64"},
-		trigger:           triggerPush,
-		pipelineName:      "push-build-darwin-amd64",
-		ghaWorkflow:       "release-mac-amd64.yaml",
-		srcRefVar:         "DRONE_COMMIT",
-		workflowRef:       "${DRONE_BRANCH}",
-		timeout:           60 * time.Minute,
-		slackOnError:      true,
-		shouldTagWorkflow: true,
-		inputs: map[string]string{
-			"release-artifacts": "false",
-			"build-packages":    "false",
+		buildType:    buildType{os: "darwin", arch: "amd64"},
+		trigger:      triggerPush,
+		pipelineName: "push-build-darwin-amd64",
+		workflows: []ghaWorkflow{
+			{
+				name:              "release-mac-amd64.yaml",
+				srcRefVar:         "DRONE_COMMIT",
+				ref:               "${DRONE_BRANCH}",
+				timeout:           60 * time.Minute,
+				slackOnError:      true,
+				shouldTagWorkflow: true,
+				inputs: map[string]string{
+					"release-artifacts": "false",
+					"build-packages":    "false",
+				},
+			},
 		},
 	}
 	return ghaBuildPipeline(bt)

--- a/dronegen/main.go
+++ b/dronegen/main.go
@@ -32,7 +32,6 @@ func main() {
 	pipelines = append(pipelines, pushPipelines()...)
 	pipelines = append(pipelines, tagPipelines()...)
 	pipelines = append(pipelines, cronPipelines()...)
-	pipelines = append(pipelines, buildOsRepoPipelines()...)
 	pipelines = append(pipelines, promoteBuildPipelines()...)
 	pipelines = append(pipelines, updateDocsPipeline())
 	pipelines = append(pipelines, buildboxPipeline())

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -20,61 +20,44 @@ import (
 	"time"
 )
 
-func buildOsRepoPipelines() []pipeline {
-	pipelines := promoteBuildOsRepoPipelines()
-
-	return pipelines
+type osPackageDeployment struct {
+	versionChannel    string
+	packageNameFilter string
+	packageToTest     string
+	displayName       string
 }
 
-func promoteBuildOsRepoPipelines() []pipeline {
-	pipelines := []pipeline{}
-
-	// Normal release pipelines
-	pipelines = append(pipelines, buildPromoteOsPackagePipelines("${DRONE_TAG}", `$($DRONE_REPO_PRIVATE && echo "*ent*" || echo "")`, "normal", "teleport-ent")...)
-
-	// teleport-ent-updater to stable/cloud only pipelines
-	pipelines = append(pipelines, buildPromoteOsPackagePipelines("cloud", "teleport-ent-updater*", "teleport-ent-updater", "")...)
-
-	return pipelines
-}
-
-func buildPromoteOsPackagePipelines(versionChannel, packageNameFilter, pipelineNameSuffix, packageToTest string) []pipeline {
-	return []pipeline{
-		buildPromoteOsPackagePipeline("apt", versionChannel, packageNameFilter, pipelineNameSuffix, packageToTest),
-		buildPromoteOsPackagePipeline("yum", versionChannel, packageNameFilter, pipelineNameSuffix, packageToTest),
+func promoteBuildOsRepoPipeline() pipeline {
+	packageDeployments := []osPackageDeployment{
+		// Normal release pipelines
+		{
+			versionChannel:    "${DRONE_TAG}",
+			packageNameFilter: `$($DRONE_REPO_PRIVATE && echo "*ent*" || echo "")`,
+			packageToTest:     "teleport-ent",
+			displayName:       "Teleport",
+		},
+		// teleport-ent-updater to stable/cloud only pipelines
+		{
+			versionChannel:    "cloud",
+			packageNameFilter: `teleport-ent-updater*`,
+			displayName:       "teleport-ent-updater",
+		},
 	}
+
+	return buildPromoteOsPackagePipelines(packageDeployments)
 }
 
-func buildPromoteOsPackagePipeline(repoType, versionChannel, packageNameFilter, pipelineNameSuffix, packageToTest string) pipeline {
+func buildPromoteOsPackagePipelines(packageDeployments []osPackageDeployment) pipeline {
 	releaseEnvironmentFilePath := "/go/vars/release-environment.txt"
 	clonePath := "/go/src/github.com/gravitational/teleport"
 
-	inputs := map[string]string{
-		"repo-type":           repoType,
-		"environment":         fmt.Sprintf("$(cat %q)", releaseEnvironmentFilePath),
-		"artifact-tag":        "${DRONE_TAG}",
-		"release-channel":     "stable",
-		"version-channel":     versionChannel,
-		"package-name-filter": packageNameFilter,
+	ghaBuild := ghaBuildType{
+		trigger:      triggerPromote,
+		pipelineName: "publish-os-package-repos",
+		checkoutPath: clonePath,
+		workflows:    buildWorkflows(releaseEnvironmentFilePath, packageDeployments),
 	}
-
-	if packageToTest != "" {
-		inputs["package-to-test"] = packageToTest
-	}
-
-	pipeline := ghaBuildPipeline(ghaBuildType{
-		trigger:           triggerPromote,
-		pipelineName:      fmt.Sprintf("publish-%s-%s-new-repos", pipelineNameSuffix, repoType),
-		ghaWorkflow:       "deploy-packages.yaml",
-		timeout:           12 * time.Hour, // DR takes a long time
-		workflowRef:       "refs/heads/master",
-		shouldTagWorkflow: true,
-		seriesRun:         true,
-		inputs:            inputs,
-	})
-
-	pipeline.Steps = []step{
-		pipeline.Steps[0],
+	setupSteps := []step{
 		{
 			Name:  "Determine if release should go to development or production",
 			Image: fmt.Sprintf("golang:%s-alpine", GoVersion),
@@ -84,8 +67,40 @@ func buildPromoteOsPackagePipeline(repoType, versionChannel, packageNameFilter, 
 				fmt.Sprintf(`(go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo "build") > %q`, releaseEnvironmentFilePath),
 			},
 		},
-		pipeline.Steps[1],
 	}
 
-	return pipeline
+	return ghaMultiBuildPipeline(setupSteps, ghaBuild)
+}
+
+func buildWorkflows(releaseEnvironmentFilePath string, packageDeployments []osPackageDeployment) []ghaWorkflow {
+	repoTypes := []string{"apt", "yum"}
+	workflows := make([]ghaWorkflow, 0, len(repoTypes)*len(packageDeployments))
+	for _, packageDeployment := range packageDeployments {
+		for _, repoType := range repoTypes {
+			inputs := map[string]string{
+				"repo-type":           repoType,
+				"environment":         fmt.Sprintf("$(cat %q)", releaseEnvironmentFilePath),
+				"artifact-tag":        "${DRONE_TAG}",
+				"release-channel":     "stable",
+				"version-channel":     packageDeployment.versionChannel,
+				"package-name-filter": packageDeployment.packageNameFilter,
+			}
+
+			if packageDeployment.packageToTest != "" {
+				inputs["package-to-test"] = packageDeployment.packageToTest
+			}
+
+			workflows = append(workflows, ghaWorkflow{
+				stepName:          fmt.Sprintf("Publish %s to stable/%s %s repo", packageDeployment.displayName, packageDeployment.versionChannel, repoType),
+				name:              "deploy-packages.yaml",
+				ref:               "refs/heads/master",
+				timeout:           12 * time.Hour, // DR takes a long time
+				shouldTagWorkflow: true,
+				seriesRun:         true,
+				inputs:            inputs,
+			})
+		}
+	}
+
+	return workflows
 }

--- a/dronegen/promote.go
+++ b/dronegen/promote.go
@@ -18,18 +18,22 @@ import "time"
 
 func promoteBuildPipelines() []pipeline {
 	promotePipelines := make([]pipeline, 0)
-	promotePipelines = append(promotePipelines, promoteBuildOsRepoPipelines()...)
+	promotePipelines = append(promotePipelines, promoteBuildOsRepoPipeline())
 
 	ociPipeline := ghaBuildPipeline(ghaBuildType{
-		buildType:         buildType{os: "linux", fips: false},
-		trigger:           triggerPromote,
-		pipelineName:      "promote-teleport-oci-distroless-images",
-		ghaWorkflow:       "promote-teleport-oci-distroless.yml",
-		timeout:           60 * time.Minute,
-		workflowRef:       "${DRONE_TAG}",
-		shouldTagWorkflow: true,
-		inputs: map[string]string{
-			"release-source-tag": "${DRONE_TAG}",
+		buildType:    buildType{os: "linux", fips: false},
+		trigger:      triggerPromote,
+		pipelineName: "promote-teleport-oci-distroless-images",
+		workflows: []ghaWorkflow{
+			{
+				name:              "promote-teleport-oci-distroless.yml",
+				timeout:           60 * time.Minute,
+				ref:               "${DRONE_TAG}",
+				shouldTagWorkflow: true,
+				inputs: map[string]string{
+					"release-source-tag": "${DRONE_TAG}",
+				},
+			},
 		},
 	})
 	ociPipeline.Trigger.Target.Include = append(ociPipeline.Trigger.Target.Include, "promote-distroless")
@@ -37,15 +41,19 @@ func promoteBuildPipelines() []pipeline {
 	promotePipelines = append(promotePipelines, ociPipeline)
 
 	updaterPipeline := ghaBuildPipeline(ghaBuildType{
-		buildType:         buildType{os: "linux", fips: false},
-		trigger:           triggerPromote,
-		pipelineName:      "promote-teleport-kube-agent-updater-oci-images",
-		ghaWorkflow:       "promote-teleport-kube-agent-updater-oci.yml",
-		timeout:           60 * time.Minute,
-		workflowRef:       "${DRONE_TAG}",
-		shouldTagWorkflow: true,
-		inputs: map[string]string{
-			"release-source-tag": "${DRONE_TAG}",
+		buildType:    buildType{os: "linux", fips: false},
+		trigger:      triggerPromote,
+		pipelineName: "promote-teleport-kube-agent-updater-oci-images",
+		workflows: []ghaWorkflow{
+			{
+				name:              "promote-teleport-kube-agent-updater-oci.yml",
+				timeout:           60 * time.Minute,
+				ref:               "${DRONE_TAG}",
+				shouldTagWorkflow: true,
+				inputs: map[string]string{
+					"release-source-tag": "${DRONE_TAG}",
+				},
+			},
 		},
 	})
 	updaterPipeline.Trigger.Target.Include = append(updaterPipeline.Trigger.Target.Include, "promote-updater")

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -21,10 +21,12 @@ import (
 
 // pushCheckoutCommands builds a list of commands for Drone to check out a git commit on a push build
 func pushCheckoutCommands(b buildType) []string {
-	cloneDirectory := "/go/src/github.com/gravitational/teleport"
+	return pushCheckoutCommandsWithPath(b, "/go/src/github.com/gravitational/teleport")
+}
 
+func pushCheckoutCommandsWithPath(b buildType, checkoutPath string) []string {
 	var commands []string
-	commands = append(commands, cloneRepoCommands(cloneDirectory, "${DRONE_COMMIT_SHA}")...)
+	commands = append(commands, cloneRepoCommands(checkoutPath, "${DRONE_COMMIT_SHA}")...)
 	commands = append(commands,
 		`mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa`,
 		`ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts`,
@@ -75,16 +77,20 @@ func pushPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:         buildType{os: "linux", arch: "arm64"},
-		trigger:           triggerPush,
-		pipelineName:      "push-build-linux-arm64",
-		ghaWorkflow:       "release-linux-arm64.yml",
-		timeout:           60 * time.Minute,
-		slackOnError:      true,
-		srcRefVar:         "DRONE_COMMIT",
-		workflowRef:       "${DRONE_BRANCH}",
-		shouldTagWorkflow: true,
-		inputs:            map[string]string{"upload-artifacts": "false"},
+		buildType:    buildType{os: "linux", arch: "arm64"},
+		trigger:      triggerPush,
+		pipelineName: "push-build-linux-arm64",
+		workflows: []ghaWorkflow{
+			{
+				name:              "release-linux-arm64.yml",
+				timeout:           60 * time.Minute,
+				slackOnError:      true,
+				srcRefVar:         "DRONE_COMMIT",
+				ref:               "${DRONE_BRANCH}",
+				shouldTagWorkflow: true,
+				inputs:            map[string]string{"upload-artifacts": "false"},
+			},
+		},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -190,43 +190,55 @@ func tagPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:         buildType{os: "linux", arch: "arm64", fips: false},
-		trigger:           triggerTag,
-		pipelineName:      "build-linux-arm64",
-		ghaWorkflow:       "release-linux-arm64.yml",
-		srcRefVar:         "DRONE_TAG",
-		workflowRef:       "${DRONE_TAG}",
-		timeout:           60 * time.Minute,
-		dependsOn:         []string{tagCleanupPipelineName},
-		shouldTagWorkflow: true,
-		inputs:            map[string]string{"upload-artifacts": "true"},
+		buildType:    buildType{os: "linux", arch: "arm64", fips: false},
+		trigger:      triggerTag,
+		pipelineName: "build-linux-arm64",
+		dependsOn:    []string{tagCleanupPipelineName},
+		workflows: []ghaWorkflow{
+			{
+				name:              "release-linux-arm64.yml",
+				srcRefVar:         "DRONE_TAG",
+				ref:               "${DRONE_TAG}",
+				timeout:           60 * time.Minute,
+				shouldTagWorkflow: true,
+				inputs:            map[string]string{"upload-artifacts": "true"},
+			},
+		},
 	}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:         buildType{os: "linux", fips: false},
-		trigger:           triggerTag,
-		pipelineName:      "build-teleport-oci-distroless-images",
-		ghaWorkflow:       "release-teleport-oci-distroless.yml",
-		srcRefVar:         "DRONE_TAG",
-		workflowRef:       "${DRONE_TAG}",
-		timeout:           60 * time.Minute,
-		shouldTagWorkflow: true,
+		buildType:    buildType{os: "linux", fips: false},
+		trigger:      triggerTag,
+		pipelineName: "build-teleport-oci-distroless-images",
 		dependsOn: []string{
 			tagCleanupPipelineName,
 			"build-linux-amd64-deb",
 			"build-linux-arm64-deb",
 		},
+		workflows: []ghaWorkflow{
+			{
+				name:              "release-teleport-oci-distroless.yml",
+				srcRefVar:         "DRONE_TAG",
+				ref:               "${DRONE_TAG}",
+				timeout:           60 * time.Minute,
+				shouldTagWorkflow: true,
+			},
+		},
 	}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:         buildType{os: "linux", fips: false},
-		trigger:           triggerTag,
-		pipelineName:      "build-teleport-kube-agent-updater-oci-images",
-		ghaWorkflow:       "release-teleport-kube-agent-updater-oci.yml",
-		srcRefVar:         "DRONE_TAG",
-		workflowRef:       "${DRONE_TAG}",
-		timeout:           60 * time.Minute,
-		shouldTagWorkflow: true,
+		buildType:    buildType{os: "linux", fips: false},
+		trigger:      triggerTag,
+		pipelineName: "build-teleport-kube-agent-updater-oci-images",
+		workflows: []ghaWorkflow{
+			{
+				name:              "release-teleport-kube-agent-updater-oci.yml",
+				srcRefVar:         "DRONE_TAG",
+				ref:               "${DRONE_TAG}",
+				timeout:           60 * time.Minute,
+				shouldTagWorkflow: true,
+			},
+		},
 	}))
 
 	// Only amd64 Windows is supported for now.


### PR DESCRIPTION
Currently promotion builds are failing due to an issue with Github where certain workflows can be canceled under specific concurrent conditions. This fixes the issue by triggering the workflow runs in series.