### PR TITLE
Boost CLI onLogin pref by proxyClient injection

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -752,6 +752,7 @@ func (proxy *ProxyClient) NewWatcher(ctx context.Context, watch types.Watch) (ty
 	return watcher, nil
 }
 
+// GetClusterAlerts connects fetches current clusters alerts using cached current cluster client.
 func (proxy *ProxyClient) GetClusterAlerts(ctx context.Context, req types.GetClusterAlertsRequest) ([]types.ClusterAlert, error) {
 	ctx, span := proxy.Tracer.Start(
 		ctx,


### PR DESCRIPTION
## Experimental

## What 

Make the tsh login function more robust by forwarding proxyClient and leveraging the proxyClient cache. . 

- before 4.348 s ±  0.151 s :
  ```
  hyperfine --shell zsh 'rm -rf ~/.tsh; tsh login --proxy=teleport.example.com:443 --user=alice'
  
  Benchmark 1: rm -rf ~/.tsh; tsh login --proxy=teleport.example.com:443 --user=alice
    Time (mean ± σ):      4.348 s ±  0.151 s    [User: 0.309 s, System: 0.088 s]
    Range (min … max):    4.093 s …  4.556 s    10 runs
  ```
  3x Remote Connect To Cluster Calls: 
  ![Screenshot 2023-04-25 at 15 15 19](https://user-images.githubusercontent.com/22402974/234289203-2565d385-09ac-4c20-a79b-7bf5b4eca57a.png)



- after 2.303 s ±  0.073 s:
  ```
  hyperfine --shell zsh 'rm -rf ~/.tsh; tsh login --proxy=teleport.example.com:443 --user=alice'
  
  Benchmark 1: rm -rf ~/.tsh; tsh login --proxy=teleport.example.com:443 --user=alice
    Time (mean ± σ):      2.303 s ±  0.073 s    [User: 0.287 s, System: 0.064 s]
    Range (min … max):    2.226 s …  2.448 s    10 runs
  ```
  1x Remote Connect To Cluster Call: 
  ![Screenshot 2023-04-25 at 15 17 53](https://user-images.githubusercontent.com/22402974/234289234-893f3ec1-4297-44aa-83cb-5cd48a0a6231.png)

