### PR TITLE
Show resource search errors in search bar when fetching a preview

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -253,15 +253,15 @@ const ExtraTopComponents = (props: {
           return <TypeToSearchItem hasNoRemainingFilterActions={false} />;
         }
         case 'preview': {
-          const nonRetryableResourceSearchErrors =
-            status.searchMode.nonRetryableResourceSearchErrors;
+          const {
+            nonRetryableResourceSearchErrors,
+            hasNoRemainingFilterActions,
+          } = status.searchMode;
 
           return (
             <>
               <TypeToSearchItem
-                hasNoRemainingFilterActions={
-                  status.searchMode.hasNoRemainingFilterActions
-                }
+                hasNoRemainingFilterActions={hasNoRemainingFilterActions}
               />
               {nonRetryableResourceSearchErrors.length > 0 && (
                 <ResourceSearchErrorsItem

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.tsx
@@ -307,6 +307,18 @@ const ExtraTopComponents = (props: {
   }
 };
 
+/**
+ * ActionPickerStatus helps with displaying ExtraTopComponents. It has two goals:
+ *
+ *   * Encapsulate business logic so that anything that ExtraTopComponents renders can just read
+ *     ActionPickerStatus fields.
+ *   * Represent only valid UI states. For example, inputState 'no-input' doesn't have hasNoResults
+ *     field as this field would make no sense in a situation where no search requests were made.
+ *
+ * As you may notice, ActionPickerStatus doesn't say whether the search request is in progress or
+ * not, simply because displaying the progress bar is handled by another component. The questions
+ * answered by ActionPickerStatus are valid to ask no matter what the state of the request is.
+ */
 type ActionPickerStatus =
   | {
       // no-input: The input is empty.

--- a/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/results.story.tsx
@@ -358,6 +358,10 @@ const AuxiliaryItems = () => (
     ExtraTopComponent={
       <>
         <NoResultsItem
+          clustersWithExpiredCerts={new Set()}
+          getClusterName={routing.parseClusterName}
+        />
+        <NoResultsItem
           clustersWithExpiredCerts={new Set([clusterUri])}
           getClusterName={routing.parseClusterName}
         />


### PR DESCRIPTION
This does not need to be merged before the v13 release.

---

#25314 made it so that we fetch a preview of matching resources as soon as the user selects one of the filters. However, we don't display errors if fetching that preview fails. This PR fixes that.

The easiest way to review this PR is to go bottom-up, from the changes to the data structures to the actual UI changes. Take a look at how `type ActionPickerStatus` has changed in `ActionPicker.tsx` and it should be easier to follow the changes that I had to make in `getActionPickerStatus` and `ExtraTopComponents`.

The previous definition of `ActionPickerStatus` assumed that we make a search request only when the user types in something in the search bar. The new definition recognizes that we fetch a preview when the input is empty and at least one filter is selected.