### PR TITLE
Determine callback URL instructions

### DIFF
--- a/docs/pages/access-controls/sso/google-workspace.mdx
+++ b/docs/pages/access-controls/sso/google-workspace.mdx
@@ -168,14 +168,17 @@ correct Google Workspace plan.
 
 </Notice>
 
-### Create an OAuth client ID
+#### Configure the OAuth Client ID
 
-In the [Create an OAuth client ID](https://console.cloud.google.com/apis/credentials/oauthclient) page of the GCP console, select "Web application" as the Application type, pick a name, then add the following as an authorized redirect URI.
+In the [Create an OAuth client ID](https://console.cloud.google.com/apis/credentials/oauthclient)
+page of the GCP console, select "Web application" as the Application type, pick a name, then add
+the callback URL. For most deployments, the callback URL is your `public_addr` value.
+
+The following is an example of an entry in the Callback URI field:
 
 ```txt
-https://<address of proxy server>:3080/v1/webapi/oidc/callback
+https://example.teleport.com/v1/webapi/oidc/callback
 ```
-
     ![OAuth client ID creation](../../../img/googleoidc/clientid-creation.png)
 
   Copy the Client ID and Client Secret from the next screen or by clicking "Download OAuth client".

--- a/examples/resources/gworkspace-connector-inline.yaml
+++ b/examples/resources/gworkspace-connector-inline.yaml
@@ -29,7 +29,7 @@ spec:
      "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/teleport-service-account%40access-304316.iam.gserviceaccount.com"
     }
   issuer_url: https://accounts.google.com
-  redirect_url: https://<cluster-url>:3080/v1/webapi/oidc/callback
+  redirect_url: https://teleport.example.com/v1/webapi/oidc/callback
   scope:
   - openid
   - email

--- a/examples/resources/gworkspace-connector.yaml
+++ b/examples/resources/gworkspace-connector.yaml
@@ -17,7 +17,7 @@ spec:
   google_admin_email: <GOOGLE_WORKSPACE_ADMIN_EMAIL>
   google_service_account_uri: file:///var/lib/teleport/gworkspace-creds.json
   issuer_url: https://accounts.google.com
-  redirect_url: https://<cluster-url>:3080/v1/webapi/oidc/callback
+  redirect_url: https://mytenant.teleport.sh/v1/webapi/oidc/callback
   scope:
   - openid
   - email


### PR DESCRIPTION
Using 3080 or 443 exclusively in instructions is confusing and can block progress if the user isn't using one of those ports. These instructions help determine the exact values that should be used.

replaces #17631 