### PR TITLE
use correct certificate extension when getting cluster of agentless node

### DIFF
--- a/lib/agentless/agentless.go
+++ b/lib/agentless/agentless.go
@@ -45,7 +45,7 @@ func SignerFromSSHCertificate(certificate *ssh.Certificate, generator CertGenera
 		validBefore := time.Unix(int64(certificate.ValidBefore), 0)
 		ttl := time.Until(validBefore)
 
-		clusterName := certificate.Permissions.Extensions[utils.CertExtensionAuthority]
+		clusterName := certificate.Permissions.Extensions[utils.CertTeleportClusterName]
 		user := certificate.Permissions.Extensions[utils.CertTeleportUser]
 
 		signer, err := createAuthSigner(ctx, user, clusterName, ttl, generator)


### PR DESCRIPTION
`lib/utils.CertTeleportClusterName` is set by the SSH user key auth handlers, so it should always be set.

Updates https://github.com/gravitational/teleport/issues/24778.