### PR TITLE
Makefile: cache `go env` values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,12 @@ else
 BUILDFLAGS ?= $(ADDFLAGS) -ldflags '-w -s' -trimpath
 endif
 
-OS ?= $(shell go env GOOS)
-ARCH ?= $(shell go env GOARCH)
+GO_ENV_OS := $(shell go env GOOS)
+OS ?= $(GO_ENV_OS)
+
+GO_ENV_ARCH := $(shell go env GOARCH)
+ARCH ?= $(GO_ENV_ARCH)
+
 FIPS ?=
 RELEASE = teleport-$(GITTAG)-$(OS)-$(ARCH)-bin
 


### PR DESCRIPTION
Spawning shells is expensive for Makefile targets.
We use the `OS` and `ARCH` variables in a lot of places.
They come from spawning a subshell and then executing `go env GOOS` or `go env GOARCH`.

So, everytime we need them, we spawn a subshell.
Just parsing the Makefile adds quite some time, even if the target itself is fast.

This PR caches those values, so that we only need to spawn a subshell once per execution.

Tests show that running `make print-version` is now much faster:
Using linux: drop from 56s to 0.240s
Using MacOS M1: drop from 291ms to 119ms
YMMV