### PR TITLE
Ensure useDocumentGateway creates the gateway only on mount

### DIFF
--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -26,10 +26,12 @@ export const makeServer = (props: Partial<tsh.Server> = {}): tsh.Server => ({
   ...props,
 });
 
+export const databaseUri = '/clusters/teleport-local/dbs/foo';
+
 export const makeDatabase = (
   props: Partial<tsh.Database> = {}
 ): tsh.Database => ({
-  uri: '/clusters/teleport-local/dbs/foo',
+  uri: databaseUri,
   name: 'foo',
   protocol: 'postgres',
   type: 'self-hosted',
@@ -69,5 +71,18 @@ export const makeRootCluster = (
     requestableRolesList: [],
     suggestedReviewersList: [],
   },
+  ...props,
+});
+
+export const makeGateway = (props: Partial<tsh.Gateway> = {}): tsh.Gateway => ({
+  uri: '/gateways/foo',
+  targetName: 'sales-production',
+  targetUri: databaseUri,
+  targetUser: 'alice',
+  localAddress: 'localhost',
+  localPort: '1337',
+  protocol: 'postgres',
+  cliCommand: 'connect-me-to-db-please',
+  targetSubresourceName: 'bar',
   ...props,
 });

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
@@ -20,11 +20,12 @@ import {
   makeEmptyAttempt,
   makeProcessingAttempt,
   makeErrorAttempt,
+  makeSuccessAttempt,
 } from 'shared/hooks/useAsync';
 
 import { Gateway } from 'teleterm/services/tshd/types';
 
