### PR TITLE
[v11] fix: truncate YubiHSM2 key IDs

### DIFF
--- a/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
@@ -186,11 +186,6 @@ to use.
 
 1. Install the YubiHSM2 [SDK](https://developers.yubico.com/YubiHSM2/Releases/).
 
-   <Admonition type="warning">
-     The YubiHSM2 SDK version `2023.01` is currently unsupported.
-     The latest known supported version is `2022.06`.
-   </Admonition>
-
 2. Start `yubihsm-connector` with debug logging enabled. This is a background
    process that you will need to keep running to facilitate connections to your
    YubiHSM2.

--- a/go.mod
+++ b/go.mod
@@ -86,6 +86,7 @@ require (
 	github.com/mattn/go-sqlite3 v1.14.15
 	github.com/mdlayher/netlink v1.6.2
 	github.com/microsoft/go-mssqldb v0.0.0-00010101000000-000000000000 // replaced
+	github.com/miekg/pkcs11 v1.1.1
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/moby/term v0.0.0-20220808134915-39b0c02b01ae
 	github.com/pkg/sftp v1.13.5 // replaced
@@ -277,7 +278,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2 // indirect
 	github.com/mdlayher/socket v0.2.3 // indirect
-	github.com/miekg/pkcs11 v1.1.1 // indirect
 	github.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/moby/spdystream v0.2.0 // indirect

--- a/lib/auth/keystore/pkcs11.go
+++ b/lib/auth/keystore/pkcs11.go
@@ -20,11 +20,15 @@ import (
 	"context"
 	"crypto"
 	"crypto/rsa"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/ThalesIgnite/crypto11"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/miekg/pkcs11"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/constants"
@@ -59,9 +63,10 @@ func (cfg *PKCS11Config) CheckAndSetDefaults() error {
 }
 
 type pkcs11KeyStore struct {
-	ctx      *crypto11.Context
-	hostUUID string
-	log      logrus.FieldLogger
+	ctx       *crypto11.Context
+	hostUUID  string
+	log       logrus.FieldLogger
+	isYubiHSM bool
 }
 
 func newPKCS11KeyStore(config *PKCS11Config, logger logrus.FieldLogger) (*pkcs11KeyStore, error) {
@@ -71,53 +76,60 @@ func newPKCS11KeyStore(config *PKCS11Config, logger logrus.FieldLogger) (*pkcs11
 		SlotNumber: config.SlotNumber,
 		Pin:        config.Pin,
 	}
+
 	ctx, err := crypto11.Configure(cryptoConfig)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "configuring PKCS#11 library")
+	}
+
+	pkcs11Ctx := pkcs11.New(config.Path)
+	info, err := pkcs11Ctx.GetInfo()
+	if err != nil {
+		return nil, trace.Wrap(err, "getting PKCS#11 module info")
 	}
 
 	logger = logger.WithFields(logrus.Fields{trace.Component: "PKCS11KeyStore"})
 
 	return &pkcs11KeyStore{
-		ctx:      ctx,
-		hostUUID: config.HostUUID,
-		log:      logger,
+		ctx:       ctx,
+		hostUUID:  config.HostUUID,
+		log:       logger,
+		isYubiHSM: strings.HasPrefix(info.ManufacturerID, "Yubico"),
 	}, nil
 }
 
-func (p *pkcs11KeyStore) findUnusedID() (uuid.UUID, error) {
-	var id uuid.UUID
-	var err error
-
-	// Some HSMs (like YubiHSM2) will silently truncate the passed ID to as few
-	// as 2 bytes. There's not a great way to detect this and I don't want to
-	// limit the ID to 2 bytes on all systems, so for now we will generate a
-	// few random IDs and hope to avoid a collision. Ideally Teleport should be
-	// the only thing creating keys for this token and there should only be 10
-	// keys per HSM at a given time:
-	// 2(rotation phases) * (4(SSH and TLS for User and Host CA) + 1(JWT CA))
-	maxIterations := 16
-	iterations := 0
-	for ; iterations < maxIterations; iterations++ {
-		id, err = uuid.NewRandom()
+func (p *pkcs11KeyStore) findUnusedID() (keyID, error) {
+	if !p.isYubiHSM {
+		id, err := uuid.NewRandom()
 		if err != nil {
-			return id, trace.Wrap(err)
+			return keyID{}, trace.Wrap(err, "generating UUID")
 		}
-		existingSigner, err := p.ctx.FindKeyPair(id[:], []byte(p.hostUUID))
+		return keyID{
+			HostID: p.hostUUID,
+			KeyID:  id.String(),
+		}, nil
+	}
+
+	// YubiHSM2 only supports two byte CKA_ID values.
+	// ID 0 and 0xffff are reserved for internal objects by Yubico
+	// https://developers.yubico.com/YubiHSM2/Concepts/Object_ID.html
+	for id := uint16(1); id < 0xffff; id++ {
+		idBytes := []byte{byte((id >> 8) & 0xff), byte(id & 0xff)}
+		existingSigner, err := p.ctx.FindKeyPair(idBytes, []byte(p.hostUUID))
+		// FindKeyPair is expected to return nil, nil if the id is not found,
+		// any error is unexpected.
 		if err != nil {
-			return id, trace.Wrap(err)
+			return keyID{}, trace.Wrap(err)
 		}
 		if existingSigner == nil {
-			// failed to find an existing keypair, so this ID is unique
-			break
-		} else {
-			p.log.Warn("Found CKA_ID collision while creating keypair, retrying with new ID")
+			// There is no existing keypair with this ID
+			return keyID{
+				HostID: p.hostUUID,
+				KeyID:  fmt.Sprintf("%04x", id),
+			}, nil
 		}
 	}
-	if iterations == maxIterations {
-		return id, trace.AlreadyExists("failed to find unused CKA_ID for HSM")
-	}
-	return id, nil
+	return keyID{}, trace.AlreadyExists("failed to find unused CKA_ID for HSM")
 }
 
 // generateRSA creates a new RSA private key and returns its identifier and a
@@ -130,17 +142,16 @@ func (p *pkcs11KeyStore) generateRSA(ctx context.Context, options ...RSAKeyOptio
 		return nil, nil, trace.Wrap(err)
 	}
 
-	signer, err := p.ctx.GenerateRSAKeyPairWithLabel(id[:], []byte(p.hostUUID), constants.RSAKeySize)
+	ckaID, err := id.pkcs11Key(p.isYubiHSM)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-
-	key := keyID{
-		HostID: p.hostUUID,
-		KeyID:  id.String(),
+	signer, err := p.ctx.GenerateRSAKeyPairWithLabel(ckaID, []byte(p.hostUUID), constants.RSAKeySize)
+	if err != nil {
+		return nil, nil, trace.Wrap(err, "generating RSA key pair")
 	}
 
-	keyID, err := key.marshal()
+	keyID, err := id.marshal()
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -159,7 +170,7 @@ func (p *pkcs11KeyStore) getSigner(ctx context.Context, rawKey []byte) (crypto.S
 	if keyID.HostID != p.hostUUID {
 		return nil, trace.NotFound("given pkcs11 key is for host: %q, but this host is: %q", keyID.HostID, p.hostUUID)
 	}
-	pkcs11ID, err := keyID.pkcs11Key()
+	pkcs11ID, err := keyID.pkcs11Key(p.isYubiHSM)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -197,7 +208,7 @@ func (p *pkcs11KeyStore) deleteKey(_ context.Context, rawKey []byte) error {
 	if keyID.HostID != p.hostUUID {
 		return trace.NotFound("pkcs11 key is for different host")
 	}
-	pkcs11ID, err := keyID.pkcs11Key()
+	pkcs11ID, err := keyID.pkcs11Key(p.isYubiHSM)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -299,10 +310,23 @@ func (k keyID) marshal() ([]byte, error) {
 	return buf, nil
 }
 
-func (k keyID) pkcs11Key() ([]byte, error) {
+func (k keyID) pkcs11Key(isYubiHSM bool) ([]byte, error) {
+	// YubiHSM IDs are 16 bits, stored as a hex string. In older Teleport
+	// versions these keys were stored as normal UUIDs and the YubiHSM SDK
+	// silently truncated them to two bytes. The first two bytes of a UUID are
+	// still normal hex.
+	if isYubiHSM {
+		id, err := hex.DecodeString(k.KeyID[:4])
+		if err != nil {
+			return nil, trace.BadParameter("parsing key ID from hex: %v", err)
+		}
+		return id, nil
+	}
+	// All other IDs are UUIDs, stored in UUID string format, and the raw bytes
+	// are used as the CKA_ID for the HSM.
 	id, err := uuid.Parse(k.KeyID)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("parsing key ID as UUID: %v", err)
 	}
 	return id[:], nil
 }


### PR DESCRIPTION
Backport #25370 to branch/v11

YubiHSM2 only supports 16 bit CKA_IDs for keys, while most other HSMs support much longer IDs.
The Teleport HSM support implementation has always used UUIDs for CKA_IDs by default, and the YubiHSM2 PKCS#11 module has silently truncated them. We had a weird hack to avoid collisions, but otherwise everything has worked.

In Yubico's 2023.01 release of their PKCS#11 module, they added some apparent support for longer IDs through the use of "Meta Objects" stored as `opaque-data` objects on the device.

https://developers.yubico.com/YubiHSM2/Component_Reference/PKCS_11/index.html

> Meta Objects are created as needed when the function to create an
  object is called with CKA_ID and/or CKA_LABEL values that are longer
  than 2 and 40 bytes respectively

The problem with this change is that the Authentication Key we recommend users to create in our docs does not have the necessary Capabilities to create or read `opaque-data` objects, so key creation and lookup fails.

The change in this commit detects Yubico HSMs (YubiHSM2 is the only one currently supported) and truncates CKA_ID values to two bytes, to avoid the Meta Objects altogether.

If you originally create the Authentication Key with the necessary Capabilities to read/write `opaque-data` objects then everything works without this change, but existing customers would be forced to do a tricky migration, so I opted to avoid that path.