### PR TITLE
WebAPI: thumbprint endpoint

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -717,6 +717,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	// Unauthenticated access to OpenID Configuration - used for AWS OIDC IdP integration
 	h.GET("/.well-known/openid-configuration", h.WithLimiter(h.openidConfiguration))
 	h.GET(OIDCJWKWURI, h.WithLimiter(h.jwksOIDC))
+	h.GET("/webapi/thumbprint", h.WithLimiter(h.thumbprint))
 
 	// Connection upgrades.
 	h.GET("/webapi/connectionupgrade", httplib.MakeHandler(h.connectionUpgrade))

--- a/lib/web/oidcidp.go
+++ b/lib/web/oidcidp.go
@@ -14,6 +14,9 @@ limitations under the License.
 package web
 
 import (
+	"crypto/sha1"
+	"crypto/tls"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -22,6 +25,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib"
 	"github.com/gravitational/teleport/lib/jwt"
 )
 
@@ -87,6 +91,62 @@ func (h *Handler) jwksOIDC(_ http.ResponseWriter, r *http.Request, _ httprouter.
 		resp.Keys = append(resp.Keys, jwk)
 	}
 	return &resp, nil
+}
+
+// thumbprint returns the thumbprint as required by AWS when adding an OIDC Identity Provider.
+// This is documented here:
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+func (h *Handler) thumbprint(_ http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {
+	// Dial requires the following address format: host:port
+	cfgPublicAddress := h.cfg.PublicProxyAddr
+	if !strings.Contains(cfgPublicAddress, "://") {
+		cfgPublicAddress = "https://" + cfgPublicAddress
+	}
+
+	addrURL, err := url.Parse(cfgPublicAddress)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	port := addrURL.Port()
+	if port == "" {
+		port = "443"
+	}
+	address := fmt.Sprintf("%s:%s", addrURL.Hostname(), port)
+	d := tls.Dialer{
+		Config: &tls.Config{
+			InsecureSkipVerify: lib.IsInsecureDevMode(),
+		},
+	}
+	conn, err := d.DialContext(r.Context(), "tcp", address)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer conn.Close()
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return nil, trace.Errorf("failed to create a tls connection")
+	}
+
+	certs := tlsConn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return nil, trace.Errorf("no certificates were provided")
+	}
+
+	/*
+		Get the last certificate of the chain
+		https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+		> If you see more than one certificate, find the last certificate displayed (at the end of the command output).
+		> This contains the certificate of the top intermediate CA in the certificate authority chain.
+
+		The guide above uses openssl but the expected list of certificates and their order is the same.
+	*/
+	lastCertificateIdx := len(certs) - 1
+	cert := certs[lastCertificateIdx]
+	thumbprint := sha1.Sum(cert.Raw)
+
+	// Convert the thumbprint ([]bytes) into their hex representation.
+	return fmt.Sprintf("%x", thumbprint), nil
 }
 
 // issuerFromPublicAddr is the address for the AWS OIDC Provider.

