### PR TITLE
Fix dynamo TestEmitAuditEventForLargeEvents

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -100,8 +100,10 @@ as well as an upgrade of the previous version of Teleport.
 - [ ] Backends
   - [ ] Teleport runs with etcd
   - [ ] Teleport runs with dynamodb
+    - [ ] AWS integration tests are passing
   - [ ] Teleport runs with SQLite
   - [ ] Teleport runs with Firestore
+    - [ ] GCP integration tests are passing
 
 - [ ] Session Recording
   - [ ] Session recording can be disabled
@@ -123,6 +125,10 @@ as well as an upgrade of the previous version of Teleport.
   - [ ] Network request are blocked when a policy deny them.
 
 - [ ] Audit Log
+  - [ ] Audit log with dynamodb
+    - [ ] AWS integration tests are passing
+  - [ ] Audit log with Firestore
+    - [ ] GCP integration tests are passing
   - [ ] Failed login attempts are recorded
   - [ ] Interactive sessions have the correct Server ID
     - [ ] `server_id` is the ID of the node in "session_recording: node" mode

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -57,8 +57,7 @@ func setupDynamoContext(t *testing.T) *dynamoContext {
 	if ok, _ := strconv.ParseBool(testEnabled); !ok {
 		t.Skip("Skipping AWS-dependent test suite.")
 	}
-
-	fakeClock := clockwork.NewFakeClock()
+	fakeClock := clockwork.NewFakeClockAt(time.Now().UTC())
 
 	log, err := New(context.Background(), Config{
 		Region:       "eu-north-1",
@@ -202,7 +201,8 @@ func TestLargeTableRetrieve(t *testing.T) {
 			UserMetadata: apievents.UserMetadata{User: "bob"},
 			Metadata: apievents.Metadata{
 				Type: events.UserLoginEvent,
-				Time: tt.suite.Clock.Now().UTC()},
+				Time: tt.suite.Clock.Now().UTC(),
+			},
 		})
 		require.NoError(t, err)
 	}
@@ -262,10 +262,10 @@ func TestEmitAuditEventForLargeEvents(t *testing.T) {
 	tt := setupDynamoContext(t)
 
 	ctx := context.Background()
-	now := tt.suite.Clock.Now()
+	now := tt.suite.Clock.Now().UTC()
 	dbQueryEvent := &apievents.DatabaseSessionQuery{
 		Metadata: apievents.Metadata{
-			Time: tt.suite.Clock.Now(),
+			Time: tt.suite.Clock.Now().UTC(),
 			Type: events.DatabaseSessionQueryEvent,
 		},
 		DatabaseQuery: strings.Repeat("A", maxItemSize),
@@ -286,13 +286,13 @@ func TestEmitAuditEventForLargeEvents(t *testing.T) {
 
 	appReqEvent := &apievents.AppSessionRequest{
 		Metadata: apievents.Metadata{
-			Time: tt.suite.Clock.Now(),
+			Time: tt.suite.Clock.Now().UTC(),
 			Type: events.AppSessionRequestEvent,
 		},
 		Path: strings.Repeat("A", maxItemSize),
 	}
 	err = tt.suite.Log.EmitAuditEvent(ctx, appReqEvent)
-	require.NoError(t, err)
+	require.ErrorContains(t, err, "ValidationException: Item size has exceeded the maximum allowed size")
 }
 
 func TestConfig_SetFromURL(t *testing.T) {
@@ -347,7 +347,6 @@ func TestConfig_SetFromURL(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-
 			uri, err := url.Parse(tt.url)
 			require.NoError(t, err)
 			require.NoError(t, tt.cfg.SetFromURL(uri))


### PR DESCRIPTION
This PR fixes dynamoevents integration tests: TestEmitAuditEventForLargeEvents.
Unfortunately those tests are not executed on CI, nor on test plan, so no-one notice them before. 


It fixes 2 things:
1. [This commit](https://github.com/gravitational/teleport/commit/d016c85a9aa9d84b48bdb5517fbf622364fb771f#diff-994cbcc3f412081f9d64ab4ae8cd7763478e5fe9111d7f1dd68511ad984ef102) changes assertion from 
`c.Assert(err, check.NotNil)` to `require.NoError(t, err)` which is not valid, because `AppSessionRequest` does not implement trimming and should fail with validation error.
2. Recently clockwork was update to [v0.4.0](https://github.com/gravitational/teleport/pull/24099). Previously fakeclock started with UTC timezone. Now it no longer does. And with non-UTC timezone, panic happens on trimming message (https://github.com/gogo/protobuf/issues/519). 