### PR TITLE
[v11] Backport dronegen changes for GitHub Actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1362,7 +1362,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
+    -tag-workflow -timeout 1h0m0s -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
     -input "upload-artifacts=false" '
   environment:
@@ -5322,8 +5322,9 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG} -input
-    oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input "upload-artifacts=true" '
+    -tag-workflow -timeout 1h0m0s -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "upload-artifacts=true" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -20284,6 +20285,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 045a5ebf373b9471ba92e45571e9f749550a20b5cd11520b89fc3ce5266e9e7b
+hmac: b797d960837073d77869974db84306e894dc81b4a8cde6e24fdb7056eb15a65e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1319,11 +1319,6 @@ image_pull_secrets:
 kind: pipeline
 type: kubernetes
 name: push-build-linux-arm64
-environment:
-  BUILDBOX_VERSION: teleport11
-  GID: "1000"
-  RUNTIME: go1.20.3
-  UID: "1000"
 trigger:
   event:
     include:
@@ -1366,9 +1361,10 @@ steps:
   pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
-    release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input upload-artifacts=false -input oss-teleport-repo="${DRONE_REPO}"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "upload-artifacts=false" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -5284,11 +5280,6 @@ image_pull_secrets:
 kind: pipeline
 type: kubernetes
 name: build-linux-arm64
-environment:
-  BUILDBOX_VERSION: teleport11
-  GID: "1000"
-  RUNTIME: go1.20.3
-  UID: "1000"
 trigger:
   event:
     include:
@@ -5303,6 +5294,8 @@ workspace:
   path: /go
 clone:
   disable: true
+depends_on:
+- clean-up-previous-build
 steps:
 - name: Check out code
   image: docker:git
@@ -5328,9 +5321,9 @@ steps:
   pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
