### PR TITLE
Fixed issue where arm64 builds don't have gitref value set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -452,7 +452,7 @@ release-darwin: release-darwin-unsigned
 # teleport, tctl, and tsh *WITHOUT* also creating an OSS build tarball.
 #
 .PHONY: release-unix-only
-release-unix-only: clean
+release-unix-only: clean version
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 
 #


### PR DESCRIPTION
This PR fixes an issue where arm64 builds built using the GHA arm64 pipelines don't have their "gitref" value set. As a result, both `teleport version` and the teleport metrics endpoint will now properly report the binary's build git reference.