### PR TITLE
Add headings to the Cloud FAQ

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -1,31 +1,151 @@
 ---
 title: Teleport Enterprise Cloud FAQ
 description: Teleport cloud frequently asked questions.
+tocDepth: 3
 ---
 
-## Can I use Teleport Enterprise Cloud in production?
+## Billing and usage
 
-Yes. Large organizations leverage Teleport Enterprise Cloud to manage the vast number of resources in their organization. Teleport Enterprise Cloud is audited regularly to ensure the most reliable and secure service possible is available to our customers.
-
-## What is the Cloud SLA?
-
-Teleport Enterprise Cloud commits to an SLA of (=cloud.sla.monthly_percentage=) of monthly uptime,
-a maximum of (=cloud.sla.monthly_downtime=) of downtime per month. While we routinely exceed this SLA,
-this number reflects risks in our architecture that we will improve over time.
-
-## Is there a status page available?
-
-[status.teleport.sh](https://status.teleport.sh)
-
-## Can I get push notifications of Teleport Enterprise Cloud downtime?
-
-Yes. Customers can subscribe to Teleport Enterprise Cloud updates at [status.teleport.sh](https://status.teleport.sh).
-
-## How does Cloud Billing work?
+### How does Cloud Billing work?
 
 Please [reach out to sales](https://goteleport.com/signup/enterprise) to discuss pricing.
 
-## Are upgrades times configurable for my Teleport Enterprise Cloud tenant?
+### Can a customer deploy multiple clusters in Teleport Enterprise Cloud?
+
+[Reach out to sales](https://goteleport.com/signup/enterprise) to discuss pricing.
+
+### If I start with Teleport Enterprise Cloud, can I move to Teleport Enterprise or Teleport Open Source, or do I need to start again?
+
+If you plan to use S3 and DynamoDB as storage backends, we can provide data for you to import. But you should reach out to us first. If you use a different backend, you will need to start over.
+
+## Security
+
+### How long will Teleport Enterprise Cloud retain my data?
+
+See our documentation on [data retention](./architecture.mdx#data-retention).
+
+### Is an independent security audit available?
+
+Security audits by independent third-parties are performed at least annually. You can request audit results and other
+related information on the [Teleport Trust Portal](https://trust.goteleport.com).
+
+### Does your SOC 2 report include Teleport Enterprise Cloud?
+
+(!docs/pages/includes/soc2.mdx!)
+
+### How do you store passwords?
+
+Password hashes are generated using
+[Golang's bcrypt](https://pkg.go.dev/golang.org/x/crypto/bcrypt).
+
+### Do you encrypt data at rest?
+
+Each deployment is using at-rest encryption using AWS DynamoDB and S3 at-rest encryption
+for customer data including session recordings and user records.
+
+### Can I get a list of IP addresses to configure a firewall?
+
+We do not have plans to offer a list of IP addresses for Teleport Enterprise
+Cloud at the moment.
+
+Teleport Enterprise Cloud infrastructure is elastic and IP addresses can and do
+change when we make infrastructure changes. This would make the maintenance of
+IP allowlists a cumbersome and brittle process for customers.
+
+However, we do provide customers with a stable tenant DNS name backed with
+TLS certificates from [letsencrypt.org](https://letsencrypt.org) that can be
+utilized to verify the integrity of any outbound connections to Teleport
+Enterprise Cloud.
+
+### Can I configure an allowlist of inbound IP addresses to Teleport Enterprise Cloud?
+
+We do not have plans to offer support for inbound connection IP allowlists.
+
+We believe mTLS with strong user and [device
+identity](../../access-controls/guides/device-trust.mdx) provides the best
+available security for client authentication.
+
+For customers that require IP-based control for compliance purposes, we do
+support IP Pinning. For more information see `pin_source_ip` in our [Teleport
+Access Controls Reference](../../access-controls/reference.mdx).
+
+### Are internal connections encrypted / authenticated?
+
+Teleport components communicate with themselves using mTLS, with a separate certificate authority for each tenant. Connections to AWS services, such as DynamoDB and
+S3, are established using encryption provided by AWS, both at rest and in transit. Each tenant has its own credentials that isolate it to interacting with only its own data.
+## Connecting resources
+
+### How do I add resources to Teleport Enterprise Cloud?
+
+You can connect servers, Kubernetes clusters, databases and applications using
+[reverse tunnels](../../management/join-services-to-your-cluster.mdx).
+
+There is no need to open any ports on your infrastructure for inbound traffic.
+
+### What is the maximum number of agents a customer can connect to their cluster?
+
+If you plan on connecting more than 10,000 nodes or agents, please contact your account executive or customer support to ensure your tenant is properly scaled.
+
+### Are dynamic node tokens available?
+
+After [connecting](#how-can-i-access-the-tctl-admin-tool) `tctl` to Teleport Enterprise Cloud, users can generate
+[dynamic tokens](../../management/join-services-to-your-cluster/join-token.mdx):
+
+```code
+$ tctl nodes add --ttl=5m --roles=node,proxy --token=$(uuid)
+```
+
+## Using `tctl`
+
+### How can I access the `tctl` admin tool?
+
+Find the appropriate download at [Teleport Enterprise Cloud Downloads](./downloads.mdx). Use the Enterprise version of `tctl`.
+
+After downloading the tools, first log in to your cluster using `tsh`, then use `tctl` remotely:
+
+```code
+$ tsh login --proxy=myinstance.teleport.sh
+$ tctl status
+```
+
+### Why am I getting `permission denied` errors when using `tctl`?
+
+If you have a local file `/etc/teleport.yaml` on your machine `tctl` will attempt to use the local cluster. Set the environment variable `TELEPORT_CONFIG_FILE` to `""` so it will not attempt to use that Teleport configuration file.
+
+```code
+$ export TELEPORT_CONFIG_FILE=""
+$ tctl tokens add --type=node
+```
+
+## Audit events and session recordings
+
+### Is there a way to forward Teleport Enterprise Cloud audit events to my company's internal Security Information and Event Management (SIEM)?
+
+Yes. We recommend Teleport's [event handler plugin](../../management/export-audit-events/fluentd.mdx) to export Teleport Enterprise Cloud audit events.
+
+### Is it possible to enable proxy recording mode?
+
+Proxy recording mode is disabled for cloud customers
+
+### Is there a way to download session recordings for easy playback?
+
+The ability to download recordings for offline viewing will be available in a future release.
+
+## Upgrading
+
+### Will Teleport be automatically upgraded with each release?
+
+Teleport Cloud follows the Teleport [Production
+readiness](../../preview/upcoming-releases.mdx) guidelines.
+
+- Major version upgrades for customer Auth and Proxy Servers occur after the
+  first minor release (for example (=teleport.major_version=).1.0) of Teleport.
+  This typically happens within one month of a new major release of Teleport
+  becoming available.
+- After the first minor release, subsequent minor and patch upgrades typically
+  occur within a week.
+
+### Are upgrades times configurable for my Teleport Enterprise Cloud tenant?
 
 Yes, you can set the window start time that works best for your organization
 for upgrades. Teleport provides a scheduled maintenance time window for any
@@ -40,35 +160,33 @@ Teleport recommends subscribing to the Teleport Enterprise Cloud updates at
 [status.teleport.sh](https://status.teleport.sh) to keep up to date on
 scheduled maintenance.
 
-## If I start with Teleport Enterprise Cloud, can I move to Teleport Enterprise or Teleport Open Source, or do I need to start again?
+### How can I find version information on connected agents?
 
-If you plan to use S3 and DynamoDB as storage backends, we can provide data for you to import. But you should reach out to us first. If you use a different backend, you will need to start over.
+To find the version of Teleport agent is attached to your cluster, run the
+following commands for the different protocols we support.
 
-## How do I set up recovery codes for my account so I don't lose access?
+```code
+$ tctl get nodes --format=text
+$ tctl get kube_server --format=text
+$ tctl get app_server --format=text
+$ tctl get db_server --format=text
+$ tctl get windows_desktop_service --format=text
+```
 
-We have a [short step-by-step guide](https://github.com/gravitational/teleport/discussions/12379) on setting up recovery codes.
+Below you can see sample output of `tctl get nodes --format=text`. Note the
+`Version` column will contain the version of the attached agent.
 
-## Are you using AWS-managed encryption keys, or CMKs via KMS?
+```code
+$ tctl get nodes --format=text
+Host     UUID                                 Public Address Labels Version
+-------- ------------------------------------ -------------- ------ ----------
+server01 46d8cad0-8967-4815-a01a-77aae62c34fe 127.0.0.1:3022        12.0.0
+server02 c33b5513-a9eb-463b-8f1b-1f209afe5b4f 127.0.0.1:3122        12.0.0
+```
 
-We use AWS-managed keys. Currently there is no option to provide your own key.
+## Architecture and networking
 
-## Is this Teleport's S3 bucket, or my bucket based on my AWS credentials?
-
-It's a Teleport-managed S3 bucket with AWS-managed keys.
-Currently there is no way to provide your own bucket.
-
-## How long will Teleport Enterprise Cloud retain my data?
-
-See our documentation on [data retention](./architecture.mdx#data-retention).
-
-## How do I add Nodes to Teleport Enterprise Cloud?
-
-You can connect servers, Kubernetes clusters, databases and applications using
-[reverse tunnels](../../management/join-services-to-your-cluster.mdx).
-
-There is no need to open any ports on your infrastructure for inbound traffic.
-
-## Which Proxy Service ports are open on my Teleport Enterprise Cloud tenant?
+### Which Proxy Service ports are open on my Teleport Enterprise Cloud tenant?
 
 Teleport Enterprise Cloud allocates a different set of ports to each tenant. To see which
 ports are available for your Teleport Enterprise Cloud tenant, run a command similar to the
@@ -114,120 +232,60 @@ Service's public web address (`ssh.public_addr`) is `mytenant.teleport.sh:443`.
 
 Read more in our [TLS Routing](../../architecture/tls-routing.mdx) guide.
 
-## How can I access the tctl admin tool?
-
-Find the appropriate download at [Teleport Enterprise Cloud Downloads](./downloads.mdx). Use the Enterprise version of `tctl`.
-
-After downloading the tools, first log in to your cluster using `tsh`, then use `tctl` remotely:
-
-```code
-$ tsh login --proxy=myinstance.teleport.sh
-$ tctl status
-```
-
-## Why am I getting `permission denied` errors when using `tctl`?
-
-If you have a local file `/etc/teleport.yaml` on your machine `tctl` will attempt to use the local cluster. Set the environment variable `TELEPORT_CONFIG_FILE` to `""` so it will not attempt to use that Teleport configuration file.
-
-```code
-$ export TELEPORT_CONFIG_FILE=""
-$ tctl tokens add --type=node
-```
-
-## Are dynamic node tokens available?
-
-After [connecting](#how-can-i-access-the-tctl-admin-tool) `tctl` to Teleport Enterprise Cloud, users can generate
-[dynamic tokens](../../management/join-services-to-your-cluster/join-token.mdx):
-
-```code
-$ tctl nodes add --ttl=5m --roles=node,proxy --token=$(uuid)
-```
-
-## Is an independent security audit available?
-
-Security audits by independent third-parties are performed at least annually. You can request audit results and other
-related information on the [Teleport Trust Portal](https://trust.goteleport.com).
-
-## Where does Teleport Enterprise Cloud run?
-
-Teleport Enterprise Cloud is deployed within AWS, using S3 and DynamoDB for storage with AWS-managed encryption keys. All data is currently hosted in us-west-2.
-Currently there is no option to select an alternative region for storage.
-
-## Will Teleport be automatically upgraded with each release?
-
-Teleport Cloud follows the Teleport [Production
-readiness](../../preview/upcoming-releases.mdx) guidelines.
-
-- Major version upgrades for customer Auth and Proxy Servers occur after the
-  first minor release (for example (=teleport.major_version=).1.0) of Teleport.
-  This typically happens within one month of a new major release of Teleport
-  becoming available.
-- After the first minor release, subsequent minor and patch upgrades typically
-  occur within a week.
-
-## Does your SOC 2 report include Teleport Enterprise Cloud?
-
-(!docs/pages/includes/soc2.mdx!)
-
-## Can a customer deploy multiple clusters in Teleport Enterprise Cloud?
-
-[Reach out to sales](https://goteleport.com/signup/enterprise) to discuss pricing.
-
-## Is FIPS mode an option?
-
-FIPS is not currently an option for Teleport Enterprise Cloud clusters.
-
-## How do you store passwords?
-
-Password hashes are generated using
-[Golang's bcrypt](https://pkg.go.dev/golang.org/x/crypto/bcrypt).
-
-## How does Teleport manage web certificates? Can I upload my own?
+### How does Teleport manage web certificates? Can I upload my own?
 
 Teleport uses [letsencrypt.org](https://letsencrypt.org/) to issue
 certificates for every customer. It is not possible to upload a custom
 certificate or use a custom domain name.
 
-## Do you encrypt data at rest?
+### Where does Teleport Enterprise Cloud run?
 
-Each deployment is using at-rest encryption using AWS DynamoDB and S3 at-rest encryption
-for customer data including session recordings and user records.
+Teleport Enterprise Cloud is deployed within AWS, using S3 and DynamoDB for storage with AWS-managed encryption keys. All data is currently hosted in us-west-2.
+Currently there is no option to select an alternative region for storage.
 
-## Can I get a list of IP addresses to configure a firewall?
+### Are you using AWS-managed encryption keys, or CMKs via KMS?
 
-We do not have plans to offer a list of IP addresses for Teleport Enterprise
-Cloud at the moment.
+We use AWS-managed keys. Currently there is no option to provide your own key.
 
-Teleport Enterprise Cloud infrastructure is elastic and IP addresses can and do
-change when we make infrastructure changes. This would make the maintenance of
-IP allowlists a cumbersome and brittle process for customers.
+### Is this Teleport's S3 bucket, or my bucket based on my AWS credentials?
 
-However, we do provide customers with a stable tenant DNS name backed with
-TLS certificates from [letsencrypt.org](https://letsencrypt.org) that can be
-utilized to verify the integrity of any outbound connections to Teleport
-Enterprise Cloud.
+It's a Teleport-managed S3 bucket with AWS-managed keys.
+Currently there is no way to provide your own bucket.
 
-## Can I configure an allowlist of inbound IP addresses to Teleport Enterprise Cloud?
-
-We do not have plans to offer support for inbound connection IP allowlists.
-
-We believe mTLS with strong user and [device
-identity](../../access-controls/guides/device-trust.mdx) provides the best
-available security for client authentication.
-
-For customers that require IP-based control for compliance purposes, we do
-support IP Pinning. For more information see `pin_source_ip` in our [Teleport
-Access Controls Reference](../../access-controls/reference.mdx).
-
-## Is IPv6 Supported for connections to Teleport Enterprise Cloud?
+### Is IPv6 Supported for connections to Teleport Enterprise Cloud?
 
 We don't currently support IPv6 connections to Teleport Enterprise Cloud.
 
-## Can I change the domain name of my Cloud instance after it's been created?
+### Can I change the domain name of my Cloud instance after it's been created?
 
 We're currently researching whether this can be done, so please contact support at support@goteleport.com.
 
-## Can I retrieve diagnostics from my hosted cluster?
+### Is FIPS mode an option?
+
+FIPS is not currently an option for Teleport Enterprise Cloud clusters.
+
+
+## Performance and reliability
+
+### Can I use Teleport Enterprise Cloud in production?
+
+Yes. Large organizations leverage Teleport Enterprise Cloud to manage the vast number of resources in their organization. Teleport Enterprise Cloud is audited regularly to ensure the most reliable and secure service possible is available to our customers.
+
+### What is the Cloud SLA?
+
+Teleport Enterprise Cloud commits to an SLA of (=cloud.sla.monthly_percentage=) of monthly uptime,
+a maximum of (=cloud.sla.monthly_downtime=) of downtime per month. While we routinely exceed this SLA,
+this number reflects risks in our architecture that we will improve over time.
+
+### Is there a status page available?
+
+[status.teleport.sh](https://status.teleport.sh)
+
+### Can I get push notifications of Teleport Enterprise Cloud downtime?
+
+Yes. Customers can subscribe to Teleport Enterprise Cloud updates at [status.teleport.sh](https://status.teleport.sh).
+
+### Can I retrieve diagnostics from my hosted cluster?
 
 We currently don't expose any metrics interfaces for a tenant.
 
@@ -238,47 +296,8 @@ Teleport cloud tenants are made up of a cluster of processes, with designated pr
 the Teleport cluster to be individually addressable and accessible from external sources. This could allow individual components to be selectively attacked, if an adversary is able to
 address traffic to any individual software instance within the cluster.
 
-## Is it possible to enable proxy recording mode?
+### How do I set up recovery codes for my account so I don't lose access?
 
-Proxy recording mode is disabled for cloud customers
+We have a [short step-by-step guide](https://github.com/gravitational/teleport/discussions/12379) on setting up recovery codes.
 
-## Is there a way to download session recordings for easy playback?
 
-The ability to download recordings for offline viewing will be available in a future release.
-
-## Is there a way to forward Teleport Enterprise Cloud audit events to my company's internal Security Information and Event Management (SIEM)?
-
-Yes. We recommend Teleport's [event handler plugin](../../management/export-audit-events/fluentd.mdx) to export Teleport Enterprise Cloud audit events.
-
-## What is the maximum number of nodes a customer can connect to their cluster?
-
-If you plan on connecting more than 10,000 nodes or agents, please contact your account executive or customer support to ensure your tenant is properly scaled.
-
-## Are internal connections encrypted / authenticated?
-
-Teleport components communicate with themselves using mTLS, with a separate certificate authority for each tenant. Connections to AWS services, such as DynamoDB and
-S3, are established using encryption provided by AWS, both at rest and in transit. Each tenant has its own credentials that isolate it to interacting with only its own data.
-
-## How can I find version information on connected agents?
-
-To find the version of Teleport agent is attached to your cluster, run the
-following commands for the different protocols we support.
-
-```code
-$ tctl get nodes --format=text
-$ tctl get kube_server --format=text
-$ tctl get app_server --format=text
-$ tctl get db_server --format=text
-$ tctl get windows_desktop_service --format=text
-```
-
-Below you can see sample output of `tctl get nodes --format=text`. Note the
-`Version` column will contain the version of the attached agent.
-
-```code
-$ tctl get nodes --format=text
-Host     UUID                                 Public Address Labels Version
--------- ------------------------------------ -------------- ------ ----------
-server01 46d8cad0-8967-4815-a01a-77aae62c34fe 127.0.0.1:3022        12.0.0
-server02 c33b5513-a9eb-463b-8f1b-1f209afe5b4f 127.0.0.1:3122        12.0.0
-```


### PR DESCRIPTION
Closes #12506

This change adds H2-level headings to the Cloud FAQ page in order to help users navigate the page. The order of headings is based on my guess as to the importance of each topic.

This change does **not** attempt to refresh the content of each question/answer entry, but will make it easier to update the page in the future since the page should be easier to navigate.