### PR TITLE
Defer users' certificate request for Kube Access

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -890,3 +890,30 @@ func (r *ImpersonatorRoundTripper) CloseIdleConnections() {
 		c.CloseIdleConnections()
 	}
 }
+
+// IdentityForwardingHeaders returns a copy of the provided headers with
+// the TeleportImpersonateUserHeader and TeleportImpersonateIPHeader headers
+// set to the identity provided.
+// The returned headers shouln't be used across requests as they contain
+// the client's IP address and the user's identity.
+func IdentityForwardingHeaders(ctx context.Context, originalHeaders http.Header) (http.Header, error) {
+	identity, err := authz.UserFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	b, err := json.Marshal(identity.GetIdentity())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	headers := originalHeaders.Clone()
+	headers.Set(TeleportImpersonateUserHeader, string(b))
+
+	clientSrcAddr, err := authz.ClientAddrFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	headers.Set(TeleportImpersonateIPHeader, clientSrcAddr.String())
+	return headers, nil
+}

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -187,11 +187,6 @@ func extractKubeCreds(ctx context.Context, cluster string, clientCfg *rest.Confi
 // newDirectTransports creates a new http.Transport that will be used to connect to the Kubernetes API server.
 // It is a direct connection, not going through a proxy.
 func newDirectTransports(tlsConfig *tls.Config, transportConfig *transport.Config) (httpTransport, error) {
-	h1Transport, err := wrapTransport(newH1Transport(tlsConfig, nil), transportConfig)
-	if err != nil {
-		return httpTransport{}, trace.Wrap(err)
-	}
-
 	h2HTTPTransport, err := newH2Transport(tlsConfig, nil)
 	if err != nil {
 		return httpTransport{}, trace.Wrap(err)
@@ -202,8 +197,7 @@ func newDirectTransports(tlsConfig *tls.Config, transportConfig *transport.Confi
 	}
 
 	return httpTransport{
-		h1Transport: h1Transport,
-		h2Transport: h2Transport,
+		transport: h2Transport,
 	}, nil
 }
 

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	mathrand "math/rand"
 	"net"
 	"net/http"
 	"path/filepath"
@@ -480,21 +479,12 @@ func (c *authContext) eventUserMetaWithLogin(login string) apievents.UserMetadat
 	return meta
 }
 
-type dialFunc func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error)
-
 // teleportClusterClient is a client for either a k8s endpoint in local cluster or a
 // proxy endpoint in a remote cluster.
 type teleportClusterClient struct {
-	remoteAddr     utils.NetAddr
-	name           string
-	dial           dialFunc
-	isRemote       bool
-	isRemoteClosed func() bool
-}
-
-// dialEndpoint dials a connection to a kube cluster using the given kube cluster endpoint
-func (c *teleportClusterClient) dialEndpoint(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
-	return c.dial(ctx, network, endpoint)
+	remoteAddr utils.NetAddr
+	name       string
+	isRemote   bool
 }
 
 // handlerWithAuthFunc is http handler with passed auth context
@@ -804,124 +794,6 @@ func (f *Forwarder) setupContext(ctx context.Context, authCtx authz.Context, req
 		}
 	}
 
