### PR TITLE
don't rely on info in SSH user cert when connecting to agentless nodes

### DIFF
--- a/lib/agentless/agentless.go
+++ b/lib/agentless/agentless.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/authz"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 // CertGenerator generates certificates from a certificate request.
@@ -40,15 +39,12 @@ type CertGenerator interface {
 // SignerFromSSHCertificate returns a function that attempts to
 // create a [ssh.Signer] for the Identity in the provided [ssh.Certificate]
 // that is signed with the OpenSSH CA and can be used to authenticate to agentless nodes.
-func SignerFromSSHCertificate(certificate *ssh.Certificate, generator CertGenerator) func(context.Context) (ssh.Signer, error) {
+func SignerFromSSHCertificate(certificate *ssh.Certificate, teleportUser, clusterName string, generator CertGenerator) func(context.Context) (ssh.Signer, error) {
 	return func(ctx context.Context) (ssh.Signer, error) {
 		validBefore := time.Unix(int64(certificate.ValidBefore), 0)
 		ttl := time.Until(validBefore)
 
-		clusterName := certificate.Permissions.Extensions[utils.CertTeleportClusterName]
-		user := certificate.Permissions.Extensions[utils.CertTeleportUser]
-
-		signer, err := createAuthSigner(ctx, user, clusterName, ttl, generator)
+		signer, err := createAuthSigner(ctx, teleportUser, clusterName, ttl, generator)
 		return signer, trace.Wrap(err)
 	}
 }

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -266,7 +266,7 @@ func (t *proxySubsys) proxyToHost(ctx context.Context, ch ssh.Channel, clientSrc
 		return trace.Wrap(err)
 	}
 
-	signer := agentless.SignerFromSSHCertificate(t.ctx.Identity.Certificate, client)
+	signer := agentless.SignerFromSSHCertificate(t.ctx.Identity.Certificate, t.ctx.Identity.TeleportUser, t.clusterName, client)
 	conn, teleportVersion, err := t.router.DialHost(ctx, clientSrcAddr, clientDstAddr, t.host, t.port, t.clusterName, t.ctx.Identity.AccessChecker, aGetter, signer)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
After finding now 2 very similar bugs today related to trying to pull connection information out of SSH certificates instead of just passing it directly, opt to pass the information directly to prevent future bugs.

Fixes https://github.com/gravitational/teleport/issues/24922.