### PR TITLE
Update Cloud FAQ doc to remove latency note

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -250,10 +250,6 @@ The ability to download recordings for offline viewing will be available in a fu
 
 Yes. We recommend Teleport's [event handler plugin](../../management/export-audit-events/fluentd.mdx) to export Teleport Enterprise Cloud audit events.
 
-## I'm noticing high latency / terminal sessions are slow ?
-
-Please reach out to support@goteleport.com. Our latency design is still being rolled out, and needs to be opted into.
-
 ## What is the maximum number of nodes a customer can connect to their cluster?
 
 If you plan on connecting more than 10,000 nodes or agents, please contact your account executive or customer support to ensure your tenant is properly scaled.


### PR DESCRIPTION
With the rollout of all proxies to all prod tenants, this is no longer an opt-in functionality