### PR TITLE
Use the GHA base container for Lint (Docs)

### DIFF
--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -41,13 +41,26 @@ jobs:
         # of gravitational/teleport. We override this in order to build only a
         # single version of the docs.
         run: |
+          if [ $GITHUB_EVENT_NAME = "pull_request" ]; then
+            BRANCH=$GITHUB_HEAD_REF;
+          elif [ $GITHUB_EVENT_NAME = "merge_group" ]; then
+            # GitHub populates $GITHUB_REF with:
+            # refs/heads/gh-readonly-queue/<base branch>/pr-<PR number>-<SHA>
+            #
+            # We strip the "refs/heads/" prefix so we can check out the branch.
+            BRANCH=$(echo $GITHUB_REF | sed -E "s|refs/heads/(.*)|\1|")
+          else
+            echo "Unexpected event name: $GITHUB_EVENT_NAME";
+            exit 1;
+          fi
+
           cd $GITHUB_WORKSPACE/docs
           echo "" > .gitmodules
           rm -rf content/*
           cd content
-          git submodule add --force -b $GITHUB_SHA -- https://github.com/gravitational/teleport
+          git submodule add --force -b $BRANCH -- https://github.com/gravitational/teleport
           cd $GITHUB_WORKSPACE/docs
-          echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"$GITHUB_SHA\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
+          echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"$BRANCH\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
           yarn install
           yarn build-node
 

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -19,30 +19,43 @@ jobs:
     permissions:
       contents: read
 
-    container:
-      image: ghcr.io/gravitational/docs:latest
-      volumes:
-        - ${{ github.workspace }}:/src/content/docs
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: "gravitational/docs"
+          path: "docs"
 
       - name: Prepare docs site configuration
+        # The environment we use for linting the docs differs from the one we
+        # use for the live docs site in that we only test a single version of
+        # the content.
+        #
+        # To do this, we replace the three submodules we use for building the
+        # live docs site with a single submodule, pointing to the
+        # gravitational/teleport branch we are linting.
+        #
         # The docs engine expects a config.json file at the root of the
         # gravitational/docs clone that associates directories with git
-        # submodules. 
-        #
-        # By default, these directories represent versioned branches
+        # submodules. By default, these directories represent versioned branches
         # of gravitational/teleport. We override this in order to build only a
         # single version of the docs.
-        run: 'echo "{\"versions\": [{\"name\": \"docs\", \"branch\": \"$GITHUB_REF_NAME\", \"deprecated\": false}]}" > /src/config.json'
+        run: |
+          cd $GITHUB_WORKSPACE/docs
+          echo "" > .gitmodules
+          rm -rf content/*
+          cd content
+          git submodule add --force -b $GITHUB_HEAD_REF -- https://github.com/gravitational/teleport
+          cd $GITHUB_WORKSPACE/docs
+          echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"$GITHUB_HEAD_REF\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
+          yarn install
+          yarn build-node
 
       - name: Check spelling
-        run: cd /src && yarn spellcheck /src/content/docs
+        run: cd $GITHUB_WORKSPACE/docs && yarn spellcheck content/teleport
 
       - name: Lint the docs
-        run: cd /src && yarn markdown-lint
+        run: cd $GITHUB_WORKSPACE/docs && yarn markdown-lint
 
       - name: Test the docs build
-        run: cd /src && yarn install && yarn build
+        run: cd $GITHUB_WORKSPACE/docs && yarn install && yarn build

--- a/.github/workflows/doc-tests.yaml
+++ b/.github/workflows/doc-tests.yaml
@@ -45,9 +45,9 @@ jobs:
           echo "" > .gitmodules
           rm -rf content/*
           cd content
-          git submodule add --force -b $GITHUB_HEAD_REF -- https://github.com/gravitational/teleport
+          git submodule add --force -b $GITHUB_SHA -- https://github.com/gravitational/teleport
           cd $GITHUB_WORKSPACE/docs
-          echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"$GITHUB_HEAD_REF\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
+          echo "{\"versions\": [{\"name\": \"teleport\", \"branch\": \"$GITHUB_SHA\", \"deprecated\": false}]}" > $GITHUB_WORKSPACE/docs/config.json
           yarn install
           yarn build-node
 


### PR DESCRIPTION
This way, we can take advantage of the software the comes pre-installed on the GHA `ubuntu-latest` container image. Otherwise, we need to find a way to portably install Chromium on the `gravitational/docs` container in order to run the Mermaid CLI. Currently, the docs engine exits with an error during the "Lint (Docs)" job when attempting to build mermaid diagrams due to not being able to locate Chromium.

For this change to work, the "Lint (Docs)" job checks out `gravitational/docs`, removes the default git submodule configuration, then adds a git submodule for the current `gravitational/teleport` branch. From there, it can install dependencies via `yarn` and run our CI scripts.

**Reviewer note:** Here is a successful `Lint (Docs)` run: https://github.com/gravitational/teleport/actions/runs/4768585354/jobs/8478204853