### PR TITLE
docs: remove unneeded sudo for removing user data dirs

### DIFF
--- a/docs/pages/management/admin/uninstall-teleport.mdx
+++ b/docs/pages/management/admin/uninstall-teleport.mdx
@@ -438,7 +438,7 @@ $ docker stop teleport
 
     ```code
     $ sudo rm -f /etc/tsh.yaml
-    $ sudo rm -rf ~/.tsh
+    $ rm -rf ~/.tsh
     ```
   </TabItem>
   <TabItem label="MacOS">
@@ -468,9 +468,9 @@ $ docker stop teleport
     ```code
     # tsh
     $ sudo rm -f /etc/tsh.yaml
-    $ sudo rm -rf ~/.tsh
+    $ rm -rf ~/.tsh
     # Teleport Connect
-    $ sudo rm -rf ~/Library/Application\ Support/Teleport\ Connect
+    $ rm -rf ~/Library/Application\ Support/Teleport\ Connect
     ```
   </TabItem>
   <TabItem label="Windows">


### PR DESCRIPTION
Similar update to https://github.com/gravitational/teleport/pull/24612 for unneeded `sudo` for user dir removals.