### PR TITLE
Do not try to verify PROXY signature for non-Teleport TLVs

### DIFF
--- a/lib/multiplexer/multiplexer.go
+++ b/lib/multiplexer/multiplexer.go
@@ -436,8 +436,8 @@ func (m *Mux) detect(conn net.Conn) (*Conn, error) {
 				continue
 			}
 
-			// If TLVs are empty we know it can't be signed, so we don't try to verify to avoid unnecessary load
-			if m.CertAuthorityGetter != nil && m.LocalClusterName != "" && len(newProxyLine.TLVs) > 0 {
+			// If proxyline is not signed, so we don't try to verify to avoid unnecessary load
+			if m.CertAuthorityGetter != nil && m.LocalClusterName != "" && newProxyLine.IsSigned() {
 				err = newProxyLine.VerifySignature(m.context, m.CertAuthorityGetter, m.LocalClusterName, m.Clock)
 				if errors.Is(err, ErrNoHostCA) {
 					m.WithFields(log.Fields{


### PR DESCRIPTION
If PROXY line came with any TLV (fx from AWS load balancer with their own TLV) we incorrectly assumed it was a signed header and tried to verify the signature, which lead to an error.