### PR TITLE
Improve API client connection failure feedback

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -597,7 +597,16 @@ func (c *Config) CheckAndSetDefaults() error {
 		PermitWithoutStream: true,
 	}))
 	if !c.DialInBackground {
-		c.DialOpts = append(c.DialOpts, grpc.WithBlock())
+		c.DialOpts = append(
+			c.DialOpts,
+			// Provides additional feedback on connection failure, otherwise,
+			// users will only receive a `context deadline exceeded` error when
+			// c.DialInBackground == false.
+			//
+			// grpc.WithReturnConnectionError implies grpc.WithBlock which is
+			// necessary connection route selection to work properly.
+			grpc.WithReturnConnectionError(),
+		)
 	}
 	return nil
 }

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -604,7 +604,7 @@ func (c *Config) CheckAndSetDefaults() error {
 			// c.DialInBackground == false.
 			//
 			// grpc.WithReturnConnectionError implies grpc.WithBlock which is
-			// necessary connection route selection to work properly.
+			// necessary for connection route selection to work properly.
 			grpc.WithReturnConnectionError(),
 		)
 	}

--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -799,9 +799,6 @@ func newTokenDemoApp() *tokenDemoApp {
 	t, err := teleport.New(ctx, teleport.Config{
 		Addrs:       []string{proxyAddr},
 		Credentials: []teleport.Credentials{creds},
-		DialOpts: []grpc.DialOption{
-			grpc.WithReturnConnectionError(),
-		},
 	})
 	if err != nil {
 		panic(err)
@@ -829,10 +826,6 @@ up an API client. Our plugin initializes a Teleport client by calling
 `client.LoadIdentityFile` to obtain a `client.Credentials`. It then uses the
 `client.Credentials` to call `client.New`, which connects to the Teleport Proxy
 Service specified in the `Addrs` field using the provided identity file.
-
-In this example, we are passing the `grpc.WithReturnConnectionError()` function
-call to `client.New`, which instructs the gRPC client to return more detailed
-connection errors.
 
 <Admonition type="warning">
 

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -748,9 +748,6 @@ func main() {
 	teleport, err := client.New(ctx, client.Config{
 		Addrs:       []string{proxyAddr},
 		Credentials: []client.Credentials{creds},
-		DialOpts: []grpc.DialOption{
-			grpc.WithReturnConnectionError(),
-		},
 	})
 	if err != nil {
 		panic(err)
@@ -782,10 +779,6 @@ initializes a Teleport client by calling `client.LoadIdentityFile` to obtain a
 `client.Credentials`. It then uses the `client.Credentials` to call
 `client.New`, which connects to the Teleport Proxy Service specified in the
 `Addrs` field using the provided identity file.
-
-In this example, we are passing the `grpc.WithReturnConnectionError()` function
-call to `client.New`, which instructs the gRPC client to return more detailed
-connection errors.
 
 <Admonition type="warning">
 


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/25535

This specifically covers cases where `DialInBackground == false`, which is the style we recommend in our docs to users consuming the API.

As the gRPC client retries connecting until a deadline is met, the error currently emitted is just "context deadline exceeded" which is completely devoid of the actual error that meant that it did not succeed. `grpc.WithReturnConnectionError()` means that the last error to occur is emitted. 

This is not the perfect solution, in some cases, the last error to be emitted is still possibly going to be related to the connection being forced to close. But, it does mean that we will start showing /more/ of the underlying errors which will be helpful.

Before:
```
all connection methods failed
        
        failed to connect to addr noah.teleport.sh:443 with TLS Routing with ALPN connection upgrade dialer
                context deadline exceeded, 
        failed to connect to addr noah.teleport.sh:443 with TLS Routing dialer
                context deadline exceeded, 
        failed to connect to addr noah.teleport.sh:443 as a web proxy
                context deadline exceeded, 
        failed to connect to addr noah.teleport.sh:443 as a reverse tunnel proxy
                context deadline exceeded, 
        failed to connect to addr noah.teleport.sh:443 as an auth server
                context deadline exceeded
exit status 1
```

After:
```
all connection methods failed
        
        failed to connect to addr noah.teleport.sh:443 with TLS Routing dialer
                context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain, use of closed network connection", 
        failed to connect to addr noah.teleport.sh:443 with TLS Routing with ALPN connection upgrade dialer
                context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain, use of closed network connection", 
        failed to connect to addr noah.teleport.sh:443 as a reverse tunnel proxy
                context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: ssh: handshake failed: ssh: overflow reading version string, close tcp 192.168.1.156:58095->52.223.52.117:443: use of closed network connection", 
        failed to connect to addr noah.teleport.sh:443 as a web proxy
                context deadline exceeded: connection error: desc = "transport: Error while dialing: failed to dial: ssh: handshake failed: ssh: overflow reading version string, close tcp 192.168.1.156:58093->52.223.52.117:443: use of closed network connection", 
        failed to connect to addr noah.teleport.sh:443 as an auth server
                context deadline exceeded: connection error: desc = "transport: authentication handshake failed: tls: first record does not look like a TLS handshake"
```
