### PR TITLE
[v11] Fix Web UI error message when host is offline

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -526,6 +526,7 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 					NodeName:       t.sessionData.ServerID,
 					Usage:          authproto.UserCertsRequest_SSH,
 					Format:         tc.CertificateFormat,
+					SSHLogin:       t.sessionData.Login,
 				},
 			},
 		}); err != nil {


### PR DESCRIPTION
This change was missed in https://github.com/gravitational/teleport/pull/24829 when backporting to v11.

Closes #25648