### PR TITLE
build: Fix ELECTRON_BUILDER_ARCH to not throw error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -258,13 +258,10 @@ endif
 
 CGOFLAG_TSH ?= $(CGOFLAG)
 
-# Map ARCH into the architecture flag for electron-builder. Ensure
-# ELECTRON_BUILDER_ARCH is not exported so we do not generate
-# an error on unsupported architectures when not running this target.
+# Map ARCH into the architecture flag for electron-builder if they
+# are different to the Go $(ARCH) we use as an input.
 ELECTRON_BUILDER_ARCH_amd64 = x64
-ELECTRON_BUILDER_ARCH_arm64 = arm64
-ELECTRON_BUILDER_ARCH_universal = universal
-ELECTRON_BUILDER_ARCH = $(or $(ELECTRON_BUILDER_ARCH_$(ARCH)),$(error Unsupported architecture: $(ARCH)))
+ELECTRON_BUILDER_ARCH = $(or $(ELECTRON_BUILDER_ARCH_$(ARCH)),$(ARCH))
 
 #
 # 'make all' builds all 4 executables and places them in the current directory.


### PR DESCRIPTION
Do not cause a `make` `$(error ...)` if the arch is not a known electron
builder architecture. A previous commit should have added

    unexport ELECTRON_BUILDER_ARCH

but it was forgotten. Instead of adding that, just add mappings where
needed and let `$(ARCH)` map directly to an electron builder arch flag
when there is no mapping. If this is invalid for an architecture we
want to build for, let EB complain then.

Issue: https://github.com/gravitational/teleport.e/issues/872
Issue: https://github.com/gravitational/teleport/issues/4226