### PR TITLE
Makes the `Per Role` per session mfa example accurate

### DIFF
--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -192,19 +192,8 @@ spec:
   allow:
     node_labels:
       env: dev
-    kubernetes_labels:
-      env: dev
-    kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
-    db_labels:
-      'env': dev
-    db_users:
-    - '*'
-    db_names:
-    - '*'
-  deny: {}
+    logins:
+      - jerry
 ---
 # access-prod.yaml
 kind: role
@@ -218,37 +207,27 @@ spec:
   allow:
     node_labels:
       env: prod
-    kubernetes_labels:
-      env: prod
-    kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
-    db_labels:
-      'env': prod
-    db_users:
-    - '*'
-    db_names:
-    - '*'
+    logins:
+      - jerry
   deny: {}
 ```
 
 Olga then assigns both roles to all engineers, including Jerry.
 
-When Jerry logs into node `dev1.example.com` (with label `env: dev`), nothing
+When Jerry logs into node `jerry@dev1.example.com` (with label `env: dev`), nothing
 special happens:
 
 ```code
-$ tsh ssh dev1.example.com
+$ tsh ssh jerry@dev1.example.com
 
 # jerry@dev1.example.com >
 ```
 
-But when Jerry logs into node `prod3.example.com` (with label `env: prod`), he
+But when Jerry logs into node `jerry@prod3.example.com` (with label `env: prod`), he
 gets prompted for an MFA check:
 
 ```code
-$ tsh ssh prod3.example.com
+$ tsh ssh jerry@prod3.example.com
 # Tap any security key <tap>
 
 # jerry@prod3.example.com >

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -214,7 +214,7 @@ spec:
 
 Olga then assigns both roles to all engineers, including Jerry.
 
-When Jerry logs into node `jerry@dev1.example.com` (with label `env: dev`), nothing
+When Jerry logs into node `dev1.example.com` (with label `env: dev` as login `jerry`), nothing
 special happens:
 
 ```code
@@ -223,7 +223,7 @@ $ tsh ssh jerry@dev1.example.com
 # jerry@dev1.example.com >
 ```
 
-But when Jerry logs into node `jerry@prod3.example.com` (with label `env: prod`), he
+But when Jerry logs into node `rod3.example.com` (with label `env: prod` as login `jerry`), he
 gets prompted for an MFA check:
 
 ```code


### PR DESCRIPTION
The previous example ignored the `logins` field in each role, so it was not actually the case that the role with `require_session_mfa: true` would cause the user to be required to mfa before each session. This cuts down the example to just an ssh node, and includes the `logins` in order to make the example accurate.