### PR TITLE
docs: fix directory instruction for docs contributing

### DIFF
--- a/docs/pages/contributing/documentation/how-to-contribute.mdx
+++ b/docs/pages/contributing/documentation/how-to-contribute.mdx
@@ -28,7 +28,7 @@ $ yarn git-update
 Next, navigate to the directory under `content` that corresponds to the latest version of Teleport.
 
 ```code
-$ cd content/(=teleport.version=).x
+$ cd content/(=teleport.major_version=).x
 ```
 
 Switch to the master branch (or versioned branch for updates specific to previous versions):


### PR DESCRIPTION
The docs have content under major version `12.x`, not specific version, `12.2.3`