### PR TITLE
dronegen: Call release-mac for universal builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4205,7 +4205,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 2h30m0s -workflow release-mac-amd64.yaml -workflow-ref=${DRONE_TAG}
+    -tag-workflow -timeout 2h30m0s -workflow release-mac.yaml -workflow-ref=${DRONE_TAG}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
     "build-packages=true" -input "release-artifacts=true" '
   environment:
@@ -17106,6 +17106,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 4ac203ede1252a20f61b5859471d03f65a4ab335d960a5c854bfa4b5d1ac223d
+hmac: bcbaa90c991ef9730c11e1555ad687a896a3bde59cf8df4c296d019c0f4f51f5
 
 ...

--- a/dronegen/mac_gha.go
+++ b/dronegen/mac_gha.go
@@ -23,6 +23,8 @@ import "time"
 // * a package with the tsh binary.
 // * a disk image (dmg) of Teleport Connect containing the signed tsh package.
 // These build assets are signed and notarized.
+// The tarballs are build for amd64, arm64 and universal. The packages and
+// disk image are build for universal only.
 func darwinTagPipelineGHA() pipeline {
 	bt := ghaBuildType{
 		buildType:    buildType{os: "darwin", arch: "amd64"},
@@ -30,7 +32,7 @@ func darwinTagPipelineGHA() pipeline {
 		pipelineName: "build-darwin-amd64",
 		workflows: []ghaWorkflow{
 			{
-				name:              "release-mac-amd64.yaml",
+				name:              "release-mac.yaml",
 				srcRefVar:         "DRONE_TAG",
 				ref:               "${DRONE_TAG}",
 				timeout:           150 * time.Minute,


### PR DESCRIPTION
Call the release-mac workflow instead of release-mac-amd64 to build
universal binaries for the release of MacOS artifacts.

Issue: https://github.com/gravitational/teleport/issues/4226
Issue: https://github.com/gravitational/teleport.e/issues/872