### PR TITLE
Modify error messages for customer portal to Teleport account

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -790,7 +790,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		if !modules.GetModules().IsBoringBinary() {
 			return nil, trace.BadParameter("binary not compiled against BoringCrypto, check " +
 				"that Enterprise FIPS release was downloaded from " +
-				"https://dashboard.gravitational.com")
+				"a Teleport account https://teleport.sh")
 		}
 	}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1690,7 +1690,7 @@ func ConstructSSHResponse(response AuthParams) (*url.URL, error) {
 		// If FIPS mode was requested, make sure older clients that use NaCl get rejected.
 		if response.FIPS {
 			return nil, trace.BadParameter("non-FIPS compliant encryption: NaCl, check " +
-				"that tsh release was downloaded from https://dashboard.gravitational.com")
+				"that tsh release was downloaded from a Teleport account https://teleport.sh")
 		}
 
 		secretKeyBytes, err := lemma_secret.EncodedStringToKey(secretV1)


### PR DESCRIPTION
As with the documentation in #25677 we are replacing all references to dashboard.gravitational.com to the Teleport accounts https://teleport.sh