### PR TITLE
docs: remove ssh discovery section from aws dynamodb guide

### DIFF
--- a/docs/pages/database-access/guides/aws-dynamodb.mdx
+++ b/docs/pages/database-access/guides/aws-dynamodb.mdx
@@ -152,19 +152,6 @@ the correct STS endpoint.
 
 ### Generate a token
 
-<Details title="Alterative methods">
-
-For users with a lot of infrastructure in AWS, or who might create or recreate
-many instances, consider alternative methods for joining new EC2 instances running
-Teleport:
-
-- [Configure Teleport to Automatically Enroll EC2 instances (Preview)](../../server-access/guides/ec2-discovery.mdx)
-- [Joining Nodes via AWS IAM
-  Role](../../management/join-services-to-your-cluster/aws-iam.mdx)
-- [Joining Nodes via AWS EC2 Identity Document](../../management/join-services-to-your-cluster/aws-ec2.mdx)
-
-</Details>
-
 A join token is required to authorize a Teleport Database Service instance
 to join the cluster. Generate a short-lived join token and save the output of
 the command:


### PR DESCRIPTION
The section included had to do with joining server access, not dbs.