### PR TITLE
Create locks using the correct property

### DIFF
--- a/web/packages/teleport/src/Locks/NewLock.tsx
+++ b/web/packages/teleport/src/Locks/NewLock.tsx
@@ -72,10 +72,10 @@ export function NewLockContent({
     additionalTargets
   );
 
-  function onAdd(name) {
+  function onAdd(target: string) {
     selectedLockTargets.push({
       type: selectedTargetType.value,
-      name,
+      name: target,
     });
     setSelectedLockTargets([...selectedLockTargets]);
   }
@@ -183,34 +183,37 @@ function TargetList({
   }
 
   const columns: TableColumn<any>[] = data.length
-    ? Object.keys(data[0]).map(c => {
-        const col: TableColumn<any> = {
-          key: c,
-          headerText: c,
-          isSortable: true,
-        };
-        if (c === 'labels') {
-          col.render = target => {
-            const labels = target.labels || [];
-            return (
-              <LabelCell data={labels.map(l => `${l.name}: ${l.value}`)} />
-            );
+    ? Object.keys(data[0])
+        .filter(k => k !== 'targetValue') // don't show targetValue in the table
+        .map(c => {
+          const col: TableColumn<any> = {
+            key: c,
+            headerText: c === 'lastUsed' ? 'Last Used' : c,
+            isSortable: true,
           };
-        }
-        return col;
-      })
+          if (c === 'labels') {
+            col.render = target => {
+              const labels = target.labels || [];
+              return (
+                <LabelCell data={labels.map(l => `${l.name}: ${l.value}`)} />
+              );
+            };
+          }
+          return col;
+        })
     : [];
 
   if (columns.length) {
     columns.push({
       altKey: 'add-btn',
-      render: ({ name }) => (
+      render: ({ targetValue }) => (
         <Cell align="right">
           <ButtonPrimary
-            onClick={onAdd.bind(null, name)}
+            onClick={onAdd.bind(null, targetValue)}
             data-testid="btn-cell"
             disabled={selectedLockTargets.some(
-              target => target.type === selectedTarget && target.name === name
+              target =>
+                target.type === selectedTarget && target.name === targetValue
             )}
           >
             + Add

--- a/web/packages/teleport/src/Locks/testFixtures.ts
+++ b/web/packages/teleport/src/Locks/testFixtures.ts
@@ -205,13 +205,21 @@ export const mockedUseTeleportUtils = {
 };
 
 export const USER_RESULT = [
-  { name: 'admin-local', roles: 'access, admin, auditor, editor' },
-  { name: 'admin', roles: 'access, admin, auditor, editor, locksmith' },
-  { name: 'worker', roles: 'access, contractor' },
+  {
+    name: 'admin-local',
+    targetValue: 'admin-local',
+    roles: 'access, admin, auditor, editor',
+  },
+  {
+    name: 'admin',
+    targetValue: 'admin',
+    roles: 'access, admin, auditor, editor, locksmith',
+  },
+  { name: 'worker', targetValue: 'worker', roles: 'access, contractor' },
 ];
 
 export const ROLES_RESULT = [
-  { name: 'admin' },
-  { name: 'contractor' },
-  { name: 'locksmith' },
+  { name: 'admin', targetValue: 'admin' },
+  { name: 'contractor', targetValue: 'contractor' },
+  { name: 'locksmith', targetValue: 'locksmith' },
 ];

--- a/web/packages/teleport/src/Locks/types.ts
+++ b/web/packages/teleport/src/Locks/types.ts
@@ -16,6 +16,8 @@ limitations under the License.
 
 import { LabelDescription } from 'design/DataTable/types';
 
+import { AgentLabel } from 'teleport/services/agents';
+
 export type Lock = {
   name: string;
   message: string;
@@ -54,11 +56,14 @@ export type AllowedTargets =
   | 'device';
 
 export type TableData = {
-  // targetValue is not displayed in the table, but is is the value
+  // targetValue is not displayed in the table, but is the value
   // that will be used when creating the lock target
   targetValue: string;
+
+  labels?: AgentLabel[];
+
   // these values are shown in the UI (each key is a separate column)
-  [key: string]: string;
+  [key: string]: any;
 };
 
 export type LockTarget = {

--- a/web/packages/teleport/src/Locks/types.ts
+++ b/web/packages/teleport/src/Locks/types.ts
@@ -54,6 +54,10 @@ export type AllowedTargets =
   | 'device';
 
 export type TableData = {
+  // targetValue is not displayed in the table, but is is the value
+  // that will be used when creating the lock target
+  targetValue: string;
+  // these values are shown in the UI (each key is a separate column)
   [key: string]: string;
 };
 

--- a/web/packages/teleport/src/Locks/useGetTargetData.test.tsx
+++ b/web/packages/teleport/src/Locks/useGetTargetData.test.tsx
@@ -80,6 +80,7 @@ describe('hook: useLocks', () => {
       expect(result.current).toStrictEqual([
         {
           name: 'watermelon',
+          targetValue: 'watermelon',
           addr: 'localhost.watermelon',
           labels: [
             {
@@ -102,6 +103,7 @@ describe('hook: useLocks', () => {
         },
         {
           name: 'banana',
+          targetValue: 'banana',
           addr: 'localhost.banana',
           labels: [
             {
@@ -133,6 +135,7 @@ describe('hook: useLocks', () => {
       expect(result.current).toStrictEqual([
         {
           name: 'node1.go.citadel',
+          targetValue: 'e14baac6-15c1-42c2-a7d9-99410d21cf4c',
           addr: '127.0.0.1:4022',
           labels: ['special:apple', 'user:orange'],
         },

--- a/web/packages/teleport/src/Locks/useGetTargetData.test.tsx
+++ b/web/packages/teleport/src/Locks/useGetTargetData.test.tsx
@@ -20,33 +20,9 @@ import { useGetTargetData } from './useGetTargetData';
 
 import {
   mockedUseTeleportUtils,
-  USER_RESULT,
   ROLES_RESULT,
+  USER_RESULT,
 } from './testFixtures';
-
-const additionalTargets = {
-  access_request: {
-    fetch: () =>
-      new Promise(resolve =>
-        resolve([
-          {
-            name: 'apple',
-            description: 'tree',
-            date: '1/2/1234',
-          },
-        ])
-      ),
-    handler: (setter, requests) => {
-      const filteredData = requests.map(r => ({
-        name: r.name,
-        description: r.description,
-        theDate: r.date,
-      }));
-      setter(filteredData);
-    },
-    options: {},
-  },
-};
 
 jest.mock('teleport/useTeleport', () => ({
   __esModule: true,
@@ -163,9 +139,22 @@ describe('hook: useLocks', () => {
         useGetTargetData('access_request', 'cluster-id', additionalTargets)
       );
       await waitForNextUpdate();
-      expect(result.current).toStrictEqual([
-        { name: 'apple', description: 'tree', theDate: '1/2/1234' },
-      ]);
+      expect(result.current).toStrictEqual([accessRequestData]);
     });
   });
 });
+
+const accessRequestData = {
+  id: '942a14e8-6a16-40bb-a873-725cec0a3cca',
+  user: 'jane',
+  roles: 'access, editor',
+  created: new Date().toDateString(),
+  reason: 'testing',
+  targetValue: '942a14e8-6a16-40bb-a873-725cec0a3cca',
+};
+
+const additionalTargets = {
+  access_request: {
+    fetchData: async () => [accessRequestData],
+  },
+};

--- a/web/packages/teleport/src/Locks/useGetTargetData.tsx
+++ b/web/packages/teleport/src/Locks/useGetTargetData.tsx
@@ -29,6 +29,7 @@ export const lockTargets: LockTarget[] = [
   { label: 'Windows Desktop', value: 'windows_desktop' },
   // Skipped for now because it's not fully implemented.
   // { label: 'Device', value: 'device' },
+  // TODO(sshahcodes): add support for locking devices
 ];
 
 export type UseGetTargetData = (
@@ -64,30 +65,42 @@ export const useGetTargetData: UseGetTargetData = (
       user: {
         fetch: fetchUsers,
         handler: (setter, users) => {
-          const filteredData = users.map(u => ({
-            name: u.name,
-            roles: u.roles.join(', '),
-          }));
+          const filteredData = users.map(
+            u =>
+              ({
+                name: u.name,
+                roles: u.roles.join(', '),
+                targetValue: u.name,
+              } as TableData)
+          );
           setter(filteredData);
         },
       },
       role: {
         fetch: fetchRoles,
         handler: (setter, roles) => {
-          const filteredData = roles.map(r => ({
-            name: r.name,
-          }));
+          const filteredData = roles.map(
+            r =>
+              ({
+                name: r.name,
+                targetValue: r.name,
+              } as TableData)
+          );
           setter(filteredData);
         },
       },
       node: {
         fetch: fetchNodes,
         handler: (setter, nodes) => {
-          const filteredData = nodes.agents.map(n => ({
-            name: n.hostname,
-            addr: n.addr,
-            labels: n.labels,
-          }));
+          const filteredData = nodes.agents.map(
+            n =>
+              ({
+                name: n.hostname,
+                addr: n.addr,
+                labels: n.labels,
+                targetValue: n.id,
+              } as TableData)
+          );
           setter(filteredData);
         },
         options: [
@@ -100,23 +113,31 @@ export const useGetTargetData: UseGetTargetData = (
       mfa_device: {
         fetch: fetchDevices,
         handler: (setter, mfas) => {
-          const filteredData = mfas.map(m => ({
-            name: m.name,
-            id: m.id,
-            description: m.description,
-            lastUsed: m.lastUsedDate.toUTCString(),
-          }));
+          const filteredData = mfas.map(
+            m =>
+              ({
+                name: m.name,
+                id: m.id,
+                description: m.description,
+                lastUsed: m.lastUsedDate.toUTCString(),
+                targetValue: m.id,
+              } as TableData)
+          );
           setter(filteredData);
         },
       },
       windows_desktop: {
         fetch: fetchDesktops,
         handler: (setter, desktops) => {
-          const filteredData = desktops.agents.map(d => ({
-            name: d.name,
-            addr: d.addr,
-            labels: d.labels,
-          }));
+          const filteredData = desktops.agents.map(
+            d =>
+              ({
+                name: d.name,
+                addr: d.addr,
+                labels: d.labels,
+                targetValue: d.name,
+              } as TableData)
+          );
           setter(filteredData);
         },
         options: [clusterId, { limit: 10 }],
@@ -136,7 +157,7 @@ export const useGetTargetData: UseGetTargetData = (
       targetDataFilters[targetType] || additionalTargets?.[targetType];
     if (!action) {
       // eslint-disable-next-line no-console
-      console.log(`unknown target type ${targetType}`);
+      console.warn(`unknown target type ${targetType}`);
       setTargetData([]);
       return;
     }

--- a/web/packages/teleport/src/Locks/useGetTargetData.tsx
+++ b/web/packages/teleport/src/Locks/useGetTargetData.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import useTeleport from 'teleport/useTeleport';
 
@@ -38,13 +38,9 @@ export type UseGetTargetData = (
   additionalTargets?: AdditionalTargets
 ) => TableData[];
 
-export type AdditionalTargets = {
-  [key: string]: {
-    fetch: (options: any) => Promise<any>;
-    handler: (setter: (data: TableData[]) => void, data: any) => void;
-    options: any;
-  };
-};
+export type AdditionalTargets = Partial<
+  Record<AllowedTargets, { fetchData(): Promise<TableData[]> }>
+>;
 
 export const useGetTargetData: UseGetTargetData = (
   targetType,
@@ -60,87 +56,59 @@ export const useGetTargetData: UseGetTargetData = (
     userService: { fetchUsers },
   } = useTeleport();
 
-  const targetDataFilters = useMemo(() => {
+  const targetDataFilters = useMemo<
+    Partial<Record<AllowedTargets, { fetchData(): Promise<TableData[]> }>>
+  >(() => {
     return {
       user: {
-        fetch: fetchUsers,
-        handler: (setter, users) => {
-          const filteredData = users.map(
-            u =>
-              ({
-                name: u.name,
-                roles: u.roles.join(', '),
-                targetValue: u.name,
-              } as TableData)
-          );
-          setter(filteredData);
+        fetchData: async () => {
+          const users = await fetchUsers();
+          return users.map(u => ({
+            name: u.name,
+            roles: u.roles.join(', '),
+            targetValue: u.name,
+          }));
         },
       },
       role: {
-        fetch: fetchRoles,
-        handler: (setter, roles) => {
-          const filteredData = roles.map(
-            r =>
-              ({
-                name: r.name,
-                targetValue: r.name,
-              } as TableData)
-          );
-          setter(filteredData);
+        fetchData: async () => {
+          const roles = await fetchRoles();
+          return roles.map(r => ({ name: r.name, targetValue: r.name }));
         },
       },
       node: {
-        fetch: fetchNodes,
-        handler: (setter, nodes) => {
-          const filteredData = nodes.agents.map(
-            n =>
-              ({
-                name: n.hostname,
-                addr: n.addr,
-                labels: n.labels,
-                targetValue: n.id,
-              } as TableData)
-          );
-          setter(filteredData);
+        fetchData: async () => {
+          const nodes = await fetchNodes(clusterId, { limit: 10 });
+          return nodes.agents.map(n => ({
+            name: n.hostname,
+            addr: n.addr,
+            labels: n.labels,
+            targetValue: n.id,
+          }));
         },
-        options: [
-          clusterId,
-          {
-            limit: 10,
-          },
-        ],
       },
       mfa_device: {
-        fetch: fetchDevices,
-        handler: (setter, mfas) => {
-          const filteredData = mfas.map(
-            m =>
-              ({
-                name: m.name,
-                id: m.id,
-                description: m.description,
-                lastUsed: m.lastUsedDate.toUTCString(),
-                targetValue: m.id,
-              } as TableData)
-          );
-          setter(filteredData);
+        fetchData: async () => {
+          const mfas = await fetchDevices();
+          return mfas.map(m => ({
+            name: m.name,
+            id: m.id,
+            description: m.description,
+            lastUsed: m.lastUsedDate.toUTCString(),
+            targetValue: m.id,
+          }));
         },
       },
       windows_desktop: {
-        fetch: fetchDesktops,
-        handler: (setter, desktops) => {
-          const filteredData = desktops.agents.map(
-            d =>
-              ({
-                name: d.name,
-                addr: d.addr,
-                labels: d.labels,
-                targetValue: d.name,
-              } as TableData)
-          );
-          setter(filteredData);
+        fetchData: async () => {
+          const desktops = await fetchDesktops(clusterId, { limit: 10 });
+          return desktops.agents.map(d => ({
+            name: d.name,
+            addr: d.addr,
+            labels: d.labels,
+            targetValue: d.name,
+          }));
         },
-        options: [clusterId, { limit: 10 }],
       },
     };
   }, [
@@ -162,9 +130,7 @@ export const useGetTargetData: UseGetTargetData = (
       return;
     }
 
-    action.fetch
-      .apply(null, action.options)
-      .then(action.handler.bind(null, setTargetData));
+    action.fetchData().then(setTargetData);
   }, [additionalTargets, targetDataFilters, targetType]);
 
   return targetData;


### PR DESCRIPTION
The "lock target" in Teleport's backend uses a different value depending on the type of lock you want to create. For example, to lock a node you use its UUID, but to lock a role you use its name.

We were incorrectly always using the name to create a lock, which appears to work fine in the UI but is not correctly enforced on the backend.

This change adds a new required field called targetValue, allowing us to specify the value to be used for the lock on a per-resource basis.

Fixes gravitational/teleport-private#556