### PR TITLE
Allow unknown fields when unmarshaling types.MFADevice

### DIFF
--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -787,7 +787,9 @@ func (d *MFADevice) MarshalJSON() ([]byte, error) {
 }
 
 func (d *MFADevice) UnmarshalJSON(buf []byte) error {
-	return jsonpb.Unmarshal(bytes.NewReader(buf), d)
+	unmarshaler := jsonpb.Unmarshaler{AllowUnknownFields: true}
+	err := unmarshaler.Unmarshal(bytes.NewReader(buf), d)
+	return trace.Wrap(err)
 }
 
 // IsSessionMFARequired returns whether this RequireMFAType requires per-session MFA.

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -139,11 +139,6 @@ func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateUserTok
 		return nil, trace.BadParameter("invalid reset password token request type")
 	}
 
-	_, err = s.GetUser(req.Name, false)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	_, err = s.ResetPassword(req.Name)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
There was a backward incompatible change introduced in https://github.com/gravitational/teleport/pull/25238 that was preventing mfa devices from being unmarshalled due to an unknown field:

```
tctl users reset norbert
ERROR: rpc error: code = Unknown desc = unknown field "credentialRpId" in types.WebauthnDevice
```

The custom `json.Unmarshaler` implemented by `types.MFADevice` did not initialize the protojson decoder to allow unknown fields. This prevented any reads of `types.MFADevice` from a backend that was upgraded and then downgraded.