### PR TITLE
Get safe destination address when proxying to cluster

### DIFF
--- a/lib/srv/transport/transportv1/transport.go
+++ b/lib/srv/transport/transportv1/transport.go
@@ -147,7 +147,12 @@ func (s *Service) ProxyCluster(stream transportv1pb.TransportService_ProxyCluste
 		return trace.BadParameter("unable to find peer")
 	}
 
-	conn, err := s.cfg.Dialer.DialSite(ctx, req.Cluster, p.Addr, s.cfg.LocalAddr)
+	clientDst, err := getDestinationAddress(p.Addr, s.cfg.LocalAddr)
+	if err != nil {
+		return trace.Wrap(err, "could get not client destination address; listener address %q, client source address %q", s.cfg.LocalAddr.String(), p.Addr.String())
+	}
+
+	conn, err := s.cfg.Dialer.DialSite(ctx, req.Cluster, p.Addr, clientDst)
 	if err != nil {
 		return trace.Wrap(err, "failed dialing cluster %q", req.Cluster)
 	}


### PR DESCRIPTION
Since we're proxying connection from grpc we rely on listener address for getting client destination address, that is used in PROXY header. But if listener's address is unspecified we need to replace it with loopback. Getting safe address was added to `ProxySSH`, but was missing from `ProxyCluster` function in the transportv1 which lead to failed connections if proxy listener mode was `separate`

Closes #25365 