### PR TITLE
Use apt.releases to fetch pub key

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -16,12 +16,12 @@ set -o nounset
     # old versions of ubuntu require that keys get added by `apt-key add`, without
     # adding the key apt shows a key signing error when installing teleport.
     if [ "$VERSION_CODENAME" = "xenial" ] || [ "$VERSION_CODENAME" = "trusty" ]; then
-      curl -o /tmp/teleport-pubkey.asc https://deb.releases.teleport.dev/teleport-pubkey.asc
+      curl -o /tmp/teleport-pubkey.asc https://apt.releases.teleport.dev/gpg
       cat /tmp/teleport-pubkey.asc | sudo apt-key add -
       echo "deb https://apt.releases.teleport.dev/ubuntu ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list
       rm /tmp/teleport-pubkey.asc
     else
-      curl https://deb.releases.teleport.dev/teleport-pubkey.asc | sudo tee /usr/share/keyrings/teleport-archive-keyring.asc
+      curl https://apt.releases.teleport.dev/gpg | sudo tee /usr/share/keyrings/teleport-archive-keyring.asc
       echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
     fi
     sudo apt-get update

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -31,12 +31,12 @@ on_azure() {
 
   if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
     if [ "$LEGACY_UBUNTU" = true ]; then
-      curl -o /tmp/teleport-pubkey.asc https://deb.releases.teleport.dev/teleport-pubkey.asc
+      curl -o /tmp/teleport-pubkey.asc https://apt.releases.teleport.dev/gpg
       cat /tmp/teleport-pubkey.asc | sudo apt-key add -
       echo "deb https://apt.releases.teleport.dev/ubuntu ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list
       rm /tmp/teleport-pubkey.asc
     else
-      sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
+      sudo curl https://apt.releases.teleport.dev/gpg \
         -o /usr/share/keyrings/teleport-archive-keyring.asc
       echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc]  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} {{ .RepoChannel }}" | sudo tee /etc/apt/sources.list.d/teleport.list >/dev/null
     fi

--- a/docs/pages/choose-an-edition/teleport-cloud/downloads.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/downloads.mdx
@@ -60,7 +60,7 @@ instructions to add a package repository and install Teleport.
     <TabItem label="Debian/Ubuntu (DEB)">
         ```code
         # Download Teleport's PGP public key
-        $ sudo curl https://deb.releases.teleport.dev/teleport-pubkey.asc \
+        $ sudo curl https://apt.releases.teleport.dev/gpg \
           -o /usr/share/keyrings/teleport-archive-keyring.asc
         # Source variables about OS version
         $ source /etc/os-release

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -863,10 +863,10 @@ install_from_repo() {
             ($ID == "debian" && $VERSION_ID == "9" )
         ]]; then
             apt install apt-transport-https gnupg -y
-            curl -fsSL https://deb.releases.teleport.dev/teleport-pubkey.asc | apt-key add -
+            curl -fsSL https://apt.releases.teleport.dev/gpg | apt-key add -
             echo "deb https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list
         else
-            curl -fsSL https://deb.releases.teleport.dev/teleport-pubkey.asc \
+            curl -fsSL https://apt.releases.teleport.dev/gpg \
                 -o /usr/share/keyrings/teleport-archive-keyring.asc
             echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
             https://apt.releases.teleport.dev/${ID} ${VERSION_CODENAME} ${REPO_CHANNEL}" > /etc/apt/sources.list.d/teleport.list


### PR DESCRIPTION
We deprecated `https://deb.releases.teleport.dev/` in favor of `https://apt.releases.teleport.dev/`

There's no diff between the two keys:

```
$ diff <(curl -fsSL https://apt.releases.teleport.dev/gpg) <(curl -fsSL https://deb.releases.teleport.dev/teleport-pubkey.asc); echo $?
0
```