### PR TITLE
Docs: add template vars/functions reference

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -530,7 +530,7 @@ Teleport provides several template variables and functions to enable more robust
 
 <Details title="External Variables"
 >
-These variables provide context from an Identity Provider or other external data source.
+These variables provide context from an Identity Provider or other external data source. We can't predict every variable an external data source will provide, but these are common values expected from SAML and OIDC identity providers.
 
 #### `{{external.logins}}`
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -63,17 +63,6 @@ Here is a full role specification:
 
 (!docs/pages/includes/role-spec.mdx!)
 
-The following variables can be used with `logins` and `windows_desktop_logins` fields:
-
-| Variable | Description |
-| - | - |
-| `{{internal.logins}}` | Substituted with a value stored in Teleport's local user database<br/>and logins from a root cluster. <br/><br/>For local users, Teleport will substitute this with the<br/>"allowed logins" parameter used in the<br/>`tctl users add [user] <allowed logins>` command. <br/><br/>If the role is within a leaf cluster in a [Trusted Cluster](../management/admin/trustedclusters.mdx),<br/>Teleport will substitute the logins from the root cluster<br/>whether the user is a local user or from an SSO provider. <br/><br/>As an example, if the user has the `ubuntu` login in the root<br/>cluster, then `ubuntu` will be substituted in the leaf<br/>cluster with this variable. |
-| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on).<br/>If using SAML, this will be expanded with "xyz" assertion value.<br/>For OIDC, this will be expanded a value of "xyz" claim. |
-
-Both variables above are there to deliver the same benefit: they allow Teleport
-administrators to define allowed OS logins via the user database, be it the
-local DB, or an identity manager behind a SAML or OIDC endpoint.
-
 ### An example of a SAML assertion
 
 Assuming you have the following SAML assertion attribute in your response:
@@ -91,10 +80,11 @@ logins:
    - '{{external["http://schemas.microsoft.com/ws/2008/06/identity/claims/windowsaccountname"]}}'
 ```
 
-### Role options
+## Role options
 
-As shown above, a role can define certain restrictions on sessions initiated by users.
-The table below documents the behavior of each option if multiple roles are assigned to a user.
+A role can define certain restrictions on sessions initiated by users. The table
+below documents the behavior of each option if multiple roles are assigned to a
+user:
 
 | Option | Description | Multi-role behavior |
 | - | - | - |
@@ -153,7 +143,7 @@ Label              | `v3`, `v4` and `v5` Default   | `v6` Default
 ------------------ | -------------- | ---------------
 `kubernetes_resources` | `[{"kind":"pod", "name":"*", "namespace":"*"}]` | `[]`
 
-## RBAC for resources
+## RBAC for infrastructure resources
 
 A Teleport role defines which resources (e.g., applications, servers, and
 databases) a user can access.
@@ -294,7 +284,106 @@ access will be denied.
 In an allow rule, the matching is not greedy, if both are set they both have to
 match for access to be allowed.
 
-## Teleport resources
+## RBAC for principals on external systems
+
+You can define Teleport roles that restrict a user's access to certain
+principals on a third-party access control system, such as AWS IAM or the user
+accounts on a Linux system. 
+
+When a user attempts to authenticate to a third-party infrastructure resource
+proxied by Teleport, Teleport determines from the user's roles which principals
+they can assume.
+
+### Fields
+
+The following role fields control a user's access to principals on external
+systems:
+
+{/* TODO: replace these with the actual field names*/}
+- Logins
+- Windows logins
+- AWS Role ARNs
+- Azure identities
+- GCP accounts
+- Kubernetes groups
+- Kubernetes users
+- DB names
+- DB users
+- DB roles
+- `host_groups`
+- `host_sudoers`
+- `desktop_groups`
+- impersonattion users
+- impersonation roles
+
+### Variables
+
+When assigning a value to the role fields listed in the previous section,
+Teleport substitutes the following variables with data from the authenticating
+user, drawing from the local user database as well as the user's external single
+sign-on provider.
+
+| Variable | Description |
+| - | - |
+| `{{internal.logins}}` | Substituted with a value stored in Teleport's local user database<br/>and logins from a root cluster. <br/><br/>For local users, Teleport will substitute this with the<br/>"allowed logins" parameter used in the<br/>`tctl users add [user] <allowed logins>` command. <br/><br/>If the role is within a leaf cluster in a [Trusted Cluster](../management/admin/trustedclusters.mdx),<br/>Teleport will substitute the logins from the root cluster<br/>whether the user is a local user or from an SSO provider. <br/><br/>As an example, if the user has the `ubuntu` login in the root<br/>cluster, then `ubuntu` will be substituted in the leaf<br/>cluster with this variable. |
+|{{internal.azure_identities}}| Returns the Azure identities defined in Teleport available to the user. Azure identities can set for a specific user or defined in a role.|
+|{{internal.db_names}}|List of all allowed database names.|
+|{{internal.db_users}}|List of all allowed database users.|
+|{{internal.gcp_service_accounts}}|List of GCP service accounts.|
+|{{internal.kube_username}}|Kubernetes usernames available to the user.|
+|{{internal.kubernetes_groups}}|List of allowed Kubernetes groups.|
+|{{internal.kubernetes_users}}|List of allowed Kubernetes users.|
+|{{internal.logins}}|List of allowed SSH logins.|
+|{{internal.windows_logins}}|List of allowed Windows logins.|
+| `{{external.xyz}}` | Substituted with a value from an external [SSO provider](https://en.wikipedia.org/wiki/Single_sign-on).<br/>If using SAML, this will be expanded with "xyz" assertion value.<br/>For OIDC, this will be expanded a value of "xyz" claim. |
+
+External variables provide user traits from an Identity Provider or another
+external data source. 
+
+In role templates, you can refer to these variables using the following two
+formats, where `trait` is the name of the trait:
+
+- **Dot syntax:** `{{external.trait}}`
+- **Bracket syntax:** `{{external["trait"]}}`
+
+Teleport will expand the template variables above with the value of the SAML
+attribute or OIDC claim called `trait`.
+
+You can specify an external trait in the first syntax if it begins with a letter
+and contains only letters, numbers, and underscores. Otherwise, you must use
+bracket syntax to specify a trait.
+
+Common examples of external traits available through an identity provider
+include the following:
+
+- `{{external.logins}}`
+- `{{external.username}}`
+- `{{external.env}}`
+
+Refer to your specific identity provider's documentation for the complete list
+of available claims and attributes.
+
+Teleport can only expand an `external` variable to a string or a list of
+strings. If you are using an OIDC-based SSO solution, ensure that you have
+configured your identity provider to include claims with values that have a
+supported data type.
+
+### Functions
+
+You can use the following functions in role fields that govern access to
+principals on external systems. Both functions can take a template variable
+named above as an argument:
+
+|Function|Description|
+|---|---|
+|{{email.local(variable)}}|Extracts the local part of an email address.|
+|{{regexp.replace(variable, expression, replacement)}}|Finds all matches of the expression within the variable and replaces them with the replacement.|
+
+{/* TODO include an example*/}
+
+{/* TODO: What about label matchers and certificate extensions?*/}
+
+## RBAC for dynamic Teleport resources
 
 RBAC lets teams limit what resources are available to Teleport users. This can be helpful if, for example,
 you don't want regular users editing SSO (`auth_connector`) or creating and editing new roles
@@ -452,16 +541,7 @@ of how template variables and functions work within Teleport roles.
 
 ### Internal Variables and Functions
 
-#### `{{email.local(variable)}}`
-
-- **Type**: Function
-- **Description**: Extracts the local part of an email address.
-- **Example**: `{{email.local(alice@example.com)}}` -> `alice`
-
-This function is often paired with an external variable, for example:
-`{{email.local(external.username)}}` for IdPs using email addresses as the username.
-
-#### `{{regexp.match(expression, variable)}}`
+### `{{regexp.match(expression, variable)}}`
 
 - **Type**: Function
 - **Description**: Returns true if the provided string matches the specified
@@ -477,99 +557,5 @@ This function is often paired with an external variable, for example:
 - **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` ->
   `true` for non-matching input.
 
