### PR TITLE
docs: clarify host labeling for Windows desktops

### DIFF
--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -81,10 +81,65 @@ host_labels:
       environment: prod
 ```
 
-The regular expression provided in the `match` rule above is applied to the desktop's
-name for desktops that are discovered via LDAP. Hosts that are statically defined (in
-the `hosts` or `non_ad_hosts` setions of your configuration) receive an auto-generated
-name, so host label matching applies against the desktop's `addr` in these cases.
+The regular expression provided in the `match` rule above is applied to the
+desktop's name for desktops that are discovered via LDAP. Hosts that are
+statically defined (in the `hosts` or `non_ad_hosts` sections of your
+configuration) receive an auto-generated name, so host label matching applies
+against the desktop's `addr` in these cases.
+
+#### Static hosts
+
+A static host definition of `192.168.1.105` would result in the following
+resource:
+
+```yaml
+kind: windows_desktop
+metadata:
+  expires: "2023-05-01T15:47:21.564561Z"
+  id: 1682955441565783000
+  labels:
+    teleport.dev/ad: "true"
+    teleport.dev/origin: config-file
+  name: 3362ad10b55d-static-192-168-1-105
+spec:
+  addr: 192.68.1.105:3389
+  domain: example.com
+  host_id: 307e091b-7f6b-42e0-b78d-3362ad10b55d
+  non_ad: false
+version: v3
+```
+
+In this case, the regular expression is evaluated against `192.68.1.105:3389`.
+
+#### Discovered hosts
+
+For hosts that are discovered via LDAP (or created by API), the regular expression
+is evaluated against the name.
+
+```yaml
+kind: windows_desktop
+metadata:
+  expires: "2023-05-01T15:47:36.677008Z"
+  id: 1682955456680526000
+  labels:
+    teleport.dev/computer_name: EC2AMAZ-37TSM4L
+    teleport.dev/dns_host_name: EC2AMAZ-37TSM4L.example.com
+    teleport.dev/is_domain_controller: "true"
+    teleport.dev/origin: dynamic
+    teleport.dev/os: Windows Server 2019 Datacenter
+    teleport.dev/os_version: 10.0 (17763)
+    teleport.dev/ou: OU=Domain Controllers,DC=example,DC=com
+    teleport.dev/windows_domain: example.com
+  name: EC2AMAZ-37TSM4L-example-com
+spec:
+  addr: 172.31.9.146:3389
+  domain: example.com
+  host_id: 307e091b-7f6b-42e0-b78d-3362ad10b55d
+  non_ad: false
+version: v3
+```
+
+In this case, the regular expression is evaluated against `EC2AMAZ-37TSM4L-example-com`.
 
 ### Using LDAP
 
@@ -171,8 +226,8 @@ roles that match the desktop. If at least one role matches the desktop but does
 not include `create_desktop_user: true`, automatic user creation will be
 disabled. Roles that do not match the desktop's labels will not be checked.
 
-In order to create the user, the requested username must be present in one of the
-role's `windows_desktop_logins`.
+In order to create the user, the requested username must be present in one of
+the role's `windows_desktop_logins`.
 
 #### User management
 
@@ -203,11 +258,11 @@ spec:
     - '{{external.desktop_groups}}'
 ```
 
-Teleport will never delete users that are created via automatic user provisioning.
-This ensures that the user's profile is preserved for future logins. Teleport will
-disable the account when the session completes (and automatically re-enable it on
-future connection attempts). This ensures that user accounts created by Teleport
-can only be accessed via Teleport.
+Teleport will never delete users that are created via automatic user
+provisioning. This ensures that the user's profile is preserved for future
+logins. Teleport will disable the account when the session completes (and
+automatically re-enable it on future connection attempts). This ensures that
+user accounts created by Teleport can only be accessed via Teleport.
 
 ## Clipboard Access
 

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -73,13 +73,18 @@ label to a Windows desktop named `test.dev.example.com` and the
 
 ```yaml
 host_labels:
-  - match: '^.*\.dev\.example\.com$'
+  - match: '^.*\.dev\.example\.com'
     labels:
       environment: dev
-  - match: '^.*\.prod\.example\.com$'
+  - match: '^.*\.prod\.example\.com'
     labels:
       environment: prod
 ```
+
+The regular expression provided in the `match` rule above is applied to the desktop's
+name for desktops that are discovered via LDAP. Hosts that are statically defined (in
+the `hosts` or `non_ad_hosts` setions of your configuration) receive an auto-generated
+name, so host label matching applies against the desktop's `addr` in these cases.
 
 ### Using LDAP
 


### PR DESCRIPTION
Label rules apply against the desktop's addr for statically defined hosts, which includes the trailing :3389.

Label rules apply against the desktop's hostname for desktops discovered via LDAP.