### PR TITLE
Convert Some DynamoDB logs to Trace

### DIFF
--- a/lib/backend/dynamo/shards.go
+++ b/lib/backend/dynamo/shards.go
@@ -90,7 +90,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 			return false
 		}
 		if _, ok := set[aws.StringValue(shard.ParentShardId)]; ok {
-			b.Debugf("Skipping child shard: %s, still polling parent %s", sid, aws.StringValue(shard.ParentShardId))
+			b.Tracef("Skipping child shard: %s, still polling parent %s", sid, aws.StringValue(shard.ParentShardId))
 			// still processing parent
 			return false
 		}
@@ -116,7 +116,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				continue
 			}
 			shardID := aws.StringValue(shards[i].ShardId)
-			b.Debugf("Adding active shard %v.", shardID)
+			b.Tracef("Adding active shard %v.", shardID)
 			set[shardID] = struct{}{}
 			go b.asyncPollShard(ctx, streamArn, shards[i], eventsC, initC)
 			started++
@@ -165,7 +165,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 					b.Debugf("Shard ID %v closed with error: %v, reseting buffers.", event.shardID, event.err)
 					return trace.Wrap(event.err)
 				}
-				b.Debugf("Shard ID %v exited gracefully.", event.shardID)
+				b.Tracef("Shard ID %v exited gracefully.", event.shardID)
 			} else {
 				b.buf.Emit(event.events...)
 			}
@@ -174,7 +174,7 @@ func (b *Backend) pollStreams(externalCtx context.Context) error {
 				return trace.Wrap(err)
 			}
 		case <-ctx.Done():
-			b.Debugf("Context is closing, returning.")
+			b.Tracef("Context is closing, returning.")
 			return nil
 		}
 	}
@@ -227,18 +227,18 @@ func (b *Backend) pollShard(ctx context.Context, streamArn *string, shard *dynam
 				return convertError(err)
 			}
 			if len(out.Records) > 0 {
-				b.Debugf("Got %v new stream shard records.", len(out.Records))
+				b.Tracef("Got %v new stream shard records.", len(out.Records))
 			}
 			if len(out.Records) == 0 {
 				if out.NextShardIterator == nil {
-					b.Debugf("Shard is closed: %v.", aws.StringValue(shard.ShardId))
+					b.Tracef("Shard is closed: %v.", aws.StringValue(shard.ShardId))
 					return io.EOF
 				}
 				iterator = out.NextShardIterator
 				continue
 			}
 			if out.NextShardIterator == nil {
-				b.Debugf("Shard is closed: %v.", aws.StringValue(shard.ShardId))
+				b.Tracef("Shard is closed: %v.", aws.StringValue(shard.ShardId))
 				return io.EOF
 			}
 			events := make([]backend.Event, 0, len(out.Records))


### PR DESCRIPTION
When running debug logging, the dynamodb logs are rather chatty but not necessarily useful for debugging.  Moving them to trace would be ideal. I moved a few to this to be consistent in the func but am mostly after new stream shards.

A ~30 minute sample (non-peak hours).  Number of samples somewhat deduped on left:
![Screenshot 2023-05-08 at 9 19 54 AM](https://user-images.githubusercontent.com/2314084/236850267-c1d78265-7723-40f0-9cb6-0464cc402e22.png)