### PR TITLE
TLS Routing behind ALB support for IP Pinning

### DIFF
--- a/api/client/contextdialer.go
+++ b/api/client/contextdialer.go
@@ -172,6 +172,12 @@ func NewDialer(ctx context.Context, keepAlivePeriod, dialTimeout time.Duration, 
 		// Base direct dialer.
 		var dialer ContextDialer = netDialer
 
+		// TODO currently there is no use case where both cfg.proxyHeaderGetter
+		// and cfg.alpnConnUpgradeRequired are set.
+		if cfg.proxyHeaderGetter != nil && cfg.alpnConnUpgradeRequired {
+			return nil, trace.NotImplemented("ALPN connection upgrade does not support multiplexer header")
+		}
+
 		// Wrap with PROXY header dialer if getter is present.
 		// Used by Proxy's web server to propagate real client IP when making calls on behalf of connected clients
 		if cfg.proxyHeaderGetter != nil {

--- a/lib/multiplexer/wrappers.go
+++ b/lib/multiplexer/wrappers.go
@@ -104,6 +104,11 @@ func (c *Conn) ReadProxyLine() (*ProxyLine, error) {
 	return proxyLine, nil
 }
 
+// HasProxyLine returns true if Conn has a valid proxy line.
+func (c *Conn) HasProxyLine() bool {
+	return c.proxyLine != nil
+}
+
 // returns a Listener that pretends to be listening on addr, closed whenever the
 // parent context is done.
 func newListener(parent context.Context, addr net.Addr) *Listener {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3788,9 +3788,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
 				ConnState:         ingress.HTTPConnStateReporter(ingress.Web, ingressReporter),
-				ConnContext: func(ctx context.Context, c net.Conn) context.Context {
-					return utils.ClientAddrContext(ctx, c.RemoteAddr(), c.LocalAddr())
-				},
+				ConnContext:       web.ConnContextForWebServer,
 			},
 			Handler: webHandler,
 			Log:     log,

--- a/lib/services/process.go
+++ b/lib/services/process.go
@@ -16,29 +16,33 @@ limitations under the License.
 
 package services
 
-import "context"
+import (
+	"context"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
 
 // ProcessReloadContext adds a flag to the context to indicate the Teleport
 // process is reloading.
 func ProcessReloadContext(parent context.Context) context.Context {
-	return addFlagToContext[processReloadFlag](parent)
+	return utils.AddFlagToContext[processReloadFlag](parent)
 }
 
 // IsProcessReloading returns true if the Teleport process is reloading.
 func IsProcessReloading(ctx context.Context) bool {
-	return getFlagFromContext[processReloadFlag](ctx)
+	return utils.GetFlagFromContext[processReloadFlag](ctx)
 }
 
 // ProcessForkedContext adds a flag to the context to indicate the Teleport
 // process has running forked child(ren).
 func ProcessForkedContext(parent context.Context) context.Context {
-	return addFlagToContext[processForkedFlag](parent)
+	return utils.AddFlagToContext[processForkedFlag](parent)
 }
 
 // HasProcessForked returns true if the Teleport process has running forked
 // child(ren).
 func HasProcessForked(ctx context.Context) bool {
-	return getFlagFromContext[processForkedFlag](ctx)
+	return utils.GetFlagFromContext[processForkedFlag](ctx)
 }
 
 // ShouldDeleteServerHeartbeatsOnShutdown checks whether server heartbeats
@@ -60,14 +64,6 @@ func ShouldDeleteServerHeartbeatsOnShutdown(ctx context.Context) bool {
 	default:
 		return true
 	}
-}
-
-func addFlagToContext[FlagType any](parent context.Context) context.Context {
-	return context.WithValue(parent, (*FlagType)(nil), (*FlagType)(nil))
-}
-func getFlagFromContext[FlagType any](ctx context.Context) bool {
-	_, ok := ctx.Value((*FlagType)(nil)).(*FlagType)
-	return ok
 }
 
 type processReloadFlag struct{}

--- a/lib/utils/context.go
+++ b/lib/utils/context.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "context"
+
+// AddFlagToContext is a generic helper to enable a struct flag type to the
+// provided context.
+func AddFlagToContext[FlagType any](parent context.Context) context.Context {
+	return context.WithValue(parent, (*FlagType)(nil), (*FlagType)(nil))
+}
+
+// GetFlagFromContext is a generic helper that returns true if provided struct
+// flag type is set.
+func GetFlagFromContext[FlagType any](ctx context.Context) bool {
+	_, ok := ctx.Value((*FlagType)(nil)).(*FlagType)
+	return ok
+}

--- a/lib/utils/example_test.go
+++ b/lib/utils/example_test.go
@@ -1,0 +1,35 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func ExampleGetFlagFromContext() {
+	type flag1 struct{}
+	type flag2 struct{}
+
+	ctx := utils.AddFlagToContext[flag1](context.Background())
+
+	fmt.Println(utils.GetFlagFromContext[flag1](ctx))
+	fmt.Println(utils.GetFlagFromContext[flag2](ctx))
+	// Output:
+	// true
+	// false
+}

--- a/lib/utils/net.go
+++ b/lib/utils/net.go
@@ -41,6 +41,11 @@ func ClientAddrContext(ctx context.Context, src net.Addr, dst net.Addr) context.
 	return context.WithValue(ctx, ClientDstAddrContextKey, dst)
 }
 
+// ClientSrcAddrContext sets client source address.
+func ClientSrcAddrContext(ctx context.Context, src net.Addr) context.Context {
+	return context.WithValue(ctx, ClientSrcAddrContextKey, src)
+}
+
 // ClientAddrFromContext gets client source address and destination addresses from the context. If an address is
 // not present, nil will be returned
 func ClientAddrFromContext(ctx context.Context) (src net.Addr, dst net.Addr) {

--- a/lib/web/addr.go
+++ b/lib/web/addr.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package web
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// xForwardedForHeader is a de-facto standard header for identifying the
+	// originating IP address of a client connecting to a web server through a
+	// proxy server.
+	xForwardedForHeader = "X-Forwarded-For"
+)
+
+// maybeUpdateClientSrcAddr overwrites client source address if X-Forwarded-For
+// is set.
+//
+// Both hijacked conn and request context are updated. The hijacked conn can be
+// used for ALPN connection upgrades or Websocket connections.
+func maybeUpdateClientSrcAddr(w http.ResponseWriter, r *http.Request) (http.ResponseWriter, *http.Request) {
+	// multiplexer handles extracting real client IP using PROXY protocol where
+	// available, so we can omit checking X-Forwarded-For.
+	if hasClientAddrFromMultiplexer(r.Context()) {
+		return w, r
+	}
+
+	// Use X-Forwarded-for if set.
+	xForwardedFor := r.Header.Get(xForwardedForHeader)
+	if xForwardedFor == "" {
+		return w, r
+	}
+
+	forwardedAddr, err := getForwardedAddr(r.RemoteAddr, xForwardedFor)
+	if err != nil {
+		logrus.Debugf("Invalid X-Forwarded-For %q: %v.", xForwardedFor, err)
+		return w, r
+	}
+
+	return responseWriterWithClientSrcAddr(w, forwardedAddr),
+		requestWithClientSrcAddr(r, forwardedAddr)
+}
+
+// getForwardedAddr returns a net.Addr from provided value of X-Forwarded-For.
+//
+// MDN reference:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+//
+// AWS ALB reference:
+// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
+func getForwardedAddr(observeredAddr, forwardedAddr string) (net.Addr, error) {
+	// In case multiple IPs are appended to X-Forwarded-For, use the first one.
+	forwardedAddr, _, _ = strings.Cut(forwardedAddr, ",")
+
+	// If forwardedAddr has a port.
+	if ipAddrPort, err := netip.ParseAddrPort(forwardedAddr); err == nil {
+		return net.TCPAddrFromAddrPort(ipAddrPort), nil
+	}
+
+	// If forwardedAddr does not have a port, use port from observeredAddr.
+	ipAddr, err := netip.ParseAddr(forwardedAddr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var port int
+	if parsed, err := utils.ParseAddr(observeredAddr); err == nil {
+		port = parsed.Port(port)
+	}
+
+	return net.TCPAddrFromAddrPort(netip.AddrPortFrom(ipAddr, uint16(port))), nil
+}
+
+func requestWithClientSrcAddr(r *http.Request, clientSrcAddr net.Addr) *http.Request {
+	ctx := utils.ClientSrcAddrContext(r.Context(), clientSrcAddr)
+	r = r.WithContext(ctx)
+	r.RemoteAddr = clientSrcAddr.String()
+	return r
+}
+
+func responseWriterWithClientSrcAddr(w http.ResponseWriter, clientSrcAddr net.Addr) http.ResponseWriter {
+	// Returns the original ResponseWriter if not a http.Hijacker.
+	_, ok := w.(http.Hijacker)
+	if !ok {
+		logrus.Debug("Provided ResponseWriter is not a hijacker.")
+		return w
+	}
+
+	return &responseWriterWithRemoteAddr{
+		ResponseWriter: w,
+		remoteAddr:     clientSrcAddr,
+	}
+}
+
+// responseWriterWithRemoteAddr is a wrapper of provided http.ResponseWriter
+// and overwrrides Hijacker interface to return a net.Conn with provided
+// remoteAddr.
+type responseWriterWithRemoteAddr struct {
+	http.ResponseWriter
+	remoteAddr net.Addr
+}
+
+// Hijack returns a net.Conn with provided remoteAddr.
+func (r *responseWriterWithRemoteAddr) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	conn, buffer, err := r.ResponseWriter.(http.Hijacker).Hijack()
+	if err != nil {
+		return conn, buffer, trace.Wrap(err)
+	}
+
+	conn = &connWithRemoteAddr{
+		Conn:       conn,
+		remoteAddr: r.remoteAddr,
+	}
+	return conn, buffer, nil
+}
+
+// connWithRemoteAddr is a net.Conn that overwrites RemoteAddr of the original
+// net.Conn.
+type connWithRemoteAddr struct {
+	net.Conn
+	remoteAddr net.Addr
+}
+
+// RemoteAddr returns the provided remoteAddr.
+func (c *connWithRemoteAddr) RemoteAddr() net.Addr {
+	return c.remoteAddr
+}

--- a/lib/web/addr_test.go
+++ b/lib/web/addr_test.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package web
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestMaybeUpdateClientSrvAddr(t *testing.T) {
+	t.Parallel()
+
+	observeredAddr := utils.MustParseAddr("11.22.33.44:1234")
+	xForwardedAddr := utils.MustParseAddr("55.66.77.88:5678")
+
+	// Setup response writer with observeredAddr.
+	fakeConn, _ := net.Pipe()
+	rw := &responseWriterWithRemoteAddr{
+		ResponseWriter: newResponseWriterHijacker(nil, fakeConn),
+		remoteAddr:     observeredAddr,
+	}
+
+	// Setup request with observeredAddr.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(utils.ClientSrcAddrContext(req.Context(), observeredAddr))
+	req.RemoteAddr = observeredAddr.String()
+
+	// Setup other requests for testing.
+	reqWithXForwardedFor := req.Clone(req.Context())
+	reqWithXForwardedFor.Header.Set("X-Forwarded-For", xForwardedAddr.String())
+
+	reqWithClientAddrFromMultiplexer := reqWithXForwardedFor.WithContext(
+		utils.AddFlagToContext[clientAddrFromMultiplexer](req.Context()),
+	)
+
+	tests := []struct {
+		name           string
+		inputRW        http.ResponseWriter
+		inputReq       *http.Request
+		wantRemoteAddr string
+	}{
+		{
+			name:           "no X-Forwarded-For header",
+			inputRW:        rw,
+			inputReq:       req,
+			wantRemoteAddr: observeredAddr.String(),
+		},
+		{
+			name:           "using X-Forwarded-For header",
+			inputRW:        rw,
+			inputReq:       reqWithXForwardedFor,
+			wantRemoteAddr: xForwardedAddr.String(),
+		},
+		{
+			name:           "addresses from multiplexer",
+			inputRW:        rw,
+			inputReq:       reqWithClientAddrFromMultiplexer,
+			wantRemoteAddr: observeredAddr.String(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			outputRW, outputReq := maybeUpdateClientSrcAddr(test.inputRW, test.inputReq)
+
+			// Verify hijacked conn.
+			hj, ok := outputRW.(http.Hijacker)
+			require.True(t, ok)
+			outputConn, _, err := hj.Hijack()
+			require.NoError(t, err)
+			require.Equal(t, test.wantRemoteAddr, outputConn.RemoteAddr().String())
+
+			// Verify request.
+			require.Equal(t, test.wantRemoteAddr, outputReq.RemoteAddr)
+
+			// Verify request context.
+			clientSrcAddr, _ := utils.ClientAddrFromContext(outputReq.Context())
+			require.Equal(t, test.wantRemoteAddr, clientSrcAddr.String())
+		})
+	}
+
+}
+
+func TestGetForwardedAddr(t *testing.T) {
+	t.Parallel()
+
+	inputObserveredAddr := "1.2.3.4:12345"
+	tests := []struct {
+		name               string
+		inputForwardedAddr string
+		wantAddr           string
+		wantError          bool
+	}{
+		{
+			name:               "empty X-Forwarded-For",
+			inputForwardedAddr: "",
+			wantError:          true,
+		},
+		{
+			name:               "invalid X-Forwarded-For",
+			inputForwardedAddr: "not-an-ip",
+			wantError:          true,
+		},
+		{
+			name:               "ipv4",
+			inputForwardedAddr: "3.4.5.6",
+			wantAddr:           "3.4.5.6:12345",
+		},
+		{
+			name:               "ipv4 with port",
+			inputForwardedAddr: "3.4.5.6:22222",
+			wantAddr:           "3.4.5.6:22222",
+		},
+		{
+			name:               "ipv6",
+			inputForwardedAddr: "2001:db8::21f:5bff:febf:ce22:8a2e",
+			wantAddr:           "[2001:db8:0:21f:5bff:febf:ce22:8a2e]:12345",
+		},
+		{
+			name:               "ipv6 with port",
+			inputForwardedAddr: "[2001:db8::21f:5bff:febf:ce22:8a2e]:22222",
+			wantAddr:           "[2001:db8:0:21f:5bff:febf:ce22:8a2e]:22222",
+		},
+		{
+			name:               "multiple",
+			inputForwardedAddr: "3.4.5.6, 7.8.9.10, 11.12.13.14",
+			wantAddr:           "3.4.5.6:12345",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualAddr, err := getForwardedAddr(inputObserveredAddr, test.inputForwardedAddr)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.wantAddr, actualAddr.String())
+			}
+		})
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -254,11 +254,12 @@ type ConnectionHandler func(ctx context.Context, conn net.Conn) error
 // Check if this request should be forwarded to an application handler to
 // be handled by the UI and handle the request appropriately.
 func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w, r = maybeUpdateClientSrcAddr(w, r)
