### PR TITLE
helm: mount kube ca certs through projected volumes

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -270,6 +270,11 @@ spec:
           sources:
             - serviceAccountToken:
                 path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
 {{- end }}
 {{- if $auth.enterprise }}
       - name: license

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -265,6 +265,8 @@ spec:
 {{- end }}
       volumes:
 {{- if $projectedServiceAccountToken }}
+      # This projected token volume mimics the `automountServiceAccountToken`
+      # behaviour but defaults to a 1h TTL instead of 1y.
       - name: auth-serviceaccount-token
         projected:
           sources:
@@ -275,6 +277,11 @@ spec:
                 - key: ca.crt
                   path: ca.crt
                 name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - path: "namespace"
+                    fieldRef:
+                      fieldPath: metadata.namespace
 {{- end }}
 {{- if $auth.enterprise }}
       - name: license

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -273,6 +273,11 @@ spec:
           sources:
             - serviceAccountToken:
                 path: token
+            - configMap:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: kube-root-ca.crt
 {{- end }}
 {{- if $proxy.highAvailability.certManager.enabled }}
       - name: teleport-tls

--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -268,6 +268,8 @@ spec:
 {{- end }}
       volumes:
 {{- if $projectedServiceAccountToken }}
+      # This projected token volume mimics the `automountServiceAccountToken`
+      # behaviour but defaults to a 1h TTL instead of 1y.
       - name: proxy-serviceaccount-token
         projected:
           sources:
@@ -278,6 +280,11 @@ spec:
                 - key: ca.crt
                   path: ca.crt
                 name: kube-root-ca.crt
+            - downwardAPI:
+                items:
+                  - path: "namespace"
+                    fieldRef:
+                      fieldPath: metadata.namespace
 {{- end }}
 {{- if $proxy.highAvailability.certManager.enabled }}
       - name: teleport-tls

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -88,6 +88,11 @@ should add an operator side-car when operator is enabled:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -214,6 +219,11 @@ should set nodeSelector when set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -305,6 +315,11 @@ should set resources when set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -381,6 +396,11 @@ should set securityContext when set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -460,6 +480,11 @@ should use OSS image and not mount license when enterprise is not set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-auth
       name: config

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -93,6 +93,11 @@ should add an operator side-car when operator is enabled:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -224,6 +229,11 @@ should set nodeSelector when set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -320,6 +330,11 @@ should set resources when set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -401,6 +416,11 @@ should set securityContext when set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-auth
       name: config
@@ -485,6 +505,11 @@ should use OSS image and not mount license when enterprise is not set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-auth
       name: config

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -141,6 +141,11 @@ should set nodeSelector when set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-proxy
       name: config
@@ -252,6 +257,11 @@ should set resources when set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-proxy
       name: config
@@ -355,6 +365,11 @@ should set securityContext for initContainers when set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-proxy
       name: config
@@ -458,6 +473,11 @@ should set securityContext when set in values:
             - key: ca.crt
               path: ca.crt
             name: kube-root-ca.crt
+        - downwardAPI:
+            items:
+            - fieldRef:
+                fieldPath: metadata.namespace
+              path: namespace
     - configMap:
         name: RELEASE-NAME-proxy
       name: config

--- a/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/proxy_deployment_test.yaml.snap
@@ -136,6 +136,11 @@ should set nodeSelector when set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-proxy
       name: config
@@ -242,6 +247,11 @@ should set resources when set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-proxy
       name: config
@@ -340,6 +350,11 @@ should set securityContext for initContainers when set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-proxy
       name: config
@@ -438,6 +453,11 @@ should set securityContext when set in values:
         sources:
         - serviceAccountToken:
             path: token
+        - configMap:
+            items:
+            - key: ca.crt
+              path: ca.crt
+            name: kube-root-ca.crt
     - configMap:
         name: RELEASE-NAME-proxy
       name: config

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -753,6 +753,11 @@ tests:
                       - key: ca.crt
                         path: ca.crt
                     name: kube-root-ca.crt
+                - downwardAPI:
+                    items:
+                      - path: "namespace"
+                        fieldRef:
+                          fieldPath: metadata.namespace
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -792,6 +797,11 @@ tests:
                       - key: ca.crt
                         path: ca.crt
                     name: kube-root-ca.crt
+                - downwardAPI:
+                    items:
+                      - path: "namespace"
+                        fieldRef:
+                          fieldPath: metadata.namespace
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -748,6 +748,11 @@ tests:
               sources:
                 - serviceAccountToken:
                     path: token
+                - configMap:
+                    items:
+                      - key: ca.crt
+                        path: ca.crt
+                    name: kube-root-ca.crt
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -782,6 +787,11 @@ tests:
               sources:
                 - serviceAccountToken:
                     path: token
+                - configMap:
+                    items:
+                      - key: ca.crt
+                        path: ca.crt
+                    name: kube-root-ca.crt
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -845,6 +845,11 @@ tests:
               sources:
                 - serviceAccountToken:
                     path: token
+                - configMap:
+                    items:
+                      - key: ca.crt
+                        path: ca.crt
+                    name: kube-root-ca.crt
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -871,6 +876,11 @@ tests:
               sources:
                 - serviceAccountToken:
                     path: token
+                - configMap:
+                    items:
+                      - key: ca.crt
+                        path: ca.crt
+                    name: kube-root-ca.crt
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:

--- a/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/proxy_deployment_test.yaml
@@ -850,6 +850,11 @@ tests:
                       - key: ca.crt
                         path: ca.crt
                     name: kube-root-ca.crt
+                - downwardAPI:
+                    items:
+                      - path: "namespace"
+                        fieldRef:
+                          fieldPath: metadata.namespace
       - notContains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
@@ -881,10 +886,14 @@ tests:
                       - key: ca.crt
                         path: ca.crt
                     name: kube-root-ca.crt
+                - downwardAPI:
+                    items:
+                      - path: "namespace"
+                        fieldRef:
+                          fieldPath: metadata.namespace
       - contains:
           path: spec.template.spec.containers[0].volumeMounts
           content:
             mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: proxy-serviceaccount-token
             readOnly: true
-


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/24941

`automountServiceAccountToken` also mounted kubernetes ca certificates. Disabling the flag broke trust between the Kubernetes client we instantiate in auth pods, and the kube API.

The PR mimics the `automountServiceAccountToken` by adding the ca certificate in the projected volume.

Tested on GKE.