### PR TITLE
[v12] Define distinct types for all device events

### DIFF
--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -586,7 +586,30 @@ const (
 	SSMRunEvent = "ssm.run"
 
 	// DeviceEvent is the catch-all event for Device Trust events.
+	// Deprecated: Use one of the more specific event codes below.
 	DeviceEvent = "device"
+	// DeviceCreateEvent is emitted on device registration.
+	// This is an inventory management event.
+	DeviceCreateEvent = "device.create"
+	// DeviceDeleteEvent is emitted on device deletion.
+	// This is an inventory management event.
+	DeviceDeleteEvent = "device.delete"
+	// DeviceUpdateEvent is emitted on device updates.
+	// This is an inventory management event.
+	DeviceUpdateEvent = "device.update"
+	// DeviceEnrollEvent is emitted when a device is enrolled.
+	// Enrollment events are issued due to end-user action, using the trusted
+	// device itself.
+	DeviceEnrollEvent = "device.enroll"
+	// DeviceAuthenticateEvent is emitted when a device is authenticated.
+	// Authentication events are issued due to end-user action, using the trusted
+	// device itself.
+	DeviceAuthenticateEvent = "device.authenticate"
+	// DeviceEnrollTokenCreateEvent is emitted when a new enrollment token is
+	// issued for a device.
+	// Device enroll tokens are issued by either a device admin or during
+	// client-side auto-enrollment.
+	DeviceEnrollTokenCreateEvent = "device.token.create"
 
 	// BotJoinEvent is emitted when a bot joins
 	BotJoinEvent = "bot.join"

--- a/lib/events/dynamic.go
+++ b/lib/events/dynamic.go
@@ -223,7 +223,10 @@ func FromEventFields(fields EventFields) (events.AuditEvent, error) {
 		e = &events.MFADeviceAdd{}
 	case MFADeviceDeleteEvent:
 		e = &events.MFADeviceDelete{}
-	case DeviceEvent:
+	case DeviceEvent, // Keep DeviceEvent here for backwards compatibility.
+		DeviceCreateEvent, DeviceDeleteEvent, DeviceUpdateEvent,
+		DeviceEnrollEvent, DeviceAuthenticateCode,
+		DeviceEnrollTokenCreateEvent:
 		e = &events.DeviceEvent{}
 	case LockCreatedEvent:
 		e = &events.LockCreate{}


### PR DESCRIPTION
Define distinct types for all device events, for better compliance with existing events and overall better user friendliness.

#25288

Backport #25294 to branch/v12