### PR TITLE
Hide Assist when the feature is disabled

### DIFF
--- a/api/client/webclient/webclient.go
+++ b/api/client/webclient/webclient.go
@@ -407,6 +407,8 @@ type AuthenticationSettings struct {
 	HasMessageOfTheDay bool `json:"has_motd"`
 	// LoadAllCAs tells tsh to load CAs for all clusters when trying to ssh into a node.
 	LoadAllCAs bool `json:"load_all_cas,omitempty"`
+	// AssistEnabled is true when Teleport Assist feature is enabled.
+	Assist AssistFeatures `json:"assist"`
 }
 
 // LocalSettings holds settings for local authentication.
@@ -456,6 +458,11 @@ type GithubSettings struct {
 type DeviceTrustSettings struct {
 	Disabled   bool `json:"disabled,omitempty"`
 	AutoEnroll bool `json:"auto_enroll,omitempty"`
+}
+
+// AssistFeatures holds assist related options.
+type AssistFeatures struct {
+	Enabled bool `json:"enabled"`
 }
 
 func (ps *ProxySettings) TunnelAddr() (string, error) {

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -127,6 +127,9 @@ type AuthPreference interface {
 	// SetSAMLIdPEnabled sets the SAML IdP to enabled.
 	SetSAMLIdPEnabled(bool)
 
+	// IsAssistEnabled returns true if assistant feature is enabled in the Auth config.
+	IsAssistEnabled() bool
+
 	// String represents a human readable version of authentication settings.
 	String() string
 }
@@ -348,6 +351,10 @@ func (c *AuthPreferenceV2) SetAllowPasswordless(b bool) {
 
 func (c *AuthPreferenceV2) GetAllowHeadless() bool {
 	return c.Spec.AllowHeadless != nil && c.Spec.AllowHeadless.Value
+}
+
+func (c *AuthPreferenceV2) IsAssistEnabled() bool {
+	return c.Spec.Assist != nil && c.Spec.Assist.APIURL != ""
 }
 
 func (c *AuthPreferenceV2) SetAllowHeadless(b bool) {

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -341,6 +341,9 @@ const (
 	// KindHeadlessAuthentication is a headless authentication resource.
 	KindHeadlessAuthentication = "headless_authentication"
 
+	// KindAssistant is a Teleport Assist resource kind.
+	KindAssistant = "assistant"
+
 	// KindIntegration is a connection to a 3rd party system API.
 	KindIntegration = "integration"
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5957,31 +5957,46 @@ func (a *ServerWithRoles) UpdateHeadlessAuthenticationState(ctx context.Context,
 
 // CreateAssistantConversation creates a new conversation entry in the backend.
 func (a *ServerWithRoles) CreateAssistantConversation(ctx context.Context, req *proto.CreateAssistantConversationRequest) (*proto.CreateAssistantConversationResponse, error) {
-	// TODO(jakule): Check if user has access to given conversation ID
+	if err := a.action(apidefaults.Namespace, types.KindAssistant, types.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return a.authServer.CreateAssistantConversation(ctx, req)
 }
 
 // GetAssistantConversations returns all conversations started by a user.
 func (a *ServerWithRoles) GetAssistantConversations(ctx context.Context, request *proto.GetAssistantConversationsRequest) (*proto.GetAssistantConversationsResponse, error) {
-	// TODO(jakule): Check if user has access to given conversation ID
+	if err := a.action(apidefaults.Namespace, types.KindAssistant, types.VerbList); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return a.authServer.GetAssistantConversations(ctx, request)
 }
 
 // GetAssistantMessages returns all messages with given conversation ID.
 func (a *ServerWithRoles) GetAssistantMessages(ctx context.Context, id string) (*proto.GetAssistantMessagesResponse, error) {
-	// TODO(jakule): Check if user has access to given conversation ID
+	if err := a.action(apidefaults.Namespace, types.KindAssistant, types.VerbRead); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return a.authServer.GetAssistantMessages(ctx, id)
 }
 
 // InsertAssistantMessage adds the message to the backend.
 func (a *ServerWithRoles) InsertAssistantMessage(ctx context.Context, msg *proto.AssistantMessage) (*emptypb.Empty, error) {
-	// TODO(jakule): Check if user has access to given conversation ID
+	if err := a.action(apidefaults.Namespace, types.KindAssistant, types.VerbCreate); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	return &emptypb.Empty{}, a.authServer.InsertAssistantMessage(ctx, msg)
 }
 
 // SetAssistantConversationTitle set the given title as the assistant conversation title.
 func (a *ServerWithRoles) SetAssistantConversationTitle(ctx context.Context, msg *proto.ConversationInfo) error {
-	// TODO(jakule): Check if user has access to given conversation ID
+	if err := a.action(apidefaults.Namespace, types.KindAssistant, types.VerbUpdate); err != nil {
+		return trace.Wrap(err)
+	}
+
 	return a.authServer.SetAssistantConversationTitle(ctx, msg)
 }
 
@@ -6019,7 +6034,7 @@ func (a *ServerWithRoles) UpdateClusterMaintenanceConfig(ctx context.Context, cm
 
 	if modules.GetModules().Features().Cloud {
 		// maintenance configuration in cloud is derived from values stored in
-		// an external cloud-specific databse.
+		// an external cloud-specific database.
 		return trace.NotImplemented("cloud clusters not support custom cluster maintenance resources")
 	}
 

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5984,7 +5984,7 @@ func (a *ServerWithRoles) GetAssistantMessages(ctx context.Context, id string) (
 
 // InsertAssistantMessage adds the message to the backend.
 func (a *ServerWithRoles) InsertAssistantMessage(ctx context.Context, msg *proto.AssistantMessage) (*emptypb.Empty, error) {
-	if err := a.action(apidefaults.Namespace, types.KindAssistant, types.VerbCreate); err != nil {
+	if err := a.action(apidefaults.Namespace, types.KindAssistant, types.VerbUpdate); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -623,8 +623,8 @@ func TestPresets(t *testing.T) {
 		err := createPresets(ctx, roleManager)
 		require.NoError(t, err)
 
-		require.Equal(t, 0, roleManager.upsertRoleCallsCount, "unexpectd call to UpsertRole")
-		require.Equal(t, 0, roleManager.getRoleCallsCount, "unexpectd call to GetRole")
+		require.Equal(t, 0, roleManager.upsertRoleCallsCount, "unexpected call to UpsertRole")
+		require.Equal(t, 0, roleManager.getRoleCallsCount, "unexpected call to GetRole")
 		require.Equal(t, presetRoleCount, roleManager.createRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.createRoleCallsCount)
 
 		// Running a second time should return Already Exists, so it fetches the role.
@@ -634,7 +634,7 @@ func TestPresets(t *testing.T) {
 		err = createPresets(ctx, roleManager)
 		require.NoError(t, err)
 
-		require.Equal(t, 0, roleManager.upsertRoleCallsCount, "unexpectd call to UpsertRole")
+		require.Equal(t, 0, roleManager.upsertRoleCallsCount, "unexpected call to UpsertRole")
 		require.Equal(t, presetRoleCount, roleManager.getRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.getRoleCallsCount)
 		require.Equal(t, presetRoleCount, roleManager.createRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.createRoleCallsCount)
 
@@ -649,13 +649,14 @@ func TestPresets(t *testing.T) {
 			allowRulesWithoutConnectionDiag = append(allowRulesWithoutConnectionDiag, r)
 		}
 		editorRole.SetRules(types.Allow, allowRulesWithoutConnectionDiag)
-		roleManager.UpsertRole(ctx, editorRole)
+		err = roleManager.UpsertRole(ctx, editorRole)
+		require.NoError(t, err)
 
 		roleManager.ResetCallCounters()
 		err = createPresets(ctx, roleManager)
 		require.NoError(t, err)
 
-		require.Equal(t, 1, roleManager.upsertRoleCallsCount, "unexpectd call to UpsertRole")
+		require.Equal(t, 1, roleManager.upsertRoleCallsCount, "unexpected call to UpsertRole")
 		require.Equal(t, presetRoleCount, roleManager.getRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.getRoleCallsCount)
 		require.Equal(t, presetRoleCount, roleManager.createRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.createRoleCallsCount)
 	})

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -211,6 +211,7 @@ func defaultAllowRules() map[string][]types.Rule {
 			types.NewRule(types.KindDevice, append(RW(), types.VerbCreateEnrollToken, types.VerbEnroll)),
 			types.NewRule(types.KindLock, RW()),
 			types.NewRule(types.KindIntegration, append(RW(), types.VerbUse)),
+			types.NewRule(types.KindAssistant, RW()),
 		},
 	}
 }

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -84,6 +84,7 @@ func NewPresetEditorRole() types.Role {
 					types.NewRule(types.KindPlugin, RW()),
 					types.NewRule(types.KindOktaImportRule, RW()),
 					types.NewRule(types.KindOktaAssignment, RW()),
+					types.NewRule(types.KindAssistant, RW()),
 					types.NewRule(types.KindLock, RW()),
 					types.NewRule(types.KindIntegration, append(RW(), types.VerbUse)),
 					// Please see defaultAllowRules when adding a new rule.

--- a/lib/web/ui/usercontext.go
+++ b/lib/web/ui/usercontext.go
@@ -100,6 +100,8 @@ type userACL struct {
 	Integrations access `json:"integrations"`
 	// DeviceTrust defines access to device trust.
 	DeviceTrust access `json:"deviceTrust"`
+	// AssistTrust defines access to assist feature.
+	AssistTrust access `json:"assist"`
 }
 
 type authType string
@@ -193,6 +195,7 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 	requestAccess := newAccess(userRoles, ctx, types.KindAccessRequest)
 	desktopAccess := newAccess(userRoles, ctx, types.KindWindowsDesktop)
 	cnDiagnosticAccess := newAccess(userRoles, ctx, types.KindConnectionDiagnostic)
+	assistAccess := newAccess(userRoles, ctx, types.KindAssistant)
 
 	var billingAccess access
 	if features.Cloud {
@@ -239,6 +242,7 @@ func NewUserContext(user types.User, userRoles services.RoleSet, features proto.
 		Plugins:                 pluginsAccess,
 		Integrations:            integrationsAccess,
 		DeviceTrust:             deviceTrust,
+		AssistTrust:             assistAccess,
 	}
 
 	// local user

--- a/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
@@ -24,10 +24,10 @@ import { ChatGPTIcon } from 'design/SVGIcon/ChatGPT';
 
 import { useHistory } from 'react-router';
 
+import { useTeleport } from 'teleport';
 import { NavigationCategory } from 'teleport/Navigation/categories';
 
 import icon from './teleport-icon.png';
-import { useTeleport } from 'teleport';
 
 interface NavigationSwitcherProps {
   onChange: (value: NavigationCategory) => void;

--- a/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
@@ -27,6 +27,7 @@ import { useHistory } from 'react-router';
 import { NavigationCategory } from 'teleport/Navigation/categories';
 
 import icon from './teleport-icon.png';
+import { useTeleport } from 'teleport';
 
 interface NavigationSwitcherProps {
   onChange: (value: NavigationCategory) => void;
@@ -126,7 +127,12 @@ const Background = styled.div`
 `;
 
 export function NavigationSwitcher(props: NavigationSwitcherProps) {
-  const [showAssist, setShowAssist] = useLocalStorage('show-assist', true);
+  const ctx = useTeleport();
+  const assistEnabled = ctx.getFeatureFlags().assist && ctx.assistEnabled;
+  const [showAssist, setShowAssist] = useLocalStorage(
+    'show-assist',
+    assistEnabled
+  );
 
   const [open, setOpen] = useState(showAssist);
 
@@ -259,11 +265,13 @@ export function NavigationSwitcher(props: NavigationSwitcherProps) {
     );
   }
 
-  items.push(
-    <DropdownItem key="assist" open={open} onClick={() => handleOpenAssist()}>
-      Assist
-    </DropdownItem>
-  );
+  if (assistEnabled) {
+    items.push(
+      <DropdownItem key="assist" open={open} onClick={() => handleOpenAssist()}>
+        Assist
+      </DropdownItem>
+    );
+  }
 
   return (
     <Container ref={ref}>

--- a/web/packages/teleport/src/features.tsx
+++ b/web/packages/teleport/src/features.tsx
@@ -616,8 +616,8 @@ export class FeatureAssist implements TeleportFeature {
     component: Assist,
   };
 
-  hasAccess() {
-    return true;
+  hasAccess(flags: FeatureFlags) {
+    return flags.assist;
   }
 }
 

--- a/web/packages/teleport/src/mocks/contexts.ts
+++ b/web/packages/teleport/src/mocks/contexts.ts
@@ -62,6 +62,7 @@ const allAccessAcl: Acl = {
   plugins: fullAccess,
   integrations: { ...fullAccess, use: true },
   deviceTrust: fullAccess,
+  assist: fullAccess,
 };
 
 export function getAcl(cfg?: { noAccess: boolean }) {

--- a/web/packages/teleport/src/services/ping/makePing.ts
+++ b/web/packages/teleport/src/services/ping/makePing.ts
@@ -22,6 +22,6 @@ export function makePing(json: any): PingResponse {
 
   return {
     automaticUpgrades: automatic_upgrades,
-    assistEnabled: auth.assist.enabled,
+    assistEnabled: auth?.assist?.enabled as boolean,
   };
 }

--- a/web/packages/teleport/src/services/ping/makePing.ts
+++ b/web/packages/teleport/src/services/ping/makePing.ts
@@ -18,9 +18,10 @@ import { PingResponse } from './types';
 
 export function makePing(json: any): PingResponse {
   json = json || {};
-  const { automatic_upgrades } = json;
+  const { auth, automatic_upgrades } = json;
 
   return {
     automaticUpgrades: automatic_upgrades,
+    assistEnabled: auth.assist.enabled,
   };
 }

--- a/web/packages/teleport/src/services/ping/ping.test.ts
+++ b/web/packages/teleport/src/services/ping/ping.test.ts
@@ -19,7 +19,7 @@ import api from 'teleport/services/api';
 import ping from './ping';
 
 test('undefined automatic upgrade resolves to false', async () => {
-  const mockContext = {};
+  const mockContext = { assist: {} };
 
   jest.spyOn(api, 'get').mockResolvedValue(mockContext);
 

--- a/web/packages/teleport/src/services/ping/types.ts
+++ b/web/packages/teleport/src/services/ping/types.ts
@@ -16,4 +16,5 @@ limitations under the License.
 
 export interface PingResponse {
   automaticUpgrades: boolean;
+  assistEnabled: boolean;
 }

--- a/web/packages/teleport/src/services/user/makeAcl.ts
+++ b/web/packages/teleport/src/services/user/makeAcl.ts
@@ -59,6 +59,7 @@ export function makeAcl(json): Acl {
   const download = json.download || defaultAccess;
 
   const deviceTrust = json.deviceTrust || defaultAccess;
+  const assist = json.assist || defaultAccess;
 
   return {
     authConnectors,
@@ -86,6 +87,7 @@ export function makeAcl(json): Acl {
     license,
     download,
     deviceTrust,
+    assist,
   };
 }
 

--- a/web/packages/teleport/src/services/user/types.ts
+++ b/web/packages/teleport/src/services/user/types.ts
@@ -77,6 +77,7 @@ export interface Acl {
   plugins: Access;
   integrations: AccessWithUse;
   deviceTrust: Access;
+  assist: Access;
 }
 
 export interface User {

--- a/web/packages/teleport/src/services/user/user.test.ts
+++ b/web/packages/teleport/src/services/user/user.test.ts
@@ -205,6 +205,13 @@ test('undefined values in context response gives proper default values', async (
         create: false,
         remove: false,
       },
+      assist: {
+        list: false,
+        read: false,
+        edit: false,
+        create: false,
+        remove: false,
+      },
       clipboardSharingEnabled: true,
       desktopSessionRecordingEnabled: true,
       directorySharingEnabled: true,

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -183,4 +183,8 @@ export default class StoreUserContext extends Store<UserContext> {
   getIntegrationsAccess() {
     return this.state.acl.integrations;
   }
+
+  getAssistantAccess() {
+    return this.state.acl.assist;
+  }
 }

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -1,5 +1,5 @@
 /*
-Copyright 2019-2021 Gravitational, Inc.
+Copyright 2019-2023 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -48,7 +48,6 @@ class TeleportContext implements types.Context {
   sshService = sessionService;
   resourceService = new ResourceService();
   userService = userService;
-  pingService = pingService;
   appService = appService;
   joinTokenService = new JoinTokenService();
   kubeService = new KubeService();
@@ -59,6 +58,7 @@ class TeleportContext implements types.Context {
   isCloud = cfg.isCloud;
 
   automaticUpgradesEnabled = false;
+  assistEnabled = false;
 
   agentService = agentService;
 
@@ -81,6 +81,7 @@ class TeleportContext implements types.Context {
 
     const pingResponse = await pingService.fetchPing();
     this.automaticUpgradesEnabled = pingResponse.automaticUpgrades;
+    this.assistEnabled = pingResponse.assistEnabled;
   }
 
   getFeatureFlags(): types.FeatureFlags {
@@ -110,6 +111,7 @@ class TeleportContext implements types.Context {
         deviceTrust: false,
         enrollIntegrationsOrPlugins: false,
         enrollIntegrations: false,
+        assist: false,
       };
     }
 
@@ -138,6 +140,7 @@ class TeleportContext implements types.Context {
         userContext.getPluginsAccess().create ||
         userContext.getIntegrationsAccess().create,
       deviceTrust: userContext.getDeviceTrustAccess().list,
+      assist: userContext.getAssistantAccess().list && this.assistEnabled,
     };
   }
 }

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -94,4 +94,5 @@ export interface FeatureFlags {
   enrollIntegrationsOrPlugins: boolean;
   enrollIntegrations: boolean;
   deviceTrust: boolean;
+  assist: boolean;
 }


### PR DESCRIPTION
This PR hides the Assist button in WebUI if the assist in not configured in the backend or when a user doesn't have permission to use it (no roles allows for it).