### PR TITLE
helm: fix updater readiness port

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -88,7 +88,7 @@ spec:
         readinessProbe:
           httpGet:
             path: /readyz
-            port: diag
+            port: healthz
           initialDelaySeconds: 5
           periodSeconds: 5
           failureThreshold: 6 # consider unready after 30s

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/updater_deployment_test.yaml.snap
@@ -49,7 +49,7 @@ sets the affinity:
         failureThreshold: 6
         httpGet:
           path: /readyz
-          port: diag
+          port: healthz
         initialDelaySeconds: 5
         periodSeconds: 5
         timeoutSeconds: 5
@@ -93,7 +93,7 @@ sets the tolerations:
         failureThreshold: 6
         httpGet:
           path: /readyz
-          port: diag
+          port: healthz
         initialDelaySeconds: 5
         periodSeconds: 5
         timeoutSeconds: 5


### PR DESCRIPTION
Rename readiness port (it was non-existent due to a wrong copy-paste) so the pod is considered ready by Kubernetes.