### PR TITLE
Add Minimum TLS version to FAQ

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -125,6 +125,12 @@ users to upgrade.
 This check is performed against all cluster components, including the Proxy
 Service and Auth Service, as well as agents running other Teleport Services.
 
+## What is the minimum TLS version that Teleport requires?
+
+Teleport requires a minimum of TLS version 1.2.
+
+This means that when applications and clients establish or accept TLS connections with Teleport processes, they must use TLS 1.2 or a higher protocol version. Teleport enforces this requirement in all operations that involve TLS connections.
+
 ## Can I suppress warnings about available upgrades?
 
 Yes. The `tctl alerts ack` command can be used to acknowledge an alert and


### PR DESCRIPTION
This question does come up from time to time, and I couldn't find a solid spot in the docs that calls it out.

https://github.com/gravitational/teleport/blob/v12.2.4/lib/utils/tls.go#L44 - this appears to be the spot in the code that sets the minimum version to tls 1.2 for all tls listeners in the codebase.