### PR TITLE
build: Support arm64 and universal binaries for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,9 @@ endif
 CHECK_CARGO := $(shell cargo --version 2>/dev/null)
 CHECK_RUST := $(shell rustc --version 2>/dev/null)
 
+RUST_VERSION ?= $(shell make --no-print-directory -C build.assets print-rust-version)
+RUST_TARGET_ARCH ?= $(CARGO_TARGET_$(OS)_$(ARCH))
+
 # Have cargo use sparse crates.io protocol:
 # https://blog.rust-lang.org/2023/03/09/Rust-1.68.0.html
 # TODO: Delete when it becomes default in Rust 1.70.0
@@ -1257,3 +1260,12 @@ build-ui-e: ensure-js-deps
 .PHONY: docker-ui
 docker-ui:
 	$(MAKE) -C build.assets ui
+
+# rustup-install-target-toolchain ensures the required rust compiler is
+# installed to build for $(ARCH)/$(OS) for the version of rust we use, as
+# defined in build.assets/Makefile. It assumes that `rustup` is already
+# installed for managing the rust toolchain.
+.PHONY: rustup-install-target-toolchain
+rustup-install-target-toolchain:
+	rustup override set $(RUST_VERSION)
+	rustup target add $(RUST_TARGET_ARCH)

--- a/Makefile
+++ b/Makefile
@@ -1164,8 +1164,8 @@ pkg:
 	mkdir -p $(BUILDDIR)/
 	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
-	# arch and runtime are currently ignored on OS X
-	# we pass them through for consistency - they will be dropped by the build script
+	# runtime is currently ignored on OS X
+	# we pass it through for consistency - it will be dropped by the build script
 	cd $(BUILDDIR) && ./build-package.sh -t oss -v $(VERSION) -p pkg -b $(TELEPORT_BUNDLEID) -a $(ARCH) $(RUNTIME_SECTION) $(TARBALL_PATH_SECTION)
 	if [ -f e/Makefile ]; then $(MAKE) -C e pkg; fi
 
@@ -1173,7 +1173,7 @@ pkg:
 .PHONY: pkg-tsh
 pkg-tsh:
 	$(eval export DEVELOPER_ID_APPLICATION DEVELOPER_ID_INSTALLER)
-	./build.assets/build-pkg-tsh.sh -t oss -v $(VERSION) -b $(TSH_BUNDLEID) $(TARBALL_PATH_SECTION)
+	./build.assets/build-pkg-tsh.sh -t oss -v $(VERSION) -b $(TSH_BUNDLEID) -a $(ARCH) $(TARBALL_PATH_SECTION)
 	mkdir -p $(BUILDDIR)/
 	mv tsh*.pkg* $(BUILDDIR)/
 

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,13 @@ endif
 endif
 endif
 
+# Set C_ARCH for building libfido2 and dependencies. ARCH is the Go
+# architecture which uses different names for architectures than C
+# uses. Export it for the build.assets/build-fido2-macos.sh script.
+C_ARCH_amd64 = x86_64
+C_ARCH = $(or $(C_ARCH_$(ARCH)),$(ARCH))
+export C_ARCH
+
 # Enable libfido2 for testing?
 # Eagerly enable if we detect the package, we want to test as much as possible.
 ifeq ("$(shell pkg-config libfido2 2>/dev/null; echo $$?)", "0")
@@ -327,6 +334,15 @@ else
 .PHONY: rdpclient
 rdpclient:
 endif
+
+# Build libfido2 and dependencies for MacOS. Uses exported C_ARCH variable defined earlier.
+.PHONY: build-fido2
+build-fido2:
+	./build.assets/build-fido2-macos.sh build
+
+.PHONY: print-fido2-pkg-path
+print-fido2-pkg-path:
+	@./build.assets/build-fido2-macos.sh pkg_config_path
 
 #
 # make full - Builds Teleport binaries with the built-in web assets and

--- a/Makefile
+++ b/Makefile
@@ -246,6 +246,14 @@ endif
 
 CGOFLAG_TSH ?= $(CGOFLAG)
 
