### PR TITLE
Move Locks section up in Web UI Test Plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/webtestplan.md
+++ b/.github/ISSUE_TEMPLATE/webtestplan.md
@@ -499,6 +499,28 @@ Add the following to enable read access to trusted clusters
 - [ ] Verify that a user can access the "Trust" screen
 - [ ] Verify that a user cannot create/delete/update a trusted cluster.
 
+## Locks
+Checking that you can view, create, and delete locks.
+
+- [ ] Existing locks listing page.
+  - [ ] It lists all of the existing locks in the system.
+  - [ ] Locks without a `Locked By` and `Start Date` are still shown with those fields empty.
+  - [ ] Clicking the trash can deletes the lock with a spinner.
+  - [ ] Table columns are sortable.
+  - [ ] Table search field filters the results.
+- [ ] Adding a new lock. (+ Add New Lock).
+  - [ ] Target switcher shows the locks for the various target types (User, Role, Login, Node, MFA Device, Windows Desktop, Access Request).
+  - [ ] Target switcher has "Access Request" in E build but not in OSS.
+  - [ ] You can add lock targets from multiple target types.
+  - [ ] Adding a target disables that "add button".
+  - [ ] You cannot proceed if you haven't selected targets to lock.
+  - [ ] You can clear the selected targets prior to creating locks.
+  - [ ] Proceeding to lock opens an animated slide panel from the right.
+  - [ ] You can remove lock targets from the slide panel.
+  - [ ] Creating a lock with message and TTL correctly create the lock.
+  - [ ] Create a lock without message and TTL, they should be optional.
+
+
 ## Teleport Connect
 
 - Auth methods
@@ -752,24 +774,3 @@ Add the following to enable read access to trusted clusters
 - [ ] Clean the Application Support dir for Connect. Start the latest stable version of the app.
   Open every possible document. Close the app. Start the current alpha. Reopen the tabs. Verify that
   the app was able to reopen the tabs without any errors.
-
-## Locks
-Checking that you can view, create, and delete locks.
-
-- [ ] Existing locks listing page.
-  - [ ] It lists all of the existing locks in the system.
-  - [ ] Locks without a `Locked By` and `Start Date` are still shown with those fields empty.
-  - [ ] Clicking the trash can deletes the lock with a spinner.
-  - [ ] Table columns are sortable.
-  - [ ] Table search field filters the results.
-- [ ] Adding a new lock. (+ Add New Lock).
-  - [ ] Target switcher shows the locks for the various target types (User, Role, Login, Node, MFA Device, Windows Desktop, Access Request).
-  - [ ] Target switcher has "Access Request" in E build but not in OSS.
-  - [ ] You can add lock targets from multiple target types.
-  - [ ] Adding a target disables that "add button".
-  - [ ] You cannot proceed if you haven't selected targets to lock.
-  - [ ] You can clear the selected targets prior to creating locks.
-  - [ ] Proceeding to lock opens an animated slide panel from the right.
-  - [ ] You can remove lock targets from the slide panel.
-  - [ ] Creating a lock with message and TTL correctly create the lock.
-  - [ ] Create a lock without message and TTL, they should be optional.


### PR DESCRIPTION
Minor tweak that moves the test plan section for the Locks UI up alongside other Web UI sections so that it isn't mistaken to be part of the Teleport Connect section.