### PR TITLE
Don't report usage for KubeServiceV2 keepalives

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3749,6 +3749,16 @@ func (a *Server) KeepAliveServer(ctx context.Context, h types.KeepAlive) error {
 	if kind == 0 {
 		return nil
 	}
+
+	// KubeServiceV2 (used by v11 kube agents) keepalives as
+	// KeepAlive_KUBERNETES but with no HostID; we shouldn't count those, as the
+	// name is going to be the host ID of the agent rather than the kube cluster
+	// name.
+	// DELETE IN: 13.0
+	if h.Type == types.KeepAlive_KUBERNETES && h.HostID == "" {
+		return nil
+	}
+
 	a.AnonymizeAndSubmit(&usagereporter.ResourceHeartbeatEvent{
 		Name:   h.Name,
 		Kind:   kind,


### PR DESCRIPTION
In v11, the Teleport kube agent creates heartbeats for each served kube cluster individually (of `KubernetesServer` type) and for the agent as a whole (of `KubeServiceV2` type). Both use the same keepalive type, and the differentiator for which resource in the backend gets an updated TTL is from the presence or absence of the `HostID` field in the `KeepAlive`.

Since we don't want to keep track of kube agents in our usage reporting, but only of the cluster themselves, this PR filters the keepalives out in `(*auth.Server) KeepAliveServer`; the actual heartbeats are already filtered by virtue of using two different methods (`UpsertKubernetesServer` and `UpsertKubeServiceV2`).