+
 	// If the request is either to the fragment authentication endpoint or if the
 	// request has a session cookie or a client cert, forward to
 	// application handlers. If the request is requesting a
 	// FQDN that is not of the proxy, redirect to application launcher.
-
 	if h.appHandler != nil && (app.HasFragment(r) || app.HasSession(r) || app.HasClientCert(r)) {
 		h.appHandler.ServeHTTP(w, r)
 		return
@@ -1877,8 +1878,6 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 }
 
 func clientMetaFromReq(r *http.Request) *auth.ForwardedClientMetadata {
-	// multiplexer handles extracting real client IP using PROXY protocol where
-	// available, so we can omit checking X-Forwarded-For.
 	return &auth.ForwardedClientMetadata{
 		UserAgent:  r.UserAgent(),
 		RemoteAddr: r.RemoteAddr,

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/utils/pingconn"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 func TestWriteUpgradeResponse(t *testing.T) {
@@ -53,11 +54,17 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 	t.Parallel()
 
 	expectedPayload := "hello@"
+	expectedIP := "1.2.3.4"
 	alpnHandler := func(_ context.Context, conn net.Conn) error {
 		// Handles connection asynchronously to verify web handler waits until
 		// connection is closed.
 		go func() {
 			defer conn.Close()
+
+			clientIP, err := utils.ClientIPFromConn(conn)
+			require.NoError(t, err)
+			require.Equal(t, expectedIP, clientIP)
+
 			n, err := conn.Write([]byte(expectedPayload))
 			require.NoError(t, err)
 			require.Equal(t, len(expectedPayload), n)
@@ -89,7 +96,7 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 		defer serverConn.Close()
 		defer clientConn.Close()
 
-		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPN, serverConn, clientConn)
+		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPN, serverConn, clientConn, expectedIP)
 
 		// Verify clientConn receives data sent by Config.ALPNHandler.
 		receive, err := bufio.NewReader(clientConn).ReadString(byte('@'))
@@ -102,7 +109,7 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 		defer serverConn.Close()
 		defer clientConn.Close()
 
-		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPNPing, serverConn, clientConn)
+		sendConnUpgradeRequest(t, h, constants.WebAPIConnUpgradeTypeALPNPing, serverConn, clientConn, expectedIP)
 
 		// Verify ping-wrapped clientConn receives data sent by Config.ALPNHandler.
 		receive, err := bufio.NewReader(pingconn.New(clientConn)).ReadString(byte('@'))
@@ -111,16 +118,19 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 	})
 }
 
