### PR TITLE
docs: encapsulate demo web app

### DIFF
--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -80,8 +80,14 @@ Teleport's certificate.
 
 ## Step 2/6. Run a simple web service
 
-Run the following commands to create a directory on your Linux host
-called `demo-app` and add a simple HTML file to serve to clients:
+This guide assumes a web-based application for Teleport to provide (and restrict)
+access to. You can use any service that listens for HTTP requests, or create a demo
+application.
+
+<Details title="Create a demo app" opened="false">
+
+Create a directory on your Linux host called `demo-app` and add a simple HTML
+file to serve to clients:
 
 ```code
 $ mkdir demo-app
@@ -104,6 +110,10 @@ $ nohup python3 -m http.server 9000 --directory demo-app &
 Since port 9000 is not open on your Linux host, there is currently no way to
 access the web service from your local workstation. We will configure Teleport to
 enable you to access the web service securely.
+
+</Details>
+
+The rest of this page assumes a service listening for HTTP requests on port `9000`. Adjust this value to match your application.
 
 ## Step 3/6. Set up Teleport on your Linux host
 

--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -80,9 +80,7 @@ Teleport's certificate.
 
 ## Step 2/6. Run a simple web service
 
-This guide assumes a web-based application for Teleport to provide (and restrict)
-access to. You can use any service that listens for HTTP requests, or create a demo
-application.
+Run a web application for Teleport to manage access to. You can use any service that listens for HTTP requests, or create a demo application using the instructions below.
 
 <Details title="Create a demo app" opened="false">
 

--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -52,9 +52,9 @@ We will run the following Teleport services:
 
 - A two-factor authenticator app such as [Authy](https://authy.com/download/), [Google Authenticator](https://www.google.com/landing/2step/), or [Microsoft Authenticator](https://www.microsoft.com/en-us/account/authenticator)
 
-- `python3` installed on your Linux host. We will use this to run a simple
-  HTTP file server, so you can use another HTTP server if you have one
-  installed.
+- A web application to provide access to through Teleport. If you don't have
+  one, make sure `python3` installed on your Linux host. We will use this to
+  run a simple HTTP file server as a demo.
 
 You must also have one of the following:
 - A registered domain name.
@@ -80,7 +80,9 @@ Teleport's certificate.
 
 ## Step 2/6. Run a simple web service
 
-Run a web application for Teleport to manage access to. You can use any service that listens for HTTP requests, or create a demo application using the instructions below.
+Run a web application for Teleport to manage access to. You can use any service
+that listens for HTTP requests, or create a demo application using the
+instructions below.
 
 <Details title="Create a demo app" opened="false">
 


### PR DESCRIPTION
In response to feedback on this page, this PR clarifies the python-based demo web app as an optional example, for a reader who doesn't have an application in mind to put behind Teleport.

This PR assumes a resolution to https://github.com/gravitational/docs/issues/278 so that the contents will actually be collapsed by default, making the default render of the page simpler.