+# Map ARCH into the architecture flag for electron-builder. Ensure
+# ELECTRON_BUILDER_ARCH is not exported so we do not generate
+# an error on unsupported architectures when not running this target.
+ELECTRON_BUILDER_ARCH_amd64 = x64
+ELECTRON_BUILDER_ARCH_arm64 = arm64
+ELECTRON_BUILDER_ARCH = $(or $(ELECTRON_BUILDER_ARCH_$(ARCH)),$(error Unsupported architecture: $(ARCH)))
+unexport ELECTRON_BUILDER_ARCH
+
 #
 # 'make all' builds all 4 executables and places them in the current directory.
 #
@@ -540,13 +548,13 @@ release-windows: release-windows-unsigned
 # proper release (a proper release needs the APP_PATH as that points to
 # the complete signed package). See web/packages/teleterm/README.md for
 # details.
-#
+
 .PHONY: release-connect
 release-connect:
 	$(eval export CSC_NAME)
 	yarn install --frozen-lockfile
 	yarn build-term
-	yarn package-term -c.extraMetadata.version=$(VERSION)
+	yarn package-term -c.extraMetadata.version=$(VERSION) --$(ELECTRON_BUILDER_ARCH)
 
 #
 # Remove trailing whitespace in all markdown files under docs/.

--- a/Makefile
+++ b/Makefile
@@ -483,7 +483,7 @@ include darwin-signing.mk
 
 .PHONY: release-darwin-unsigned
 release-darwin-unsigned: RELEASE:=$(RELEASE)-unsigned
-release-darwin-unsigned: clean full build-archive
+release-darwin-unsigned: full build-archive
 
 .PHONY: release-darwin
 ifneq ($(ARCH),universal)

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -13,6 +13,13 @@ set -eu
 
 readonly MACOS_VERSION_MIN=10.13
 
+# Cross-architecture building
+# Set C_ARCH to $(uname -m) if unset, and validate supported architecture
+if ! [[ "${C_ARCH:=$(uname -m)}" =~ ^(x86_64|arm64)$ ]]; then
+  echo "unknown or unsupported build architecture: $C_ARCH" >&2
+  exit 1
+fi
+
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
@@ -21,7 +28,7 @@ readonly CRYPTO_COMMIT=31157bc0b46e04227b8468d3e6915e4d0332777c
 readonly FIDO2_VERSION=1.13.0
 readonly FIDO2_COMMIT=486a8f8667e42f55cee2bba301b41433cacec830
 
-readonly LIB_CACHE="/tmp/teleport-fido2-cache"
+readonly LIB_CACHE="/tmp/teleport-fido2-cache-$C_ARCH"
 readonly PKGFILE_DIR="$LIB_CACHE/fido2-${FIDO2_VERSION}_cbor-${CBOR_VERSION}_crypto-${CRYPTO_VERSION}"
 
 # Library cache paths, implicitly matched by fetch_and_build.
