### PR TITLE
Teleport Proxy Behind ALB support for IP Pinning

### DIFF
--- a/api/client/contextdialer.go
+++ b/api/client/contextdialer.go
@@ -172,12 +172,6 @@ func NewDialer(ctx context.Context, keepAlivePeriod, dialTimeout time.Duration, 
 		// Base direct dialer.
 		var dialer ContextDialer = netDialer
 
-		// Wrap with PROXY header dialer if getter is present.
-		// Used by Proxy's web server to propagate real client IP when making calls on behalf of connected clients
-		if cfg.proxyHeaderGetter != nil {
-			dialer = NewPROXYHeaderDialer(dialer, cfg.proxyHeaderGetter)
-		}
-
 		// Wrap with proxy URL dialer if proxy URL is detected.
 		if proxyURL := utils.GetProxyURL(addr); proxyURL != nil {
 			dialer = newProxyURLDialer(proxyURL, dialer, opts...)
@@ -186,6 +180,12 @@ func NewDialer(ctx context.Context, keepAlivePeriod, dialTimeout time.Duration, 
 		// Wrap with alpnConnUpgradeDialer if upgrade is required for TLS Routing.
 		if cfg.alpnConnUpgradeRequired {
 			dialer = newALPNConnUpgradeDialer(dialer, cfg.tlsConfig, cfg.alpnConnUpgradeWithPing)
+		}
+
+		// Wrap with PROXY header dialer if getter is present.
+		// Used by Proxy's web server to propagate real client IP when making calls on behalf of connected clients
+		if cfg.proxyHeaderGetter != nil {
+			dialer = NewPROXYHeaderDialer(dialer, cfg.proxyHeaderGetter)
 		}
 
 		// Dial.

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -426,3 +426,14 @@ const (
 	// has very short idle timeouts.
 	WebAPIConnUpgradeTypeALPNPing = "alpn-ping"
 )
+
+const (
+	// XForwardedForHeader is a de-facto standard header for identifying the
+	// originating IP address of a client connecting to a web server through a
+	// proxy server.
+	XForwardedForHeader = "X-Forwarded-For"
+	// UseXForwardedForHeader is a login request header that specifies that the
+	// Proxy server should use the client IP from the value of
+	// `X-Forwarded-For` header.
+	UseXForwardedForHeader = "X-Teleport-Use-X-Forwarded-For"
+)

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -772,6 +772,18 @@ func Test_clientMetaFromReq(t *testing.T) {
 		UserAgent:  ua,
 		RemoteAddr: "192.0.2.1:1234",
 	}, got)
+
+	t.Run(constants.UseXForwardedForHeader, func(t *testing.T) {
+		r := r.Clone(context.Background())
+		r.Header.Set(constants.UseXForwardedForHeader, types.True)
+		r.Header.Set(constants.XForwardedForHeader, "1.2.3.4")
+
+		got := clientMetaFromReq(r)
+		require.Equal(t, &auth.ForwardedClientMetadata{
+			UserAgent:  ua,
+			RemoteAddr: "1.2.3.4:1234",
+		}, got)
+	})
 }
 
 func TestWebSessionsCRUD(t *testing.T) {

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -24,6 +24,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/netip"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -32,6 +33,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils/pingconn"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestWriteUpgradeResponse(t *testing.T) {
@@ -53,11 +55,17 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 	t.Parallel()
 
 	expectedPayload := "hello@"
+	expectedIP := "1.2.3.4"
 	alpnHandler := func(_ context.Context, conn net.Conn) error {
 		// Handles connection asynchronously to verify web handler waits until
 		// connection is closed.
 		go func() {
 			defer conn.Close()
+
+			clientIP, err := utils.ClientIPFromConn(conn)
+			require.NoError(t, err)
+			require.Equal(t, expectedIP, clientIP)
+
 			n, err := conn.Write([]byte(expectedPayload))
 			require.NoError(t, err)
 			require.Equal(t, len(expectedPayload), n)
@@ -89,7 +97,7 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 		defer serverConn.Close()
 		defer clientConn.Close()
 
-		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPN, serverConn, clientConn)
+		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPN, serverConn, clientConn, expectedIP)
 
 		// Verify clientConn receives data sent by Config.ALPNHandler.
 		receive, err := bufio.NewReader(clientConn).ReadString(byte('@'))
@@ -102,7 +110,7 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 		defer serverConn.Close()
 		defer clientConn.Close()
 
-		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPNPing, serverConn, clientConn)
+		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPNPing, serverConn, clientConn, expectedIP)
 
 		// Verify ping-wrapped clientConn receives data sent by Config.ALPNHandler.
 		receive, err := bufio.NewReader(pingconn.New(clientConn)).ReadString(byte('@'))
@@ -111,12 +119,66 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 	})
 }
 
