### PR TITLE
Connect: Make notification more readable

### DIFF
--- a/web/packages/shared/components/Notification/Notification.tsx
+++ b/web/packages/shared/components/Notification/Notification.tsx
@@ -232,7 +232,7 @@ const shortTextCss = css`
 const Container = styled(Flex)`
   flex-direction: row;
   justify-content: space-between;
-  background: ${props => props.theme.colors.levels.surface};
+  background: ${props => props.theme.colors.levels.elevated};
   min-height: 40px;
   width: 320px;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.24);


### PR DESCRIPTION
This change only affects Connect, `WarningDropdown` in desktop access overwrites the background with its own color.

Before
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/20583051/236801729-3707d74c-6491-4cfd-85ce-6a12ad9b2c3d.png">


After
<img width="1377" alt="image" src="https://user-images.githubusercontent.com/20583051/236801681-241579a7-ccaa-4539-beff-97ffa01c0129.png">