@@ -82,6 +89,7 @@ cbor_build() {
   cd "$src"
 
   cmake \
+    -DCMAKE_OSX_ARCHITECTURES="$C_ARCH" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$dest" \
     -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_VERSION_MIN" \
@@ -105,7 +113,8 @@ crypto_build() {
   echo 'crypto: building' >&2
   cd "$src"
 
-  ./config \
+  ./Configure \
+    "darwin64-$C_ARCH-cc" \
     -mmacosx-version-min="$MACOS_VERSION_MIN" \
     --prefix="$dest" \
     no-shared \
@@ -137,6 +146,7 @@ fido2_build() {
     -DBUILD_EXAMPLES=OFF \
     -DBUILD_MANPAGES=OFF \
     -DBUILD_TOOLS=OFF \
+    -DCMAKE_OSX_ARCHITECTURES="$C_ARCH" \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX="$dest" \
     -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_VERSION_MIN" \
@@ -172,6 +182,7 @@ EOF
   # Word splitting desired for pkg-config.
   #shellcheck disable=SC2046
   gcc \
+    -arch "$C_ARCH" \
     $(pkg-config --cflags --libs libfido2-static) \
     -o "$toydir/toy.bin" \
     "$toydir/toy.c"

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -101,16 +101,11 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
         echo "You must be running on OS X to build .pkg files"
         exit 4
     fi
-    if [[ "${ARCH}" != "" ]]; then
-        echo "arch parameter is ignored when building for OS X"
-        unset ARCH
-    fi
     if [[ "${RUNTIME}" != "" ]]; then
         echo "runtime parameter is ignored when building for OS X"
         unset RUNTIME
     fi
     PLATFORM="darwin"
-    ARCH="amd64"
     if [[ ! $(type pkgbuild) ]]; then
         echo "You need to install pkgbuild"
         echo "Run: xcode-select --install"
@@ -136,6 +131,7 @@ else
     fi
 fi
 
+PACKAGE_ARCH=""
 # handle differences between 'gravitational' arch and system arch
 if [[ "${ARCH}" == "386" || "${ARCH}" == "i386" ]]; then
     TEXT_ARCH="32-bit x86"
@@ -147,6 +143,7 @@ if [[ "${ARCH}" == "386" || "${ARCH}" == "i386" ]]; then
 elif [[ "${ARCH}" == "amd64" || "${ARCH}" == "x86_64" ]]; then
     TEXT_ARCH="64-bit x86"
     TARBALL_ARCH="amd64"
+    PACKAGE_ARCH="amd64"
     DEB_PACKAGE_ARCH="amd64"
     DEB_OUTPUT_ARCH="amd64"
     RPM_PACKAGE_ARCH="x86_64"
@@ -162,6 +159,7 @@ elif [[ "${ARCH}" == "arm" ]]; then
 elif [[ "${ARCH}" == "arm64" ]]; then
     TEXT_ARCH="64-bit ARM"
     TARBALL_ARCH="arm64"
+    PACKAGE_ARCH="arm64"
     DEB_PACKAGE_ARCH="arm64"
     DEB_OUTPUT_ARCH="arm64"
     RPM_PACKAGE_ARCH="aarch64"
@@ -203,13 +201,17 @@ fi
 
 # set file list
 if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
+    if [[ -z "${PACKAGE_ARCH}" ]]; then
+        echo "Unsupported architecture: ${ARCH}"
+        exit 1
+    fi
     SIGN_PKG="true"
     FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot"
     BUNDLE_ID="${b:-com.gravitational.teleport}"
     if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
-        PKG_FILENAME="teleport-ent-${TELEPORT_VERSION}.${PACKAGE_TYPE}"
+        PKG_FILENAME="teleport-ent-${TELEPORT_VERSION}-${PACKAGE_ARCH}.${PACKAGE_TYPE}"
     else
-        PKG_FILENAME="teleport-${TELEPORT_VERSION}.${PACKAGE_TYPE}"
+        PKG_FILENAME="teleport-${TELEPORT_VERSION}-${PACKAGE_ARCH}.${PACKAGE_TYPE}"
     fi
 else
     FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/examples/systemd/teleport.service"

--- a/build.assets/build-package.sh
+++ b/build.assets/build-package.sh
@@ -26,7 +26,7 @@ while getopts ":t:v:p:a:r:s:b:n" o; do
             ;;
         a)
             a=${OPTARG}
-            if [[ ${a} != "amd64" && ${a} != "x86_64" && ${a} != "386" && ${a} != "i386" && ${a} != "arm" && ${a} != "arm64" ]]; then usage; fi
+            if [[ ${a} != "amd64" && ${a} != "x86_64" && ${a} != "386" && ${a} != "i386" && ${a} != "arm" && ${a} != "arm64" && ${a} != "universal" ]]; then usage; fi
             ;;
         r)
             r=${OPTARG}
@@ -164,6 +164,9 @@ elif [[ "${ARCH}" == "arm64" ]]; then
     DEB_OUTPUT_ARCH="arm64"
     RPM_PACKAGE_ARCH="aarch64"
     RPM_OUTPUT_ARCH="arm64" # backwards compatibility
+elif [[ "${ARCH}" == "universal" ]]; then
+    TARBALL_ARCH="universal"
+    PACKAGE_ARCH="universal"
 fi
 
 # amd64 RPMs should use CentOS 7 compatible artifacts
@@ -205,13 +208,18 @@ if [[ "${PACKAGE_TYPE}" == "pkg" ]]; then
         echo "Unsupported architecture: ${ARCH}"
         exit 1
     fi
+    # No architecture tag on package filename for universal (multi-arch) binaries.
+    ARCH_TAG=""
+    if [[ "${PACKAGE_ARCH}" != "universal" ]]; then
+        ARCH_TAG="-${PACKAGE_ARCH}"
+    fi
     SIGN_PKG="true"
     FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot"
     BUNDLE_ID="${b:-com.gravitational.teleport}"
     if [[ "${TELEPORT_TYPE}" == "ent" ]]; then
-        PKG_FILENAME="teleport-ent-${TELEPORT_VERSION}-${PACKAGE_ARCH}.${PACKAGE_TYPE}"
+        PKG_FILENAME="teleport-ent-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
     else
-        PKG_FILENAME="teleport-${TELEPORT_VERSION}-${PACKAGE_ARCH}.${PACKAGE_TYPE}"
+        PKG_FILENAME="teleport-${TELEPORT_VERSION}${ARCH_TAG}.${PACKAGE_TYPE}"
     fi
 else
     FILE_LIST="${TAR_PATH}/tsh ${TAR_PATH}/tctl ${TAR_PATH}/teleport ${TAR_PATH}/tbot ${TAR_PATH}/examples/systemd/teleport.service"

--- a/build.assets/build-pkg-tsh.sh
+++ b/build.assets/build-pkg-tsh.sh
@@ -6,6 +6,7 @@ TELEPORT_TYPE=''     # -t, oss or ent
 TELEPORT_VERSION=''  # -v, version, without leading 'v'
 TARBALL_DIRECTORY='' # -s
 BUNDLEID="${TSH_BUNDLEID}"
+PACKAGE_ARCH=amd64   # -a, default to amd64 for backward-compatibilty.
 
 usage() {
   log "Usage: $0 -t oss|eng -v version [-s tarball_directory] [-b bundle_id] [-n]"
@@ -35,7 +36,7 @@ main() {
   . "$buildassets/build-common.sh"
 
   local opt=''
-  while getopts "t:v:s:b:n" opt; do
+  while getopts "t:v:s:b:a:n" opt; do
     case "$opt" in
       t)
         if [[ "$OPTARG" != "oss" && "$OPTARG" != "ent" ]]; then
@@ -57,6 +58,9 @@ main() {
         ;;
       b)
         BUNDLEID="$OPTARG"
+        ;;
+      a)
+        PACKAGE_ARCH="$OPTARG"
         ;;
       n)
         DRY_RUN_PREFIX='echo + '  # declared by build-common.sh