-#### `{{regexp.replace(variable, expression, replacement)}}`
 
-- **Type**: Function
-- **Description**: Finds all matches of the expression and replaces them with
-  the replacement. Supports expansion.
-- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}`
-  -> `alice` (when input is `alice@example.com`)
 
-#### `{{internal.azure_identities}}`
-
-- **Type**: Variable
-- **Description**: Returns the Azure identities defined in Teleport available to
-  the user. Azure identities can set for a specific user or defined in a role.
-- **Example**: `{{internal.azure_identities}}` -> `"/subscriptions/0000.../.../id1"`
-
-#### `{{internal.db_names}}`
-
-- **Type**: Variable
-- **Description**: List of all allowed database names.
-- **Example**: `{{internal.db_names}}` -> `["db_name_1", "db_name_2"]`
-
-#### `{{internal.db_users}}`
-
-- **Type**: Variable
-- **Description**: List of all allowed database users.
-- **Example**: `{{internal.db_users}}` -> `["db_user_1", "db_user_2"]`
-
-#### `{{internal.gcp_service_accounts}}`
-
-- **Type**: Variable
-- **Description**: List of GCP service accounts defined in Teleport available
-  to the user.
-- **Example**: `internal.gcp_service_accounts}}` -> `"user@google-cloud-project.iam.gserviceaccount.com"`
-
-#### `{{internal.kube_username}}`
-
-- **Type**: Variable
-- **Description**: Kubernetes usernames available to the user.
-- **Example**: `{{internal.kube_username}}` -> `["myuser", "kube-admin"]`.
-
-#### `{{internal.kubernetes_groups}}`
-
-- **Type**: Variable
-- **Description**: List of allowed Kubernetes groups.
-- **Example**: `{{internal.kubernetes_groups}}` -> `["group1", "group2"]`
-
-#### `{{internal.kubernetes_users}}`
-
-- **Type**: Variable
-- **Description**: List of allowed Kubernetes users.
-- **Example**: `{{internal.kubernetes_users}}` -> `["user1", "user2"]`
-
-#### `{{internal.logins}}`
-
-- **Type**: Variable
-- **Description**: List of allowed SSH logins.
-- **Example**: `{{internal.logins}}` -> `["user1", "user2"]`
-
-#### `{{internal.windows_logins}}`
-
-- **Type**: Variable
-- **Description**: List of allowed Windows logins.
-- **Example**: `{{internal.windows_logins}}` -> `["user1", "user2"]`
-
-### External variables
-
-External variables provide user traits from an Identity Provider or another
-external data source. 
-
-In role templates, you can refer to these variables using the following two
-formats, where `trait` is the name of the trait:
-
-- **Dot syntax:** `{{external.trait}}`
-- **Bracket syntax:** `{{external["trait"]}}`
-
-Teleport will expand the template variables above with the value of the SAML
-attribute or OIDC claim called `trait`.
-
-You can specify an external trait in the first syntax if it begins with a letter
-and contains only letters, numbers, and underscores. Otherwise, you must use
-bracket syntax to specify a trait.
-
-Common examples of external traits available through an identity provider
-include the following:
-
-- `{{external.logins}}`
-- `{{external.username}}`
-- `{{external.env}}`
-
-Refer to your specific identity provider's documentation for the complete list
-of available claims and attributes.
-
-Teleport can only expand an `external` variable to a string or a list of
-strings. If you are using an OIDC-based SSO solution, ensure that you have
-configured your identity provider to include claims with values that have a
-supported data type.

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -151,11 +151,17 @@ and submitting requests.
 
 ### Fields
 
-{/* TODO: Add actual names for these fields*/}
-- c.Roles.AllowReview
-- allow.Where
-- allow.Roles
-- allow.ClaimsToRoles
+The following role fields control a user's ability to request and review Access
+Requests:
+
+{/* TODO: look at (allow|deny).request.search_as_roles*/}
+{/* TODO: look at (allow|deny).request.roles*/}
+{/* TODO: look at (allow|deny).review_requests.preview_as_roles*/}
+{/* TODO: look at (allow|deny).review_request.roles*/}
+- allow.Where {/* TODO: get the actual name */}
+
+{/* TODO: See what the TraitsToRoleMatchers call in appendRoleMatchers
+does and how to describe this behavior */}
 
 ### Variables
 
@@ -167,6 +173,32 @@ Teleport does not perform variable expansion on the values of the fields above.
 |---|---|
 |`{{regexp.match(regexp)}}`|Returns `true` if the regular expression matches a user's role.|
 |`{{regexp.not_match(regexp)}}`|Returns `true` if the regular expression does not match a user's role.|
+
+Regular expressions support both wildcards (the `*` character) and [Go-style
+regular expressions](https://pkg.go.dev/regexp). If an expression begins with
+the `^` character and ends with the `$` character, Teleport will evaluate it as
+a regular expression. Otherwise, it will evaluate it as a wildcard expression.
+Wildcards match a sequence of one or more characters.
+
+## Impersonation
+
+Teleport roles allow you to control the extent to which one user can impersonate
+another in order to request credentials for connecting to Teleport. Read more
+about Teleport [impersonation](../access-controls/guides/impersonation.mdx).
+
+### Fields
+
+{/* TODO: fields for impersonating users and roles, plus "where". */}
+
+### Variables
+
+{/* TODO: see
+https://goteleport.com/docs/access-controls/guides/impersonation/#filter-fields
+*/}
+
+### Functions
+
+{/* TODO */}
 
 ## Infrastructure resources
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -446,7 +446,7 @@ guide for a more in depth explanation of the language.
 
 Teleport provides several template variables and functions to enable more robust access control:
 
-<Details title="Internal Variables and Functions">
+### Internal Variables and Functions
 
 #### `{{email.local(variable)}}`
 
@@ -526,10 +526,8 @@ Teleport provides several template variables and functions to enable more robust
 - **Description**: List of allowed Windows logins.
 - **Example**: `{{internal.windows_logins}}` -> ["user1", "user2"]
 
-</Details>
+### External Variables
 
-<Details title="External Variables"
->
 These variables provide context from an Identity Provider or other external data source. We can't predict every variable an external data source will provide, but these are common values expected from SAML and OIDC identity providers.
 
 #### `{{external.logins}}`
@@ -596,8 +594,6 @@ These variables provide context from an Identity Provider or other external data
 - **Provider**: OIDC/SAML
 
 Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
-
-</Details>
 
 [(1)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
 [(2)]: ../../database-access/rbac/#template-variables

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -40,9 +40,7 @@ To see the list of roles in a Teleport cluster, an administrator can execute:
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
-# You can also run tctl on your Auth Service host without running "tsh login"
-# first.
-$ tsh login --user=myuser --proxy=teleport.example.com
+$ tsh login --user=myuser --proxy=<Var name="mytenant.teleport.sh" />
 $ tctl get roles
 ```
 
