### PR TITLE
[v13] dronegen: Call release-mac for universal builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -541,7 +541,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 2h30m0s -workflow release-mac-amd64.yaml -workflow-ref=${DRONE_BRANCH}
+    -tag-workflow -timeout 2h30m0s -workflow release-mac.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
     -input "build-packages=false" -input "release-artifacts=false" '
   environment:
@@ -4278,7 +4278,7 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
-    -tag-workflow -timeout 2h30m0s -workflow release-mac-amd64.yaml -workflow-ref=${DRONE_TAG}
+    -tag-workflow -timeout 2h30m0s -workflow release-mac.yaml -workflow-ref=${DRONE_TAG}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
     "build-packages=true" -input "release-artifacts=true" '
   environment:
@@ -17179,6 +17179,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 137bb34b614d6b33001c00d069a4afbeaf751344c50a9bb9558007412cbd3ab2
+hmac: a9344cfad6d8a4736f256325c52fb7238c729ec00c1ca15171645f23f357a7d8
 
 ...

--- a/dronegen/mac_gha.go
+++ b/dronegen/mac_gha.go
@@ -23,6 +23,8 @@ import "time"
 // * a package with the tsh binary.
 // * a disk image (dmg) of Teleport Connect containing the signed tsh package.
 // These build assets are signed and notarized.
+// The tarballs are build for amd64, arm64 and universal. The packages and
+// disk image are build for universal only.
 func darwinTagPipelineGHA() pipeline {
 	bt := ghaBuildType{
 		buildType:    buildType{os: "darwin", arch: "amd64"},
@@ -30,7 +32,7 @@ func darwinTagPipelineGHA() pipeline {
 		pipelineName: "build-darwin-amd64",
 		workflows: []ghaWorkflow{
 			{
-				name:              "release-mac-amd64.yaml",
+				name:              "release-mac.yaml",
 				srcRefVar:         "DRONE_TAG",
 				ref:               "${DRONE_TAG}",
 				timeout:           150 * time.Minute,
@@ -58,7 +60,7 @@ func darwinPushPipelineGHA() pipeline {
 		pipelineName: "push-build-darwin-amd64",
 		workflows: []ghaWorkflow{
 			{
-				name:              "release-mac-amd64.yaml",
+				name:              "release-mac.yaml",
 				srcRefVar:         "DRONE_COMMIT",
 				ref:               "${DRONE_BRANCH}",
 				timeout:           150 * time.Minute,


### PR DESCRIPTION
Call the release-mac workflow instead of release-mac-amd64 to build
universal binaries for the release of MacOS artifacts.

Backport: https://github.com/gravitational/teleport/pull/25675