### PR TITLE
docs: remove non working adopters link

### DIFF
--- a/docs/pages/adopters.mdx
+++ b/docs/pages/adopters.mdx
@@ -24,7 +24,7 @@ Click "Improve the Docs" below and send us a PR.
 | Zapier         | Technology        | Secure access for SSH.                                          |
 | ExtraHop       | Infosec           | [Case study](https://goteleport.com/case-study/extrahop/)       |
 | Twitch         | Technology        | SSH access.                                                     |
-| GitLab         | Technology        | [Team review](https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/11568#note_451982812)|
+| GitLab         | Technology        | Team review                                                     |
 | SumoLogic      | Technology        | Achieve FedRAMP compliance and secure access to infrastructure. |
 | Gladly         | Technology        | [Case study](https://goteleport.com/case-study/gladly/)         |
 | VerticalChange | Technology        | [Testimonial](https://goteleport.com/case-study/verticalchange-testimonial/)|


### PR DESCRIPTION
Removing url.  We can replace if we get a working one later.