### PR TITLE
Make PAM user creation script copy/pasteable

### DIFF
--- a/docs/pages/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/server-access/guides/ssh-pam.mdx
@@ -208,15 +208,26 @@ session   required   pam_permit.so
 
 Next, create a script that will be run by `pam_exec.so`.
 
+Create a directory where you will store the script:
+
 ```code
-mkdir -p /etc/pam-exec.d
-cat > /etc/pam-exec.d/teleport_acct <<"EOF"
+$ mkdir -p /etc/pam-exec.d
+```
+
+In `/etc/pam-exec.d`, add a file called `teleport_acct` with the following
+content:
+
+```text
 #!/bin/sh
 COMMENT="User ${TELEPORT_LOGIN} for ${TELEPORT_USERNAME} with roles ${TELEPORT_ROLES} created by Teleport."
 /bin/id -u "${TELEPORT_LOGIN}" > /dev/null 2>&1 || /sbin/useradd -m -s /bin/bash -c "${COMMENT}" "${TELEPORT_LOGIN}" 2>> /tmp/pam.error
 exit 0
-EOF
-chmod +x /etc/pam-exec.d/teleport_acct
+```
+
+Ensure that your script is executable:
+
+```code
+$ chmod +x /etc/pam-exec.d/teleport_acct
 ```
 
 This script will check if the login assigned to `TELEPORT_LOGIN` exists and, if


### PR DESCRIPTION
Closes #18343

The user creation script in our SSH PAM guide is inside a heredoc within a `code` snippet. The shebang within the script does not render within the `code` snippet, since the snippet component treats the hash as a comment.

This change turns the script into a code snippet with a `text` label to prevent rendering issues and separates commands that are intended to be run outside the script into their own code snippets.