### PR TITLE
docs: remove dynamic database resource in example aws dynamodb

### DIFF
--- a/docs/pages/database-access/guides/aws-dynamodb.mdx
+++ b/docs/pages/database-access/guides/aws-dynamodb.mdx
@@ -197,9 +197,6 @@ teleport:
   auth_token: (=presets.tokens.first=)
 db_service:
   enabled: "yes"
-  resources:
-  - labels:
-      "*": "*"
   # Lists statically registered databases proxied by this agent.
   databases:
     - name: "example-dynamodb"


### PR DESCRIPTION
having this resource label will pull in all dynamic defined dbs which is likely not intended by setting up this dynamodb example.