### PR TITLE
Show <1m for remaining tsh status valid time for last minute

### DIFF
--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -3790,8 +3790,7 @@ func printStatus(debug bool, p *profileInfo, env map[string]string, isActive boo
 	duration := time.Until(p.ValidUntil)
 	if duration.Nanoseconds() > 0 {
 		// Display <1m if less then 1 minute left while valid instead of 0s
-		oneMinuteAhead := time.Now().UTC().Add(1 * time.Minute)
-		if p.ValidUntil.Before(oneMinuteAhead) {
+		if duration < time.Minute {
 			humanDuration = "valid for <1m"
 		} else {
 			humanDuration = fmt.Sprintf("valid for %v", duration.Round(time.Minute))

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -3786,10 +3786,16 @@ func onShow(cf *CLIConf) error {
 // printStatus prints the status of the profile.
 func printStatus(debug bool, p *profileInfo, env map[string]string, isActive bool) {
 	var prefix string
-	duration := time.Until(p.ValidUntil)
 	humanDuration := "EXPIRED"
+	duration := time.Until(p.ValidUntil)
 	if duration.Nanoseconds() > 0 {
-		humanDuration = fmt.Sprintf("valid for %v", duration.Round(time.Minute))
+		// Display <1m if less then 1 minute left while valid instead of 0s
+		oneMinuteAhead := time.Now().UTC().Add(1 * time.Minute)
+		if p.ValidUntil.Before(oneMinuteAhead) {
+			humanDuration = "valid for <1m"
+		} else {
+			humanDuration = fmt.Sprintf("valid for %v", duration.Round(time.Minute))
+		}
 	}
 
 	proxyURL := p.getProxyURLLine(isActive, env)

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -3789,11 +3789,10 @@ func printStatus(debug bool, p *profileInfo, env map[string]string, isActive boo
 	humanDuration := "EXPIRED"
 	duration := time.Until(p.ValidUntil)
 	if duration.Nanoseconds() > 0 {
-		// Display <1m if less then 1 minute left while valid instead of 0s
+		humanDuration = fmt.Sprintf("valid for %v", duration.Round(time.Minute))
+		// If certificate is valid for less than a minute, display "<1m" instead of "0s".
 		if duration < time.Minute {
 			humanDuration = "valid for <1m"
-		} else {
-			humanDuration = fmt.Sprintf("valid for %v", duration.Round(time.Minute))
 		}
 	}
 


### PR DESCRIPTION
Changes from showing 0s from rounding time to showing <1m which is more user friendly.  Currently a user could see `0s` or `1m0s` remaining since it was rounding. 


Ex current:
```text
> Profile URL:        https://teleport.example.com:443
  Logged in as:       steven
  Cluster:            tele1c
  Roles:              access, auditortest, editor, reviewer, ssotester
  Logins:             root, ubuntu, steven
  Kubernetes:         enabled
  Kubernetes groups:  developer-exec, system:masters
  Valid until:        2023-04-25 09:02:45 -0700 PDT [0s]
```

To:

```text
> Profile URL:        https://teleport.example.com:443
  Logged in as:       steven
  Cluster:            tele1c
  Roles:              access, auditortest, editor, reviewer, ssotester
  Logins:             root, ubuntu, steven
  Kubernetes:         enabled
  Kubernetes groups:  developer-exec, system:masters
  Valid until:        2023-04-25 09:02:45 -0700 PDT [<1m]
```


