### PR TITLE
docs: MySQL secrets clarification

### DIFF
--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -37,7 +37,7 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 (!docs/pages/includes/database-access/tctl-auth-sign.mdx!)
 
-Create the secrets:
+From your local workstation, create the secrets:
 
 ```code
 # Export Teleport's certificate authority and generate certificate/key pair
@@ -48,7 +48,8 @@ $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 
 The command will create 3 files: `server.cas`, `server.crt` and `server.key`
-which you'll need to enable mutual TLS on your MySQL server.
+which you'll need to enable mutual TLS on your MySQL server. Copy these files
+to the environment running MySQL
 
 ## Step 3/4. Configure MySQL/MariaDB
 


### PR DESCRIPTION
Closes #12790 

Since this issue was created we've standardized our prerequisites section for all database docs to clarify that `tctl` is run locally after authenticating with `tsh` to the Teleport cluster. This PR addresses and remaining confusion around where `tctl` is run when creating secrets for MySQL, and where the secrets need to ultimately go.