### PR TITLE
[v10] Backport dronegen changes for GitHub Actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1318,7 +1318,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
+    -tag-workflow -timeout 1h0m0s -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
     -input "upload-artifacts=false" '
   environment:
@@ -5277,8 +5277,9 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG} -input
-    oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input "upload-artifacts=true" '
+    -tag-workflow -timeout 1h0m0s -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "upload-artifacts=true" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -20240,6 +20241,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 59835f9006a1945dcb345f0b740857d64b712982b83fd0ed45f5ada2a838775e
+hmac: 0f66eef0fd310ee80bb80671bffba2bb97b2f426888260d6bec8fb5aedd5c860
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -1275,11 +1275,6 @@ image_pull_secrets:
 kind: pipeline
 type: kubernetes
 name: push-build-linux-arm64
-environment:
-  BUILDBOX_VERSION: teleport10
-  GID: "1000"
-  RUNTIME: go1.19.8
-  UID: "1000"
 trigger:
   event:
     include:
@@ -1322,9 +1317,10 @@ steps:
   pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
-    release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input upload-artifacts=false -input oss-teleport-repo="${DRONE_REPO}"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "upload-artifacts=false" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -5239,11 +5235,6 @@ image_pull_secrets:
 kind: pipeline
 type: kubernetes
 name: build-linux-arm64
-environment:
-  BUILDBOX_VERSION: teleport10
-  GID: "1000"
-  RUNTIME: go1.19.8
-  UID: "1000"
 trigger:
   event:
     include:
@@ -5258,6 +5249,8 @@ workspace:
   path: /go
 clone:
   disable: true
+depends_on:
+- clean-up-previous-build
 steps:
 - name: Check out code
   image: docker:git
