### PR TITLE
Bump Buf to 1.18.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -288,7 +288,7 @@ RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.17.0" && \
+    VERSION="1.18.0" && \
       curl -fsSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Keep up with the latest releases.

* https://github.com/bufbuild/buf/releases/tag/v1.18.0