### PR TITLE
[v12] Ensure useDocumentGateway creates the gateway only on mount

### DIFF
--- a/web/packages/teleterm/src/services/tshd/testHelpers.ts
+++ b/web/packages/teleterm/src/services/tshd/testHelpers.ts
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as tsh from './types';
+
+export const makeServer = (props: Partial<tsh.Server> = {}): tsh.Server => ({
+  uri: '/clusters/teleport-local/servers/178ef081-259b-4aa5-a018-449b5ea7e694',
+  tunnel: false,
+  name: '178ef081-259b-4aa5-a018-449b5ea7e694',
+  hostname: 'foo',
+  addr: '127.0.0.1:3022',
+  labelsList: [],
+  ...props,
+});
+
+export const databaseUri = '/clusters/teleport-local/dbs/foo';
+
+export const makeDatabase = (
+  props: Partial<tsh.Database> = {}
+): tsh.Database => ({
+  uri: databaseUri,
+  name: 'foo',
+  protocol: 'postgres',
+  type: 'self-hosted',
+  desc: '',
+  hostname: '',
+  addr: '',
+  labelsList: [],
+  ...props,
+});
+
+export const makeKube = (props: Partial<tsh.Kube> = {}): tsh.Kube => ({
+  name: 'foo',
+  labelsList: [],
+  uri: '/clusters/bar/kubes/foo',
+  ...props,
+});
+
+export const makeLabelsList = (labels: Record<string, string>): tsh.Label[] =>
+  Object.entries(labels).map(([name, value]) => ({ name, value }));
+
+export const makeRootCluster = (
+  props: Partial<tsh.Cluster> = {}
+): tsh.Cluster => ({
+  uri: '/clusters/teleport-local',
+  name: 'teleport-local',
+  connected: true,
+  leaf: false,
+  proxyHost: 'teleport-local:3080',
+  authClusterId: '73c4746b-d956-4f16-9848-4e3469f70762',
+  loggedInUser: {
+    activeRequestsList: [],
+    assumedRequests: {},
+    name: 'admin',
+    acl: {},
+    sshLoginsList: [],
+    rolesList: [],
+    requestableRolesList: [],
+    suggestedReviewersList: [],
+  },
+  ...props,
+});
+
+export const makeGateway = (props: Partial<tsh.Gateway> = {}): tsh.Gateway => ({
+  uri: '/gateways/foo',
+  targetName: 'sales-production',
+  targetUri: databaseUri,
+  targetUser: 'alice',
+  localAddress: 'localhost',
+  localPort: '1337',
+  protocol: 'postgres',
+  cliCommand: 'connect-me-to-db-please',
+  targetSubresourceName: 'bar',
+  ...props,
+});

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -26,6 +26,7 @@ import apiDb from 'gen-proto-js/teleport/lib/teleterm/v1/database_pb';
 import apiGateway from 'gen-proto-js/teleport/lib/teleterm/v1/gateway_pb';
 import apiServer from 'gen-proto-js/teleport/lib/teleterm/v1/server_pb';
 import apiKube from 'gen-proto-js/teleport/lib/teleterm/v1/kube_pb';
+import apiLabel from 'gen-proto-js/teleport/lib/teleterm/v1/label_pb';
 import apiService, {
   FileTransferDirection,
 } from 'gen-proto-js/teleport/lib/teleterm/v1/service_pb';
@@ -287,6 +288,8 @@ export type AssumedRequest = {
 };
 
 export { FileTransferDirection };
+
+export type Label = apiLabel.Label.AsObject;
 
 // Replaces object property with a new type
 type Modify<T, R> = Omit<T, keyof R> & R;

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.story.tsx
@@ -20,11 +20,12 @@ import {
   makeEmptyAttempt,
   makeProcessingAttempt,
   makeErrorAttempt,
+  makeSuccessAttempt,
 } from 'shared/hooks/useAsync';
 
 import { Gateway } from 'teleterm/services/tshd/types';
 
