### PR TITLE
Isolate windows toolchain download locations

### DIFF
--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -90,7 +90,7 @@ function Install-Go {
     )
     begin {
         $GoDownloadUrl = "https://go.dev/dl/go$GoVersion.windows-amd64.zip"
-        $GoInstallZip = "go$GoVersion.windows-amd64.zip"
+        $GoInstallZip = "$ToolchainDir/go$GoVersion.windows-amd64.zip"
         Invoke-WebRequest -Uri $GoDownloadUrl -OutFile $GoInstallZip
         Expand-Archive -Path $GoInstallZip -DestinationPath $ToolchainDir
         Enable-Go -ToolchainDir $ToolchainDir
@@ -117,14 +117,14 @@ function Install-Node {
     <#
     .SYNOPSIS
         Downloads ands installs Node into the supplied toolchain dir
-    #>
+    #>`
     [CmdletBinding()]
     param(
         [string] $ToolchainDir,
         [string] $NodeVersion
     )
     begin {
-        $NodeZipfile = "node-$NodeVersion-win-x64.zip"
+        $NodeZipfile = "$ToolchainDir/node-$NodeVersion-win-x64.zip"
         Invoke-WebRequest -Uri https://nodejs.org/download/release/v$NodeVersion/node-v$NodeVersion-win-x64.zip -OutFile $NodeZipfile
         Expand-Archive -Path $NodeZipfile -DestinationPath $ToolchainDir
         Rename-Item -Path "$ToolchainDir/node-v$NodeVersion-win-x64" -NewName "$ToolchainDir/node"

--- a/build.assets/windows/build.ps1
+++ b/build.assets/windows/build.ps1
@@ -117,7 +117,7 @@ function Install-Node {
     <#
     .SYNOPSIS
         Downloads ands installs Node into the supplied toolchain dir
-    #>`
+    #>
     [CmdletBinding()]
     param(
         [string] $ToolchainDir,


### PR DESCRIPTION
There is a possible race condition when two jobs install Node or Go at the smae time on a Windows runner. 

This patch forcibly isolates the download location to a given pipeline execution, so that jobs can no longer stomp on each others downloads.