@@ -553,6 +551,9 @@ formats, where `trait` is the name of the trait:
 - `{{external.trait}}`
 - `{{external["trait"]}}`
 
+Teleport will expand the template variables above with the value of the SAML
+attribute or OIDC claim called `trait`.
+
 You can specify an external trait in the first syntax if it begins with a letter
 and contains only letters, numbers, and underscores. Otherwise, you must use the
 second syntax to specify a trait.
@@ -562,12 +563,12 @@ include the following:
 
 - `{{external.logins}}`
 - `{{external.username}}`
-- `{{external.access["label"]}}`
 - `{{external.env}}`
 
-{/* TODO: nested traits, e.g., external.access["label"]? */}
-{/* TODO: talk about the value a trait can have: scalar and composite? Strings,
-objects, and lists? Or is it always a map[string][]string as in Interpolate?*/}
+Refer to your specific identity provider's documentation for the complete list
+of available claims and attributes.
 
-Refer to your specific provider's documentation for the complete list of
-available variables and attributes.
+Teleport can only expand an `external` variable to a string or a list of
+strings. If you are using an OIDC-based SSO solution, ensure that you have
+configured your identity provider to include claims with values that have a
+supported data type.

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -2,6 +2,7 @@
 title: Access Controls Reference Documentation
 description: This reference shows you the configuration settings that you can include in a Teleport role, which enables you to apply access controls for your infrastructure.
 h1: Teleport Access Controls Reference
