### PR TITLE
Update version vars

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1432,7 +1432,6 @@
     }
   ],
   "variables": {
-    "version": "7.0",
     "ansible": {
       "min_version": "2.9.6"
     },
@@ -1487,9 +1486,9 @@
       "last_report": "August 9th, 2022"
     },
     "teleport": {
-      "major_version": "12",
-      "version": "12.1.1",
-      "golang": "1.19",
+      "major_version": "14",
+      "version": "14.0.0-dev",
+      "golang": "1.20",
       "plugin": {
         "version": "12.1.1"
       },


### PR DESCRIPTION
Reflect that `14.0.0-dev` is the current edge version when we update the docs to make v13 the default version.