### PR TITLE
provide starting message for tar ball install

### DIFF
--- a/build.assets/install
+++ b/build.assets/install
@@ -11,6 +11,7 @@ BINDIR=/usr/local/bin
 VARDIR=/var/lib/teleport
 
 [ ! $(id -u) != "0" ] || { echo "ERROR: You must be root"; exit 1; }
+echo "Starting Teleport installation..."
 cd $(dirname $0)
 mkdir -p $VARDIR $BINDIR
 cp -f teleport tctl tsh tbot $BINDIR/ || exit 1


### PR DESCRIPTION
On small machines like `t2.nano` the user may not see any output for 20-30 seconds after starting `install`.  This gives a starting message while it's doing the copying.

New output with first line.

```bash
Starting Teleport installation...
Teleport binaries have been copied to /usr/local/bin

Thanks for installing Teleport.

Is it OK if we collect some info about your install?
Please run this command to send in a survey.
Optional: Replace email to join our newsletter and get a swag package.
$ curl -X POST https://usage.teleport.dev -F OS=linux -F use-case="access my ..." -F email="alice@example.com"

Otherwise, ignore
```