### PR TITLE
[v12] Add missing Connection header for ALPN connection upgrade (#25346)

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -810,4 +810,11 @@ const (
 	// WebAPIConnUpgradeTypeALPN is a connection upgrade type that specifies
 	// the upgraded connection should be handled by the ALPN handler.
 	WebAPIConnUpgradeTypeALPN = "alpn"
+	// WebAPIConnUpgradeConnectionHeader is the standard header that controls
+	// whether the network connection stays open after the current transaction
+	// finishes.
+	WebAPIConnUpgradeConnectionHeader = "Connection"
+	// WebAPIConnUpgradeConnectionType is the value of the "Connection" header
+	// used for connection upgrades.
+	WebAPIConnUpgradeConnectionType = "Upgrade"
 )

--- a/lib/srv/alpnproxy/conn_upgrade_test.go
+++ b/lib/srv/alpnproxy/conn_upgrade_test.go
@@ -226,6 +226,7 @@ func mockConnUpgradeHandler(t *testing.T, upgradeType string, write []byte) http
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, teleport.WebAPIConnUpgrade, r.URL.Path)
 		require.Equal(t, upgradeType, r.Header.Get(teleport.WebAPIConnUpgradeHeader))
+		require.Equal(t, teleport.WebAPIConnUpgradeConnectionType, r.Header.Get(teleport.WebAPIConnUpgradeConnectionHeader))
 
 		hj, ok := w.(http.Hijacker)
 		require.True(t, ok)

--- a/lib/web/conn_upgrade.go
+++ b/lib/web/conn_upgrade.go
@@ -91,6 +91,7 @@ func (h *Handler) upgradeALPN(ctx context.Context, conn net.Conn) error {
 func writeUpgradeResponse(w io.Writer, upgradeType string) error {
 	header := make(http.Header)
 	header.Add(teleport.WebAPIConnUpgradeHeader, upgradeType)
+	header.Add(teleport.WebAPIConnUpgradeConnectionHeader, teleport.WebAPIConnUpgradeConnectionType)
 	response := &http.Response{
 		Status:     http.StatusText(http.StatusSwitchingProtocols),
 		StatusCode: http.StatusSwitchingProtocols,

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
 )
 
 func TestWriteUpgradeResponse(t *testing.T) {
@@ -106,6 +108,8 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 		io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 
+		require.Equal(t, teleport.WebAPIConnUpgradeTypeALPN, resp.Header.Get(teleport.WebAPIConnUpgradeHeader))
+		require.Equal(t, teleport.WebAPIConnUpgradeConnectionType, resp.Header.Get(teleport.WebAPIConnUpgradeConnectionHeader))
 		require.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
 
 		// Verify clientConn receives data sent by Config.ALPNHandler.


### PR DESCRIPTION
Backport #25346 to branch/v12

some new refactoring on v13 is not present in v12. so constants and dialer are not in `./api` yet. Adjusted the original fix to those locations but no logic change.