### PR TITLE
Add login hooks.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -677,8 +677,8 @@ func (a *Server) CallLoginHooks(ctx context.Context) error {
 	return trace.NewAggregate(errs...)
 }
 
-// resetLoginHooks will clear out the login hooks.
-func (a *Server) resetLoginHooks() {
+// ResetLoginHooks will clear out the login hooks.
+func (a *Server) ResetLoginHooks() {
 	a.loginHooksMu.Lock()
 	a.loginHooks = nil
 	a.loginHooksMu.Unlock()

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -472,7 +472,7 @@ var (
 )
 
 // LoginHook is a function that will be called on login.
-type LoginHook func(context.Context) error
+type LoginHook func(context.Context, types.User) error
 
 // Server keeps the cluster together. It acts as a certificate authority (CA) for
 // a cluster and:
@@ -657,7 +657,7 @@ func (a *Server) RegisterLoginHook(hook LoginHook) {
 }
 
 // CallLoginHooks will call the registered login hooks.
-func (a *Server) CallLoginHooks(ctx context.Context) error {
+func (a *Server) CallLoginHooks(ctx context.Context, user types.User) error {
 	// Make a copy of the login hooks to operate on.
 	a.loginHooksMu.RLock()
 	loginHooks := make([]LoginHook, len(a.loginHooks))
@@ -671,7 +671,7 @@ func (a *Server) CallLoginHooks(ctx context.Context) error {
 	var errs []error
 
 	for _, hook := range loginHooks {
-		errs = append(errs, hook(ctx))
+		errs = append(errs, hook(ctx, user))
 	}
 
 	return trace.NewAggregate(errs...)

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -668,14 +668,20 @@ func (a *Server) CallLoginHooks(ctx context.Context) error {
 		return nil
 	}
 
-	errs := make(chan error, len(loginHooks))
+	var errs []error
 
 	for _, hook := range loginHooks {
-		errs <- hook(ctx)
+		errs = append(errs, hook(ctx))
 	}
 
-	close(errs)
-	return trace.NewAggregateFromChannel(errs, ctx)
+	return trace.NewAggregate(errs...)
+}
+
+// resetLoginHooks will clear out the login hooks.
+func (a *Server) resetLoginHooks() {
+	a.loginHooksMu.Lock()
+	a.loginHooks = nil
+	a.loginHooksMu.Unlock()
 }
 
 // CloseContext returns the close context

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -471,7 +471,9 @@ var (
 	}
 )
 
-// LoginHook is a function that will be called on login.
+// LoginHook is a function that will be called on a successful login. This will likely be used
+// for enterprise services that need to add in feature specific operations after a user has been
+// successfully authenticated. An example would be creating objects based on the user.
 type LoginHook func(context.Context, types.User) error
 
 // Server keeps the cluster together. It acts as a certificate authority (CA) for

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -671,7 +671,6 @@ func (a *Server) CallLoginHooks(ctx context.Context, user types.User) error {
 	}
 
 	var errs []error
-
 	for _, hook := range loginHooks {
 		errs = append(errs, hook(ctx, user))
 	}

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -556,7 +556,7 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 
 	// used to keep track of calls to login hooks.
 	var loginHookCounter atomic.Int32
-	var loginHook LoginHook = func(ctx context.Context) error {
+	var loginHook LoginHook = func(_ context.Context, _ types.User) error {
 		loginHookCounter.Add(1)
 		return nil
 	}

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -628,7 +628,7 @@ func TestServer_Authenticate_passwordless(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			svr.Auth().resetLoginHooks()
+			svr.Auth().ResetLoginHooks()
 			loginHookCounter.Store(0)
 			for _, hook := range test.loginHooks {
 				svr.Auth().RegisterLoginHook(hook)

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -618,6 +618,10 @@ func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODia
 		return nil, trace.Wrap(err, "Failed to create user from provided parameters.")
 	}
 
+	if err := a.CallLoginHooks(ctx, user); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Auth was successful, return session, certificate, etc. to caller.
 	auth := GithubAuthResponse{
 		Req: GithubAuthRequestFromProto(req),
@@ -731,10 +735,6 @@ func (a *Server) calculateGithubUser(ctx context.Context, connector types.Github
 		return nil, trace.Wrap(err)
 	}
 	p.Traits = evaluationOutput.Traits
-
-	if err := a.CallLoginHooks(ctx); err != nil {
-		return nil, trace.Wrap(err)
-	}
 
 	// Kube groups and users are ultimately only set in the traits, not any
 	// other property of the User. In case the login rules changed the relevant

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -732,6 +732,10 @@ func (a *Server) calculateGithubUser(ctx context.Context, connector types.Github
 	}
 	p.Traits = evaluationOutput.Traits
 
+	if err := a.CallLoginHooks(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	// Kube groups and users are ultimately only set in the traits, not any
 	// other property of the User. In case the login rules changed the relevant
 	// traits values, reset the value on the user params for accurate

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -642,7 +642,7 @@ func (s *Server) AuthenticateSSHUser(ctx context.Context, req AuthenticateSSHReq
 	}
 	UserLoginCount.Inc()
 	return &SSHLoginResponse{
-		Username:    username,
+		Username:    user.GetName(),
 		Cert:        certs.SSH,
 		TLSCert:     certs.TLS,
 		HostSigners: AuthoritiesToTrustedCerts(hostCertAuthorities),

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -154,6 +154,10 @@ func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserReque
 	} else {
 		event.Code = events.UserLocalLoginCode
 		event.Status.Success = true
+
+		if err := s.CallLoginHooks(ctx); err != nil {
+			return "", trace.Wrap(err)
+		}
 	}
 	if err := s.emitter.EmitAuditEvent(s.closeCtx, event); err != nil {
 		log.WithError(err).Warn("Failed to emit login event.")

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -112,17 +112,17 @@ type SessionCreds struct {
 
 // AuthenticateUser authenticates user based on the request type.
 // Returns the username of the authenticated user.
-func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserRequest) (string, error) {
-	user := req.Username
+func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserRequest) (types.User, error) {
+	username := req.Username
 
-	mfaDev, actualUser, err := s.authenticateUser(ctx, req)
+	mfaDev, actualUsername, err := s.authenticateUser(ctx, req)
 	// err is handled below.
 	switch {
-	case user != "" && actualUser != "" && user != actualUser:
-		log.Warnf("Authenticate user mismatch (%q vs %q). Using request user (%q)", user, actualUser, user)
-	case user == "" && actualUser != "":
-		log.Debugf("User %q authenticated via passwordless", actualUser)
-		user = actualUser
+	case username != "" && actualUsername != "" && username != actualUsername:
+		log.Warnf("Authenticate user mismatch (%q vs %q). Using request user (%q)", username, actualUsername, username)
+	case username == "" && actualUsername != "":
+		log.Debugf("User %q authenticated via passwordless", actualUsername)
+		username = actualUsername
 	}
 
 	event := &apievents.UserLogin{
@@ -131,7 +131,7 @@ func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserReque
 			Code: events.UserLocalLoginFailureCode,
 		},
 		UserMetadata: apievents.UserMetadata{
-			User: user,
+			User: username,
 		},
 		Method: events.LoginMethodLocal,
 	}
@@ -147,6 +147,8 @@ func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserReque
 			event.UserAgent = req.ClientMetadata.UserAgent
 		}
 	}
+
+	var user types.User
 	if err != nil {
 		event.Code = events.UserLocalLoginFailureCode
 		event.Status.Success = false
@@ -155,13 +157,17 @@ func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserReque
 		event.Code = events.UserLocalLoginCode
 		event.Status.Success = true
 
-		user, err := s.GetUser(actualUser, false /* withSecrets */)
+		var err error
+		user, err = s.GetUser(username, false /* withSecrets */)
 		if err != nil {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 
+		// After we're sure that the user has been logged in successfully, we should call
+		// the registered login hooks. Login hooks can be registered by other processes to
+		// execute arbitrary operations after a successful login.
 		if err := s.CallLoginHooks(ctx, user); err != nil {
-			return "", trace.Wrap(err)
+			return nil, trace.Wrap(err)
 		}
 	}
 	if err := s.emitter.EmitAuditEvent(s.closeCtx, event); err != nil {
@@ -451,13 +457,7 @@ func (s *Server) AuthenticateWebUser(ctx context.Context, req AuthenticateUserRe
 		return session, nil
 	}
 
-	actualUser, err := s.AuthenticateUser(ctx, req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	username = actualUser
-
-	user, err := s.GetUser(username, false /* withSecrets */)
+	user, err := s.AuthenticateUser(ctx, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -575,18 +575,11 @@ func (s *Server) AuthenticateSSHUser(ctx context.Context, req AuthenticateSSHReq
 		return nil, trace.Wrap(err)
 	}
 
-	actualUser, err := s.AuthenticateUser(ctx, req.AuthenticateUserRequest)
+	user, err := s.AuthenticateUser(ctx, req.AuthenticateUserRequest)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	username = actualUser
 
-	// It's safe to extract the roles and traits directly from services.User as
-	// this endpoint is only used for local accounts.
-	user, err := s.GetUser(username, false /* withSecrets */)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	accessInfo := services.AccessInfoFromUser(user)
 	checker, err := services.NewAccessChecker(accessInfo, clusterName.GetClusterName(), s)
 	if err != nil {

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -575,6 +575,8 @@ func (s *Server) AuthenticateSSHUser(ctx context.Context, req AuthenticateSSHReq
 		return nil, trace.Wrap(err)
 	}
 
+	// It's safe to extract the roles and traits directly from services.User as
+	// this endpoint is only used for local accounts.
 	user, err := s.AuthenticateUser(ctx, req.AuthenticateUserRequest)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -155,7 +155,12 @@ func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserReque
 		event.Code = events.UserLocalLoginCode
 		event.Status.Success = true
 
-		if err := s.CallLoginHooks(ctx); err != nil {
+		user, err := s.GetUser(actualUser, false)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		if err := s.CallLoginHooks(ctx, user); err != nil {
 			return "", trace.Wrap(err)
 		}
 	}

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -155,7 +155,7 @@ func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserReque
 		event.Code = events.UserLocalLoginCode
 		event.Status.Success = true
 
-		user, err := s.GetUser(actualUser, false)
+		user, err := s.GetUser(actualUser, false /* withSecrets */)
 		if err != nil {
 			return "", trace.Wrap(err)
 		}


### PR DESCRIPTION
Login hooks have been added to support performing arbitrary operations on user login. This is done to support generating of an Okta assignment on user login for the Okta service feature.

Please refer to https://github.com/gravitational/teleport.e/blob/master/rfd/0003e-application-access-okta-integration.md#teleport-to-okta-user-reconciliation for more information.

Note: This diverges slightly from the RFD as it only happens on login as opposed to happening regularly.

There will need to be a follow on PR to handle SAML/OIDC logins.