### PR TITLE
docs: Add warning about TLS multiplexing to Kubernetes IAM joining

### DIFF
--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -14,6 +14,14 @@ Once the Kubernetes cluster is registered for the first time, the agent will sto
 its Teleport identity in a Kubernetes secret. The agent will use this identity
 to automatically join the cluster on subsequent restarts.
 
+<Notice type="warning" scope={["oss", "enterprise"]}>
+
+The IAM join method will not work if TLS is terminated at a load balancer in
+front of your Teleport Proxy Service unless the service using this method is
+connecting directly to the Auth Service.
+
+</Notice>
+
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)


### PR DESCRIPTION
The node IAM joining guide has a nice big yellow warning stating that it won't work unless TLS multiplexing is enabled, which saves people from wasting time trying to set it up in environments where this isn't the case.

This PR adds the same notice to the Kubernetes IAM joining guide, whose only current warning is one tiny line in the prerequisites.