### PR TITLE
Disallow OktaAssignment deletion from tctl.

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -1204,11 +1204,6 @@ func (rc *ResourceCommand) Delete(ctx context.Context, client auth.ClientI) (err
 			return trace.Wrap(err)
 		}
 		fmt.Printf("Okta import rule %q has been deleted\n", rc.ref.Name)
-	case types.KindOktaAssignment:
-		if err := client.OktaClient().DeleteOktaAssignment(ctx, rc.ref.Name); err != nil {
-			return trace.Wrap(err)
-		}
-		fmt.Printf("Okta assignment %q has been deleted\n", rc.ref.Name)
 	case types.KindUserGroup:
 		if err := client.DeleteUserGroup(ctx, rc.ref.Name); err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
tctl no longer allows OktaAssignment deletion as OktaAssignments are internal objects that should only be managed by users.

Note: This still allows retrieval of Okta assignments from tctl. Let me know if you feel strongly about excising this as well.