### PR TITLE
Retry search in Connect if current workspace cert has expired

### DIFF
--- a/web/packages/shared/hooks/useAsync.ts
+++ b/web/packages/shared/hooks/useAsync.ts
@@ -22,9 +22,19 @@ import { useCallback, useState, useRef, useEffect } from 'react';
  *
  * * The first element is the representation of the attempt to run that async function as data, the
  *   so called attempt object.
- * * The second element is a function which when called starts to execute the async function.
+ * * The second element is a function which when called starts to execute the async function (the
+ * `run` function).
  * * The third element is a function that lets you directly update the attempt object if needed.
  *
+ * `useAsync` automatically ignores stale promises either when the underlying component gets
+ * unmounted. If the `run` function gets executed again while the promise from the previous
+ * execution still hasn't finished, the return value of the previous promise will be ignored.
+ *
+ * The primary interface through which you should interact with the result of the callback is the
+ * attempt object. The `run` function has a return value as well which is useful if you need to
+ * chain its result with some other action inside an event handler or in `useEffect`. The return
+ * value of the `run` function corresponds to the return value of that specific invocation of the
+ * callback passed to `useAsync`. This means you need to manually handle the `CanceledError` case.
  *
  * @example
  * export function useUserProfile(userId) {
@@ -44,7 +54,7 @@ import { useCallback, useState, useRef, useEffect } from 'react';
  *     if (!fetchUserProfileAttempt.status) {
  *       fetchUserProfile()
  *     }
- *   }, [fetchUserProfileAttempt])
+ *   }, [fetchUserProfileAttempt, fetchUserProfile])
  *
  *    switch (fetchUserProfileAttempt.status) {
  *      case '':
@@ -55,6 +65,21 @@ import { useCallback, useState, useRef, useEffect } from 'react';
  *      case 'success':
  *       return <UserAvatar url={fetchUserProfileAttempt.data.avatarUrl} />;
  *    }
+ * }
+ *
+ * @example Consuming the `run` return value
+ * function UserProfile(props) {
+ *   const { fetchUserProfileAttempt, fetchUserProfile } = useUserProfile(props.id);
+ *
+ *   useEffect(async () => {
+ *     if (!fetchUserProfileAttempt.status) {
+ *       const [profile, err] = fetchUserProfile()
+ *
+ *       if (err && !(err instanceof CanceledError)) {
+ *         // Handle the error.
+ *       }
+ *     }
+ *   }, [fetchUserProfileAttempt, fetchUserProfile])
  * }
  *
  */

--- a/web/packages/shared/hooks/useAsync.ts
+++ b/web/packages/shared/hooks/useAsync.ts
@@ -114,14 +114,7 @@ export function useAsync<Args extends unknown[], AttemptData>(
     [setState, cb, isMounted]
   );
 