@@ -119,8 +123,8 @@ of the key to sign packages"
   [[ "$TELEPORT_TYPE" == 'ent' ]] && ent='-ent'
   local tarname=''
   tarname="$(printf \
-    "teleport%s-v%s-darwin-amd64-bin.tar.gz" \
-    "$ent" "$TELEPORT_VERSION")"
+    "teleport%s-v%s-darwin-%s-bin.tar.gz" \
+    "$ent" "$TELEPORT_VERSION" "$PACKAGE_ARCH")"
   [[ -n "$TARBALL_DIRECTORY" ]] && tarname="$TARBALL_DIRECTORY/$tarname"
 
   tarout='' # find_or_fetch_tarball writes to this
@@ -165,7 +169,7 @@ of the key to sign packages"
 
   # Prepare and sign the installer package.
   # Note that the installer does __NOT__ have a `v` in the version number.
-  target="$tmp/tsh-$TELEPORT_VERSION.pkg" # switches from app to pkg
+  target="$tmp/tsh-$TELEPORT_VERSION-$PACKAGE_ARCH.pkg" # switches from app to pkg
   local pkg_root="$tmp/root"
   local pkg_component_plist="$tmp/tsh-component.plist"
   local pkg_scripts="$buildassets/macos/scripts"

--- a/build.assets/build-pkg-tsh.sh
+++ b/build.assets/build-pkg-tsh.sh
@@ -169,7 +169,12 @@ of the key to sign packages"
 
   # Prepare and sign the installer package.
   # Note that the installer does __NOT__ have a `v` in the version number.
