### PR TITLE
Change Helm reference `--set` formatting

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -314,18 +314,11 @@ By default no devices are forbidden.
 
 `proxyListenerMode` controls proxy TLS routing used by Teleport. Possible values are `multiplex`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   proxyListenerMode: multiplex
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set proxyListenerMode=multiplex
-  ```
-  </TabItem>
-</Tabs>
 
 ## `sessionRecording`
 
@@ -337,18 +330,11 @@ By default no devices are forbidden.
 It is passed as-is in the configuration.
 For possible values, [see the Teleport Configuration Reference](../../reference/config.mdx).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   sessionRecording: proxy
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set sessionRecording=proxy
-  ```
-  </TabItem>
-</Tabs>
 
 ## `separatePostgresListener`
 
@@ -370,18 +356,11 @@ in front of Teleport, such as when using AWS ACM.
 
 These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   separatePostgresListener: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set separatePostgresListener=true
-  ```
-  </TabItem>
-</Tabs>
 
 ## `separateMongoListener`
 
@@ -402,18 +381,11 @@ in front of Teleport, such as when using AWS ACM.
 
 These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is set to `multiplex`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   separateMongoListener: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set separateMongoListener=true
-  ```
-  </TabItem>
-</Tabs>
 
 ## `publicAddr`
 
