### PR TITLE
Fix cluster alerts timeout

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -392,7 +392,7 @@ const (
 
 const (
 	// TimeoutGetClusterAlerts is the timeout for grabbing cluster alerts from tctl and tsh
-	TimeoutGetClusterAlerts = time.Millisecond * 500
+	TimeoutGetClusterAlerts = time.Millisecond * 750
 )
 
 const (

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -118,10 +118,7 @@ type ClusterAlertGetter interface {
 // ShowClusterAlerts shows cluster alerts with the given labels and severity.
 func ShowClusterAlerts(ctx context.Context, client ClusterAlertGetter, w io.Writer, labels map[string]string, minSeverity, maxSeverity types.AlertSeverity) error {
 	// get any "on login" alerts
-	alertCtx, cancelAlertCtx := context.WithTimeout(ctx, constants.TimeoutGetClusterAlerts)
-	defer cancelAlertCtx()
-
-	alerts, err := client.GetClusterAlerts(alertCtx, types.GetClusterAlertsRequest{
+	alerts, err := client.GetClusterAlerts(ctx, types.GetClusterAlertsRequest{
 		Labels:   labels,
 		Severity: minSeverity,
 	})

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -215,6 +216,8 @@ func TryRun(commands []CLICommand, args []string) error {
 		}
 	}
 
+	ctx, cancel := context.WithTimeout(ctx, constants.TimeoutGetClusterAlerts)
+	defer cancel()
 	if err := common.ShowClusterAlerts(ctx, client, os.Stderr, nil,
 		types.AlertSeverity_HIGH, types.AlertSeverity_HIGH); err != nil {
 		log.WithError(err).Warn("Failed to display cluster alerts.")

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1207,6 +1207,13 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	case show.FullCommand():
 		err = onShow(&cf)
 	case status.FullCommand():
+		// onStatus can be invoked directly with `tsh status` but is also
+		// invoked from other commands. When invoked directly, we use a
+		// context with a short timeout to prevent the command from taking
+		// too long due to fetching alerts on slow networks.
+		var cancel context.CancelFunc
+		cf.Context, cancel = context.WithTimeout(cf.Context, constants.TimeoutGetClusterAlerts)
+		defer cancel()
 		err = onStatus(&cf)
 	case lsApps.FullCommand():
 		err = onApps(&cf)


### PR DESCRIPTION
tsh shows clusters alerts for both `tsh login` and `tsh status`. We intentionally used a short (500ms) timeout to avoid slowing down `tsh status` which was previously an "offline" command.

As a side effect, cluster alerts would not always show on login if they took longer than 500ms to fetch.

This change ensures that we always wait for cluster alerts to come back for `tsh login`, but we still enforce a short timeout for the `tsh status` command. (The timeout was increased slightly since the context now wraps the entire command and not just the cluster alerts call)

Fixes #25239