### PR TITLE
tctl: ensure that lock targets are valid UUIDs

### DIFF
--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"unicode"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -574,4 +575,38 @@ func FormatAlert(alert types.ClusterAlert) string {
 		}
 	}
 	return buf.String()
+}
+
+// UUIDVar is like kingpin's StringVar, but it requires that the
+// provided flag is a valid UUID.
+//
+// Example usage:
+//
+//	var dest string
+//	UUIDVar(cmd.Flag("uuid", "a UUID value"), &dest)
+func UUIDVar(s kingpin.Settings, value *string) {
+	u := uuidFlag{target: value}
+	s.SetValue(&u)
+}
+
+// uuidFlag is a custom kingpin parser for CLI arguments that must be UUIDs.
+type uuidFlag struct {
+	target *string
+}
+
+func (u *uuidFlag) Set(value string) error {
+	_, err := uuid.Parse(value)
+	if err != nil {
+		return trace.BadParameter("%v is not a valid UUID", value)
+	}
+
+	*u.target = value
+	return nil
+}
+
+func (u *uuidFlag) String() string {
+	if u == nil || u.target == nil {
+		return ""
+	}
+	return string(*u.target)
 }

--- a/tool/tctl/common/lock_command.go
+++ b/tool/tctl/common/lock_command.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // LockCommand implements `tctl lock` group of commands.
@@ -47,11 +48,11 @@ func (c *LockCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	c.mainCmd.Flag("user", "Name of a Teleport user to disable.").StringVar(&c.spec.Target.User)
 	c.mainCmd.Flag("role", "Name of a Teleport role to disable.").StringVar(&c.spec.Target.Role)
 	c.mainCmd.Flag("login", "Name of a local UNIX user to disable.").StringVar(&c.spec.Target.Login)
-	c.mainCmd.Flag("node", "UUID of a Teleport node to disable.").StringVar(&c.spec.Target.Node)
-	c.mainCmd.Flag("mfa-device", "UUID of a user MFA device to disable.").StringVar(&c.spec.Target.MFADevice)
+	utils.UUIDVar(c.mainCmd.Flag("node", "UUID of a Teleport node to disable."), &c.spec.Target.Node)
+	utils.UUIDVar(c.mainCmd.Flag("mfa-device", "UUID of a user MFA device to disable."), &c.spec.Target.MFADevice)
+	utils.UUIDVar(c.mainCmd.Flag("access-request", "UUID of an access request to disable."), &c.spec.Target.AccessRequest)
+	utils.UUIDVar(c.mainCmd.Flag("device", "UUID of a trusted device to disable."), &c.spec.Target.Device)
 	c.mainCmd.Flag("windows-desktop", "Name of a Windows desktop to disable.").StringVar(&c.spec.Target.WindowsDesktop)
-	c.mainCmd.Flag("access-request", "UUID of an access request to disable.").StringVar(&c.spec.Target.AccessRequest)
-	c.mainCmd.Flag("device", "UUID of a trusted device to disable.").StringVar(&c.spec.Target.Device)
 	c.mainCmd.Flag("message", "Message to display to locked-out users.").StringVar(&c.spec.Message)
 	c.mainCmd.Flag("expires", "Time point (RFC3339) when the lock expires.").StringVar(&c.expires)
 	c.mainCmd.Flag("ttl", "Time duration after which the lock expires.").DurationVar(&c.ttl)


### PR DESCRIPTION
The help message mentioned when UUIDs were required, but nothing enforced this.

Add a custom parser that validates the provided flags are proper UUIDs.

Updates gravitational/teleport-private#556