### PR TITLE
Add option to override kube context on `tsh kube login`

### DIFF
--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -991,12 +991,13 @@ func selectedKubeCluster(currentTeleportCluster string) string {
 
 type kubeLoginCommand struct {
 	*kingpin.CmdClause
-	kubeCluster       string
-	siteName          string
-	impersonateUser   string
-	impersonateGroups []string
-	namespace         string
-	all               bool
+	kubeCluster         string
+	siteName            string
+	impersonateUser     string
+	impersonateGroups   []string
+	namespace           string
+	all                 bool
+	overrideContextName string
 }
 
 func newKubeLoginCommand(parent *kingpin.CmdClause) *kubeLoginCommand {
@@ -1010,6 +1011,7 @@ func newKubeLoginCommand(parent *kingpin.CmdClause) *kubeLoginCommand {
 	// TODO (tigrato): move this back to namespace once teleport drops the namespace flag.
 	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
 	c.Flag("all", "Generate a kubeconfig with every cluster the user has access to.").BoolVar(&c.all)
+	c.Flag("set-context-name", "Define a custom context name.").StringVar(&c.overrideContextName)
 	return c
 }
 
@@ -1017,6 +1019,10 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	if c.kubeCluster == "" && !c.all {
 		return trace.BadParameter("kube-cluster name is required. Check 'tsh kube ls' for a list of available clusters.")
 	}
+	if c.all && c.overrideContextName != "" {
+		return trace.BadParameter("cannot use --set-context-name with --all")
+	}
+
 	// Set CLIConf.KubernetesCluster so that the kube cluster's context is automatically selected.
 	cf.KubernetesCluster = c.kubeCluster
 	cf.SiteName = c.siteName
@@ -1044,7 +1050,7 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 
 	// Update default kubeconfig file located at ~/.kube/config or the value of
 	// KUBECONFIG env var even if the context exists.
-	if err := updateKubeConfig(cf, tc, ""); err != nil {
+	if err := updateKubeConfig(cf, tc, "", c.overrideContextName); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -1053,7 +1059,7 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	profileKubeconfigPath := keypaths.KubeConfigPath(
 		profile.FullProfilePath(cf.HomePath), tc.WebProxyHost(), tc.Username, currentTeleportCluster, c.kubeCluster,
 	)
-	if err := updateKubeConfig(cf, tc, profileKubeconfigPath); err != nil {
+	if err := updateKubeConfig(cf, tc, profileKubeconfigPath, c.overrideContextName); err != nil {
 		return trace.Wrap(err)
 	}
 	if c.kubeCluster != "" {
@@ -1136,7 +1142,7 @@ func fetchKubeStatus(ctx context.Context, tc *client.TeleportClient) (*kubernete
 
 // buildKubeConfigUpdate returns a kubeconfig.Values suitable for updating the user's kubeconfig
 // based on the CLI parameters and the given kubernetesStatus.
-func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus) (*kubeconfig.Values, error) {
+func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus, overrideContextName string) (*kubeconfig.Values, error) {
 	v := &kubeconfig.Values{
 		ClusterAddr:         kubeStatus.clusterAddr,
 		TeleportClusterName: kubeStatus.teleportClusterName,
@@ -1147,7 +1153,8 @@ func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus) (*kubeconf
 		ImpersonateGroups:   cf.kubernetesImpersonationConfig.kubernetesGroups,
 		Namespace:           cf.kubeNamespace,
 		// Only switch the current context if kube-cluster is explicitly set on the command line.
-		SelectCluster: cf.KubernetesCluster,
+		SelectCluster:   cf.KubernetesCluster,
+		OverrideContext: overrideContextName,
 	}
 
 	if cf.executablePath == "" {
@@ -1199,7 +1206,7 @@ type impersonationConfig struct {
 // updateKubeConfig adds Teleport configuration to the users's kubeconfig based on the CLI
 // parameters and the kubernetes services in the current Teleport cluster. If no path for
 // the kubeconfig is given, it will use environment values or known defaults to get a path.
-func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient, path string) error {
+func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient, path string, overrideContext string) error {
 	// Fetch proxy's advertised ports to check for k8s support.
 	if _, err := tc.Ping(cf.Context); err != nil {
 		return trace.Wrap(err)
@@ -1218,7 +1225,7 @@ func updateKubeConfig(cf *CLIConf, tc *client.TeleportClient, path string) error
 		cf.Proxy = tc.WebProxyAddr
 	}
 
-	values, err := buildKubeConfigUpdate(cf, kubeStatus)
+	values, err := buildKubeConfigUpdate(cf, kubeStatus, overrideContext)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -4687,7 +4687,7 @@ func updateKubeConfigOnLogin(cf *CLIConf, tc *client.TeleportClient, opts ...upd
 	if len(cf.KubernetesCluster) == 0 {
 		return nil
 	}
-	err := updateKubeConfig(cf, tc, "")
+	err := updateKubeConfig(cf, tc, "" /* update the default kubeconfig */, "" /* do not override the context name */)
 	return trace.Wrap(err)
 }
 

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -2170,7 +2170,7 @@ func TestKubeConfigUpdate(t *testing.T) {
 	}
 	for _, testcase := range tests {
 		t.Run(testcase.desc, func(t *testing.T) {
-			values, err := buildKubeConfigUpdate(testcase.cf, testcase.kubeStatus)
+			values, err := buildKubeConfigUpdate(testcase.cf, testcase.kubeStatus, "")
 			testcase.errorAssertion(t, err)
 			require.Equal(t, testcase.expectedValues, values)
 		})


### PR DESCRIPTION
This PR allows users to change the kubeconfig's context name when `tsh kube login` is executed.

It allows users to override our default naming convention `{teleport-cluster}-{kube-cluster}` and replace it with a custom name.

`tsh kube login cluster --set-context-name=ctx` overrides the context name to `ctx`. `--set-context` cannot be executed with `--all`.

Fixes #12833