### PR TITLE
Provide an error message when no db is given or detected for tsh db connect

### DIFF
--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -779,6 +779,8 @@ func onDatabaseConnect(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
+ 
+
 	route, database, err := getDatabaseInfo(cf, tc, cf.DatabaseService)
 	if err != nil {
 		return trace.Wrap(err)
@@ -850,6 +852,10 @@ func getDatabaseInfo(cf *CLIConf, tc *client.TeleportClient, dbName string) (*tl
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, nil, trace.Wrap(err)
 	}
+  if dbName == "" {
+    return nil, nil, trace.NotFound(
+         "No database name given or detected. Provide a database name as an argument or use 'tsh db login [<flags>] <db>' prior to attempting to connect")
+   }
 	db, err := getDatabase(cf, tc, dbName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -779,7 +779,6 @@ func onDatabaseConnect(cf *CLIConf) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
- 
 
 	route, database, err := getDatabaseInfo(cf, tc, cf.DatabaseService)
 	if err != nil {
@@ -852,10 +851,10 @@ func getDatabaseInfo(cf *CLIConf, tc *client.TeleportClient, dbName string) (*tl
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, nil, trace.Wrap(err)
 	}
-  if dbName == "" {
-    return nil, nil, trace.NotFound(
-         "No database name given or detected. Provide a database name as an argument or use 'tsh db login [<flags>] <db>' prior to attempting to connect")
-   }
+	if dbName == "" {
+		return nil, nil, trace.NotFound(
+			"No database name given or detected. Provide a database name as an argument\n       or use 'tsh db login [<flags>] <db>' prior to attempting to connect")
+	}
 	db, err := getDatabase(cf, tc, dbName)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/tool/tsh/db.go
+++ b/tool/tsh/db.go
@@ -853,7 +853,7 @@ func getDatabaseInfo(cf *CLIConf, tc *client.TeleportClient, dbName string) (*tl
 	}
 	if dbName == "" {
 		return nil, nil, trace.NotFound(
-			"No database name given or detected. Provide a database name as an argument\n       or use 'tsh db login [<flags>] <db>' prior to attempting to connect")
+			"No database given or detected. Provide a database as an argument\n       or use 'tsh db login [<flags>] <db>' prior to attempting to connect")
 	}
 	db, err := getDatabase(cf, tc, dbName)
 	if err != nil {


### PR DESCRIPTION
If a user types `tsh db connect` with no db logged already logged in they get an error on an empty database not found.

```bash
ERROR: database "" not found, use 'tsh db ls' to see registered databases
```
Updated to:

```bash
ERROR: No database given or detected. Provide a database as an argument
       or use 'tsh db login [<flags>] <db>' prior to attempting to connect
```

