### PR TITLE
check for correct kube and ssh listen address in starting message

### DIFF
--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -243,14 +243,8 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 	process.RegisterCriticalFunc("windows_desktop.serve", func() error {
 		if useTunnel {
 			log.Info("Starting Windows desktop service via proxy reverse tunnel.")
-			utils.Consolef(cfg.Console, log, teleport.ComponentWindowsDesktop,
-				"Windows desktop service %s:%s is starting via proxy reverse tunnel.",
-				teleport.Version, teleport.Gitref)
 		} else {
 			log.Infof("Starting Windows desktop service on %v.", listener.Addr())
-			utils.Consolef(cfg.Console, log, teleport.ComponentWindowsDesktop,
-				"Windows desktop service %s:%s is starting on %v.",
-				teleport.Version, teleport.Gitref, listener.Addr())
 		}
 		process.BroadcastEvent(Event{Name: WindowsDesktopReady, Payload: nil})
 		err := srv.Serve(listener)

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -261,14 +261,8 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	process.RegisterCriticalFunc("kube.serve", func() error {
 		if conn.UseTunnel() {
 			log.Info("Starting Kube service via proxy reverse tunnel.")
-			utils.Consolef(cfg.Console, log, teleport.ComponentKube,
-				"Kubernetes service %s:%s is starting via proxy reverse tunnel.",
-				teleport.Version, teleport.Gitref)
 		} else {
 			log.Infof("Starting Kube service on %v.", listener.Addr())
-			utils.Consolef(cfg.Console, log, teleport.ComponentKube,
-				"Kubernetes service %s:%s is starting on %v.",
-				teleport.Version, teleport.Gitref, listener.Addr())
 		}
 		process.BroadcastEvent(Event{Name: KubernetesReady, Payload: nil})
 		err := kubeServer.Serve(listener)

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/utils"
 )
 
 func (process *TeleportProcess) initKubernetes() {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1794,8 +1794,7 @@ func (process *TeleportProcess) initAuthService() error {
 		return trace.Wrap(err)
 	}
 	process.RegisterCriticalFunc("auth.tls", func() error {
-		utils.Consolef(cfg.Console, log, teleport.ComponentAuth, "Auth service %s:%s is starting on %v.",
-			teleport.Version, teleport.Gitref, authAddr)
+		log.Infof("Auth service %s:%s is starting on %v.", teleport.Version, teleport.Gitref, authAddr)
 
 		// since tlsServer.Serve is a blocking call, we emit this even right before
 		// the service has started
@@ -2471,8 +2470,6 @@ func (process *TeleportProcess) initSSH() error {
 			warnOnErr(process.closeImportedDescriptors(teleport.ComponentNode), log)
 
 			log.Infof("Service %s:%s is starting on %v %v.", teleport.Version, teleport.Gitref, cfg.SSH.Addr.Addr, process.Config.CachePolicy)
-			utils.Consolef(cfg.Console, log, teleport.ComponentNode, "Service %s:%s is starting on %v.",
-				teleport.Version, teleport.Gitref, cfg.SSH.Addr.Addr)
 
 			go s.Serve(limiter.WrapListener(listener))
 		} else {
@@ -3630,8 +3627,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			return trace.Wrap(err)
 		}
 		process.RegisterCriticalFunc("proxy.reversetunnel.server", func() error {
-			utils.Consolef(cfg.Console, log, teleport.ComponentProxy, "Reverse tunnel service %s:%s is starting on %v.",
-				teleport.Version, teleport.Gitref, cfg.Proxy.ReverseTunnelListenAddr.Addr)
 			log.Infof("Starting %s:%s on %v using %v", teleport.Version, teleport.Gitref, cfg.Proxy.ReverseTunnelListenAddr.Addr, process.Config.CachePolicy)
 			if err := tsrv.Start(); err != nil {
 				log.Error(err)
@@ -3800,8 +3795,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		}
 
 		process.RegisterCriticalFunc("proxy.web", func() error {
-			utils.Consolef(cfg.Console, log, teleport.ComponentProxy, "Web proxy service %s:%s is starting on %v.",
-				teleport.Version, teleport.Gitref, cfg.Proxy.WebAddr.Addr)
 			log.Infof("Web proxy service %s:%s is starting on %v.", teleport.Version, teleport.Gitref, cfg.Proxy.WebAddr.Addr)
 			defer webHandler.Close()
 			process.BroadcastEvent(Event{Name: ProxyWebServerReady, Payload: webHandler})
@@ -4471,10 +4464,6 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 	}
 
 	process.RegisterCriticalFunc("proxy.reversetunnel.web", func() error {
-		utils.Consolef(
-			cfg.Console, log, teleport.ComponentProxy,
-			"Minimal web proxy service %s:%s is starting on %v.",
-			teleport.Version, teleport.Gitref, cfg.Proxy.ReverseTunnelListenAddr.Addr)
 		log.Infof("Minimal web proxy service %s:%s is starting on %v.", teleport.Version, teleport.Gitref, cfg.Proxy.ReverseTunnelListenAddr.Addr)
 		defer minimalWebHandler.Close()
 		if err := minimalWebServer.Serve(minimalListener.Web()); err != nil && err != http.ErrServerClosed {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3988,17 +3988,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	transportpb.RegisterTransportServiceServer(sshGRPCServer, transportService)
 
 	process.RegisterCriticalFunc("proxy.ssh", func() error {
-		// If a ssh proxy address is specified provide the address and specifics
 		sshListenerAddr := listeners.ssh.Addr().String()
-		sshListenerAddrDetails := sshListenerAddr
 		if cfg.Proxy.SSHAddr.Addr != "" {
 			sshListenerAddr = cfg.Proxy.SSHAddr.Addr
-			// will include address and type (tcp)
-			sshListenerAddrDetails = fmt.Sprintf("%v", cfg.Proxy.SSHAddr)
 		}
-		utils.Consolef(cfg.Console, log, teleport.ComponentProxy, "SSH proxy service %s:%s is starting on %v.",
-			teleport.Version, teleport.Gitref, sshListenerAddr)
-		log.Infof("SSH proxy service %s:%s is starting on %v", teleport.Version, teleport.Gitref, sshListenerAddrDetails)
+		log.Infof("SSH proxy service %s:%s is starting on %v", teleport.Version, teleport.Gitref, sshListenerAddr)
 
 		// start ssh server
 		go func() {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3988,9 +3988,17 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 	transportpb.RegisterTransportServiceServer(sshGRPCServer, transportService)
 
 	process.RegisterCriticalFunc("proxy.ssh", func() error {
+		// If a ssh proxy address is specified provide the address and specifics
+		sshListenerAddr := listeners.ssh.Addr().String()
+		sshListenerAddrDetails := sshListenerAddr
+		if cfg.Proxy.SSHAddr.Addr != "" {
+			sshListenerAddr = cfg.Proxy.SSHAddr.Addr
+			// will include address and type (tcp)
+			sshListenerAddrDetails = fmt.Sprintf("%v", cfg.Proxy.SSHAddr)
+		}
 		utils.Consolef(cfg.Console, log, teleport.ComponentProxy, "SSH proxy service %s:%s is starting on %v.",
-			teleport.Version, teleport.Gitref, cfg.Proxy.SSHAddr.Addr)
-		log.Infof("SSH proxy service %s:%s is starting on %v", teleport.Version, teleport.Gitref, cfg.Proxy.SSHAddr)
+			teleport.Version, teleport.Gitref, sshListenerAddr)
+		log.Infof("SSH proxy service %s:%s is starting on %v", teleport.Version, teleport.Gitref, sshListenerAddrDetails)
 
 		// start ssh server
 		go func() {
@@ -4124,9 +4132,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				trace.Component: component,
 			})
 
-			kubeListenAddr := fmt.Sprintf("%v", listeners.kube.Addr())
+			kubeListenAddr := listeners.kube.Addr().String()
 			if cfg.Proxy.Kube.ListenAddr.Addr != "" {
-				kubeListenAddr = fmt.Sprintf("%v", cfg.Proxy.Kube.ListenAddr.Addr)
+				kubeListenAddr = cfg.Proxy.Kube.ListenAddr.Addr
 			}
 			log.Infof("Starting Kube proxy on %v.", kubeListenAddr)
 			err := kubeServer.Serve(listeners.kube)

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4124,7 +4124,11 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				trace.Component: component,
 			})
 
-			log.Infof("Starting Kube proxy on %v.", cfg.Proxy.Kube.ListenAddr.Addr)
+			kubeListenAddr := fmt.Sprintf("%v", listeners.kube.Addr())
+			if cfg.Proxy.Kube.ListenAddr.Addr != "" {
+				kubeListenAddr = fmt.Sprintf("%v", cfg.Proxy.Kube.ListenAddr.Addr)
+			}
+			log.Infof("Starting Kube proxy on %v.", kubeListenAddr)
 			err := kubeServer.Serve(listeners.kube)
 			if err != nil && err != http.ErrServerClosed {
 				log.Warningf("Kube TLS server exited with error: %v.", err)

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
-	"math"
 	"os"
 	"runtime"
 	"strconv"
@@ -277,21 +276,6 @@ const (
 // Color formats the string in a terminal escape color
 func Color(color int, v interface{}) string {
 	return fmt.Sprintf("\x1b[%dm%v\x1b[0m", color, v)
-}
-
-// Consolef prints the same message to a 'ui console' (if defined) and also to
-// the logger with INFO priority
-func Consolef(w io.Writer, log logrus.FieldLogger, component, msg string, params ...interface{}) {
-	msg = fmt.Sprintf(msg, params...)
-	log.Info(msg)
-	if w != nil {
-		component := strings.ToUpper(component)
-		// 13 is the length of "[KUBERNETES]", which is the longest component
-		// name prefix we have *today*. Use a Max function here to avoid
-		// negative spacing, in case we add longer component names.
-		spacing := int(math.Max(float64(12-len(component)), 0))
-		fmt.Fprintf(w, "[%v]%v %v\n", strings.ToUpper(component), strings.Repeat(" ", spacing), msg)
-	}
 }
 
 // InitCLIParser configures kingpin command line args parser with

--- a/lib/utils/cli_test.go
+++ b/lib/utils/cli_test.go
@@ -19,12 +19,10 @@ package utils
 import (
 	"crypto/x509"
 	"fmt"
-	"io"
 	"strings"
 	"testing"
 
 	"github.com/gravitational/trace"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -58,17 +56,6 @@ func TestUserMessageFromError(t *testing.T) {
 		message := UserMessageFromError(tt.inError)
 		require.True(t, strings.HasPrefix(message, tt.outString), tt.comment)
 	}
-}
-
-// Regressions test - Consolef used to panic when component name was longer
-// than 8 bytes.
-func TestConsolefLongComponent(t *testing.T) {
-	t.Parallel()
-
-	require.NotPanics(t, func() {
-		component := strings.Repeat("na ", 10) + "batman!"
-		Consolef(io.Discard, logrus.New(), component, "test message")
-	})
 }
 
 // TestEscapeControl tests escape control

--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -198,9 +198,8 @@ func TryRun(commands []CLICommand, args []string) error {
 		if utils.IsUntrustedCertErr(err) {
 			err = trace.WrapWithMessage(err, utils.SelfSignedCertsMsg)
 		}
-		utils.Consolef(os.Stderr, log.WithField(trace.Component, teleport.ComponentClient), teleport.ComponentClient,
-			"Cannot connect to the auth server: %v.\nIs the auth server running on %q?",
-			err, cfg.AuthServerAddresses()[0].Addr)
+		log.Errorf("Cannot connect to the auth server. Is the auth server running on %q? %v",
+			cfg.AuthServerAddresses()[0].Addr, err)
 		return trace.NewAggregate(&common.ExitCodeError{Code: 1}, err)
 	}
 


### PR DESCRIPTION
The starting Kube proxy message is showing no listen address when none is put in the Teleport config file. Same for SSH Proxy.  As this is defaulted on in multiplex these configs are often not set.

Currently in default multiplex mode for Kube proxy:

```bash
2023-05-07T10:47:55-04:00 INFO [PROXY:PRO] Starting Kube proxy on . service/service.go:4095
```

Now with the default multiplex approach should show as when the `web_listen_addr` is `0.0.0.0:443`:

```bash
2023-05-07T10:47:55-04:00 INFO [PROXY:PRO] Starting Kube proxy on [::]:443. service/service.go:4131
```


Same issue with ssh proxy

```bash
2023-05-07T11:35:14-04:00 INFO [PROXY:SER] SSH proxy service 12.2.4:v12.2.4-0-g0f5a2d8 is starting on . pid:41246.1 utils/cli.go:286
2023-05-07T11:35:14-04:00 INFO [PROXY:SER] SSH proxy service 12.2.4:v12.2.4-0-g0f5a2d8 is starting on {  } pid:41246.1 service/service.go:3855
```

Now updated to 

```bash
2023-05-07T11:35:58-04:00 INFO [PROXY:SER] SSH proxy service 14.0.0-dev: is starting on [::]:443. pid:42055.1 utils/cli.go:286
```
