### PR TITLE
Updates distroless Dockerfile to handle fips realeases

### DIFF
--- a/build.assets/charts/Dockerfile-distroless
+++ b/build.assets/charts/Dockerfile-distroless
@@ -6,11 +6,21 @@ COPY fetch-debs ./
 RUN ./fetch-debs dumb-init libpam0g libaudit1 libcap-ng0
 
 FROM debian:11 AS teleport
-# NOTE that the TELEPORT_RELEASE_INFIX *must* include the leading dash if set
+# Install the teleport binary from an architecture-specific debian package. Note
+# that we cannot simply pass a ready-made package filename in as a build-arg, as
+# this dockerfile is used for a multiarch build and any build-args will be
+# re-used for multiple ${TARGETARCH}es. In order to get around this we pass
+# various components of the architecture-specific debian package filename in as
+# individual build args and re-assemble it *inside* the build.
+
+# NOTE that the TELEPORT_RELEASE_INFIX and TELEPORT_FIPS_INFIX 
+# *must* include the leading dash if set.
 ARG TELEPORT_RELEASE_INFIX
+ARG TELEPORT_FIPS_INFIX=""
 ARG TELEPORT_VERSION
+# TARGETARCH is supplied by the `buildx` mechanics
 ARG TARGETARCH
-ENV TELEPORT_DEB_FILE_NAME=teleport${TELEPORT_RELEASE_INFIX}_${TELEPORT_VERSION}_${TARGETARCH}.deb
+ENV TELEPORT_DEB_FILE_NAME=teleport${TELEPORT_RELEASE_INFIX}_${TELEPORT_VERSION}${TELEPORT_FIPS_INFIX}_${TARGETARCH}.deb
 COPY $TELEPORT_DEB_FILE_NAME ./$TELEPORT_DEB_FILE_NAME
 RUN dpkg-deb -R $TELEPORT_DEB_FILE_NAME /opt/staging && \
     mkdir -p /opt/staging/etc/teleport && \


### PR DESCRIPTION
The `distroless` Dockerfile installs Teleport from a architecture-specific Debian
package file, and so needs to be able to construct the filename during the build 
from various suupplied components, plus the target archecture during a multiarch 
build.

This patch updates the dockerfile to handle constructing a filename for a fips-
compatible Teleport build.