### PR TITLE
terraform: enable ACLs in the certs bucket

### DIFF
--- a/examples/aws/terraform/ha-autoscale-cluster/s3.tf
+++ b/examples/aws/terraform/ha-autoscale-cluster/s3.tf
@@ -7,8 +7,9 @@ resource "aws_s3_bucket" "certs" {
 }
 
 resource "aws_s3_bucket_acl" "certs" {
-  bucket = aws_s3_bucket.certs.bucket
-  acl    = "private"
+  depends_on = [aws_s3_bucket_ownership_controls.certs]
+  bucket     = aws_s3_bucket.certs.bucket
+  acl        = "private"
 }
 
 // For demo purposes, CMK is not needed
@@ -20,6 +21,14 @@ resource "aws_s3_bucket_server_side_encryption_configuration" "certs" {
     apply_server_side_encryption_by_default {
       sse_algorithm = "AES256"
     }
+  }
+}
+
+resource "aws_s3_bucket_ownership_controls" "certs" {
+  bucket = aws_s3_bucket.certs.id
+
+  rule {
+    object_ownership = "BucketOwnerPreferred"
   }
 }
 


### PR DESCRIPTION
Fixes an issue that happens when creating new buckets with our HA AWS Terraform. It seems the bucket defaults changed to "no-acl" mode, which breaks Terraform. The PR reverts this change.

```╷
│ Error: error creating S3 bucket ACL for hugo-teleport13.teleportdemo.net: AccessControlListNotSupported: The bucket does not allow ACLs
│ 	status code: 400, request id: VKKR1SMCVKA9RY2B, host id: TXM+l4DymVNnhts/dPCWmsbQVG6/1MaraJMNLs9nfxyv4bYhgxHVmPQaP0z/tuwoQRZ1p6ZQWNQ=
│
│   with aws_s3_bucket_acl.certs,
│   on s3.tf line 9, in resource "aws_s3_bucket_acl" "certs":
│    9: resource "aws_s3_bucket_acl" "certs" {
│
```