@@ -5283,9 +5276,9 @@ steps:
   pull: if-not-exists
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow
-    release-linux-arm64.yml -workflow-ref=${DRONE_TAG} -input oss-teleport-ref=${DRONE_TAG}
-    -input upload-artifacts=true -input oss-teleport-repo="${DRONE_REPO}"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -workflow release-linux-arm64.yml -workflow-ref=${DRONE_TAG} -input
+    oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input "upload-artifacts=true" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -20247,6 +20240,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: c033b7e21ecf8503a8e5125e0e0d5b127dab1948f71c1f757788141e733045bd
+hmac: 59835f9006a1945dcb345f0b740857d64b712982b83fd0ed45f5ada2a838775e
 
 ...

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 type ghaBuildType struct {
@@ -26,6 +27,7 @@ type ghaBuildType struct {
 	ghaWorkflow  string
 	srcRefVar    string
 	workflowRef  string
+	timeout      time.Duration
 	slackOnError bool
 	dependsOn    []string
 	inputs       map[string]string
@@ -42,6 +44,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
 	cmd.WriteString(`-repo teleport.e `)
 	cmd.WriteString(`-tag-workflow `)
+	fmt.Fprintf(&cmd, `-timeout %s `, b.timeout.String())
 	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
 	fmt.Fprintf(&cmd, `-workflow-ref=%s `, b.workflowRef)
 

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -16,8 +16,11 @@ package main
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
+
+	"golang.org/x/exp/maps"
 )
 
 type ghaBuildType struct {
@@ -54,8 +57,12 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 		fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
 	}
 
-	for k, v := range b.inputs {
-		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, v)
+	// Sort inputs so the are output in a consistent order to avoid
+	// spurious changes in the generated drone config.
+	keys := maps.Keys(b.inputs)
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, b.inputs[k])
 	}
 
 	p.Steps = []step{

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -22,13 +22,13 @@ import (
 type ghaBuildType struct {
 	buildType
 	trigger
-	pipelineName   string
-	ghaWorkflow    string
-	srcRefVar      string
-	workflowRefVar string
-	slackOnError   bool
-	dependsOn      []string
-	inputs         map[string]string
+	pipelineName string
+	ghaWorkflow  string
+	srcRefVar    string
+	workflowRef  string
+	slackOnError bool
+	dependsOn    []string
+	inputs       map[string]string
 }
 
 func ghaBuildPipeline(b ghaBuildType) pipeline {
@@ -43,10 +43,13 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 	cmd.WriteString(`-repo teleport.e `)
 	cmd.WriteString(`-tag-workflow `)
 	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
-	fmt.Fprintf(&cmd, `-workflow-ref=${%s} `, b.workflowRefVar)
+	fmt.Fprintf(&cmd, `-workflow-ref=%s `, b.workflowRef)
 
-	cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
-	fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
+	// If we don't need to build teleport...
+	if b.srcRefVar != "" {
+		cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
+		fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
+	}
 
 	for k, v := range b.inputs {
 		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, v)

--- a/dronegen/gha.go
+++ b/dronegen/gha.go
@@ -14,27 +14,42 @@
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 type ghaBuildType struct {
 	buildType
 	trigger
-	namePrefix      string
-	uploadArtifacts bool
-	srcRefVar       string
-	workflowRefVar  string
-	slackOnError    bool
+	pipelineName   string
+	ghaWorkflow    string
+	srcRefVar      string
+	workflowRefVar string
+	slackOnError   bool
+	dependsOn      []string
+	inputs         map[string]string
 }
 
 func ghaBuildPipeline(b ghaBuildType) pipeline {
-	p := newKubePipeline(fmt.Sprintf("%sbuild-%s-%s", b.namePrefix, b.os, b.arch))
+	p := newKubePipeline(b.pipelineName)
 	p.Trigger = b.trigger
 	p.Workspace = workspace{Path: "/go"}
-	p.Environment = map[string]value{
-		"BUILDBOX_VERSION": buildboxVersion,
-		"RUNTIME":          goRuntime,
-		"UID":              {raw: "1000"},
-		"GID":              {raw: "1000"},
+	p.DependsOn = append(p.DependsOn, b.dependsOn...)
+
+	var cmd strings.Builder
+	cmd.WriteString(`go run ./cmd/gh-trigger-workflow `)
+	cmd.WriteString(`-owner ${DRONE_REPO_OWNER} `)
+	cmd.WriteString(`-repo teleport.e `)
+	cmd.WriteString(`-tag-workflow `)
+	fmt.Fprintf(&cmd, `-workflow %s `, b.ghaWorkflow)
+	fmt.Fprintf(&cmd, `-workflow-ref=${%s} `, b.workflowRefVar)
+
+	cmd.WriteString(`-input oss-teleport-repo=${DRONE_REPO} `)
+	fmt.Fprintf(&cmd, `-input oss-teleport-ref=${%s} `, b.srcRefVar)
+
+	for k, v := range b.inputs {
+		fmt.Fprintf(&cmd, `-input "%s=%s" `, k, v)
 	}
 
 	p.Steps = []step{
@@ -56,11 +71,7 @@ func ghaBuildPipeline(b ghaBuildType) pipeline {
 			},
 			Commands: []string{
 				`cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"`,
-				`go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e -workflow release-linux-arm64.yml ` +
-					fmt.Sprintf(`-workflow-ref=${%s} `, b.workflowRefVar) +
-					fmt.Sprintf(`-input oss-teleport-ref=${%s} `, b.srcRefVar) +
-					fmt.Sprintf(`-input upload-artifacts=%t `, b.uploadArtifacts) +
-					`-input oss-teleport-repo="${DRONE_REPO}"`,
+				cmd.String(),
 			},
 		},
 	}

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -73,13 +73,14 @@ func pushPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:       buildType{os: "linux", arch: "arm64"},
-		trigger:         triggerPush,
-		namePrefix:      "push-",
-		uploadArtifacts: false,
-		slackOnError:    true,
-		srcRefVar:       "DRONE_COMMIT",
-		workflowRefVar:  "DRONE_BRANCH",
+		buildType:      buildType{os: "linux", arch: "arm64"},
+		trigger:        triggerPush,
+		pipelineName:   "push-build-linux-arm64",
+		ghaWorkflow:    "release-linux-arm64.yml",
+		slackOnError:   true,
+		srcRefVar:      "DRONE_COMMIT",
+		workflowRefVar: "DRONE_BRANCH",
+		inputs:         map[string]string{"upload-artifacts": "false"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -73,14 +73,14 @@ func pushPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:      buildType{os: "linux", arch: "arm64"},
-		trigger:        triggerPush,
-		pipelineName:   "push-build-linux-arm64",
-		ghaWorkflow:    "release-linux-arm64.yml",
-		slackOnError:   true,
-		srcRefVar:      "DRONE_COMMIT",
-		workflowRefVar: "DRONE_BRANCH",
-		inputs:         map[string]string{"upload-artifacts": "false"},
+		buildType:    buildType{os: "linux", arch: "arm64"},
+		trigger:      triggerPush,
+		pipelineName: "push-build-linux-arm64",
+		ghaWorkflow:  "release-linux-arm64.yml",
+		slackOnError: true,
+		srcRefVar:    "DRONE_COMMIT",
+		workflowRef:  "${DRONE_BRANCH}",
+		inputs:       map[string]string{"upload-artifacts": "false"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -14,7 +14,10 @@
 
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // pushCheckoutCommands builds a list of commands for Drone to check out a git commit on a push build
 func pushCheckoutCommands(b buildType) []string {
@@ -77,6 +80,7 @@ func pushPipelines() []pipeline {
 		trigger:      triggerPush,
 		pipelineName: "push-build-linux-arm64",
 		ghaWorkflow:  "release-linux-arm64.yml",
+		timeout:      60 * time.Minute,
 		slackOnError: true,
 		srcRefVar:    "DRONE_COMMIT",
 		workflowRef:  "${DRONE_BRANCH}",

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -191,11 +191,14 @@ func tagPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:       buildType{os: "linux", arch: "arm64", fips: false},
-		trigger:         triggerTag,
-		uploadArtifacts: true,
-		srcRefVar:       "DRONE_TAG",
-		workflowRefVar:  "DRONE_TAG",
+		buildType:      buildType{os: "linux", arch: "arm64", fips: false},
+		trigger:        triggerTag,
+		pipelineName:   "build-linux-arm64",
+		ghaWorkflow:    "release-linux-arm64.yml",
+		srcRefVar:      "DRONE_TAG",
+		workflowRefVar: "DRONE_TAG",
+		dependsOn:      []string{tagCleanupPipelineName},
+		inputs:         map[string]string{"upload-artifacts": "true"},
 	}))
 
 	// Only amd64 Windows is supported for now.

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"strings"
+	"time"
 )
 
 const (
@@ -197,6 +198,7 @@ func tagPipelines() []pipeline {
 		ghaWorkflow:  "release-linux-arm64.yml",
 		srcRefVar:    "DRONE_TAG",
 		workflowRef:  "${DRONE_TAG}",
+		timeout:      60 * time.Minute,
 		dependsOn:    []string{tagCleanupPipelineName},
 		inputs:       map[string]string{"upload-artifacts": "true"},
 	}))

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -191,14 +191,14 @@ func tagPipelines() []pipeline {
 	}
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
-		buildType:      buildType{os: "linux", arch: "arm64", fips: false},
-		trigger:        triggerTag,
-		pipelineName:   "build-linux-arm64",
-		ghaWorkflow:    "release-linux-arm64.yml",
-		srcRefVar:      "DRONE_TAG",
-		workflowRefVar: "DRONE_TAG",
-		dependsOn:      []string{tagCleanupPipelineName},
-		inputs:         map[string]string{"upload-artifacts": "true"},
+		buildType:    buildType{os: "linux", arch: "arm64", fips: false},
+		trigger:      triggerTag,
+		pipelineName: "build-linux-arm64",
+		ghaWorkflow:  "release-linux-arm64.yml",
+		srcRefVar:    "DRONE_TAG",
+		workflowRef:  "${DRONE_TAG}",
+		dependsOn:    []string{tagCleanupPipelineName},
+		inputs:       map[string]string{"upload-artifacts": "true"},
 	}))
 
 	// Only amd64 Windows is supported for now.


### PR DESCRIPTION
Backport a couple of partial PRs to more easily backport other changes
to branch/v10:

* #22707
* #22867
* #22926
* #24102 (just the sorting commit)

Ignore changes to the distroless OCI pipelines from those PRs as those
pipelines are not backported to `branch/v10`. But we do want the other
code changes to dronegen.