### PR TITLE
Add the debug command `tsh fido2 attobj`

### DIFF
--- a/tool/tsh/fido2.go
+++ b/tool/tsh/fido2.go
@@ -99,17 +99,17 @@ func (c *fido2AttobjCommand) run(_ *CLIConf) error {
 
 	ao := &protocol.AttestationObject{}
 	if err := webauthncbor.Unmarshal(aoRaw, ao); err != nil {
-		return fmt.Errorf("attestation object unmarshal: %w", err)
+		return trace.Wrap(err, "attestation object unmarshal")
 	}
 	if err := ao.AuthData.Unmarshal(ao.RawAuthData); err != nil {
-		return fmt.Errorf("authdata unmarshal: %w", err)
+		return trace.Wrap(err, "authdata unmarshal")
 	}
 
 	// Print attestation object as JSON.
 	enc := json.NewEncoder(os.Stdout)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(ao); err != nil {
-		return fmt.Errorf("encode attestation object to JSON: %w", err)
+		return trace.Wrap(err, "encode attestation object to JSON")
 	}
 
 	// Print public key.
@@ -118,7 +118,7 @@ func (c *fido2AttobjCommand) run(_ *CLIConf) error {
 		if err == nil {
 			fmt.Println("\nAuthData.AttData.public_key:")
 			if err := enc.Encode(pubKey); err != nil {
-				return fmt.Errorf("encode public key: %w", err)
+				return trace.Wrap(err, "encode public key")
 			}
 		}
 	}

--- a/tool/tsh/fido2.go
+++ b/tool/tsh/fido2.go
@@ -48,7 +48,10 @@ func newFIDO2Command(app *kingpin.Application) *fido2Command {
 	root.diag.CmdClause = diag
 
 	attObj := f2.Command("attobj", "Parse a stored attestation object").Hidden()
-	attObj.Arg("att-obj", "Attestation object encoded in base64 standard or RawURL").StringVar(&root.attobj.attObjB64)
+	attObj.
+		Arg("att-obj", "Attestation object encoded in base64 standard or RawURL").
+		Required().
+		StringVar(&root.attobj.attObjB64)
 	root.attobj.CmdClause = attObj
 
 	return root

--- a/tool/tsh/fido2.go
+++ b/tool/tsh/fido2.go
@@ -18,12 +18,34 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 )
 
-func onFIDO2Diag(cf *CLIConf) error {
+type fido2Command struct {
+	diag *fido2DiagCommand
+}
+
+func newFIDO2Command(app *kingpin.Application) *fido2Command {
+	cmd := &fido2Command{
+		diag: &fido2DiagCommand{},
+	}
+
+	f2 := app.Command("fido2", "FIDO2 commands").Hidden()
+
+	diag := f2.Command("diag", "Run FIDO2 diagnostics").Hidden()
+	cmd.diag.CmdClause = diag
+
+	return cmd
+}
+
+type fido2DiagCommand struct {
+	*kingpin.CmdClause
+}
+
+func (_ *fido2DiagCommand) run(cf *CLIConf) error {
 	diag, err := wancli.FIDO2Diag(cf.Context, os.Stdout)
 	// Abort if we got a nil diagnostic, otherwise print as much as we can.
 	if diag == nil {

--- a/tool/tsh/fido2.go
+++ b/tool/tsh/fido2.go
@@ -15,9 +15,16 @@
 package main
 
 import (
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
+	"github.com/go-webauthn/webauthn/protocol"
+	"github.com/go-webauthn/webauthn/protocol/webauthncbor"
+	"github.com/go-webauthn/webauthn/protocol/webauthncose"
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
@@ -25,20 +32,26 @@ import (
 )
 
 type fido2Command struct {
-	diag *fido2DiagCommand
+	diag   *fido2DiagCommand
+	attobj *fido2AttobjCommand
 }
 
 func newFIDO2Command(app *kingpin.Application) *fido2Command {
-	cmd := &fido2Command{
-		diag: &fido2DiagCommand{},
+	root := &fido2Command{
+		diag:   &fido2DiagCommand{},
+		attobj: &fido2AttobjCommand{},
 	}
 
 	f2 := app.Command("fido2", "FIDO2 commands").Hidden()
 
 	diag := f2.Command("diag", "Run FIDO2 diagnostics").Hidden()
-	cmd.diag.CmdClause = diag
+	root.diag.CmdClause = diag
 
-	return cmd
+	attObj := f2.Command("attobj", "Parse a stored attestation object").Hidden()
+	attObj.Arg("att-obj", "Attestation object encoded in base64 standard or RawURL").StringVar(&root.attobj.attObjB64)
+	root.attobj.CmdClause = attObj
+
+	return root
 }
 
 type fido2DiagCommand struct {
@@ -60,4 +73,85 @@ func (_ *fido2DiagCommand) run(cf *CLIConf) error {
 	}
 
 	return trace.Wrap(err)
+}
+
+type fido2AttobjCommand struct {
+	*kingpin.CmdClause
+
+	attObjB64 string
+}
+
+func (c *fido2AttobjCommand) run(_ *CLIConf) error {
+	var aoRaw []byte
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawURLEncoding,
+	} {
+		var err error
+		aoRaw, err = enc.DecodeString(c.attObjB64)
+		if err == nil {
+			break
+		}
+	}
+	if aoRaw == nil {
+		return errors.New("failed to decode attestation object")
+	}
+
+	ao := &protocol.AttestationObject{}
+	if err := webauthncbor.Unmarshal(aoRaw, ao); err != nil {
+		return fmt.Errorf("attestation object unmarshal: %w", err)
+	}
+	if err := ao.AuthData.Unmarshal(ao.RawAuthData); err != nil {
+		return fmt.Errorf("authdata unmarshal: %w", err)
+	}
+
+	// Print attestation object as JSON.
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(ao); err != nil {
+		return fmt.Errorf("encode attestation object to JSON: %w", err)
+	}
+
+	// Print public key.
+	if len(ao.AuthData.AttData.CredentialPublicKey) > 0 {
+		pubKey, err := webauthncose.ParsePublicKey(ao.AuthData.AttData.CredentialPublicKey)
+		if err == nil {
+			fmt.Println("\nAuthData.AttData.public_key:")
+			if err := enc.Encode(pubKey); err != nil {
+				return fmt.Errorf("encode public key: %w", err)
+			}
+		}
+	}
+
+	// Print attestation certificates.
+	if x5c, ok := ao.AttStatement["x5c"]; ok {
+		if x5cArray, ok := x5c.([]interface{}); ok {
+			for i, certI := range x5cArray {
+				certDER, ok := certI.([]byte)
+				if !ok {
+					continue
+				}
+
+				cert, err := x509.ParseCertificate(certDER)
+				if err != nil {
+					continue
+				}
+
+				type niceCert struct {
+					Raw     []byte
+					Issuer  string
+					Subject string
+				}
+
+				fmt.Printf("\nattStmt.x509[%v]:\n", i)
+				enc.Encode(niceCert{
+					Raw:     cert.Raw,
+					Issuer:  cert.Issuer.String(),
+					Subject: cert.Subject.String(),
+				})
+			}
+		}
+	}
+
+	return nil
 }

--- a/tool/tsh/fido2.go
+++ b/tool/tsh/fido2.go
@@ -134,6 +134,7 @@ func (c *fido2AttobjCommand) run(_ *CLIConf) error {
 
 				cert, err := x509.ParseCertificate(certDER)
 				if err != nil {
+					log.WithError(err).Warnf("Failed to parse X.509 from x5c[%v], continuing", i)
 					continue
 				}
 

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1300,6 +1300,8 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = onDaemonStop(&cf)
 	case f2.diag.FullCommand():
 		err = f2.diag.run(&cf)
+	case f2.attobj.FullCommand():
+		err = f2.attobj.run(&cf)
 	case tid.diag.FullCommand():
 		err = tid.diag.run(&cf)
 	case webauthnwin.diag.FullCommand():

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -982,12 +982,9 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 
 	config := app.Command("config", "Print OpenSSH configuration details")
 
-	f2 := app.Command("fido2", "FIDO2 commands").Hidden()
-	f2Diag := f2.Command("diag", "Run FIDO2 diagnostics").Hidden()
-
-	// touchid subcommands.
+	// FIDO2, TouchID and WebAuthnWin commands.
+	f2 := newFIDO2Command(app)
 	tid := newTouchIDCommand(app)
-
 	webauthnwin := newWebauthnwinCommand(app)
 
 	// Device Trust commands.
@@ -1301,8 +1298,8 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = onDaemonStart(&cf)
 	case daemonStop.FullCommand():
 		err = onDaemonStop(&cf)
-	case f2Diag.FullCommand():
-		err = onFIDO2Diag(&cf)
+	case f2.diag.FullCommand():
+		err = f2.diag.run(&cf)
 	case tid.diag.FullCommand():
 		err = tid.diag.run(&cf)
 	case webauthnwin.diag.FullCommand():


### PR DESCRIPTION
Add a helper/debug command to parse attestation objects.

Useful when inspecting MFA devices, otherwise attestation objects are rather opaque to inspect. Works directly with data acquired from `tctl get users/foo --with-secrets`.