### PR TITLE
Add client compatibility to installation guide

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -5,26 +5,23 @@ h1: Installation
 videoBanner: VifXROQFjwg
 ---
 
-<Admonition type="tip" title="First time trying Teleport?">
+This guide shows you how to install Teleport binaries on your platform,
+including:
+- `teleport`
+- `tsh`
+- `tctl`
+- `tbot`
 
 If you are new to Teleport, we recommend following our [getting started
 guide](./get-started.mdx).
 
-</Admonition>
+For best results, Teleport clients (`tsh`, `tctl`, `tbot`) should be the same major
+version as the cluster they are connecting to. Teleport servers are compatible
+with clients that are on the same major version or one major version older.
+Teleport servers do not support clients that are on a newer major version.
 
-<Admonition type="warning" title="Teleport client compatibility">
+See our [Upgrading](./management/operations/upgrading.mdx) guide for more information.
 
-For best results, Teleport clients (`tsh`, `tctl`, `tbot`)
-should be the same major version as the cluster they are
-connecting to. Teleport servers are compatible with clients
-that are on the same major version or one major version older.
-Teleport servers do not support clients that are on a newer
-major version.
-
-See our [Upgrading](./management/operations/upgrading.mdx) guide for more
-information.
-
-</Admonition>
 
 ## Operating system support
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -12,6 +12,17 @@ guide](./get-started.mdx).
 
 </Admonition>
 
+<Admonition type="warning" title="Teleport client compatibility">
+
+When installing Teleport clients - `tsh`, `tctl`, and `tbot` - ensure to
+install the same major version as the Teleport cluster. For example, if the cluster is
+running Teleport 12, you should install a Teleport 12 client.
+
+See our [Upgrading](./management/operations/upgrading.mdx) guide for more
+information.
+
+</Admonition>
+
 ## Operating system support
 
 Teleport is officially supported on the platforms listed below. It is worth
@@ -127,7 +138,7 @@ chart.
   <Notice type="danger">
 
   The Teleport package in Homebrew is not maintained by Teleport and we can't
-  guarantee its reliability or security. 
+  guarantee its reliability or security.
 
   </Notice>
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -14,9 +14,12 @@ guide](./get-started.mdx).
 
 <Admonition type="warning" title="Teleport client compatibility">
 
-When installing Teleport clients - `tsh`, `tctl`, and `tbot` - ensure to
-install the same major version as the Teleport cluster. For example, if the cluster is
-running Teleport 12, you should install a Teleport 12 client.
+For best results, Teleport clients (`tsh`, `tctl`, `tbot`)
+should be the same major version as the cluster they are
+connecting to. Teleport servers are compatible with clients
+that are on the same major version or one major version older.
+Teleport servers do not support clients that are on a newer
+major version.
 
 See our [Upgrading](./management/operations/upgrading.mdx) guide for more
 information.


### PR DESCRIPTION
This PR adds a note to emphasize that clients must be at the same major version as Teleport servers