### PR TITLE
Fix GitHub connector API endpoint URL path getting ignored when making HTTP requests

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -226,7 +226,10 @@ func orgUsesExternalSSO(ctx context.Context, endpointURL, org string, client htt
 	// supports external SSO. There doesn't seem to be any way to get this
 	// information from the Github REST API without being an owner of the
 	// Github organization, so check if this exists instead.
-	ssoURL := fmt.Sprintf("%s/orgs/%s/sso", endpointURL, url.PathEscape(org))
+	ssoURL, err := url.JoinPath(endpointURL, "orgs", url.PathEscape(org), "sso")
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
 
 	const retries = 3
 	var resp *http.Response
@@ -555,19 +558,14 @@ func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODia
 
 	// Get the Github organizations the user is a member of so we don't
 	// make unnecessary API requests
-	endpointURL, err := url.Parse(connector.GetEndpointURL())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	apiEndpointURL, err := url.Parse(connector.GetAPIEndpointURL())
+	apiEndpoint, err := buildAPIEndpoint(connector.GetAPIEndpointURL())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	ghClient := &githubAPIClient{
-		token:               token.AccessToken,
-		authServer:          a,
-		endpointHostname:    endpointURL.Host,
-		apiEndpointHostname: apiEndpointURL.Host,
+		token:       token.AccessToken,
+		authServer:  a,
+		apiEndpoint: apiEndpoint,
 	}
 	userResp, err := ghClient.getUser()
 	if err != nil {
@@ -683,6 +681,21 @@ func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODia
 	}
 
 	return &auth, nil
+}
+
+// buildAPIEndpoint takes a URL of a GitHub API endpoint and returns only
+// the joined host and path.
+func buildAPIEndpoint(apiEndpointURLStr string) (string, error) {
+	apiEndpointURL, err := url.Parse(apiEndpointURLStr)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	apiEndpoint, err := url.JoinPath(apiEndpointURL.Host, apiEndpointURL.Path)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return apiEndpoint, nil
 }
 
 // CreateUserParams is a set of parameters used to create a user for an
@@ -847,11 +860,9 @@ type githubAPIClient struct {
 	token string
 	// authServer points to the Auth Server.
 	authServer *Server
-	// endpointHostname is the Github hostname to connect to.
-	endpointHostname string
-	// apiEndpointHostname is the API endpoint of the Github instance
+	// apiEndpoint is the API endpoint of the Github instance
 	// to connect to.
-	apiEndpointHostname string
+	apiEndpoint string
 }
 
 // userResponse represents response from "user" API call
@@ -963,7 +974,7 @@ func (c *githubAPIClient) getTeams() ([]teamResponse, error) {
 
 // get makes a GET request to the provided URL using the client's token for auth
 func (c *githubAPIClient) get(page string) ([]byte, string, error) {
-	request, err := http.NewRequest("GET", formatGithubURL(c.apiEndpointHostname, page), nil)
+	request, err := http.NewRequest("GET", formatGithubURL(c.apiEndpoint, page), nil)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -977,7 +988,7 @@ func (c *githubAPIClient) get(page string) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
-	if response.StatusCode != 200 {
+	if response.StatusCode != http.StatusOK {
 		return nil, "", trace.AccessDenied("bad response: %v %v",
 			response.StatusCode, string(bytes))
 	}

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -115,7 +115,6 @@ func TestPopulateClaims(t *testing.T) {
 		},
 		Teams: []string{"team1", "team2", "team1"},
 	}))
-
 }
 
 func TestCreateGithubUser(t *testing.T) {
@@ -547,5 +546,42 @@ func TestGithubURLFormat(t *testing.T) {
 
 	for _, tt := range tts {
 		require.Equal(t, tt.expect, formatGithubURL(tt.host, tt.path))
+	}
+}
+
+func TestBuildAPIEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no path",
+			input:    "https://github.com",
+			expected: "github.com",
+		},
+		{
+			name:     "with path",
+			input:    "https://mykewlapiendpoint/apage",
+			expected: "mykewlapiendpoint/apage",
+		},
+		{
+			name:     "with path and double slashes",
+			input:    "https://mykewlapiendpoint//apage//",
+			expected: "mykewlapiendpoint/apage/",
+		},
+		{
+			name:     "with path and query",
+			input:    "https://mykewlapiendpoint/apage?legit=nope",
+			expected: "mykewlapiendpoint/apage",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildAPIEndpoint(tt.input)
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, got)
+		})
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/24582.