+tocDepth: 3
 ---
 
 This guide shows you how to use Teleport roles to manage role-based access
@@ -441,3 +442,162 @@ Here is an explanation of the fields used in the `where` and `filter` conditions
 Check out our [predicate language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
 guide for a more in depth explanation of the language.
 
+## Template variables and functions
+
+Teleport provides several template variables and functions to enable more robust access control:
+
+<Details title="Internal Variables and Functions">
+
+#### `{{email.local(variable)}}`
+
+- **Type**: Function
+- **Description**: Extracts the local part of an email address.
+- **Example**: `{{email.local(alice@example.com)}}` -> alice
+
+#### `{{regexp.match(expression, variable)}}`
+
+- **Type**: Function
+- **Description**: Returns true if the provided string matches the specified pattern.
+- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> true for matching input
+
+#### `{{regexp.not_match(expression, variable)}}`
+
+- **Type**: Function
+- **Description**: Returns true if the provided string does not match the specified pattern.
+- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` -> true for non-matching input
+
+#### `{{regexp.replace(variable, expression, replacement)}}`
+
+- **Type**: Function
+- **Description**: Finds all matches of the expression and replaces them with the replacement. Supports expansion.
+- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}` -> alice (when input is alice@example.com)
+
+#### `{{internal.azure_identities}}`
+
+- **Type**: Variable
+
+#### `{{internal.db_names}}`
+
+- **Type**: Variable
+- **Description**: List of all allowed database names.
+- **Example**: `{{internal.db_names}}` -> ["db_name_1", "db_name_2"]
+
+#### `{{internal.db_users}}`
+
+- **Type**: Variable
+- **Description**: List of all allowed database users.
+- **Example**: `{{internal.db_users}}` -> ["db_user_1", "db_user_2"]
+
+#### `{{internal.gcp_service_accounts}}`
+
+- **Type**: Variable
+
+#### `{{internal.jwt}}`
+
+- **Type**: Variable
+- **Description**: A JWT token signed by Teleport that contains user identity information.
+- **Example**: `"Authorization: Bearer {{internal.jwt}}"` -> `"Authorization": "Bearer eyJhbGci...`
+
+#### `{{internal.kube_username}}`
+
+- **Type**: Variable
+
+#### `{{internal.kubernetes_groups}}`
+
+- **Type**: Variable
+- **Description**: List of allowed Kubernetes groups.
+- **Example**: `{{internal.kubernetes_groups}}` -> ["group1", "group2"]
+
+#### `{{internal.kubernetes_users}}`
+
+- **Type**: Variable
+- **Description**: List of allowed Kubernetes users.
+- **Example**: `{{internal.kubernetes_users}}` -> ["user1", "user2"]
+
+#### `{{internal.logins}}`
+
+- **Type**: Variable
+- **Description**: List of allowed SSH logins.
+- **Example**: `{{internal.logins}}` -> ["user1", "user2"]
+
+#### `{{internal.windows_logins}}`
+
+- **Type**: Variable
+- **Description**: List of allowed Windows logins.
+- **Example**: `{{internal.windows_logins}}` -> ["user1", "user2"]
+
+</Details>
+
+<Details title="External Variables"
+>
+These variables provide context from an Identity Provider or other external data source.
+
+#### `{{external.logins}}`
+
+- **Type**: Variable
+
+#### `{{external.username}}`
+
+- **Type**: Variable
+
+#### `{{external.access["label"]}}`
+
+- **Type**: Variable
+
+#### `{{external.env}}`
+
+- **Type**: Variable
+
+#### `{{external.first_name}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's first name from the SSO provider.
+- **Example**: `{{external.first_name}}` -> `"Alice"`
+- **Provider**: OIDC/SAML
+
+#### `{{external.last_name}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's last name from the SSO provider.
+- **Example**: `{{external.last_name}}` -> `"Smith"`
+- **Provider**: OIDC/SAML
+
+#### `{{external.email}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's email address from the SSO provider.
+- **Example**: `{{external.email}}` -> `"alice@example.com"`
+- **Provider**: OIDC/SAML
+
+#### `{{external.groups}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's group membership from the SSO provider.
+- **Example**: `{{external.groups}}` -> `["group1", "group2"]`
+- **Provider**: OIDC/SAML
+
+#### `{{external.azure_identities}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's Azure identities from the SSO provider [(1)].
+- **Example**: `{{external.azure_identities}}` -> `["identity1"]`
+- **Provider**: OIDC/SAML
+
+#### `{{external.databases}}`
+
+- **Type**: Variable
+- **Description**: Fetches the user's allowed database names from the SSO provider [(2)].
+- **Example**: `{{external.databases}}` -> `["db1", "db2"]`
+- **Provider**: OIDC/SAML
+
+#### `{{external["custom_attribute"]}}`
+
+- **Type**: Variable
+- **Provider**: OIDC/SAML
+
+Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
+
+</Details>
+
+[(1)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
+[(2)]: ../../database-access/rbac/#template-variables

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -313,12 +313,32 @@ conditions:
 
 #### Variables
 
-{/* TODO: label expression variables*/}
+You can use the following template variables in the fields above:
+
+|Variable|Type|Description|
+|---|---|---|
+|`{{user.spec.traits}}`|`map[string][]string`|All of the user's traits.|
+|`{{labels.<key>}}`|`string`|The label with the specified `key`.|
+
+{/*TODO: Double-check labels.key. Check the RFD.*/}}
 
 #### Functions
 
-{/* TODO: label expression functions*/}
+You can use the following functions in label expression fields:
 
+{/* TODO: Fill this in based on the RFD and source*/}
+
+|Function|Description|
+|---|---|
+|`{{labels_matching(arg)}}`||
+|`{{contains(list,item)}}`||
+|`{{contains_any(list,item)}}`||
+|`{{contains_all(list,item)}}`||
+|`{{regexp.match(list,regexp)}}`||
+|`{{regexp.replace(list,regexp,replacement)}}`||
+|`{{email.local(email)}}`||
+|`{{strings.upper(value)}}`||
+|`{{strings.lower(value)}}`||
 
 ## Principals on external systems
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -428,7 +428,8 @@ have a cluster using the legacy U2F support.
 
 ## Filter fields
 
-Here is an explanation of the fields used in the `where` and `filter` conditions within this guide.
+Here is an explanation of the fields used in the `where` and `filter` conditions
+within this guide:
 
 | Field                      | Description                                       |
 | -------------------------- | ------------------------------------------------- |
@@ -548,15 +549,15 @@ external data source.
 In role templates, you can refer to these variables using the following two
 formats, where `trait` is the name of the trait:
 
-- `{{external.trait}}`
-- `{{external["trait"]}}`
+- **Dot syntax:** `{{external.trait}}`
+- **Bracket syntax:** `{{external["trait"]}}`
 
 Teleport will expand the template variables above with the value of the SAML
 attribute or OIDC claim called `trait`.
 
 You can specify an external trait in the first syntax if it begins with a letter
-and contains only letters, numbers, and underscores. Otherwise, you must use the
-second syntax to specify a trait.
+and contains only letters, numbers, and underscores. Otherwise, you must use
+bracket syntax to specify a trait.
 
 Common examples of external traits available through an identity provider
 include the following:

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -490,7 +490,7 @@ This function is often paired with an external variable, for example:
 
 - **Type**: Variable
 - **Description**: Returns the Azure identities defined in Teleport available to
-  the user. Azure identities can set for a specific user or defined in a role [(1)].
+  the user. Azure identities can set for a specific user or defined in a role.
 - **Example**: `{{internal.azure_identities}}` -> `"/subscriptions/0000.../.../id1"`
 
 #### `{{internal.db_names}}`
@@ -542,83 +542,32 @@ This function is often paired with an external variable, for example:
 - **Description**: List of allowed Windows logins.
 - **Example**: `{{internal.windows_logins}}` -> `["user1", "user2"]`
 
-### External Variables
+### External variables
 
-These variables provide context from an Identity Provider or other external data source. We can't predict every variable an external data source will provide, but these are common values expected from SAML and OIDC identity providers.
+External variables provide user traits from an Identity Provider or another
+external data source. 
 
-#### `{{external.logins}}`
+In role templates, you can refer to these variables using the following two
+formats, where `trait` is the name of the trait:
 
-- **Type**: Variable
-- **Provider**: Common across several IdPs
+- `{{external.trait}}`
+- `{{external["trait"]}}`
 
-#### `{{external.username}}`
+You can specify an external trait in the first syntax if it begins with a letter
+and contains only letters, numbers, and underscores. Otherwise, you must use the
+second syntax to specify a trait.
 
-- **Type**: Variable
-- **Provider**: Common across several IdPs
+Common examples of external traits available through an identity provider
+include the following:
 
-#### `{{external.access["label"]}}`
+- `{{external.logins}}`
+- `{{external.username}}`
+- `{{external.access["label"]}}`
+- `{{external.env}}`
 
-- **Type**: Variable
-- **Provider**: Common across several IdPs
+{/* TODO: nested traits, e.g., external.access["label"]? */}
+{/* TODO: talk about the value a trait can have: scalar and composite? Strings,
+objects, and lists? Or is it always a map[string][]string as in Interpolate?*/}
 
-#### `{{external.env}}`
-
-- **Type**: Variable
-- **Provider**: Common across several IdPs
-
-#### `{{external.first_name}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's first name from the SSO provider.
-- **Example**: `{{external.first_name}}` -> `"Alice"`
-- **Provider**: OIDC/SAML
-
-**Note**: Per OIDC specifications this value may be given as `given_name`.
-
-#### `{{external.last_name}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's last name from the SSO provider.
-- **Example**: `{{external.last_name}}` -> `"Smith"`
-- **Provider**: OIDC/SAML
-
-**Note**: Per OIDC specifications this value may be given as `family_name`.
-
-#### `{{external.email}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's email address from the SSO provider.
-- **Example**: `{{external.email}}` -> `"alice@example.com"`
-- **Provider**: OIDC/SAML
-
-#### `{{external.groups}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's group membership from the SSO provider.
-- **Example**: `{{external.groups}}` -> `["group1", "group2"]`
-- **Provider**: OIDC/SAML
-
-#### `{{external.azure_identities}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's Azure identities from the SSO provider [(2)].
-- **Example**: `{{external.azure_identities}}` -> `["identity1"]`
-- **Provider**: OIDC/SAML
-
-#### `{{external.databases}}`
-
-- **Type**: Variable
-- **Description**: Fetches the user's allowed database names from the SSO provider [(3)].
-- **Example**: `{{external.databases}}` -> `["db1", "db2"]`
-- **Provider**: OIDC/SAML
-
-#### `{{external["custom_attribute"]}}`
-
-- **Type**: Variable
-- **Provider**: OIDC/SAML
-
-Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
-
-[(1)]: ../../application-access/controls/#enabling-a-user-to-access-azure-managed-identities
-[(2)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
-[(3)]: ../../database-access/rbac/#template-variables
+Refer to your specific provider's documentation for the complete list of
+available variables and attributes.

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -444,7 +444,12 @@ guide for a more in depth explanation of the language.
 
 ## Template variables and functions
 
-Teleport provides several template variables and functions to enable more robust access control:
+Teleport enables operators to define roles with template variables and functions
+to provide more precise controls over which users can access resources in your
+infrastructure.
+
+See the [Teleport Role Templates](./guides/role-templates) guide for an overview
+of how template variables and functions work within Teleport roles.
 
 ### Internal Variables and Functions
 
@@ -506,15 +511,6 @@ This function is often paired with an external variable, for example:
 - **Description**: List of GCP service accounts defined in Teleport available
   to the user.
 - **Example**: `internal.gcp_service_accounts}}` -> `"user@google-cloud-project.iam.gserviceaccount.com"`
-
-#### `{{internal.jwt}}`
-
-- **Type**: Variable
-- **Description**: A JWT token signed by Teleport that contains user identity information.
-- **Example**: `"Authorization: Bearer {{internal.jwt}}"` -> `"Authorization": "Bearer eyJhbGci...`
-
-**Note**: This variable is used when defining application access, and is not
-available when defining roles.
 
 #### `{{internal.kube_username}}`
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -452,45 +452,60 @@ Teleport provides several template variables and functions to enable more robust
 
 - **Type**: Function
 - **Description**: Extracts the local part of an email address.
-- **Example**: `{{email.local(alice@example.com)}}` -> alice
+- **Example**: `{{email.local(alice@example.com)}}` -> `alice`
+
+This function is often paired with an external variable, for example:
+`{{email.local(external.username)}}` for IdPs using email addresses as the username.
 
 #### `{{regexp.match(expression, variable)}}`
 
 - **Type**: Function
-- **Description**: Returns true if the provided string matches the specified pattern.
-- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> true for matching input
+- **Description**: Returns true if the provided string matches the specified
+  pattern.
+- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> `true`
+  for matching input.
 
 #### `{{regexp.not_match(expression, variable)}}`
 
 - **Type**: Function
-- **Description**: Returns true if the provided string does not match the specified pattern.
-- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` -> true for non-matching input
+- **Description**: Returns true if the provided string does not match the
+  specified pattern.
+- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` ->
+  `true` for non-matching input.
 
 #### `{{regexp.replace(variable, expression, replacement)}}`
 
 - **Type**: Function
-- **Description**: Finds all matches of the expression and replaces them with the replacement. Supports expansion.
-- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}` -> alice (when input is alice@example.com)
+- **Description**: Finds all matches of the expression and replaces them with
+  the replacement. Supports expansion.
+- **Example**: `{{regexp.replace(external.email, "^(.*)@example.com$", "$1")}}`
+  -> `alice` (when input is `alice@example.com`)
 
 #### `{{internal.azure_identities}}`
 
 - **Type**: Variable
+- **Description**: Returns the Azure identities defined in Teleport available to
+  the user. Azure identities can set for a specific user or defined in a role [(1)].
+- **Example**: `{{internal.azure_identities}}` -> `"/subscriptions/0000.../.../id1"`
 
 #### `{{internal.db_names}}`
 
 - **Type**: Variable
 - **Description**: List of all allowed database names.
-- **Example**: `{{internal.db_names}}` -> ["db_name_1", "db_name_2"]
+- **Example**: `{{internal.db_names}}` -> `["db_name_1", "db_name_2"]`
 
 #### `{{internal.db_users}}`
 
 - **Type**: Variable
 - **Description**: List of all allowed database users.
-- **Example**: `{{internal.db_users}}` -> ["db_user_1", "db_user_2"]
+- **Example**: `{{internal.db_users}}` -> `["db_user_1", "db_user_2"]`
 
 #### `{{internal.gcp_service_accounts}}`
 
 - **Type**: Variable
+- **Description**: List of GCP service accounts defined in Teleport available
+  to the user.
+- **Example**: `internal.gcp_service_accounts}}` -> `"user@google-cloud-project.iam.gserviceaccount.com"`
 
 #### `{{internal.jwt}}`
 
@@ -498,33 +513,38 @@ Teleport provides several template variables and functions to enable more robust
 - **Description**: A JWT token signed by Teleport that contains user identity information.
 - **Example**: `"Authorization: Bearer {{internal.jwt}}"` -> `"Authorization": "Bearer eyJhbGci...`
 
