### PR TITLE
[Web] Desktop Discovery UI fixes

### DIFF
--- a/web/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
+++ b/web/packages/teleport/src/Discover/Desktop/ConnectTeleport/RunConfigureScriptAnimation.tsx
@@ -23,7 +23,6 @@ import {
 
 import { KeywordHighlight } from 'shared/components/AnimatedTerminal/TerminalContent';
 
-import cfg from 'teleport/config';
 import { ResourceKind } from 'teleport/Discover/Shared';
 
 import { generateCommand } from 'teleport/Discover/Shared/generateCommand';
@@ -32,7 +31,9 @@ import { JoinToken } from 'teleport/services/joinToken';
 
 const lines = (joinToken: JoinToken) => [
   {
-    text: generateCommand(cfg.getConfigureADUrl(joinToken.id)),
+    text: generateCommand(
+      'https://teleport.example.com/v1/webapi/scripts/desktop-access/configure/<YOUR_TOKEN>/configure-ad.ps1'
+    ),
     isCommand: true,
   },
   {
@@ -84,8 +85,8 @@ windows_desktop_service:
 ];
 
 const selectedLines = {
-  start: 4,
-  end: 29,
+  start: 3,
+  end: 28,
 };
 
 const highlights: KeywordHighlight[] = [

--- a/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/DesktopService.tsx
+++ b/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/DesktopService.tsx
@@ -22,14 +22,14 @@ import {
   ServerLightGreen1,
 } from 'teleport/Discover/Desktop/DiscoverDesktops/ServerIcon';
 
-const ripple = keyframes`
+const ripple = rippleColor => keyframes`
   0% {
     box-shadow: 0 0 0 0 rgba(255, 255, 255, 0),
-    0 0 0 40px rgba(255, 255, 255, 0.18);
+    0 0 0 40px ${rippleColor};
   }
   100% {
-    box-shadow: 0 0 0 40px rgba(255, 255, 255, 0.18),
-    0 0 0 40px rgba(204, 233, 251, 0);
+    box-shadow: 0 0 0 40px ${rippleColor},
+    0 0 0 40px rgba(255, 255, 255, 0);
   }
 `;
 
@@ -43,7 +43,8 @@ const Container = styled.div`
 `;
 
 const Ripple = styled.div`
-  animation: ${ripple} 1.5s linear infinite;
+  animation: ${({ theme }) => ripple(theme.colors.spotBackground[2])} 1.5s
+    linear infinite;
   border-radius: 50%;
   width: 100px;
   height: 100px;
@@ -61,7 +62,6 @@ const Ripple = styled.div`
     display: block;
     width: 100px;
     height: 100px;
-    background: rgba(34, 44, 89, 1);
     transform: scale(1);
   }
 `;

--- a/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/ProxyDesktopServiceDiagram.tsx
+++ b/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/ProxyDesktopServiceDiagram.tsx
@@ -30,7 +30,9 @@ import { ProxyServerIcon } from './Server';
 const NodeHostname = styled.div`
   font-family: Menlo, DejaVu Sans Mono, Consolas, Lucida Console, monospace;
   font-size: 12px;
-  color: rgba(255, 255, 255, 0.7);
+  color: ${props => props.theme.colors.text.primary};
+  max-width: 184px;
+  overflow-wrap: break-word;
 `;
 
 const NodeTitle = styled.div`

--- a/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/ServerIcon.tsx
+++ b/web/packages/teleport/src/Discover/Desktop/DiscoverDesktops/ServerIcon.tsx
@@ -22,7 +22,8 @@ const Server = styled.div`
   height: 16px;
   padding: 0 7px;
   box-sizing: border-box;
-  background: #f5e6fe;
+  background: ${({ theme }) =>
+    theme.name === 'light' ? '#6c6c6c' : '#f2e9f7'};
   margin-bottom: 8px;
   border-radius: 5px;
   display: flex;
@@ -111,7 +112,8 @@ const ServerLines = styled.div`
 const ServerLine = styled.div`
   height: 3px;
   border-radius: 5px;
-  background: rgba(0, 0, 0, 0.4);
+  background: ${({ theme }) =>
+    theme.name === 'light' ? 'rgba(255, 255, 255, 0.4)' : 'rgba(0, 0, 0, 0.4)'};
   margin-left: 5px;
   overflow: hidden;
 `;

--- a/web/packages/teleport/src/Discover/Shared/HintBox.tsx
+++ b/web/packages/teleport/src/Discover/Shared/HintBox.tsx
@@ -28,7 +28,7 @@ const HintBoxContainer = styled(Box)`
   background-color: ${props => props.theme.colors.spotBackground[0]};
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
-  border: 2px solid ${props => props.theme.colors.warning}; ;
+  border: 2px solid ${props => props.theme.colors.warning.main}; ;
 `;
 
 export const WaitingInfo = styled(Box)`


### PR DESCRIPTION
## Purpose

This PR closes https://github.com/gravitational/teleport/issues/25163
This PR closes https://github.com/gravitational/teleport/issues/25161

Fixes minor UI bugs discovered in the Desktop discovery flow.

## Implementation

The issue outlined in https://github.com/gravitational/teleport/issues/25161 was caused because we assumed that the outputted config selected in the animated terminal window would start on line `4`, however this wouldn't be the case if the generated URL in the first command was shorter or longer and thus took up a different number of lines. By replacing the URL in the animated terminal window with a fixed example URL, the config will always start on the same line.

![image](https://user-images.githubusercontent.com/56373201/235751314-9862295d-fd78-49d0-91dc-43468abccc9c.png)