--- a/lib/web/oidcidp.go
+++ b/lib/web/oidcidp.go
@@ -109,17 +109,13 @@ func (h *Handler) thumbprint(_ http.ResponseWriter, r *http.Request, _ httproute
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	port := addrURL.Port()
-	if port == "" {
-		port = "443"
-	}
-	address := fmt.Sprintf("%s:%s", addrURL.Hostname(), port)
+
 	d := tls.Dialer{
 		Config: &tls.Config{
 			InsecureSkipVerify: lib.IsInsecureDevMode(),
 		},
 	}
-	conn, err := d.DialContext(r.Context(), "tcp", address)
+	conn, err := d.DialContext(r.Context(), "tcp", addrURL.Host)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/oidcidp.go
+++ b/lib/web/oidcidp.go
@@ -96,9 +96,11 @@ func (h *Handler) jwksOIDC(_ http.ResponseWriter, r *http.Request, _ httprouter.
 // thumbprint returns the thumbprint as required by AWS when adding an OIDC Identity Provider.
 // This is documented here:
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+// Returns the thumbprint of the top intermediate CA that signed the TLS cert used to serve HTTPS requests.
+// In case of a self signed certificate, then it returns the thumbprint of the TLS cert itself.
 func (h *Handler) thumbprint(_ http.ResponseWriter, r *http.Request, _ httprouter.Params) (interface{}, error) {
 	// Dial requires the following address format: host:port
-	cfgPublicAddress := h.cfg.PublicProxyAddr
+	cfgPublicAddress := h.PublicProxyAddr()
 	if !strings.Contains(cfgPublicAddress, "://") {
 		cfgPublicAddress = "https://" + cfgPublicAddress
 	}

--- a/lib/web/oidcidp.go
+++ b/lib/web/oidcidp.go
@@ -133,14 +133,13 @@ func (h *Handler) thumbprint(_ http.ResponseWriter, r *http.Request, _ httproute
 		return nil, trace.Errorf("no certificates were provided")
 	}
 
-	/*
-		Get the last certificate of the chain
-		https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
-		> If you see more than one certificate, find the last certificate displayed (at the end of the command output).
-		> This contains the certificate of the top intermediate CA in the certificate authority chain.
+	// Get the last certificate of the chain
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+	// > If you see more than one certificate, find the last certificate displayed (at the end of the command output).
+	// > This contains the certificate of the top intermediate CA in the certificate authority chain.
+	//
+	// The guide above uses openssl but the expected list of certificates and their order is the same.
 
-		The guide above uses openssl but the expected list of certificates and their order is the same.
-	*/
 	lastCertificateIdx := len(certs) - 1
 	cert := certs[lastCertificateIdx]
 	thumbprint := sha1.Sum(cert.Raw)

--- a/lib/web/oidcidp_test.go
+++ b/lib/web/oidcidp_test.go
@@ -74,7 +74,6 @@ func TestOIDCIdPPublicEndpoints(t *testing.T) {
 }
 
 func TestThumbprint(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 
 	// Proxy starts with self-signed certificates.

--- a/lib/web/oidcidp_test.go
+++ b/lib/web/oidcidp_test.go
@@ -16,9 +16,12 @@ package web
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib"
 )
 
 // TestOIDCIdPPublicEndpoints ensures the public endpoints for the AWS OIDC integration are available.
@@ -68,4 +71,30 @@ func TestOIDCIdPPublicEndpoints(t *testing.T) {
 	require.Equal(t, key.KeyType, "RSA")
 	require.Equal(t, key.Alg, "RS256")
 	require.NotNil(t, key.KeyID) // AWS requires this to be present (even if empty string).
+}
+
+func TestThumbprint(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	// Proxy starts with self-signed certificates.
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	env := newWebPack(t, 1)
+	proxy := env.proxies[0]
+
+	// Request OpenID Configuration public endpoint.
+	publicClt := proxy.newClient(t)
+	resp, err := publicClt.Get(ctx, proxy.webURL.String()+"/webapi/thumbprint", nil)
+	require.NoError(t, err)
+
+	thumbprint := strings.Trim(string(resp.Bytes()), "\"")
+
+	// The Proxy is started using httptest.NewTLSServer, which uses a hard-coded cert
+	// located at go/src/net/http/internal/testcert/testcert.go
+	// The following value is the sha1 fingerprint of that certificate.
+	expectedThumbprint := "15dbd260c7465ecca6de2c0b2181187f66ee0d1a"
+
+	require.Equal(t, expectedThumbprint, thumbprint)
 }


### PR DESCRIPTION
This was manually tested against a couple of Certificate providers:
- Teleport Stage (<tenant>.cloud.gravitational.io)
- Cloudflare
- GitHub (token.actions.githubusercontent.com)
- Spacelift