### PR TITLE
Use solid color for table row border to fix Safari rendering issue

### DIFF
--- a/web/packages/design/src/DataTable/StyledTable.tsx
+++ b/web/packages/design/src/DataTable/StyledTable.tsx
@@ -98,7 +98,7 @@ export const StyledTable = styled.table(
 //
 // `getSolidRowBorderColor` is a workaround. Instead of setting a color with an alpha channel to the border and letting
 // the browser mix it with the background color, we calculate the final (non-alpha) color in the JS code.
-// The final color is created by lightening or darkening the table background color by the value of theme.colors.spotBackground[0].
+// The final color is created by lightening or darkening the table background color by the value of the alpha channel of theme.colors.spotBackground[0].
 function getSolidRowBorderColor(theme) {
   const alpha = decomposeColor(theme.colors.spotBackground[0]).values[3] || 0;
   return emphasize(theme.colors.levels.surface, alpha);

--- a/web/packages/design/src/DataTable/StyledTable.tsx
+++ b/web/packages/design/src/DataTable/StyledTable.tsx
@@ -18,12 +18,20 @@ import styled from 'styled-components';
 
 import { space, borderRadius } from 'design/system';
 
+import {
+  darken,
+  decomposeColor,
+  lighten,
+} from 'design/theme/utils/colorManipulator';
+
 import Icon from '../Icon';
 
 export const StyledTable = styled.table(
   props => `
   background: ${props.theme.colors.levels.surface};
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 
@@ -76,8 +84,8 @@ export const StyledTable = styled.table(
   // When border-collapse: collapse is set on a table element, Safari incorrectly renders the row border with alpha channel.
   // It looks like the collapsed border was rendered twice, that is, opacity 0.07 looks like opacity 0.14.
   // A workaround is to not use collapse and apply border to td elements.
-  & > tbody > tr:not(:last-of-type) > td {
-    border-bottom: 1px solid ${props.theme.colors.spotBackground[0]};
+  tbody tr {
+    border-bottom: 1px solid ${getSolidRowBorderColor(props.theme)};
   }
 
   tbody tr:hover {
@@ -88,6 +96,23 @@ export const StyledTable = styled.table(
   space,
   borderRadius
 );
+
+// When `border-collapse: collapse` is set on a table element, Safari incorrectly renders row border with alpha channel.
+// It looks like the collapsed border was rendered twice, that is, opacity 0.07 looks like opacity 0.14 (this is more visible
+// on dark theme).
+// Sometimes, there is also an artifact visible after hovering the rows - some of them have correct border color, some not.
+//
+// `getSolidRowBorderColor` is a workaround. The colors below were created by lightening or darkening the table background by
+// the value of theme.colors.spotBackground[0]
+function getSolidRowBorderColor(theme) {
+  const alpha = decomposeColor(theme.colors.spotBackground[0]).values[3];
+  if (theme.name === 'dark') {
+    return lighten(theme.colors.levels.surface, alpha);
+  }
+  if (theme.name === 'light') {
+    return darken(theme.colors.levels.surface, alpha);
+  }
+}
 
 export const StyledPanel = styled.nav<{ showTopBorder: boolean }>`
   padding: 16px 24px;

--- a/web/packages/design/src/DataTable/StyledTable.tsx
+++ b/web/packages/design/src/DataTable/StyledTable.tsx
@@ -96,8 +96,9 @@ export const StyledTable = styled.table(
 // Sometimes, there is also an artifact visible after hovering the rows - some of them have correct border color, some not.
 // WebKit issue https://bugs.webkit.org/show_bug.cgi?id=35456.
 //
-// `getSolidRowBorderColor` is a workaround. The color is created by lightening or darkening the table background by
-// the value of theme.colors.spotBackground[0].
+// `getSolidRowBorderColor` is a workaround. Instead of setting a color with an alpha channel to the border and letting
+// the browser mix it with the background color, we calculate the final (non-alpha) color in the JS code.
+// The final color is created by lightening or darkening the table background color by the value of theme.colors.spotBackground[0].
 function getSolidRowBorderColor(theme) {
   const alpha = decomposeColor(theme.colors.spotBackground[0]).values[3];
   return emphasize(theme.colors.levels.surface, alpha);

--- a/web/packages/design/src/DataTable/StyledTable.tsx
+++ b/web/packages/design/src/DataTable/StyledTable.tsx
@@ -18,11 +18,7 @@ import styled from 'styled-components';
 
 import { space, borderRadius } from 'design/system';
 
-import {
-  darken,
-  decomposeColor,
-  lighten,
-} from 'design/theme/utils/colorManipulator';
+import { decomposeColor, emphasize } from 'design/theme/utils/colorManipulator';
 
 import Icon from '../Icon';
 
@@ -81,9 +77,6 @@ export const StyledTable = styled.table(
     line-height: 16px;
   }
 
-  // When border-collapse: collapse is set on a table element, Safari incorrectly renders the row border with alpha channel.
-  // It looks like the collapsed border was rendered twice, that is, opacity 0.07 looks like opacity 0.14.
-  // A workaround is to not use collapse and apply border to td elements.
   tbody tr {
     border-bottom: 1px solid ${getSolidRowBorderColor(props.theme)};
   }
@@ -99,19 +92,15 @@ export const StyledTable = styled.table(
 
 // When `border-collapse: collapse` is set on a table element, Safari incorrectly renders row border with alpha channel.
 // It looks like the collapsed border was rendered twice, that is, opacity 0.07 looks like opacity 0.14 (this is more visible
-// on dark theme).
+// on the dark theme).
 // Sometimes, there is also an artifact visible after hovering the rows - some of them have correct border color, some not.
+// WebKit issue https://bugs.webkit.org/show_bug.cgi?id=35456.
 //
-// `getSolidRowBorderColor` is a workaround. The colors below were created by lightening or darkening the table background by
-// the value of theme.colors.spotBackground[0]
+// `getSolidRowBorderColor` is a workaround. The color is created by lightening or darkening the table background by
+// the value of theme.colors.spotBackground[0].
 function getSolidRowBorderColor(theme) {
   const alpha = decomposeColor(theme.colors.spotBackground[0]).values[3];
-  if (theme.name === 'dark') {
-    return lighten(theme.colors.levels.surface, alpha);
-  }
-  if (theme.name === 'light') {
-    return darken(theme.colors.levels.surface, alpha);
-  }
+  return emphasize(theme.colors.levels.surface, alpha);
 }
 
 export const StyledPanel = styled.nav<{ showTopBorder: boolean }>`

--- a/web/packages/design/src/DataTable/StyledTable.tsx
+++ b/web/packages/design/src/DataTable/StyledTable.tsx
@@ -100,7 +100,7 @@ export const StyledTable = styled.table(
 // the browser mix it with the background color, we calculate the final (non-alpha) color in the JS code.
 // The final color is created by lightening or darkening the table background color by the value of theme.colors.spotBackground[0].
 function getSolidRowBorderColor(theme) {
-  const alpha = decomposeColor(theme.colors.spotBackground[0]).values[3];
+  const alpha = decomposeColor(theme.colors.spotBackground[0]).values[3] || 0;
   return emphasize(theme.colors.levels.surface, alpha);
 }
 

--- a/web/packages/teleport/src/Account/ManageDevices/__snapshots__/ManageDevices.story.test.tsx.snap
+++ b/web/packages/teleport/src/Account/ManageDevices/__snapshots__/ManageDevices.story.test.tsx.snap
@@ -140,7 +140,9 @@ exports[`render device dashboard 1`] = `
 
 .c11 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -204,8 +206,8 @@ exports[`render device dashboard 1`] = `
   line-height: 16px;
 }
 
-.c11 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c11 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c11 tbody tr:hover {
@@ -682,7 +684,9 @@ exports[`render failed state for creating restricted privilege token 1`] = `
 
 .c12 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -746,8 +750,8 @@ exports[`render failed state for creating restricted privilege token 1`] = `
   line-height: 16px;
 }
 
-.c12 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c12 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c12 tbody tr:hover {

--- a/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -605,7 +605,9 @@ exports[`failed state 1`] = `
 
 .c24 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -667,8 +669,8 @@ exports[`failed state 1`] = `
   line-height: 16px;
 }
 
-.c24 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c24 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c24 tbody tr:hover {
@@ -1718,7 +1720,9 @@ exports[`loaded state 1`] = `
 
 .c24 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -1780,8 +1784,8 @@ exports[`loaded state 1`] = `
   line-height: 16px;
 }
 
-.c24 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c24 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c24 tbody tr:hover {

--- a/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
+++ b/web/packages/teleport/src/Audit/__snapshots__/Audit.story.test.tsx.snap
@@ -185,7 +185,9 @@ exports[`list of all events 1`] = `
 
 .c17 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -251,8 +253,8 @@ exports[`list of all events 1`] = `
   line-height: 16px;
 }
 
-.c17 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c17 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c17 tbody tr:hover {
@@ -7699,7 +7701,9 @@ exports[`loaded audit log screen 1`] = `
 
 .c21 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -7765,8 +7769,8 @@ exports[`loaded audit log screen 1`] = `
   line-height: 16px;
 }
 
-.c21 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c21 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c21 tbody tr:hover {

--- a/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
+++ b/web/packages/teleport/src/Clusters/__snapshots__/Clusters.story.test.tsx.snap
@@ -238,7 +238,9 @@ exports[`render clusters 1`] = `
 
 .c19 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -304,8 +306,8 @@ exports[`render clusters 1`] = `
   line-height: 16px;
 }
 
-.c19 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c19 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c19 tbody tr:hover {

--- a/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -253,7 +253,9 @@ exports[`render DocumentNodes 1`] = `
 
 .c30 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -315,8 +317,8 @@ exports[`render DocumentNodes 1`] = `
   line-height: 16px;
 }
 
-.c30 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c30 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c30 tbody tr:hover {

--- a/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -534,7 +534,9 @@ exports[`failed 1`] = `
 
 .c24 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -596,8 +598,8 @@ exports[`failed 1`] = `
   line-height: 16px;
 }
 
-.c24 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c24 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c24 tbody tr:hover {
@@ -1385,7 +1387,9 @@ exports[`open source loaded 1`] = `
 
 .c24 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -1447,8 +1451,8 @@ exports[`open source loaded 1`] = `
   line-height: 16px;
 }
 
-.c24 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c24 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c24 tbody tr:hover {

--- a/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -494,7 +494,9 @@ exports[`failed 1`] = `
 
 .c24 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -556,8 +558,8 @@ exports[`failed 1`] = `
   line-height: 16px;
 }
 
-.c24 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c24 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c24 tbody tr:hover {
@@ -1304,7 +1306,9 @@ exports[`loaded 1`] = `
 
 .c24 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -1366,8 +1370,8 @@ exports[`loaded 1`] = `
   line-height: 16px;
 }
 
-.c24 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c24 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c24 tbody tr:hover {

--- a/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -545,7 +545,9 @@ exports[`failed 1`] = `
 
 .c24 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -607,8 +609,8 @@ exports[`failed 1`] = `
   line-height: 16px;
 }
 
-.c24 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c24 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c24 tbody tr:hover {
@@ -1640,7 +1642,9 @@ exports[`loaded 1`] = `
 
 .c27 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
 }
@@ -1702,8 +1706,8 @@ exports[`loaded 1`] = `
   line-height: 16px;
 }
 
-.c27 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c27 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c27 tbody tr:hover {

--- a/web/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
+++ b/web/packages/teleport/src/Recordings/__snapshots__/Recordings.story.test.tsx.snap
@@ -390,7 +390,9 @@ exports[`rendering of Session Recordings 1`] = `
 
 .c21 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -456,8 +458,8 @@ exports[`rendering of Session Recordings 1`] = `
   line-height: 16px;
 }
 
-.c21 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c21 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c21 tbody tr:hover {

--- a/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
+++ b/web/packages/teleport/src/Sessions/__snapshots__/Sessions.story.test.tsx.snap
@@ -239,7 +239,9 @@ exports[`loaded 1`] = `
 
 .c19 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -305,8 +307,8 @@ exports[`loaded 1`] = `
   line-height: 16px;
 }
 
-.c19 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c19 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c19 tbody tr:hover {
@@ -1078,7 +1080,9 @@ exports[`loaded with CTA 1`] = `
 
 .c25 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -1144,8 +1148,8 @@ exports[`loaded with CTA 1`] = `
   line-height: 16px;
 }
 
-.c25 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c25 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c25 tbody tr:hover {

--- a/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
+++ b/web/packages/teleport/src/Users/__snapshots__/Users.story.test.tsx.snap
@@ -289,7 +289,9 @@ exports[`success state 1`] = `
 
 .c20 {
   background: #222C59;
+  border-collapse: collapse;
   border-spacing: 0;
+  border-style: hidden;
   font-size: 12px;
   width: 100%;
   border-top-left-radius: 0px;
@@ -355,8 +357,8 @@ exports[`success state 1`] = `
   line-height: 16px;
 }
 
-.c20 > tbody > tr:not(:last-of-type) > td {
-  border-bottom: 1px solid rgba(255,255,255,0.07);
+.c20 tbody tr {
+  border-bottom: 1px solid rgb(49,58,100);
 }
 
 .c20 tbody tr:hover {


### PR DESCRIPTION
e counterpart https://github.com/gravitational/teleport.e/pull/1310

When `border-collapse: collapse` is set on a table element, Safari incorrectly renders row border with alpha channel.
It looks like the collapsed border was rendered twice, that is, opacity 0.07 looks like opacity 0.14 (this is more visible on dark theme). Sometimes, there is also an artifact visible after hovering the rows - some of them have correct border color, some not. Here you can see it - the first two rows have too bright border: 
<img width="906" alt="Screenshot 2023-05-05 at 08 06 49" src="https://user-images.githubusercontent.com/20583051/236392853-ec63e163-5e06-4f7b-ae91-33ab89b8593b.png"> 

-----------
This PR redo the changes I made in https://github.com/gravitational/teleport/pull/25333, but in a different way. I realized that adding a border to `td` elements is risky, because these elements don't necessarily have the same height as `tr` (this caused a bug for the status cell in `RequestList.tsx`):
![image](https://user-images.githubusercontent.com/20583051/236393622-dc9e9489-162e-4be7-8e8d-f99a2ff149a0.png)

The updated workaround is to use a solid color for the borders.