### PR TITLE
Do not change proto user on make grpc

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -244,7 +244,7 @@ ui: buildbox
 .PHONY: grpc
 grpc: buildbox
 	docker run \
-		$(DOCKERFLAGS) -t $(BUILDBOX) \
+		$(DOCKERFLAGS) -u $(UID):$(GID) -t $(BUILDBOX) \
 		make -C /go/src/github.com/gravitational/teleport grpc/host
 
 # protos-up-to-date checks if GRPC stubs are up to date from inside the buildbox


### PR DESCRIPTION
Currently, when running `make grpc` on Linux, all files modified inside the Docker container are owned by root. This change preserves the original user of all files.