-    release-linux-arm64.yml -workflow-ref=${DRONE_TAG} -input oss-teleport-ref=${DRONE_TAG}
-    -input upload-artifacts=true -input oss-teleport-repo="${DRONE_REPO}"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG} -input
+    oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input "upload-artifacts=true" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -20291,6 +20284,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 5f920d6511d5e89e2bfa788d11b42a8db5b3f6f5c98500b137b6fba4d1ab03ee
+hmac: 045a5ebf373b9471ba92e45571e9f749550a20b5cd11520b89fc3ce5266e9e7b
 
 ...

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type ghaBuildType struct {
@@ -26,6 +27,7 @@ type ghaBuildType struct {
 	ghaWorkflow  string
 	srcRefVar    string
 	workflowRef  string
+	timeout      time.Duration
 	slackOnError bool
 	dependsOn    []string
 	inputs       map[string]string
@@ -42,6 +44,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
 	cmd.WriteString(`-repo teleport.e `)
 	cmd.WriteString(`-tag-workflow `)
+	fmt.Fprintf(&cmd, `-timeout %s `, b.timeout.String())
 	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
 	fmt.Fprintf(&cmd, `-workflow-ref=%s `, b.workflowRef)
 

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -22,13 +22,13 @@ import (
 type ghaBuildType struct {
 	buildType
 	trigger
-	pipelineName   string
-	ghaWorkflow    string
-	srcRefVar      string
-	workflowRefVar string
-	slackOnError   bool
-	dependsOn      []string
-	inputs         map[string]string
+	pipelineName string
+	ghaWorkflow  string
+	srcRefVar    string
+	workflowRef  string
+	slackOnError bool
+	dependsOn    []string
+	inputs       map[string]string
 }
 
 func ghaBuildPipeline(b ghaBuildType) pipeline {
@@ -43,10 +43,13 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 	cmd.WriteString(`-repo teleport.e `)
 	cmd.WriteString(`-tag-workflow `)
 	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
-	fmt.Fprintf(&cmd, `-workflow-ref=${%s} `, b.workflowRefVar)
+	fmt.Fprintf(&cmd, `-workflow-ref=%s `, b.workflowRef)
 
-	cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
-	fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
+	// If we don't need to build teleport...
+	if b.srcRefVar != "" {
+		cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
+		fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
+	}
 
 	for k, v := range b.inputs {
 		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, v)

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -14,27 +14,42 @@
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type ghaBuildType struct {
 	buildType
 	trigger
-	namePrefix      string
-	uploadArtifacts bool
-	srcRefVar       string
-	workflowRefVar  string
-	slackOnError    bool
+	pipelineName   string
+	ghaWorkflow    string
+	srcRefVar      string
+	workflowRefVar string
+	slackOnError   bool
+	dependsOn      []string
+	inputs         map[string]string
 }
 
 func ghaBuildPipeline(b ghaBuildType) pipeline {
-	p := newKubePipeline(fmt.Sprintf("%sbuild-%s-%s", b.namePrefix, b.os, b.arch))
+	p := newKubePipeline(b.pipelineName)
 	p.Trigger = b.trigger
 	p.Workspace = workspace{Path: "/go"}
-	p.Environment = map[string]value{
-		"BUILDBOX_VERSION": buildboxVersion,
-		"RUNTIME":          goRuntime,
-		"UID":              {raw: "1000"},
-		"GID":              {raw: "1000"},
+	p.DependsOn = append(p.DependsOn, b.dependsOn...)
+
+	var cmd strings.Builder
+	cmd.WriteString(`go run ./cmd/gh-trigger-workflow `)
+	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
+	cmd.WriteString(`-repo teleport.e `)
+	cmd.WriteString(`-tag-workflow `)
+	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
+	fmt.Fprintf(&cmd, `-workflow-ref=${%s} `, b.workflowRefVar)
+
+	cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
+	fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
+
+	for k, v := range b.inputs {
+		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, v)
 	}
 
 	p.Steps = []step{
@@ -56,11 +71,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 			},
 			Commands: []string{
 				`cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"`,
-				`go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow release-linux-arm64.yml ` +
-					fmt.Sprintf(`-workflow-ref=${%s} `, b.workflowRefVar) +
-					fmt.Sprintf(`-input oss-teleport-ref=${%s} `, b.srcRefVar) +
-					fmt.Sprintf(`-input upload-artifacts=%t `, b.uploadArtifacts) +
-					`-input oss-teleport-repo="${DRONE_REPO}"`,
+				cmd.String(),
 			},
 		},
 	}

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -14,7 +14,10 @@
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // pushCheckoutCommands builds a list of commands for Drone to check out a git commit on a push build
 func pushCheckoutCommands(b buildType) []string {
@@ -76,6 +79,7 @@ func pushPipelines() []pipeline {
 		trigger:      triggerPush,
 		pipelineName: "push-build-linux-arm64",
 		ghaWorkflow:  "release-linux-arm64.yml",
+		timeout:      60 * time.Minute,
 		slackOnError: true,
 		srcRefVar:    "DRONE_COMMIT",
 		workflowRef:  "${DRONE_BRANCH}",

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -72,13 +72,14 @@ func pushPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:       buildType{os: "linux", arch: "arm64"},
-		trigger:         triggerPush,
-		namePrefix:      "push-",
-		uploadArtifacts: false,
-		slackOnError:    true,
-		srcRefVar:       "DRONE_COMMIT",
-		workflowRefVar:  "DRONE_BRANCH",
+		buildType:      buildType{os: "linux", arch: "arm64"},
+		trigger:        triggerPush,
+		pipelineName:   "push-build-linux-arm64",
+		ghaWorkflow:    "release-linux-arm64.yml",
+		slackOnError:   true,
+		srcRefVar:      "DRONE_COMMIT",
+		workflowRefVar: "DRONE_BRANCH",
+		inputs:         map[string]string{"upload-artifacts": "false"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -72,14 +72,14 @@ func pushPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:      buildType{os: "linux", arch: "arm64"},
-		trigger:        triggerPush,
-		pipelineName:   "push-build-linux-arm64",
-		ghaWorkflow:    "release-linux-arm64.yml",
-		slackOnError:   true,
-		srcRefVar:      "DRONE_COMMIT",
-		workflowRefVar: "DRONE_BRANCH",
-		inputs:         map[string]string{"upload-artifacts": "false"},
+		buildType:    buildType{os: "linux", arch: "arm64"},
+		trigger:      triggerPush,
+		pipelineName: "push-build-linux-arm64",
+		ghaWorkflow:  "release-linux-arm64.yml",
+		slackOnError: true,
+		srcRefVar:    "DRONE_COMMIT",
+		workflowRef:  "${DRONE_BRANCH}",
+		inputs:       map[string]string{"upload-artifacts": "false"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -189,14 +189,14 @@ func tagPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:      buildType{os: "linux", arch: "arm64", fips: false},
-		trigger:        triggerTag,
-		pipelineName:   "build-linux-arm64",
-		ghaWorkflow:    "release-linux-arm64.yml",
-		srcRefVar:      "DRONE_TAG",
-		workflowRefVar: "DRONE_TAG",
-		dependsOn:      []string{tagCleanupPipelineName},
-		inputs:         map[string]string{"upload-artifacts": "true"},
+		buildType:    buildType{os: "linux", arch: "arm64", fips: false},
+		trigger:      triggerTag,
+		pipelineName: "build-linux-arm64",
+		ghaWorkflow:  "release-linux-arm64.yml",
+		srcRefVar:    "DRONE_TAG",
+		workflowRef:  "${DRONE_TAG}",
+		dependsOn:    []string{tagCleanupPipelineName},
+		inputs:       map[string]string{"upload-artifacts": "true"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -189,11 +189,14 @@ func tagPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:       buildType{os: "linux", arch: "arm64", fips: false},
-		trigger:         triggerTag,
-		uploadArtifacts: true,
-		srcRefVar:       "DRONE_TAG",
-		workflowRefVar:  "DRONE_TAG",
+		buildType:      buildType{os: "linux", arch: "arm64", fips: false},
+		trigger:        triggerTag,
+		pipelineName:   "build-linux-arm64",
+		ghaWorkflow:    "release-linux-arm64.yml",
+		srcRefVar:      "DRONE_TAG",
+		workflowRefVar: "DRONE_TAG",
+		dependsOn:      []string{tagCleanupPipelineName},
+		inputs:         map[string]string{"upload-artifacts": "true"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 const (
@@ -195,6 +196,7 @@ func tagPipelines() []pipeline {
 		ghaWorkflow:  "release-linux-arm64.yml",
 		srcRefVar:    "DRONE_TAG",
 		workflowRef:  "${DRONE_TAG}",
+		timeout:      60 * time.Minute,
 		dependsOn:    []string{tagCleanupPipelineName},
 		inputs:       map[string]string{"upload-artifacts": "true"},
 	}))


### PR DESCRIPTION
Backport a couple of partial PRs to more easily backport other changes
to branch/v11:

* #22707
* #22867
* #22926

Ignore changes to the distroless OCI pipelines from those PRs as those
pipelines are not backported to `branch/v11`. But we do want the other
code changes to dronegen.