### PR TITLE
Add logger to the authorizer.

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -264,6 +264,9 @@ const (
 	// ComponentAthena represents athena clients.
 	ComponentAthena = "athena"
 
+	// ComponentProxySecureGRPC represents secure gRPC server running on Proxy (used for Kube).
+	ComponentProxySecureGRPC = "proxy:secure-grpc"
+
 	// VerboseLogEnvVar forces all logs to be verbose (down to DEBUG level)
 	VerboseLogsEnvVar = "TELEPORT_DEBUG"
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -59,6 +59,7 @@ type AuthorizerOpts struct {
 	ClusterName string
 	AccessPoint AuthorizerAccessPoint
 	LockWatcher *services.LockWatcher
+	Logger      logrus.FieldLogger
 
 	// DisableDeviceAuthorization disables device authorization via [Authorizer].
 	// It is meant for services that do explicit device authorization, like the
@@ -74,10 +75,15 @@ func NewAuthorizer(opts AuthorizerOpts) (Authorizer, error) {
 	if opts.AccessPoint == nil {
 		return nil, trace.BadParameter("missing parameter accessPoint")
 	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = logrus.WithFields(logrus.Fields{trace.Component: "authorizer"})
+	}
 	return &authorizer{
 		clusterName:                opts.ClusterName,
 		accessPoint:                opts.AccessPoint,
 		lockWatcher:                opts.LockWatcher,
+		logger:                     logger,
 		disableDeviceAuthorization: opts.DisableDeviceAuthorization,
 	}, nil
 }
@@ -132,6 +138,7 @@ type authorizer struct {
 	accessPoint                AuthorizerAccessPoint
 	lockWatcher                *services.LockWatcher
 	disableDeviceAuthorization bool
+	logger                     logrus.FieldLogger
 }
 
 // Context is authorization context
@@ -232,8 +239,7 @@ func (a *authorizer) Authorize(ctx context.Context) (*Context, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	if err := CheckIPPinning(ctx, authContext.Identity.GetIdentity(), authContext.Checker.PinSourceIP(),
-		logrus.WithFields(logrus.Fields{trace.Component: "authorizer"})); err != nil {
+	if err := CheckIPPinning(ctx, authContext.Identity.GetIdentity(), authContext.Checker.PinSourceIP(), a.logger); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/service/db.go
+++ b/lib/service/db.go
@@ -100,6 +100,7 @@ func (process *TeleportProcess) initDatabaseService() (retErr error) {
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
+		Logger:      log,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -156,6 +156,7 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
+		Logger:      log,
 		// Device authorization breaks browser-based access.
 		DisableDeviceAuthorization: true,
 	})

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -182,6 +182,7 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 		ClusterName: teleportClusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
+		Logger:      log,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1715,6 +1715,7 @@ func (process *TeleportProcess) initAuthService() error {
 		ClusterName: clusterName,
 		AccessPoint: authServer,
 		LockWatcher: lockWatcher,
+		Logger:      log,
 		// Auth Server does explicit device authorization.
 		// Various Auth APIs must allow access to unauthorized devices, otherwise it
 		// is not possible to acquire device-aware certificates in the first place.
@@ -3905,6 +3906,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		ClusterName: clusterName,
 		AccessPoint: accessPoint,
 		LockWatcher: lockWatcher,
+		Logger:      log,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -4049,6 +4051,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
+			Logger:      log,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -4139,6 +4142,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
+			Logger:      log,
 		})
 		if err != nil {
 			return trace.Wrap(err)
@@ -4878,6 +4882,7 @@ func (process *TeleportProcess) initApps() {
 			ClusterName: clusterName,
 			AccessPoint: accessPoint,
 			LockWatcher: lockWatcher,
+			Logger:      log,
 			// Device authorization breaks browser-based access.
 			DisableDeviceAuthorization: true,
 		})
@@ -5519,6 +5524,9 @@ func (process *TeleportProcess) initSecureGRPCServer(cfg initSecureGRPCServerCfg
 		ClusterName: clusterName,
 		AccessPoint: cfg.accessPoint,
 		LockWatcher: cfg.lockWatcher,
+		Logger: process.log.WithFields(logrus.Fields{
+			trace.Component: teleport.Component(teleport.ComponentProxySecureGRPC, process.id),
+		}),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Adds logger to the authorizer so we don't have to use default logger for debug logs.
Closes #25035