### PR TITLE
ensure forwarded SSH agent is always closed

### DIFF
--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -1161,6 +1161,7 @@ func (s *Server) handleAgentForward(ch ssh.Channel, req *ssh.Request, ctx *srv.S
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		ctx.AddCloser(userAgent)
 	}
 
 	err = agent.ForwardToAgent(ctx.RemoteClient.Client, userAgent)


### PR DESCRIPTION
Previously when handling an SSH agent forward request from a SSH connection to a registered SSH node, the forwarding SSH server would open a SSH channel for the SSH agent but never close it. tsh wasn't affected by this and would exit cleanly when the SSH session was closed. OpenSSH ssh would hang waiting for the open SSH agent channel to close, which would never happen.

Fixes https://github.com/gravitational/teleport/issues/24936.