### PR TITLE
[v13] Fixes cache init problem with missing `kube_service`

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -152,6 +152,13 @@ const (
 	// KindKubeServer is an kubernetes server resource.
 	KindKubeServer = "kube_server"
 
+	// KindKubeService is a special resource type that is used to keep compatibility
+	// with Teleport 12 clients.
+	// Teleport 13 no longer supports kube_service resource type, but Teleport 12
+	// clients still expect it to be present in the server.
+	// TODO(tigrato): DELETE in 14.0.0
+	KindKubeService = "kube_service"
+
 	// KindKubernetesCluster is a Kubernetes cluster.
 	KindKubernetesCluster = "kube_cluster"
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1511,15 +1511,6 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 	return filteredNodes, nil
 }
 
-const (
-	// kubeService is a special resource type that is used to keep compatibility
-	// with Teleport 12 clients.
-	// Teleport 13 no longer supports kube_service resource type, but Teleport 12
-	// clients still expect it to be present in the server.
-	// TODO(tigrato): DELETE in 14.0.0
-	kubeService = "kube_service"
-)
-
 // ListResources returns a paginated list of resources filtered by user access.
 func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResourcesRequest) (*types.ListResourcesResponse, error) {
 	// kubeService is a special resource type that is used to keep compatibility
@@ -1527,7 +1518,7 @@ func (a *ServerWithRoles) ListResources(ctx context.Context, req proto.ListResou
 	// Teleport 13 no longer supports kube_service resource type, but Teleport 12
 	// clients still expect it to be present in the server.
 	// TODO(tigrato): DELETE in 14.0.0
-	if req.ResourceType == kubeService {
+	if req.ResourceType == types.KindKubeService {
 		return &types.ListResourcesResponse{}, nil
 	}
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -422,6 +422,10 @@ func (a *authorizer) authorizeRemoteBuiltinRole(r RemoteBuiltinRole) (*Context, 
 					types.NewRule(types.KindSessionRecordingConfig, services.RO()),
 					types.NewRule(types.KindClusterAuthPreference, services.RO()),
 					types.NewRule(types.KindKubeServer, services.RO()),
+					// types.KindKubeService is a special resource type that is used to keep compatibility
+					// with Teleport 12 clients.
+					// TODO(tigrato): DELETE in 14.0.0
+					types.NewRule(types.KindKubeService, services.RO()),
 					types.NewRule(types.KindInstaller, services.RO()),
 					types.NewRule(types.KindUIConfig, services.RO()),
 					types.NewRule(types.KindDatabaseService, services.RO()),
@@ -510,6 +514,10 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 				types.NewRule(types.KindWebSession, services.RW()),
 				types.NewRule(types.KindWebToken, services.RW()),
 				types.NewRule(types.KindKubeServer, services.RW()),
+				// types.KindKubeService is a special resource type that is used to keep compatibility
+				// with Teleport 12 clients.
+				// TODO(tigrato): DELETE in 14.0.0
+				types.NewRule(types.KindKubeService, services.RO()),
 				types.NewRule(types.KindDatabaseServer, services.RO()),
 				types.NewRule(types.KindLock, services.RO()),
 				types.NewRule(types.KindToken, []string{types.VerbRead, types.VerbDelete}),
@@ -739,6 +747,10 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					KubernetesLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
 					Rules: []types.Rule{
 						types.NewRule(types.KindKubeServer, services.RW()),
+						// kubeService is a special resource type that is used to keep compatibility
+						// with Teleport 12 clients.
+						// TODO(tigrato): DELETE in 14.0.0
+						types.NewRule(types.KindKubeService, services.RO()),
 						types.NewRule(types.KindEvent, services.RW()),
 						types.NewRule(types.KindCertAuthority, services.ReadNoSecrets()),
 						types.NewRule(types.KindClusterName, services.RO()),

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -850,7 +850,6 @@ func (c *Cache) Start() error {
 		Jitter: retryutils.NewHalfJitter(),
 		Clock:  c.Clock,
 	})
-
 	if err != nil {
 		c.Close()
 		return trace.Wrap(err)
@@ -891,6 +890,12 @@ func (c *Cache) NewWatcher(ctx context.Context, watch types.Watch) (types.Watche
 	validKinds := make([]types.WatchKind, 0, len(watch.Kinds))
 Outer:
 	for _, requested := range watch.Kinds {
+		// If the watch is for a kube_service resource, we need ignore it because
+		// Teleport 13 no longer supports kube_service resource type, but Teleport 12
+		// clients still expect it to be present in the server and try to watch it.
+		if requested.Kind == types.KindKubeService {
+			continue
+		}
 		if cacheOK {
 			// if cache has been initialized, we already know which kinds are confirmed by the event source
 			// and can validate the kinds requested for fanout against that.

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -893,7 +893,9 @@ Outer:
 		// If the watch is for a kube_service resource, we need ignore it because
 		// Teleport 13 no longer supports kube_service resource type, but Teleport 12
 		// clients still expect it to be present in the server and try to watch it.
-		if requested.Kind == types.KindKubeService {
+		// Clients that request kube_service resource type do not support partial
+		// success.
+		if requested.Kind == types.KindKubeService && !watch.AllowPartialSuccess {
 			continue
 		}
 		if cacheOK {


### PR DESCRIPTION
This PR fixes a cache init problem when Teleport 12 Kube/Proxy clients connect to a Teleport 13 cluster and expect to watch the unsupported `kube_service` object.

It allows the operation but ignores the resources being watched.