### PR TITLE
fix reverse tunnel cannot connect if proxy address contains https

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5175,6 +5175,12 @@ func (process *TeleportProcess) SingleProcessModeResolver(mode types.ProxyListen
 		if !ok {
 			return nil, mode, trace.BadParameter(`failed to find reverse tunnel address, if running in single process mode, make sure "auth_service", "proxy_service", and "app_service" are all enabled`)
 		}
+
+		// In case the web address has "https" scheme for TLS Routing, make
+		// sure "tcp" is used when dialing reverse tunnel.
+		if mode == types.ProxyListenerMode_Multiplex && addr.AddrNetwork == "https" {
+			addr.AddrNetwork = "tcp"
+		}
 		return addr, mode, nil
 	}
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -5175,12 +5175,6 @@ func (process *TeleportProcess) SingleProcessModeResolver(mode types.ProxyListen
 		if !ok {
 			return nil, mode, trace.BadParameter(`failed to find reverse tunnel address, if running in single process mode, make sure "auth_service", "proxy_service", and "app_service" are all enabled`)
 		}
-
-		// In case the web address has "https" scheme for TLS Routing, make
-		// sure "tcp" is used when dialing reverse tunnel.
-		if mode == types.ProxyListenerMode_Multiplex && addr.AddrNetwork == "https" {
-			addr.AddrNetwork = "tcp"
-		}
 		return addr, mode, nil
 	}
 }
