### PR TITLE
Update to Readme for Teleport Usage

### DIFF
--- a/examples/teleport-usage/README.md
+++ b/examples/teleport-usage/README.md
@@ -29,6 +29,7 @@ The following information is required:
 This script is dependent of environment variables being set. Below is an example on how to run the script in Docker using environment variables:
 
 > **_NOTE:_** The latest container image version can be found at the top of this page. This version is independent of your Teleport cluster.
+
 ```console
 $ docker run -it --rm -e "TABLE_NAME=cluster-events" \
 -e "AWS_REGION=us-east-1" \

--- a/examples/teleport-usage/README.md
+++ b/examples/teleport-usage/README.md
@@ -32,7 +32,7 @@ This script is dependent of environment variables being set. Below is an example
 
 ```console
 $ docker run -it --rm -e "TABLE_NAME=cluster-events" \
--e "AWS_REGION=us-east-1" \
--e "START_DATE=2022-12-01" \ 
-public.ecr.aws/gravitational/teleport-usage:<container-version>
+    -e "AWS_REGION=us-east-1" \
+    -e "START_DATE=2022-12-01" \ 
+    public.ecr.aws/gravitational/teleport-usage:<container-version>
 ```

--- a/examples/teleport-usage/README.md
+++ b/examples/teleport-usage/README.md
@@ -24,20 +24,14 @@ The following information is required:
 | `AWS_REGION`         | AWS Region where the dynamoDB table is deployed                     |
 | `START_DATE`         | The date for when to start the query. The format must be YYYY-MM-DD |
 
-Optionally, the environment variable `SHOW_USERS` can be set to `true` to display a list of users for each protocol.
-
 ## Running Docker Container
 
-With prompt:
+This script is dependent of environment variables being set. Below is an example on how to run the script in Docker using environment variables:
 
+> **_NOTE:_** The latest container image version can be found at the top of this page. This version is independent of your Teleport cluster.
 ```console
-$ docker run -it --rm public.ecr.aws/gravitational/teleport-usage:<VERSION>
-```
-
-With environment variables:
-
-```console
-$ docker run -it --rm public.ecr.aws/gravitational/teleport-usage:<VERSION> \
--e "TABLE_NAME=cluster-events" -e "AWS_REGION=us-east-1" \
--e "START_DATE=2022-12-01"
+$ docker run -it --rm -e "TABLE_NAME=cluster-events" \
+-e "AWS_REGION=us-east-1" \
+-e "START_DATE=2022-12-01" \ 
+public.ecr.aws/gravitational/teleport-usage:<container-version>
 ```


### PR DESCRIPTION
Cleaning up the Readme. Removing the prompt option as it is no longer an option. Removed the show_users parameter as it is now always displayed and there is no flag not to display. Also clarifying where to find the container image version. Lastly, reordered the docker command to be backward compatible with Docker.