+**Note**: This variable is used when defining application access, and is not
+available when defining roles.
+
 #### `{{internal.kube_username}}`
 
 - **Type**: Variable
+- **Description**: Kubernetes usernames available to the user.
+- **Example**: `{{internal.kube_username}}` -> `["myuser", "kube-admin"]`.
 
 #### `{{internal.kubernetes_groups}}`
 
 - **Type**: Variable
 - **Description**: List of allowed Kubernetes groups.
-- **Example**: `{{internal.kubernetes_groups}}` -> ["group1", "group2"]
+- **Example**: `{{internal.kubernetes_groups}}` -> `["group1", "group2"]`
 
 #### `{{internal.kubernetes_users}}`
 
 - **Type**: Variable
 - **Description**: List of allowed Kubernetes users.
-- **Example**: `{{internal.kubernetes_users}}` -> ["user1", "user2"]
+- **Example**: `{{internal.kubernetes_users}}` -> `["user1", "user2"]`
 
 #### `{{internal.logins}}`
 
 - **Type**: Variable
 - **Description**: List of allowed SSH logins.
-- **Example**: `{{internal.logins}}` -> ["user1", "user2"]
+- **Example**: `{{internal.logins}}` -> `["user1", "user2"]`
 
 #### `{{internal.windows_logins}}`
 
 - **Type**: Variable
 - **Description**: List of allowed Windows logins.
