### PR TITLE
Pass the `auth.Server` itself to `inventory.NewController`

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -298,11 +298,11 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		Services:        services,
 		Cache:           services,
 		keyStore:        keyStore,
-		inventory:       inventory.NewController(cfg.Presence, services, inventory.WithAuthServerID(cfg.HostUUID)),
 		traceClient:     cfg.TraceClient,
 		fips:            cfg.FIPS,
 		loadAllCAs:      cfg.LoadAllCAs,
 	}
+	as.inventory = inventory.NewController(&as, services, inventory.WithAuthServerID(cfg.HostUUID))
 	for _, o := range opts {
 		if err := o(&as); err != nil {
 			return nil, trace.Wrap(err)


### PR DESCRIPTION
This makes it so that the `inventory.Controller` will call `KeepAliveServer` and `UpsertNode` on `auth.Server` rather than on `local.PresenceService` (bypassing the wrapper methods implemented on `auth.Server`).