@@ -5196,15 +5190,26 @@ func (process *TeleportProcess) singleProcessMode(mode types.ProxyListenerMode) 
 	}
 
 	if !process.Config.Proxy.DisableTLS && !process.Config.Proxy.DisableALPNSNIListener && mode == types.ProxyListenerMode_Multiplex {
-		if len(process.Config.Proxy.PublicAddrs) != 0 {
-			return &process.Config.Proxy.PublicAddrs[0], true
-		}
+		var addr utils.NetAddr
+		switch {
+		// Use the public address if available.
+		case len(process.Config.Proxy.PublicAddrs) != 0:
+			addr = process.Config.Proxy.PublicAddrs[0]
+
 		// If WebAddress is unspecified "0.0.0.0" replace 0.0.0.0 with localhost since 0.0.0.0 is never a valid
 		// principal (auth server explicitly removes it when issuing host certs) and when WebPort is used
 		// in the single process mode to establish SSH reverse tunnel connection the host is validated against
 		// the valid principal list.
-		addr := process.Config.Proxy.WebAddr
-		addr.Addr = utils.ReplaceUnspecifiedHost(&addr, defaults.HTTPListenPort)
+		default:
+			addr = process.Config.Proxy.WebAddr
+			addr.Addr = utils.ReplaceUnspecifiedHost(&addr, defaults.HTTPListenPort)
+		}
+
+		// In case the address has "https" scheme for TLS Routing, make sure
+		// "tcp" is used when dialing reverse tunnel.
+		if addr.AddrNetwork == "https" {
+			addr.AddrNetwork = "tcp"
+		}
 		return &addr, true
 	}
 

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1168,6 +1168,19 @@ func TestSingleProcessModeResolver(t *testing.T) {
 		wantAddr  string
 	}{
 		{
+			name: "not single process mode",
+			mode: types.ProxyListenerMode_Separate,
+			config: servicecfg.Config{
+				Proxy: servicecfg.ProxyConfig{
+					Enabled: true,
+				},
+				Auth: servicecfg.AuthConfig{
+					Enabled: false,
+				},
+			},
+			wantError: true,
+		},
+		{
 			name: "reverse tunnel disabled",
 			mode: types.ProxyListenerMode_Separate,
 			config: servicecfg.Config{
@@ -1202,6 +1215,7 @@ func TestSingleProcessModeResolver(t *testing.T) {
 					Enabled: true,
 					TunnelPublicAddrs: []utils.NetAddr{
 						*utils.MustParseAddr("example.com:12345"),
+						*utils.MustParseAddr("example.org:12345"),
 					},
 				},
 				Auth: servicecfg.AuthConfig{
@@ -1218,6 +1232,7 @@ func TestSingleProcessModeResolver(t *testing.T) {
 					Enabled: true,
 					PublicAddrs: []utils.NetAddr{
 						*utils.MustParseAddr("example.com:12345"),
+						*utils.MustParseAddr("example.org:12345"),
 					},
 				},
 				Auth: servicecfg.AuthConfig{
@@ -1227,7 +1242,7 @@ func TestSingleProcessModeResolver(t *testing.T) {
 			wantAddr: "tcp://example.com:12345",
 		},
 		{
-			name: "multiplex web addr",
+			name: "multiplex web addr with https scheme",
 			mode: types.ProxyListenerMode_Multiplex,
 			config: servicecfg.Config{
 				Proxy: servicecfg.ProxyConfig{

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1156,3 +1156,106 @@ func TestEnterpriseServicesEnabled(t *testing.T) {
 		})
 	}
 }
+
+func TestSingleProcessModeResolver(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mode      types.ProxyListenerMode
+		config    servicecfg.Config
+		wantError bool
+		wantAddr  string
+	}{
+		{
+			name: "reverse tunnel disabled",
+			mode: types.ProxyListenerMode_Separate,
+			config: servicecfg.Config{
+				Proxy: servicecfg.ProxyConfig{
+					Enabled:              true,
+					DisableReverseTunnel: true,
+				},
+				Auth: servicecfg.AuthConfig{
+					Enabled: true,
+				},
+			},
+			wantError: true,
+		},
+		{
+			name: "separate port localhost",
+			mode: types.ProxyListenerMode_Separate,
+			config: servicecfg.Config{
+				Proxy: servicecfg.ProxyConfig{
+					Enabled: true,
+				},
+				Auth: servicecfg.AuthConfig{
+					Enabled: true,
+				},
+			},
+			wantAddr: "tcp://localhost:3024",
+		},
+		{
+			name: "separate port tunnel addr",
+			mode: types.ProxyListenerMode_Separate,
+			config: servicecfg.Config{
+				Proxy: servicecfg.ProxyConfig{
+					Enabled: true,
+					TunnelPublicAddrs: []utils.NetAddr{
+						*utils.MustParseAddr("example.com:12345"),
+					},
+				},
+				Auth: servicecfg.AuthConfig{
+					Enabled: true,
+				},
+			},
+			wantAddr: "tcp://example.com:12345",
+		},
+		{
+			name: "multiplex public addr",
+			mode: types.ProxyListenerMode_Multiplex,
+			config: servicecfg.Config{
+				Proxy: servicecfg.ProxyConfig{
+					Enabled: true,
+					PublicAddrs: []utils.NetAddr{
+						*utils.MustParseAddr("example.com:12345"),
+					},
+				},
+				Auth: servicecfg.AuthConfig{
+					Enabled: true,
+				},
+			},
+			wantAddr: "tcp://example.com:12345",
+		},
+		{
+			name: "multiplex web addr",
+			mode: types.ProxyListenerMode_Multiplex,
+			config: servicecfg.Config{
+				Proxy: servicecfg.ProxyConfig{
+					Enabled: true,
+					WebAddr: *utils.MustParseAddr("https://example.com:12345"),
+				},
+				Auth: servicecfg.AuthConfig{
+					Enabled: true,
+				},
+			},
+			wantAddr: "tcp://example.com:12345",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			process := TeleportProcess{Config: &test.config}
+			resolver := process.SingleProcessModeResolver(test.mode)
+			require.NotNil(t, resolver)
+			addr, mode, err := resolver(context.Background())
+			if test.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, mode, test.mode)
+			require.Equal(t, addr.FullAddress(), test.wantAddr)
+		})
+	}
+}


### PR DESCRIPTION
Fixes #24796 

Related change:
https://github.com/gravitational/teleport/pull/23866

Prior to the above change, TLS routing dialer was forcing "tcp" network when "https" is passed in:
https://github.com/gravitational/teleport/blob/eec5803ed6ac25cbd6d967e9840171c96e728839/lib/utils/proxy/proxy.go#L154

Instead re-applying the same forcing-network-tcp fix, this change tries to make sure "tcp" is passed in.