### PR TITLE
usermgmt: Use actual Teleport service group name rather than hardcoded string

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -302,7 +302,7 @@ func (u *HostUserManagement) DeleteAllUsers() error {
 	teleportGroup, err := u.backend.LookupGroup(types.TeleportServiceGroup)
 	if err != nil {
 		if isUnknownGroupError(err, types.TeleportServiceGroup) {
-			log.Debugf("'teleport-service' group not found, not deleting users")
+			log.Debugf("%q group not found, not deleting users", types.TeleportServiceGroup)
 			return nil
 		}
 		return trace.Wrap(err)


### PR DESCRIPTION
The group isn't called `teleport-service` any more, it's called `teleport-system`. This is quite confusing when it appears so often in logs.

Related to https://github.com/gravitational/teleport/issues/25434