### PR TITLE
Account for request errors when displaying "no results" message in the search bar

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.story.tsx
@@ -355,20 +355,16 @@ const AuxiliaryItems = () => (
     ExtraTopComponent={
       <>
         <NoResultsItem
-          clusters={[
-            {
-              uri: clusterUri,
-              name: 'teleport-12-ent.asteroid.earth',
-              connected: false,
-              leaf: false,
-              proxyHost: 'test:3030',
-              authClusterId: '73c4746b-d956-4f16-9848-4e3469f70762',
-            },
-          ]}
+          clustersWithExpiredCerts={new Set([clusterUri])}
+          getClusterName={routing.parseClusterName}
+        />
+        <NoResultsItem
+          clustersWithExpiredCerts={new Set([clusterUri, '/clusters/foobar'])}
+          getClusterName={routing.parseClusterName}
         />
         <ResourceSearchErrorsItem
           getClusterName={routing.parseClusterName}
-          onShowDetails={() => window.alert('Error details')}
+          showErrorsInModal={() => window.alert('Error details')}
           errors={[
             new ResourceSearchError(
               '/clusters/foo',
@@ -381,7 +377,7 @@ const AuxiliaryItems = () => (
         />
         <ResourceSearchErrorsItem
           getClusterName={routing.parseClusterName}
-          onShowDetails={() => window.alert('Error details')}
+          showErrorsInModal={() => window.alert('Error details')}
           errors={[
             new ResourceSearchError(
               '/clusters/bar',

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
@@ -35,17 +35,17 @@ describe('getActionPickerStatus', () => {
       new Error('whoops')
     );
 
-    const status = getActionPickerStatus(
-      'foo',
-      [],
-      [],
-      [makeSuccessAttempt([])],
-      makeSuccessAttempt({
+    const status = getActionPickerStatus({
+      inputValue: 'foo',
+      filters: [],
+      allClusters: [],
+      actionAttempts: [makeSuccessAttempt([])],
+      resourceSearchAttempt: makeSuccessAttempt({
         errors: [retryableError, nonRetryableError],
         results: [],
         search: 'foo',
-      })
-    );
+      }),
+    });
 
     expect(status.status).toBe('finished');
 
@@ -64,17 +64,17 @@ describe('getActionPickerStatus', () => {
       new Error('ssh: cert has expired')
     );
 
-    const status = getActionPickerStatus(
-      'foo',
-      [],
-      [offlineCluster],
-      [makeSuccessAttempt([])],
-      makeSuccessAttempt({
+    const status = getActionPickerStatus({
+      inputValue: 'foo',
+      filters: [],
+      allClusters: [offlineCluster],
+      actionAttempts: [makeSuccessAttempt([])],
+      resourceSearchAttempt: makeSuccessAttempt({
         errors: [retryableError],
         results: [],
         search: 'foo',
-      })
-    );
+      }),
+    });
 
     expect(status.status).toBe('finished');
     const { clustersWithExpiredCerts } = status.status === 'finished' && status;
@@ -102,17 +102,17 @@ describe('getActionPickerStatus', () => {
         new Error('ssh: cert has expired')
       ),
     ];
-    const status = getActionPickerStatus(
-      'foo',
-      [],
-      [],
-      [makeSuccessAttempt([])],
-      makeSuccessAttempt({
+    const status = getActionPickerStatus({
+      inputValue: 'foo',
+      filters: [],
+      allClusters: [],
+      actionAttempts: [makeSuccessAttempt([])],
+      resourceSearchAttempt: makeSuccessAttempt({
         errors: retryableErrors,
         results: [],
         search: 'foo',
-      })
-    );
+      }),
+    });
 
     expect(status.status).toBe('finished');
     const { clustersWithExpiredCerts } = status.status === 'finished' && status;

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
@@ -37,7 +37,7 @@ describe('getActionPickerStatus', () => {
 
     const status = getActionPickerStatus({
       inputValue: 'foo',
-      filters: [],
+      filterActionsAttempt: makeSuccessAttempt([]),
       allClusters: [],
       actionAttempts: [makeSuccessAttempt([])],
       resourceSearchAttempt: makeSuccessAttempt({
@@ -66,7 +66,7 @@ describe('getActionPickerStatus', () => {
 
     const status = getActionPickerStatus({
       inputValue: 'foo',
-      filters: [],
+      filterActionsAttempt: makeSuccessAttempt([]),
       allClusters: [offlineCluster],
       actionAttempts: [makeSuccessAttempt([])],
       resourceSearchAttempt: makeSuccessAttempt({
@@ -104,7 +104,7 @@ describe('getActionPickerStatus', () => {
     ];
     const status = getActionPickerStatus({
       inputValue: 'foo',
-      filters: [],
+      filterActionsAttempt: makeSuccessAttempt([]),
       allClusters: [],
       actionAttempts: [makeSuccessAttempt([])],
       resourceSearchAttempt: makeSuccessAttempt({

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { makeSuccessAttempt } from 'shared/hooks/useAsync';
+
+import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
+import { ResourceSearchError } from 'teleterm/ui/services/resources';
+
+import { getActionPickerStatus } from './ActionPicker';
+
+describe('getActionPickerStatus', () => {
+  it('partitions resource search errors into clusters with expired certs and non-retryable errors', () => {
+    const retryableError = new ResourceSearchError(
+      '/clusters/foo',
+      'server',
+      new Error('ssh: cert has expired')
+    );
+
+    const nonRetryableError = new ResourceSearchError(
+      '/clusters/bar',
+      'database',
+      new Error('whoops')
+    );
+
+    const status = getActionPickerStatus(
+      'foo',
+      [],
+      [],
+      [makeSuccessAttempt([])],
+      makeSuccessAttempt({
+        errors: [retryableError, nonRetryableError],
+        results: [],
+        search: 'foo',
+      })
+    );
+
+    expect(status.status).toBe('finished');
+
+    const { clustersWithExpiredCerts, nonRetryableResourceSearchErrors } =
+      status.status === 'finished' && status;
+
+    expect([...clustersWithExpiredCerts]).toEqual([retryableError.clusterUri]);
+    expect(nonRetryableResourceSearchErrors).toEqual([nonRetryableError]);
+  });
+
+  it('merges non-connected clusters with clusters that returned retryable errors', () => {
+    const offlineCluster = makeRootCluster({ connected: false });
+    const retryableError = new ResourceSearchError(
+      '/clusters/foo',
+      'server',
+      new Error('ssh: cert has expired')
+    );
+
+    const status = getActionPickerStatus(
+      'foo',
+      [],
+      [offlineCluster],
+      [makeSuccessAttempt([])],
+      makeSuccessAttempt({
+        errors: [retryableError],
+        results: [],
+        search: 'foo',
+      })
+    );
+
+    expect(status.status).toBe('finished');
+    const { clustersWithExpiredCerts } = status.status === 'finished' && status;
+
+    expect(clustersWithExpiredCerts.size).toBe(2);
+    expect(clustersWithExpiredCerts).toContain(offlineCluster.uri);
+    expect(clustersWithExpiredCerts).toContain(retryableError.clusterUri);
+  });
+
+  it('includes a cluster with expired cert only once even if multiple requests fail with retryable errors', () => {
+    const retryableErrors = [
+      new ResourceSearchError(
+        '/clusters/foo',
+        'server',
+        new Error('ssh: cert has expired')
+      ),
+      new ResourceSearchError(
+        '/clusters/foo',
+        'database',
+        new Error('ssh: cert has expired')
+      ),
+      new ResourceSearchError(
+        '/clusters/foo',
+        'kube',
+        new Error('ssh: cert has expired')
+      ),
+    ];
+    const status = getActionPickerStatus(
+      'foo',
+      [],
+      [],
+      [makeSuccessAttempt([])],
+      makeSuccessAttempt({
+        errors: retryableErrors,
+        results: [],
+        search: 'foo',
+      })
+    );
+
+    expect(status.status).toBe('finished');
+    const { clustersWithExpiredCerts } = status.status === 'finished' && status;
+    expect([...clustersWithExpiredCerts]).toEqual(['/clusters/foo']);
+  });
+});

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -332,7 +332,7 @@ export function getActionPickerStatus({
   const clustersWithExpiredCerts = new Set(
     allClusters.filter(c => !c.connected).map(c => c.uri)
   );
-  let nonRetryableResourceSearchErrors = [];
+  const nonRetryableResourceSearchErrors = [];
 
   if (resourceSearchAttempt.status === 'success') {
     resourceSearchAttempt.data.errors.forEach(err => {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -157,13 +157,13 @@ export function ActionPicker(props: { input: ReactElement }) {
 
   const actionPickerStatus = useMemo(
     () =>
-      getActionPickerStatus(
+      getActionPickerStatus({
         inputValue,
         filters,
-        clustersService.getClusters(),
         actionAttempts,
-        resourceSearchAttempt
-      ),
+        resourceSearchAttempt,
+        allClusters: clustersService.getClusters(),
+      }),
     [
       inputValue,
       filters,
@@ -294,13 +294,19 @@ type ActionPickerStatus =
       clustersWithExpiredCerts: Set<uri.ClusterUri>;
     };
 
-export function getActionPickerStatus(
-  inputValue: string,
-  filters: SearchFilter[],
-  allClusters: tsh.Cluster[],
-  actionAttempts: Attempt<SearchAction[]>[],
-  resourceSearchAttempt: Attempt<CrossClusterResourceSearchResult>
-): ActionPickerStatus {
+export function getActionPickerStatus({
+  inputValue,
+  filters,
+  allClusters,
+  actionAttempts,
+  resourceSearchAttempt,
+}: {
+  inputValue: string;
+  filters: SearchFilter[];
+  allClusters: tsh.Cluster[];
+  actionAttempts: Attempt<SearchAction[]>[];
+  resourceSearchAttempt: Attempt<CrossClusterResourceSearchResult>;
+}): ActionPickerStatus {
   if (!inputValue) {
     const hasSelectedAllFilters = filters.length === 2;
 

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -596,7 +596,7 @@ export function NoResultsItem(props: {
 
   if (clustersWithExpiredCerts.length > 1) {
     // prettier-ignore
-    expiredCertsCopy = `The following clusters were excluded from the search because you are not logged in to them: ${clustersWithExpiredCerts.join( ', ')}.`;
+    expiredCertsCopy = `The following clusters were excluded from the search because you are not logged in to them: ${clustersWithExpiredCerts.join(', ')}.`;
   }
 
   return (

--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -34,6 +34,12 @@ import {
 
 import type * as resourcesServiceTypes from 'teleterm/ui/services/resources';
 
+export type CrossClusterResourceSearchResult = {
+  results: resourcesServiceTypes.SearchResult[];
+  errors: resourcesServiceTypes.ResourceSearchError[];
+  search: string;
+};
+
 /**
  * useResourceSearch returns a function which searches for the given list of space-separated keywords across
  * all root and leaf clusters that the user is currently logged in to.
@@ -48,11 +54,7 @@ export function useResourceSearch() {
     async (
       search: string,
       filters: SearchFilter[]
-    ): Promise<{
-      results: resourcesServiceTypes.SearchResult[];
-      errors: resourcesServiceTypes.ResourceSearchError[];
-      search: string;
-    }> => {
+    ): Promise<CrossClusterResourceSearchResult> => {
       // useResourceSearch has to return _something_ when the input is empty. Imagine this scenario:
       //
       // 1. The user types in 'data' into the search bar.


### PR DESCRIPTION
# What needs to be fixed

When the user types in a query for which there's no search results, we look at `ClustersService` to see if there are any clusters that are not "connected", that is clusters with expired certs. We then tell the user that those clusters were not included in the search because the user is not logged in to them.

![no results found message](https://user-images.githubusercontent.com/27113/233980957-2cdbf22c-3c27-46a7-9fa5-2411de8f45cb.png)


However, the `connected` property is updated only in a couple of scenarios, the most relevant being the start of the app. After that we pretty much don't touch it at all, so at the moment it only tells us whether the user had valid certs when the app was started.

Naturally, this approach doesn't handle a scenario in which the user was logged in to multiple clusters, left the app running, then came back to it, ran a search and then refreshed the cert for the active workspace (#24880). If they type a query with no search results now, those other clusters with expired certs will not be listed in that "no results" message. Instead, those failed requests will be treated like any other failed requests, even though we know that they failed due to expired certs.

# How this PR fixes that

This PR makes it so that the list of clusters with expired certs is based not only on the state of `ClustersService`, but also the results of the resource search requests.

To do this, I refactored how any extra top messages above the results are rendered. The business and presentational logic used to be scattered around `ActionPicker` and auxiliary components that were passed to `ResultList` as `ExtraTopComponent`. Instead, I made the distinction more clear cut:

* `getActionPickerStatus` is a function which takes necessary arguments and returns `ActionPickerStatus`, a discriminated union describing possible states for the action picker.
* `ExtraTopComponents` takes `ActionPickerStatus` and renders relevant top messages through auxiliary components.
* The auxiliary components receive relevant pieces of action picker status.

The idea here being that all business logic is performed in `getActionPickerStatus` so that after `ActionPickerStatus` is returned, the other components can just display what's necessary.

## Other business logic changes

* Leaf clusters are included in the "excluded clusters" message too.
   * It doesn't hurt us to include them there too. This way we also make less assumptions about how much the user knows about the relation of any given leaf cluster to the root cluster.
* When there are multiple excluded clusters, they're included at the end of the message.
   * This makes reading the message easier because the first line doesn't change and what follows are just cluster names.
* Retryable errors are excluded from the error item.