### PR TITLE
Add UserGroups to RequestableResourceKinds.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -643,6 +643,7 @@ var RequestableResourceKinds = []string{
 	KindApp,
 	KindWindowsDesktop,
 	KindKubePod,
+	KindUserGroup,
 }
 
 // KubernetesResourcesKinds lists the supported Kubernetes resource kinds.


### PR DESCRIPTION
UserGroups have been added to RequestableResourceKinds so that users can correctly assume roles that have been granted access to user groups.