-func sendConnUpgradeRequest(t *testing.T, h *Handler, upgradeType string, serverConn, clientConn net.Conn) {
+func TestConnWithXForwardedAddr(t *testing.T) {
+	t.Parallel()
+
+	mockConn, _ := net.Pipe()
+	mockIPv4Addr := net.TCPAddrFromAddrPort(netip.AddrPortFrom(netip.MustParseAddr("1.2.3.4"), 12345))
+	mockInputConn := newConnWithRemoteAddr(mockConn, mockIPv4Addr)
+
+	tests := []struct {
+		name               string
+		inputForwardedAddr string
+		wantRemoteAddr     string
+	}{
+		{
+			name:               "empty X-Forwarded-For",
+			inputForwardedAddr: "",
+			wantRemoteAddr:     "1.2.3.4:12345",
+		},
+		{
+			name:               "invalid X-Forwarded-For",
+			inputForwardedAddr: "not-an-ip",
+			wantRemoteAddr:     "1.2.3.4:12345",
+		},
+		{
+			name:               "ipv4",
+			inputForwardedAddr: "3.4.5.6",
+			wantRemoteAddr:     "3.4.5.6:12345",
+		},
+		{
+			name:               "ipv4 with port",
+			inputForwardedAddr: "3.4.5.6:22222",
+			wantRemoteAddr:     "3.4.5.6:22222",
+		},
+		{
+			name:               "ipv6",
+			inputForwardedAddr: "2001:db8::21f:5bff:febf:ce22:8a2e",
+			wantRemoteAddr:     "[2001:db8:0:21f:5bff:febf:ce22:8a2e]:12345",
+		},
+		{
+			name:               "ipv6 with port",
+			inputForwardedAddr: "[2001:db8::21f:5bff:febf:ce22:8a2e]:22222",
+			wantRemoteAddr:     "[2001:db8:0:21f:5bff:febf:ce22:8a2e]:22222",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			conn := connWithXForwardedAddr(mockInputConn, test.inputForwardedAddr)
+			require.NotNil(t, conn)
+			require.Equal(t, test.wantRemoteAddr, conn.RemoteAddr().String())
+		})
+	}
+}
+
+func sendConnUpgradeRequest(t *testing.T, h *Handler, upgradeType string, serverConn, clientConn net.Conn, xForwardedFor string) {
 	t.Helper()
 
 	r, err := http.NewRequest("GET", "http://localhost/webapi/connectionupgrade", nil)
 	require.NoError(t, err)
 	r.Header.Add("Upgrade", upgradeType)
+	r.Header.Add("X-Forwarded-For", xForwardedFor)
 
 	go func() {
 		// serverConn will be hijacked.

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -161,6 +161,11 @@ func TestConnWithXForwardedAddr(t *testing.T) {
 			inputForwardedAddr: "[2001:db8::21f:5bff:febf:ce22:8a2e]:22222",
 			wantRemoteAddr:     "[2001:db8:0:21f:5bff:febf:ce22:8a2e]:22222",
 		},
+		{
+			name:               "multiple",
+			inputForwardedAddr: "3.4.5.6, 7.8.9.10, 11.12.13.14",
+			wantRemoteAddr:     "3.4.5.6:12345",
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
implements #24711 

part of #21870

overview
- `tsh` login to set `X-Teleport-Use-X-Forwarded-For` to `true` if it is detected Proxy is behind L7 load balancer
- Proxy upon receiving `X-Teleport-Use-X-Forwarded-For` to retrieve client address from `X-Forwarded-For`
- `/webapi/connectionupgrade` to always use client address `X-Forwarded-For`