### PR TITLE
docs: automatic user creation for windows desktops

### DIFF
--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -30,6 +30,12 @@ spec:
     # if unspecified. If one or more of the user's roles has disabled
     # the clipboard, then it will be disabled.
     desktop_clipboard: true
+
+    # Specify whether local users should be created automatically at connection
+    # time. By default, this feature is disabled, and the user must already exist.
+    # Note: this is applicable to local users only and is not supported in Active
+    # Directory environments.
+    create_desktop_user: true
   allow:
     # Label selectors for desktops this role has access to.
     windows_desktop_labels:
@@ -122,6 +128,81 @@ New clusters automatically populate the preset `access` role with the following:
 allow:
   windows_desktop_logins: ["{{internal.windows_logins}}"]
 ```
+
+### Automatic User Creation
+
+<Details title="Version Warning: Before 12.3" opened={false}>
+Teleport versions prior to 12.3 don't support the options shown below.
+</Details>
+
+Teleport's Desktop Service can be configured to automatically create local
+Windows users upon login.
+
+#### Configuration
+
+<Admonition type="warning" title="Local users only">
+Automatic user provisioning is only supported for local users, and does
+not take effect in Active Directory environments.
+</Admonition>
+
+This feature is disabled by default, and can be enabled by setting the
+`create_desktop_user` role option on one of the user's roles.
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: allow-user-provisioning
+spec:
+  options:
+    create_desktop_user: true
+  allow:
+    windows_desktop_labels: { '*': '*' }
+    windows_desktop_logins: jane
+```
+
+When a Teleport user connects to a desktop, Teleport checks each of the user's
+roles that match the desktop. If at least one role matches the desktop but does
+not include `create_desktop_user: true`, automatic user creation will be
+disabled. Roles that do not match the desktop's labels will not be checked.
+
+In order to create the user, the requested username must be present in one of the
+role's `windows_desktop_logins`.
+
+#### User management
+
+By default, the newly-created user will be placed in two Windows groups:
+
+- `Remote Desktop Users`: a built-in Windows group allowing remote desktop access
+- `Teleport Users`: a custom group that Teleport places all
+  automatically-created users in
+
+To add the user to additional groups, specify the `desktop_groups` role option:
+
+```yaml
+kind: role
+version: v6
+metadata:
+  name: allow-user-provisioning
+spec:
+  options:
+    create_desktop_user: true
+  allow:
+    windows_desktop_labels: { '*': '*' }
+    windows_desktop_logins: jane
+    desktop_groups:
+    - developers
+    # to make the newly-created user an administrator
+    - Administrators
+    # IdP trait templating is also supported
+    - '{{external.desktop_groups}}'
+```
+
+Teleport will never delete users that are created via automatic user provisioning.
+This ensures that the user's profile is preserved for future logins. Teleport will
+disable the account when the session completes (and automatically re-enable it on
+future connection attempts). This ensures that user accounts created by Teleport
+can only be accessed via Teleport.
 
 ## Clipboard Access
 


### PR DESCRIPTION
This documents the automatic user creation for local Windows users which is slated to be released in Teleport 12.3.

Do not merge/backport until released.

A couple questions for reviewers:

- This is very similar to the corresponding feature for server access. Should we somehow link to that page as well?
- Do you think this content makes more sense in a standalone guide as opposed to on the RBAC page?
- Is it clear enough that this is only for local users and does not work with AD?