### PR TITLE
Allow OktaAssignment action status CLEANUP_FAILED -> CLEANUP_PENDING.

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -336,7 +336,8 @@ func (o *OktaAssignmentActionV1) GetStatus() string {
 // * SUCCESSFUL -> (CLEANUP_PENDING, CLEANUP_PROCESSING)
 // * FAILED -> (PROCESSING, CLEANUP_PENDING, CLEANUP_PROCESSING)
 // * CLEANUP_PENDING -> CLEANUP_PROCESSING
-// * CLEANUP_PROCESSING -> (CLEANUP_FAILED, CLEANED_UP)
+// * CLEANUP_PROCESSING -> (CLEANED_UP, CLEANUP_FAILED)
+// * CLEANUP_FAILED -> (CLEANUP_PENDING)
 func (o *OktaAssignmentActionV1) SetStatus(status string) error {
 	invalidTransition := false
 	switch o.Status {
@@ -384,7 +385,11 @@ func (o *OktaAssignmentActionV1) SetStatus(status string) error {
 	case OktaAssignmentActionV1_CLEANED_UP:
 		invalidTransition = true
 	case OktaAssignmentActionV1_CLEANUP_FAILED:
-		invalidTransition = true
+		switch status {
+		case constants.OktaAssignmentActionStatusCleanupPending:
+		default:
+			invalidTransition = true
+		}
 	case OktaAssignmentActionV1_UNKNOWN:
 		// All transitions are allowed from UNKNOWN.
 	default:

--- a/api/types/okta_test.go
+++ b/api/types/okta_test.go
@@ -107,7 +107,7 @@ func TestOktaAssignments_SetStatus(t *testing.T) {
 		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusProcessing, invalid: true},
 		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusSuccessful, invalid: true},
 		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusFailed, invalid: true},
-		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusCleanupPending, invalid: true},
+		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusCleanupPending},
 		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusCleanupProcessing, invalid: true},
 		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusCleanedUp, invalid: true},
 		{startStatus: constants.OktaAssignmentActionStatusCleanupFailed, nextStatus: constants.OktaAssignmentActionStatusCleanupFailed, invalid: true},


### PR DESCRIPTION
OktaAssignment actions can transition from CLEANUP_FAILED to CLEANUP_PENDING. This will allow for the retry of cleanups in the Okta service.