### PR TITLE
docs: use Teleport template version in nodes list in docker guide

### DIFF
--- a/docs/pages/management/guides/docker.mdx
+++ b/docs/pages/management/guides/docker.mdx
@@ -245,7 +245,7 @@ Open another terminal window and confirm that you joined the SSH Service to the 
 $ docker exec teleport tctl nodes ls
 # Host           UUID                Public Address  Labels Version
 # -------------- ------------------- --------------- ------ -------
-# example-server edc6b7ae-0ae5-43... 172.17.0.3:3022        12.2.2
+# example-server edc6b7ae-0ae5-43... 172.17.0.3:3022        (=teleport.version=)
 ```
 
 Issue this command, which will log in to your Teleport cluster via the Proxy Service at


### PR DESCRIPTION
Teleport version was hard-coded.  Will backport this into existing backports for guide.