### PR TITLE
Docs: replace DNS partial with generic instructions for kubernetes

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -170,8 +170,7 @@ to create a public IP for Teleport.
 (!docs/pages/includes/dns.mdx!)
 */}
 
-Configure DNS entries for `tele.example.com` for traffic to the Teleport Proxy
-web UI, and `*.tele.example.com` for web apps using Application Access, using `A`
+Configure DNS entries for `tele.example.com` for traffic to the Teleport Web UI, and `*.tele.example.com` for web apps using Application Access, using `A`
 records for an IP address and `CNAME` records for a hostname. The record
 type and configuration will depend on your Kubernetes provider, see their
 documentation for more information.

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -171,7 +171,8 @@ to create a public IP for Teleport.
 */}
 
 Configure DNS entries for `tele.example.com` for traffic to the Teleport Proxy
-web UI, and `*.tele.example.com` for web apps using Application Access. The record
+web UI, and `*.tele.example.com` for web apps using Application Access, using `A`
+records for an IP address and `CNAME` records for a hostname. The record
 type and configuration will depend on your Kubernetes provider, see their
 documentation for more information.
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -34,6 +34,7 @@ cluster to Teleport.
 />
 
 ## Prerequisites
+
 - A registered domain name. This is required for Teleport to set up TLS via Let's Encrypt and for Teleport clients to verify the Proxy Service host.
 - A Kubernetes cluster hosted by a cloud provider, which is required for the load balancer we deploy in this guide.
 
@@ -165,7 +166,14 @@ to create a public IP for Teleport.
   </TabItem>
 </Tabs>
 
+{/* Disabling the DNS partial until it's updated to cover this scope.
 (!docs/pages/includes/dns.mdx!)
+*/}
+
+Configure DNS entries for `tele.example.com` for traffic to the Teleport Proxy
+web UI, and `*.tele.example.com` for web apps using Application Access. The record
+type and configuration will depend on your Kubernetes provider, see their
+documentation for more information.
 
 Use the following command to confirm that Teleport is running:
 


### PR DESCRIPTION
Closes #15930

From the issue:

>The dns.mdx partial only includes instructions for getting the IP of your local host, which assumes you can run the command from a shell on the host OS. This doesn't apply to Kubernetes.
>The instructions for creating DNS A records don't apply to cases where the cloud provider assigns the load balancer a hostname, rather than an IP address, as A records that point to a domain name are invalid. In these cases, the DNS records should be CNAME records.