-- **Example**: `{{internal.windows_logins}}` -> ["user1", "user2"]
+- **Example**: `{{internal.windows_logins}}` -> `["user1", "user2"]`
 
 ### External Variables
 
@@ -533,18 +553,22 @@ These variables provide context from an Identity Provider or other external data
 #### `{{external.logins}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.username}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.access["label"]}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.env}}`
 
 - **Type**: Variable
+- **Provider**: Common across several IdPs
 
 #### `{{external.first_name}}`
 
@@ -553,12 +577,16 @@ These variables provide context from an Identity Provider or other external data
 - **Example**: `{{external.first_name}}` -> `"Alice"`
 - **Provider**: OIDC/SAML
 
+**Note**: Per OIDC specifications this value may be given as `given_name`.
+
 #### `{{external.last_name}}`
 
 - **Type**: Variable
 - **Description**: Fetches the user's last name from the SSO provider.
 - **Example**: `{{external.last_name}}` -> `"Smith"`
 - **Provider**: OIDC/SAML
+
+**Note**: Per OIDC specifications this value may be given as `family_name`.
 
 #### `{{external.email}}`
 
@@ -577,14 +605,14 @@ These variables provide context from an Identity Provider or other external data
 #### `{{external.azure_identities}}`
 
 - **Type**: Variable
