### PR TITLE
Improve session tracker participant tracking

### DIFF
--- a/api/types/session_tracker.go
+++ b/api/types/session_tracker.go
@@ -252,7 +252,7 @@ func (s *SessionTrackerV1) AddParticipant(participant Participant) {
 func (s *SessionTrackerV1) RemoveParticipant(id string) error {
 	for i, participant := range s.Spec.Participants {
 		if participant.ID == id {
-			s.Spec.Participants = append(s.Spec.Participants[:i], s.Spec.Participants[i+1:]...)
+			s.Spec.Participants[i], s.Spec.Participants = s.Spec.Participants[len(s.Spec.Participants)-1], s.Spec.Participants[:len(s.Spec.Participants)-1]
 			return nil
 		}
 	}

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -224,21 +224,19 @@ func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *
 	session := scx.getSession()
 	if session != nil && !session.isStopped() {
 		scx.Infof("Joining existing session %v.", session.id)
-
 		mode := types.SessionParticipantMode(scx.env[teleport.EnvSSHJoinMode])
+		if mode == "" {
+			mode = types.SessionPeerMode
+		}
+
 		switch mode {
-		case types.SessionModeratorMode, types.SessionObserverMode:
+		case types.SessionModeratorMode, types.SessionObserverMode, types.SessionPeerMode:
 		default:
-			if mode == types.SessionPeerMode || len(mode) == 0 {
-				mode = types.SessionPeerMode
-			} else {
-				return trace.BadParameter("Unrecognized session participant mode: %v", mode)
-			}
+			return trace.BadParameter("Unrecognized session participant mode: %v", mode)
 		}
 
 		// Update the in-memory data structure that a party member has joined.
-		_, err := session.join(ch, scx, mode)
-		if err != nil {
+		if err := session.join(ch, scx, mode); err != nil {
 			return trace.Wrap(err)
 		}
 
@@ -255,9 +253,10 @@ func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *
 		sid = string(rsession.NewID())
 		scx.SetEnv(sshutils.SessionEnvVar, sid)
 	}
+
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition
-	sess, err := newSession(ctx, rsession.ID(sid), s, scx)
+	sess, p, err := newSession(ctx, rsession.ID(sid), s, scx, ch)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -267,14 +266,14 @@ func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *
 
 	// Start an interactive session (TTY attached). Close the session if an error
 	// occurs, otherwise it will be closed by the callee.
-	if err := sess.startInteractive(ctx, ch, scx); err != nil {
+	if err := sess.startInteractive(ctx, scx, p); err != nil {
 		sess.Close()
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-// OpenExecSession opens an non-interactive exec session.
+// OpenExecSession opens a non-interactive exec session.
 func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
 	var sessionID rsession.ID
 
@@ -295,7 +294,7 @@ func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Chann
 
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
-	sess, err := newSession(ctx, sessionID, s, scx)
+	sess, _, err := newSession(ctx, sessionID, s, scx, channel)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -645,7 +644,7 @@ type session struct {
 }
 
 // newSession creates a new session with a given ID within a given context.
-func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *ServerContext) (*session, error) {
+func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *ServerContext, ch ssh.Channel) (*session, *party, error) {
 	serverSessions.Inc()
 	startTime := time.Now().UTC()
 	rsess := rsession.Session{
@@ -669,7 +668,7 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 	if term != nil {
 		winsize, err := term.GetWinSize()
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return nil, nil, trace.Wrap(err)
 		}
 		rsess.TerminalParams.W = int(winsize.Width)
 		rsess.TerminalParams.H = int(winsize.Height)
@@ -712,20 +711,25 @@ func newSession(ctx context.Context, id rsession.ID, r *SessionRegistry, scx *Se
 		}
 	}()
 
+	// create a new "party" (connected client) and launch/join the session.
+	p := newParty(sess, types.SessionPeerMode, ch, scx)
+	sess.parties[p.id] = p
+	sess.participants[p.id] = p
+
 	var err error
-	if err = sess.trackSession(ctx, scx.Identity.TeleportUser, policySets); err != nil {
+	if err = sess.trackSession(ctx, scx.Identity.TeleportUser, policySets, p); err != nil {
 		if trace.IsNotImplemented(err) {
-			return nil, trace.NotImplemented("Attempted to use Moderated Sessions with an Auth Server below the minimum version of 9.0.0.")
+			return nil, nil, trace.NotImplemented("Attempted to use Moderated Sessions with an Auth Server below the minimum version of 9.0.0.")
 		}
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
 	sess.recorder, err = newRecorder(sess, scx)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.Wrap(err)
 	}
 
-	return sess, nil
+	return sess, p, nil
 }
 
 // ID returns a string representation of the session ID.
@@ -1109,7 +1113,16 @@ func (s *session) launch() {
 
 // startInteractive starts a new interactive process (or a shell) in the
 // current session.
-func (s *session) startInteractive(ctx context.Context, ch ssh.Channel, scx *ServerContext) error {
+func (s *session) startInteractive(ctx context.Context, scx *ServerContext, p *party) error {
+	canStart, _, err := s.checkIfStart()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if !canStart && services.IsRecordAtProxy(p.ctx.SessionRecordingConfig.GetMode()) {
+		go s.Stop()
+		return trace.AccessDenied("session requires additional moderation but is in proxy-record mode")
+	}
+
 	inReader, inWriter := io.Pipe()
 	s.inWriter = inWriter
 	s.io.AddReader("reader", inReader)
@@ -1124,8 +1137,6 @@ func (s *session) startInteractive(ctx context.Context, ch ssh.Channel, scx *Ser
 	// Emit a session.start event for the interactive session.
 	s.emitSessionStartEvent(scx)
 
-	// create a new "party" (connected client) and launch/join the session.
-	p := newParty(s, types.SessionPeerMode, ch, scx)
 	if err := s.addParty(p, types.SessionPeerMode); err != nil {
 		return trace.Wrap(err)
 	}
@@ -1546,9 +1557,10 @@ func (s *session) checkPresence() error {
 
 		if participant.Mode == string(types.SessionModeratorMode) && time.Now().UTC().After(participant.LastActive.Add(PresenceMaxDifference)) {
 			s.log.Warnf("Participant %v is not active, kicking.", participant.ID)
-			party := s.parties[rsession.ID(participant.ID)]
-			if party != nil {
-				party.closeUnderSessionLock()
+			if party := s.parties[rsession.ID(participant.ID)]; party != nil {
+				if err := party.closeUnderSessionLock(); err != nil {
+					s.log.Errorf("Failed to remove party %v: %v", party.id, err)
+				}
 			}
 		}
 	}
@@ -1755,17 +1767,6 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 	s.participants[p.id] = p
 	p.ctx.AddCloser(p)
 
-	s.log.Debugf("Tracking participant: %s", p.id)
-	participant := &types.Participant{
-		ID:         p.id.String(),
-		User:       p.user,
-		Mode:       string(p.mode),
-		LastActive: time.Now().UTC(),
-	}
-	if err := s.tracker.AddParticipant(s.serverCtx, participant); err != nil {
-		return trace.Wrap(err)
-	}
-
 	// Write last chunk (so the newly joined parties won't stare at a blank
 	// screen).
 	if _, err := p.Write(s.io.GetRecentHistory()); err != nil {
@@ -1825,36 +1826,48 @@ func (s *session) addParty(p *party, mode types.SessionParticipantMode) error {
 	return nil
 }
 
-func (s *session) join(ch ssh.Channel, ctx *ServerContext, mode types.SessionParticipantMode) (*party, error) {
-	if ctx.Identity.TeleportUser != s.initiator {
+func (s *session) join(ch ssh.Channel, scx *ServerContext, mode types.SessionParticipantMode) error {
+	if scx.Identity.TeleportUser != s.initiator {
 		accessContext := auth.SessionAccessContext{
-			Username: ctx.Identity.TeleportUser,
-			Roles:    ctx.Identity.AccessChecker.Roles(),
+			Username: scx.Identity.TeleportUser,
+			Roles:    scx.Identity.AccessChecker.Roles(),
 		}
 
 		modes := s.access.CanJoin(accessContext)
 		if !auth.SliceContainsMode(modes, mode) {
-			return nil, trace.AccessDenied("insufficient permissions to join session %v", s.id)
+			return trace.AccessDenied("insufficient permissions to join session %v", s.id)
 		}
 
 		if s.presenceEnabled {
 			_, err := ch.SendRequest(teleport.MFAPresenceRequest, false, nil)
 			if err != nil {
-				return nil, trace.WrapWithMessage(err, "failed to send MFA presence request")
+				return trace.WrapWithMessage(err, "failed to send MFA presence request")
 			}
 		}
 	}
 
-	p := newParty(s, mode, ch, ctx)
+	// create a new "party" (connected client) and launch/join the session.
+	p := newParty(s, mode, ch, scx)
 	if err := s.addParty(p, mode); err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
+	}
+
+	s.log.Debugf("Tracking participant: %s", p.id)
+	participant := &types.Participant{
+		ID:         p.id.String(),
+		User:       p.user,
+		Mode:       string(p.mode),
+		LastActive: time.Now().UTC(),
+	}
+	if err := s.tracker.AddParticipant(s.serverCtx, participant); err != nil {
+		return trace.Wrap(err)
 	}
 
 	// Emit session join event to both the Audit Log as well as over the
 	// "x-teleport-event" channel in the SSH connection.
 	s.emitSessionJoinEvent(p.ctx)
 
-	return p, nil
+	return nil
 }
 
 func (s *session) getParties() (parties []*party) {
@@ -1925,27 +1938,27 @@ func (p *party) String() string {
 func (p *party) Close() error {
 	p.s.mu.Lock()
 	defer p.s.mu.Unlock()
-	p.closeUnderSessionLock()
-	return nil
+	return p.closeUnderSessionLock()
 }
 
-// closeUnderSessionLock closes the party, and removes it from it's session.
+// closeUnderSessionLock closes the party, and removes it from its session.
 // Must be called under session Lock.
-func (p *party) closeUnderSessionLock() {
+func (p *party) closeUnderSessionLock() error {
+	var err error
 	p.closeOnce.Do(func() {
 		p.log.Infof("Closing party %v", p.id)
 		// Remove party from its session
-		if err := p.s.removePartyUnderLock(p); err != nil {
-			p.ctx.Errorf("Failed to remove party %v: %v", p.id, err)
-		}
-		p.ch.Close()
+		err = trace.NewAggregate(p.s.removePartyUnderLock(p), p.ch.Close())
 	})
+
+	return err
 }
 
 // trackSession creates a new session tracker for the ssh session.
 // While ctx is open, the session tracker's expiration will be extended
 // on an interval until the session tracker is closed.
-func (s *session) trackSession(ctx context.Context, teleportUser string, policySet []*types.SessionTrackerPolicySet) error {
+func (s *session) trackSession(ctx context.Context, teleportUser string, policySet []*types.SessionTrackerPolicySet, p *party) error {
+	s.log.Debugf("Tracking participant: %s", p.id)
 	trackerSpec := types.SessionTrackerSpecV1{
 		SessionID:    s.id.String(),
 		Kind:         string(types.SSHSessionKind),
@@ -1958,6 +1971,14 @@ func (s *session) trackSession(ctx context.Context, teleportUser string, policyS
 		Reason:       s.scx.env[teleport.EnvSSHSessionReason],
 		HostPolicies: policySet,
 		Created:      s.registry.clock.Now(),
+		Participants: []types.Participant{
+			{
+				ID:         p.id.String(),
+				User:       p.user,
+				Mode:       string(p.mode),
+				LastActive: time.Now().UTC(),
+			},
+		},
 	}
 
 	if s.scx.env[teleport.EnvSSHSessionInvited] != "" {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -114,7 +114,7 @@ func TestIsApprovedFileTransfer(t *testing.T) {
 	})
 	auditorRoleSet := services.NewRoleSet(auditorRole)
 	auditScx := newTestServerContext(t, reg.Srv, auditorRoleSet)
-	// change the teleport user so we dont match the user in the test cases
+	// change the teleport user so we don't match the user in the test cases
 	auditScx.Identity.TeleportUser = "mod"
 	auditSess, _ := testOpenSession(t, reg, auditorRoleSet)
 	approvers := make(map[string]*party)
@@ -557,7 +557,7 @@ func TestParties(t *testing.T) {
 
 	// If a party leaves, the session should remove the party and continue.
 	p := sess.getParties()[0]
-	p.Close()
+	require.NoError(t, p.Close())
 
 	partyIsRemoved := func() bool {
 		return len(sess.getParties()) == 2 && !sess.isStopped()
@@ -566,8 +566,7 @@ func TestParties(t *testing.T) {
 
 	// If a party's session context is closed, the party should leave the session.
 	p = sess.getParties()[0]
-	err = p.ctx.Close()
-	require.NoError(t, err)
+	require.NoError(t, p.ctx.Close())
 
 	partyIsRemoved = func() bool {
 		return len(sess.getParties()) == 1 && !sess.isStopped()
@@ -579,7 +578,8 @@ func TestParties(t *testing.T) {
 	})
 
 	// If all parties are gone, the session should linger for a short duration.
-	sess.getParties()[0].Close()
+	p = sess.getParties()[0]
+	require.NoError(t, p.Close())
 	require.False(t, sess.isStopped())
 
 	// Wait for session to linger (time.Sleep)
@@ -589,12 +589,13 @@ func TestParties(t *testing.T) {
 	testJoinSession(t, reg, sess)
 	require.Equal(t, 1, len(sess.getParties()))
 
-	// andvance clock and give lingerAndDie goroutine a second to complete.
+	// advance clock and give lingerAndDie goroutine a second to complete.
 	regClock.Advance(defaults.SessionIdlePeriod)
 	require.False(t, sess.isStopped())
 
 	// If no parties remain it should be closed after the duration.
-	sess.getParties()[0].Close()
+	p = sess.getParties()[0]
+	require.NoError(t, p.Close())
 	require.False(t, sess.isStopped())
 
 	// Wait for session to linger (time.Sleep)
@@ -889,7 +890,12 @@ func TestTrackingSession(t *testing.T) {
 				access:    sessionEvaluator{moderated: tt.moderated},
 			}
 
-			err = sess.trackSession(ctx, me.Name, nil)
+			p := &party{
+				user: me.Name,
+				id:   rsession.NewID(),
+				mode: types.SessionPeerMode,
+			}
+			err = sess.trackSession(ctx, me.Name, nil, p)
 			tt.assertion(t, err)
 			tt.createAssertion(t, trackingService.CreatedCount())
 		})

--- a/lib/srv/sessiontracker.go
+++ b/lib/srv/sessiontracker.go
@@ -207,7 +207,9 @@ func (s *SessionTracker) AddParticipant(ctx context.Context, p *types.Participan
 func (s *SessionTracker) RemoveParticipant(ctx context.Context, participantID string) error {
 	s.trackerCond.L.Lock()
 	defer s.trackerCond.L.Unlock()
-	s.tracker.RemoveParticipant(participantID)
+	if err := s.tracker.RemoveParticipant(participantID); err != nil {
+		return trace.Wrap(err)
+	}
 	s.trackerCond.Broadcast()
 
 	if s.service != nil {


### PR DESCRIPTION
SessionTrackers were being created without any participants and then immediately updated to include the initial user that created the session. By adding the initial party to the SessionTracker when the session is created there will be one less UpdateSessionTracker call to Auth per session. This will help reduce connection latency for interactive sessions and reduce Auth load.

Closes #17027