### PR TITLE
[v12] docs: Change `listen_addr` to `web_listen_addr` in custom Helm deployment guide

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -158,7 +158,7 @@ Due to this, your `proxy_service.public_addr` should always end in `:443`:
 
 ```yaml
 proxy_service:
-  listen_addr: 0.0.0.0:3080
+  web_listen_addr: 0.0.0.0:3080
   public_addr: custom.example.com:443
 ```
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -101,7 +101,7 @@ proxy:
         severity: INFO
     proxy_service:
       enabled: true
-      listen_addr: 0.0.0.0:3080
+      web_listen_addr: 0.0.0.0:3080
       public_addr: custom.example.com:443
       
 # If you are running Kubernetes 1.23 or above, disable PodSecurityPolicies


### PR DESCRIPTION
Backport #24933 to branch/v12