### PR TITLE
[v11] Fix issuing credentials for non SSH protocols

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -542,7 +542,15 @@ func (proxy *ProxyClient) IssueUserCertsWithMFA(ctx context.Context, params Reis
 			return nil, trace.Wrap(MFARequiredUnknown(err))
 		}
 		if !check.Required {
-			return nil, trace.Wrap(services.ErrSessionMFANotRequired)
+			log.Debug("MFA not required for access.")
+			// MFA is not required.
+			// SSH certs can be used without embedding the node name.
+			if params.usage() == proto.UserCertsRequest_SSH && key.Cert != nil {
+				return key, nil
+			}
+			// All other targets need their name embedded in the cert for routing,
+			// fall back to non-MFA reissue.
+			return proxy.reissueUserCerts(ctx, CertCacheKeep, params)
 		}
 	case proto.MFARequired_MFA_REQUIRED_YES:
 		// Proceed with the prompt for MFA below.


### PR DESCRIPTION
When MFA is not required for protocols other than SSH `tsh` needs to fallback to reissuing certificates without MFA instead of preventing access.

Closes #25419

Note: This applies directly to v11 and is not a backport. The issue only exists on branch/v12 and branch/v11 due to incorrectly backporting the logic in https://github.com/gravitational/teleport/pull/24250 to these branches.