-import { DocumentGateway } from './DocumentGateway';
+import { DocumentGateway, DocumentGatewayProps } from './DocumentGateway';
 
 export default {
   title: 'Teleterm/DocumentGateway',
@@ -42,22 +43,23 @@ const gateway: Gateway = {
   targetSubresourceName: 'bar',
 };
 
+const onlineDocumentGatewayProps: DocumentGatewayProps = {
+  gateway: gateway,
+  defaultPort: gateway.localPort,
+  disconnect: async () => [undefined, null],
+  connected: true,
+  reconnect: async () => [undefined, null],
+  connectAttempt: makeSuccessAttempt(undefined),
+  disconnectAttempt: makeEmptyAttempt(),
+  runCliCommand: () => {},
+  changeDbName: async () => [undefined, null],
+  changeDbNameAttempt: makeEmptyAttempt(),
+  changePort: async () => [undefined, null],
+  changePortAttempt: makeEmptyAttempt(),
+};
+
 export function Online() {
-  return (
-    <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
-    />
-  );
+  return <DocumentGateway {...onlineDocumentGatewayProps} />;
 }
 
 export function OnlineWithLongValues() {
@@ -78,17 +80,9 @@ export function OnlineWithLongValues() {
 
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={gateway}
       defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }
@@ -96,19 +90,10 @@ export function OnlineWithLongValues() {
 export function OnlineWithFailedDbNameAttempt() {
   return (
     <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
+      {...onlineDocumentGatewayProps}
       changeDbNameAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting database name.'
       )}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }
@@ -116,16 +101,7 @@ export function OnlineWithFailedDbNameAttempt() {
 export function OnlineWithFailedPortAttempt() {
   return (
     <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
+      {...onlineDocumentGatewayProps}
       changePortAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting port.'
       )}
@@ -136,18 +112,10 @@ export function OnlineWithFailedPortAttempt() {
 export function OnlineWithFailedDbNameAndPortAttempts() {
   return (
     <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
+      {...onlineDocumentGatewayProps}
       changeDbNameAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting database name.'
       )}
-      changePort={() => Promise.resolve([undefined, null])}
       changePortAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting port.'
       )}
@@ -158,39 +126,25 @@ export function OnlineWithFailedDbNameAndPortAttempts() {
 export function Offline() {
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={undefined}
       defaultPort="1337"
-      disconnect={() => Promise.resolve([undefined, null])}
       connected={false}
-      reconnect={() => {}}
       connectAttempt={makeEmptyAttempt()}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }
 
 export function OfflineWithFailedConnectAttempt() {
-  const connectAttempt = makeErrorAttempt<void>(
-    'listen tcp 127.0.0.1:62414: bind: address already in use'
-  );
-
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={undefined}
       defaultPort="62414"
-      disconnect={() => Promise.resolve([undefined, null])}
       connected={false}
-      reconnect={() => {}}
-      connectAttempt={connectAttempt}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
+      connectAttempt={makeErrorAttempt<void>(
+        'listen tcp 127.0.0.1:62414: bind: address already in use'
+      )}
     />
   );
 }
@@ -198,17 +152,11 @@ export function OfflineWithFailedConnectAttempt() {
 export function Processing() {
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={undefined}
       defaultPort="1337"
-      disconnect={() => Promise.resolve([undefined, null])}
       connected={false}
-      reconnect={() => {}}
       connectAttempt={makeProcessingAttempt()}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import Document from 'teleterm/ui/Document';
 import * as types from 'teleterm/ui/services/workspacesService';
 
-import useDocumentGateway from './useDocumentGateway';
+import { useDocumentGateway } from './useDocumentGateway';
 import { OfflineDocumentGateway } from './OfflineDocumentGateway';
 import { OnlineDocumentGateway } from './OnlineDocumentGateway';
 

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import {
+  makeRootCluster,
+  makeGateway,
+} from 'teleterm/services/tshd/testHelpers';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { DocumentGateway } from 'teleterm/ui/services/workspacesService';
+
+import { WorkspaceContextProvider } from '../Documents';
+import { MockAppContextProvider } from '../fixtures/MockAppContextProvider';
+
+import { useDocumentGateway } from './useDocumentGateway';
+
+jest.mock('teleterm/staticConfig', () => ({
+  staticConfig: {
+    prehogAddress: undefined,
+  },
+}));
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('creates a gateway on mount if it does not exist already', async () => {
+  const { appContext, gateway, doc, $wrapper } = testSetup();
+
+  jest
+    .spyOn(appContext.clustersService, 'createGateway')
+    .mockImplementation(async () => {
+      appContext.clustersService.setState(draftState => {
+        draftState.gateways.set(gateway.uri, gateway);
+      });
+      return gateway;
+    });
+
+  const { result, waitFor } = renderHook(() => useDocumentGateway(doc), {
+    wrapper: $wrapper,
+  });
+
+  await waitFor(() => result.current.connectAttempt.status === 'success');
+
+  expect(appContext.clustersService.createGateway).toHaveBeenCalledWith({
+    targetUri: doc.targetUri,
+    subresource_name: doc.targetSubresourceName,
+    user: doc.targetUser,
+    port: doc.port,
+  });
+  expect(appContext.clustersService.createGateway).toHaveBeenCalledTimes(1);
+});
+
+it('does not create a gateway on mount if the gateway already exists', async () => {
+  const { appContext, gateway, doc, $wrapper } = testSetup();
+  appContext.clustersService.setState(draftState => {
+    draftState.gateways.set(gateway.uri, gateway);
+  });
+  jest.spyOn(appContext.clustersService, 'createGateway');
+
+  renderHook(() => useDocumentGateway(doc), {
+    wrapper: $wrapper,
+  });
+
+  expect(appContext.clustersService.createGateway).not.toHaveBeenCalled();
+});
+
+// Regression test.
+it('does not attempt to create a gateway immediately after closing it if the gateway was already running', async () => {
+  const { appContext, gateway, doc, $wrapper } = testSetup();
+  appContext.clustersService.setState(draftState => {
+    draftState.gateways.set(gateway.uri, gateway);
+  });
+
+  jest
+    .spyOn(appContext.clustersService, 'removeGateway')
+    .mockImplementation(async gatewayUri => {
+      appContext.clustersService.setState(draftState => {
+        draftState.gateways.delete(gatewayUri);
+      });
+    });
+  jest
+    .spyOn(appContext.clustersService, 'createGateway')
+    .mockResolvedValue(gateway);
+
+  const { result, waitFor } = renderHook(() => useDocumentGateway(doc), {
+    wrapper: $wrapper,
+  });
+
+  act(() => {
+    result.current.disconnect();
+  });
+
+  await waitFor(() => result.current.disconnectAttempt.status === 'success');
+
+  expect(appContext.clustersService.createGateway).not.toHaveBeenCalled();
+});
+
+const testSetup = () => {
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster({ connected: true });
+  const gateway = makeGateway();
+  const doc: DocumentGateway = {
+    uri: '/docs/1',
+    kind: 'doc.gateway',
+    targetName: gateway.targetName,
+    targetUri: gateway.targetUri,
+    targetUser: gateway.targetUser,
+    targetSubresourceName: gateway.targetSubresourceName,
+    gatewayUri: gateway.uri,
+    origin: 'resource_table',
+    title: '',
+  };
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(cluster.uri, cluster);
+  });
+  appContext.workspacesService.setState(draftState => {
+    draftState.rootClusterUri = cluster.uri;
+    draftState.workspaces[cluster.uri] = {
+      documents: [doc],
+      location: doc.uri,
+      localClusterUri: cluster.uri,
+      accessRequests: undefined,
+    };
+  });
+  const workspaceContext = {
+    rootClusterUri: cluster.uri,
+    localClusterUri: cluster.uri,
+    documentsService: appContext.workspacesService.getWorkspaceDocumentService(
+      cluster.uri
+    ),
+    accessRequestsService: undefined,
+  };
+  const $wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      <WorkspaceContextProvider value={workspaceContext}>
+        {children}
+      </WorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  return { gateway, doc, appContext, workspaceContext, $wrapper };
+};

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
@@ -94,18 +94,6 @@ export default function useGateway(doc: types.DocumentGateway) {
     });
   });
 
