### PR TITLE
[Assitant] Fix WebSocket connection disconnect

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -742,7 +742,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.PUT("/webapi/headless/:headless_authentication_id", h.WithAuth(h.putHeadlessState))
 
 	// WebSocket endpoint for the chat conversation
-	h.GET("/webapi/assistant", h.WithAuth(h.assistant))
+	h.GET("/webapi/sites/:site/assistant", h.WithClusterAuth(h.assistant))
 
 	// Sets the title for the conversation.
 	h.POST("/webapi/assistant/conversations/:conversation_id/title", h.WithAuth(h.setAssistantTitle))

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -318,6 +318,7 @@ func insertAssistantMessage(ctx context.Context, h *Handler, sctx *SessionContex
 ) error {
 	// Create a new auth client as the WS is a long-living connection
 	// and client created at the beginning will timeout at some point.
+	// TODO(jakule): Fix the timeout issue https://github.com/gravitational/teleport/issues/25758
 	authClient, err := newRemoteClient(ctx, sctx, site)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/gorilla/websocket"
-	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
 	"github.com/julienschmidt/httprouter"
@@ -40,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/ai"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/reversetunnel"
 )
 
 const (

--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -100,7 +100,7 @@ export function createViteConfig(
           changeOrigin: false,
           secure: false,
         },
-        '^\\/v1\\/webapi\\/assistant': {
+        '^\\/v1\\/webapi\\/sites\\/(.*?)\\/assistant': {
           target: `wss://${target}`,
           changeOrigin: false,
           secure: false,

--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -281,7 +281,7 @@ export function MessagesContextProvider(
   const [responding, setResponding] = useState(false);
   const [messages, setMessages] = useState<Message[]>([]);
 
-  const socketUrl = `wss://${getHostName()}/v1/webapi/assistant?access_token=${getAccessToken()}&conversation_id=${
+  const socketUrl = `wss://${getHostName()}/v1/webapi/sites/${clusterId}/assistant?access_token=${getAccessToken()}&conversation_id=${
     props.conversationId
   }`;
 


### PR DESCRIPTION
Currently, we use auth client created at the beginning of WS connection. When the client keeps the connection open for a while, our auth client will time out, resulting in `grpc: closed connection` when we try to use it (for adding assistant messages).
This PR creates a new auth client for every message we want to store in the backend, so the connection won't time out before we want to use it.