-	clientSrc, clientDst := utils.ClientAddrFromContext(req.Context())
-
-	forwarderType := f.cfg.KubeServiceType
-
-	// Get a dialer for either a k8s endpoint in current cluster or a tunneled
-	// endpoint for a leaf teleport cluster.
-	var dialFn dialFunc
-	var isRemoteClosed func() bool
-	if isRemoteCluster {
-		// Tunnel is nil for a teleport process with "kubernetes_service" but
-		// not "proxy_service".
-		if f.cfg.ReverseTunnelSrv == nil {
-			return nil, trace.BadParameter("this Teleport process can not dial Kubernetes endpoints in remote Teleport clusters; only proxy_service supports this, make sure a Teleport proxy is first in the request path")
-		}
-
-		targetCluster, err := f.cfg.ReverseTunnelSrv.GetSite(teleportClusterName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		dialFn = func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
-			_, span := f.cfg.tracer.Start(
-				ctx,
-				"kube.Forwarder/setupContext.dialFn.remote_cluster",
-				oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-				oteltrace.WithAttributes(
-					semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
-					semconv.RPCMethodKey.String("reverse_tunnel.Dial"),
-					semconv.RPCSystemKey.String("kube"),
-				),
-			)
-			defer span.End()
-			return targetCluster.DialTCP(reversetunnel.DialParams{
-				From:                  &utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
-				To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: endpoint.addr},
-				ConnType:              types.KubeTunnel,
-				ServerID:              endpoint.serverID,
-				ProxyIDs:              endpoint.proxyIDs,
-				OriginalClientDstAddr: clientDst,
-			})
-		}
-		isRemoteClosed = targetCluster.IsClosed
-	} else if f.cfg.ReverseTunnelSrv != nil {
-		// Not a remote cluster and we have a reverse tunnel server.
-		// Use the local reversetunnel.Site which knows how to dial by serverID
-		// (for "kubernetes_service" connected over a tunnel) and falls back to
-		// direct dial if needed.
-		localCluster, err := f.cfg.ReverseTunnelSrv.GetSite(f.cfg.ClusterName)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		dialFn = func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
-			_, span := f.cfg.tracer.Start(
-				ctx,
-				"kube.Forwarder/setupContext.dialFn.reverse_tunnel",
-				oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-				oteltrace.WithAttributes(
-					semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
-					semconv.RPCMethodKey.String("reverse_tunnel.Dial"),
-					semconv.RPCSystemKey.String("kube"),
-				),
-			)
-			defer span.End()
-
-			// Make sure we will only send signed PROXY headers to teleport kube service node, not real kube cluster
-			if forwarderType != ProxyService && endpoint.serverID == "" {
-				clientDst = nil
-			}
-			return localCluster.DialTCP(reversetunnel.DialParams{
-				From:                  &utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
-				To:                    &utils.NetAddr{AddrNetwork: "tcp", Addr: endpoint.addr},
-				ConnType:              types.KubeTunnel,
-				ServerID:              endpoint.serverID,
-				ProxyIDs:              endpoint.proxyIDs,
-				OriginalClientDstAddr: clientDst,
-			})
-		}
-		isRemoteClosed = localCluster.IsClosed
-	} else {
-		// Don't have a reverse tunnel server, so we can only dial directly.
-		dialFn = func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
-			ctx, span := f.cfg.tracer.Start(
-				ctx,
-				"kube.Forwarder/setupContext.dialFn.direct",
-				oteltrace.WithSpanKind(oteltrace.SpanKindClient),
-				oteltrace.WithAttributes(
-					semconv.RPCServiceKey.String(f.cfg.KubeServiceType),
-					semconv.RPCMethodKey.String("direct.Dial"),
-					semconv.RPCSystemKey.String("kube"),
-				),
-			)
-			defer span.End()
-			conn, err := new(net.Dialer).DialContext(ctx, network, endpoint.addr)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-
-			// Make sure we will only send signed PROXY headers to teleport kube service node, not real kube cluster
-			if forwarderType != ProxyService && endpoint.serverID == "" {
-				clientDst = nil
-			}
-			// Teleport proxy will send signed PROXY headers to the kube service
-			if f.cfg.PROXYSigner != nil && clientSrc != nil && clientDst != nil {
-				signedHeader, err := f.cfg.PROXYSigner.SignPROXYHeader(clientSrc, clientDst)
-				if err != nil {
-					return nil, trace.Wrap(err, "could not create signed PROXY header")
-				}
-				if _, err := conn.Write(signedHeader); err != nil {
-					return nil, trace.Wrap(err, "could not write signed PROXY header into connection")
-				}
-			}
-
-			return conn, nil
-		}
-		isRemoteClosed = func() bool { return false }
-	}
-
 	netConfig, err := f.cfg.CachingAuthClient.GetClusterNetworkingConfig(f.ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -946,11 +818,9 @@ func (f *Forwarder) setupContext(ctx context.Context, authCtx authz.Context, req
 		certExpires:           identity.Expires,
 		disconnectExpiredCert: srv.GetDisconnectExpiredCertFromIdentity(roles, authPref, &identity),
 		teleportCluster: teleportClusterClient{
-			name:           teleportClusterName,
-			remoteAddr:     utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
-			dial:           dialFn,
-			isRemote:       isRemoteCluster,
-			isRemoteClosed: isRemoteClosed,
+			name:       teleportClusterName,
+			remoteAddr: utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
+			isRemote:   isRemoteCluster,
 		},
 		httpMethod:  req.Method,
 		kubeServers: kubeServers,
@@ -1393,9 +1263,20 @@ func (f *Forwarder) deleteSession(id uuid.UUID) {
 
 // remoteJoin forwards a join request to a remote cluster.
 func (f *Forwarder) remoteJoin(ctx *authContext, w http.ResponseWriter, req *http.Request, p httprouter.Params, sess *clusterSession) (resp any, err error) {
+	tlsConfig, impersonationHeaders, err := f.getTLSConfig(sess)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	dialer := &websocket.Dialer{
-		TLSClientConfig: sess.tlsConfig,
+		TLSClientConfig: tlsConfig,
 		NetDialContext:  sess.DialWithContext,
+	}
+
+	headers := req.Header
+	if impersonationHeaders {
+		if headers, err = auth.IdentityForwardingHeaders(req.Context(), req.Header); err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	url := "wss://" + req.URL.Host
@@ -1404,7 +1285,7 @@ func (f *Forwarder) remoteJoin(ctx *authContext, w http.ResponseWriter, req *htt
 	}
 	url = url + req.URL.Path
 
-	wsTarget, respTarget, err := dialer.Dial(url, nil)
+	wsTarget, respTarget, err := dialer.DialContext(req.Context(), url, headers)
 	if err != nil {
 		msg, err := io.ReadAll(respTarget.Body)
 		if err != nil {
@@ -1852,7 +1733,7 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 		return nil, trace.Wrap(err)
 	}
 
-	dialer, err := f.getDialer(*authCtx, sess, req)
+	dialer, err := f.getSPDYDialer(*authCtx, sess, req)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2132,13 +2013,18 @@ func (f *Forwarder) catchAll(authCtx *authContext, w http.ResponseWriter, req *h
 }
 
 func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http.Request) (remotecommand.Executor, error) {
+	tlsConfig, useImpersonation, err := f.getTLSConfig(sess)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	upgradeRoundTripper := NewSpdyRoundTripperWithDialer(roundTripperConfig{
-		ctx:             req.Context(),
-		authCtx:         ctx,
-		dial:            sess.DialWithContext,
-		tlsConfig:       sess.tlsConfig,
-		pingPeriod:      f.cfg.ConnPingPeriod,
-		originalHeaders: req.Header,
+		ctx:                   req.Context(),
+		authCtx:               ctx,
+		dialWithContext:       sess.DialWithContext,
+		tlsConfig:             tlsConfig,
+		pingPeriod:            f.cfg.ConnPingPeriod,
+		originalHeaders:       req.Header,
+		useIdentityForwarding: useImpersonation,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
 	if sess.kubeAPICreds != nil {
@@ -2153,14 +2039,23 @@ func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http
 	return remotecommand.NewSPDYExecutorForTransports(rt, upgradeRoundTripper, req.Method, req.URL)
 }
 
-func (f *Forwarder) getDialer(ctx authContext, sess *clusterSession, req *http.Request) (httpstream.Dialer, error) {
+// getSPDYDialer returns a dialer that can be used to upgrade the connection
+// to SPDY protocol.
+// SPDY is a deprecated protocol, but it is still used by kubectl to manage data streams.
+// The dialer uses an HTTP1.1 connection to upgrade to SPDY.
+func (f *Forwarder) getSPDYDialer(ctx authContext, sess *clusterSession, req *http.Request) (httpstream.Dialer, error) {
+	tlsConfig, useImpersonation, err := f.getTLSConfig(sess)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	upgradeRoundTripper := NewSpdyRoundTripperWithDialer(roundTripperConfig{
-		ctx:             req.Context(),
-		authCtx:         ctx,
-		dial:            sess.DialWithContext,
-		tlsConfig:       sess.tlsConfig,
-		pingPeriod:      f.cfg.ConnPingPeriod,
-		originalHeaders: req.Header,
+		ctx:                   req.Context(),
+		authCtx:               ctx,
+		dialWithContext:       sess.DialWithContext,
+		tlsConfig:             tlsConfig,
+		pingPeriod:            f.cfg.ConnPingPeriod,
+		originalHeaders:       req.Header,
+		useIdentityForwarding: useImpersonation,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
 	if sess.kubeAPICreds != nil {
@@ -2186,12 +2081,11 @@ type clusterSession struct {
 	// It is non-nil if the kubernetes cluster is served by this teleport service,
 	// nil otherwise.
 	kubeAPICreds kubeCreds
-	tlsConfig    *tls.Config
 	forwarder    *forward.Forwarder
 	// noAuditEvents is true if this teleport service should leave audit event
 	// logging to another service.
-	noAuditEvents        bool
-	kubeClusterEndpoints []kubeClusterEndpoint
+	noAuditEvents bool
+	targetAddr    string
 	// kubeAddress is the address of this session's active connection (if there is one)
 	kubeAddress string
 	// upgradeToHTTP2 indicates whether the transport should be configured to use HTTP2.
@@ -2200,6 +2094,8 @@ type clusterSession struct {
 	upgradeToHTTP2 bool
 	// monitorCancel is the conn monitor monitorCancel function.
 	monitorCancel context.CancelFunc
+	// requestContext is the context of the original request.
+	requestContext context.Context
 }
 
 // close cancels the connection monitor context if available.
@@ -2207,18 +2103,6 @@ func (s *clusterSession) close() {
 	if s.monitorCancel != nil {
 		s.monitorCancel()
 	}
-}
-
-// kubeClusterEndpoint can be used to connect to a kube cluster
-type kubeClusterEndpoint struct {
-	// addr is a direct network address.
-	addr string
-	// serverID is the server:cluster ID of the endpoint,
-	// which is used to find its corresponding reverse tunnel.
-	serverID string
-	// proxyIDs is the list of proxy ids that the cluster is
-	// connected to.
-	proxyIDs []string
 }
 
 func (s *clusterSession) monitorConn(conn net.Conn, err error) (net.Conn, error) {
@@ -2262,7 +2146,7 @@ func (s *clusterSession) monitorConn(conn net.Conn, err error) (net.Conn, error)
 }
 
 func (s *clusterSession) Dial(network, addr string) (net.Conn, error) {
-	return s.monitorConn(s.dial(context.Background(), network))
+	return s.monitorConn(s.dial(s.requestContext, network))
 }
 
 func (s *clusterSession) DialWithContext(ctx context.Context, network, addr string) (net.Conn, error) {
@@ -2270,28 +2154,11 @@ func (s *clusterSession) DialWithContext(ctx context.Context, network, addr stri
 }
 
 func (s *clusterSession) dial(ctx context.Context, network string) (net.Conn, error) {
-	if len(s.kubeClusterEndpoints) == 0 {
-		return nil, trace.BadParameter("no kube services to dial")
-	}
+	dialer := s.parent.getContextDialerFunc(s)
 
-	// Shuffle endpoints to balance load
-	shuffledEndpoints := make([]kubeClusterEndpoint, len(s.kubeClusterEndpoints))
-	copy(shuffledEndpoints, s.kubeClusterEndpoints)
-	mathrand.Shuffle(len(shuffledEndpoints), func(i, j int) {
-		shuffledEndpoints[i], shuffledEndpoints[j] = shuffledEndpoints[j], shuffledEndpoints[i]
-	})
+	conn, err := dialer(ctx, network, s.targetAddr)
 
-	errs := []error{}
-	for _, endpoint := range shuffledEndpoints {
-		conn, err := s.teleportCluster.dialEndpoint(ctx, network, endpoint)
-		if err != nil {
-			errs = append(errs, err)
-			continue
-		}
-		s.kubeAddress = endpoint.addr
-		return conn, nil
-	}
-	return nil, trace.NewAggregate(errs...)
+	return conn, trace.Wrap(err)
 }
 
 // TODO(awly): unit test this
@@ -2315,12 +2182,6 @@ func (f *Forwarder) newClusterSession(ctx context.Context, authCtx authContext) 
 }
 
 func (f *Forwarder) newClusterSessionRemoteCluster(ctx context.Context, authCtx authContext) (*clusterSession, error) {
-	tlsConfig, err := f.getOrRequestClientCreds(ctx, authCtx)
-	if err != nil {
-		f.log.Warningf("Failed to get certificate for %v: %v.", authCtx, err)
-		return nil, trace.AccessDenied("access denied: failed to authenticate with auth server")
-	}
-
 	f.log.Debugf("Forwarding kubernetes session for %v to remote cluster.", authCtx)
 	return &clusterSession{
 		parent:      f,
@@ -2329,14 +2190,14 @@ func (f *Forwarder) newClusterSessionRemoteCluster(ctx context.Context, authCtx 
 		// and the targetKubernetes cluster endpoint is determined from the identity
 		// encoded in the TLS certificate. We're setting the dial endpoint to a hardcoded
 		// `kube.teleport.cluster.local` value to indicate this is a Kubernetes proxy request
-		kubeClusterEndpoints: []kubeClusterEndpoint{{addr: reversetunnel.LocalKubernetes}},
-		tlsConfig:            tlsConfig.Clone(),
+		targetAddr:     reversetunnel.LocalKubernetes,
+		requestContext: ctx,
 	}, nil
 }
 
 func (f *Forwarder) newClusterSessionSameCluster(ctx context.Context, authCtx authContext) (*clusterSession, error) {
 	// Try local creds first
-	sess, localErr := f.newClusterSessionLocal(authCtx)
+	sess, localErr := f.newClusterSessionLocal(ctx, authCtx)
 	if localErr == nil {
 		return sess, nil
 	}
@@ -2346,65 +2207,37 @@ func (f *Forwarder) newClusterSessionSameCluster(ctx context.Context, authCtx au
 		return nil, trace.Wrap(localErr)
 	}
 
-	// Validate that the requested kube cluster is registered.
-	var endpoints []kubeClusterEndpoint
-	for _, s := range kubeServers {
-		kubeCluster := s.GetCluster()
-		if kubeCluster.GetName() != authCtx.kubeClusterName {
-			continue
-		}
-
-		// TODO(awly): check RBAC
-		endpoints = append(endpoints, kubeClusterEndpoint{
-			serverID: fmt.Sprintf("%s.%s", s.GetHostID(), authCtx.teleportCluster.name),
-			addr:     s.GetHostname(),
-			proxyIDs: s.GetProxyIDs(),
-		})
-		continue
-
+	if len(kubeServers) == 0 {
+		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
-	if len(endpoints) == 0 {
-		return nil, trace.NotFound("kubernetes cluster %q is not found in teleport cluster %q", authCtx.kubeClusterName, authCtx.teleportCluster.name)
-	}
-	return f.newClusterSessionDirect(ctx, authCtx, endpoints)
+
+	return f.newClusterSessionDirect(ctx, authCtx)
 }
 
-func (f *Forwarder) newClusterSessionLocal(ctx authContext) (*clusterSession, error) {
-	details, err := f.findKubeDetailsByClusterName(ctx.kubeClusterName)
+func (f *Forwarder) newClusterSessionLocal(ctx context.Context, authCtx authContext) (*clusterSession, error) {
+	details, err := f.findKubeDetailsByClusterName(authCtx.kubeClusterName)
 	if err != nil {
-		return nil, trace.NotFound("kubernetes cluster %q not found", ctx.kubeClusterName)
+		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
 
 	f.log.Debugf("Handling kubernetes session for %v using local credentials.", ctx)
 	return &clusterSession{
-		parent:               f,
-		authContext:          ctx,
-		kubeAPICreds:         details.kubeCreds,
-		kubeClusterEndpoints: []kubeClusterEndpoint{{addr: details.getTargetAddr()}},
-		tlsConfig:            details.getTLSConfig().Clone(),
+		parent:         f,
+		authContext:    authCtx,
+		kubeAPICreds:   details.kubeCreds,
+		targetAddr:     details.getTargetAddr(),
+		requestContext: ctx,
 	}, nil
 }
 
-func (f *Forwarder) newClusterSessionDirect(ctx context.Context, authCtx authContext, endpoints []kubeClusterEndpoint) (*clusterSession, error) {
-	if len(endpoints) == 0 {
-		return nil, trace.BadParameter("no kube cluster endpoints provided")
-	}
-
-	tlsConfig, err := f.getOrRequestClientCreds(ctx, authCtx)
-	if err != nil {
-		f.log.Warningf("Failed to get certificate for %v: %v.", authCtx, err)
-		return nil, trace.AccessDenied("access denied: failed to authenticate with auth server")
-	}
-
-	f.log.WithField("kube_service.endpoints", endpoints).Debugf("Kubernetes session for %v forwarded to remote kubernetes_service instance.", authCtx)
+func (f *Forwarder) newClusterSessionDirect(ctx context.Context, authCtx authContext) (*clusterSession, error) {
 	return &clusterSession{
-		parent:               f,
-		authContext:          authCtx,
-		kubeClusterEndpoints: endpoints,
-		tlsConfig:            tlsConfig.Clone(),
+		parent:      f,
+		authContext: authCtx,
 		// This session talks to a kubernetes_service, which should handle
 		// audit logging. Avoid duplicate logging.
-		noAuditEvents: true,
+		noAuditEvents:  true,
+		requestContext: ctx,
 	}, nil
 }
 
@@ -2439,6 +2272,7 @@ func (f *Forwarder) makeSessionForwarder(sess *clusterSession) (*forward.Forward
 // if the new context has been created, cancel function is returned as a
 // second argument. Caller should call this function to signal that CSR has been
 // completed or failed.
+// TODO(tigrato): DELETE in 15.0.0
 func (f *Forwarder) getOrCreateRequestContext(key string) (context.Context, context.CancelFunc) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -2456,6 +2290,7 @@ func (f *Forwarder) getOrCreateRequestContext(key string) (context.Context, cont
 	}
 }
 
+// TODO(tigrato): DELETE in 15.0.0
 func (f *Forwarder) serializedRequestClientCreds(tracingCtx context.Context, authContext authContext) (*tls.Config, error) {
 	ctx, cancel := f.getOrCreateRequestContext(authContext.key())
 	if cancel != nil {
@@ -2482,6 +2317,7 @@ func (f *Forwarder) serializedRequestClientCreds(tracingCtx context.Context, aut
 	}
 }
 
+// TODO(tigrato): DELETE in 15.0.0
 func (f *Forwarder) requestCertificate(ctx context.Context, authCtx authContext) (*tls.Config, error) {
 	_, span := f.cfg.tracer.Start(
 		ctx,

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -24,7 +24,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -637,15 +636,7 @@ func TestAuthenticate(t *testing.T) {
 				),
 			},
 		},
-		{
-			desc:           "local user and remote cluster, no tunnel",
-			user:           authz.LocalUser{},
-			roleKubeGroups: []string{"kube-group-a", "kube-group-b"},
-			routeToCluster: "remote",
-			haveKubeCreds:  true,
 
-			wantErr: true,
-		},
 		{
 			desc:              "unknown kubernetes cluster in local cluster",
 			user:              authz.LocalUser{},
@@ -795,7 +786,6 @@ func TestAuthenticate(t *testing.T) {
 			require.Empty(t, cmp.Diff(gotCtx, tt.wantCtx,
 				cmp.AllowUnexported(authContext{}, teleportClusterClient{}),
 				cmpopts.IgnoreFields(authContext{}, "clientIdleTimeout", "sessionTTL", "Context", "recordingConfig", "disconnectExpiredCert", "kubeCluster"),
-				cmpopts.IgnoreFields(teleportClusterClient{}, "dial", "isRemoteClosed"),
 			))
 
 			// validate authCtx.key() to make sure it includes certExpires timestamp.
@@ -988,90 +978,13 @@ func mockAuthCtx(ctx context.Context, t *testing.T, kubeCluster string, isRemote
 	}
 }
 
-func TestNewClusterSessionLocal(t *testing.T) {
-	ctx := context.Background()
-	f := newMockForwader(ctx, t)
-	authCtx := mockAuthCtx(ctx, t, "kube-cluster", false)
-
-	// Set creds for kube cluster local
-	f.clusterDetails = map[string]*kubeDetails{
-		"local": {
-			kubeCreds: &staticKubeCreds{
-				targetAddr: "k8s.example.com:443",
-				tlsConfig: &tls.Config{
-					Certificates: []tls.Certificate{
-						{
-							Certificate: [][]byte{[]byte("cert")},
-						},
-					},
-				},
-				transportConfig: &transport.Config{},
-			},
-		},
-	}
-
-	// Fail when kubeCluster is not specified
-	authCtx.kubeClusterName = ""
-	_, err := f.newClusterSession(ctx, authCtx)
-	require.Error(t, err)
-	require.True(t, trace.IsNotFound(err))
-	require.Empty(t, 0, f.clientCredentials.Len())
-
-	// Fail when creds aren't available
-	authCtx.kubeClusterName = "other"
-	_, err = f.newClusterSession(ctx, authCtx)
-	require.Error(t, err)
-	require.True(t, trace.IsNotFound(err))
-	require.Empty(t, 0, f.clientCredentials.Len())
-
-	// Succeed when creds are available
-	authCtx.kubeClusterName = "local"
-	sess, err := f.newClusterSession(ctx, authCtx)
-	require.NoError(t, err)
-	require.Equal(t, []kubeClusterEndpoint{{addr: f.clusterDetails["local"].getTargetAddr()}}, sess.kubeClusterEndpoints)
-
-	// Make sure newClusterSession used provided creds
-	// instead of requesting a Teleport client cert.
-	// this validates the equality of the referenced values
-	require.Equal(t, f.clusterDetails["local"].getTLSConfig(), sess.tlsConfig)
-
-	// Make sure that sess.tlsConfig was cloned from the value we store in f.creds["local"].tlsConfig.
-	// This is important because each connection must refer to a different memory address so it can be manipulated to enable/disable http2
-	require.NotSame(t, f.clusterDetails["local"].getTLSConfig(), sess.tlsConfig)
-
-	require.Nil(t, f.cfg.AuthClient.(*mockCSRClient).lastCert)
-	require.Empty(t, 0, f.clientCredentials.Len())
-}
-
-func TestNewClusterSessionRemote(t *testing.T) {
-	ctx := context.Background()
-	f := newMockForwader(ctx, t)
-	authCtx := mockAuthCtx(ctx, t, "kube-cluster", true)
-
-	// Succeed on remote cluster session
-	sess, err := f.newClusterSession(ctx, authCtx)
-	require.NoError(t, err)
-	require.Equal(t, []kubeClusterEndpoint{{addr: reversetunnel.LocalKubernetes}}, sess.kubeClusterEndpoints)
-
-	// Make sure newClusterSession obtained a new client cert instead of using f.creds.
-	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
-	// Make sure that sess.tlsConfig was cloned from the value we store in the cache.
-	// This is important because each connection must refer to a different memory address so it can be manipulated to enable/disable http2
-	// getClientCreds returns the cached version of the client tlsConfig.
-	require.NotNil(t, f.getClientCreds(authCtx))
-	require.NotSame(t, f.getClientCreds(authCtx), sess.tlsConfig)
-	//nolint:staticcheck // SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
-	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
-	require.Equal(t, 1, f.clientCredentials.Len())
-}
-
 func TestNewClusterSessionDirect(t *testing.T) {
 	ctx := context.Background()
 	f := newMockForwader(ctx, t)
 	authCtx := mockAuthCtx(ctx, t, "kube-cluster", false)
 
 	// helper function to create kube services
-	newKubeServer := func(name, addr, kubeCluster string) (types.KubeServer, kubeClusterEndpoint) {
+	newKubeServer := func(name, addr, kubeCluster string) types.KubeServer {
 		cluster, err := types.NewKubernetesClusterV3(types.Metadata{
 			Name: kubeCluster,
 		},
@@ -1085,15 +998,12 @@ func TestNewClusterSessionDirect(t *testing.T) {
 			Cluster:  cluster,
 		})
 		require.NoError(t, err)
-		kubeServiceEndpoint := kubeClusterEndpoint{
-			addr:     addr,
-			serverID: fmt.Sprintf("%s.%s", name, authCtx.teleportCluster.name),
-		}
-		return kubeService, kubeServiceEndpoint
+
+		return kubeService
 	}
 
 	// no kube services for kube cluster
-	otherKubeService, _ := newKubeServer("other", "other.example.com", "other-kube-cluster")
+	otherKubeService := newKubeServer("other", "other.example.com", "other-kube-cluster")
 	f.cfg.CachingAuthClient = mockAccessPoint{
 		kubeServers: []types.KubeServer{otherKubeService, otherKubeService, otherKubeService},
 	}
@@ -1101,67 +1011,16 @@ func TestNewClusterSessionDirect(t *testing.T) {
 	require.Error(t, err)
 
 	// multiple kube services for kube cluster
-	publicKubeService, publicEndpoint := newKubeServer("public", "k8s.example.com", "kube-cluster")
-	tunnelKubeService, tunnelEndpoint := newKubeServer("tunnel", reversetunnel.LocalKubernetes, "kube-cluster")
+	publicKubeService := newKubeServer("public", "k8s.example.com", "kube-cluster")
+	tunnelKubeService := newKubeServer("tunnel", reversetunnel.LocalKubernetes, "kube-cluster")
 
 	f.cfg.CachingAuthClient = mockAccessPoint{
 		kubeServers: []types.KubeServer{publicKubeService, otherKubeService, tunnelKubeService, otherKubeService},
 	}
 	authCtx.kubeServers, err = f.cfg.CachingAuthClient.GetKubernetesServers(context.Background())
 	require.NoError(t, err)
-	sess, err := f.newClusterSession(ctx, authCtx)
-	require.NoError(t, err)
-	require.Equal(t, []kubeClusterEndpoint{publicEndpoint, tunnelEndpoint}, sess.kubeClusterEndpoints)
 
-	// Make sure newClusterSession obtained a new client cert instead of using f.creds.
-	require.Equal(t, f.cfg.AuthClient.(*mockCSRClient).lastCert.Raw, sess.tlsConfig.Certificates[0].Certificate[0])
-	//nolint:staticcheck // SA1019 there's no non-deprecated public API for testing the contents of the RootCAs pool
-	require.Equal(t, [][]byte{f.cfg.AuthClient.(*mockCSRClient).ca.Cert.RawSubject}, sess.tlsConfig.RootCAs.Subjects())
-	// Make sure that sess.tlsConfig was cloned from the value we store in the cache.
-	// This is important because each connection must refer to a different memory address so it can be manipulated to enable/disable http2
-	require.NotNil(t, f.getClientCreds(authCtx))
-	require.NotSame(t, f.getClientCreds(authCtx), sess.tlsConfig)
-	require.Equal(t, 1, f.clientCredentials.Len())
-}
-
-func TestClusterSessionDial(t *testing.T) {
-	ctx := context.Background()
-	sess := &clusterSession{
-		authContext: authContext{
-			teleportCluster: teleportClusterClient{
-				dial: func(_ context.Context, _ string, endpoint kubeClusterEndpoint) (net.Conn, error) {
-					if endpoint.addr == "" {
-						return nil, trace.BadParameter("no addr")
-					}
-					return &net.TCPConn{}, nil
-				},
-			},
-		},
-	}
-
-	// fail with no endpoints
-	_, err := sess.dial(ctx, "")
-	require.True(t, trace.IsBadParameter(err))
-
-	// succeed with one endpoint
-	sess.kubeClusterEndpoints = []kubeClusterEndpoint{{
-		addr:     "addr1",
-		serverID: "server1",
-	}}
-	_, err = sess.dial(ctx, "")
-	require.NoError(t, err)
-	require.Equal(t, sess.kubeAddress, "addr1")
-
-	// fail if no endpoints are reachable
-	sess.kubeClusterEndpoints = make([]kubeClusterEndpoint, 10)
-	_, err = sess.dial(ctx, "")
-	require.Error(t, err)
-
-	// succeed if at least one endpoint is reachable
-	sess.kubeClusterEndpoints[5] = kubeClusterEndpoint{addr: "addr1"}
-	_, err = sess.dial(ctx, "")
-	require.NoError(t, err)
-	require.Equal(t, "addr1", sess.kubeAddress)
+	require.Nil(t, f.getClientCreds(authCtx))
 }
 
 // TestKubeFwdHTTPProxyEnv ensures that kube forwarder doesn't respect HTTPS_PROXY env
@@ -1190,10 +1049,6 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 
 	t.Cleanup(mockKubeAPI.Close)
 
-	authCtx.teleportCluster.dial = func(ctx context.Context, network string, endpoint kubeClusterEndpoint) (net.Conn, error) {
-		return new(net.Dialer).DialContext(ctx, mockKubeAPI.Listener.Addr().Network(), mockKubeAPI.Listener.Addr().String())
-	}
-
 	checkTransportProxy := func(rt http.RoundTripper) http.RoundTripper {
 		tr, ok := rt.(*http.Transport)
 		require.True(t, ok)
@@ -1214,10 +1069,7 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 					WrapTransport: checkTransportProxy,
 				},
 				transport: httpTransport{
-					h1Transport: newH1Transport(&tls.Config{
-						InsecureSkipVerify: true,
-					}, nil),
-					h2Transport: h2Transport,
+					transport: h2Transport,
 				},
 			},
 		},
@@ -1227,9 +1079,6 @@ func TestKubeFwdHTTPProxyEnv(t *testing.T) {
 	sess, err := f.newClusterSession(ctx, authCtx)
 	require.NoError(t, err)
 	t.Cleanup(sess.close)
-	require.Equal(t, []kubeClusterEndpoint{{addr: f.clusterDetails["local"].getTargetAddr()}}, sess.kubeClusterEndpoints)
-
-	sess.tlsConfig.InsecureSkipVerify = true
 
 	t.Setenv("HTTP_PROXY", "example.com:9999")
 	t.Setenv("HTTPS_PROXY", "example.com:9999")

--- a/lib/kube/proxy/transport.go
+++ b/lib/kube/proxy/transport.go
@@ -48,19 +48,13 @@ import (
 // Kubernetes cluster. If the servers don't support impersonation, a single
 // transport is used per request. Otherwise, a new transport is used for all
 // requests in order to improve performance.
-// TODO(tigrato): Remove the check once all servers support impersonation.
+// TODO(tigrato): DELETE IN 15.0.0
+// TODO(tigrato): Remove the check in Teleport 15, when all servers support impersonation.
 func (f *Forwarder) transportForRequest(sess *clusterSession) (http.RoundTripper, error) {
-	// If the cluster is remote, we need to check if all remote proxies support
-	// impersonation. If it does, use a single transport per request. Otherwise,
-	// fall back to using a new transport for each request.
-	if sess.teleportCluster.isRemote {
-		if proxies, err := f.getRemoteClusterProxies(sess.teleportCluster.name); err == nil &&
-			allServersSupportImpersonation(proxies) {
-			return f.transportForRequestWithImpersonation(sess)
-		}
-		// If the cluster is not remote, validate the kube services support of
-		// impersonation.
-	} else if allServersSupportImpersonation(sess.kubeServers) {
+	// allServersSupportImpersonation returns true if all servers support impersonation,
+	// otherwise fallback to using a single transport per request with user's identity
+	// embedded in the certificate.
+	if f.allServersSupportImpersonation(sess) {
 		// If all servers support impersonation, use a new transport for each
 		// request. This will ensure that the client certificate is valid for the
 		// server that the request is being sent to.
@@ -68,6 +62,23 @@ func (f *Forwarder) transportForRequest(sess *clusterSession) (http.RoundTripper
 	}
 	// Otherwise, use a single transport per request.
 	return f.transportForRequestWithoutImpersonation(sess)
+}
+
+// allServersSupportImpersonation returns true if all servers support impersonation.
+// If the cluster is remote, it checks if all remote proxies support impersonation, otherwise
+// it checks if all kube_services support impersonation.
+// TODO(tigrato): DELETE in 15.0.0
+func (f *Forwarder) allServersSupportImpersonation(sess *clusterSession) bool {
+	// If the cluster is remote, we need to check if all remote proxies support
+	// impersonation. If it does, use a single transport per request. Otherwise,
+	// fall back to using a new transport for each request.
+	if sess.teleportCluster.isRemote {
+		proxies, err := f.getRemoteClusterProxies(sess.teleportCluster.name)
+		return err == nil && allServersSupportImpersonation(proxies)
+	}
+	// If the cluster is not remote, validate the kube services support of
+	// impersonation.
+	return allServersSupportImpersonation(sess.kubeServers)
 }
 
 // getRemoteClusterProxies returns a list of proxies registered at the remote cluster.
@@ -98,9 +109,14 @@ type dialContextFunc func(context.Context, string, string) (net.Conn, error)
 // TODO(tigrato): Remove this once all servers support impersonation.
 func (f *Forwarder) transportForRequestWithoutImpersonation(sess *clusterSession) (http.RoundTripper, error) {
 	if sess.kubeAPICreds != nil {
-		return sess.kubeAPICreds.getTransport(sess.upgradeToHTTP2), nil
+		return sess.kubeAPICreds.getTransport(), nil
 	}
-	transport := newTransport(sess.DialWithContext, sess.tlsConfig)
+	// Get the TLS config for the next hop that does not support impersonation.
+	tlsConfig, _, err := f.getTLSConfig(sess)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	transport := newTransport(sess.DialWithContext, tlsConfig)
 	if !sess.upgradeToHTTP2 {
 		return tracehttp.NewTransport(transport), nil
 	}
@@ -129,10 +145,7 @@ func (f *Forwarder) transportForRequestWithImpersonation(sess *clusterSession) (
 	f.cachedTransportMu.Unlock()
 	if ok {
 		if cached, ok := cachedI.(*httpTransport); ok {
-			if sess.upgradeToHTTP2 {
-				return cached.h2Transport, nil
-			}
-			return cached.h1Transport, nil
+			return cached.transport, nil
 		}
 	}
 
@@ -144,7 +157,7 @@ func (f *Forwarder) transportForRequestWithImpersonation(sess *clusterSession) (
 	} else if sess.kubeAPICreds != nil {
 		// If agent is running in agent mode, get the transport from the configured cluster
 		// credentials.
-		return sess.kubeAPICreds.getTransport(sess.upgradeToHTTP2), nil
+		return sess.kubeAPICreds.getTransport(), nil
 	} else if f.cfg.ReverseTunnelSrv != nil {
 		// If agent is running in proxy mode, create a new transport for the local cluster.
 		httpTransport, err = f.newLocalClusterTransport(sess.kubeClusterName)
@@ -159,13 +172,8 @@ func (f *Forwarder) transportForRequestWithImpersonation(sess *clusterSession) (
 	f.cachedTransportMu.Lock()
 	f.cachedTransport.Set(key, httpTransport, transportCacheTTL)
 	f.cachedTransportMu.Unlock()
-	// Return the transport depending on whether HTTP/2 is enabled.
-	// Distinction is made because the SPDY protocol is not supported by HTTP/2
-	// and we must use HTTP/1.1 for it.
-	if sess.upgradeToHTTP2 {
-		return httpTransport.h2Transport, nil
-	}
-	return httpTransport.h1Transport, nil
+
+	return httpTransport.transport, nil
 }
 
 // transportCacheKey returns a key used to cache transports.
@@ -309,13 +317,11 @@ func (f *Forwarder) newRemoteClusterTransport(clusterName string) (*httpTranspor
 		return nil, trace.BadParameter("this Teleport process can not dial Kubernetes endpoints in remote Teleport clusters; only proxy_service supports this, make sure a Teleport proxy is first in the request path")
 	}
 	// Dialer that will be used to dial the remote cluster via the reverse tunnel.
-	dialFn := f.remoteClusterDiater(clusterName)
+	dialFn := f.remoteClusterDialer(clusterName)
 	tlsConfig, err := f.getTLSConfigForLeafCluster(clusterName)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	// Create a new HTTP/1 transport that will be used to dial the remote cluster.
-	h1Transport := newH1Transport(tlsConfig, dialFn)
 	// Create a new HTTP/2 transport that will be used to dial the remote cluster.
 	h2Transport, err := newH2Transport(tlsConfig, dialFn)
 	if err != nil {
@@ -323,8 +329,7 @@ func (f *Forwarder) newRemoteClusterTransport(clusterName string) (*httpTranspor
 	}
 
 	return &httpTransport{
-		h1Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h1Transport)),
-		h2Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h2Transport)),
+		transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h2Transport)),
 	}, nil
 }
 
@@ -357,9 +362,9 @@ func (f *Forwarder) getTLSConfigForLeafCluster(clusterName string) (*tls.Config,
 	return tlsConfig, nil
 }
 
-// remoteClusterDiater returns a dialer that can be used to dial Kubernetes Proxy
+// remoteClusterDialer returns a dialer that can be used to dial Kubernetes Proxy
 // in a remote Teleport cluster via the reverse tunnel.
-func (f *Forwarder) remoteClusterDiater(clusterName string) dialContextFunc {
+func (f *Forwarder) remoteClusterDialer(clusterName string) dialContextFunc {
 	return func(ctx context.Context, _, _ string) (net.Conn, error) {
 		_, span := f.cfg.tracer.Start(
 			ctx,
@@ -398,25 +403,23 @@ func (f *Forwarder) remoteClusterDiater(clusterName string) dialContextFunc {
 // newLocalClusterTransport returns a new [http.Transport] (https://golang.org/pkg/net/http/#Transport)
 // that can be used to dial Kubernetes Service in a local Teleport cluster.
 func (f *Forwarder) newLocalClusterTransport(kubeClusterName string) (*httpTransport, error) {
-	dialFn := f.localClusterDiater(kubeClusterName)
-
-	h1Transport := newH1Transport(f.cfg.ConnTLSConfig, dialFn)
+	dialFn := f.localClusterDialer(kubeClusterName)
+	// Create a new HTTP/2 transport that will be used to dial the remote cluster.
 	h2Transport, err := newH2Transport(f.cfg.ConnTLSConfig, dialFn)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return &httpTransport{
-		h1Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h1Transport)),
-		h2Transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h2Transport)),
+		transport: tracehttp.NewTransport(auth.NewImpersonatorRoundTripper(h2Transport)),
 	}, nil
 }
 
-// localClusterDiater returns a dialer that can be used to dial Kubernetes Service
+// localClusterDialer returns a dialer that can be used to dial Kubernetes Service
 // in a local Teleport cluster using the reverse tunnel.
 // The endpoints are fetched from the cached auth client and are shuffled
 // to avoid hotspots.
-func (f *Forwarder) localClusterDiater(kubeClusterName string) dialContextFunc {
+func (f *Forwarder) localClusterDialer(kubeClusterName string) dialContextFunc {
 	return func(ctx context.Context, _, _ string) (net.Conn, error) {
 		_, span := f.cfg.tracer.Start(
 			ctx,
@@ -452,6 +455,7 @@ func (f *Forwarder) localClusterDiater(kubeClusterName string) dialContextFunc {
 			},
 		)
 
+		var errs []error
 		// Validate that the requested kube cluster is registered.
 		for _, s := range kubeServers {
 			kubeCluster := s.GetCluster()
@@ -462,7 +466,7 @@ func (f *Forwarder) localClusterDiater(kubeClusterName string) dialContextFunc {
 			// It is a combination of the server's hostname and the cluster name.
 			// <host_id>.<cluster_name>
 			serverID := fmt.Sprintf("%s.%s", s.GetHostID(), f.cfg.ClusterName)
-			if conn, err := localCluster.DialTCP(reversetunnel.DialParams{
+			conn, err := localCluster.DialTCP(reversetunnel.DialParams{
 				// Send a sentinel value to the remote cluster because this connection
 				// will be used to forward multiple requests to the remote cluster from
 				// different users.
@@ -473,23 +477,19 @@ func (f *Forwarder) localClusterDiater(kubeClusterName string) dialContextFunc {
 				ConnType: types.KubeTunnel,
 				ServerID: serverID,
 				ProxyIDs: s.GetProxyIDs(),
-			}); err == nil {
+			})
+			if err == nil {
 				return conn, nil
 			}
+			errs = append(errs, trace.Wrap(err))
+		}
+
+		if len(errs) > 0 {
+			return nil, trace.NewAggregate(errs...)
 		}
 
 		return nil, trace.NotFound("kubernetes cluster %q is not found in teleport cluster %q", kubeClusterName, f.cfg.ClusterName)
 	}
-}
-
-// newH1Transport creates a new HTTP/1.1 transport.
-func newH1Transport(tlsConfig *tls.Config, dial dialContextFunc) *http.Transport {
-	tlsConfig = tlsConfig.Clone()
-	if tlsConfig == nil {
-		tlsConfig = &tls.Config{}
-	}
-	tlsConfig.NextProtos = []string{teleport.HTTPNextProtoTLS}
-	return newTransport(dial, tlsConfig)
 }
 
 // newH2Transport creates a new HTTP/2 transport with ALPN support.
@@ -506,4 +506,62 @@ func newH2Transport(tlsConfig *tls.Config, dial dialContextFunc) (*http.Transpor
 		return nil, trace.Wrap(err)
 	}
 	return h2HTTPTransport, nil
+}
+
+// getTLSConfig returns TLS config required to connect to the next hop.
+// If the current Kubernetes service serves the target cluster, it returns the
+// Kubernetes API tls configuration.
+// If the current service is a proxy and the next hop supports impersonation,
+// it returns the proxy's TLS config.
+// Otherwise, it requests a certificate from the auth server with the identity
+// of the user that is requesting the connection embedded in the certificate.
+// The boolean returned indicates whether the upstream server supports
+// impersonation.
+func (f *Forwarder) getTLSConfig(sess *clusterSession) (*tls.Config, bool, error) {
+	if sess.kubeAPICreds != nil {
+		return sess.kubeAPICreds.getTLSConfig(), false, nil
+	}
+
+	// if the next hop supports impersonation, we can use the TLS config
+	// of the proxy to connect to it.
+	if f.allServersSupportImpersonation(sess) {
+		return f.cfg.ConnTLSConfig.Clone(), true, nil
+	}
+
+	// If the next hop does not support impersonation, we need to get a
+	// certificate from the auth server with the identity of the user
+	// that is requesting the connection.
+	// TODO(tigrato): DELETE in 15.0.0
+	tlsConfig, err := f.getOrRequestClientCreds(sess.requestContext, sess.authContext)
+	if err != nil {
+		f.log.Warningf("Failed to get certificate for %v: %v.", sess.authContext, err)
+		return nil, false, trace.AccessDenied("access denied: failed to authenticate with auth server")
+	}
+	return tlsConfig, false, nil
+}
+
+// getContextDialerFunc returns a dialer function that can be used to connect
+// to the next hop.
+// If the next hop is a remote cluster, it returns a dialer that connects to
+// the remote cluster proxy using the reverse tunnel server.
+// If the next hop is a kubernetes service, it returns a dialer that connects
+// to the first available kubernetes service.
+// If the next hop is a local cluster, it returns a dialer that directly dials
+// to the next hop.
+func (f *Forwarder) getContextDialerFunc(s *clusterSession) dialContextFunc {
+	if s.kubeAPICreds != nil {
+		// If this is a kubernetes service, we need to connect to the kubernetes
+		// API server using a direct dialer.
+		return new(net.Dialer).DialContext
+	} else if s.teleportCluster.isRemote {
+		// If this is a remote cluster, we need to connect to the local proxy
+		// and then forward the connection to the remote cluster.
+		return f.remoteClusterDialer(s.teleportCluster.name)
+	} else if f.cfg.ReverseTunnelSrv != nil {
+		// If this is a local cluster, we need to connect to the remote proxy
+		// and then forward the connection to the local cluster.
+		return f.localClusterDialer(s.kubeClusterName)
+	}
+
+	return new(net.Dialer).DialContext
 }

--- a/lib/kube/proxy/transport_test.go
+++ b/lib/kube/proxy/transport_test.go
@@ -161,7 +161,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 	}{
 		{
 			name:          "local site",
-			dialerCreator: f.localClusterDiater,
+			dialerCreator: f.localClusterDialer,
 			want: reversetunnel.DialParams{
 				From: &utils.NetAddr{
 					Addr:        "0.0.0.0:0",
@@ -178,7 +178,7 @@ func TestForwarderClusterDialer(t *testing.T) {
 		},
 		{
 			name:          "remote site",
-			dialerCreator: f.remoteClusterDiater,
+			dialerCreator: f.remoteClusterDialer,
 			want: reversetunnel.DialParams{
 				From: &utils.NetAddr{
 					Addr:        "0.0.0.0:0",


### PR DESCRIPTION
Teleport 13 introduced a new process to forward a user's identity without proxy signing new certificates with the user's identity on it.

This PR builds on top of that and aims to defer the auth's cert request to cases where the upstream server does not support impersonation (running Teleport 12.x.x) as opposed to Teleport 13 where we request the cert anyway,

It also enables identity forwarding for calls that are not simple requests, including remote sessions and port-forwarding requests. It is the initial step for Kube Access to support Offline (no auth)  access.

This PR also removes some dead and duplicated code.

Part of #25541