### PR TITLE
Split assist title Web API.

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -733,7 +733,8 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/assistant", h.WithAuth(h.assistant))
 
 	// Sets the title for the conversation.
-	h.POST("/webapi/assistant/conversations/:conversation_id/title", h.WithAuth(h.generateAssistantTitle))
+	h.POST("/webapi/assistant/conversations/:conversation_id/title", h.WithAuth(h.setAssistantTitle))
+	h.POST("/webapi/assistant/conversations/:conversation_id/title/summary", h.WithAuth(h.generateAssistantTitle))
 
 	// Creates a new conversation - the conversation ID is returned in the response.
 	h.POST("/webapi/assistant/conversations", h.WithAuth(h.createAssistantConversation))


### PR DESCRIPTION
Split the API to have separate endpoints for setting a title and generating a "title summary". In this case, a title can be edited end set directly without always creating a summary of it.