### PR TITLE
[docs] Fix application resource headers rewrite spec

### DIFF
--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -93,8 +93,10 @@ spec:
     - "grafana.internal.dev"
     # Headers passthrough configuration.
     headers:
-    - "X-Custom-Header: example"
-    - "X-External-Trait: {{external.env}}"
+    - name: "X-Custom-Header"
+      value: "example"
+    - name: "X-External-Trait"
+      value: "{{external.env}}"
   # Optional dynamic labels.
   dynamic_labels:
   - name: "hostname"


### PR DESCRIPTION
The application resource spec [here](https://goteleport.com/docs/application-access/reference/#application-resource) incorrectly says that headers rewrite section accepts a list of strings while it actually accepts a list of key/value pairs.
