### PR TITLE
Document how to open a local terminal in Teleport Connect

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -61,6 +61,9 @@ The top bar of Teleport Connect consists of:
 - The **additional actions menu** (to the left of the profile selector), containing options such as
   opening a config file or creating an access request in an Enterprise cluster.
 
+The **status bar** at the bottom displays **cluster breadcrumbs** in the bottom left, indicating
+which cluster the current tab is bound to, and the **Share Feedback** button in the bottom right.
+
 ## Connecting to an SSH server
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -71,6 +71,20 @@ The top bar of Teleport Connect consists of:
 
 Alternatively, you can look for the server in the search bar and press `Enter` to connect to it.
 
+## Opening a local terminal
+
+To open a terminal with a local shell session, either select "Open new terminal" from the additional
+actions menu or press `Ctrl/Cmd + Shift + T`.
+
+Any tsh command executed within the tab targets the current cluster. Teleport Connect accomplishes
+this by setting the environment variables `TELEPORT_PROXY` and `TELEPORT_CLUSTER` for the session.
+Additionally, Teleport Connect prepends the `PATH`/`Path` environment variable in the session with the
+directory containing the tsh binary, even if [tsh is not globally available](#using-tsh-outside-of-teleport-connect).
+
+When using [Trusted Clusters](../management/admin/trustedclusters.mdx), the cluster selector allows
+you to determine which cluster the shell session will be bound to. The selected cluster will be
+reflected in both the tab title and the status bar.
+
 ## Connecting to a Kubernetes cluster
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -67,7 +67,7 @@ which cluster the current tab is bound to, and the **Share Feedback** button in 
 ## Connecting to an SSH server
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
-   You can also press `Ctrl/Cmd + T` to achieve the same result.
+   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
 2. Look for the SSH server you want to connect to and click the Connect button to the right.
 3. Select or enter the SSH user you wish to log in as and press `Enter`.
 4. A new tab will open with a shell session on the chosen server.
@@ -77,7 +77,7 @@ Alternatively, you can look for the server in the search bar and press `Enter` t
 ## Opening a local terminal
 
 To open a terminal with a local shell session, either select "Open new terminal" from the additional
-actions menu or press `Ctrl/Cmd + Shift + T`.
+actions menu or press <span style="white-space: nowrap;">`Ctrl/Cmd + Shift + T`</span>.
 
 Any tsh command executed within the tab targets the current cluster. Teleport Connect accomplishes
 this by setting the environment variables `TELEPORT_PROXY` and `TELEPORT_CLUSTER` for the session.
@@ -91,7 +91,7 @@ reflected in both the tab title and the status bar.
 ## Connecting to a Kubernetes cluster
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
-   You can also press `Ctrl/Cmd + T` to achieve the same result.
+   You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
 2. Select the Kubes section.
 3. Look for the cluster you wish to connect to and click the Connect button to the right.
 4. A new local terminal tab will open which is preconfigured with the `$KUBECONFIG` environment variable
@@ -104,7 +104,7 @@ Alternatively, you can look for the cluster in the search bar and press `Enter` 
 ## Connecting to a database
 
 1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
-  can also press `Ctrl/Cmd + T` to achieve the same result.
+  can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
 2. Select the Databases section.
 3. Look for the database server you wish to connect to and click the Connect button to the right.
 4. Select or enter the database user you with to use and press `Enter`.
@@ -134,7 +134,7 @@ your first cluster, open the profile selector at the top right and click the *+A
 button. You can switch between active profiles in multiple ways:
 
 - Click at the profile selector button at the top right.
-- Open the profile selector with a shortcut (`Ctrl/Cmd + I`).
+- Open the profile selector with a shortcut (<span style="white-space: nowrap;">`Ctrl/Cmd + I`</span>).
 - Using the connection list at the top left to select a connection will automatically switch you to
   the right profile.
 
@@ -220,7 +220,7 @@ Below is the list of the supported config properties.
 
 ### Configuring keyboard shortcuts
 
-A valid shortcut contains at least one modifier and a single key code, for example `Shift+Tab`.
+A valid shortcut contains at least one modifier and a single key code, for example <span style="white-space: nowrap;">`Shift+Tab`</span>.
 Function keys such as `F1` do not require a modifier.
 Modifiers and a key code must be combined by the `+` character.
 


### PR DESCRIPTION
v13 removes the big command bar in the center of the top bar and replaces it with the search bar. Connect still supports opening new local terminal tabs but it's no longer as plain as "Use the command bar at the top which says _Enter a command and press enter_".

The backports to v11 and v12 will only document the status bar since the search bar is not available in those versions.