-  const setAttempt = useCallback(
-    (attempt: Attempt<AttemptData>) => {
-      setState(attempt);
-    },
-    [setState]
-  );
-
-  return [state, run, setAttempt] as const;
+  return [state, run, setState] as const;
 }
 
 function useIsMounted() {

--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -49,3 +49,25 @@ export const makeKube = (props: Partial<tsh.Kube> = {}): tsh.Kube => ({
 
 export const makeLabelsList = (labels: Record<string, string>): tsh.Label[] =>
   Object.entries(labels).map(([name, value]) => ({ name, value }));
+
+export const makeRootCluster = (
+  props: Partial<tsh.Cluster> = {}
+): tsh.Cluster => ({
+  uri: '/clusters/teleport-local',
+  name: 'teleport-local',
+  connected: true,
+  leaf: false,
+  proxyHost: 'teleport-local:3080',
+  authClusterId: '73c4746b-d956-4f16-9848-4e3469f70762',
+  loggedInUser: {
+    activeRequestsList: [],
+    assumedRequests: {},
+    name: 'admin',
+    acl: {},
+    sshLoginsList: [],
+    rolesList: [],
+    requestableRolesList: [],
+    suggestedReviewersList: [],
+  },
+  ...props,
+});

--- a/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
+++ b/web/packages/teleterm/src/ui/ClusterConnect/ClusterLogin/ClusterLogin.tsx
@@ -59,7 +59,7 @@ export function ClusterLoginPresentation({
         <Text typography="h4">
           Login to <b>{title}</b>
         </Text>
-        <ButtonIcon ml="auto" p={3} onClick={onCloseDialog}>
+        <ButtonIcon ml="auto" p={3} onClick={onCloseDialog} aria-label="Close">
           <Icons.Close fontSize="20px" />
         </ButtonIcon>
       </DialogHeader>

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -16,7 +16,6 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { act } from '@testing-library/react';
 import { render, screen, waitFor } from 'design/utils/testing';
 import { makeSuccessAttempt } from 'shared/hooks/useAsync';
 
@@ -322,7 +321,7 @@ it('shows a login modal when a request to a cluster from the current workspace f
   expect(screen.getByRole('menu')).toBeInTheDocument();
 });
 
-const getMockedSearchContext = () => ({
+const getMockedSearchContext = (): SearchContext.SearchContext => ({
   inputValue: 'foo',
   filters: [],
   setFilter: () => {},
@@ -339,5 +338,7 @@ const getMockedSearchContext = () => ({
   pauseUserInteraction: async cb => {
     cb();
   },
-  addWindowEventListener: () => () => {},
+  addWindowEventListener: () => ({
+    cleanup: () => {},
+  }),
 });

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -181,7 +181,7 @@ it('notifies about resource search errors and allows to display details', () => 
     .spyOn(SearchContext, 'useSearchContext')
     .mockImplementation(() => mockedSearchContext);
   jest.spyOn(appContext.modalsService, 'openRegularDialog');
-  jest.spyOn(mockedSearchContext, 'lockOpen');
+  jest.spyOn(mockedSearchContext, 'pauseUserInteraction');
 
   render(
     <MockAppContextProvider appContext={appContext}>
@@ -204,7 +204,7 @@ it('notifies about resource search errors and allows to display details', () => 
       errors: [resourceSearchError],
     })
   );
-  expect(mockedSearchContext.lockOpen).toHaveBeenCalled();
+  expect(mockedSearchContext.pauseUserInteraction).toHaveBeenCalled();
 });
 
 it('maintains focus on the search input after closing a resource search error modal', async () => {
@@ -271,7 +271,6 @@ const getMockedSearchContext = () => ({
   removeFilter: () => {},
   isOpen: true,
   open: () => {},
-  lockOpen: async () => {},
   close: () => {},
   closeAndResetInput: () => {},
   resetInput: () => {},
@@ -279,4 +278,8 @@ const getMockedSearchContext = () => ({
   onInputValueChange: () => {},
   activePicker: pickers.actionPicker,
   inputRef: undefined,
+  pauseUserInteraction: async cb => {
+    cb();
+  },
+  addWindowEventListener: () => () => {},
 });

--- a/web/packages/teleterm/src/ui/Search/SearchBar.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.tsx
@@ -58,6 +58,7 @@ function SearchBar() {
     isOpen,
     open,
     close,
+    addWindowEventListener,
   } = useSearchContext();
   const ctx = useAppContext();
   ctx.clustersService.useState();
@@ -75,10 +76,9 @@ function SearchBar() {
       }
     };
     if (isOpen) {
-      window.addEventListener('click', onClickOutside);
-      return () => window.removeEventListener('click', onClickOutside);
+      return addWindowEventListener('click', onClickOutside, { capture: true });
     }
-  }, [close, isOpen]);
+  }, [close, isOpen, addWindowEventListener]);
 
   function handleOnFocus(e: React.FocusEvent) {
     open(e.relatedTarget);

--- a/web/packages/teleterm/src/ui/Search/SearchBar.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.tsx
@@ -76,7 +76,10 @@ function SearchBar() {
       }
     };
     if (isOpen) {
-      return addWindowEventListener('click', onClickOutside, { capture: true });
+      const { cleanup } = addWindowEventListener('click', onClickOutside, {
+        capture: true,
+      });
+      return cleanup;
     }
   }, [close, isOpen, addWindowEventListener]);
 

--- a/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
@@ -93,7 +93,7 @@ describe('addWindowEventListener', () => {
       ),
     });
 
-    const cleanupFunction = result.current.addWindowEventListener(
+    const { cleanup } = result.current.addWindowEventListener(
       'click',
       onWindowClick,
       // Add an extra arg to make sure that the same set of args is passed to removeEventListener as
@@ -104,7 +104,7 @@ describe('addWindowEventListener', () => {
     fireEvent(window, createEvent.click(window));
     expect(onWindowClick).toHaveBeenCalledTimes(1);
 
-    cleanupFunction();
+    cleanup();
 
     fireEvent(window, createEvent.click(window));
     // Verify that the listener was removed by the cleanup function.
@@ -130,11 +130,11 @@ describe('addWindowEventListener', () => {
       );
     });
 
-    const cleanupFunction = result.current.addWindowEventListener(
+    const { cleanup } = result.current.addWindowEventListener(
       'click',
       jest.fn()
     );
-    expect(cleanupFunction).toBeUndefined();
+    expect(cleanup).toBeUndefined();
 
     await act(async () => {
       resolveAction();

--- a/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
@@ -16,12 +16,12 @@
 
 import React from 'react';
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, createEvent, render, screen } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react-hooks';
 
 import { SearchContextProvider, useSearchContext } from './SearchContext';
 
-describe('lockOpen', () => {
+describe('pauseUserInteraction', () => {
   let resolveSuccessAction, rejectFailureAction;
   const successAction = new Promise(resolve => {
     resolveSuccessAction = resolve;
@@ -32,17 +32,18 @@ describe('lockOpen', () => {
 
   test.each([
     {
-      name: 'prevents the search bar from being closed for the duration of the action',
+      name: 'prevents the window listeners from being added for the duration of the action',
       action: successAction,
       finishAction: resolveSuccessAction,
     },
     {
-      name: 'properly cleans up the ref even after the action fails',
+      name: 'properly cleans up the state even after the action fails',
       action: failureAction,
       finishAction: rejectFailureAction,
     },
   ])('$name', async ({ action, finishAction }) => {
     const inputFocus = jest.fn();
+    const onWindowClick = jest.fn();
     const { result } = renderHook(() => useSearchContext(), {
       wrapper: ({ children }) => (
         <SearchContextProvider>{children}</SearchContextProvider>
@@ -52,38 +53,93 @@ describe('lockOpen', () => {
       focus: inputFocus,
     } as unknown as HTMLInputElement;
 
+    let pauseInteractionPromise: Promise<void>;
     act(() => {
-      result.current.open();
+      pauseInteractionPromise = result.current.pauseUserInteraction(
+        () => action
+      );
     });
 
-    let lockOpenPromise: Promise<void>;
-    act(() => {
-      lockOpenPromise = result.current.lockOpen(action);
-    });
-
-    // Closing while the search bar is locked open should be a noop.
-    act(() => {
-      result.current.close();
-    });
-    expect(result.current.isOpen).toBe(true);
+    // Adding a window event while the interaction is paused should be a noop.
+    result.current.addWindowEventListener('click', onWindowClick);
+    fireEvent(window, createEvent.click(window));
+    expect(onWindowClick).not.toHaveBeenCalled();
 
     await act(async () => {
       finishAction();
       try {
-        await lockOpenPromise;
+        await pauseInteractionPromise;
       } catch {
         // Ignore the error happening when `finishAction` rejects `action`.
       }
     });
 
-    // The search bar should be no longer locked open, so close should behave as expected.
-    act(() => {
-      result.current.close();
-    });
-    expect(result.current.isOpen).toBe(false);
+    // User interaction is no longer paused, so addWindowEventListener should add a listener.
+    result.current.addWindowEventListener('click', onWindowClick);
+    fireEvent(window, createEvent.click(window));
+    expect(onWindowClick).toHaveBeenCalledTimes(1);
 
-    // Called the first time during `open`, then again after `lockOpen` finishes.
-    expect(inputFocus).toHaveBeenCalledTimes(2);
+    // Verify that the search input has received focus after pauseInteractionPromise finishes.
+    expect(inputFocus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('addWindowEventListener', () => {
+  it('returns a cleanup function', () => {
+    const onWindowClick = jest.fn();
+    const { result } = renderHook(() => useSearchContext(), {
+      wrapper: ({ children }) => (
+        <SearchContextProvider>{children}</SearchContextProvider>
+      ),
+    });
+
+    const cleanupFunction = result.current.addWindowEventListener(
+      'click',
+      onWindowClick,
+      // Add an extra arg to make sure that the same set of args is passed to removeEventListener as
+      // it is to addEventListener.
+      { capture: true }
+    );
+
+    fireEvent(window, createEvent.click(window));
+    expect(onWindowClick).toHaveBeenCalledTimes(1);
+
+    cleanupFunction();
+
+    fireEvent(window, createEvent.click(window));
+    // Verify that the listener was removed by the cleanup function.
+    expect(onWindowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not return a cleanup function when user interaction is paused', async () => {
+    let resolveAction;
+    const action = new Promise(resolve => {
+      resolveAction = resolve;
+    });
+
+    const { result } = renderHook(() => useSearchContext(), {
+      wrapper: ({ children }) => (
+        <SearchContextProvider>{children}</SearchContextProvider>
+      ),
+    });
+
+    let pauseInteractionPromise;
+    act(() => {
+      pauseInteractionPromise = result.current.pauseUserInteraction(
+        () => action
+      );
+    });
+
+    const cleanupFunction = result.current.addWindowEventListener(
+      'click',
+      jest.fn()
+    );
+    expect(cleanupFunction).toBeUndefined();
+
+    await act(async () => {
+      resolveAction();
+      await pauseInteractionPromise;
+    });
   });
 });
 

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -43,9 +43,9 @@ export interface SearchContext {
   setFilter(filter: SearchFilter): void;
   removeFilter(filter: SearchFilter): void;
   pauseUserInteraction(action: () => Promise<any>): Promise<void>;
-  addWindowEventListener(
-    ...args: Parameters<typeof window.addEventListener>
-  ): () => void;
+  addWindowEventListener(...args: Parameters<typeof window.addEventListener>): {
+    cleanup: () => void;
+  };
 }
 
 const SearchContext = createContext<SearchContext>(null);
@@ -145,12 +145,15 @@ export const SearchContextProvider: FC = props => {
   const addWindowEventListener = useCallback(
     (...args: Parameters<typeof window.addEventListener>) => {
       if (isUserInteractionPaused) {
-        return;
+        return { cleanup: undefined };
       }
 
       window.addEventListener(...args);
-      return () => {
-        window.removeEventListener(...args);
+
+      return {
+        cleanup: () => {
+          window.removeEventListener(...args);
+        },
       };
     },
     [isUserInteractionPaused]

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -37,12 +37,15 @@ export interface SearchContext {
   changeActivePicker(picker: SearchPicker): void;
   isOpen: boolean;
   open(fromElement?: Element): void;
-  lockOpen(action: Promise<any>): Promise<void>;
   close(): void;
   closeAndResetInput(): void;
   resetInput(): void;
   setFilter(filter: SearchFilter): void;
   removeFilter(filter: SearchFilter): void;
+  pauseUserInteraction(action: () => Promise<any>): Promise<void>;
+  addWindowEventListener(
+    ...args: Parameters<typeof window.addEventListener>
+  ): () => void;
 }
 
 const SearchContext = createContext<SearchContext>(null);
@@ -51,7 +54,6 @@ export const SearchContextProvider: FC = props => {
   const previouslyActive = useRef<Element>();
   const inputRef = useRef<HTMLInputElement>();
   const [isOpen, setIsOpen] = useState(false);
-  const [isLockedOpen, setIsLockedOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
   const [activePicker, setActivePicker] = useState(actionPicker);
   // TODO(ravicious): Consider using another data structure for search filters as we know that we
@@ -69,25 +71,17 @@ export const SearchContextProvider: FC = props => {
   }
 
   const close = useCallback(() => {
-    if (isLockedOpen) {
-      return;
-    }
-
     setIsOpen(false);
     setActivePicker(actionPicker);
     if (previouslyActive.current instanceof HTMLElement) {
       previouslyActive.current.focus();
     }
-  }, [isLockedOpen]);
+  }, []);
 
   const closeAndResetInput = useCallback(() => {
-    if (isLockedOpen) {
-      return;
-    }
-
     close();
     setInputValue('');
-  }, [isLockedOpen, close]);
+  }, [close]);
 
   const resetInput = useCallback(() => {
     setInputValue('');
@@ -109,28 +103,58 @@ export const SearchContextProvider: FC = props => {
     setIsOpen(true);
   }
 
+  const [isUserInteractionPaused, setIsUserInteractionPaused] = useState(false);
   /**
-   * lockOpen forces the search bar to stay open for the duration of the action. It also restores
-   * focus on the search input after the action is done.
+   * pauseUserInteraction temporarily causes addWindowEventListener not to add listeners for the
+   * duration of the action. It also restores focus on the search input after the action is done.
    *
-   * This is useful in situations where want the search bar to not close when the user interacts
-   * with modals shown from the search bar.
+   * This is useful in situations where want the search bar to show some other element the user can
+   * interact with, for example a modal. When the user interacts with the modal, we don't want the
+   * search bar listeners to intercept those interactions, which could for example cause the search
+   * bar to close or make the user unable to press Enter in the modal as the search bar would
+   * swallow that event.
    */
-  async function lockOpen(action: Promise<any>): Promise<void> {
-    setIsLockedOpen(true);
+  const pauseUserInteraction = useCallback(
+    async (action: () => Promise<any>): Promise<void> => {
+      setIsUserInteractionPaused(true);
 
-    try {
-      await action;
-    } finally {
-      // By the time the action passes, the user might have caused the focus to be lost on the
-      // search input, so let's bring it back.
-      //
-      // focus needs to be executed before the state update, otherwise the search bar will close for
-      // some reason.
-      inputRef.current?.focus();
-      setIsLockedOpen(false);
-    }
-  }
+      try {
+        await action();
+      } finally {
+        // By the time the action passes, the user might have caused the focus to be lost on the
+        // search input, so let's bring it back.
+        //
+        // focus needs to be executed before the state update, otherwise the search bar will close
+        // for some reason.
+        inputRef.current?.focus();
+        setIsUserInteractionPaused(false);
+      }
+    },
+    []
+  );
+
+  /**
+   * addWindowEventListener is meant to be used in useEffect calls which register event listeners
+   * related to the search bar. It automatically removes the listener when the user interaction gets
+   * paused.
+   *
+   * pauseUserInteraction is supposed to be called in situations where the search bar is obstructed
+   * by another element (such as a modal) and we don't want interactions with that other element to
+   * have any effect on the search bar.
+   */
+  const addWindowEventListener = useCallback(
+    (...args: Parameters<typeof window.addEventListener>) => {
+      if (isUserInteractionPaused) {
+        return;
+      }
+
+      window.addEventListener(...args);
+      return () => {
+        window.removeEventListener(...args);
+      };
+    },
+    [isUserInteractionPaused]
+  );
 
   function setFilter(filter: SearchFilter) {
     // UI prevents adding more than one filter of the same type
@@ -165,9 +189,10 @@ export const SearchContextProvider: FC = props => {
         resetInput,
         isOpen,
         open,
-        lockOpen,
         close,
         closeAndResetInput,
+        pauseUserInteraction,
+        addWindowEventListener,
       }}
       children={props.children}
     />

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -43,10 +43,14 @@ export interface SearchContext {
   setFilter(filter: SearchFilter): void;
   removeFilter(filter: SearchFilter): void;
   pauseUserInteraction(action: () => Promise<any>): Promise<void>;
-  addWindowEventListener(...args: Parameters<typeof window.addEventListener>): {
-    cleanup: () => void;
-  };
+  addWindowEventListener: AddWindowEventListener;
 }
+
+export type AddWindowEventListener = (
+  ...args: Parameters<typeof window.addEventListener>
+) => {
+  cleanup: () => void;
+};
 
 const SearchContext = createContext<SearchContext>(null);
 

--- a/web/packages/teleterm/src/ui/Search/actions.tsx
+++ b/web/packages/teleterm/src/ui/Search/actions.tsx
@@ -22,6 +22,7 @@ import {
   connectToKube,
   connectToServer,
 } from 'teleterm/ui/services/workspacesService';
+import { retryWithRelogin } from 'teleterm/ui/utils';
 
 export interface SimpleAction {
   type: 'simple-action';
@@ -95,7 +96,9 @@ export function mapToActions(
         searchResult: result,
         parameter: {
           getSuggestions: () =>
-            ctx.resourcesService.getDbUsers(result.resource.uri),
+            retryWithRelogin(ctx, result.resource.uri, () =>
+              ctx.resourcesService.getDbUsers(result.resource.uri)
+            ),
           placeholder: 'Provide db username',
         },
         perform: dbUser => {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.story.tsx
@@ -324,6 +324,7 @@ const SearchResultItems = () => {
       attempts={[attempt]}
       onPick={() => {}}
       onBack={() => {}}
+      addWindowEventListener={() => ({ cleanup: () => {} })}
       render={searchResult => {
         const Component = ComponentMap[searchResult.kind];
 
@@ -350,6 +351,7 @@ const AuxiliaryItems = () => (
     onBack={() => {}}
     render={() => null}
     attempts={[]}
+    addWindowEventListener={() => ({ cleanup: () => {} })}
     ExtraTopComponent={
       <>
         <NoResultsItem

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -69,6 +69,7 @@ export function ActionPicker(props: { input: ReactElement }) {
     closeAndResetInput,
     filters,
     removeFilter,
+    addWindowEventListener,
   } = useSearchContext();
   const {
     filterActionsAttempt,
@@ -205,6 +206,7 @@ export function ActionPicker(props: { input: ReactElement }) {
         attempts={actionAttempts}
         onPick={onPick}
         onBack={close}
+        addWindowEventListener={addWindowEventListener}
         render={item => {
           const Component = ComponentMap[item.searchResult.kind];
           return {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -62,7 +62,7 @@ export function ActionPicker(props: { input: ReactElement }) {
 
   const {
     changeActivePicker,
-    lockOpen,
+    pauseUserInteraction,
     close,
     inputValue,
     resetInput,
@@ -170,15 +170,16 @@ export function ActionPicker(props: { input: ReactElement }) {
     resourceSearchAttempt.data.errors.length > 0
   ) {
     const showErrorsInModal = () => {
-      lockOpen(
-        new Promise(resolve => {
-          modalsService.openRegularDialog({
-            kind: 'resource-search-errors',
-            errors: resourceSearchAttempt.data.errors,
-            getClusterName,
-            onCancel: () => resolve(undefined),
-          });
-        })
+      pauseUserInteraction(
+        () =>
+          new Promise(resolve => {
+            modalsService.openRegularDialog({
+              kind: 'resource-search-errors',
+              errors: resourceSearchAttempt.data.errors,
+              getClusterName,
+              onCancel: () => resolve(undefined),
+            });
+          })
       );
     };
 

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -419,7 +419,7 @@ export function DatabaseItem(props: SearchResultItem<SearchResultDatabase>) {
         gap={1}
       >
         <Text typography="body1">
-          Set up a db connection for{' '}
+          Set up a db connection to{' '}
           <strong>
             <HighlightField field="name" searchResult={searchResult} />
           </strong>

--- a/web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx
@@ -35,8 +35,13 @@ interface ParameterPickerProps {
 }
 
 export function ParameterPicker(props: ParameterPickerProps) {
-  const { inputValue, closeAndResetInput, changeActivePicker, resetInput } =
-    useSearchContext();
+  const {
+    inputValue,
+    closeAndResetInput,
+    changeActivePicker,
+    resetInput,
+    addWindowEventListener,
+  } = useSearchContext();
   const [suggestionsAttempt, fetch] = useAsync(
     props.action.parameter.getSuggestions
   );
@@ -77,6 +82,7 @@ export function ParameterPicker(props: ParameterPickerProps) {
         attempts={[inputSuggestionAttempt, attempt]}
         onPick={onPick}
         onBack={onBack}
+        addWindowEventListener={addWindowEventListener}
         render={item => ({
           key: item,
           Component: (

--- a/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
@@ -27,6 +27,8 @@ import { Attempt } from 'shared/hooks/useAsync';
 
 import LinearProgress from 'teleterm/ui/components/LinearProgress';
 
+import { useSearchContext } from '../SearchContext';
+
 type ResultListProps<T> = {
   /**
    * List of attempts containing results to render.
@@ -47,6 +49,7 @@ export function ResultList<T>(props: ResultListProps<T>) {
   const { attempts, ExtraTopComponent, onPick, onBack } = props;
   const activeItemRef = useRef<HTMLDivElement>();
   const [activeItemIndex, setActiveItemIndex] = useState(0);
+  const { addWindowEventListener } = useSearchContext();
 
   const items = useMemo(() => {
     return attempts.map(a => a.data || []).flat();
@@ -98,9 +101,8 @@ export function ResultList<T>(props: ResultListProps<T>) {
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [items, onPick, onBack, activeItemIndex]);
+    return addWindowEventListener('keydown', handleKeyDown, { capture: true });
+  }, [items, onPick, onBack, activeItemIndex, addWindowEventListener]);
 
   return (
     <>

--- a/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
@@ -22,12 +22,11 @@ import React, {
   useState,
 } from 'react';
 import styled, { css } from 'styled-components';
-
 import { Attempt } from 'shared/hooks/useAsync';
 
 import LinearProgress from 'teleterm/ui/components/LinearProgress';
 
-import { useSearchContext } from '../SearchContext';
+import { AddWindowEventListener } from '../SearchContext';
 
 type ResultListProps<T> = {
   /**
@@ -43,13 +42,19 @@ type ResultListProps<T> = {
   onPick(item: T): void;
   onBack(): void;
   render(item: T): { Component: ReactElement; key: string };
+  addWindowEventListener: AddWindowEventListener;
 };
 
 export function ResultList<T>(props: ResultListProps<T>) {
-  const { attempts, ExtraTopComponent, onPick, onBack } = props;
+  const {
+    attempts,
+    ExtraTopComponent,
+    onPick,
+    onBack,
+    addWindowEventListener,
+  } = props;
   const activeItemRef = useRef<HTMLDivElement>();
   const [activeItemIndex, setActiveItemIndex] = useState(0);
-  const { addWindowEventListener } = useSearchContext();
 
   const items = useMemo(() => {
     return attempts.map(a => a.data || []).flat();

--- a/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
@@ -101,7 +101,10 @@ export function ResultList<T>(props: ResultListProps<T>) {
       }
     };
 
-    return addWindowEventListener('keydown', handleKeyDown, { capture: true });
+    const { cleanup } = addWindowEventListener('keydown', handleKeyDown, {
+      capture: true,
+    });
+    return cleanup;
   }, [items, onPick, onBack, activeItemIndex, addWindowEventListener]);
 
   return (

--- a/web/packages/teleterm/src/ui/Search/pickers/useActionAttempts.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/useActionAttempts.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import {
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useCallback,
+} from 'react';
 import {
   makeEmptyAttempt,
   makeSuccessAttempt,
@@ -32,19 +38,77 @@ import { mapToActions } from 'teleterm/ui/Search/actions';
 import Logger from 'teleterm/logger';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { useSearchContext } from 'teleterm/ui/Search/SearchContext';
+import { SearchFilter } from 'teleterm/ui/Search/searchResult';
+import { routing } from 'teleterm/ui/uri';
+import { isRetryable } from 'teleterm/ui/utils/retryWithRelogin';
 
 export function useActionAttempts() {
   const searchLogger = useRef(new Logger('search'));
   const ctx = useAppContext();
-  // Both states are used by mapToActions.
-  ctx.workspacesService.useState();
-  ctx.clustersService.useState();
+  const { modalsService, workspacesService } = ctx;
   const searchContext = useSearchContext();
-  const { inputValue, filters } = searchContext;
+  const { inputValue, filters, pauseUserInteraction } = searchContext;
 
   const [resourceSearchAttempt, runResourceSearch, setResourceSearchAttempt] =
     useAsync(useResourceSearch());
-  const runResourceSearchDebounced = useDebounce(runResourceSearch, 200);
+  /**
+   * runRetryableResourceSearch implements retryWithRelogin logic for resource search. We check if
+   * among all resource search requests there's a request belonging to the current workspace and if
+   * it failed with a retryable error. If so, we show the login modal.
+   *
+   * We're interested only in errors coming from clusters within the current workspace because
+   * otherwise we'd nag the user to log in to each cluster they've added to the app.
+   *
+   * Technically we could wrap runResourceSearch into a custom promise which would make it fit into
+   * retryWithRelogin. However, by doing this we'd give up some of the finer control over the whole
+   * process, for example we couldn't as easily call pauseUserInteraction only when necessary.
+   *
+   * This logic _cannot_ be included within the callback passed to useAsync and has to be performed
+   * outside of it. If it was included within useAsync, then this logic would fire for any request
+   * made to the cluster, even for stale requests which are ignored by useAsync.
+   */
+  const runRetryableResourceSearch = useCallback(
+    async (search: string, filters: SearchFilter[]): Promise<void> => {
+      const activeRootClusterUri = workspacesService.getRootClusterUri();
+      const [results, err] = await runResourceSearch(search, filters);
+      // Since resource search uses Promise.allSettled underneath, the only error that could be
+      // returned here is CanceledError from useAsync. In that case, we can just return early.
+      if (err) {
+        return;
+      }
+
+      const hasActiveWorkspaceRequestFailedWithRetryableError =
+        results.errors.some(
+          error =>
+            routing.belongsToProfile(activeRootClusterUri, error.clusterUri) &&
+            isRetryable(error.cause)
+        );
+
+      if (!hasActiveWorkspaceRequestFailedWithRetryableError) {
+        return;
+      }
+
+      await pauseUserInteraction(
+        () =>
+          new Promise<void>(resolve => {
+            modalsService.openClusterConnectDialog({
+              clusterUri: activeRootClusterUri,
+              onSuccess: () => resolve(),
+              onCancel: () => resolve(),
+            });
+          })
+      );
+
+      // Retrying the request no matter if the user logged in through the modal or not, for the same
+      // reasons as described in retryWithRelogin.
+      runResourceSearch(search, filters);
+    },
+    [modalsService, workspacesService, runResourceSearch, pauseUserInteraction]
+  );
+  const runDebouncedResourceSearch = useDebounce(
+    runRetryableResourceSearch,
+    200
+  );
   const resourceActionsAttempt = useMemo(
     () =>
       mapAttempt(resourceSearchAttempt, ({ results, search }) => {
@@ -74,13 +138,13 @@ export function useActionAttempts() {
     // 3. Now you see the stale results for `foo`, because the debounce didn't kick in yet.
     setResourceSearchAttempt(makeEmptyAttempt());
 
-    runResourceSearchDebounced(inputValue, filters);
+    runDebouncedResourceSearch(inputValue, filters);
   }, [
     inputValue,
     filters,
     setResourceSearchAttempt,
     runFilterSearch,
-    runResourceSearchDebounced,
+    runDebouncedResourceSearch,
   ]);
 
   return {

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -43,7 +43,6 @@ import type * as resourcesServiceTypes from 'teleterm/ui/services/resources';
  */
 export function useResourceSearch() {
   const { clustersService, resourcesService } = useAppContext();
-  clustersService.useState();
 
   return useCallback(
     async (
@@ -125,8 +124,6 @@ export function useResourceSearch() {
  */
 export function useFilterSearch() {
   const { clustersService, workspacesService } = useAppContext();
-  clustersService.useState();
-  workspacesService.useState();
 
   return useCallback(
     (search: string, filters: SearchFilter[]): FilterSearchResult[] => {

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -48,7 +48,7 @@ export function useResourceSearch() {
   return useCallback(
     async (
       search: string,
-      restrictions: SearchFilter[]
+      filters: SearchFilter[]
     ): Promise<{
       results: resourcesServiceTypes.SearchResult[];
       errors: resourcesServiceTypes.ResourceSearchError[];
@@ -67,10 +67,10 @@ export function useResourceSearch() {
         return { results: [], errors: [], search };
       }
 
-      const clusterSearchFilter = restrictions.find(
+      const clusterSearchFilter = filters.find(
         s => s.filter === 'cluster'
       ) as ClusterSearchFilter;
-      const resourceTypeSearchFilter = restrictions.find(
+      const resourceTypeSearchFilter = filters.find(
         s => s.filter === 'resource-type'
       ) as ResourceTypeSearchFilter;
 
@@ -129,7 +129,7 @@ export function useFilterSearch() {
   workspacesService.useState();
 
   return useCallback(
-    (search: string, restrictions: SearchFilter[]): FilterSearchResult[] => {
+    (search: string, filters: SearchFilter[]): FilterSearchResult[] => {
       const getClusters = () => {
         let clusters = clustersService.getClusters();
         // Cluster filter should not be visible if there is only one cluster
@@ -179,10 +179,8 @@ export function useFilterSearch() {
         }));
       };
 
-      const shouldReturnClusters = !restrictions.some(
-        r => r.filter === 'cluster'
-      );
-      const shouldReturnResourceTypes = !restrictions.some(
+      const shouldReturnClusters = !filters.some(r => r.filter === 'cluster');
+      const shouldReturnResourceTypes = !filters.some(
         r => r.filter === 'resource-type'
       );
 

--- a/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
+++ b/web/packages/teleterm/src/ui/utils/retryWithRelogin.ts
@@ -49,13 +49,7 @@ export async function retryWithRelogin<T>(
   try {
     return await actionToRetry();
   } catch (error) {
-    // TODO(ravicious): Replace this with actual check on metadata.
-    const isRetryable =
-      error instanceof Error &&
-      (error.message.includes('ssh: handshake failed') ||
-        error.message.includes('ssh: cert has expired'));
-
-    if (isRetryable) {
+    if (isRetryable(error)) {
       retryableErrorFromActionToRetry = error;
       logger.info(`Activating relogin on error ${error}`);
     } else {
@@ -82,6 +76,15 @@ export async function retryWithRelogin<T>(
   await login(appContext, rootClusterUri);
 
   return await actionToRetry();
+}
+
+export function isRetryable(error: unknown): boolean {
+  // TODO(ravicious): Replace this with actual check on metadata.
+  return (
+    error instanceof Error &&
+    (error.message.includes('ssh: handshake failed') ||
+      error.message.includes('ssh: cert has expired'))
+  );
 }
 
 // Notice that we don't differentiate between onSuccess and onCancel. In both cases, we're going to


### PR DESCRIPTION
The main goal of this PR is to detect if any search request made to clusters from the current workspace has failed, if so offer the user a way to relogin and then retry the search.

We do this only for current workspace requests because otherwise we'd have to get the user through a modal for every cluster they're logged in to.

As usual, the first couple of commits are small refactors of related functions. The actual feature is implemented in the last two commits.

The best way to test it is to copy the tsh folder with the expired certs:

```
cp -R ~/Library/Application\ Support/Electron/tsh{,-with-expired-certs}
```

Then start Connect, log in to the cluster and then replace the fresh certs with expired ones:

```
rm -rf ~/Library/Application\ Support/Electron/tsh && cp -R ~/Library/Application\ Support/Electron/tsh{-with-expired-certs,}
```

The next request to the cluster should make Connect think that the certs have expired.

## `lockOpen` -> `pauseUserInteraction`

The big thing is how `lockOpen` has been refactored into `pauseUserInteraction`. `lockOpen` was added in #24520. #24520 makes it so that when any of the requests fails, we offer the ability to open a modal which shows error details. We don't want the search bar to get closed when the user interacts with the modal, so we introduced `lockOpen`.

This PR shows another modal, the login modal, while the search bar is supposed to stay open. However, the login modal is much more complex than the one with error details. It not only contains some buttons, but also some form fields.

Because `ResultList` adds a global window listener which captures some keyboard presses, it was impossible to press Enter in the login modal while the search bar was open.

So I completely changed how `lockOpen` works. Instead of merely causing the `close` function to be a noop, I added a new function to `SearchContext` called `addWindowEventListener`. Any window listener related to the search bar should be registered through this function. `addWindowEventListener` is supposed to be used in `useEffect` and it automatically removes the listeners for the duration of `pauseUserInteraction`, which is the new name for `lockOpen`.

`pauseUserInteraction` is intended for those cases where we want to keep the search bar displayed while the user interacts with some other element of the UI.

### Why do we need global window listeners in the first place?

One is used to detect outside clicks while the search bar is open to close the search bar. I'm not sure if there's a way to get rid of this one. The other listener is to provide keyboard navigation while the search bar is open. Grzegorz had some ideas on how to get rid of this one but the current situation is a consequence of how the components and the underlying DOM tree are structured. The input tag is rendered outside of `ResultList` but `ResultList` would need to add event listeners on the input.