@@ -443,18 +415,11 @@ For example, if users are accessing the cluster with the domain
 Changing the RP ID will invalidate all already registered webauthn second factors.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   publicAddr: ["loadbalancer.example.com:443"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set publicAddr[0]=loadbalancer.example.com:443
-  ```
-  </TabItem>
-</Tabs>
 
 ## `kubePublicAddr`
 
@@ -468,18 +433,11 @@ This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set 
 When `kubePublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3026.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   kubePublicAddr: ["loadbalancer.example.com:3026"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set kubePublicAddr[0]=loadbalancer.example.com:3026
-  ```
-  </TabItem>
-</Tabs>
 
 ## `mongoPublicAddr`
 
@@ -494,18 +452,11 @@ requires [`separateMongoListener`](#separatePostgresListener) enabled.
 When `mongoPublicAddr` is not set, the addresses are inferred from [`clusterName`](#clusterName) is used.
 Default port is 27017.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   mongoPublicAddr: ["loadbalancer.example.com:27017"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set mongoPublicAddr[0]=loadbalancer.example.com:27017
-  ```
-  </TabItem>
-</Tabs>
 
 ## `mysqlPublicAddr`
 
@@ -519,18 +470,11 @@ This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set 
 When `mysqlPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3036.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   mysqlPublicAddr: ["loadbalancer.example.com:3036"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set mysqlPublicAddr[0]=loadbalancer.example.com:3036
-  ```
-  </TabItem>
-</Tabs>
 
 ## `postgresPublicAddr`
 
@@ -545,18 +489,11 @@ requires [`separatePostgresListener`](#separatePostgresListener) enabled.
 When `postgresPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 5432.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   postgresPublicAddr: ["loadbalancer.example.com:5432"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set postgresPublicAddr[0]=loadbalancer.example.com:5432
-  ```
-  </TabItem>
-</Tabs>
 
 ## `sshPublicAddr`
 
@@ -570,18 +507,11 @@ This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set 
 hen `sshPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3023.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   sshPublicAddr: ["loadbalancer.example.com:3023"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set sshPublicAddr[0]=loadbalancer.example.com:3023
-  ```
-  </TabItem>
-</Tabs>
 
 ## `tunnelPublicAddr`
 
@@ -595,18 +525,11 @@ This setting will not apply if [`proxyListenerMode`](#proxylistenermode) is set 
 When `tunnelPublicAddr` is not set, the addresses are inferred from [`publicAddr`](#publicAddr) if set,
 else [`clusterName`](#clusterName) is used. Default port is 3024.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   tunnelPublicAddr: ["loadbalancer.example.com:3024"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set tunnelPublicAddr[0]=loadbalancer.example.com:3024
-  ```
-  </TabItem>
-</Tabs>
 
 ## `enterprise`
 
@@ -636,18 +559,11 @@ $ kubectl --namespace teleport create secret generic license --from-file=/path/t
   ```
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   enterprise: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set enterprise=true
-  ```
-  </TabItem>
-</Tabs>
 
 ## `installCRDs`
 
@@ -664,18 +580,11 @@ If several releases of the `teleport-cluster` chart are deployed in the same Kub
 release should have `installCRDs` enabled. Unless you are deploying multiple `teleport-cluster` Helm releases in
 the same Kubernetes cluster or installing the CRDs on your own you should not have to set this value.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   installCRDs: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set installCRDs=true
-  ```
-  </TabItem>
-</Tabs>
 
 ## `operator`
 
@@ -691,19 +600,12 @@ Enabling the operator will also deploy the Teleport CRDs in the Kubernetes clust
 If you are deploying multiple releases of the Helm chart in the same cluster you can override this behavior with
 [`installCRDs`](#installCRDs).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   operator:
    enabled: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set operator.enabled=true
-  ```
-  </TabItem>
-</Tabs>
 
 ### `operator.image`
 
@@ -716,19 +618,12 @@ You can override this to use your own Teleport Operator image rather than a Tele
 
 This setting requires [`operator.enabled`](#operatorenabled).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   operator:
     image: my.docker.registry/teleport-operator-image-name
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set operator.image=my.docker.registry/teleport-operator-image-name
-  ```
-  </TabItem>
-</Tabs>
 
 ### `operator.resources`
 
@@ -741,8 +636,8 @@ documentation.
 
 It is recommended to set resource requests/limits for each container based on their observed usage.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   operator:
     resources:
@@ -750,14 +645,6 @@ It is recommended to set resource requests/limits for each container based on th
         cpu: 1
         memory: 2Gi
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set operator.resources.requests.cpu=1 \
-  --set operator.resources.requests.memory=2Gi
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleportVersionOverride`
 
@@ -773,18 +660,11 @@ You can optionally override this to use a different published Teleport Docker im
 See our [installation guide](../../installation.mdx#docker) for information on
 Docker image versions.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleportVersionOverride: "11"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleportVersionOverride="11"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `acme`
 
@@ -828,22 +708,13 @@ As an example, this can be overridden to use the [Let's Encrypt staging server](
 
 You can also use any other ACME-compatible server.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   acme: true
   acmeEmail: user@email.com
   acmeURI: https://acme-staging-v02.api.letsencrypt.org/directory
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set acme=true \
-  --set acmeEmail=user@email.com \
-  --set acmeURI=https://acme-staging-v02.api.letsencrypt.org/directory
-  ```
-  </TabItem>
-</Tabs>
 
 ## `podSecurityPolicy`
 
@@ -865,19 +736,12 @@ To disable PSP creation, you can set `enabled` to `false`.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   podSecurityPolicy:
     enabled: false
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set podSecurityPolicy.enabled=false
-  ```
-  </TabItem>
-</Tabs>
 
 ## `labels`
 
@@ -892,21 +756,13 @@ Teleport's RBAC policies to define access rules for the cluster.
   These are Teleport-specific RBAC labels, not Kubernetes labels.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   labels:
     environment: production
     region: us-east
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set labels.environment=production \
-  --set labels.region=us-east
-  ```
-  </TabItem>
-</Tabs>
 
 ## `chartMode`
 
@@ -943,19 +799,12 @@ This driver addon must be configured to use persistent volumes in EKS clusters a
 
 `persistence.enabled` can be used to enable data persistence using either a new or pre-existing `PersistentVolumeClaim`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   persistence:
     enabled: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set persistence.enabled=true
-  ```
-  </TabItem>
-</Tabs>
 
 ### `persistence.existingClaimName`
 
@@ -967,19 +816,12 @@ This driver addon must be configured to use persistent volumes in EKS clusters a
 
 The default is left blank, which will automatically create a `PersistentVolumeClaim` to use for Teleport storage in `standalone` or `scratch` mode.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   persistence:
     existingClaimName: my-existing-pvc-name
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set persistence.existingClaimName=my-existing-pvc-name
-  ```
-  </TabItem>
-</Tabs>
 
 ### `persistence.volumeSize`
 
@@ -993,19 +835,12 @@ You can set `volumeSize` to request a different size of persistent volume when i
   `volumeSize` will be ignored if `existingClaimName` is set.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   persistence:
     volumeSize: 50Gi
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set persistence.volumeSize=50Gi
-  ```
-  </TabItem>
-</Tabs>
 
 ## `aws`
 
@@ -1074,19 +909,12 @@ Teleport pods must not be scheduled on the same physical host.
   This setting only has any effect when `highAvailability.replicaCount` is greater than `1`.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     requireAntiAffinity: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set highAvailability.requireAntiAffinity=true
-  ```
-  </TabItem>
-</Tabs>
 
 ## `highAvailability.podDisruptionBudget`
 
@@ -1100,20 +928,13 @@ Teleport pods must not be scheduled on the same physical host.
 
 Enable a Pod Disruption Budget for the Teleport Pod to ensure HA during voluntary disruptions.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     podDisruptionBudget:
       enabled: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set highAvailability.podDisruptionBudget.enabled=true
-  ```
-  </TabItem>
-</Tabs>
 
 ### `highAvailability.podDisruptionBudget.minAvailable`
 
@@ -1125,20 +946,13 @@ Enable a Pod Disruption Budget for the Teleport Pod to ensure HA during voluntar
 
 Ensures that this number of replicas is available during voluntary disruptions, can be a number of replicas or a percentage.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     podDisruptionBudget:
       minAvailable: 1
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set highAvailability.podDisruptionBudget.minAvailable=1
-  ```
-  </TabItem>
-</Tabs>
 
 ## `highAvailability.certManager`
 
@@ -1175,8 +989,8 @@ Setting `highAvailability.certManager.addCommonName` to `true` will instruct `ce
   and the relevant sections of the [AWS](../../deploy-a-cluster/helm-deployments/aws.mdx#step-47-configure-tls-certificates-for-teleport) and [GCP](../../deploy-a-cluster/helm-deployments/gcp.mdx#step-47-install-and-configure-cert-manager) guides for more information.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     certManager:
@@ -1184,15 +998,6 @@ Setting `highAvailability.certManager.addCommonName` to `true` will instruct `ce
       addCommonName: true
       issuerName: letsencrypt-production
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set highAvailability.certManager.enabled=true \
-  --set highAvailability.certManager.addCommonName=true \
-  --set highAvailability.certManager.issuerName=letsencrypt-production
-  ```
-  </TabItem>
-</Tabs>
 
 ### `highAvailability.certManager.issuerName`
 
@@ -1209,22 +1014,14 @@ Sets the name of the `cert-manager` `Issuer` or `ClusterIssuer` to use for issui
   of the [AWS](../../deploy-a-cluster/helm-deployments/aws.mdx#step-47-configure-tls-certificates-for-teleport) and [GCP](../../deploy-a-cluster/helm-deployments/gcp.mdx#step-47-install-and-configure-cert-manager) guides for more information.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     certManager:
       enabled: true
       issuerName: letsencrypt-production
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set highAvailability.certManager.enabled=true \
-  --set highAvailability.certManager.issuerName=letsencrypt-production
-  ```
-  </TabItem>
-</Tabs>
 
 ### `highAvailability.certManager.issuerKind`
 
@@ -1235,20 +1032,13 @@ Sets the name of the `cert-manager` `Issuer` or `ClusterIssuer` to use for issui
 Sets the `Kind` of `Issuer` to be used when issuing certificates with `cert-manager`. Defaults to `Issuer` to keep permissions
 scoped to a single namespace.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     certManager:
       issuerKind: ClusterIssuer
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set highAvailability.certManager.issuerKind=ClusterIssuer
-  ```
-  </TabItem>
-</Tabs>
 
 ### `highAvailability.certManager.issuerGroup`
 
@@ -1258,20 +1048,13 @@ scoped to a single namespace.
 
 Sets the `Group` of `Issuer` to be used when issuing certificates with `cert-manager`. Defaults to `cert-manager.io` to use built-in issuers.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     certManager:
       issuerGroup: cert-manager.io
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set highAvailability.certManager.issuerGroup=cert-manager.io
-  ```
-  </TabItem>
-</Tabs>
 
 ## `highAvailability.minReadySeconds`
 
@@ -1284,19 +1067,12 @@ Amount of time to wait during a pod rollout before moving to the next pod.
 
 This is used to give time for the agents to connect back to newly created pods before continuing the rollout.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     minReadySeconds: 15
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set highAvailability.minReadySeconds=15
-  ```
-  </TabItem>
-</Tabs>
 
 ## `tls.existingSecretName`
 
@@ -1315,19 +1091,12 @@ kubectl create secret tls my-tls-secret --cert=/path/to/cert/file --key=/path/to
 
 See https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets for more information.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   tls:
     existingSecretName: my-tls-secret
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set tls.existingSecretName=my-tls-secret
-  ```
-  </TabItem>
-</Tabs>
 
 ## `tls.existingCASecretName`
 
@@ -1354,19 +1123,12 @@ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
   The filename used for the root CA in the secret must be `ca.pem`.
 </Notice>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   tls:
     existingCASecretName: my-root-ca
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set tls.existingSecretName=my-root-ca
-  ```
-  </TabItem>
-</Tabs>
 
 ## `image`
 
@@ -1378,18 +1140,11 @@ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.pem
 
 You can override this to use your own Teleport Community image rather than a Teleport-published image.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   image: my.docker.registry/teleport-community-image-name
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set image=my.docker.registry/teleport-community-image-name
-  ```
-  </TabItem>
-</Tabs>
 
 ## `enterpriseImage`
 
@@ -1401,18 +1156,11 @@ You can override this to use your own Teleport Community image rather than a Tel
 
 You can override this to use your own Teleport Enterprise image rather than a Teleport-published image.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   enterpriseImage: my.docker.registry/teleport-enterprise-image-name
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set enterpriseImage=my.docker.registry/teleport-enterprise-image
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log`
 
@@ -1434,19 +1182,12 @@ The default is `INFO`, which is recommended in production.
 
 `DEBUG` is useful during first-time setup or to see more detailed logs for debugging.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     level: DEBUG
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.level=DEBUG
-  ```
-  </TabItem>
-</Tabs>
 
 ### `log.output`
 
@@ -1460,19 +1201,12 @@ This can be set to any of the built-in values: `stdout`, `stderr` or `syslog` to
 
 The value can also be set to a file path (such as `/var/log/teleport.log`) to write logs to a file. Bear in mind that a few service startup messages will still go to `stderr` for resilience.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     output: stderr
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.output=stderr
-  ```
-  </TabItem>
-</Tabs>
 
 ### `log.format`
 
@@ -1484,19 +1218,12 @@ The value can also be set to a file path (such as `/var/log/teleport.log`) to wr
 
 Possible values are `text` (default) or `json`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     format: json
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.format=json
-  ```
-  </TabItem>
-</Tabs>
 
 ### `log.extraFields`
 
@@ -1508,20 +1235,12 @@ Possible values are `text` (default) or `json`.
 
 See the [Teleport config file reference](../../reference/config.mdx) for more details on possible values for `extra_fields`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     extraFields: ["timestamp", "level"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "log.extraFields[0]=timestamp" \
-  --set "log.extraFields[1]=level"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `nodeSelector`
 
@@ -1534,21 +1253,13 @@ nodes that Teleport pods will run on.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector)
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   nodeSelector:
     role: bastion
     environment: security
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set nodeSelector.role=bastion \
-  --set nodeSelector.environment=security
-  ```
-  </TabItem>
-</Tabs>
 
 ## `affinity`
 
@@ -1564,8 +1275,8 @@ Kubernetes affinity to set for pod assignments.
   You cannot set both `affinity` and `highAvailability.requireAntiAffinity` as they conflict with each other. Only set one or the other.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   affinity:
     nodeAffinity:
@@ -1577,15 +1288,6 @@ Kubernetes affinity to set for pod assignments.
             values:
             - teleport
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=gravitational.io/dedicated \
-  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
-  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=teleport
-  ```
-  </TabItem>
-</Tabs>
 
 ## `annotations.config`
 
@@ -1597,24 +1299,13 @@ Kubernetes affinity to set for pod assignments.
 
 Kubernetes annotations which should be applied to the `ConfigMap` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     config:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.config."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.deployment`
 
@@ -1626,24 +1317,13 @@ Kubernetes annotations which should be applied to the `ConfigMap` created by the
 
 Kubernetes annotations which should be applied to the `Deployment` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     deployment:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.deployment."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.pod`
 
@@ -1655,24 +1335,13 @@ Kubernetes annotations which should be applied to the `Deployment` created by th
 
 Kubernetes annotations which should be applied to each `Pod` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     pod:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.pod."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.service`
 
@@ -1684,24 +1353,13 @@ Kubernetes annotations which should be applied to each `Pod` created by the char
 
 Kubernetes annotations which should be applied to the `Service` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     service:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.service."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.serviceAccount`
 
@@ -1713,24 +1371,13 @@ Kubernetes annotations which should be applied to the `Service` created by the c
 
 Kubernetes annotations which should be applied to the `serviceAccount` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     serviceAccount:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.certSecret`
 
@@ -1745,24 +1392,13 @@ Kubernetes annotations which should be applied to the `secret` generated by
 `highAvailability.certManager.enabled` is set to `true` and requires
 `cert-manager` v1.5.0+.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     certSecret:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.certSecret."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `serviceAccount.create`
 
@@ -1793,19 +1429,12 @@ If `serviceAccount.create` is false, service account with this name should be cr
 
 Allows to specify the service type.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   service:
     type: LoadBalancer
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set service.type=LoadBalancer
-  ```
-  </TabItem>
-</Tabs>
 
 ## `service.spec.loadBalancerIP`
 
@@ -1817,20 +1446,13 @@ Allows to specify the service type.
 
 Allows to specify the `loadBalancerIP`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   service:
     spec:
       loadBalancerIP: 1.2.3.4
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set service.spec.loadBalancerIP=1.2.3.4
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraArgs`
 
@@ -1840,19 +1462,12 @@ Allows to specify the `loadBalancerIP`.
 
 A list of extra arguments to pass to the `teleport start` command when running a Teleport Pod.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraArgs:
   - "--bootstrap=/etc/teleport-bootstrap/roles.yaml"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraArgs={--bootstrap=/etc/teleport-bootstrap/roles.yaml}"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraEnv`
 
@@ -1864,21 +1479,13 @@ A list of extra arguments to pass to the `teleport start` command when running a
 
 A list of extra environment variables to be set on the main Teleport container.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraEnv:
   - name: MY_ENV
     value: my-value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraEnv[0].name=MY_ENV" \
-  --set "extraEnv[0].value=my-value"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraVolumes`
 
@@ -1891,22 +1498,14 @@ A list of extra environment variables to be set on the main Teleport container.
 A list of extra Kubernetes `Volumes` which should be available to any `Pod` created by the chart. These volumes
 will also be available to any `initContainers` configured by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraVolumes:
   - name: myvolume
     secret:
       secretName: mysecret
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraVolumes[0].name=myvolume" \
-  --set "extraVolumes[0].secret.secretName=mysecret"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraVolumeMounts`
 
@@ -1919,21 +1518,13 @@ will also be available to any `initContainers` configured by the chart.
 A list of extra Kubernetes volume mounts which should be mounted into any `Pod` created by the chart. These volume
 mounts will also be mounted into any `initContainers` configured by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraVolumeMounts:
   - name: myvolume
     mountPath: /path/to/mount/volume
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraVolumeMounts[0].name=myvolume" \
-  --set "extraVolumeMounts[0].path=/path/to/mount/volume"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `imagePullPolicy`
 
@@ -1945,18 +1536,11 @@ mounts will also be mounted into any `initContainers` configured by the chart.
 
 Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   imagePullPolicy: Always
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set imagePullPolicy=Always
-  ```
-  </TabItem>
-</Tabs>
 
 ## `imagePullSecrets`
 
@@ -1968,19 +1552,12 @@ Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
 
 A list of secrets containing authorization tokens which can be optionally used to access a private Docker registry.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   imagePullSecrets:
   - name: my-docker-registry-key
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set "imagePullSecrets[0].name=my-docker-registry-key"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `initContainers`
 
@@ -1992,23 +1569,14 @@ A list of secrets containing authorization tokens which can be optionally used t
 
 A list of `initContainers` which will be run before the main Teleport container in any pod created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   initContainers:
   - name: teleport-init
     image: alpine
     args: ['echo test']
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "initContainers[0].name=teleport-init" \
-  --set "initContainers[0].image=alpine" \
-  --set "initContainers[0].args={echo test}"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `postStart`
 
@@ -2020,22 +1588,14 @@ A list of `initContainers` which will be run before the main Teleport container 
 
 A `postStart` lifecycle handler to be configured on the main Teleport container.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   postStart:
     command:
     - echo
     - foo
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set "postStart.command[0]=echo" \
-  --set "postStart.command[1]=foo"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `resources`
 
@@ -2048,22 +1608,14 @@ A `postStart` lifecycle handler to be configured on the main Teleport container.
 Resource requests/limits which should be configured for Teleport containers. These resource limits will also be
 applied to `initContainers`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   resources:
     requests:
       cpu: 1
       memory: 2Gi
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set resources.requests.cpu=1 \
-  --set resources.requests.memory=2Gi
-  ```
-  </TabItem>
-</Tabs>
 
 ## `securityContext`
 
@@ -2075,19 +1627,12 @@ applied to `initContainers`.
 
 The `securityContext` applies to the main Teleport containers.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   securityContext:
     runAsUser: 99
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set securityContext.runAsUser=99
-  ```
-  </TabItem>
-</Tabs>
 
 ## `tolerations`
 
@@ -2099,8 +1644,8 @@ The `securityContext` applies to the main Teleport containers.
 
 Kubernetes Tolerations to set for pod assignment.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   tolerations:
   - key: "dedicated"
@@ -2108,16 +1653,6 @@ Kubernetes Tolerations to set for pod assignment.
     value: "teleport"
     effect: "NoSchedule"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set tolerations[0].key=dedicated \
-  --set tolerations[0].operator=Equal \
-  --set tolerations[0].value=teleport \
-  --set tolerations[0].effect=NoSchedule
-  ```
-  </TabItem>
-</Tabs>
 
 ## `priorityClassName`
 
@@ -2129,18 +1664,11 @@ Kubernetes Tolerations to set for pod assignment.
 
 Kubernetes PriorityClass to set for pod.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   priorityClassName: "system-cluster-critical"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set priorityClassName=system-cluster-critical
-  ```
-  </TabItem>
-</Tabs>
 
 ## `probeTimeoutSeconds`
 
@@ -2152,15 +1680,8 @@ Kubernetes PriorityClass to set for pod.
 
 Kubernetes timeouts for the liveness and readiness probes.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   probeTimeoutSeconds: 5
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set probeTimeoutSeconds=5
-  ```
-  </TabItem>
-</Tabs>

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -321,8 +321,8 @@ By default no devices are forbidden.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set proxyListenerMode=multiplex
+  ```text
+  --set proxyListenerMode=multiplex
   ```
   </TabItem>
 </Tabs>
@@ -344,8 +344,8 @@ For possible values, [see the Teleport Configuration Reference](../../reference/
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set sessionRecording=proxy
+  ```text
+  --set sessionRecording=proxy
   ```
   </TabItem>
 </Tabs>
@@ -377,8 +377,8 @@ These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is se
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set separatePostgresListener=true
+  ```text
+  --set separatePostgresListener=true
   ```
   </TabItem>
 </Tabs>
@@ -409,8 +409,8 @@ These settings will not apply if [`proxyListenerMode`](#proxylistenermode) is se
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set separateMongoListener=true
+  ```text
+  --set separateMongoListener=true
   ```
   </TabItem>
 </Tabs>
@@ -450,8 +450,8 @@ Changing the RP ID will invalidate all already registered webauthn second factor
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set publicAddr[0]=loadbalancer.example.com:443
+  ```text
+  --set publicAddr[0]=loadbalancer.example.com:443
   ```
   </TabItem>
 </Tabs>
@@ -475,8 +475,8 @@ else [`clusterName`](#clusterName) is used. Default port is 3026.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set kubePublicAddr[0]=loadbalancer.example.com:3026
+  ```text
+  --set kubePublicAddr[0]=loadbalancer.example.com:3026
   ```
   </TabItem>
 </Tabs>
@@ -501,8 +501,8 @@ Default port is 27017.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set mongoPublicAddr[0]=loadbalancer.example.com:27017
+  ```text
+  --set mongoPublicAddr[0]=loadbalancer.example.com:27017
   ```
   </TabItem>
 </Tabs>
@@ -526,8 +526,8 @@ else [`clusterName`](#clusterName) is used. Default port is 3036.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set mysqlPublicAddr[0]=loadbalancer.example.com:3036
+  ```text
+  --set mysqlPublicAddr[0]=loadbalancer.example.com:3036
   ```
   </TabItem>
 </Tabs>
@@ -552,8 +552,8 @@ else [`clusterName`](#clusterName) is used. Default port is 5432.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set postgresPublicAddr[0]=loadbalancer.example.com:5432
+  ```text
+  --set postgresPublicAddr[0]=loadbalancer.example.com:5432
   ```
   </TabItem>
 </Tabs>
@@ -577,8 +577,8 @@ else [`clusterName`](#clusterName) is used. Default port is 3023.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set sshPublicAddr[0]=loadbalancer.example.com:3023
+  ```text
+  --set sshPublicAddr[0]=loadbalancer.example.com:3023
   ```
   </TabItem>
 </Tabs>
@@ -602,8 +602,8 @@ else [`clusterName`](#clusterName) is used. Default port is 3024.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set tunnelPublicAddr[0]=loadbalancer.example.com:3024
+  ```text
+  --set tunnelPublicAddr[0]=loadbalancer.example.com:3024
   ```
   </TabItem>
 </Tabs>
@@ -643,8 +643,8 @@ $ kubectl --namespace teleport create secret generic license --from-file=/path/t
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set enterprise=true
+  ```text
+  --set enterprise=true
   ```
   </TabItem>
 </Tabs>
@@ -671,8 +671,8 @@ the same Kubernetes cluster or installing the CRDs on your own you should not ha
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set installCRDs=true
+  ```text
+  --set installCRDs=true
   ```
   </TabItem>
 </Tabs>
@@ -699,8 +699,8 @@ If you are deploying multiple releases of the Helm chart in the same cluster you
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set operator.enabled=true
+  ```text
+  --set operator.enabled=true
   ```
   </TabItem>
 </Tabs>
@@ -724,8 +724,8 @@ This setting requires [`operator.enabled`](#operatorenabled).
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set operator.image=my.docker.registry/teleport-operator-image-name
+  ```text
+  --set operator.image=my.docker.registry/teleport-operator-image-name
   ```
   </TabItem>
 </Tabs>
@@ -752,8 +752,8 @@ It is recommended to set resource requests/limits for each container based on th
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set operator.resources.requests.cpu=1 \
+  ```text
+  --set operator.resources.requests.cpu=1 \
   --set operator.resources.requests.memory=2Gi
   ```
   </TabItem>
@@ -780,8 +780,8 @@ Docker image versions.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleportVersionOverride="11"
+  ```text
+  --set teleportVersionOverride="11"
   ```
   </TabItem>
 </Tabs>
@@ -837,8 +837,8 @@ You can also use any other ACME-compatible server.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set acme=true \
+  ```text
+  --set acme=true \
   --set acmeEmail=user@email.com \
   --set acmeURI=https://acme-staging-v02.api.letsencrypt.org/directory
   ```
@@ -873,8 +873,8 @@ To disable PSP creation, you can set `enabled` to `false`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set podSecurityPolicy.enabled=false
+  ```text
+  --set podSecurityPolicy.enabled=false
   ```
   </TabItem>
 </Tabs>
@@ -901,8 +901,8 @@ Teleport's RBAC policies to define access rules for the cluster.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set labels.environment=production \
+  ```text
+  --set labels.environment=production \
   --set labels.region=us-east
   ```
   </TabItem>
@@ -951,8 +951,8 @@ This driver addon must be configured to use persistent volumes in EKS clusters a
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set persistence.enabled=true
+  ```text
+  --set persistence.enabled=true
   ```
   </TabItem>
 </Tabs>
@@ -975,8 +975,8 @@ The default is left blank, which will automatically create a `PersistentVolumeCl
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set persistence.existingClaimName=my-existing-pvc-name
+  ```text
+  --set persistence.existingClaimName=my-existing-pvc-name
   ```
   </TabItem>
 </Tabs>
@@ -1001,7 +1001,7 @@ You can set `volumeSize` to request a different size of persistent volume when i
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set persistence.volumeSize=50Gi
   ```
   </TabItem>
@@ -1082,8 +1082,8 @@ Teleport pods must not be scheduled on the same physical host.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set highAvailability.requireAntiAffinity=true
+  ```text
+  --set highAvailability.requireAntiAffinity=true
   ```
   </TabItem>
 </Tabs>
@@ -1186,8 +1186,8 @@ Setting `highAvailability.certManager.addCommonName` to `true` will instruct `ce
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set highAvailability.certManager.enabled=true \
+  ```text
+  --set highAvailability.certManager.enabled=true \
   --set highAvailability.certManager.addCommonName=true \
   --set highAvailability.certManager.issuerName=letsencrypt-production
   ```
@@ -1219,8 +1219,8 @@ Sets the name of the `cert-manager` `Issuer` or `ClusterIssuer` to use for issui
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set highAvailability.certManager.enabled=true \
+  ```text
+  --set highAvailability.certManager.enabled=true \
   --set highAvailability.certManager.issuerName=letsencrypt-production
   ```
   </TabItem>
@@ -1244,7 +1244,7 @@ scoped to a single namespace.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set highAvailability.certManager.issuerKind=ClusterIssuer
   ```
   </TabItem>
@@ -1267,7 +1267,7 @@ Sets the `Group` of `Issuer` to be used when issuing certificates with `cert-man
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set highAvailability.certManager.issuerGroup=cert-manager.io
   ```
   </TabItem>
@@ -1385,7 +1385,7 @@ You can override this to use your own Teleport Community image rather than a Tel
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set image=my.docker.registry/teleport-community-image-name
   ```
   </TabItem>
@@ -1408,7 +1408,7 @@ You can override this to use your own Teleport Enterprise image rather than a Te
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set enterpriseImage=my.docker.registry/teleport-enterprise-image
   ```
   </TabItem>
@@ -1442,7 +1442,7 @@ The default is `INFO`, which is recommended in production.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set log.level=DEBUG
   ```
   </TabItem>
@@ -1468,7 +1468,7 @@ The value can also be set to a file path (such as `/var/log/teleport.log`) to wr
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set log.output=stderr
   ```
   </TabItem>
@@ -1492,7 +1492,7 @@ Possible values are `text` (default) or `json`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set log.format=json
   ```
   </TabItem>
@@ -1516,7 +1516,7 @@ See the [Teleport config file reference](../../reference/config.mdx) for more de
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set "log.extraFields[0]=timestamp" \
   --set "log.extraFields[1]=level"
   ```
@@ -1543,7 +1543,7 @@ nodes that Teleport pods will run on.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set nodeSelector.role=bastion \
   --set nodeSelector.environment=security
   ```
@@ -1579,8 +1579,8 @@ Kubernetes affinity to set for pod assignments.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=gravitational.io/dedicated \
+  ```text
+  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=gravitational.io/dedicated \
   --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
   --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=teleport
   ```
@@ -1606,8 +1606,8 @@ Kubernetes annotations which should be applied to the `ConfigMap` created by the
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.config."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.config."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1635,8 +1635,8 @@ Kubernetes annotations which should be applied to the `Deployment` created by th
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.deployment."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.deployment."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1664,8 +1664,8 @@ Kubernetes annotations which should be applied to each `Pod` created by the char
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.pod."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.pod."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1693,8 +1693,8 @@ Kubernetes annotations which should be applied to the `Service` created by the c
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.service."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.service."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1722,8 +1722,8 @@ Kubernetes annotations which should be applied to the `serviceAccount` created b
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1754,8 +1754,8 @@ Kubernetes annotations which should be applied to the `secret` generated by
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.certSecret."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.certSecret."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1801,8 +1801,8 @@ Allows to specify the service type.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set service.type=LoadBalancer
+  ```text
+  --set service.type=LoadBalancer
   ```
   </TabItem>
 </Tabs>
@@ -1826,8 +1826,8 @@ Allows to specify the `loadBalancerIP`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set service.spec.loadBalancerIP=1.2.3.4
+  ```text
+  --set service.spec.loadBalancerIP=1.2.3.4
   ```
   </TabItem>
 </Tabs>
@@ -1848,8 +1848,8 @@ A list of extra arguments to pass to the `teleport start` command when running a
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraArgs={--bootstrap=/etc/teleport-bootstrap/roles.yaml}"
+  ```text
+  --set "extraArgs={--bootstrap=/etc/teleport-bootstrap/roles.yaml}"
   ```
   </TabItem>
 </Tabs>
@@ -1873,8 +1873,8 @@ A list of extra environment variables to be set on the main Teleport container.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraEnv[0].name=MY_ENV" \
+  ```text
+  --set "extraEnv[0].name=MY_ENV" \
   --set "extraEnv[0].value=my-value"
   ```
   </TabItem>
@@ -1901,8 +1901,8 @@ will also be available to any `initContainers` configured by the chart.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraVolumes[0].name=myvolume" \
+  ```text
+  --set "extraVolumes[0].name=myvolume" \
   --set "extraVolumes[0].secret.secretName=mysecret"
   ```
   </TabItem>
@@ -1928,8 +1928,8 @@ mounts will also be mounted into any `initContainers` configured by the chart.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraVolumeMounts[0].name=myvolume" \
+  ```text
+  --set "extraVolumeMounts[0].name=myvolume" \
   --set "extraVolumeMounts[0].path=/path/to/mount/volume"
   ```
   </TabItem>
@@ -1952,8 +1952,8 @@ Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set imagePullPolicy=Always
+  ```text
+  --set imagePullPolicy=Always
   ```
   </TabItem>
 </Tabs>
@@ -2002,8 +2002,8 @@ A list of `initContainers` which will be run before the main Teleport container 
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "initContainers[0].name=teleport-init" \
+  ```text
+  --set "initContainers[0].name=teleport-init" \
   --set "initContainers[0].image=alpine" \
   --set "initContainers[0].args={echo test}"
   ```
@@ -2058,8 +2058,8 @@ applied to `initContainers`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set resources.requests.cpu=1 \
+  ```text
+  --set resources.requests.cpu=1 \
   --set resources.requests.memory=2Gi
   ```
   </TabItem>
@@ -2083,8 +2083,8 @@ The `securityContext` applies to the main Teleport containers.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set securityContext.runAsUser=99
+  ```text
+  --set securityContext.runAsUser=99
   ```
   </TabItem>
 </Tabs>
@@ -2110,8 +2110,8 @@ Kubernetes Tolerations to set for pod assignment.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set tolerations[0].key=dedicated \
+  ```text
+  --set tolerations[0].key=dedicated \
   --set tolerations[0].operator=Equal \
   --set tolerations[0].value=teleport \
   --set tolerations[0].effect=NoSchedule
@@ -2136,8 +2136,8 @@ Kubernetes PriorityClass to set for pod.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set priorityClassName=system-cluster-critical
+  ```text
+  --set priorityClassName=system-cluster-critical
   ```
   </TabItem>
 </Tabs>
@@ -2159,8 +2159,8 @@ Kubernetes timeouts for the liveness and readiness probes.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set probeTimeoutSeconds=5
+  ```text
+  --set probeTimeoutSeconds=5
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -91,8 +91,8 @@ This parameter is not mandatory to preserve backwards compatibility with older c
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set roles=kube\,app\,db
+  ```text
+  --set roles=kube\,app\,db
   ```
 
   <Admonition type="note">
@@ -222,8 +222,8 @@ of your `teleport-kube-agent` resources with the same name as your
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set roleBindingName=myrolebinding
+  ```text
+  --set roleBindingName=myrolebinding
   ```
 
   </TabItem>
@@ -250,8 +250,8 @@ release.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set roleName=myrole
+  ```text
+  --set roleName=myrole
   ```
 
   </TabItem>
@@ -302,8 +302,8 @@ fail to join the Teleport cluster.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set authToken=<replace-with-actual-token>
+  ```text
+  --set authToken=<replace-with-actual-token>
   ```
   </TabItem>
 </Tabs>
@@ -346,8 +346,8 @@ pods](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-a
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set joinParams.method="token"|"ec2"|"iam"
+  ```text
+  --set joinParams.method="token"|"ec2"|"iam"
   ```
   </TabItem>
 </Tabs>
@@ -375,8 +375,8 @@ Secret, see [`secretName`](#secretName) for more details and instructions.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set joinParams.token="my-token"
+  ```text
+  --set joinParams.token="my-token"
   ```
   </TabItem>
 </Tabs>
@@ -415,8 +415,8 @@ connecting to the cluster.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set kubeClusterName=my-gke-cluster
+  ```text
+  --set kubeClusterName=my-gke-cluster
   ```
   </TabItem>
 </Tabs>
@@ -448,8 +448,8 @@ You can specify multiple apps by adding additional list elements.
   (!docs/pages/includes/yaml-lint-note.mdx!)
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "apps[0].name=grafana" \
+  ```text
+  --set "apps[0].name=grafana" \
   --set "apps[0].uri=http://localhost:3000" \
   --set "apps[0].purpose=monitoring" \
   --set "apps[1].name=grafana" \
@@ -490,8 +490,8 @@ You can specify multiple selectors by including additional list elements.
 
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "appResources[0].labels.env=prod" \
+  ```text
+  --set "appResources[0].labels.env=prod" \
   --set "appResources[1].labels.env=test"
   ```
 
@@ -683,8 +683,8 @@ You can specify multiple databases by adding additional list elements.
   (!docs/pages/includes/yaml-lint-note.mdx!)
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "databases[0].name=aurora" \
+  ```text
+  --set "databases[0].name=aurora" \
   --set "databases[0].uri=postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432" \
   --set "databases[0].protocol=postgres" \
   --set "databases[0].aws.region=us-east-1" \
@@ -759,8 +759,7 @@ You can specify multiple selectors by adding elements to the list.
 
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $
+  ```text
   --set "databaseResources[0].labels.env=prod" \
   --set "databaseResources[0].labels.engine=postgres" \
   --set "databaseResources[1].labels.env=test" \
@@ -803,8 +802,8 @@ See [this link for information on Community Docker image versions](../../managem
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleportVersionOverride="11"
+  ```text
+  --set teleportVersionOverride="11"
   ```
   </TabItem>
 </Tabs>
@@ -831,8 +830,8 @@ responsibility to mount the file using [`extraVolumes`](#extraVolumes).
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set caPin[0]="sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
+  ```text
+  --set caPin[0]="sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
   ```
   </TabItem>
 </Tabs>
@@ -855,8 +854,8 @@ This can be used for joining a Teleport instance to a Teleport cluster which doe
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set insecureSkipProxyTLSVerify=false
+  ```text
+  --set insecureSkipProxyTLSVerify=false
   ```
   </TabItem>
 </Tabs>
@@ -944,7 +943,7 @@ When `existingDataVolume` is set to the name of an existing volume, the `/var/li
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set existingDataVolume=my-volume
   ```
   </TabItem>
@@ -978,8 +977,8 @@ To disable PSP creation, you can set `enabled` to `false`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set podSecurityPolicy.enabled=false
+  ```text
+  --set podSecurityPolicy.enabled=false
   ```
   </TabItem>
 </Tabs>
@@ -1016,8 +1015,8 @@ These labels can then be used with Teleport's RBAC policies to define access rul
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set labels.environment=production \
+  ```text
+  --set labels.environment=production \
   --set labels.region=us-east
   ```
   </TabItem>
@@ -1082,7 +1081,7 @@ running.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set storage.enabled=true
   ```
   </TabItem>
@@ -1107,7 +1106,7 @@ name needs to exist on the Kubernetes cluster for Teleport to use.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set storage.storageClassName=teleport-storage-class
   ```
   </TabItem>
@@ -1129,7 +1128,7 @@ The size of persistent volume to create.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set storage.requests=128Mi
   ```
   </TabItem>
@@ -1161,8 +1160,8 @@ connecting to a Teleport Cloud instance enrolled in automatic updates.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set image=my.docker.registry/teleport-image-name
+  ```text
+  --set image=my.docker.registry/teleport-image-name
   ```
   </TabItem>
 </Tabs>
@@ -1331,8 +1330,8 @@ Ensures that this number of replicas is available during voluntary disruptions, 
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set clusterRoleName=kubernetes-clusterrole
+  ```text
+  --set clusterRoleName=kubernetes-clusterrole
   ```
   </TabItem>
 </Tabs>
@@ -1356,8 +1355,8 @@ Ensures that this number of replicas is available during voluntary disruptions, 
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set clusterRoleBindingName=kubernetes-clusterrolebinding
+  ```text
+  --set clusterRoleBindingName=kubernetes-clusterrolebinding
   ```
   </TabItem>
 </Tabs>
@@ -1377,8 +1376,8 @@ Ensures that this number of replicas is available during voluntary disruptions, 
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set priorityClassName=teleport-kube-agent
+  ```text
+  --set priorityClassName=teleport-kube-agent
   ```
   </TabItem>
 </Tabs>
@@ -1403,9 +1402,9 @@ When off, the `serviceAccount.name` parameter should be set to the existing `Ser
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set serviceAccount.create=false
-  $ --set serviceAccount.name=kubernetes-serviceaccount
+  ```text
+  --set serviceAccount.create=false
+  --set serviceAccount.name=kubernetes-serviceaccount
   ```
   </TabItem>
 </Tabs>
@@ -1432,8 +1431,8 @@ namespace of your `teleport-kube-agent` resources with the same name as your
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set serviceAccount.name=kubernetes-serviceaccount
+  ```text
+  --set serviceAccount.name=kubernetes-serviceaccount
   ```
   </TabItem>
 </Tabs>
@@ -1471,8 +1470,8 @@ $ kubectl --namespace teleport create secret generic teleport-kube-agent-join-to
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set secretName="secret-i-created-before" \
+  ```text
+  --set secretName="secret-i-created-before" \
     --set joinParams.method="token" \
     --set joinParams.tokenName=""
   ```
@@ -1507,7 +1506,7 @@ The default is `INFO`, which is recommended in production.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set log.level=DEBUG
   ```
   </TabItem>
@@ -1533,7 +1532,7 @@ The value can also be set to a file path (such as `/var/log/teleport.log`) to wr
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set log.output=stderr
   ```
   </TabItem>
@@ -1557,7 +1556,7 @@ Possible values are `text` (default) or `json`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set log.format=json
   ```
   </TabItem>
@@ -1581,7 +1580,7 @@ See the [Teleport config file reference](../../reference/config.mdx) for more de
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set "log.extraFields[0]=timestamp" \
   --set "log.extraFields[1]=level"
   ```
@@ -1617,8 +1616,8 @@ Kubernetes affinity to set for pod assignments.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=gravitational.io/dedicated \
+  ```text
+  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=gravitational.io/dedicated \
   --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
   --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=teleport
   ```
@@ -1681,7 +1680,7 @@ nodes that Teleport pods will run on.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
+  ```text
   --set nodeSelector.role=node \
   --set nodeSelector.region=us-east
   ```
@@ -1707,8 +1706,8 @@ Kubernetes labels that should be applied to the `ClusterRole` created by the cha
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.clusterRole."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.clusterRole."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1736,8 +1735,8 @@ Kubernetes labels that should be applied to the `ClusterRoleBinding` created by 
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.clusterRoleBinding."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.clusterRoleBinding."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1766,8 +1765,8 @@ the Teleport pod.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.role."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.role."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1796,8 +1795,8 @@ chart for the Teleport pod.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.roleBinding."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.roleBinding."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1825,8 +1824,8 @@ Kubernetes labels that should be applied to the `ConfigMap` created by the chart
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.config."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.config."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1854,8 +1853,8 @@ Kubernetes labels that should be applied to the `Deployment` or `StatefulSet` cr
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.deployment."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.deployment."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1883,8 +1882,8 @@ Kubernetes labels that should be applied to every `Pod` in the `Deployment` or `
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.pod."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.pod."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1912,8 +1911,8 @@ Kubernetes labels that should be applied to the `PodDisruptionBudget` created by
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.podDisruptionBudget."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.podDisruptionBudget."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1941,8 +1940,8 @@ Kubernetes labels that should be applied to the `PodSecurityPolicy` created by t
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.podSecurityPolicy."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.podSecurityPolicy."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -1970,8 +1969,8 @@ Kubernetes labels that should be applied to the `Secret` created by the chart (i
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.secret."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.secret."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -2000,8 +1999,8 @@ chart for the Teleport pod.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set extraLabels.serviceAccount."app\.kubernetes\.io\/name"=teleport-kube-agent
+  ```text
+  --set extraLabels.serviceAccount."app\.kubernetes\.io\/name"=teleport-kube-agent
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -2034,8 +2033,8 @@ Kubernetes annotations which should be applied to the `ConfigMap` created by the
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.config."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.config."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -2063,8 +2062,8 @@ Kubernetes annotations which should be applied to the `Deployment` created by th
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.deployment."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.deployment."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -2092,8 +2091,8 @@ Kubernetes annotations which should be applied to each `Pod` created by the char
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.pod."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.pod."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -2121,8 +2120,8 @@ Kubernetes annotations which should be applied to the `ServiceAccount` created b
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
+  ```text
+  --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
   ```
   <Admonition type="warning" title="Escaping values">
     You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
@@ -2152,8 +2151,8 @@ will also be available to any `initContainers` configured by the chart.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraVolumes[0].name=myvolume" \
+  ```text
+  --set "extraVolumes[0].name=myvolume" \
   --set "extraVolumes[0].secret.secretName=mysecret"
   ```
   </TabItem>
@@ -2175,8 +2174,8 @@ A list of extra arguments to pass to the `teleport start` command when running a
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraArgs={--debug}"
+  ```text
+  --set "extraArgs={--debug}"
   ```
   </TabItem>
 </Tabs>
@@ -2200,8 +2199,8 @@ A list of extra environment variables to be set on the main Teleport container.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraEnv[0].name=HTTPS_PROXY" \
+  ```text
+  --set "extraEnv[0].name=HTTPS_PROXY" \
   --set "extraEnv[0].value=\"http://username:password@my.proxy.host:3128\""
   ```
   </TabItem>
@@ -2227,8 +2226,8 @@ mounts will also be mounted into any `initContainers` configured by the chart.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "extraVolumeMounts[0].name=myvolume" \
+  ```text
+  --set "extraVolumeMounts[0].name=myvolume" \
   --set "extraVolumeMounts[0].path=/path/to/mount/volume"
   ```
   </TabItem>
@@ -2251,8 +2250,8 @@ Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set imagePullPolicy=Always
+  ```text
+  --set imagePullPolicy=Always
   ```
   </TabItem>
 </Tabs>
@@ -2277,8 +2276,8 @@ A list of `initContainers` which will be run before the main Teleport container 
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "initContainers[0].name=teleport-init" \
+  ```text
+  --set "initContainers[0].name=teleport-init" \
   --set "initContainers[0].image=alpine" \
   --set "initContainers[0].args={echo test}"
   ```
@@ -2306,8 +2305,8 @@ will also be applied to `initContainers`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set resources.requests.cpu=1 \
+  ```text
+  --set resources.requests.cpu=1 \
   --set resources.requests.memory=2Gi
   ```
   </TabItem>
@@ -2372,8 +2371,8 @@ Kubernetes Tolerations to set for pod assignment.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set tolerations[0].key=dedicated \
+  ```text
+  --set tolerations[0].key=dedicated \
   --set tolerations[0].operator=Equal \
   --set tolerations[0].value=teleport \
   --set tolerations[0].effect=NoSchedule
@@ -2398,8 +2397,8 @@ Kubernetes timeouts for the liveness and readiness probes.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set probeTimeoutSeconds=5
+  ```text
+  --set probeTimeoutSeconds=5
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -84,25 +84,11 @@ This parameter is not mandatory to preserve backwards compatibility with older c
 | Teleport Application service | `app`             | [`apps`](#apps)                             |
 | Teleport Database service    | `db`              | [`databases`](#databases)                   |
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   roles: kube,app,db
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set roles=kube\,app\,db
-  ```
-
-  <Admonition type="note">
-    When specifying multiple roles using `--set` syntax, you must escape the commas using a backslash (`\`).
-
-    This is a quirk of Helm's CLI parser.
-  </Admonition>
-
-  </TabItem>
-</Tabs>
 
 If you specify a role here, you may also need to specify some other settings which are detailed in this reference.
 
@@ -215,19 +201,11 @@ You should set this value if there is a `RoleBinding` resource in the namespace
 of your `teleport-kube-agent` resources with the same name as your
 `teleport-kube-agent` release.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   roleBindingName: myrolebinding
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set roleBindingName=myrolebinding
-  ```
-
-  </TabItem>
-</Tabs>
 
 ## `roleName`
 
@@ -243,19 +221,11 @@ You should set this value if there is a `Role` resource in the namespace of your
 `teleport-kube-agent` resources with the same name as your `teleport-kube-agent`
 release.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   roleName: myrole 
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set roleName=myrole
-  ```
-
-  </TabItem>
-</Tabs>
 
 ## `serviceAccountName`
 
@@ -295,18 +265,11 @@ A token must be specified for the agent to join the Teleport cluster, either tho
 If you do not have the correct services (Teleport refers to these internally as `Roles`) assigned to your join token, the Teleport instance will
 fail to join the Teleport cluster.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   authToken: <replace-with-actual-token>
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set authToken=<replace-with-actual-token>
-  ```
-  </TabItem>
-</Tabs>
 
 ## `joinParams`
 
@@ -338,19 +301,12 @@ set up on the pods's service account. For access to instance metadata (the quick
 pods](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node).
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   joinParams:
     method: "token"|"ec2"|"iam"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set joinParams.method="token"|"ec2"|"iam"
-  ```
-  </TabItem>
-</Tabs>
 
 ### `joinParams.tokenName`
 | Type     | Default value | Required? |
@@ -367,19 +323,12 @@ agent's configuration.
 If method is `token`, `joinParams.tokenName` can be empty if the token is provided through an existing Kubernetes
 Secret, see [`secretName`](#secretName) for more details and instructions.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   joinParams:
     tokenName: "my-token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set joinParams.token="my-token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `proxyAddr`
 
@@ -408,18 +357,11 @@ Here are a few examples:
 `kubeClusterName` sets the name used for the Kubernetes cluster proxied by the Teleport agent. This name will be shown to Teleport users
 connecting to the cluster.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   kubeClusterName: my-gke-cluster
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set kubeClusterName=my-gke-cluster
-  ```
-  </TabItem>
-</Tabs>
 
 ## `apps`
 
@@ -431,8 +373,8 @@ connecting to the cluster.
 
 You can specify multiple apps by adding additional list elements.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   apps:
   - name: grafana
@@ -444,25 +386,6 @@ You can specify multiple apps by adding additional list elements.
     labels:
       purpose: ci
   ```
-
-  (!docs/pages/includes/yaml-lint-note.mdx!)
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "apps[0].name=grafana" \
-  --set "apps[0].uri=http://localhost:3000" \
-  --set "apps[0].purpose=monitoring" \
-  --set "apps[1].name=grafana" \
-  --set "apps[1].uri=http://jenkins:8080" \
-  --set "apps[1].purpose=ci"
-  ```
-
-  <Admonition type="note">
-    Note that when using `--set` syntax, YAML list elements must be indexed starting at `0`.
-  </Admonition>
-
-  </TabItem>
-</Tabs>
 
 <Admonition type="tip" title="Supported values">
   You can see a list of all the supported [values which can be used in a Teleport application access configuration here](../../application-access/reference.mdx#configuration).
@@ -478,8 +401,8 @@ You can specify multiple apps by adding additional list elements.
 
 You can specify multiple selectors by including additional list elements.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   appResources:
   - labels:
@@ -487,20 +410,6 @@ You can specify multiple selectors by including additional list elements.
   - labels:
       "env": "test"
   ```
-
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "appResources[0].labels.env=prod" \
-  --set "appResources[1].labels.env=test"
-  ```
-
-  <Admonition type="note">
-    Note that when using `--set` syntax, YAML list elements must be indexed starting at `0`.
-  </Admonition>
-
-  </TabItem>
-</Tabs>
 
 <Admonition type="tip" title="Example">
   Once `appResources` is set, you can dynamically register application with `tsh` by following [this guide](../../application-access/guides/dynamic-registration.mdx).
@@ -536,8 +445,8 @@ You can specify multiple database filters by adding additional list elements.
 - `regions` is a list of AWS regions which should be scanned for databases.
 - `tags` can be used to set AWS tags that must be matched for databases to be discovered.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   roles: db
   awsDatabases:
@@ -557,10 +466,6 @@ You can specify multiple database filters by adding additional list elements.
     serviceAccount:
       eks.amazonaws.com/role-arn: arn:aws:iam::1234567890:role/my-rds-autodiscovery-role
   ```
-
-  (!docs/pages/includes/yaml-lint-note.mdx!)
-  </TabItem>
-</Tabs>
 
 ## `azureDatabases`
 
@@ -618,8 +523,8 @@ The default for each of these optional settings is `*`, which will auto-discover
 subscriptions, regions, or resource groups accessible by the Teleport service
 principal in Azure.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   roles: db
   azureDatabases:
@@ -646,10 +551,6 @@ principal in Azure.
     value: "11111111-2222-3333-4444-555555555555"
   ```
 
-  (!docs/pages/includes/yaml-lint-note.mdx!)
-  </TabItem>
-</Tabs>
-
 ## `databases`
 
 | Type   | Default value | Required?                                                                                                                             |
@@ -660,8 +561,8 @@ principal in Azure.
 
 You can specify multiple databases by adding additional list elements.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   databases:
   - name: aurora-postgres
@@ -679,29 +580,6 @@ You can specify multiple databases by adding additional list elements.
     static_labels:
       env: staging
   ```
-
-  (!docs/pages/includes/yaml-lint-note.mdx!)
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "databases[0].name=aurora" \
-  --set "databases[0].uri=postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432" \
-  --set "databases[0].protocol=postgres" \
-  --set "databases[0].aws.region=us-east-1" \
-  --set "databases[0].static_labels.env=staging" \
-  --set "databases[1].name=mysql" \
-  --set "databases[1].uri=mysql-instance-1.xxx.us-east-1.rds.amazonaws.com:3306" \
-  --set "databases[1].protocol=mysql" \
-  --set "databases[1].aws.region=us-east-1" \
-  --set "databases[1].static_labels.env=staging"
-  ```
-
-  <Admonition type="note">
-    Note that when using `--set` syntax, YAML list elements must be indexed starting at `0`.
-  </Admonition>
-
-  </TabItem>
-</Tabs>
 
 <Admonition type="tip" title="Supported values">
   You can see a list of all the supported [values which can be used in a Teleport database service configuration here](../../database-access/reference/configuration.mdx).
@@ -745,8 +623,8 @@ You can specify multiple databases by adding additional list elements.
 
 You can specify multiple selectors by adding elements to the list.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   databaseResources:
   - labels:
@@ -756,22 +634,6 @@ You can specify multiple selectors by adding elements to the list.
       "env": "test"
       "engine": "mysql"
   ```
-
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "databaseResources[0].labels.env=prod" \
-  --set "databaseResources[0].labels.engine=postgres" \
-  --set "databaseResources[1].labels.env=test" \
-  --set "databaseResources[0].labels.engine=mysql"
-  ```
-
-  <Admonition type="note">
-    Note that when using `--set` syntax, YAML list elements must be indexed starting at `0`.
-  </Admonition>
-
-  </TabItem>
-</Tabs>
 
 <Admonition type="tip" title="Example">
   Once `databaseResources` is set, you can dynamically register database with `tsh` by following [this guide](../../database-access/guides/dynamic-registration.mdx).
@@ -795,18 +657,11 @@ See [this link for information on Community Docker image versions](../../managem
   not require a Teleport license file to be provided.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleportVersionOverride: "11"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleportVersionOverride="11"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `caPin`
 
@@ -823,18 +678,11 @@ Each list element can be the pin itself (recommended, works out of the box),
 or a path to a file containing the pin. For the latter it is your
 responsibility to mount the file using [`extraVolumes`](#extraVolumes).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   caPin: ["sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set caPin[0]="sha256:7e12c17c20d9cb504bbcb3f0236be3f446861f1396dcbb44425fe28ec1c108f1"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `insecureSkipProxyTLSVerify`
 
@@ -847,18 +695,11 @@ Proxy Service specified using [`proxyAddr`](#proxyaddr).
 
 This can be used for joining a Teleport instance to a Teleport cluster which does not have valid TLS certificates for testing.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   insecureSkipProxyTLSVerify: false
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set insecureSkipProxyTLSVerify=false
-  ```
-  </TabItem>
-</Tabs>
 
 <Admonition type="warning">
   Using a self-signed TLS certificate and disabling TLS verification is OK for testing, but is not viable when running a production Teleport
@@ -914,19 +755,12 @@ $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.p
   The key containing the root CA in the secret must be `ca.pem`.
 </Notice>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   tls:
     existingCASecretName: my-root-ca
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set tls.existingSecretName=my-root-ca
-  ```
-  </TabItem>
-</Tabs>
 
 ## `existingDataVolume`
 
@@ -936,18 +770,11 @@ $ kubectl create secret generic my-root-ca --from-file=ca.pem=/path/to/root-ca.p
 
 When `existingDataVolume` is set to the name of an existing volume, the `/var/lib/teleport` mount will use this volume instead of creating a new `emptyDir` volume.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   existingDataVolume: my-volume
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set existingDataVolume=my-volume
-  ```
-  </TabItem>
-</Tabs>
 
 ## `podSecurityPolicy`
 
@@ -969,19 +796,12 @@ To disable PSP creation, you can set `enabled` to `false`.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/policy/pod-security-policy/)
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   podSecurityPolicy:
     enabled: false
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set podSecurityPolicy.enabled=false
-  ```
-  </TabItem>
-</Tabs>
 
 ## `labels`
 
@@ -1006,21 +826,13 @@ These labels can then be used with Teleport's RBAC policies to define access rul
   For more information on how to set static/dynamic labels for Teleport services, see [labelling nodes and applications](../../management/admin/labels.mdx).
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   labels:
     environment: production
     region: us-east
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set labels.environment=production \
-  --set labels.region=us-east
-  ```
-  </TabItem>
-</Tabs>
 
 ## `storage`
 
@@ -1073,19 +885,12 @@ If `storage.enabled` is `false`, the chart configures the Teleport pod to manage
 its data with a temporary directory that exists until the Teleport pod stops
 running.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   storage:
     enabled: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set storage.enabled=true
-  ```
-  </TabItem>
-</Tabs>
 
 ### `storage.storageClassName`
 
@@ -1098,19 +903,12 @@ name needs to exist on the Kubernetes cluster for Teleport to use.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/storage-classes/)
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   storage:
     storageClassName: teleport-storage-class
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set storage.storageClassName=teleport-storage-class
-  ```
-  </TabItem>
-</Tabs>
 
 ### `storage.requests`
 
@@ -1120,19 +918,12 @@ name needs to exist on the Kubernetes cluster for Teleport to use.
 
 The size of persistent volume to create.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   storage:
     requests: 128Mi
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set storage.requests=128Mi
-  ```
-  </TabItem>
-</Tabs>
 
 ## `image`
 
@@ -1153,18 +944,11 @@ For this reason, it is strongly discouraged to set a custom image when
 connecting to a Teleport Cloud instance enrolled in automatic updates.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   image: my.docker.registry/teleport-image-name
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set image=my.docker.registry/teleport-image-name
-  ```
-  </TabItem>
-</Tabs>
 
 ## `imagePullSecrets`
 
@@ -1176,19 +960,12 @@ connecting to a Teleport Cloud instance enrolled in automatic updates.
 
 A list of secrets containing authorization tokens which can be optionally used to access a private Docker registry.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   imagePullSecrets:
   - name: my-docker-registry-key
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set "imagePullSecrets[0].name=my-docker-registry-key"
-  ```
-  </TabItem>
-</Tabs>
 
 ### `highAvailability`
 
@@ -1209,19 +986,12 @@ Set to a number higher than `1` for a high availability mode where multiple Tele
   clusters with more traffic.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     replicaCount: 3
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set highAvailability.replicaCount=3
-  ```
-  </TabItem>
-</Tabs>
 
 ## `highAvailability.requireAntiAffinity`
 
@@ -1245,19 +1015,12 @@ Teleport pods must not be scheduled on the same physical host.
   This setting only has any effect when `highAvailability.replicaCount` is greater than `1`.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     requireAntiAffinity: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set highAvailability.requireAntiAffinity=true
-  ```
-  </TabItem>
-</Tabs>
 
 ## `highAvailability.podDisruptionBudget`
 
@@ -1271,20 +1034,13 @@ Teleport pods must not be scheduled on the same physical host.
 
 Enable a Pod Disruption Budget for the Teleport Pod to ensure HA during voluntary disruptions.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     podDisruptionBudget:
       enabled: true
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set highAvailability.podDisruptionBudget.enabled=true
-  ```
-  </TabItem>
-</Tabs>
 
 ### `highAvailability.podDisruptionBudget.minAvailable`
 
@@ -1296,20 +1052,13 @@ Enable a Pod Disruption Budget for the Teleport Pod to ensure HA during voluntar
 
 Ensures that this number of replicas is available during voluntary disruptions, can be a number of replicas or a percentage.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   highAvailability:
     podDisruptionBudget:
       minAvailable: 1
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```shell
-  --set highAvailability.podDisruptionBudget.minAvailable=1
-  ```
-  </TabItem>
-</Tabs>
 
 ## `clusterRoleName`
 
@@ -1323,18 +1072,11 @@ Ensures that this number of replicas is available during voluntary disruptions, 
   Most users will not need to change this.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   clusterRoleName: kubernetes-clusterrole
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set clusterRoleName=kubernetes-clusterrole
-  ```
-  </TabItem>
-</Tabs>
 
 ## `clusterRoleBindingName`
 
@@ -1348,18 +1090,11 @@ Ensures that this number of replicas is available during voluntary disruptions, 
 
 `clusterRoleBindingName` can be optionally used to override the name of the Kubernetes `ClusterRoleBinding` used by the `teleport-kube-agent` chart's `ServiceAccount`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   clusterRoleBindingName: kubernetes-clusterrolebinding
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set clusterRoleBindingName=kubernetes-clusterrolebinding
-  ```
-  </TabItem>
-</Tabs>
 
 ## `priorityClassName`
 
@@ -1369,18 +1104,11 @@ Ensures that this number of replicas is available during voluntary disruptions, 
 
 `priorityClassName` allows to specify a priority class for the `teleport-kube-agent` deployment/statefulset.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   priorityClassName: "teleport-kube-agent"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set priorityClassName=teleport-kube-agent
-  ```
-  </TabItem>
-</Tabs>
 
 ## `serviceAccount.create`
 
@@ -1393,21 +1121,13 @@ Ensures that this number of replicas is available during voluntary disruptions, 
 Boolean value to control whether Helm Chart should create the `ServiceAccount`.
 When off, the `serviceAccount.name` parameter should be set to the existing `ServiceAccount` name.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   serviceAccount:
     create: false
     name: kubernetes-serviceaccount
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set serviceAccount.create=false
-  --set serviceAccount.name=kubernetes-serviceaccount
-  ```
-  </TabItem>
-</Tabs>
 
 ## `serviceAccount.name`
 
@@ -1423,19 +1143,12 @@ You should set this value if there is a `ServiceAccount` resource in the
 namespace of your `teleport-kube-agent` resources with the same name as your
 `teleport-kube-agent` release.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   serviceAccount:
     name: kubernetes-serviceaccount
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set serviceAccount.name=kubernetes-serviceaccount
-  ```
-  </TabItem>
-</Tabs>
 
 ## `secretName`
 
@@ -1460,23 +1173,14 @@ $ kubectl --namespace teleport create secret generic teleport-kube-agent-join-to
   The key used for the auth token inside the secret must be `auth-token`, as in the command above.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   secretName: "secret-i-created-before"
   joinParams:
     method: "token"
     tokenName: ""
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set secretName="secret-i-created-before" \
-    --set joinParams.method="token" \
-    --set joinParams.tokenName=""
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log`
 
@@ -1498,19 +1202,12 @@ The default is `INFO`, which is recommended in production.
 
 `DEBUG` is useful during first-time setup or to see more detailed logs for debugging.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     level: DEBUG
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.level=DEBUG
-  ```
-  </TabItem>
-</Tabs>
 
 ### `log.output`
 
@@ -1524,19 +1221,12 @@ This can be set to any of the built-in values: `stdout`, `stderr` or `syslog` to
 
 The value can also be set to a file path (such as `/var/log/teleport.log`) to write logs to a file. Bear in mind that a few service startup messages will still go to `stderr` for resilience.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     output: stderr
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.output=stderr
-  ```
-  </TabItem>
-</Tabs>
 
 ### `log.format`
 
@@ -1548,19 +1238,12 @@ The value can also be set to a file path (such as `/var/log/teleport.log`) to wr
 
 Possible values are `text` (default) or `json`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     format: json
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.format=json
-  ```
-  </TabItem>
-</Tabs>
 
 ### `log.extraFields`
 
@@ -1572,20 +1255,12 @@ Possible values are `text` (default) or `json`.
 
 See the [Teleport config file reference](../../reference/config.mdx) for more details on possible values for `extra_fields`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     extraFields: ["timestamp", "level"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "log.extraFields[0]=timestamp" \
-  --set "log.extraFields[1]=level"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `affinity`
 
@@ -1601,8 +1276,8 @@ Kubernetes affinity to set for pod assignments.
   You cannot set both `affinity` and `highAvailability.requireAntiAffinity` as they conflict with each other.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   affinity:
     nodeAffinity:
@@ -1614,15 +1289,6 @@ Kubernetes affinity to set for pod assignments.
             values:
             - teleport
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=gravitational.io/dedicated \
-  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In \
-  --set affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=teleport
-  ```
-  </TabItem>
-</Tabs>
 
 ## `dnsConfig`
 
@@ -1671,21 +1337,13 @@ nodes that Teleport pods will run on.
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/)
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   nodeSelector:
     role: node
     region: us-east
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set nodeSelector.role=node \
-  --set nodeSelector.region=us-east
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.clusterRole`
 
@@ -1697,24 +1355,13 @@ nodes that Teleport pods will run on.
 
 Kubernetes labels that should be applied to the `ClusterRole` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     clusterRole:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.clusterRole."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.clusterRoleBinding`
 
@@ -1726,24 +1373,13 @@ Kubernetes labels that should be applied to the `ClusterRole` created by the cha
 
 Kubernetes labels that should be applied to the `ClusterRoleBinding` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     clusterRoleBinding:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.clusterRoleBinding."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.role`
 
@@ -1756,24 +1392,13 @@ Kubernetes labels that should be applied to the `ClusterRoleBinding` created by 
 Kubernetes labels that should be applied to the `Role` created by the chart for
 the Teleport pod.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     role:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.role."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.roleBinding`
 
@@ -1786,24 +1411,13 @@ the Teleport pod.
 Kubernetes labels that should be applied to the `RoleBinding` created by the
 chart for the Teleport pod.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     roleBinding:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.roleBinding."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.config`
 
@@ -1815,24 +1429,13 @@ chart for the Teleport pod.
 
 Kubernetes labels that should be applied to the `ConfigMap` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     config:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.config."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.deployment`
 
@@ -1844,24 +1447,13 @@ Kubernetes labels that should be applied to the `ConfigMap` created by the chart
 
 Kubernetes labels that should be applied to the `Deployment` or `StatefulSet` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     deployment:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.deployment."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.pod`
 
@@ -1873,24 +1465,13 @@ Kubernetes labels that should be applied to the `Deployment` or `StatefulSet` cr
 
 Kubernetes labels that should be applied to every `Pod` in the `Deployment` or `StatefulSet` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     pod:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.pod."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.podDisruptionBudget`
 
@@ -1902,24 +1483,13 @@ Kubernetes labels that should be applied to every `Pod` in the `Deployment` or `
 
 Kubernetes labels that should be applied to the `PodDisruptionBudget` created by the chart (if enabled).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     podDisruptionBudget:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.podDisruptionBudget."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.podSecurityPolicy`
 
@@ -1931,24 +1501,13 @@ Kubernetes labels that should be applied to the `PodDisruptionBudget` created by
 
 Kubernetes labels that should be applied to the `PodSecurityPolicy` created by the chart (if enabled).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     podSecurityPolicy:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.podSecurityPolicy."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.secret`
 
@@ -1960,24 +1519,13 @@ Kubernetes labels that should be applied to the `PodSecurityPolicy` created by t
 
 Kubernetes labels that should be applied to the `Secret` created by the chart (if enabled).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     secret:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.secret."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraLabels.serviceAccount`
 
@@ -1990,24 +1538,13 @@ Kubernetes labels that should be applied to the `Secret` created by the chart (i
 Kubernetes labels that should be applied to the `ServiceAccount` created by the
 chart for the Teleport pod.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraLabels:
     serviceAccount:
       app.kubernetes.io/name: teleport-kube-agent
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set extraLabels.serviceAccount."app\.kubernetes\.io\/name"=teleport-kube-agent
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.config`
 
@@ -2024,24 +1561,13 @@ Kubernetes annotations which should be applied to the `ConfigMap` created by the
   In this instance, you should apply annotations manually to your created `ConfigMap`.
 </Admonition>
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     config:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.config."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.deployment`
 
@@ -2053,24 +1579,13 @@ Kubernetes annotations which should be applied to the `ConfigMap` created by the
 
 Kubernetes annotations which should be applied to the `Deployment` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     deployment:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.deployment."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.pod`
 
@@ -2082,24 +1597,13 @@ Kubernetes annotations which should be applied to the `Deployment` created by th
 
 Kubernetes annotations which should be applied to each `Pod` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     pod:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.pod."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `annotations.serviceAccount`
 
@@ -2111,24 +1615,13 @@ Kubernetes annotations which should be applied to each `Pod` created by the char
 
 Kubernetes annotations which should be applied to the `ServiceAccount` created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   annotations:
     serviceAccount:
       kubernetes.io/annotation: value
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set annotations.serviceAccount."kubernetes\.io\/annotation"=value
-  ```
-  <Admonition type="warning" title="Escaping values">
-    You must escape values entered on the command line correctly for Helm's CLI to understand them. We recommend
-    using a `values.yaml` file instead to avoid confusion and errors.
-  </Admonition>
-  </TabItem>
-</Tabs>
 
 ## `extraVolumes`
 
@@ -2141,22 +1634,14 @@ Kubernetes annotations which should be applied to the `ServiceAccount` created b
 A list of extra Kubernetes `Volumes` which should be available to any `Pod` created by the chart. These volumes
 will also be available to any `initContainers` configured by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraVolumes:
   - name: myvolume
     secret:
       secretName: mysecret
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraVolumes[0].name=myvolume" \
-  --set "extraVolumes[0].secret.secretName=mysecret"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraArgs`
 
@@ -2166,19 +1651,12 @@ will also be available to any `initContainers` configured by the chart.
 
 A list of extra arguments to pass to the `teleport start` command when running a Teleport Pod.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraArgs:
   - "--debug"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraArgs={--debug}"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraEnv`
 
@@ -2190,21 +1668,13 @@ A list of extra arguments to pass to the `teleport start` command when running a
 
 A list of extra environment variables to be set on the main Teleport container.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraEnv:
   - name: HTTPS_PROXY
     value: "http://username:password@my.proxy.host:3128"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraEnv[0].name=HTTPS_PROXY" \
-  --set "extraEnv[0].value=\"http://username:password@my.proxy.host:3128\""
-  ```
-  </TabItem>
-</Tabs>
 
 ## `extraVolumeMounts`
 
@@ -2217,21 +1687,13 @@ A list of extra environment variables to be set on the main Teleport container.
 A list of extra Kubernetes volume mounts which should be mounted into any `Pod` created by the chart. These volume
 mounts will also be mounted into any `initContainers` configured by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   extraVolumeMounts:
   - name: myvolume
     mountPath: /path/to/mount/volume
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "extraVolumeMounts[0].name=myvolume" \
-  --set "extraVolumeMounts[0].path=/path/to/mount/volume"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `imagePullPolicy`
 
@@ -2243,18 +1705,11 @@ mounts will also be mounted into any `initContainers` configured by the chart.
 
 Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   imagePullPolicy: Always
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set imagePullPolicy=Always
-  ```
-  </TabItem>
-</Tabs>
 
 ## `initContainers`
 
@@ -2266,23 +1721,14 @@ Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
 
 A list of `initContainers` which will be run before the main Teleport container in any pod created by the chart.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   initContainers:
   - name: teleport-init
     image: alpine
     args: ['echo test']
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "initContainers[0].name=teleport-init" \
-  --set "initContainers[0].image=alpine" \
-  --set "initContainers[0].args={echo test}"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `resources`
 
@@ -2295,22 +1741,14 @@ A list of `initContainers` which will be run before the main Teleport container 
 Resource requests/limits which should be configured for each container inside the pod. These resource limits
 will also be applied to `initContainers`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   resources:
     requests:
       cpu: 1
       memory: 2Gi
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set resources.requests.cpu=1 \
-  --set resources.requests.memory=2Gi
-  ```
-  </TabItem>
-</Tabs>
 
 ## `initSecurityContext`
 
@@ -2360,8 +1798,8 @@ To unset the security context, set it to `null` or `~`.
 
 Kubernetes Tolerations to set for pod assignment.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   tolerations:
   - key: "dedicated"
@@ -2369,16 +1807,6 @@ Kubernetes Tolerations to set for pod assignment.
     value: "teleport"
     effect: "NoSchedule"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set tolerations[0].key=dedicated \
-  --set tolerations[0].operator=Equal \
-  --set tolerations[0].value=teleport \
-  --set tolerations[0].effect=NoSchedule
-  ```
-  </TabItem>
-</Tabs>
 
 ## `probeTimeoutSeconds`
 
@@ -2390,15 +1818,8 @@ Kubernetes Tolerations to set for pod assignment.
 
 Kubernetes timeouts for the liveness and readiness probes.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   probeTimeoutSeconds: 5
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set probeTimeoutSeconds=5
-  ```
-  </TabItem>
-</Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
@@ -27,8 +27,8 @@ This parameter contains the host/port combination of the Teleport Auth Service.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.address="teleport.example.com:3025"
+  ```text
+  --set teleport.address="teleport.example.com:3025"
   ```
   </TabItem>
 </Tabs>
@@ -63,8 +63,8 @@ Check out the [Event Handler Helm Chart documentation](https://github.com/gravit
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretName="teleport-plugin-event-handler-identity"
+  ```text
+  --set teleport.identitySecretName="teleport-plugin-event-handler-identity"
   ```
   </TabItem>
 </Tabs>
@@ -85,8 +85,8 @@ Name of the key in the Kubernetes secret that holds the credentials for the conn
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretPath="auth_id"
+  ```text
+  --set teleport.identitySecretPath="auth_id"
   ```
   </TabItem>
 </Tabs>
@@ -107,8 +107,8 @@ Fluentd URL where the events will be sent.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set fluentd.url="https://fluentd:24224/events.log"
+  ```text
+  --set fluentd.url="https://fluentd:24224/events.log"
   ```
   </TabItem>
 </Tabs>
@@ -129,8 +129,8 @@ Fluentd URL where the session logs will be sent.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set fluentd.sessionUrl="https://fluentd:24224/session.log"
+  ```text
+  --set fluentd.sessionUrl="https://fluentd:24224/session.log"
   ```
   </TabItem>
 </Tabs>
@@ -151,8 +151,8 @@ Secret containing the credentials to connect to Fluentd. It must to contain the 
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set fluentd.secretName="teleport-plugin-event-handler-fluentd"
+  ```text
+  --set fluentd.secretName="teleport-plugin-event-handler-fluentd"
   ```
   </TabItem>
 </Tabs>
@@ -173,8 +173,8 @@ Name of the key which contains the CA certificate inside the secret.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set fluentd.caPath="ca.crt"
+  ```text
+  --set fluentd.caPath="ca.crt"
   ```
   </TabItem>
 </Tabs>
@@ -195,8 +195,8 @@ Name of the key which contains the client's private key inside the secret.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set fluentd.keyPath="client.key"
+  ```text
+  --set fluentd.keyPath="client.key"
   ```
   </TabItem>
 </Tabs>
@@ -217,8 +217,8 @@ Name of the key which contains the client's certificate inside the secret.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set fluentd.certPath="client.crt"
+  ```text
+  --set fluentd.certPath="client.crt"
   ```
   </TabItem>
 </Tabs>
@@ -239,8 +239,8 @@ Logger output. Can be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.output="/var/log/teleport/fluentd.log"
+  ```text
+  --set log.output="/var/log/teleport/fluentd.log"
   ```
   </TabItem>
 </Tabs>
@@ -261,8 +261,8 @@ Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.severity="DEBUG"
+  ```text
+  --set log.severity="DEBUG"
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-event-handler.mdx
@@ -19,19 +19,12 @@ This reference details available values for the `teleport-plugin-event-handler` 
 
 This parameter contains the host/port combination of the Teleport Auth Service.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     address: "teleport.example.com:3025"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.address="teleport.example.com:3025"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretName`
 
@@ -55,19 +48,12 @@ data:
 
 Check out the [Event Handler Helm Chart documentation](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/event-handler/#prerequisites) for more information about how to acquire these credentials.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretName: "teleport-plugin-event-handler-identity"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretName="teleport-plugin-event-handler-identity"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretPath`
 
@@ -77,19 +63,12 @@ Check out the [Event Handler Helm Chart documentation](https://github.com/gravit
 
 Name of the key in the Kubernetes secret that holds the credentials for the connection. If the secret follows the format above, it can be omitted.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretPath: "auth_id"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretPath="auth_id"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `fluentd.url`
 
@@ -99,19 +78,12 @@ Name of the key in the Kubernetes secret that holds the credentials for the conn
 
 Fluentd URL where the events will be sent.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   fluentd:
     url: "https://fluentd:24224/events.log"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set fluentd.url="https://fluentd:24224/events.log"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `fluentd.sessionUrl`
 
@@ -121,19 +93,12 @@ Fluentd URL where the events will be sent.
 
 Fluentd URL where the session logs will be sent.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   fluentd:
     sessionUrl: "https://fluentd:24224/session.log"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set fluentd.sessionUrl="https://fluentd:24224/session.log"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `fluentd.certificate.secretName`
 
@@ -143,19 +108,12 @@ Fluentd URL where the session logs will be sent.
 
 Secret containing the credentials to connect to Fluentd. It must to contain the CA certificate, the client key and the client certificate.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   fluentd:
     secretName: "teleport-plugin-event-handler-fluentd"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set fluentd.secretName="teleport-plugin-event-handler-fluentd"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `fluentd.certificate.caPath`
 
@@ -165,19 +123,12 @@ Secret containing the credentials to connect to Fluentd. It must to contain the 
 
 Name of the key which contains the CA certificate inside the secret.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   fluentd:
     caPath: "ca.crt"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set fluentd.caPath="ca.crt"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `fluentd.certificate.keyPath`
 
@@ -187,19 +138,12 @@ Name of the key which contains the CA certificate inside the secret.
 
 Name of the key which contains the client's private key inside the secret.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   fluentd:
     keyPath: "client.key"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set fluentd.keyPath="client.key"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `fluentd.certificate.certPath`
 
@@ -209,19 +153,12 @@ Name of the key which contains the client's private key inside the secret.
 
 Name of the key which contains the client's certificate inside the secret.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   fluentd:
     certPath: "client.crt"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set fluentd.certPath="client.crt"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.output`
 
@@ -231,19 +168,12 @@ Name of the key which contains the client's certificate inside the secret.
 
 Logger output. Can be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/fluentd.log`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     output: /var/log/teleport/fluentd.log
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.output="/var/log/teleport/fluentd.log"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.severity`
 
@@ -253,16 +183,9 @@ Logger output. Can be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/
 
 Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     severity: DEBUG
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.severity="DEBUG"
-  ```
-  </TabItem>
-</Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
@@ -22,19 +22,12 @@ This reference details available values for the `teleport-plugin-jira` chart.
 This parameter contains the host/port combination of the Teleport Auth Service
 or Proxy Service.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     address: "teleport.example.com:3025"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.address="teleport.example.com:3025"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretName`
 
@@ -61,19 +54,12 @@ Check out the [Jira Helm Chart
 documentation](../../access-controls/access-request-plugins/ssh-approval-jira.mdx)
 for more information about how to acquire these credentials.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretName: "teleport-plugin-jira-identity"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretName="teleport-plugin-jira-identity"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretPath`
 
@@ -85,19 +71,12 @@ Name of the key in the Kubernetes secret that holds the credentials for the
 connection to the Auth Service. If the secret follows the format above, it can
 be omitted.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretPath: "auth_id"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretPath="auth_id"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.apiTokenFromSecret`
 
@@ -107,19 +86,12 @@ be omitted.
 
 Secret containing the Jira token of the bot user.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     apiTokenFromSecret: "teleport-jira-plugin-token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.apiTokenFromSecret="teleport-jira-plugin-token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.apiTokenSecretPath`
 
@@ -129,19 +101,12 @@ Secret containing the Jira token of the bot user.
 
 Key where the token is located inside the secret specified by `jira.apiTokenFromSecret`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     apiTokenSecretPath: "token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.apiTokenSecretPath="token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.issueType`
 
@@ -151,19 +116,12 @@ Key where the token is located inside the secret specified by `jira.apiTokenFrom
 
 Issue type to be created when a new Access Request is made.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     issueType: Task
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.issueType=Task
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.project`
 
@@ -173,19 +131,12 @@ Issue type to be created when a new Access Request is made.
 
 List of project who will receive notifications about Access Requests.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     project: MYPROJ
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.project=MYPROJ
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.recipients`
 
@@ -195,21 +146,14 @@ List of project who will receive notifications about Access Requests.
 
 List of recipients who will receive notifications about Access Requests.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     recipients:
       - user1@example.com
       - user2@example.com
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.recipients[0]="user1@example.com",jira.recipients[0]="user1@example.com"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.token`
 
@@ -221,19 +165,12 @@ Jira token of the bot user to impersonate when sending Access Request
 messages. It's only recommended for testing purposes. Please use
 [`jira.apiTokenFromSecret`](#jiraapitokenfromsecret) instead.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     token: "jiraapitoken"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.token="jiraapitoken"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.url`
 
@@ -243,19 +180,12 @@ messages. It's only recommended for testing purposes. Please use
 
 Base URL of the Jira instance.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     url: "https://jira.example.com/"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.url="https://jira.example.com/"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `jira.username`
 
@@ -265,19 +195,12 @@ Base URL of the Jira instance.
 
 Jira username or email address associated with the token.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   jira:
     username: "user@example.com"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set jira.username="user@example.com"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.output`
 
@@ -287,19 +210,12 @@ Jira username or email address associated with the token.
 
 Logger output. Can be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/jira.log`
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     output: /var/log/teleport/jira.log
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.output="/var/log/teleport/jira.log"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.severity`
 
@@ -309,16 +225,9 @@ Logger output. Can be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/
 
 Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     severity: DEBUG
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.severity="DEBUG"
-  ```
-  </TabItem>
-</Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-jira.mdx
@@ -30,8 +30,8 @@ or Proxy Service.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.address="teleport.example.com:3025"
+  ```text
+  --set teleport.address="teleport.example.com:3025"
   ```
   </TabItem>
 </Tabs>
@@ -69,8 +69,8 @@ for more information about how to acquire these credentials.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretName="teleport-plugin-jira-identity"
+  ```text
+  --set teleport.identitySecretName="teleport-plugin-jira-identity"
   ```
   </TabItem>
 </Tabs>
@@ -93,8 +93,8 @@ be omitted.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretPath="auth_id"
+  ```text
+  --set teleport.identitySecretPath="auth_id"
   ```
   </TabItem>
 </Tabs>
@@ -115,8 +115,8 @@ Secret containing the Jira token of the bot user.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.apiTokenFromSecret="teleport-jira-plugin-token"
+  ```text
+  --set jira.apiTokenFromSecret="teleport-jira-plugin-token"
   ```
   </TabItem>
 </Tabs>
@@ -137,8 +137,8 @@ Key where the token is located inside the secret specified by `jira.apiTokenFrom
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.apiTokenSecretPath="token"
+  ```text
+  --set jira.apiTokenSecretPath="token"
   ```
   </TabItem>
 </Tabs>
@@ -159,8 +159,8 @@ Issue type to be created when a new Access Request is made.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.issueType=Task
+  ```text
+  --set jira.issueType=Task
   ```
   </TabItem>
 </Tabs>
@@ -181,8 +181,8 @@ List of project who will receive notifications about Access Requests.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.project=MYPROJ
+  ```text
+  --set jira.project=MYPROJ
   ```
   </TabItem>
 </Tabs>
@@ -205,8 +205,8 @@ List of recipients who will receive notifications about Access Requests.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.recipients[0]="user1@example.com",jira.recipients[0]="user1@example.com"
+  ```text
+  --set jira.recipients[0]="user1@example.com",jira.recipients[0]="user1@example.com"
   ```
   </TabItem>
 </Tabs>
@@ -229,8 +229,8 @@ messages. It's only recommended for testing purposes. Please use
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.token="jiraapitoken"
+  ```text
+  --set jira.token="jiraapitoken"
   ```
   </TabItem>
 </Tabs>
@@ -251,8 +251,8 @@ Base URL of the Jira instance.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.url="https://jira.example.com/"
+  ```text
+  --set jira.url="https://jira.example.com/"
   ```
   </TabItem>
 </Tabs>
@@ -273,8 +273,8 @@ Jira username or email address associated with the token.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set jira.username="user@example.com"
+  ```text
+  --set jira.username="user@example.com"
   ```
   </TabItem>
 </Tabs>
@@ -295,8 +295,8 @@ Logger output. Can be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.output="/var/log/teleport/jira.log"
+  ```text
+  --set log.output="/var/log/teleport/jira.log"
   ```
   </TabItem>
 </Tabs>
@@ -317,8 +317,8 @@ Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.severity="DEBUG"
+  ```text
+  --set log.severity="DEBUG"
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
@@ -21,19 +21,12 @@ This reference details available values for the `teleport-plugin-mattermost` cha
 
 This parameter contains the host/port combination of the Teleport Auth Service or Proxy Service.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     address: "teleport.example.com:3025"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.address="teleport.example.com:3025"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretName`
 
@@ -58,19 +51,12 @@ data:
 Check out the [Access Requests with Mattermost](../../access-controls/access-request-plugins/ssh-approval-mattermost.mdx) guide
 for more information about how to acquire these credentials.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretName: "teleport-plugin-mattermost-identity"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretName="teleport-plugin-mattermost-identity"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretPath`
 
@@ -82,19 +68,12 @@ The key in the Kubernetes secret specified by `teleport.identitySecretName` that
 credentials for the connection to your Teleport cluster. If the secret has the path,
 `"auth_id"`, you can omit this field.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretPath: "auth_id"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretPath="auth_id"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `mattermost.url`
 
@@ -104,19 +83,12 @@ credentials for the connection to your Teleport cluster. If the secret has the p
 
 Base URL of the Mattermost instance.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   mattermost:
     url: "https://mattermost.example.com/"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set mattermost.url="https://mattermost.example.com/"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `mattermost.token`
 
@@ -129,19 +101,12 @@ messages. Ignored when `mattermost.tokenFromSecret` is set.
 It's only recommended for testing purposes. Please use
 [`mattermost.tokenFromSecret`](#mattermosttokenfromsecret) instead.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   mattermost:
     token: "xoxb-1234"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set mattermost.token="xoxb-1234"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `mattermost.tokenFromSecret`
 
@@ -151,19 +116,12 @@ It's only recommended for testing purposes. Please use
 
 Secret containing the Mattermost token of the bot user.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   mattermost:
     tokenFromSecret: "teleport-mattermost-plugin-token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set mattermost.tokenFromSecret="teleport-mattermost-plugin-token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `mattermost.tokenSecretPath`
 
@@ -173,19 +131,12 @@ Secret containing the Mattermost token of the bot user.
 
 Key where the token is located inside the secret specified by `mattermost.tokenFromSecret`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   mattermost:
     tokenSecretPath: "token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set mattermost.tokenSecretPath="token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `mattermost.recipients`
 
@@ -195,21 +146,14 @@ Key where the token is located inside the secret specified by `mattermost.tokenF
 
 List of recipients who will receive notifications about Access Requests.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   mattermost:
     recipients:
       - user1@example.com
       - user2@example.com
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set mattermost.recipients[0]="user1@example.com",mattermost.recipients[0]="user1@example.com"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.output`
 
@@ -219,19 +163,12 @@ List of recipients who will receive notifications about Access Requests.
 
 Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/mattermost.log`
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     output: /var/log/teleport/mattermost.log
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.output="/var/log/teleport/mattermost.log"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.severity`
 
@@ -241,16 +178,9 @@ Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/telepor
 
 Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     severity: DEBUG
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.severity="DEBUG"
-  ```
-  </TabItem>
-</Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-mattermost.mdx
@@ -29,8 +29,8 @@ This parameter contains the host/port combination of the Teleport Auth Service o
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.address="teleport.example.com:3025"
+  ```text
+  --set teleport.address="teleport.example.com:3025"
   ```
   </TabItem>
 </Tabs>
@@ -66,8 +66,8 @@ for more information about how to acquire these credentials.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretName="teleport-plugin-mattermost-identity"
+  ```text
+  --set teleport.identitySecretName="teleport-plugin-mattermost-identity"
   ```
   </TabItem>
 </Tabs>
@@ -90,8 +90,8 @@ credentials for the connection to your Teleport cluster. If the secret has the p
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretPath="auth_id"
+  ```text
+  --set teleport.identitySecretPath="auth_id"
   ```
   </TabItem>
 </Tabs>
@@ -112,8 +112,8 @@ Base URL of the Mattermost instance.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set mattermost.url="https://mattermost.example.com/"
+  ```text
+  --set mattermost.url="https://mattermost.example.com/"
   ```
   </TabItem>
 </Tabs>
@@ -137,8 +137,8 @@ It's only recommended for testing purposes. Please use
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set mattermost.token="xoxb-1234"
+  ```text
+  --set mattermost.token="xoxb-1234"
   ```
   </TabItem>
 </Tabs>
@@ -159,8 +159,8 @@ Secret containing the Mattermost token of the bot user.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set mattermost.tokenFromSecret="teleport-mattermost-plugin-token"
+  ```text
+  --set mattermost.tokenFromSecret="teleport-mattermost-plugin-token"
   ```
   </TabItem>
 </Tabs>
@@ -181,8 +181,8 @@ Key where the token is located inside the secret specified by `mattermost.tokenF
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set mattermost.tokenSecretPath="token"
+  ```text
+  --set mattermost.tokenSecretPath="token"
   ```
   </TabItem>
 </Tabs>
@@ -205,8 +205,8 @@ List of recipients who will receive notifications about Access Requests.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set mattermost.recipients[0]="user1@example.com",mattermost.recipients[0]="user1@example.com"
+  ```text
+  --set mattermost.recipients[0]="user1@example.com",mattermost.recipients[0]="user1@example.com"
   ```
   </TabItem>
 </Tabs>
@@ -227,8 +227,8 @@ Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/telepor
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.output="/var/log/teleport/mattermost.log"
+  ```text
+  --set log.output="/var/log/teleport/mattermost.log"
   ```
   </TabItem>
 </Tabs>
@@ -249,8 +249,8 @@ Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.severity="DEBUG"
+  ```text
+  --set log.severity="DEBUG"
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
@@ -27,8 +27,8 @@ This parameter contains the host/port combination of the Teleport Auth Service o
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.address="teleport.example.com:3025"
+  ```text
+  --set teleport.address="teleport.example.com:3025"
   ```
   </TabItem>
 </Tabs>
@@ -63,8 +63,8 @@ Read the [PagerDuty Helm Chart documentation](https://github.com/gravitational/t
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretName="teleport-plugin-pagerduty-identity"
+  ```text
+  --set teleport.identitySecretName="teleport-plugin-pagerduty-identity"
   ```
   </TabItem>
 </Tabs>
@@ -85,8 +85,8 @@ Name of the key in the Kubernetes secret that holds the credentials for the conn
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretPath="auth_id"
+  ```text
+  --set teleport.identitySecretPath="auth_id"
   ```
   </TabItem>
 </Tabs>
@@ -107,8 +107,8 @@ Base URL of the PagerDuty instance
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set pagerduty.url="https://pagerduty.example.com/"
+  ```text
+  --set pagerduty.url="https://pagerduty.example.com/"
   ```
   </TabItem>
 </Tabs>
@@ -130,8 +130,8 @@ Please use [`pagerduty.apiKeyFromSecret`](#pagerdutyapikeyfromsecret) instead.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set pagerduty.apiKey="pagerdutyapikey"
+  ```text
+  --set pagerduty.apiKey="pagerdutyapikey"
   ```
   </TabItem>
 </Tabs>
@@ -152,8 +152,8 @@ Secret containing the PagerDuty token of the bot user.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set pagerduty.apiKeyFromSecret="teleport-pagerduty-plugin-token"
+  ```text
+  --set pagerduty.apiKeyFromSecret="teleport-pagerduty-plugin-token"
   ```
   </TabItem>
 </Tabs>
@@ -174,8 +174,8 @@ Key where the token is located inside the secret specified by `pagerduty.apiKeyF
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set pagerduty.apiKeySecretPath="apiKey"
+  ```text
+  --set pagerduty.apiKeySecretPath="apiKey"
   ```
   </TabItem>
 </Tabs>
@@ -196,8 +196,8 @@ Key where the token is located inside the secret specified by `pagerduty.apiKeyF
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set pagerduty.userEmail="apiKey"
+  ```text
+  --set pagerduty.userEmail="apiKey"
   ```
   </TabItem>
 </Tabs>
@@ -220,8 +220,8 @@ List of recipients who will receive notifications about Access Requests.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set pagerduty.recipients[0]="user1@example.com",pagerduty.recipients[0]="user1@example.com"
+  ```text
+  --set pagerduty.recipients[0]="user1@example.com",pagerduty.recipients[0]="user1@example.com"
   ```
   </TabItem>
 </Tabs>
@@ -242,8 +242,8 @@ Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/telepor
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.output="/var/log/teleport/pagerduty.log"
+  ```text
+  --set log.output="/var/log/teleport/pagerduty.log"
   ```
   </TabItem>
 </Tabs>
@@ -264,8 +264,8 @@ Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.severity="DEBUG"
+  ```text
+  --set log.severity="DEBUG"
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-pagerduty.mdx
@@ -19,19 +19,12 @@ This reference details available values for the `teleport-plugin-pagerduty` char
 
 This parameter contains the host/port combination of the Teleport Auth Service or Proxy Service.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     address: "teleport.example.com:3025"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.address="teleport.example.com:3025"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretName`
 
@@ -55,19 +48,12 @@ data:
 
 Read the [PagerDuty Helm Chart documentation](https://github.com/gravitational/teleport-plugins/tree/v(=teleport.version=)/charts/access/pagerduty#prerequisites) for more information about how to acquire these credentials.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretName: "teleport-plugin-pagerduty-identity"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretName="teleport-plugin-pagerduty-identity"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretPath`
 
@@ -77,19 +63,12 @@ Read the [PagerDuty Helm Chart documentation](https://github.com/gravitational/t
 
 Name of the key in the Kubernetes secret that holds the credentials for the connection. If the secret follows the format above, it can be omitted.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretPath: "auth_id"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretPath="auth_id"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `pagerduty.url`
 
@@ -99,19 +78,12 @@ Name of the key in the Kubernetes secret that holds the credentials for the conn
 
 Base URL of the PagerDuty instance
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   pagerduty:
     url: "https://pagerduty.example.com/"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set pagerduty.url="https://pagerduty.example.com/"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `pagerduty.apiKey`
 
@@ -122,19 +94,12 @@ Base URL of the PagerDuty instance
 PagerDuty API key of the bot user to impersonate when sending messages. It's only recommended for testing purposes.
 Please use [`pagerduty.apiKeyFromSecret`](#pagerdutyapikeyfromsecret) instead.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   pagerduty:
     apiKey: "pagerdutyapikey"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set pagerduty.apiKey="pagerdutyapikey"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `pagerduty.apiKeyFromSecret`
 
@@ -144,19 +109,12 @@ Please use [`pagerduty.apiKeyFromSecret`](#pagerdutyapikeyfromsecret) instead.
 
 Secret containing the PagerDuty token of the bot user.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   pagerduty:
     apiKeyFromSecret: "teleport-pagerduty-plugin-token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set pagerduty.apiKeyFromSecret="teleport-pagerduty-plugin-token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `pagerduty.apiKeySecretPath`
 
@@ -166,19 +124,12 @@ Secret containing the PagerDuty token of the bot user.
 
 Key where the token is located inside the secret specified by `pagerduty.apiKeyFromSecret`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   pagerduty:
     apiKeySecretPath: "apiKey"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set pagerduty.apiKeySecretPath="apiKey"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `pagerduty.userEmail`
 
@@ -188,19 +139,12 @@ Key where the token is located inside the secret specified by `pagerduty.apiKeyF
 
 Key where the token is located inside the secret specified by `pagerduty.apiKeyFromSecret`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   pagerduty:
     userEmail: "apiKey"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set pagerduty.userEmail="apiKey"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `pagerduty.recipients`
 
@@ -210,21 +154,14 @@ Key where the token is located inside the secret specified by `pagerduty.apiKeyF
 
 List of recipients who will receive notifications about Access Requests.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   pagerduty:
     recipients:
       - user1@example.com
       - user2@example.com
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set pagerduty.recipients[0]="user1@example.com",pagerduty.recipients[0]="user1@example.com"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.output`
 
@@ -234,19 +171,12 @@ List of recipients who will receive notifications about Access Requests.
 
 Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/pagerduty.log`
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     output: /var/log/teleport/pagerduty.log
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.output="/var/log/teleport/pagerduty.log"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.severity`
 
@@ -256,16 +186,9 @@ Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/telepor
 
 Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     severity: DEBUG
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.severity="DEBUG"
-  ```
-  </TabItem>
-</Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
@@ -29,8 +29,8 @@ connect to it directly).
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.address="teleport.example.com:3025"
+  ```text
+  --set teleport.address="teleport.example.com:3025"
   ```
   </TabItem>
 </Tabs>
@@ -68,8 +68,8 @@ for more information about how to acquire these credentials.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretName="teleport-plugin-slack-identity"
+  ```text
+  --set teleport.identitySecretName="teleport-plugin-slack-identity"
   ```
   </TabItem>
 </Tabs>
@@ -92,8 +92,8 @@ credentials for the connection to your Teleport cluster. If the secret has the p
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set teleport.identitySecretPath="auth_id"
+  ```text
+  --set teleport.identitySecretPath="auth_id"
   ```
   </TabItem>
 </Tabs>
@@ -117,8 +117,8 @@ It's only recommended for testing purposes. Please use
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set slack.token="xoxb-1234"
+  ```text
+  --set slack.token="xoxb-1234"
   ```
   </TabItem>
 </Tabs>
@@ -139,8 +139,8 @@ Secret containing the Slack token of the bot user.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set slack.tokenFromSecret="teleport-slack-plugin-token"
+  ```text
+  --set slack.tokenFromSecret="teleport-slack-plugin-token"
   ```
   </TabItem>
 </Tabs>
@@ -161,8 +161,8 @@ Key where the token is located inside the secret specified by `slack.tokenFromSe
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set slack.tokenSecretPath="token"
+  ```text
+  --set slack.tokenSecretPath="token"
   ```
   </TabItem>
 </Tabs>
@@ -185,8 +185,8 @@ a mapping for `*` in case no matching roles are found.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set "roleToRecipients.dev[0]=dev-access-requests,roleToRecipients.dev[1]=user@example.com,roleToRecipients.\*[0]=access-requests"
+  ```text
+  --set "roleToRecipients.dev[0]=dev-access-requests,roleToRecipients.dev[1]=user@example.com,roleToRecipients.\*[0]=access-requests"
   ```
   </TabItem>
 </Tabs>
@@ -207,8 +207,8 @@ Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/telepor
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.output="/var/log/teleport/slack.log"
+  ```text
+  --set log.output="/var/log/teleport/slack.log"
   ```
   </TabItem>
 </Tabs>
@@ -229,8 +229,8 @@ Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
   ```
   </TabItem>
   <TabItem label="--set">
-  ```code
-  $ --set log.severity="DEBUG"
+  ```text
+  --set log.severity="DEBUG"
   ```
   </TabItem>
 </Tabs>

--- a/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
+++ b/docs/pages/reference/helm-reference/teleport-plugin-slack.mdx
@@ -21,19 +21,12 @@ This parameter contains the host/port combination of the Teleport Proxy
 Service (or the Auth Service if you are configuring your plugin to
 connect to it directly).
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     address: "teleport.example.com:3025"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.address="teleport.example.com:3025"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretName`
 
@@ -60,19 +53,12 @@ Check out the [Access Requests with
 Slack](../../access-controls/access-request-plugins/ssh-approval-slack.mdx) guide
 for more information about how to acquire these credentials.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretName: "teleport-plugin-slack-identity"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretName="teleport-plugin-slack-identity"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `teleport.identitySecretPath`
 
@@ -84,19 +70,12 @@ The key in the Kubernetes secret specified by `teleport.identitySecretName` that
 credentials for the connection to your Teleport cluster. If the secret has the path,
 `"auth_id"`, you can omit this field.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   teleport:
     identitySecretPath: "auth_id"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set teleport.identitySecretPath="auth_id"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `slack.token`
 
@@ -109,19 +88,12 @@ messages. Ignored when `slack.tokenFromSecret` is set.
 It's only recommended for testing purposes. Please use
 [`slack.tokenFromSecret`](#slacktokenfromsecret) instead.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   slack:
     token: "xoxb-1234"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set slack.token="xoxb-1234"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `slack.tokenFromSecret`
 
@@ -131,19 +103,12 @@ It's only recommended for testing purposes. Please use
 
 Secret containing the Slack token of the bot user.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   slack:
     tokenFromSecret: "teleport-slack-plugin-token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set slack.tokenFromSecret="teleport-slack-plugin-token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `slack.tokenSecretPath`
 
@@ -153,19 +118,12 @@ Secret containing the Slack token of the bot user.
 
 Key where the token is located inside the secret specified by `slack.tokenFromSecret`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   slack:
     tokenSecretPath: "token"
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set slack.tokenSecretPath="token"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `roleToRecipients`
 
@@ -176,20 +134,13 @@ Key where the token is located inside the secret specified by `slack.tokenFromSe
 Mapping of roles to a list of channels and Slack emails. It must contain
 a mapping for `*` in case no matching roles are found.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   roleToRecipients:
     dev: ["dev-access-requests", "user@example.com"]
     "*": ["access-requests"]
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set "roleToRecipients.dev[0]=dev-access-requests,roleToRecipients.dev[1]=user@example.com,roleToRecipients.\*[0]=access-requests"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.output`
 
@@ -199,19 +150,12 @@ a mapping for `*` in case no matching roles are found.
 
 Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/teleport/slack.log`
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     output: /var/log/teleport/slack.log
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.output="/var/log/teleport/slack.log"
-  ```
-  </TabItem>
-</Tabs>
 
 ## `log.severity`
 
@@ -221,16 +165,9 @@ Logger output. Could be `stdout`, `stderr` or a file name, eg. `/var/log/telepor
 
 Logger severity. Possible values are `INFO`, `ERROR`, `DEBUG` or `WARN`.
 
-<Tabs>
-  <TabItem label="values.yaml">
+`values.yaml` example:
+
   ```yaml
   log:
     severity: DEBUG
   ```
-  </TabItem>
-  <TabItem label="--set">
-  ```text
-  --set log.severity="DEBUG"
-  ```
-  </TabItem>
-</Tabs>


### PR DESCRIPTION
Closes #9686

Since the `--set` flag examples aren't commands, this change removes the shell prompts and changes code fence labels from `code` to `text`.