### PR TITLE
[v13] Acquire user certs from root cluster during web file transfers

### DIFF
--- a/lib/web/files.go
+++ b/lib/web/files.go
@@ -222,7 +222,8 @@ func (f *fileTransfer) issueSingleUseCert(webauthn string, httpReq *http.Request
 		return trace.Wrap(err)
 	}
 
-	cert, err := f.authClient.GenerateUserCerts(httpReq.Context(), proto.UserCertsRequest{
+	// Always acquire certs from the root cluster, that is where both the user and their devices are registered.
+	cert, err := f.sctx.cfg.RootClient.GenerateUserCerts(httpReq.Context(), proto.UserCertsRequest{
 		PublicKey: key.MarshalSSHPublicKey(),
 		Username:  f.sctx.GetUser(),
 		Expires:   time.Now().Add(time.Minute).UTC(),


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/24765/