### PR TITLE
Provide client address information in transport request

### DIFF
--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -552,20 +552,21 @@ func (p *AgentPool) getVersion(ctx context.Context) (string, error) {
 // transport creates a new transport instance.
 func (p *AgentPool) transport(ctx context.Context, channel ssh.Channel, requests <-chan *ssh.Request, conn sshutils.Conn) *transport {
 	return &transport{
-		closeContext:        ctx,
-		component:           p.Component,
-		localClusterName:    p.LocalCluster,
-		kubeDialAddr:        p.KubeDialAddr,
-		authClient:          p.Client,
-		reverseTunnelServer: p.ReverseTunnelServer,
-		server:              p.Server,
-		emitter:             p.Client,
-		sconn:               conn,
-		channel:             channel,
-		requestCh:           requests,
-		log:                 p.log,
-		authServers:         p.LocalAuthAddresses,
-		proxySigner:         p.PROXYSigner,
+		closeContext:         ctx,
+		component:            p.Component,
+		localClusterName:     p.LocalCluster,
+		kubeDialAddr:         p.KubeDialAddr,
+		authClient:           p.Client,
+		reverseTunnelServer:  p.ReverseTunnelServer,
+		server:               p.Server,
+		emitter:              p.Client,
+		sconn:                conn,
+		channel:              channel,
+		requestCh:            requests,
+		log:                  p.log,
+		authServers:          p.LocalAuthAddresses,
+		proxySigner:          p.PROXYSigner,
+		forwardClientAddress: true,
 	}
 }
 

--- a/lib/reversetunnel/srv.go
+++ b/lib/reversetunnel/srv.go
@@ -688,6 +688,7 @@ func (s *server) handleTransport(sconn *ssh.ServerConn, nch ssh.NewChannel) {
 		localClusterName: s.ClusterName,
 		emitter:          s.Emitter,
 		proxySigner:      s.proxySigner,
+		sconn:            sconn,
 	}
 	go t.start()
 }


### PR DESCRIPTION
If client address information is missing in dial request, we take it from the parent ssh connection, otherwise we end up with localhost/Proxy address as client source address. It's needed for correctly propagating IP information of users connecting to auth server through proxy tunnel listener (fx command `tctl status` etc). 