### PR TITLE
[v13] Revert usage of `session.SetEnvs`

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -225,22 +225,20 @@ func (ns *NodeSession) createServerSession(ctx context.Context) (*tracessh.Sessi
 		return nil, trace.Wrap(err)
 	}
 
-	envs := map[string]string{}
-
 	// pass language info into the remote session.
 	langVars := []string{"LANG", "LANGUAGE"}
 	for _, env := range langVars {
 		if value := os.Getenv(env); value != "" {
-			envs[env] = value
+			if err := sess.Setenv(ctx, env, value); err != nil {
+				log.Warn(err)
+			}
 		}
 	}
 	// pass environment variables set by client
 	for key, val := range ns.env {
-		envs[key] = val
-	}
-
-	if err := sess.SetEnvs(ctx, envs); err != nil {
-		log.Warn(err)
+		if err := sess.Setenv(ctx, key, val); err != nil {
+			log.Warn(err)
+		}
 	}
 
 	// if agent forwarding was requested (and we have a agent to forward),

--- a/lib/srv/term.go
+++ b/lib/srv/term.go
@@ -693,7 +693,9 @@ func (t *remoteTerminal) prepareRemoteSession(ctx context.Context, session *trac
 		teleport.SSHSessionID:           string(scx.SessionID()),
 	}
 
-	if err := session.SetEnvs(ctx, envs); err != nil {
-		t.log.WithError(err).Debug("Unable to set environment variables")
+	for k, v := range envs {
+		if err := session.Setenv(ctx, k, v); err != nil {
+			t.log.Debugf("Unable to set environment variable: %v: %v", k, v)
+		}
 	}
 }


### PR DESCRIPTION
Due to unknown session requests causing sessions to be terminated in prior versions we cannot use `session.SetEnvs` without breaking backward compatibility until v14.

#23874 only exists in the latest versions of v12, so anyone upgrading to v13 from an older version of v12 will be unable to establish a SSH session.