### PR TITLE
Close search bar in Connect on blur

### DIFF
--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -323,7 +323,6 @@ const getMockedSearchContext = (): SearchContext.SearchContext => ({
   isOpen: true,
   open: () => {},
   close: () => {},
-  closeAndResetInput: () => {},
   resetInput: () => {},
   changeActivePicker: () => {},
   onInputValueChange: () => {},

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -363,7 +363,7 @@ const getMockedSearchContext = (): SearchContext.SearchContext => ({
   closeWithoutRestoringFocus: () => {},
   resetInput: () => {},
   changeActivePicker: () => {},
-  onInputValueChange: () => {},
+  setInputValue: () => {},
   activePicker: pickers.actionPicker,
   inputRef: undefined,
   pauseUserInteraction: async cb => {

--- a/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.test.tsx
@@ -16,7 +16,7 @@
 
 import React from 'react';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from 'design/utils/testing';
+import { render, screen, waitFor, act } from 'design/utils/testing';
 import { makeSuccessAttempt } from 'shared/hooks/useAsync';
 
 import Logger, { NullService } from 'teleterm/logger';
@@ -315,6 +315,43 @@ it('shows a login modal when a request to a cluster from the current workspace f
   expect(screen.getByRole('menu')).toBeInTheDocument();
 });
 
+it('closes on a click on an unfocusable element outside of the search bar', async () => {
+  const user = userEvent.setup();
+  const cluster = makeRootCluster();
+  const resourceSearchResult = {
+    results: [],
+    errors: [],
+    search: 'foo',
+  };
+  const resourceSearch = async () => resourceSearchResult;
+  jest
+    .spyOn(useSearch, 'useResourceSearch')
+    .mockImplementation(() => resourceSearch);
+
+  const appContext = new MockAppContext();
+  appContext.workspacesService.setState(draft => {
+    draft.rootClusterUri = cluster.uri;
+  });
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(cluster.uri, cluster);
+  });
+
+  render(
+    <MockAppContextProvider appContext={appContext}>
+      <SearchBarConnected />
+      <p data-testid="unfocusable-element">Lorem ipsum</p>
+    </MockAppContextProvider>
+  );
+
+  await user.type(screen.getByRole('searchbox'), 'foo');
+  expect(screen.getByRole('menu')).toBeInTheDocument();
+
+  act(() => {
+    screen.getByTestId('unfocusable-element').click();
+  });
+  expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+});
+
 const getMockedSearchContext = (): SearchContext.SearchContext => ({
   inputValue: 'foo',
   filters: [],
@@ -323,6 +360,7 @@ const getMockedSearchContext = (): SearchContext.SearchContext => ({
   isOpen: true,
   open: () => {},
   close: () => {},
+  closeWithoutRestoringFocus: () => {},
   resetInput: () => {},
   changeActivePicker: () => {},
   onInputValueChange: () => {},
@@ -334,4 +372,5 @@ const getMockedSearchContext = (): SearchContext.SearchContext => ({
   addWindowEventListener: () => ({
     cleanup: () => {},
   }),
+  makeEventListener: cb => cb,
 });

--- a/web/packages/teleterm/src/ui/Search/SearchBar.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.tsx
@@ -71,19 +71,22 @@ function SearchBar() {
     },
   });
 
+  // Handle outside click when the search bar is open.
   useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
     const onClickOutside = e => {
       if (!e.composedPath().includes(containerRef.current)) {
         close();
       }
     };
 
-    if (isOpen) {
-      const { cleanup } = addWindowEventListener('click', onClickOutside, {
-        capture: true,
-      });
-      return cleanup;
-    }
+    const { cleanup } = addWindowEventListener('click', onClickOutside, {
+      capture: true,
+    });
+    return cleanup;
   }, [close, isOpen, addWindowEventListener]);
 
   // closeIfAnotherElementReceivedFocus handles a scenario where the focus shifts from the search

--- a/web/packages/teleterm/src/ui/Search/SearchBar.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.tsx
@@ -128,7 +128,11 @@ function SearchBar() {
       )}
       {isOpen && (
         <activePicker.picker
-          // autofocusing cannot be done in `open` function as it would focus the input from closed state
+          // When the search bar transitions from closed to open state, `inputRef.current` within
+          // the `open` function refers to the input element from when the search bar was closed.
+          //
+          // Thus, calling `focus()` on it would have no effect. Instead, we add `autoFocus` on the
+          // input when the search bar is open.
           input={<Input {...defaultInputProps} autoFocus={true} />}
         />
       )}

--- a/web/packages/teleterm/src/ui/Search/SearchBar.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchBar.tsx
@@ -53,7 +53,7 @@ function SearchBar() {
   const {
     activePicker,
     inputValue,
-    onInputValueChange,
+    setInputValue,
     inputRef,
     isOpen,
     open,
@@ -125,7 +125,7 @@ function SearchBar() {
     placeholder: activePicker.placeholder,
     value: inputValue,
     onChange: e => {
-      onInputValueChange(e.target.value);
+      setInputValue(e.target.value);
     },
     onFocus: (e: React.FocusEvent) => {
       open(e.relatedTarget);

--- a/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
@@ -146,11 +146,12 @@ describe('addWindowEventListener', () => {
 describe('open', () => {
   it('manages the focus properly when called with no arguments', () => {
     const SearchInput = () => {
-      const { inputRef, open, close } = useSearchContext();
+      const { inputRef, isOpen, open, close } = useSearchContext();
 
       return (
         <>
           <input data-testid="search-input" ref={inputRef} />
+          <div data-testid="is-open">{String(isOpen)}</div>
           <button data-testid="open" onClick={() => open()} />
           <button data-testid="close" onClick={() => close()} />
         </>
@@ -168,11 +169,11 @@ describe('open', () => {
     );
 
     const otherInput = screen.getByTestId('other-input');
-    const searchInput = screen.getByTestId('search-input');
     otherInput.focus();
 
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
     screen.getByTestId('open').click();
-    expect(searchInput).toHaveFocus();
+    expect(screen.getByTestId('is-open')).toHaveTextContent('true');
 
     screen.getByTestId('close').click();
     expect(otherInput).toHaveFocus();

--- a/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.test.tsx
@@ -179,3 +179,49 @@ describe('open', () => {
     expect(otherInput).toHaveFocus();
   });
 });
+
+describe('close', () => {
+  it('restores focus on the previously active element', () => {
+    const previouslyActive = {
+      focus: jest.fn(),
+    } as unknown as HTMLInputElement;
+    const { result } = renderHook(() => useSearchContext(), {
+      wrapper: ({ children }) => (
+        <SearchContextProvider>{children}</SearchContextProvider>
+      ),
+    });
+
+    act(() => {
+      result.current.open(previouslyActive);
+    });
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(previouslyActive.focus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('closeWithoutRestoringFocus', () => {
+  it('does not restore focus on the previously active element', () => {
+    const previouslyActive = {
+      focus: jest.fn(),
+    } as unknown as HTMLInputElement;
+    const { result } = renderHook(() => useSearchContext(), {
+      wrapper: ({ children }) => (
+        <SearchContextProvider>{children}</SearchContextProvider>
+      ),
+    });
+
+    act(() => {
+      result.current.open(previouslyActive);
+    });
+
+    act(() => {
+      result.current.closeWithoutRestoringFocus();
+    });
+
+    expect(previouslyActive.focus).not.toHaveBeenCalled();
+  });
+});

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -88,7 +88,8 @@ export const SearchContextProvider: FC = props => {
       'focus' in previouslyActive.current &&
       typeof previouslyActive.current.focus === 'function'
     ) {
-      previouslyActive.current.focus();
+      // TODO(ravicious): Revert this to a regular `focus()` call once #25683 gets merged.
+      previouslyActive.current['focus']();
     }
   }, []);
 

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -84,12 +84,10 @@ export const SearchContextProvider: FC = props => {
     if (
       // The Element type is not guaranteed to have the focus function so we're forced to manually
       // perform the type check.
-      previouslyActive.current &&
-      'focus' in previouslyActive.current &&
-      typeof previouslyActive.current.focus === 'function'
+      previouslyActive.current
     ) {
-      // TODO(ravicious): Revert this to a regular `focus()` call once #25683 gets merged.
-      previouslyActive.current['focus']();
+      // TODO(ravicious): Revert to a regular `focus()` call (#25186@4f9077eb7) once #25683 gets in.
+      previouslyActive.current['focus']?.();
     }
   }, []);
 

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -58,7 +58,8 @@ export type AddWindowEventListener = (
 const SearchContext = createContext<SearchContext>(null);
 
 export const SearchContextProvider: FC = props => {
-  const previouslyActive = useRef<HTMLElement>();
+  // The type of the ref is Element to adhere to the type of document.activeElement.
+  const previouslyActive = useRef<Element>();
   const inputRef = useRef<HTMLInputElement>();
   const [isOpen, setIsOpen] = useState(false);
   const [inputValue, setInputValue] = useState('');
@@ -80,7 +81,13 @@ export const SearchContextProvider: FC = props => {
   const close = useCallback(() => {
     setIsOpen(false);
     setActivePicker(actionPicker);
-    if (previouslyActive.current) {
+    if (
+      // The Element type is not guaranteed to have the focus function so we're forced to manually
+      // perform the type check.
+      previouslyActive.current &&
+      'focus' in previouslyActive.current &&
+      typeof previouslyActive.current.focus === 'function'
+    ) {
       previouslyActive.current.focus();
     }
   }, []);
@@ -107,8 +114,7 @@ export const SearchContextProvider: FC = props => {
       return;
     }
 
-    previouslyActive.current =
-      fromElement || (document.activeElement as HTMLElement);
+    previouslyActive.current = fromElement || document.activeElement;
     setIsOpen(true);
   }
 

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -38,7 +38,6 @@ export interface SearchContext {
   isOpen: boolean;
   open(fromElement?: Element): void;
   close(): void;
-  closeAndResetInput(): void;
   resetInput(): void;
   setFilter(filter: SearchFilter): void;
   removeFilter(filter: SearchFilter): void;
@@ -81,11 +80,6 @@ export const SearchContextProvider: FC = props => {
       previouslyActive.current.focus();
     }
   }, []);
-
-  const closeAndResetInput = useCallback(() => {
-    close();
-    setInputValue('');
-  }, [close]);
 
   const resetInput = useCallback(() => {
     setInputValue('');
@@ -197,7 +191,6 @@ export const SearchContextProvider: FC = props => {
         isOpen,
         open,
         close,
-        closeAndResetInput,
         pauseUserInteraction,
         addWindowEventListener,
       }}

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -33,7 +33,7 @@ export interface SearchContext {
   inputValue: string;
   filters: SearchFilter[];
   activePicker: SearchPicker;
-  onInputValueChange(value: string): void;
+  setInputValue(value: string): void;
   changeActivePicker(picker: SearchPicker): void;
   isOpen: boolean;
   open(fromElement?: Element): void;
@@ -208,7 +208,7 @@ export const SearchContextProvider: FC = props => {
       value={{
         inputRef,
         inputValue,
-        onInputValueChange: setInputValue,
+        setInputValue,
         changeActivePicker,
         activePicker,
         filters,

--- a/web/packages/teleterm/src/ui/Search/SearchContext.tsx
+++ b/web/packages/teleterm/src/ui/Search/SearchContext.tsx
@@ -90,14 +90,15 @@ export const SearchContextProvider: FC = props => {
       // Even if the search bar is already open, we want to focus on the input anyway. The search
       // input might lose focus due to user interaction while the search bar stays open. Focusing
       // here again makes it possible to use the shortcut to grant the focus to the input again.
+      //
+      // Also note that SearchBar renders two distinct input elements, one when the search bar is
+      // closed and another when its open. During the initial call to this function,
+      // inputRef.current is equal to the element from when the search bar was closed.
       inputRef.current?.focus();
       return;
     }
 
-    // In case `open` was called without `fromElement` (e.g. when using the keyboard shortcut), we
-    // must read `document.activeElement` before we focus the input.
     previouslyActive.current = fromElement || document.activeElement;
-    inputRef.current?.focus();
     setIsOpen(true);
   }
 

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -69,7 +69,6 @@ export function ActionPicker(props: { input: ReactElement }) {
     close,
     inputValue,
     resetInput,
-    closeAndResetInput,
     filters,
     removeFilter,
     addWindowEventListener,
@@ -112,17 +111,16 @@ export function ActionPicker(props: { input: ReactElement }) {
         // Overall, the context should probably encapsulate more logic so that the components don't
         // have to worry about low-level stuff such as input state. Input state already lives in the
         // search context so it should be managed from there, if possible.
-        if (action.preventAutoClose === true) {
-          resetInput();
-        } else {
-          closeAndResetInput();
+        resetInput();
+        if (!action.preventAutoClose) {
+          close();
         }
       }
       if (action.type === 'parametrized-action') {
         changeActivePicker(getParameterPicker(action));
       }
     },
-    [changeActivePicker, closeAndResetInput, resetInput]
+    [changeActivePicker, close, resetInput]
   );
 
   const filterButtons = filters.map(s => {

--- a/web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ParameterPicker.tsx
@@ -37,7 +37,7 @@ interface ParameterPickerProps {
 export function ParameterPicker(props: ParameterPickerProps) {
   const {
     inputValue,
-    closeAndResetInput,
+    close,
     changeActivePicker,
     resetInput,
     addWindowEventListener,
@@ -62,13 +62,13 @@ export function ParameterPicker(props: ParameterPickerProps) {
   const onPick = useCallback(
     (item: string) => {
       props.action.perform(item);
-      if (props.action.preventAutoClose === true) {
-        resetInput();
-      } else {
-        closeAndResetInput();
+
+      resetInput();
+      if (!props.action.preventAutoClose) {
+        close();
       }
     },
-    [closeAndResetInput, resetInput, props.action]
+    [close, resetInput, props.action]
   );
 
   const onBack = useCallback(() => {


### PR DESCRIPTION
Adding `onBlur` to the search input fixes two scenarios:

* Pressing the shortcut to open a new terminal tab while the search bar is open now automatically closes the search bar.
* It is now possible to tab out of the search bar.
   * I don't 100% understand what the problem was before. Matter of fact is that pressing Tab while the input was focused did result on the input receiving a blur event, but the input was receiving focus back again. Since we had `onFocus` on the overall search bar container and not the input itself, I imagine it might have went like this:
      * You click on the search bar.
      * `onFocus` on the search bar container gets called.
      * `open` gets called, rendering a new input with `autoFocus`.
      * The new input gets focused.
      * Pressing Tab at this point blurs the input and shifts focus to another element within the search bar.
      * `onFocus` of the search bar container gets triggered again.
   * I haven't verified this though.