### PR TITLE
headless rysnc fix

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3646,7 +3646,7 @@ func (tc *TeleportClient) headlessLogin(ctx context.Context, priv *keys.PrivateK
 
 	tshApprove := fmt.Sprintf("tsh headless approve --user=%v --proxy=%v %v", tc.Username, tc.WebProxyAddr, headlessAuthenticationID)
 
-	fmt.Fprintf(tc.Stdout, "Complete headless authentication in your local web browser:\n\n%s\n"+
+	fmt.Fprintf(tc.Stderr, "Complete headless authentication in your local web browser:\n\n%s\n"+
 		"\nor execute this command in your local terminal:\n\n%s\n", webUILink, tshApprove)
 
 	response, err := SSHAgentHeadlessLogin(ctx, SSHLoginHeadless{


### PR DESCRIPTION
Use Stderr during headless login to fix `rsync --rsh` compatibility.

Closes https://github.com/gravitational/teleport/issues/24810