### PR TITLE
Reuse auth connection for Okta client

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -3567,6 +3567,14 @@ func (c *Client) DeleteLoginRule(ctx context.Context, name string) error {
 	return trail.FromGRPC(err)
 }
 
+// OktaClient returns an Okta client.
+// Clients connecting older Teleport versions still get an okta client when
+// calling this method, but all RPCs will return "not implemented" errors (as per
+// the default gRPC behavior).
+func (c *Client) OktaClient() *okta.Client {
+	return okta.NewClient(oktapb.NewOktaServiceClient(c.conn))
+}
+
 // GetCertAuthority retrieves a CA by type and domain.
 func (c *Client) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
 	ca, err := c.TrustClient().GetCertAuthority(ctx, &trustpb.GetCertAuthorityRequest{

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -65,8 +65,6 @@ type Client struct {
 	*APIClient
 	// HTTPClient is used to make http requests to the server
 	*HTTPClient
-	// oktaClient is used to make Okta resoruce requests to the server.
-	oktaClient services.Okta
 }
 
 // Make sure Client implements all the necessary methods.
@@ -125,15 +123,9 @@ func NewClient(cfg client.Config, params ...roundtrip.ClientParam) (*Client, err
 		return nil, trace.Wrap(err)
 	}
 
-	oktaClient, err := client.NewOktaClient(cfg.Context, cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	return &Client{
 		APIClient:  apiClient,
 		HTTPClient: httpClient,
-		oktaClient: oktaClient,
 	}, nil
 }
 
@@ -472,7 +464,7 @@ func (c *Client) ListReleases(ctx context.Context) ([]*types.Release, error) {
 }
 
 func (c *Client) OktaClient() services.Okta {
-	return c.oktaClient
+	return c.APIClient.OktaClient()
 }
 
 // WebService implements features used by Web UI clients


### PR DESCRIPTION
The Okta client was creating a separate connection to Auth in `auth.NewClient` instead of reusing the gRPC connection of the api client. Since this method is used by every Teleport instance when establishing their initial connection to Auth it poses two problems:
 1) Auth now has one additional connection per instance
 2) Proxies require an additional trasnport channel per tunnel

Fixes #25235