-func sendConnUpgradeRequest(t *testing.T, h *Handler, upgradeType string, serverConn, clientConn net.Conn) {
+func sendConnUpgradeRequest(t *testing.T, h *Handler, upgradeType string, serverConn, clientConn net.Conn, xForwardedFor string) {
 	t.Helper()
 
 	r, err := http.NewRequest("GET", "http://localhost/webapi/connectionupgrade", nil)
 	require.NoError(t, err)
 	r.Header.Add("Upgrade", upgradeType)
+	r.Header.Add("X-Forwarded-For", xForwardedFor)
+
+	// serverConn will be hijacked.
+	w := newResponseWriterHijacker(nil, serverConn)
+	w, r = maybeUpdateClientSrcAddr(w, r)
 
 	go func() {
-		// serverConn will be hijacked.
-		w := newResponseWriterHijacker(nil, serverConn)
 		_, err := h.connectionUpgrade(w, r, nil)
 		require.NoError(t, err)
 	}()
@@ -145,7 +155,7 @@ type responseWriterHijacker struct {
 	conn net.Conn
 }
 
-func newResponseWriterHijacker(w http.ResponseWriter, conn net.Conn) *responseWriterHijacker {
+func newResponseWriterHijacker(w http.ResponseWriter, conn net.Conn) http.ResponseWriter {
 	if w == nil {
 		w = httptest.NewRecorder()
 	}
@@ -155,6 +165,6 @@ func newResponseWriterHijacker(w http.ResponseWriter, conn net.Conn) *responseWr
 	}
 }
 
-func (h responseWriterHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+func (h *responseWriterHijacker) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	return h.conn, nil, nil
 }

--- a/lib/web/context.go
+++ b/lib/web/context.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package web
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// ConnContextForWebServer implements the http.Server.ConnContext when creating
+// the web server.
+func ConnContextForWebServer(ctx context.Context, conn net.Conn) context.Context {
+	// Set connection addresses.
+	ctx = utils.ClientAddrContext(ctx, conn.RemoteAddr(), conn.LocalAddr())
+
+	// Set a flag on whether the addresses come from the multiplexer.
+	ctx = withClientAddrFromMultiplexer(ctx, conn)
+	return ctx
+}
+
+func withClientAddrFromMultiplexer(ctx context.Context, conn net.Conn) context.Context {
+	if tlsConn, ok := conn.(*tls.Conn); ok {
+		conn = tlsConn.NetConn()
+	}
+
+	multiplexConn, ok := conn.(*multiplexer.Conn)
+	if ok && multiplexConn.HasProxyLine() {
+		return utils.AddFlagToContext[clientAddrFromMultiplexer](ctx)
+	}
+	return ctx
+}
+func hasClientAddrFromMultiplexer(ctx context.Context) bool {
+	return utils.GetFlagFromContext[clientAddrFromMultiplexer](ctx)
+}
+
+type clientAddrFromMultiplexer struct{}


### PR DESCRIPTION
Implements #24711

Related #21870

Changes:
- Use client source address from `X-Forwarded-For`