### PR TITLE
Connect: Fix logout sequence

### DIFF
--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -81,7 +81,7 @@ export class MockTshClient implements TshClient {
 
   getCluster: (clusterUri: string) => Promise<Cluster>;
   getAuthSettings: (clusterUri: string) => Promise<AuthSettings>;
-  removeCluster: (clusterUri: string) => Promise<undefined>;
+  removeCluster = () => Promise.resolve();
   loginLocal: (
     params: LoginLocalParams,
     abortSignal?: TshAbortSignal
@@ -94,7 +94,7 @@ export class MockTshClient implements TshClient {
     params: LoginPasswordlessParams,
     abortSignal?: TshAbortSignal
   ) => Promise<undefined>;
-  logout: (clusterUri: string) => Promise<undefined>;
+  logout = () => Promise.resolve();
   transferFile: () => undefined;
   reportUsageEvent: () => undefined;
 }

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.story.tsx
@@ -16,6 +16,8 @@
 
 import React from 'react';
 
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+
 import { ClusterLogout } from './ClusterLogout';
 
 export default {
@@ -24,13 +26,12 @@ export default {
 
 export const Story = () => {
   return (
-    <ClusterLogout
-      status=""
-      statusText=""
-      removeCluster={() => Promise.resolve([undefined, null])}
-      onClose={() => {}}
-      clusterUri="/clusters/foo"
-      clusterTitle="foo"
-    />
+    <MockAppContextProvider>
+      <ClusterLogout
+        onClose={() => {}}
+        clusterUri="/clusters/foo"
+        clusterTitle="foo"
+      />
+    </MockAppContextProvider>
   );
 };

--- a/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
+++ b/web/packages/teleterm/src/ui/ClusterLogout/ClusterLogout.tsx
@@ -25,20 +25,32 @@ import { ButtonIcon, ButtonPrimary, Text } from 'design';
 
 import { Close } from 'design/Icon';
 
-import { Props, State, useClusterLogout } from './useClusterLogout';
+import { RootClusterUri } from 'teleterm/ui/uri';
 
-export default function Container(props: Props) {
-  const state = useClusterLogout(props);
-  return <ClusterLogout {...state} />;
+import { useClusterLogout } from './useClusterLogout';
+
+interface ClusterLogoutProps {
+  clusterTitle: string;
+  clusterUri: RootClusterUri;
+  onClose(): void;
 }
 
 export function ClusterLogout({
-  status,
+  clusterUri,
   onClose,
-  statusText,
   clusterTitle,
-  removeCluster,
-}: State) {
+}: ClusterLogoutProps) {
+  const { removeCluster, status, statusText } = useClusterLogout({
+    clusterUri,
+  });
+
+  async function removeClusterAndClose(): Promise<void> {
+    const [, err] = await removeCluster();
+    if (!err) {
+      onClose();
+    }
+  }
+
   return (
     <DialogConfirmation
       open={true}
@@ -51,7 +63,7 @@ export function ClusterLogout({
       <form
         onSubmit={e => {
           e.preventDefault();
-          removeCluster();
+          removeClusterAndClose();
         }}
       >
         <DialogHeader justifyContent="space-between" mb={0}>

--- a/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
+++ b/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
@@ -35,8 +35,13 @@ export function useClusterLogout({ clusterUri, onClose, clusterTitle }: Props) {
         await ctx.workspacesService.setActiveWorkspace(null);
       }
     }
-    ctx.workspacesService.removeWorkspace(clusterUri);
+
+    // remove connections first, they depend both on the cluster and the workspace
     ctx.connectionTracker.removeItemsBelongingToRootCluster(clusterUri);
+    // remove the workspace next, because it depends on the cluster
+    ctx.workspacesService.removeWorkspace(clusterUri);
+    // remove the cluster, it does not depend on anything
+    await ctx.clustersService.removeClusterAndResources(clusterUri);
   });
 
   useEffect(() => {

--- a/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
+++ b/web/packages/teleterm/src/ui/ClusterLogout/useClusterLogout.ts
@@ -15,13 +15,16 @@
  */
 
 import { useAsync } from 'shared/hooks/useAsync';
-import { useEffect } from 'react';
 
 import { RootClusterUri } from 'teleterm/ui/uri';
 
 import { useAppContext } from '../appContextProvider';
 
-export function useClusterLogout({ clusterUri, onClose, clusterTitle }: Props) {
+export function useClusterLogout({
+  clusterUri,
+}: {
+  clusterUri: RootClusterUri;
+}) {
   const ctx = useAppContext();
   const [{ status, statusText }, removeCluster] = useAsync(async () => {
     await ctx.clustersService.logout(clusterUri);
@@ -44,26 +47,9 @@ export function useClusterLogout({ clusterUri, onClose, clusterTitle }: Props) {
     await ctx.clustersService.removeClusterAndResources(clusterUri);
   });
 
-  useEffect(() => {
-    if (status === 'success') {
-      onClose();
-    }
-  }, [status]);
-
   return {
     status,
     statusText,
     removeCluster,
-    onClose,
-    clusterUri,
-    clusterTitle,
   };
 }
-
-export type Props = {
-  onClose?(): void;
-  clusterTitle?: string;
-  clusterUri: RootClusterUri;
-};
-
-export type State = ReturnType<typeof useClusterLogout>;

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.test.tsx
@@ -39,15 +39,14 @@ const documentsReopenDialog: DialogDocumentsReopen = {
   onCancel: () => {},
 };
 
-jest.mock('teleterm/ui/ClusterLogout/ClusterLogout', () => {
-  const MockClusterLogout = () => (
+jest.mock('teleterm/ui/ClusterLogout', () => ({
+  ClusterLogout: () => (
     <div
       data-testid="mocked-dialog"
       data-dialog-kind={clusterLogoutDialog.kind}
     ></div>
-  );
-  return MockClusterLogout;
-});
+  ),
+}));
 
 jest.mock('teleterm/ui/DocumentsReopen', () => ({
   DocumentsReopen: () => (

--- a/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
+++ b/web/packages/teleterm/src/ui/ModalsHost/ModalsHost.tsx
@@ -22,7 +22,7 @@ import { ClusterConnect } from 'teleterm/ui/ClusterConnect';
 import { DocumentsReopen } from 'teleterm/ui/DocumentsReopen';
 import { Dialog } from 'teleterm/ui/services/modals';
 
-import ClusterLogout from '../ClusterLogout/ClusterLogout';
+import { ClusterLogout } from '../ClusterLogout';
 import { ResourceSearchErrors } from '../Search/ResourceSearchErrors';
 import { assertUnreachable } from '../utils';
 

--- a/web/packages/teleterm/src/ui/hooks/useLoggedInUser.ts
+++ b/web/packages/teleterm/src/ui/hooks/useLoggedInUser.ts
@@ -25,8 +25,7 @@ import { LoggedInUser } from 'teleterm/services/tshd/types';
  * It should be used within components that reside outside of WorkspaceContext, typically anything
  * that's outside of Document-type components.
  *
- * It might return undefined if there's no active workspace or during the logout procedure because
- * ClustersService state is cleared up before WorkspacesService state.
+ * It might return undefined if there's no active workspace.
  */
 export function useLoggedInUser(): LoggedInUser | undefined {
   const { clustersService, workspacesService } = useAppContext();
@@ -51,10 +50,8 @@ export function useLoggedInUser(): LoggedInUser | undefined {
  * rendered inside of them.
  *
  * In general, the callsite should always assume that this function might return undefined.
- * One case where it will for sure return undefined is during the logout process as
- * ClustersService state is cleared up before WorkspacesService state. On top of that, each
- * workspace is always rendered, even when the cluster is not connected, with at least the default
- * document. In that scenario useWorkspaceLoggedInUser could return undefined when used within the
+ * Each workspace is always rendered, even when the cluster is not connected, with at least the default
+ * document. In that scenario, useWorkspaceLoggedInUser could return undefined when used within the
  * default document.
  */
 export function useWorkspaceLoggedInUser(): LoggedInUser | undefined {

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -189,6 +189,8 @@ test('logout from cluster', async () => {
 
   expect(logout).toHaveBeenCalledWith(clusterUri);
   expect(removeCluster).toHaveBeenCalledWith(clusterUri);
+  expect(service.findCluster(clusterMock.uri).connected).toBe(false);
+  expect(service.findCluster(leafClusterMock.uri).connected).toBe(false);
 });
 
 test('create a gateway', async () => {

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.test.ts
@@ -123,10 +123,7 @@ test('add cluster', async () => {
 });
 
 test('remove cluster', async () => {
-  const { removeCluster } = getClientMocks();
-  const service = createService({
-    removeCluster,
-  });
+  const service = createService({});
 
   service.setState(draftState => {
     draftState.clusters = new Map([
@@ -135,9 +132,8 @@ test('remove cluster', async () => {
     ]);
   });
 
-  await service.removeCluster(clusterUri);
+  await service.removeClusterAndResources(clusterUri);
 
-  expect(removeCluster).toHaveBeenCalledWith(clusterUri);
   expect(service.findCluster(clusterUri)).toBeUndefined();
   expect(service.findCluster(leafClusterMock.uri)).toBeUndefined();
 });
@@ -192,8 +188,7 @@ test('logout from cluster', async () => {
   await service.logout(clusterUri);
 
   expect(logout).toHaveBeenCalledWith(clusterUri);
-  expect(service.findCluster(clusterUri)).toBeUndefined();
-  expect(service.findCluster(leafClusterMock.uri)).toBeUndefined();
+  expect(removeCluster).toHaveBeenCalledWith(clusterUri);
 });
 
 test('create a gateway', async () => {

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -87,9 +87,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
     this.setState(draft => {
       draft.clusters.forEach(cluster => {
-        const isRootOrLeafThatBelongsToRoot =
-          routing.ensureRootClusterUri(cluster.uri) === clusterUri;
-        if (isRootOrLeafThatBelongsToRoot) {
+        if (routing.belongsToProfile(clusterUri, cluster.uri)) {
           cluster.connected = false;
         }
       });
@@ -323,9 +321,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
   async removeClusterAndResources(clusterUri: uri.RootClusterUri) {
     this.setState(draft => {
       draft.clusters.forEach(cluster => {
-        const isRootOrLeafThatBelongsToRoot =
-          routing.ensureRootClusterUri(cluster.uri) === clusterUri;
-        if (isRootOrLeafThatBelongsToRoot) {
+        if (routing.belongsToProfile(clusterUri, cluster.uri)) {
           draft.clusters.delete(cluster.uri);
         }
       });

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -71,11 +71,14 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
     return cluster;
   }
 
+  /**
+   * Logs out of the cluster and removes the profile.
+   * Does not remove the cluster from the state.
+   */
   async logout(clusterUri: uri.RootClusterUri) {
     // TODO(gzdunek): logout and removeCluster should be combined into a single acton in tshd
     await this.client.logout(clusterUri);
-    await this.removeCluster(clusterUri);
-    await this.removeClusterKubeConfigs(clusterUri);
+    await this.client.removeCluster(clusterUri);
   }
 
   async loginLocal(
@@ -301,11 +304,8 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
     return response;
   }
 
-  /**
-   * Removes cluster and its leaf clusters (if any)
-   */
-  async removeCluster(clusterUri: uri.RootClusterUri) {
-    await this.client.removeCluster(clusterUri);
+  /** Removes cluster, its leafs and other resources. */
+  async removeClusterAndResources(clusterUri: uri.RootClusterUri) {
     const leafClustersUris = this.getClusters()
       .filter(
         item =>
@@ -318,6 +318,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
         draft.clusters.delete(leafClusterUri);
       });
     });
+    await this.removeClusterKubeConfigs(clusterUri);
   }
 
   async getAuthSettings(clusterUri: uri.RootClusterUri) {

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -87,7 +87,8 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
 
     this.setState(draft => {
       draft.clusters.forEach(cluster => {
-        const isRootOrLeafThatBelongsToRoot = routing.ensureRootClusterUri(cluster.uri) === clusterUri;
+        const isRootOrLeafThatBelongsToRoot =
+          routing.ensureRootClusterUri(cluster.uri) === clusterUri;
         if (isRootOrLeafThatBelongsToRoot) {
           cluster.connected = false;
         }
@@ -322,11 +323,12 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
   async removeClusterAndResources(clusterUri: uri.RootClusterUri) {
     this.setState(draft => {
       draft.clusters.forEach(cluster => {
-        const isRootOrLeafThatBelongsToRoot = routing.ensureRootClusterUri(cluster.uri) === clusterUri;
+        const isRootOrLeafThatBelongsToRoot =
+          routing.ensureRootClusterUri(cluster.uri) === clusterUri;
         if (isRootOrLeafThatBelongsToRoot) {
           draft.clusters.delete(cluster.uri);
         }
-      })
+      });
     });
     await this.removeClusterKubeConfigs(clusterUri);
   }


### PR DESCRIPTION
Fix for the UI crash that happens when logging out while there is `DocumentGateway` open. This happens because we first remove the cluster and later the workspace, and in the meantime we change the active workspace, which causes a re-render. This causes useGateway to crash when checking if its root cluster is connected.

This PR makes the logout sequence occur in the order of dependencies between services. 

I'm not sure about `removeClusterAndResources` name, any better ideas are welcome.