### PR TITLE
[web] Add lock target matcher and fix button themes

### DIFF
--- a/web/packages/teleport/src/Locks/Locks.tsx
+++ b/web/packages/teleport/src/Locks/Locks.tsx
@@ -34,12 +34,28 @@ import { NavLink } from 'teleport/components/Router';
 
 import { useLocks } from './useLocks';
 import { StyledSpinner } from './shared';
+import { LockForTable } from './types';
 
 function getFormattedDate(d: string): string {
   try {
     return formatRelative(new Date(d), Date.now());
   } catch (e) {
     return '';
+  }
+}
+
+function lockTargetsMatcher(
+  targetValue: any,
+  searchValue: string,
+  propName: keyof LockForTable & string
+) {
+  if (propName === 'targets') {
+    return targetValue.some(
+      ({ name, value }) =>
+        name.toLocaleUpperCase().includes(searchValue) ||
+        value.toLocaleUpperCase().includes(searchValue) ||
+        `${name}: ${value}`.toLocaleUpperCase().includes(searchValue)
+    );
   }
 }
 
@@ -122,6 +138,7 @@ export function Locks() {
         ]}
         emptyText="No Locks Found"
         isSearchable
+        customSearchMatchers={[lockTargetsMatcher]}
         pagination={{ pageSize: 20 }}
       />
     </FeatureBox>
@@ -158,9 +175,8 @@ const ButtonBG = styled.span`
   font-size: 13px;
   border-radius: 2px;
   padding: 8px;
-  background-color: #2e3860;
-  border-radius: 2px;
+  background-color: ${({ theme }) => theme.colors.buttons.trashButton.default};
   :hover {
-    background-color: #414b70;
+    background-color: ${({ theme }) => theme.colors.buttons.trashButton.hover};
   }
 `;


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/24850

This PR will enable searching the lock targets. The example below shows a lock target as `user:mfa`, previously, search didnt work for this field at all. the `lockTargetMatcher` will allow us to search by the lock type and lock value, so `user` would show all of the results in the image and `mfa` would keep only the `user:mfa` entry down here.
![Screenshot 2023-04-19 at 3 37 40 PM](https://user-images.githubusercontent.com/5201977/233194356-16882f6a-29c5-4388-a47a-ecc3d7b42d6a.png)

The message, locked by, and dates still filter as expected. This custom search is additive to the normal filter.


Also, the buttons didn't account for the new themes.
Before
![Screenshot 2023-04-19 at 3 34 04 PM](https://user-images.githubusercontent.com/5201977/233194868-88919b15-b9d7-4fea-b222-6ec16956cd1f.png)

After:
![Screenshot 2023-04-19 at 3 34 12 PM](https://user-images.githubusercontent.com/5201977/233194900-ecfb5470-f682-4694-a27d-a2249521ccf1.png)


