### PR TITLE
dronegen: Remove push-build-darwin-amd64 pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -492,79 +492,6 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: push-build-darwin-amd64
-trigger:
-  event:
-    include:
-    - push
-    exclude:
-    - pull_request
-  repo:
-    include:
-    - gravitational/*
-  branch:
-    include:
-    - master
-    - branch/*
-workspace:
-  path: /go
-clone:
-  disable: true
-steps:
-- name: Check out code
-  image: docker:git
-  pull: if-not-exists
-  commands:
-  - mkdir -pv "/go/src/github.com/gravitational/teleport"
-  - cd "/go/src/github.com/gravitational/teleport"
-  - git init
-  - git remote add origin ${DRONE_REMOTE_URL}
-  - git fetch origin --tags
-  - git checkout -qf "${DRONE_COMMIT_SHA}"
-  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
-    chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - mkdir -pv /go/cache
-  - rm -f /root/.ssh/id_rsa
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Delegate build to GitHub
-  image: golang:1.18-alpine
-  pull: if-not-exists
-  commands:
-  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
-  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 2h30m0s -workflow release-mac-amd64.yaml -workflow-ref=${DRONE_BRANCH}
-    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "build-packages=false" -input "release-artifacts=false" '
-  environment:
-    GHA_APP_KEY:
-      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
-- name: Send Slack notification
-  image: plugins/slack:1.4.1
-  settings:
-    template: |-
-      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
-      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
-    webhook:
-      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
-  when:
-    status:
-    - failure
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
 # Generated at dronegen/windows.go (main.newWindowsPipeline)
 ################################################
 
@@ -17179,6 +17106,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 9f1ad0be018d525a0f7557151af1d91981d712e872d38fdb3d747753c3078b93
+hmac: d55fcf99887fe79edc4755565dbed4f33f341bbe22949307d5056401ceba6d70
 
 ...

--- a/dronegen/mac_gha.go
+++ b/dronegen/mac_gha.go
@@ -45,31 +45,3 @@ func darwinTagPipelineGHA() pipeline {
 	}
 	return ghaBuildPipeline(bt)
 }
-
-// darwinPushPipelineGHA returns a pipeline that kicks off a push build of the
-// teleport binaries and the teleport connect dmg. The binaries are signed and
-// notarized even though we do not release these assets. This tests that the
-// signing and notarization process continues to work so we don't wait until
-// release time to discover breakage.
-func darwinPushPipelineGHA() pipeline {
-	bt := ghaBuildType{
-		buildType:    buildType{os: "darwin", arch: "amd64"},
-		trigger:      triggerPush,
-		pipelineName: "push-build-darwin-amd64",
-		workflows: []ghaWorkflow{
-			{
-				name:              "release-mac-amd64.yaml",
-				srcRefVar:         "DRONE_COMMIT",
-				ref:               "${DRONE_BRANCH}",
-				timeout:           150 * time.Minute,
-				slackOnError:      true,
-				shouldTagWorkflow: true,
-				inputs: map[string]string{
-					"release-artifacts": "false",
-					"build-packages":    "false",
-				},
-			},
-		},
-	}
-	return ghaBuildPipeline(bt)
-}

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -96,7 +96,6 @@ func pushPipelines() []pipeline {
 	// Only amd64 Windows is supported for now.
 	ps = append(ps, pushPipeline(buildType{os: "windows", arch: "amd64", windowsUnsigned: true}))
 
-	ps = append(ps, darwinPushPipelineGHA())
 	ps = append(ps, windowsPushPipeline())
 	return ps
 }


### PR DESCRIPTION
The Mac builds on GHA are very expensive, so don't run the push build for
each merge to master/release branches. This would soon double as we add
arm64 pipelines. We may switch to a nightly build, but we'll kick that
off straight from GHA and not from drone.