-import { DocumentGateway } from './DocumentGateway';
+import { DocumentGateway, DocumentGatewayProps } from './DocumentGateway';
 
 export default {
   title: 'Teleterm/DocumentGateway',
@@ -42,22 +43,23 @@ const gateway: Gateway = {
   targetSubresourceName: 'bar',
 };
 
+const onlineDocumentGatewayProps: DocumentGatewayProps = {
+  gateway: gateway,
+  defaultPort: gateway.localPort,
+  disconnect: async () => [undefined, null],
+  connected: true,
+  reconnect: async () => [undefined, null],
+  connectAttempt: makeSuccessAttempt(undefined),
+  disconnectAttempt: makeEmptyAttempt(),
+  runCliCommand: () => {},
+  changeDbName: async () => [undefined, null],
+  changeDbNameAttempt: makeEmptyAttempt(),
+  changePort: async () => [undefined, null],
+  changePortAttempt: makeEmptyAttempt(),
+};
+
 export function Online() {
-  return (
-    <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
-    />
-  );
+  return <DocumentGateway {...onlineDocumentGatewayProps} />;
 }
 
 export function OnlineWithLongValues() {
@@ -78,17 +80,9 @@ export function OnlineWithLongValues() {
 
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={gateway}
       defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }
@@ -96,19 +90,10 @@ export function OnlineWithLongValues() {
 export function OnlineWithFailedDbNameAttempt() {
   return (
     <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
+      {...onlineDocumentGatewayProps}
       changeDbNameAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting database name.'
       )}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }
@@ -116,16 +101,7 @@ export function OnlineWithFailedDbNameAttempt() {
 export function OnlineWithFailedPortAttempt() {
   return (
     <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
+      {...onlineDocumentGatewayProps}
       changePortAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting port.'
       )}
@@ -136,18 +112,10 @@ export function OnlineWithFailedPortAttempt() {
 export function OnlineWithFailedDbNameAndPortAttempts() {
   return (
     <DocumentGateway
-      gateway={gateway}
-      defaultPort={gateway.localPort}
-      disconnect={() => Promise.resolve([undefined, null])}
-      connected={true}
-      reconnect={() => {}}
-      connectAttempt={{ status: 'success', data: undefined, statusText: null }}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
+      {...onlineDocumentGatewayProps}
       changeDbNameAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting database name.'
       )}
-      changePort={() => Promise.resolve([undefined, null])}
       changePortAttempt={makeErrorAttempt<void>(
         'Something went wrong with setting port.'
       )}
@@ -158,39 +126,25 @@ export function OnlineWithFailedDbNameAndPortAttempts() {
 export function Offline() {
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={undefined}
       defaultPort="1337"
-      disconnect={() => Promise.resolve([undefined, null])}
       connected={false}
-      reconnect={() => {}}
       connectAttempt={makeEmptyAttempt()}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }
 
 export function OfflineWithFailedConnectAttempt() {
-  const connectAttempt = makeErrorAttempt<void>(
-    'listen tcp 127.0.0.1:62414: bind: address already in use'
-  );
-
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={undefined}
       defaultPort="62414"
-      disconnect={() => Promise.resolve([undefined, null])}
       connected={false}
-      reconnect={() => {}}
-      connectAttempt={connectAttempt}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
+      connectAttempt={makeErrorAttempt<void>(
+        'listen tcp 127.0.0.1:62414: bind: address already in use'
+      )}
     />
   );
 }
@@ -198,17 +152,11 @@ export function OfflineWithFailedConnectAttempt() {
 export function Processing() {
   return (
     <DocumentGateway
+      {...onlineDocumentGatewayProps}
       gateway={undefined}
       defaultPort="1337"
-      disconnect={() => Promise.resolve([undefined, null])}
       connected={false}
-      reconnect={() => {}}
       connectAttempt={makeProcessingAttempt()}
-      runCliCommand={() => {}}
-      changeDbName={() => Promise.resolve([undefined, null])}
-      changeDbNameAttempt={makeEmptyAttempt()}
-      changePort={() => Promise.resolve([undefined, null])}
-      changePortAttempt={makeEmptyAttempt()}
     />
   );
 }

--- a/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/DocumentGateway.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import Document from 'teleterm/ui/Document';
 import * as types from 'teleterm/ui/services/workspacesService';
 
-import useDocumentGateway from './useDocumentGateway';
+import { useDocumentGateway } from './useDocumentGateway';
 import { OfflineDocumentGateway } from './OfflineDocumentGateway';
 import { OnlineDocumentGateway } from './OnlineDocumentGateway';
 

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import {
+  makeRootCluster,
+  makeGateway,
+} from 'teleterm/services/tshd/testHelpers';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import { DocumentGateway } from 'teleterm/ui/services/workspacesService';
+
+import { WorkspaceContextProvider } from '../Documents';
+import { MockAppContextProvider } from '../fixtures/MockAppContextProvider';
+
+import { useDocumentGateway } from './useDocumentGateway';
+
+jest.mock('teleterm/staticConfig', () => ({
+  staticConfig: {
+    prehogAddress: undefined,
+  },
+}));
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+it('creates a gateway on mount if it does not exist already', async () => {
+  const { appContext, gateway, doc, $wrapper } = testSetup();
+
+  jest
+    .spyOn(appContext.clustersService, 'createGateway')
+    .mockImplementation(async () => {
+      appContext.clustersService.setState(draftState => {
+        draftState.gateways.set(gateway.uri, gateway);
+      });
+      return gateway;
+    });
+
+  const { result, waitFor } = renderHook(() => useDocumentGateway(doc), {
+    wrapper: $wrapper,
+  });
+
+  await waitFor(() => result.current.connectAttempt.status === 'success');
+
+  expect(appContext.clustersService.createGateway).toHaveBeenCalledWith({
+    targetUri: doc.targetUri,
+    subresource_name: doc.targetSubresourceName,
+    user: doc.targetUser,
+    port: doc.port,
+  });
+  expect(appContext.clustersService.createGateway).toHaveBeenCalledTimes(1);
+});
+
+it('does not create a gateway on mount if the gateway already exists', async () => {
+  const { appContext, gateway, doc, $wrapper } = testSetup();
+  appContext.clustersService.setState(draftState => {
+    draftState.gateways.set(gateway.uri, gateway);
+  });
+  jest.spyOn(appContext.clustersService, 'createGateway');
+
+  renderHook(() => useDocumentGateway(doc), {
+    wrapper: $wrapper,
+  });
+
+  expect(appContext.clustersService.createGateway).not.toHaveBeenCalled();
+});
+
+// Regression test.
+it('does not attempt to create a gateway immediately after closing it if the gateway was already running', async () => {
+  const { appContext, gateway, doc, $wrapper } = testSetup();
+  appContext.clustersService.setState(draftState => {
+    draftState.gateways.set(gateway.uri, gateway);
+  });
+
+  jest
+    .spyOn(appContext.clustersService, 'removeGateway')
+    .mockImplementation(async gatewayUri => {
+      appContext.clustersService.setState(draftState => {
+        draftState.gateways.delete(gatewayUri);
+      });
+    });
+  jest
+    .spyOn(appContext.clustersService, 'createGateway')
+    .mockResolvedValue(gateway);
+
+  const { result, waitFor } = renderHook(() => useDocumentGateway(doc), {
+    wrapper: $wrapper,
+  });
+
+  act(() => {
+    result.current.disconnect();
+  });
+
+  await waitFor(() => result.current.disconnectAttempt.status === 'success');
+
+  expect(appContext.clustersService.createGateway).not.toHaveBeenCalled();
+});
+
+const testSetup = () => {
+  const appContext = new MockAppContext();
+  const cluster = makeRootCluster({ connected: true });
+  const gateway = makeGateway();
+  const doc: DocumentGateway = {
+    uri: '/docs/1',
+    kind: 'doc.gateway',
+    targetName: gateway.targetName,
+    targetUri: gateway.targetUri,
+    targetUser: gateway.targetUser,
+    targetSubresourceName: gateway.targetSubresourceName,
+    gatewayUri: gateway.uri,
+    origin: 'resource_table',
+    title: '',
+  };
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(cluster.uri, cluster);
+  });
+  appContext.workspacesService.setState(draftState => {
+    draftState.rootClusterUri = cluster.uri;
+    draftState.workspaces[cluster.uri] = {
+      documents: [doc],
+      location: doc.uri,
+      localClusterUri: cluster.uri,
+      accessRequests: undefined,
+    };
+  });
+  const workspaceContext = {
+    rootClusterUri: cluster.uri,
+    localClusterUri: cluster.uri,
+    documentsService: appContext.workspacesService.getWorkspaceDocumentService(
+      cluster.uri
+    ),
+    accessRequestsService: undefined,
+  };
+  const $wrapper = ({ children }) => (
+    <MockAppContextProvider appContext={appContext}>
+      <WorkspaceContextProvider value={workspaceContext}>
+        {children}
+      </WorkspaceContextProvider>
+    </MockAppContextProvider>
+  );
+
+  return { gateway, doc, appContext, workspaceContext, $wrapper };
+};

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.ts
@@ -24,7 +24,7 @@ import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { routing } from 'teleterm/ui/uri';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 
-export default function useGateway(doc: types.DocumentGateway) {
+export function useDocumentGateway(doc: types.DocumentGateway) {
   const ctx = useAppContext();
   const { documentsService: workspaceDocumentsService } = useWorkspaceContext();
   // The port to show as default in the input field in case creating a gateway fails.
@@ -37,9 +37,6 @@ export default function useGateway(doc: types.DocumentGateway) {
   const defaultPort = doc.port || '';
   const gateway = ctx.clustersService.findGateway(doc.gatewayUri);
   const connected = !!gateway;
-  const rootCluster = ctx.clustersService.findRootClusterByResource(
-    doc.targetUri
-  );
   const cluster = ctx.clustersService.findClusterByResource(doc.targetUri);
 
   const [connectAttempt, createGateway] = useAsync(async (port: string) => {
@@ -67,6 +64,7 @@ export default function useGateway(doc: types.DocumentGateway) {
 
   const [disconnectAttempt, disconnect] = useAsync(async () => {
     await ctx.clustersService.removeGateway(doc.gatewayUri);
+    workspaceDocumentsService.close(doc.uri);
   });
 
   const [changeDbNameAttempt, changeDbName] = useAsync(async (name: string) => {
@@ -93,18 +91,6 @@ export default function useGateway(doc: types.DocumentGateway) {
     });
   });
 
-  const reconnect = (port: string) => {
-    if (rootCluster.connected) {
-      createGateway(port);
-      return;
-    }
-
-    ctx.commandLauncher.executeCommand('cluster-connect', {
-      clusterUri: rootCluster.uri,
-      onSuccess: () => createGateway(doc.port),
-    });
-  };
-
   const runCliCommand = () => {
     const { rootClusterId, leafClusterId } = routing.parseClusterUri(
       cluster.uri
@@ -116,22 +102,17 @@ export default function useGateway(doc: types.DocumentGateway) {
     });
   };
 
-  useEffect(() => {
-    if (disconnectAttempt.status === 'success') {
-      workspaceDocumentsService.close(doc.uri);
-    }
-  }, [disconnectAttempt.status]);
-
-  const shouldCreateGateway =
-    rootCluster.connected && !connected && connectAttempt.status === '';
-
   useEffect(
-    function createGatewayOnDocumentOpen() {
-      if (shouldCreateGateway) {
+    function createGatewayOnMount() {
+      // Since the user can close DocumentGateway without shutting down the gateway, it's possible
+      // to open DocumentGateway while the gateway is already running. In that scenario, we must
+      // not attempt to create a gateway.
+      if (!gateway && connectAttempt.status === '') {
         createGateway(doc.port);
       }
     },
-    [shouldCreateGateway]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
   );
 
   return {
@@ -139,8 +120,10 @@ export default function useGateway(doc: types.DocumentGateway) {
     defaultPort,
     disconnect,
     connected,
-    reconnect,
+    reconnect: createGateway,
     connectAttempt,
+    // TODO(ravicious): Show disconnectAttempt errors in UI.
+    disconnectAttempt,
     runCliCommand,
     changeDbName,
     changeDbNameAttempt,

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -52,7 +52,7 @@ beforeAll(() => {
   Logger.init(new NullService());
 });
 
-afterEach(() => {
+beforeEach(() => {
   jest.restoreAllMocks();
 });
 


### PR DESCRIPTION
Backport #25322.

The original PR didn't backport cleanly because v12 was lacking `tshd/testHelpers.ts` which was added with the search bar. I included the file in this PR with some small required changes to `tshd/types.ts`.