### PR TITLE
[v11] fix github url formatting (#25089)

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/coreos/go-oidc/oauth2"
@@ -950,8 +951,8 @@ func (c *githubAPIClient) getTeams() ([]teamResponse, error) {
 }
 
 // get makes a GET request to the provided URL using the client's token for auth
-func (c *githubAPIClient) get(url string) ([]byte, string, error) {
-	request, err := http.NewRequest("GET", fmt.Sprintf("https://api.%s/%s", c.endpointHostname, url), nil)
+func (c *githubAPIClient) get(page string) ([]byte, string, error) {
+	request, err := http.NewRequest("GET", formatGithubURL(c.endpointHostname, page), nil)
 	if err != nil {
 		return nil, "", trace.Wrap(err)
 	}
@@ -975,6 +976,11 @@ func (c *githubAPIClient) get(url string) ([]byte, string, error) {
 	wls := utils.ParseWebLinks(response)
 
 	return bytes, wls.NextPage, nil
+}
+
+// formatGithubURL is a helper for formatting github api request URLs.
+func formatGithubURL(host string, path string) string {
+	return fmt.Sprintf("https://%s/%s", host, strings.TrimPrefix(path, "/"))
 }
 
 const (

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -532,3 +532,31 @@ func TestCheckGithubOrgSSOSupport(t *testing.T) {
 		})
 	}
 }
+
+func TestGithubURLFormat(t *testing.T) {
+	tts := []struct {
+		host   string
+		path   string
+		expect string
+	}{
+		{
+			host:   "example.com",
+			path:   "foo/bar",
+			expect: "https://example.com/foo/bar",
+		},
+		{
+			host:   "example.com",
+			path:   "/foo/bar?spam=eggs",
+			expect: "https://example.com/foo/bar?spam=eggs",
+		},
+		{
+			host:   "example.com",
+			path:   "/foo/bar",
+			expect: "https://example.com/foo/bar",
+		},
+	}
+
+	for _, tt := range tts {
+		require.Equal(t, tt.expect, formatGithubURL(tt.host, tt.path))
+	}
+}


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/25089