### PR TITLE
docs: expand admonition for additional DB types

### DIFF
--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -53,9 +53,6 @@ proxy_service:
   mongo_public_addr: "mongo.teleport.example.com:443"
 ```
 
-Database types that support native TLS (Redis, ElasticSearch, OpenSearch) share
-the same port specified by `proxy_service.public_addr`.
-
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Cloud">
 

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -20,19 +20,18 @@ appearing in `teleport.yaml` configuration file:
 The following Proxy service configuration is relevant for database access:
 
 <Admonition
-  type="warning"
-  title="Proxy TLS Warning for PostgreSQL"
+type="warning"
+title="TLS for database connections"
 >
-  The PostgreSQL connection requires TLS enabled for the SSL connection that operates on the `web_listen_addr`.
-  Do not set `--insecure-no-tls` for the proxy Teleport instances as a parameter.  If you are terminating TLS at a
-  Application Load Balancer (ALB) or other service that may require enabling a backend protocol of HTTPS for the target address.  
+The `--insecure-no-tls` `tsh` flag is only supported for MySQL/MariaDB and PostgreSQL
+connections using a unique port, specified with `mysql_public_addr` or `postgres_public_addr`.
 </Admonition>
 
 ```yaml
 proxy_service:
   enabled: "yes"
-  # PostgreSQL proxy is listening on the regular web proxy port.
-  web_listen_addr: "0.0.0.0:3080"
+  # Database proxy is listening on the regular web proxy port.
+  web_listen_addr: "0.0.0.0:443"
   # MySQL proxy is listening on a separate port and needs to be enabled
   # on the proxy server.
   mysql_listen_addr: "0.0.0.0:3036"
@@ -45,7 +44,7 @@ proxy_service:
   # By default database clients will be connecting to the Proxy over this
   # hostname. To override public address for specific database protocols
   # use postgres_public_addr and mysql_public_addr.
-  public_addr: "teleport.example.com:3080"
+  public_addr: "teleport.example.com:443"
   # Address advertised to MySQL clients. If not set, public_addr is used.
   mysql_public_addr: "mysql.teleport.example.com:3306"
   # Address advertised to PostgreSQL clients. If not set, public_addr is used.
@@ -53,6 +52,9 @@ proxy_service:
   # Address advertised to Mongo clients. If not set, public_addr is used.
   mongo_public_addr: "mongo.teleport.example.com:443"
 ```
+
+Database types that support native TLS (Redis, ElasticSearch, OpenSearch) share
+the same port specified by `proxy_service.public_addr`.
 
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Cloud">
@@ -65,7 +67,7 @@ address.
 ```yaml
 proxy_service:
   enabled: "yes"
-  # PostgreSQL proxy is listening on the regular web proxy port.
+  # Database proxy is listening on the regular web proxy port.
   web_listen_addr: "0.0.0.0:3080"
   # MySQL proxy is listening on a separate port.
   mysql_listen_addr: "0.0.0.0:3036"
@@ -75,6 +77,8 @@ proxy_service:
   mysql_public_addr: "mytenant.teleport.sh:3036"
   # Address advertised to PostgreSQL clients.
   postgres_public_addr: "mytenant.teleport.sh:443"
+  # Address advertised to Mongo clients. If not set, public_addr is used.
+  mongo_public_addr: "mongo.teleport.example.com:443
 ```
 
 </TabItem>


### PR DESCRIPTION
Closes #13009

Supported databases other than Postgres support TLS connections on `web_listen_addr`.