### PR TITLE
Support additional expected instance roles.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4685,6 +4685,12 @@ func (process *TeleportProcess) waitForAppDepend() {
 
 // registerExpectedServices sets up the instance role -> identity event mapping.
 func (process *TeleportProcess) registerExpectedServices(cfg *servicecfg.Config) {
+	// Register additional expected services for this Teleport instance.
+	// Meant for enterprise support.
+	for _, service := range cfg.AdditionalExpectedRoles {
+		process.SetExpectedInstanceRole(service.Role, service.IdentityEvent)
+	}
+
 	if cfg.Auth.Enabled {
 		process.SetExpectedInstanceRole(types.RoleAuth, AuthIdentityEvent)
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4687,8 +4687,8 @@ func (process *TeleportProcess) waitForAppDepend() {
 func (process *TeleportProcess) registerExpectedServices(cfg *servicecfg.Config) {
 	// Register additional expected services for this Teleport instance.
 	// Meant for enterprise support.
-	for _, service := range cfg.AdditionalExpectedRoles {
-		process.SetExpectedInstanceRole(service.Role, service.IdentityEvent)
+	for _, r := range cfg.AdditionalExpectedRoles {
+		process.SetExpectedInstanceRole(r.Role, r.IdentityEvent)
 	}
 
 	if cfg.Auth.Enabled {

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -272,7 +272,10 @@ type Config struct {
 
 // RoleAndIdentityEvent is a role and its corresponding identity event.
 type RoleAndIdentityEvent struct {
-	Role          types.SystemRole
+	// Role is a system role.
+	Role types.SystemRole
+
+	// IdentityEvent is the identity event associated with the above role.
 	IdentityEvent string
 }
 

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -239,7 +239,7 @@ type Config struct {
 	// CircuitBreakerConfig configures the auth client circuit breaker.
 	CircuitBreakerConfig breaker.Config
 
-	// AdditionalExpectedInstanceRoles are additional roles to attach to the Teleport instances.
+	// AdditionalExpectedRoles are additional roles to attach to the Teleport instances.
 	AdditionalExpectedRoles []RoleAndIdentityEvent
 
 	// AdditionalReadyEvents are additional events to watch for to consider the Teleport instance ready.

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -239,6 +239,9 @@ type Config struct {
 	// CircuitBreakerConfig configures the auth client circuit breaker.
 	CircuitBreakerConfig breaker.Config
 
+	// AdditionalExpectedInstanceRoles are additional roles to attach to the Teleport instances.
+	AdditionalExpectedRoles []RoleAndIdentityEvent
+
 	// AdditionalReadyEvents are additional events to watch for to consider the Teleport instance ready.
 	AdditionalReadyEvents []string
 
@@ -265,6 +268,12 @@ type Config struct {
 	// and the value is retrieved via AuthServerAddresses() and set via SetAuthServerAddresses()
 	// as we still need to keep multiple addresses and return them for older config versions.
 	authServers []utils.NetAddr
+}
+
+// RoleAndIdentityEvent is a role and its corresponding identity event.
+type RoleAndIdentityEvent struct {
+	Role          types.SystemRole
+	IdentityEvent string
 }
 
 // JoinParams is a set of extra parameters for joining the auth server.


### PR DESCRIPTION
For enterprise specific services, there's no way to attach the Okta role to the current instance so that it's known to the inventory. This new config option will allow enterprise services to set this option to ensure that, when querying the inventory, these roles/services will display properly.