### PR TITLE
ai: Use a more robust JSON parser

### DIFF
--- a/lib/ai/chat.go
+++ b/lib/ai/chat.go
@@ -171,7 +171,6 @@ top:
 
 		// if we can parse it, return the parsed payload, otherwise return a non-streaming message
 		var c CompletionCommand
-		fmt.Printf("Command payload: %s", payload)
 		err = yaml.Unmarshal([]byte(payload), &c)
 		switch err {
 		case nil:

--- a/lib/ai/chat.go
+++ b/lib/ai/chat.go
@@ -19,10 +19,10 @@ package ai
 import (
 	"context"
 	"errors"
-	"fmt"
-	"gopkg.in/yaml.v3"
 	"io"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/gravitational/trace"
 	"github.com/sashabaranov/go-openai"

--- a/lib/ai/chat.go
+++ b/lib/ai/chat.go
@@ -18,8 +18,9 @@ package ai
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
+	"fmt"
+	"gopkg.in/yaml.v3"
 	"io"
 	"strings"
 
@@ -170,7 +171,8 @@ top:
 
 		// if we can parse it, return the parsed payload, otherwise return a non-streaming message
 		var c CompletionCommand
-		err = json.Unmarshal([]byte(payload), &c)
+		fmt.Printf("Command payload: %s", payload)
+		err = yaml.Unmarshal([]byte(payload), &c)
 		switch err {
 		case nil:
 			return &c, nil


### PR DESCRIPTION
This is an ugly hack to avoid breaking if the model returns a line ending with a comma.

For example, the following broken input was correctly understood:

```
 {
	"command": "ls /home",
	"nodes": [],
	"labels": [
		{
			"key": "role",
			"value": "production",
		}
	]
}
```

![image](https://user-images.githubusercontent.com/16366487/236013464-70e399fd-d0e6-4650-88c5-f39e83de1a3f.png)