-  const reconnect = (port: string) => {
-    if (rootCluster.connected) {
-      createGateway(port);
-      return;
-    }
-
-    ctx.commandLauncher.executeCommand('cluster-connect', {
-      clusterUri: rootCluster.uri,
-      onSuccess: () => createGateway(doc.port),
-    });
-  };
-
   const runCliCommand = () => {
     const { rootClusterId, leafClusterId } = routing.parseClusterUri(
       cluster.uri
@@ -134,7 +122,7 @@ export default function useGateway(doc: types.DocumentGateway) {
     defaultPort,
     disconnect,
     connected,
-    reconnect,
+    reconnect: createGateway,
     connectAttempt,
     runCliCommand,
     changeDbName,

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
@@ -67,6 +67,7 @@ export default function useGateway(doc: types.DocumentGateway) {
 
   const [disconnectAttempt, disconnect] = useAsync(async () => {
     await ctx.clustersService.removeGateway(doc.gatewayUri);
+    workspaceDocumentsService.close(doc.uri);
   });
 
   const [changeDbNameAttempt, changeDbName] = useAsync(async (name: string) => {
@@ -115,12 +116,6 @@ export default function useGateway(doc: types.DocumentGateway) {
       leafClusterId,
     });
   };
-
-  useEffect(() => {
-    if (disconnectAttempt.status === 'success') {
-      workspaceDocumentsService.close(doc.uri);
-    }
-  }, [disconnectAttempt.status]);
 
   const shouldCreateGateway =
     rootCluster.connected && !connected && connectAttempt.status === '';

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -52,7 +52,7 @@ beforeAll(() => {
   Logger.init(new NullService());
 });
 
-afterEach(() => {
+beforeEach(() => {
   jest.restoreAllMocks();
 });
 


### PR DESCRIPTION
This PR fixes a bug while also simplifying the gateway creation logic.

The bug is here:

https://github.com/gravitational/teleport/blob/4d0f6c58ea3f0b660a386b3a54cdaf67e67494f7/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts#L38-L39

https://github.com/gravitational/teleport/blob/4d0f6c58ea3f0b660a386b3a54cdaf67e67494f7/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts#L125-L135

It is possible to close `DocumentGateway` without shutting down the underlying gateway which is intended behavior. But if you then reopen `DocumentGateway` with the same parameters (for example, through the connection list) and then attempt to shut down the gateway, the gateway will be immediately recreated but without this being reflected in the UI. If you then attempt to open the same `DocumentGateway` again, it'll return an error about the port being occupied (since there's a gateway running on it already).

This happens because if you open `DocumentGateway` while a gateway is already running, `createGateway` is not called on mount and `connectionAttempt.status` stays at `''`. So when you then shut down the gateway, `rootCluster.connected` evaluates to true, `!connected` evaluates to true (since you just removed the gateway from `ClustersService`) and `connectAttempt.status === ''` evaluates to true as well and the hook calls `createGateway`.

## Removing old cruft

`useDocumentGateway` does include some code from times where we didn't have `retryWithRelogin`, those are the bits that check `rootCluster.connected`. Back in the day, [we'd automatically start the gateway if the cluster changes `connected` from false to true](https://github.com/gravitational/webapps/pull/879/commits/9a69e894fc8290eed0fff3a07dd234db2f9b11d9), it was also possible for a root cluster to change its `connected` value during the app's lifecycle.

This is no longer needed as `createGateway` uses `retryWithRelogin` underneath. We should really only create the gateway on mount or when the user clicks the "Reconnect" button.

### Leaf clusters and `connected` property

Leaf clusters start with `connected` being false and switch to true after the response from `ListLeafClusters` comes back. However, we don't need to wait for the leaf cluster deatils before we attempt to create the gateway.

If the leaf cluster is actually online but the app thinks it's not `connected` only because it's still waiting for the response from `ListLeafClusters` to come back, there's nothing stopping us from attempting to make a gateway. If the request to create the gateway fails, the user will see the error and will be able to attempt to reconnect. This mostly related to the flow where the user reopens the session on app launch, before `ListLeafClusters` response comes in.