### PR TITLE
Remove U2F migration testplan instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -90,14 +90,7 @@ as well as an upgrade of the previous version of Teleport.
     - [ ] Login via platform authenticator
       - [ ] Touch ID
       - [ ] Windows Hello
-    - [ ] Login via WebAuthn using an U2F device
-
-    U2F devices must be registered in a previous version of Teleport.
-
-    Using Teleport v9, set `auth_service.authentication.second_factor = u2f`,
-    restart the server and then register an U2F device (`tsh mfa add`). Upgrade
-    the installation to the current Teleport version (one major at a time) and try to
-    log in using the U2F device as your second factor - it should work.
+    - [ ] Login via WebAuthn using an U2F/CTAP1 device
 
   - [ ] Login OIDC
   - [ ] Login SAML


### PR DESCRIPTION
Registering a "legacy" U2F device is getting ever harder: most browsers don't support "pure" U2F anymore, so this is becoming impractical/difficult to test. Historically this has been stable, so I'm removing those instructions in favor of our existing (automated) tests.

Registering an U2F/CTAP1 device using WebAuthn is interesting, so keeping the item itself in that spirit.