### PR TITLE
docs: document "and" logic for labels

### DIFF
--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -204,7 +204,7 @@ As an example this entry would match to databases that have `env: prod` label an
   accessible only by the members of the "DBA" group and nobody else).
 </Admonition>
 
-### Extende labels syntax
+### Extended labels syntax
 
 Below are a few examples for more complex filtering using various regexes.
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -151,8 +151,8 @@ Label              | `v3`, `v4` and `v5` Default   | `v6` Default
 
 ## RBAC for hosts
 
-A Teleport role can also define which hosts (nodes) a user can have access to.
-This works by [labeling nodes](../management/admin/labels.mdx) and listing
+A Teleport role defines which resources (applications, servers, databases,...) a user can have access to.
+This works by [labeling resources](../management/admin/labels.mdx) and listing
 allow/deny labels in a role definition.
 
 Consider the following use case:
@@ -186,16 +186,25 @@ spec:
       'workload': ['database', 'backup']
 ```
 
+Setting multiple entries under labels works as "and" logic to match to all entries.
+As an example this entry would match to databases that have `env: prod` label and
+`region` label `us-west-1` or `eu-central-1`.
+```yaml
+    db_labels:
+      'env': 'prod'
+      'region': ['us-west-1', 'eu-central-1']
+```
+
 <Admonition
   type="tip"
   title="Dynamic RBAC"
 >
-  Node labels can be dynamic, i.e. determined at runtime by an output of an executable. In this case, you can implement "permissions follow workload"
+  Resource labels can be dynamic, i.e. determined at runtime by an output of an executable. In this case, you can implement "permissions follow workload"
   policies (eg., any server where PostgreSQL is running becomes *automatically*
   accessible only by the members of the "DBA" group and nobody else).
 </Admonition>
 
-### Extended Node labels syntax
+### Extended Resource labels syntax
 
 Below are a few examples for more complex filtering using various regexes.
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -204,7 +204,7 @@ As an example this entry would match to databases that have `env: prod` label an
   accessible only by the members of the "DBA" group and nobody else).
 </Admonition>
 
-### Extended Resource labels syntax
+### Extende labels syntax
 
 Below are a few examples for more complex filtering using various regexes.
 

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -151,7 +151,7 @@ Label              | `v3`, `v4` and `v5` Default   | `v6` Default
 
 ## RBAC for resources
 
-A Teleport role defines which resources (applications, servers, databases,...) a user can have access to.
+A Teleport role defines which resources (e.g., applications, servers, and databases) a user can have access to.
 This works by [labeling resources](../management/admin/labels.mdx) and listing
 allow/deny labels in a role definition.
 
@@ -186,9 +186,10 @@ spec:
       'workload': ['database', 'backup']
 ```
 
-Multiple label entries are treated as logical "AND" operations.
-As an example this entry would match to databases that have `env: prod` label and
-`region` label `us-west-1` or `eu-central-1`.
+Teleport handles multiple label entries with logical "AND" operations.
+As an example this entry would match to databases that have the `env: prod` label and a
+`region` label of either `us-west-1` or `eu-central-1`:
+
 ```yaml
     db_labels:
       'env': 'prod'

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -149,7 +149,7 @@ Label              | `v3`, `v4` and `v5` Default   | `v6` Default
 ------------------ | -------------- | ---------------
 `kubernetes_resources` | `[{"kind":"pod", "name":"*", "namespace":"*"}]` | `[]`
 
-## RBAC for hosts
+## RBAC for resources
 
 A Teleport role defines which resources (applications, servers, databases,...) a user can have access to.
 This works by [labeling resources](../management/admin/labels.mdx) and listing

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -186,7 +186,7 @@ spec:
       'workload': ['database', 'backup']
 ```
 
-Setting multiple entries under labels works as "and" logic to match to all entries.
+Multiple label entries are treated as logical "AND" operations.
 As an example this entry would match to databases that have `env: prod` label and
 `region` label `us-west-1` or `eu-central-1`.
 ```yaml


### PR DESCRIPTION
We do not mention that labels have "and" logic.  Also this language was heavy handed in SSH servers only.