### PR TITLE
Populate the time locked status value when local user locked

### DIFF
--- a/api/types/user.go
+++ b/api/types/user.go
@@ -434,7 +434,7 @@ func (u *UserV2) SetLocked(until time.Time, reason string) {
 	u.Spec.Status.IsLocked = true
 	u.Spec.Status.LockExpires = until
 	u.Spec.Status.LockedMessage = reason
-	u.Spec.Status.LockedTime = time.Now()
+	u.Spec.Status.LockedTime = time.Now().UTC()
 }
 
 // SetRecoveryAttemptLockExpires sets the lock expiry time for both recovery and login attempt.

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -434,6 +434,8 @@ func (u *UserV2) SetLocked(until time.Time, reason string) {
 	u.Spec.Status.IsLocked = true
 	u.Spec.Status.LockExpires = until
 	u.Spec.Status.LockedMessage = reason
+	u.Spec.Status.LockedTime = time.Now()
+
 }
 
 // SetRecoveryAttemptLockExpires sets the lock expiry time for both recovery and login attempt.

--- a/api/types/user.go
+++ b/api/types/user.go
@@ -435,7 +435,6 @@ func (u *UserV2) SetLocked(until time.Time, reason string) {
 	u.Spec.Status.LockExpires = until
 	u.Spec.Status.LockedMessage = reason
 	u.Spec.Status.LockedTime = time.Now()
-
 }
 
 // SetRecoveryAttemptLockExpires sets the lock expiry time for both recovery and login attempt.


### PR DESCRIPTION
The `locked_time` field was not set when a user was locked. Now it will be populated when the lock is being set instead of `0001-01-01T00:00:00Z`.  This is for local user locks after failed login attempts or password resets.


```yaml
kind: user
metadata:
  id: 1682131098799299000
  name: steven2
spec:
  expires: "0001-01-01T00:00:00Z"
  roles:
  - access
  status:
    is_locked: true
    lock_expires: "2023-04-22T02:58:18.798894Z"
    locked_message: user has exceeded maximum failed login attempts
    locked_time: "2023-04-22T02:38:18.798906Z"
    recovery_attempt_lock_expires: "0001-01-01T00:00:00Z"
```