### PR TITLE
[v13] darwin: Use notarytool to notarize instead of altool

### DIFF
--- a/web/packages/teleterm/README.md
+++ b/web/packages/teleterm/README.md
@@ -115,6 +115,7 @@ When running `yarn package-term`, you need to provide these environment variable
 - `APPLE_PASSWORD`
 - `CONNECT_TSH_APP_PATH`
 - `CSC_NAME` (optional, developer certificate ID)
+- `TEAMID`
 
 The details behind those vars are described below.
 
@@ -150,6 +151,11 @@ towards the specific developer ID certificate/key we want to use, if multiple ar
 On top of that, you must provide env vars that will be used for notarization. `APPLE_USERNAME` must
 be set to the account email address associated with the developer ID. `APPLE_PASSWORD` must be [an
 app-specific password](https://support.apple.com/en-us/HT204397), not the account password.
+
+The Team ID needed as an input for notarization must be provided via the `TEAMID` environment
+variable. The top-level `Makefile` exports this when `yarm package-term` is called from `make
+release-connect` with either the developer or production Team ID depending on the `ENVIRONMENT_NAME`
+environment variable. See the top-level `darwin-signing.mk` for details.
 
 ## Architecture
 

--- a/web/packages/teleterm/notarize.js
+++ b/web/packages/teleterm/notarize.js
@@ -13,6 +13,13 @@ exports.default = async function notarizing(context) {
     return;
   }
 
+  if (!process.env.TEAMID) {
+    console.warn(
+      'missing $TEAMID: notarization will be skipped. Run `make release-connect` instead'
+    );
+    return;
+  }
+
   const appName = context.packager.appInfo.productFilename;
   const appBundleId = context.packager.appInfo.macBundleIdentifier;
 
@@ -21,5 +28,7 @@ exports.default = async function notarizing(context) {
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_USERNAME,
     appleIdPassword: process.env.APPLE_PASSWORD,
+    tool: 'notarytool',
+    teamId: process.env.TEAMID,
   });
 };


### PR DESCRIPTION
Switch to using the newer `notarytool` to notarize MacOS binaries
instead of the older `altool`, as `altool` is deprecated and will no
longer work come Fall 2023. This also makes for a quieter build as
altool's output was quite verbose, and anecdotally, it seems to be more
reliable - I haven't had a single notarization failure this way as
opposed to the many we see in CI with `altool`.

We used to use `gon` as part of our notarizing tool. `gon` still has an
open issue to upgrade to `notarytool`, so we've switched away from it
and used the Apple CLI tools instead to do the notarization. This is
available now that we have moved to GitHub Actions for builds as it has
a newer Xcode that contains notarytool.

Update the Teleport Connect notarization, which was quite a bit simpler,
although we do need an extra `$TEAMID` input, so handle it when that is
not supplied and document in the README that it is needed.

Backport: https://github.com/gravitational/teleport/pull/25407