### PR TITLE
Fix vite config

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -75,7 +75,7 @@ export function createViteConfig(
         transformPlugin(),
       ],
       define: {
-        'process.env.NODE_ENV': process.env.NODE_ENV,
+        'process.env': { NODE_ENV: process.env.NODE_ENV },
       },
     };
 


### PR DESCRIPTION
This PR will provide an object to `process.env` in the vite config `define` rather than an individual key