-  target="$tmp/tsh-$TELEPORT_VERSION-$PACKAGE_ARCH.pkg" # switches from app to pkg
+  # The package for the universal binary does not have an architecture in the name.
+  local arch_tag=""
+  if [[ "$PACKAGE_ARCH" != "universal" ]]; then
+    arch_tag="-$PACKAGE_ARCH"
+  fi
+  target="$tmp/tsh-$TELEPORT_VERSION$arch_tag.pkg" # switches from app to pkg
   local pkg_root="$tmp/root"
   local pkg_component_plist="$tmp/tsh-component.plist"
   local pkg_scripts="$buildassets/macos/scripts"

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -67,6 +67,7 @@ module.exports = {
     ].filter(Boolean),
   },
   dmg: {
+    artifactName: '${productName}-${version}-${arch}.${ext}',
     contents: [
       {
         x: 130,

--- a/web/packages/teleterm/electron-builder-config.js
+++ b/web/packages/teleterm/electron-builder-config.js
@@ -1,4 +1,5 @@
 const { env, platform } = require('process');
+const fs = require('fs');
 
 const isMac = platform === 'darwin';
 
@@ -28,6 +29,9 @@ if (!isMac && env.CONNECT_TSH_BIN_PATH === undefined) {
   throw new Error('You must provide CONNECT_TSH_BIN_PATH');
 }
 
+// Holds tsh.app Info.plist during build. Used in afterPack.
+let tshAppPlist;
+
 /**
  * @type { import('electron-builder').Configuration }
  */
@@ -36,7 +40,36 @@ module.exports = {
   asar: true,
   asarUnpack: '**\\*.{node,dll}',
   afterSign: 'notarize.js',
-  files: ['build/app/dist'],
+  afterPack: packed => {
+    // @electron-universal adds the `ElectronAsarIntegrity` key to every .plist
+    // file it finds, causing signature verification to fail for tsh.app that gets
+    // embedded in Teleport Connect. This causes the error "invalid Info.plist (plist
+    // or signature have been modified)".
+    // Workaround this by copying the tsp.app plist file before adding the key and
+    // replace it after it is done.
+
+    if (!env.CONNECT_TSH_APP_PATH) {
+      // Not embedding tsh.app
+      return;
+    }
+
+    const path = `${packed.appOutDir}/Teleport Connect.app/Contents/MacOS/tsh.app/Contents/Info.plist`;
+    if (packed.appOutDir.endsWith('mac-universal--x64')) {
+      tshAppPlist = fs.readFileSync(path);
+    }
+    if (packed.appOutDir.endsWith('mac-universal')) {
+      fs.writeFileSync(path, tshAppPlist);
+    }
+  },
+  files: [
+    'build/app/dist',
+    // node-pty creates some files that differ across architecture builds causing
+    // the error "can't reconcile the non-macho files" as they cant be combined
+    // with lipo for a universal build. They aren't needed so skip them.
+    '!node_modules/node-pty/build/*/.forge-meta',
+    '!node_modules/node-pty/build/Debug/.deps/**',
+    '!node_modules/node-pty/bin',
+  ],
   mac: {
     target: 'dmg',
     category: 'public.app-category.developer-tools',
@@ -46,6 +79,8 @@ module.exports = {
     // If CONNECT_TSH_APP_PATH is provided, we assume that tsh.app is already signed.
     signIgnore: env.CONNECT_TSH_APP_PATH && ['tsh.app'],
     icon: 'build_resources/icon-mac.png',
+    // x64ArchFiles is for x64 and universal files (lipo tool should skip them)
+    x64ArchFiles: 'Contents/MacOS/tsh.app/Contents/MacOS/tsh',
     // On macOS, helper apps (such as tsh.app) should be under Contents/MacOS, hence using
     // `extraFiles` instead of `extraResources`.
     // https://developer.apple.com/documentation/bundleresources/placing_content_in_a_bundle


### PR DESCRIPTION
Add support for building arm64 and universal binaries for MacOS, via the
`ARCH=arm64` and `ARCH=universal` vars in the `Makefile`. This includes
changes for building C code (libfido2 and dependencies), rust
(rdpclient) and the packaging (`.pkg` and `.dmg`). Go supports this
without any extra fuss.

We now also copy the release artifacts into a release artifact directory
so it is easier for CI to find the artifacts to release, as previously
they were all scattered over the repository (they are still scattered,
but also copied to the release artifact directory. This will be cleaned
up when we find any dependencies on the old locations).

Issue: https://github.com/gravitational/teleport/issues/4226
Issue: https://github.com/gravitational/teleport.e/issues/872
