### PR TITLE
Bump Cloud version to 12.3.1

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1406,7 +1406,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "12.2.4",
+      "version": "12.3.1",
       "major_version": "12",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Teleport Cloud will upgrade tenants to 12.3.1 on 5/3/23. See: https://github.com/gravitational/cloud/issues/4329