### PR TITLE
Use the correct emitter in `auth.TLSServer`

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1205,6 +1205,13 @@ func (a *Server) SetEmitter(emitter apievents.Emitter) {
 	a.emitter = emitter
 }
 
+// EmitAuditEvent implements [apievents.Emitter] by delegating to its dedicated
+// emitter rather than falling back to the implementation from [Services] (using
+// the audit log directly, which is almost never what you want).
+func (a *Server) EmitAuditEvent(ctx context.Context, e apievents.AuditEvent) error {
+	return trace.Wrap(a.emitter.EmitAuditEvent(ctx, e))
+}
+
 // SetUsageReporter sets the server's usage reporter. Note that this is only
 // safe to use before server start.
 func (a *Server) SetUsageReporter(reporter usagereporter.UsageReporter) {

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -142,7 +142,7 @@ func NewTestServer(cfg TestServerConfig) (*TestServer, error) {
 		tlsCfg.APIConfig.AuditLog = authServer.AuditLog
 	}
 	if tlsCfg.APIConfig.Emitter == nil {
-		tlsCfg.APIConfig.Emitter = authServer.AuthServer.emitter
+		tlsCfg.APIConfig.Emitter = authServer.AuthServer
 	}
 	if tlsCfg.AcceptedUsage == nil {
 		tlsCfg.AcceptedUsage = authServer.AcceptedUsage
@@ -583,7 +583,7 @@ func (a *TestAuthServer) NewTestTLSServer() (*TestTLSServer, error) {
 		AuthServer: a.AuthServer,
 		Authorizer: a.Authorizer,
 		AuditLog:   a.AuditLog,
-		Emitter:    a.AuthServer.emitter,
+		Emitter:    a.AuthServer,
 	}
 	srv, err := NewTestTLSServer(TestTLSServerConfig{
 		APIConfig:     apiConfig,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1714,7 +1714,7 @@ func (process *TeleportProcess) initAuthService() error {
 		Authorizer:     authorizer,
 		AuditLog:       process.auditLog,
 		PluginRegistry: process.PluginRegistry,
-		Emitter:        checkingEmitter,
+		Emitter:        authServer,
 		MetadataGetter: uploadHandler,
 	}
 


### PR DESCRIPTION
This PR adds an explicit implementation of `apievents.Emitter` to `auth.Server`, which delegates the call to `EmitAuditEvent` to the `emitter` of the auth server; this is then used to pass the auth server itself to the `auth.TLSServer` as the emitter, which lets future calls to `(*auth.Server).SetEmitter` actually take effect on anything that grabs the emitter from the `auth.TLSServer` (as it's the case with all the plugins).

Fixes gravitational/teleport.e#1221