### PR TITLE
[v12] Fix Web UI error message when host is offline

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -532,6 +532,7 @@ func (t *TerminalHandler) issueSessionMFACerts(ctx context.Context, tc *client.T
 					NodeName:       t.sessionData.ServerID,
 					Usage:          authproto.UserCertsRequest_SSH,
 					Format:         tc.CertificateFormat,
+					SSHLogin:       t.sessionData.Login,
 				},
 			},
 		}); err != nil {


### PR DESCRIPTION
This change was missed in https://github.com/gravitational/teleport/pull/25430 when backporting to v12.

Closes #25648