### PR TITLE
Use web address when appropriate for a jump host

### DIFF
--- a/api/client/proxy/client.go
+++ b/api/client/proxy/client.go
@@ -60,10 +60,8 @@ func (f SSHDialerFunc) Dial(ctx context.Context, network string, addr string, co
 // ClientConfig contains configuration needed for a Client
 // to be able to connect to the cluster.
 type ClientConfig struct {
-	// ProxyWebAddress is the address of the Proxy Web server.
-	ProxyWebAddress string
-	// ProxySSHAddress is the address of the Proxy SSH server.
-	ProxySSHAddress string
+	// ProxyAddress is the address of the Proxy server.
+	ProxyAddress string
 	// TLSRoutingEnabled indicates if the cluster is using TLS Routing.
 	TLSRoutingEnabled bool
 	// TLSConfig contains the tls.Config required for mTLS connections.
@@ -98,11 +96,8 @@ type ClientConfig struct {
 // CheckAndSetDefaults ensures required options are present and
 // sets the default value of any that are omitted.
 func (c *ClientConfig) CheckAndSetDefaults() error {
-	if c.ProxyWebAddress == "" {
-		return trace.BadParameter("missing required parameter ProxyWebAddress")
-	}
-	if c.ProxySSHAddress == "" {
-		return trace.BadParameter("missing required parameter ProxySSHAddress")
+	if c.ProxyAddress == "" {
+		return trace.BadParameter("missing required parameter ProxyAddress")
 	}
 	if c.SSHDialer == nil {
 		return trace.BadParameter("missing required parameter SSHDialer")
@@ -297,16 +292,10 @@ func newGRPCClient(ctx context.Context, cfg *ClientConfig) (_ *Client, err error
 	dialCtx, cancel := context.WithTimeout(ctx, cfg.DialTimeout)
 	defer cancel()
 
-	// Dial web proxy with TLS Routing.
-	addr := cfg.ProxySSHAddress
-	if cfg.TLSRoutingEnabled {
-		addr = cfg.ProxyWebAddress
-	}
-
 	c := &clusterName{}
 	conn, err := grpc.DialContext(
 		dialCtx,
-		addr,
+		cfg.ProxyAddress,
 		append([]grpc.DialOption{
 			grpc.WithContextDialer(newDialerForGRPCClient(ctx, cfg)),
 			grpc.WithTransportCredentials(&clusterCredentials{TransportCredentials: cfg.creds(), clusterName: c}),
@@ -395,7 +384,7 @@ func newSSHClient(ctx context.Context, cfg *ClientConfig) (*Client, error) {
 		Timeout:           cfg.SSHConfig.Timeout,
 	}
 
-	clt, err := cfg.SSHDialer.Dial(ctx, "tcp", cfg.ProxySSHAddress, clientCfg)
+	clt, err := cfg.SSHDialer.Dial(ctx, "tcp", cfg.ProxyAddress, clientCfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -460,7 +449,7 @@ func (c *Client) ClientConfig(ctx context.Context, cluster string) client.Config
 	case c.cfg.TLSRoutingEnabled:
 		return client.Config{
 			Context:                    ctx,
-			Addrs:                      []string{c.cfg.ProxyWebAddress},
+			Addrs:                      []string{c.cfg.ProxyAddress},
 			Credentials:                []client.Credentials{c.cfg.clientCreds()},
 			ALPNSNIAuthDialClusterName: cluster,
 			CircuitBreakerConfig:       breaker.NoopBreakerConfig(),
@@ -480,7 +469,7 @@ func (c *Client) ClientConfig(ctx context.Context, cluster string) client.Config
 				default:
 				}
 
-				conn, err := dialSSH(dialCtx, c.sshClient, c.cfg.ProxySSHAddress, "@"+cluster, nil)
+				conn, err := dialSSH(dialCtx, c.sshClient, c.cfg.ProxyAddress, "@"+cluster, nil)
 				return conn, trace.Wrap(err)
 			}),
 		}
@@ -540,7 +529,7 @@ func (c *Client) dialHostSSH(ctx context.Context, target, cluster string, keyrin
 		keyring = nil
 	}
 
-	conn, err := dialSSH(ctx, c.sshClient, c.cfg.ProxySSHAddress, target+"@"+cluster, keyring)
+	conn, err := dialSSH(ctx, c.sshClient, c.cfg.ProxyAddress, target+"@"+cluster, keyring)
 	return conn, ClusterDetails{FIPS: details.FIPSEnabled}, trace.Wrap(err)
 }
 

--- a/api/client/proxy/client_test.go
+++ b/api/client/proxy/client_test.go
@@ -377,8 +377,7 @@ func newFakeProxy(t *testing.T, sshHandler sshHandler, transportService transpor
 
 func (f *fakeProxy) clientConfig(t *testing.T) ClientConfig {
 	return ClientConfig{
-		ProxyWebAddress: "127.0.0.1",
-		ProxySSHAddress: "127.0.0.1",
+		ProxyAddress: "127.0.0.1",
 		SSHDialer: SSHDialerFunc(func(ctx context.Context, network string, addr string, config *ssh.ClientConfig) (*tracessh.Client, error) {
 			conn, chans, reqs, err := f.fakeSSHServer.newClientConn()
 			if err != nil {

--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -56,9 +56,9 @@ var (
 		// it from ever completing the 100 runs successfully.
 		"TestSSHOnMultipleNodes", "TestSSHWithMFA",
 
-		// TestProxySSH takes around 10-15s to run, largely due to the 7-10 seconds it takes to create a
+		// TestProxySSH and TestList takes around 10-15s to run, largely due to the 7-10 seconds it takes to create a
 		// tsh test suite. This prevents it from ever completing the 100 runs successfully.
-		"TestProxySSH",
+		"TestProxySSH", "TestList",
 	}
 )
 

--- a/tool/tsh/kube_proxy_test.go
+++ b/tool/tsh/kube_proxy_test.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -118,7 +119,9 @@ func checkKubeLocalProxyConfigPaths(t *testing.T, s *suite, config *clientcmdapi
 	t.Helper()
 
 	tshHome := os.Getenv(types.HomeEnvVar)
-	proxy := s.root.Config.Auth.ClusterName.GetClusterName()
+	proxy, _, err := net.SplitHostPort(s.root.Config.Proxy.WebAddr.String())
+	require.NoError(t, err)
+
 	user := s.user.GetName()
 	wantCAPath := keypaths.KubeLocalCAPath(tshHome, proxy, user, teleportCluster)
 	wantKeyPath := keypaths.UserKeyPath(tshHome, proxy, user)

--- a/tool/tsh/kube_test.go
+++ b/tool/tsh/kube_test.go
@@ -161,8 +161,8 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 					[]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"},
 
 					[]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", p.leafKubeCluster, ""},
-					[]string{p.root.Config.Proxy.WebAddr.String(), "localhost", p.rootKubeCluster2, p.formatedLabels},
-					[]string{p.root.Config.Proxy.WebAddr.String(), "localhost", p.rootKubeCluster1, p.formatedLabels},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, p.formatedLabels},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, p.formatedLabels},
 				)
 				return table.AsBuffer().String()
 			},

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -688,11 +688,10 @@ func TestList(t *testing.T) {
 		},
 	}
 
+	tshHome, _ := mustLogin(t, s)
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
-			tshHome, _ := mustLogin(t, s)
 			stdout := &bytes.Buffer{}
-
 			err := Run(context.Background(), test.command, setHomePath(tshHome), setOverrideStdout(stdout))
 			require.NoError(t, err)
 

--- a/tool/tsh/proxy_test.go
+++ b/tool/tsh/proxy_test.go
@@ -19,6 +19,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -26,7 +27,6 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
-	"strings"
 	"testing"
 	"text/template"
 	"time"
@@ -464,8 +464,8 @@ Host *
 `, tshPath)), 0o644)
 	require.NoError(t, err)
 
-	// Connect to "localnode" with OpenSSH.
-	mustRunOpenSSHCommand(t, sshConfigFile, "localnode.root",
+	// Connect to "rootnode" with OpenSSH.
+	mustRunOpenSSHCommand(t, sshConfigFile, "rootnode.root",
 		s.root.Config.SSH.Addr.Port(defaults.SSHServerListenPort), "echo", "hello")
 }
 
@@ -631,37 +631,72 @@ func TestList(t *testing.T) {
 	testCases := []struct {
 		description string
 		command     []string
-		resultNodes []string
+		assertion   func(t *testing.T, out []byte)
 	}{
 		{
 			description: "List root cluster nodes",
-			command:     []string{"ls"},
-			resultNodes: []string{"localnode " + rootNodeAddress.String()},
+			command:     []string{"ls", "-f", "json"},
+			assertion: func(t *testing.T, out []byte) {
+				var results []types.ServerV2
+				require.NoError(t, json.Unmarshal(out, &results))
+
+				require.Len(t, results, 1)
+				require.Equal(t, "rootnode", results[0].Spec.Hostname)
+				require.Equal(t, rootNodeAddress.String(), results[0].Spec.Addr)
+			},
 		},
 		{
 			description: "List leaf cluster nodes",
-			command:     []string{"ls", "-c", "leaf1"},
-			resultNodes: []string{"localnode " + leafNodeAddress.String()},
+			command:     []string{"ls", "-c", "leaf1", "-f", "json"},
+			assertion: func(t *testing.T, out []byte) {
+				var results []types.ServerV2
+				require.NoError(t, json.Unmarshal(out, &results))
+
+				require.Len(t, results, 1)
+				require.Equal(t, "leafnode", results[0].Spec.Hostname)
+				require.Equal(t, leafNodeAddress.String(), results[0].Spec.Addr)
+			},
 		},
 		{
 			description: "List all clusters nodes",
-			command:     []string{"ls", "-R"},
-			resultNodes: []string{"leaf1     localnode", "localhost localnode"},
+			command:     []string{"ls", "-R", "-f", "json"},
+			assertion: func(t *testing.T, out []byte) {
+				expected := map[string]string{
+					"root":  "rootnode",
+					"leaf1": "leafnode",
+				}
+
+				type result struct {
+					Cluster string         `json:"cluster"`
+					Node    types.ServerV2 `json:"node"`
+				}
+				var results []result
+				require.NoError(t, json.Unmarshal(out, &results))
+
+				require.Equal(t, len(expected), len(results))
+				for _, res := range results {
+					node, ok := expected[res.Cluster]
+					require.True(t, ok, "expected node to be present for cluster %s", res.Cluster)
+					require.Equal(t, node, res.Node.Spec.Hostname)
+					address := leafNodeAddress
+					if res.Cluster == s.root.Config.Auth.ClusterName.GetName() {
+						address = rootNodeAddress
+					}
+					require.Equal(t, address.String(), results[0].Node.Spec.Addr)
+				}
+			},
 		},
 	}
 
 	for _, test := range testCases {
 		t.Run(test.description, func(t *testing.T) {
 			tshHome, _ := mustLogin(t, s)
-			stdout := new(bytes.Buffer)
+			stdout := &bytes.Buffer{}
 
 			err := Run(context.Background(), test.command, setHomePath(tshHome), setOverrideStdout(stdout))
-
 			require.NoError(t, err)
-			require.Equal(t, len(test.resultNodes), len(strings.Split(stdout.String(), "\n"))-4) // 4 - unimportant new lines
-			for _, node := range test.resultNodes {
-				require.Contains(t, stdout.String(), node)
-			}
+
+			test.assertion(t, stdout.Bytes())
 		})
 	}
 }

--- a/tool/tsh/tsh_helper_test.go
+++ b/tool/tsh/tsh_helper_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 type suite struct {
@@ -55,7 +56,7 @@ func (s *suite) setupRootCluster(t *testing.T, options testSuiteOptions) {
 		Version: "v2",
 		Global: config.Global{
 			DataDir:  t.TempDir(),
-			NodeName: "localnode",
+			NodeName: "rootnode",
 		},
 		SSH: config.SSH{
 			Service: config.Service{
@@ -77,12 +78,13 @@ func (s *suite) setupRootCluster(t *testing.T, options testSuiteOptions) {
 				EnabledFlag:   "true",
 				ListenAddress: localListenerAddr(),
 			},
-			ClusterName: "localhost",
+			ClusterName: "root",
 		},
 	}
 
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+	cfg.Log = utils.NewLoggerForTests()
 	err = config.ApplyFileConfig(fileConfig, cfg)
 	require.NoError(t, err)
 
@@ -143,7 +145,7 @@ func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
 		Version: "v2",
 		Global: config.Global{
 			DataDir:  t.TempDir(),
-			NodeName: "localnode",
+			NodeName: "leafnode",
 		},
 		SSH: config.SSH{
 			Service: config.Service{
@@ -172,6 +174,7 @@ func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
 
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+	cfg.Log = utils.NewLoggerForTests()
 	err = config.ApplyFileConfig(fileConfig, cfg)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Determines whether the jump host provided via `tsh ssh -J` is belongs to the Proxy SSH or Web server to ensure when using jump hosts that connections are established directly on the target cluster.

Closes #25178