-- **Description**: Fetches the user's Azure identities from the SSO provider [(1)].
+- **Description**: Fetches the user's Azure identities from the SSO provider [(2)].
 - **Example**: `{{external.azure_identities}}` -> `["identity1"]`
 - **Provider**: OIDC/SAML
 
 #### `{{external.databases}}`
 
 - **Type**: Variable
-- **Description**: Fetches the user's allowed database names from the SSO provider [(2)].
+- **Description**: Fetches the user's allowed database names from the SSO provider [(3)].
 - **Example**: `{{external.databases}}` -> `["db1", "db2"]`
 - **Provider**: OIDC/SAML
 
@@ -595,5 +623,6 @@ These variables provide context from an Identity Provider or other external data
 
 Please note that the `{{external.*}}` values and the `{{external["abcxyz"]}}` syntax are provider-dependent, as they rely on information from the SSO provider such as OIDC or SAML. Make sure to refer to your specific provider's documentation for the complete list of available variables and attributes.
 
-[(1)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
-[(2)]: ../../database-access/rbac/#template-variables
+[(1)]: ../../application-access/controls/#enabling-a-user-to-access-azure-managed-identities
+[(2)]: ../../application-access/cloud-apis/azure/#denying-access-to-azure-identities
+[(3)]: ../../database-access/rbac/#template-variables

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -143,7 +143,32 @@ Label              | `v3`, `v4` and `v5` Default   | `v6` Default
 ------------------ | -------------- | ---------------
 `kubernetes_resources` | `[{"kind":"pod", "name":"*", "namespace":"*"}]` | `[]`
 
-## RBAC for infrastructure resources
+## Access Requests
+
+You can define Teleport roles that manage the level of control a user has over
+the lifecycle and scope of Teleport Access Requests, including both reviewing
+and submitting requests.
+
+### Fields
+
+{/* TODO: Add actual names for these fields*/}
+- c.Roles.AllowReview
+- allow.Where
+- allow.Roles
+- allow.ClaimsToRoles
+
+### Variables
+
+Teleport does not perform variable expansion on the values of the fields above.
+
+### Functions
+
+|Function|Description|
+|---|---|
+|`{{regexp.match(regexp)}}`|Returns `true` if the regular expression matches a user's role.|
+|`{{regexp.not_match(regexp)}}`|Returns `true` if the regular expression does not match a user's role.|
+
+## Infrastructure resources
 
 A Teleport role defines which resources (e.g., applications, servers, and
 databases) a user can access.
@@ -257,6 +282,20 @@ spec:
       contains(user.spec.traits["teams"], labels["team"])
 ```
 
+Typically you will only want to use one of `<kind>_labels` or
+`<kind>_labels_expression` in a single role, but you are allowed to specify
+both.
+If you have both in a deny rule, the matching is greedy, if either one matches
+access will be denied.
+In an allow rule, the matching is not greedy, if both are set they both have to
+match for access to be allowed.
+
+Read the [predicate
+language](../reference/predicate-language.mdx#label-expressions) guide for a
+more in depth explanation of the language.
+
+#### Fields
+
 The `<kind>_labels_expression` fields have the same purpose of the
 matching `<kind>_labels` fields, but support predicate expressions instead
 of label matchers.
@@ -272,19 +311,16 @@ conditions:
 - `windows_desktop_labels_expression`
 - `group_labels_expression`
 
-Check out our
-[predicate language](../reference/predicate-language.mdx#label-expressions)
-guide for a more in depth explanation of the language.
+#### Variables
 
-Typically you will only want to use one of `<kind>_labels` or
-`<kind>_labels_expression` in a single role, but you are allowed to specify
-both.
-If you have both in a deny rule, the matching is greedy, if either one matches
-access will be denied.
-In an allow rule, the matching is not greedy, if both are set they both have to
-match for access to be allowed.
+{/* TODO: label expression variables*/}
 
-## RBAC for principals on external systems
+#### Functions
+
+{/* TODO: label expression functions*/}
+
+
+## Principals on external systems
 
 You can define Teleport roles that restrict a user's access to certain
 principals on a third-party access control system, such as AWS IAM or the user
@@ -527,35 +563,6 @@ within this guide:
 | `ssh_session.participants` | The list of participants from an SSH session      |
 | `user.metadata.name`       | The user's name                                   |
 
-Check out our [predicate language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
+Read the [predicate
+language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
 guide for a more in depth explanation of the language.
-
-## Template variables and functions
-
-Teleport enables operators to define roles with template variables and functions
-to provide more precise controls over which users can access resources in your
-infrastructure.
-
-See the [Teleport Role Templates](./guides/role-templates) guide for an overview
-of how template variables and functions work within Teleport roles.
-
-### Internal Variables and Functions
-
-### `{{regexp.match(expression, variable)}}`
-
-- **Type**: Function
-- **Description**: Returns true if the provided string matches the specified
-  pattern.
-- **Example**: `{{regexp.match("^Email: (.*)$", external.raw_email)}}` -> `true`
-  for matching input.
-
-#### `{{regexp.not_match(expression, variable)}}`
-
-- **Type**: Function
-- **Description**: Returns true if the provided string does not match the
-  specified pattern.
-- **Example**: `{{regexp.not_match("^Email: (.*)$", external.raw_email)}}` ->
-  `true` for non-matching input.
-
-
-


### PR DESCRIPTION
WIP

Closes #11263

Adds a single consolidated reference to all template variables and functions teleport provides for RBAC.