### PR TITLE
Web: Remove hard coded coloring (mainly for discover related components)

### DIFF
--- a/web/packages/design/src/theme/darkTheme.ts
+++ b/web/packages/design/src/theme/darkTheme.ts
@@ -123,7 +123,7 @@ const colors = {
     ...blueGrey,
   },
 
-  lightgrey: {
+  grey: {
     ...grey,
   },
 

--- a/web/packages/design/src/theme/darkTheme.ts
+++ b/web/packages/design/src/theme/darkTheme.ts
@@ -119,7 +119,7 @@ const colors = {
   dark: '#000000',
   light: '#FFFFFF',
 
-  grey: {
+  blueGrey: {
     ...blueGrey,
   },
 

--- a/web/packages/design/src/theme/darkTheme.ts
+++ b/web/packages/design/src/theme/darkTheme.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { fonts } from './fonts';
 import { getContrastRatio } from './utils/colorManipulator';
-import { lightBlue, blueGrey, yellow } from './palette';
+import { lightBlue, blueGrey, yellow, grey } from './palette';
 import typography, { fontSizes, fontWeights } from './typography';
 import { sharedStyles } from './sharedStyles';
 
@@ -121,6 +121,10 @@ const colors = {
 
   grey: {
     ...blueGrey,
+  },
+
+  lightgrey: {
+    ...grey,
   },
 
   error: {

--- a/web/packages/design/src/theme/lightTheme.ts
+++ b/web/packages/design/src/theme/lightTheme.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { fonts } from './fonts';
 import { getContrastRatio } from './utils/colorManipulator';
-import { lightBlue, blueGrey, yellow } from './palette';
+import { lightBlue, blueGrey, grey, yellow } from './palette';
 import typography, { fontSizes, fontWeights } from './typography';
 import { sharedStyles } from './sharedStyles';
 
@@ -117,6 +117,10 @@ const colors = {
 
   grey: {
     ...blueGrey,
+  },
+
+  lightGrey: {
+    ...grey,
   },
 
   error: {

--- a/web/packages/design/src/theme/lightTheme.ts
+++ b/web/packages/design/src/theme/lightTheme.ts
@@ -119,7 +119,7 @@ const colors = {
     ...blueGrey,
   },
 
-  lightGrey: {
+  grey: {
     ...grey,
   },
 

--- a/web/packages/design/src/theme/lightTheme.ts
+++ b/web/packages/design/src/theme/lightTheme.ts
@@ -115,7 +115,7 @@ const colors = {
   dark: '#000000',
   light: '#FFFFFF',
 
-  grey: {
+  blueGrey: {
     ...blueGrey,
   },
 

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/CommonElements.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/CommonElements.tsx
@@ -56,7 +56,7 @@ export const PathInput = forwardRef<
 
 const StyledFieldInput = styled(FieldInput)`
   input {
-    border: 1px solid rgba(255, 255, 255, 0.1);
+    border: 1px solid ${props => props.theme.colors.text.placeholder};
     background: transparent;
     color: white;
     box-shadow: none;

--- a/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileListItem.tsx
+++ b/web/packages/shared/components/FileTransfer/FileTransferStateless/FileList/FileListItem.tsx
@@ -110,7 +110,7 @@ const Li = styled.li`
 
 const ProgressBackground = styled.div`
   border-radius: 50px;
-  background: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   width: 100%;
 `;
 

--- a/web/packages/teleport/src/Console/Tabs/JoinedUsers/JoinedUsers.jsx
+++ b/web/packages/teleport/src/Console/Tabs/JoinedUsers/JoinedUsers.jsx
@@ -103,7 +103,7 @@ const StyledUsers = styled.div`
   justify-content: center;
   margin-right: 3px;
   background-color: ${props =>
-    props.active ? props.theme.colors.brand : props.theme.colors.grey[900]};
+    props.active ? props.theme.colors.brand : props.theme.colors.blueGrey[900]};
 `;
 
 const StyledAvatar = styled.div`
@@ -121,8 +121,8 @@ const StyledAvatar = styled.div`
 `;
 
 const UserItem = styled.div`
-  border-bottom: 1px solid ${props => props.theme.colors.grey[50]};
-  color: ${props => props.theme.colors.grey[600]};
+  border-bottom: 1px solid ${props => props.theme.colors.blueGrey[50]};
+  color: ${props => props.theme.colors.blueGrey[600]};
   font-size: 12px;
   align-items: center;
   display: flex;

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/RdsDatabaseList.tsx
@@ -168,7 +168,7 @@ const StatusLight = styled(Box)`
     if (status === Status.Warning) {
       return theme.colors.warning;
     }
-    return theme.colors.grey[300]; // Unknown
+    return theme.colors.blueGrey[300]; // Unknown
   }};
 `;
 

--- a/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
+++ b/web/packages/teleport/src/Discover/Database/SetupAccess/SetupAccess.tsx
@@ -392,7 +392,7 @@ function DbEngineInstructions({
 
 const StyledBox = styled(Box)`
   max-width: 800px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   border-radius: 8px;
   padding: 20px;
 `;

--- a/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Database/TestConnection/TestConnection.tsx
@@ -168,7 +168,7 @@ export function TestConnectionView({
 
 const StyledBox = styled(Box)`
   max-width: 800px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   border-radius: 8px;
   padding: 20px;
 `;

--- a/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/HelmChart/HelmChart.tsx
@@ -453,8 +453,7 @@ const InstallHelmChart = ({
 
 const StyledBox = styled(Box)`
   max-width: 1000px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
-  border: 2px solid #2f3659;
 `;

--- a/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Kubernetes/TestConnection/TestConnection.tsx
@@ -205,7 +205,7 @@ export function TestConnection({
 
 const StyledBox = styled(Box)`
   max-width: 800px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   border-radius: 8px;
   padding: 20px;
 `;

--- a/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
+++ b/web/packages/teleport/src/Discover/Server/TestConnection/TestConnection.tsx
@@ -113,7 +113,7 @@ export function TestConnection({
 
 const StyledBox = styled(Box)`
   max-width: 800px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   border-radius: 8px;
   padding: 20px;
 `;

--- a/web/packages/teleport/src/Discover/Shared/CommandBox.tsx
+++ b/web/packages/teleport/src/Discover/Shared/CommandBox.tsx
@@ -21,10 +21,9 @@ import { Box, Text } from 'design';
 
 const Container = styled(Box)`
   max-width: 1000px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
-  border: 2px solid #2f3659;
 `;
 
 interface CommandBoxProps {

--- a/web/packages/teleport/src/Discover/Shared/HintBox.tsx
+++ b/web/packages/teleport/src/Discover/Shared/HintBox.tsx
@@ -25,7 +25,7 @@ import { TextIcon } from 'teleport/Discover/Shared/Text';
 
 const HintBoxContainer = styled(Box)`
   max-width: 1000px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
   border: 2px solid ${props => props.theme.colors.warning}; ;
@@ -33,17 +33,17 @@ const HintBoxContainer = styled(Box)`
 
 export const WaitingInfo = styled(Box)`
   max-width: 1000px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
-  border: 2px solid #2f3659;
+  border: 2px solid ${props => props.theme.colors.text.placeholder};
   display: flex;
   align-items: center;
 `;
 
 export const SuccessInfo = styled(Box)`
   max-width: 1000px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
   border: 2px solid ${props => props.theme.colors.success};

--- a/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.tsx
@@ -18,20 +18,30 @@ import React from 'react';
 import { useTheme } from 'styled-components';
 import ReactSelectCreatable from 'react-select/creatable';
 
+import { StyledSelect } from 'shared/components/Select/Select';
+
 const styles = theme => ({
   multiValue: (base, state) => {
-    return state.data.isFixed ? { ...base, backgroundColor: 'gray' } : base;
+    return state.data.isFixed
+      ? {
+          ...base,
+          backgroundColor: `${theme.colors.lightGrey['600']} !important`,
+        }
+      : base;
   },
   multiValueLabel: (base, state) => {
     if (state.data.isFixed) {
-      return { ...base, color: theme.colors.text.primary, paddingRight: 6 };
+      return {
+        ...base,
+        paddingRight: 6,
+      };
     }
 
     if (state.isDisabled) {
       return { ...base, paddingRight: 6 };
     }
 
-    return { ...base, color: theme.colors.text.primaryInverse };
+    return { ...base };
   },
   multiValueRemove: (base, state) => {
     return state.data.isFixed || state.isDisabled
@@ -39,11 +49,7 @@ const styles = theme => ({
       : {
           ...base,
           cursor: 'pointer',
-          color: theme.colors.text.primaryInverse,
         };
-  },
-  menuList: base => {
-    return { ...base, color: theme.colors.text.primaryInverse };
   },
 });
 
@@ -77,18 +83,21 @@ export const SelectCreatable = ({
 }: SelectCreatableProps) => {
   const theme = useTheme();
   return (
-    <ReactSelectCreatable
-      className="react-select"
-      components={{
-        DropdownIndicator: null,
-      }}
-      styles={styles(theme)}
-      {...rest}
-      isMulti={isMulti}
-      isClearable={isClearable}
-      isDisabled={isDisabled}
-      autoFocus={autoFocus}
-    />
+    <StyledSelect>
+      <ReactSelectCreatable
+        className="react-select-container"
+        classNamePrefix="react-select"
+        components={{
+          DropdownIndicator: null,
+        }}
+        styles={styles(theme)}
+        {...rest}
+        isMulti={isMulti}
+        isClearable={isClearable}
+        isDisabled={isDisabled}
+        autoFocus={autoFocus}
+      />
+    </StyledSelect>
   );
 };
 

--- a/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.tsx
@@ -25,7 +25,7 @@ const styles = theme => ({
     return state.data.isFixed
       ? {
           ...base,
-          backgroundColor: `${theme.colors.lightGrey['600']} !important`,
+          backgroundColor: `${theme.colors.grey['600']} !important`,
         }
       : base;
   },

--- a/web/packages/teleport/src/Discover/Shared/SetupAccess/SetupAccessWrapper.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SetupAccess/SetupAccessWrapper.tsx
@@ -146,7 +146,7 @@ export function SetupAccessWrapper({
 
 const StyledBox = styled(Box)`
   max-width: 700px;
-  background-color: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   border-radius: 8px;
   padding: 20px;
 `;

--- a/web/packages/teleport/src/Discover/Shared/Step.tsx
+++ b/web/packages/teleport/src/Discover/Shared/Step.tsx
@@ -47,7 +47,7 @@ export function Step(props: StepProps) {
 }
 
 export const StepContainer = styled.div`
-  background: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
   border-radius: 8px;
   padding: 16px;
   margin-bottom: 12px;

--- a/web/packages/teleport/src/Integrations/IntegrationList.tsx
+++ b/web/packages/teleport/src/Integrations/IntegrationList.tsx
@@ -157,7 +157,7 @@ const StatusLight = styled(Box)`
     if (status === Status.Warning) {
       return theme.colors.warning.main;
     }
-    return theme.colors.grey[300]; // Unknown
+    return theme.colors.blueGrey[300]; // Unknown
   }};
 `;
 

--- a/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
@@ -51,7 +51,7 @@ const ActiveValue = styled.div<OpenProps>`
   cursor: pointer;
 
   &:focus {
-    background: rgba(255, 255, 255, 0.05);
+    background-color: ${props => props.theme.colors.spotBackground[0]};
   }
 `;
 

--- a/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
+++ b/web/packages/teleport/src/components/EventRangePicker/Custom/Custom.jsx
@@ -106,7 +106,7 @@ const StyledCloseButton = styled.button`
   background: transparent;
   border-radius: 2px;
   border: none;
-  color: ${props => props.theme.colors.grey[900]};
+  color: ${props => props.theme.colors.blueGrey[900]};
   cursor: pointer;
   height: 24px;
   width: 24px;
@@ -121,7 +121,7 @@ const StyledCloseButton = styled.button`
   right: 0px;
 
   &:hover {
-    background: ${props => props.theme.colors.grey[200]};
+    background: ${props => props.theme.colors.blueGrey[200]};
   }
 `;
 

--- a/web/packages/teleport/src/components/Toggle/Toggle.tsx
+++ b/web/packages/teleport/src/components/Toggle/Toggle.tsx
@@ -91,7 +91,7 @@ const StyledInput = styled.input.attrs({ type: 'checkbox' })`
     background: ${props => props.theme.colors.levels.surface};
 
     &:before {
-      background: ${props => props.theme.colors.grey[700]};
+      background: ${props => props.theme.colors.blueGrey[700]};
     }
   }
 `;

--- a/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.story.tsx
+++ b/web/packages/teleport/src/components/ToolTipNoPermBadge/ToolTipNoPermBadge.story.tsx
@@ -47,5 +47,5 @@ const SomeBox = styled.div`
   display: flex;
   position: relative;
   align-items: center;
-  background: rgba(255, 255, 255, 0.05);
+  background-color: ${props => props.theme.colors.spotBackground[0]};
 `;

--- a/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
@@ -16,7 +16,14 @@ limitations under the License.
 
 import { fonts } from 'design/theme/fonts';
 import { getContrastRatio } from 'design/theme/utils/colorManipulator';
-import { lightBlue, teal, pink, blueGrey, yellow } from 'design/theme/palette';
+import {
+  lightBlue,
+  teal,
+  pink,
+  blueGrey,
+  yellow,
+  grey,
+} from 'design/theme/palette';
 import typography, { fontSizes, fontWeights } from 'design/theme/typography';
 import { sharedStyles } from 'design/theme/sharedStyles';
 
@@ -116,6 +123,10 @@ const colors = {
 
   grey: {
     ...blueGrey,
+  },
+
+  lightGrey: {
+    ...grey,
   },
 
   error: {

--- a/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
@@ -121,7 +121,7 @@ const colors = {
     },
   },
 
-  grey: {
+  blueGrey: {
     ...blueGrey,
   },
 

--- a/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
@@ -125,7 +125,7 @@ const colors = {
     ...blueGrey,
   },
 
-  lightGrey: {
+  grey: {
     ...grey,
   },
 

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionStatusIndicator.tsx
@@ -31,7 +31,7 @@ const StyledStatus = styled<Props>(Box)`
     const { $connected, theme } = props;
     const backgroundColor = $connected
       ? theme.colors.success
-      : theme.colors.grey[300];
+      : theme.colors.blueGrey[300];
     return {
       backgroundColor,
     };


### PR DESCRIPTION
I renamed the theme colors (grey -> blueGrey and lightGrey -> grey) to its more appropriate form at the last two commits