### PR TITLE
Update metrics docs

### DIFF
--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -18,10 +18,9 @@
 | `backend_requests`                              | counter     | cache               | Number of write requests to the backend.                                                           |
 | `backend_write_seconds`                         | histogram   | cache               | Latency for backend write operations.                                                              |
 | `cluster_name_not_found_total`                  | counter     | Teleport Auth       | Number of times a cluster was not found.                                                           |
-| `dynamo_requests_total`                         | counter     | DynamoDB            | Number of requests to the DynamoDB API.                                                            |
-| `dynamo_requests`                               | counter     | DynamoDB            | Number of failed requests to the DynamoDB API.                                                     |
+| `dynamo_requests_total`                         | counter     | DynamoDB            | Total number of requests to the DynamoDB API.                                                            |
+| `dynamo_requests`                               | counter     | DynamoDB            | Total number of requests to the DynamoDB API grouped by result.                                          |
 | `dynamo_requests_seconds`                       | histogram   | DynamoDB            | Latency of DynamoDB API requests.                                                                  |
-| `dynamo_requests_total`                         | counter     | DynamoDB            | Number of requests to the DynamoDB API                                                             |
 | `etcd_backend_batch_read_requests`              | counter     | etcd                | Number of read requests to the etcd database.                                                      |
 | `etcd_backend_batch_read_seconds`               | histogram   | etcd                | Latency for etcd read operations.                                                                  |
 | `etcd_backend_read_requests`                    | counter     | etcd                | Number of read requests to the etcd database.                                                      |
@@ -44,10 +43,9 @@
 | `grpc_server_handled_total`                     | counter     | Teleport Auth       | Total number of RPCs completed on the server, regardless of success or failure.                    |
 | `grpc_server_msg_received_total`                | counter     | Teleport Auth       | Total number of RPC stream messages received on the server.                                        |
 | `grpc_server_msg_sent_total`                    | counter     | Teleport Auth       | Total number of gRPC stream messages sent by the server.                                           |
-| `heartbeat_missed_total`                        | counter     | Teleport Auth       | Number of times the Auth Service did not receive a heartbeat from a Teleport Instance.                          |
 | `heartbeat_connections_received_total`          | counter     | Teleport Auth       | Number of times the Auth Service received a heartbeat connection.                                  |
 | `s3_requests_total`                             | counter     | Amazon S3           | Total number of requests to the S3 API.                                                            |
-| `s3_requests`                                   | counter     | Amazon S3           | Number of requests to the S3 API by result.                                                        |
+| `s3_requests`                                   | counter     | Amazon S3           | Total number of requests to the S3 API grouped by result.                                                        |
 | `s3_requests_seconds`                           | histogram   | Amazon S3           | Request latency for the S3 API.                                                                    |
 | `teleport_audit_emit_events`                    | counter     | Teleport Audit Log  | Number of audit events emitted.                                                                    |
 | `teleport_connected_resources`                  | gauge       | Teleport Auth       | Number and type of resources connected via keepalives.                                             |


### PR DESCRIPTION
- Removes a duplicate entry of `dynamo_requests_total`
- Update the description of `dynamo_requests` to better clarify its purpose
- Removes nonexistent `heartbeat_missed_total` metric