### PR TITLE
Fix `TestKubernetesLicenseEnforcement` data race

### DIFF
--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -1903,7 +1903,7 @@ func TestKubernetesLicenseEnforcement(t *testing.T) {
 				kubeCluster,
 			)
 
-			_, err = client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+			_, err := client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
 			tt.assertErrFunc(t, err)
 		})
 	}

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -56,17 +56,19 @@ import (
 )
 
 type TestContext struct {
-	HostID      string
-	ClusterName string
-	TLSServer   *auth.TestTLSServer
-	AuthServer  *auth.Server
-	AuthClient  *auth.Client
-	Authz       authz.Authorizer
-	KubeServer  *TLSServer
-	Emitter     *eventstest.ChannelEmitter
-	Context     context.Context
-	listener    net.Listener
-	cancel      context.CancelFunc
+	HostID          string
+	ClusterName     string
+	TLSServer       *auth.TestTLSServer
+	AuthServer      *auth.Server
+	AuthClient      *auth.Client
+	Authz           authz.Authorizer
+	KubeServer      *TLSServer
+	Emitter         *eventstest.ChannelEmitter
+	Context         context.Context
+	listener        net.Listener
+	cancel          context.CancelFunc
+	heartbeatCtx    context.Context
+	heartbeatCancel context.CancelFunc
 }
 
 // KubeClusterConfig defines the cluster to be created
@@ -89,11 +91,14 @@ type TestConfig struct {
 // SetupTestContext creates a kube service with clusters configured.
 func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestContext {
 	ctx, cancel := context.WithCancel(ctx)
+	heartbeatCtx, heartbeatCancel := context.WithCancel(ctx)
 	testCtx := &TestContext{
-		ClusterName: "root.example.com",
-		HostID:      uuid.New().String(),
-		Context:     ctx,
-		cancel:      cancel,
+		ClusterName:     "root.example.com",
+		HostID:          uuid.New().String(),
+		Context:         ctx,
+		cancel:          cancel,
+		heartbeatCtx:    heartbeatCtx,
+		heartbeatCancel: heartbeatCancel,
 	}
 	t.Cleanup(func() { testCtx.Close() })
 
@@ -223,11 +228,17 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		// this is used to make sure that heartbeat started and the clusters
 		// are registered in the auth server
 		OnHeartbeat: func(err error) {
-			// ignore not found errors because although the heartbeat is called before
-			// the close does not wait for the resource cleanup to finish.
-			if trace.IsNotFound(err) {
-				return
+			select {
+			case <-heartbeatCtx.Done():
+				// ignore not found errors because although the heartbeat is called before
+				// the close does not wait for the resource cleanup to finish.
+				if trace.IsNotFound(err) {
+					return
+				}
+			default:
+
 			}
+
 			assert.NoError(t, err)
 			select {
 			case heartbeatsWaitChannel <- struct{}{}:
@@ -269,6 +280,9 @@ func (c *TestContext) startKubeService(t *testing.T) {
 
 // Close closes resources associated with the test context.
 func (c *TestContext) Close() error {
+	// cancel the heartbeat context to stop validating the heartbeat not found
+	// errors when deprovisioning.
+	c.heartbeatCancel()
 	// kubeServer closes the listener
 	err := c.KubeServer.Close()
 	authCErr := c.AuthClient.Close()

--- a/lib/kube/proxy/utils_testing.go
+++ b/lib/kube/proxy/utils_testing.go
@@ -223,7 +223,12 @@ func SetupTestContext(ctx context.Context, t *testing.T, cfg TestConfig) *TestCo
 		// this is used to make sure that heartbeat started and the clusters
 		// are registered in the auth server
 		OnHeartbeat: func(err error) {
-			require.NoError(t, err)
+			// ignore not found errors because although the heartbeat is called before
+			// the close does not wait for the resource cleanup to finish.
+			if trace.IsNotFound(err) {
+				return
+			}
+			assert.NoError(t, err)
 			select {
 			case heartbeatsWaitChannel <- struct{}{}:
 			default:


### PR DESCRIPTION
When `TestKubernetesLicenseEnforcement`'s parallel tests run, they inherit the  `err` var from the main function and tried to write the result into it without any protection which results in a data race.

The PR allocates the `err` var locally to the closure in order to prevent the data race. (It was a typo)

Fixes #25357