### PR TITLE
Remove obsolete targets from Makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -448,14 +448,6 @@ release-darwin: release-darwin-unsigned
 	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 
 #
-# make release-unix-only - Produces an Enterprise binary release tarball containing
-# teleport, tctl, and tsh *WITHOUT* also creating an OSS build tarball.
-#
-.PHONY: release-unix-only
-release-unix-only: clean
-	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
-
-#
 # make release-windows-unsigned - Produces a binary release archive containing only tsh.
 #
 .PHONY: release-windows-unsigned

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -417,57 +417,6 @@ release-arm64: buildbox-arm
 	$(MAKE) release ARCH=arm64 BUILDBOX_NAME=$(BUILDBOX_ARM)
 
 # #############################################################################
-# GHA release build targets
-# #############################################################################
-
-#
-# The `release-oss` and `release-enterprise` make targets are for building OSS
-# and Enterprise releases from GitHub actions. These make targets execute in a
-# container based on a caller-supplied `BUILDBOX` image.
-#
-# Unlike the other release targets, these release targets do not attempt to
-# automatically construct the buildbox image at build time - the build box
-# image *must* be pre-built and the tag supplied via `BUILDBOX=...` on the
-# make command line
-#
-# Separating the construction of build environment from the actual build itself
-# allows us to use the appropriate GHA actions to pre-build the buildbox
-# image, so that the image construction works nicely with GHA.
-#
-
-define RELEASE_RECIPE
-		docker run \
-			--rm \
-			--platform linux/$(ARCH) \
-			--memory-swap -1 \
-			-h buildbox \
-			-e GOMODCACHE=$(GOMODCACHE) \
-			-e GOCACHE=$(GOCACHE) \
-			-v "/tmp:/tmp" \
-			-v "$(WORKSPACE):/go/teleport" \
-			-w /go/teleport \
-			$(BUILDBOX) \
-		make $(1) ARCH=$(ARCH) ADDFLAGS="$(ADDFLAGS)" OS=$(OS) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no
-endef
-
-# It's ok to ignore `go: command not found`. Makefile's $(shell go env)-line commands are producing it.
-.PHONY: release-oss-ensure-webassets
-release-oss-ensure-webassets:
-	$(call RELEASE_RECIPE,ensure-webassets)
-
-.PHONY: release-enterprise-ensure-webassets
-release-enterprise-ensure-webassets:
-	$(call RELEASE_RECIPE,ensure-webassets-e)
-
-.PHONY: release-oss
-release-oss:
-	$(call RELEASE_RECIPE,full build-archive)
-
-.PHONY: release-enterprise
-release-enterprise:
-	$(call RELEASE_RECIPE,release-unix-only)
-
-# #############################################################################
 
 #
 # Create a Teleport FIPS package using the build container.


### PR DESCRIPTION
These targets were originally set up to allow parallel arm64 builds using GHA. These targets were obsoleted when the ARM64 builds were expanded to be full-fledged teleport releases, but were not removed at that time.

Leaving these targets is messy and confusing, so this patch removes them.