### PR TITLE
docs: add information on viewing status and logs for systemd service

### DIFF
--- a/docs/pages/includes/start-teleport.mdx
+++ b/docs/pages/includes/start-teleport.mdx
@@ -28,3 +28,6 @@ $ sudo systemctl start teleport
 
 </TabItem>
 </Tabs>
+
+You can check the status of {{ service }} with `systemctl status teleport`
+and view its logs with `journalctl -fu teleport`.


### PR DESCRIPTION
Often folks who are not as familiar with systemd configuration do not know the status and log mechanisms.