### PR TITLE
[v13] fix session recordings from Web UI to agentless nodes having name set as node UUID

### DIFF
--- a/lib/reversetunnel/localsite.go
+++ b/lib/reversetunnel/localsite.go
@@ -400,6 +400,10 @@ func (s *localSite) dialAndForward(params DialParams) (_ net.Conn, retErr error)
 		TargetServer:    params.TargetServer,
 		Clock:           s.clock,
 	}
+	// Ensure the hostname is set correctly if we have details of the target
+	if params.TargetServer != nil {
+		serverConfig.TargetHostname = params.TargetServer.GetHostname()
+	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/reversetunnel/remotesite.go
+++ b/lib/reversetunnel/remotesite.go
@@ -859,6 +859,10 @@ func (s *remoteSite) dialAndForward(params DialParams) (_ net.Conn, retErr error
 		TargetServer:    params.TargetServer,
 		Clock:           s.clock,
 	}
+	// Ensure the hostname is set correctly if we have details of the target
+	if params.TargetServer != nil {
+		serverConfig.TargetHostname = params.TargetServer.GetHostname()
+	}
 	remoteServer, err := forward.New(serverConfig)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Backport of https://github.com/gravitational/teleport/pull/25109.