### PR TITLE
Document HA for Access Request plugins

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/index.mdx
+++ b/docs/pages/access-controls/access-request-plugins/index.mdx
@@ -8,9 +8,8 @@ Teleport Just-in-Time Access Requests allow users to receive temporary elevated
 privileges by seeking consent from one or more reviewers, depending on your
 configuration.
 
-With Teleport's Access Request plugins, users can request, approve, and deny
-access without leaving your organization's existing messaging and project
-management solutions.
+With Teleport's Access Request plugins, users can manage Access Requests from
+within your organization's existing messaging and project management solutions.
 
 ## Plugin guides
 

--- a/docs/pages/access-controls/access-request-plugins/index.mdx
+++ b/docs/pages/access-controls/access-request-plugins/index.mdx
@@ -6,7 +6,35 @@ layout: tocless-doc
 
 Teleport Just-in-Time Access Requests allow users to receive temporary elevated
 privileges by seeking consent from one or more reviewers, depending on your
-configuration. 
+configuration.
+
+With Teleport's Access Request plugins, users can request, approve, and deny
+access without leaving your organization's existing messaging and project
+management solutions.
+
+## Plugin guides
 
 (!docs/pages/includes/access-request-integrations.mdx!)
+
+## Architecture
+
+Access Request plugins are self-contained programs that connect to the Teleport
+Auth Service's gRPC API in order to listen for audit events that relate to new
+or updated Access Requests. After processing an Access Request event, Access
+Request plugins interact with a third-party API (e.g., the Slack or PagerDuty
+APIs). 
+
+Access Request plugins can run within private networks that are isolated from
+the Teleport Auth Service. To access the Auth Service API, they connect to the
+Proxy Service, which establishes a reverse tunnel for the plugin to access the
+Auth Service.
+
+You can run multiple instances of an Access Request plugin for high
+availability. To do so, run each instance in a separate availability zone. There
+is no need for additional configuration or load balancing, as plugins avoid
+creating duplicate requests to their third-party APIs.
+
+To read more about the architecture of an Access Request plugin, and start
+writing your own, read our [Access Request plugin development
+guide](../../api/access-plugin.mdx).
 

--- a/docs/pages/access-controls/access-request-plugins/index.mdx
+++ b/docs/pages/access-controls/access-request-plugins/index.mdx
@@ -19,20 +19,19 @@ management solutions.
 ## Architecture
 
 Access Request plugins are self-contained programs that connect to the Teleport
-Auth Service's gRPC API in order to listen for audit events that relate to new
-or updated Access Requests. After processing an Access Request event, Access
-Request plugins interact with a third-party API (e.g., the Slack or PagerDuty
-APIs). 
+Auth Service's gRPC API to listen for audit events relating to new or updated
+Access Requests. After processing an Access Request event, Access Request plugins
+interact with a third-party API (e.g., the Slack or PagerDuty APIs). 
 
 Access Request plugins can run within private networks that are isolated from
 the Teleport Auth Service. To access the Auth Service API, they connect to the
 Proxy Service, which establishes a reverse tunnel for the plugin to access the
 Auth Service.
 
-You can run multiple instances of an Access Request plugin for high
-availability. To do so, run each instance in a separate availability zone. There
-is no need for additional configuration or load balancing, as plugins avoid
-creating duplicate requests to their third-party APIs.
+You can run multiple instances of an Access Request plugin for high availability
+by deploying each instance in a separate availability zone. There is no need for
+additional configuration or load balancing, as plugins avoid creating duplicate
+requests to their third-party APIs.
 
 To read more about the architecture of an Access Request plugin, and start
 writing your own, read our [Access Request plugin development

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -572,9 +572,8 @@ the Teleport Web UI.
 
 ### Integrating with an external tool
 
-With Teleport's Access Request plugins, users can request, approve, and deny
-access without leaving your organization's existing messaging and project
-management solutions.
+With Teleport's Access Request plugins, users can manage Access Requests from
+within your organization's existing messaging and project management solutions.
 
 (!docs/pages/includes/access-request-integrations.mdx!)
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -571,6 +571,11 @@ the requested node, the hostname will be displayed in the Review Request page of
 the Teleport Web UI.
 
 ### Integrating with an external tool
+
+With Teleport's Access Request plugins, users can request, approve, and deny
+access without leaving your organization's existing messaging and project
+management solutions.
+
 (!docs/pages/includes/access-request-integrations.mdx!)
 
 ### Using TTLs with Access Requests

--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -154,6 +154,11 @@ to the original set of roles.
 ## Next Steps
 
 ### Integrating with an external tool
+
+With Teleport's Access Request plugins, users can request, approve, and deny
+access without leaving your organization's existing messaging and project
+management solutions.
+
 (!docs/pages/includes/access-request-integrations.mdx!)
 
 ### Advanced RBAC

--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -155,9 +155,8 @@ to the original set of roles.
 
 ### Integrating with an external tool
 
-With Teleport's Access Request plugins, users can request, approve, and deny
-access without leaving your organization's existing messaging and project
-management solutions.
+With Teleport's Access Request plugins, users can manage Access Requests from
+within your organization's existing messaging and project management solutions.
 
 (!docs/pages/includes/access-request-integrations.mdx!)
 

--- a/docs/pages/includes/access-request-integrations.mdx
+++ b/docs/pages/includes/access-request-integrations.mdx
@@ -1,7 +1,3 @@
-With Teleport's Access Request plugins, users can request,
-approve, and deny access without leaving your organization's existing messaging
-and project management solutions.
-
 | Integration | Type | Setup Instructions |
 | - | - | - |
 | Slack | Messaging | [Set up Slack](../access-controls/access-request-plugins/ssh-approval-slack.mdx) |


### PR DESCRIPTION
Closes #8970

Add an "Architecture" section to the Access Request plugin index page that describes how Access Request plugins run, including what an HA setup looks like.