### PR TITLE
Added passing add-keys-to-agent setting to kube login

### DIFF
--- a/lib/kube/kubeconfig/kubeconfig.go
+++ b/lib/kube/kubeconfig/kubeconfig.go
@@ -58,6 +58,9 @@ type Values struct {
 	// This value is empty if a proxy was not specified.
 	ProxyAddr string
 
+	// AddKeysToAgent specifies the behavior of how certs are handled.
+	AddKeysToAgent string
+
 	// TLSServerName is SNI host value passed to the server.
 	TLSServerName string
 
@@ -152,6 +155,9 @@ func Update(path string, v Values, storeAllCAs bool) error {
 			}
 			if v.ProxyAddr != "" {
 				execArgs = append(execArgs, fmt.Sprintf("--proxy=%s", v.ProxyAddr))
+			}
+			if v.AddKeysToAgent != "" {
+				execArgs = append(execArgs, fmt.Sprintf("--add-keys-to-agent=%s", v.AddKeysToAgent))
 			}
 			authInfo := &clientcmdapi.AuthInfo{
 				Impersonate:       v.Impersonate,

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -1163,6 +1163,11 @@ func buildKubeConfigUpdate(cf *CLIConf, kubeStatus *kubernetesStatus, overrideCo
 		return v, nil
 	}
 
+	// if AddKeysToAgent is not the default, set it to the specified value.
+	if cf.AddKeysToAgent != client.AddKeysToAgentAuto {
+		v.AddKeysToAgent = cf.AddKeysToAgent
+	}
+
 	if len(kubeStatus.kubeClusters) == 0 {
 		// If there are no registered k8s clusters, we may have an older teleport cluster.
 		// Fall back to the old kubeconfig, with static credentials from v.Credentials.


### PR DESCRIPTION
This is to address the issue from #22326 where even if specified it stops working for kube login commands.