### PR TITLE
[v13] Extend cross-account discovery for EKS clusters

### DIFF
--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -192,8 +192,14 @@ func (s *Server) initAWSWatchers(matchers []services.AWSMatcher) error {
 			for _, region := range matcher.Regions {
 				switch t {
 				case services.AWSMatcherEKS:
-					// TODO(gavin): support assume_role_arn for AWS EKS.
-					client, err := s.Clients.GetAWSEKSClient(s.ctx, region)
+					client, err := s.Clients.GetAWSEKSClient(
+						s.ctx,
+						region,
+						cloud.WithAssumeRole(
+							matcher.AssumeRole.RoleARN,
+							matcher.AssumeRole.ExternalID,
+						),
+					)
 					if err != nil {
 						return trace.Wrap(err)
 					}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -422,6 +422,8 @@ func TestDiscoveryKube(t *testing.T) {
 		gcpMatchers                   []services.GCPMatcher
 		expectedClustersToExistInAuth []types.KubeCluster
 		clustersNotUpdated            []string
+		expectedAssumedRoles          []string
+		expectedExternalIDs           []string
 	}{
 		{
 			name:                 "no clusters in auth server, import 2 prod clusters from EKS",
@@ -437,6 +439,36 @@ func TestDiscoveryKube(t *testing.T) {
 				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
 				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
 			},
+		},
+		{
+			name:                 "no clusters in auth server, import 2 prod clusters from EKS with assumed roles",
+			existingKubeClusters: []types.KubeCluster{},
+			awsMatchers: []services.AWSMatcher{
+				{
+					Types:   []string{"eks"},
+					Regions: []string{"eu-west-1"},
+					Tags:    map[string]utils.Strings{"env": {"prod"}},
+					AssumeRole: services.AssumeRole{
+						RoleARN:    "arn:aws:iam::123456789012:role/teleport-role",
+						ExternalID: "external-id",
+					},
+				},
+				{
+					Types:   []string{"eks"},
+					Regions: []string{"eu-west-1"},
+					Tags:    map[string]utils.Strings{"env": {"prod"}},
+					AssumeRole: services.AssumeRole{
+						RoleARN:    "arn:aws:iam::123456789012:role/teleport-role2",
+						ExternalID: "external-id2",
+					},
+				},
+			},
+			expectedClustersToExistInAuth: []types.KubeCluster{
+				mustConvertEKSToKubeCluster(t, eksMockClusters[0], mainDiscoveryGroup),
+				mustConvertEKSToKubeCluster(t, eksMockClusters[1], mainDiscoveryGroup),
+			},
+			expectedAssumedRoles: []string{"arn:aws:iam::123456789012:role/teleport-role", "arn:aws:iam::123456789012:role/teleport-role2"},
+			expectedExternalIDs:  []string{"external-id", "external-id2"},
 		},
 		{
 			name:                 "no clusters in auth server, import 2 stg clusters from EKS",
@@ -580,8 +612,9 @@ func TestDiscoveryKube(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-
+			sts := &mocks.STSMock{}
 			testClients := cloud.TestCloudClients{
+				STS:            sts,
 				AzureAKSClient: newPopulatedAKSMock(),
 				EKS:            newPopulatedEKSMock(),
 				GCPGKE:         newPopulatedGCPMock(),
@@ -691,6 +724,9 @@ func TestDiscoveryKube(t *testing.T) {
 				}
 				return len(clustersNotUpdated) == 0 && clustersFoundInAuth
 			}, 5*time.Second, 200*time.Millisecond)
+
+			require.Equal(t, tc.expectedAssumedRoles, sts.GetAssumedRoleARNs(), "roles incorrectly assumed")
+			require.Equal(t, tc.expectedExternalIDs, sts.GetAssumedRoleExternalIDs(), "external IDs incorrectly assumed")
 		})
 	}
 }


### PR DESCRIPTION
Backport #24905 to branch/v13