### PR TITLE
Make TS a dev dep of root package.json, fix design dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,9 @@
     "webpack": "^5.76.2",
     "x-default-browser": "^0.5.2"
   },
+  "devDependencies": {
+    "typescript": "^4.9.4"
+  },
   "workspaces": {
     "packages": [
       "web/packages/build/**",

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -91,7 +91,6 @@
     "react-transition-group": "^4.4.2",
     "rollup-plugin-visualizer": "^5.9.0",
     "styled-components": "5.1.0",
-    "typescript": "^4.9.4",
     "vite": "^4.2.0",
     "vite-tsconfig-paths": "^4.0.7",
     "webpack": "^5.76.2",

--- a/web/packages/design/package.json
+++ b/web/packages/design/package.json
@@ -16,7 +16,9 @@
   },
   "dependencies": {
     "cross-env": "5.0.5",
-    "styled-system": "^3.1.11",
+    "styled-system": "^3.1.11"
+  },
+  "devDependencies": {
     "@gravitational/build": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Why

I ran into a problem where the language server in my editor was disagreeing with `yarn tsc`. See [`SearchContext.tsx`](https://github.com/gravitational/teleport/blob/4f9077eb70fb5ed6e78c17e829806ccd64cc21a1/web/packages/teleterm/src/ui/Search/SearchContext.tsx#L85-L89) which had no errors in my editor vs [the error in CI](https://github.com/gravitational/teleport/actions/runs/4885362681/jobs/8719328296?pr=25186#step:6:7).

After some digging, I discovered that my editor was using TS 4.9.4 (as described in build's package.json) but `yarn tsc` was using 4.8.4. That 4.8.4 was coming from electron-builder which deep down in its deps has `typescript@^4.0.2` which resolved to `4.8.4`.

## How

I fixed this by moving TS to the dev deps in the root package.json. This makes `yarn tsc` use the version defined in the root package.json.

I think we should do it this way because:

* TS is a project-wide dep.
* electron-builder has the right to use whatever TS version it wants but it shouldn't interfere with our tooling.

Does this guarantee that `yarn tsc` will use the version from the root package.json? I couldn't find anything which would definitely prove this but my assumption is that it'll remain that way.

See https://github.com/yarnpkg/yarn/issues/8135 for a problem similar to ours where someone defines TS in a workspace package and then a dep in another workspace package uses another version of TS.

Defining dev deps in the root is considered safe I think, especially since we don't publish any of our packages. See [Workspaces in Yarn](https://classic.yarnpkg.com/blog/2017/08/02/introducing-workspaces/):

> The following example is a simplified root `package.json` that enables Workspaces for the project and defines third-party packages needed for the project build and test environment.

## Fixing the design dep

Also, a couple of months ago I noticed that the design package incorrectly specifies the build package as a regular dep instead of a dev dependency.

## Alternative solutions to the TypeScript problem

### Put TypeScript in `resolutions`

Yarn supports [selective dep resolutions](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/#toc-why-would-you-want-to-do-this). We use it for React, Webpack and a couple of other packages. `resolutions` is a pretty heavy-handed approach which I'm not sure is the best approach to this problem.

Putting TS in `resolutions` will make **any** package depending on **any** version of TS use the specific one from `resolutions`, even if that package version does not satisfy the semver range specified by the package. If you read the "Why would you want to do this?" section of the linked page, it talks about security patches and so on. I don't think it's a good tool to address workspace-wide deps.

Besides, as I said electron-builder has every right to use whatever TS version it wants, that's how npm/yarn deps work.

### Run `yarn-deduplicate`

Running `yarn-deduplicate` fixes the problem by making both electron-builder and @gravitational/build use the same TS version. However, this has two problems:

* It changes what package versions are used throughout the whole project, potentially introducing breaking changes.
* The next time we update either TS in @gravitational/build or electron-builder itself, we risk running into the same problem without clear warnings or errors.

### Manually adjust `yarn.lock`.

This has the same problem as `yarn-deduplicate` minus the issue with affecting all deps.

---

It should be safe to merge this before v13 release as TS changes should affect only CI and building the app. I'll make a dev tag build to test the changes before merging the v13 backport.