### PR TITLE
Install Node Script: respect version variable

### DIFF
--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -931,12 +931,12 @@ func TestJoinScript(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Contains(t, script, ""+
-				"    PACKAGE_LIST=${TELEPORT_PACKAGE_NAME}\n"+
+				"    PACKAGE_LIST=${TELEPORT_PACKAGE_PIN_VERSION}\n"+
 				"    # (warning): This expression is constant. Did you forget the $ on a variable?\n"+
 				"    # Disabling the warning above because expression is templated.\n"+
 				"    # shellcheck disable=SC2050\n"+
 				"    if [[ \"true\" == \"true\" ]]; then\n"+
-				"        PACKAGE_LIST=\"${PACKAGE_LIST} ${TELEPORT_PACKAGE_NAME}-updater\"\n"+
+				"        PACKAGE_LIST+=\" ${TELEPORT_UPDATER_PIN_VERSION}\"\n"+
 				"    fi\n",
 			)
 		})
@@ -945,12 +945,12 @@ func TestJoinScript(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Contains(t, script, ""+
-				"    PACKAGE_LIST=${TELEPORT_PACKAGE_NAME}\n"+
+				"    PACKAGE_LIST=${TELEPORT_PACKAGE_PIN_VERSION}\n"+
 				"    # (warning): This expression is constant. Did you forget the $ on a variable?\n"+
 				"    # Disabling the warning above because expression is templated.\n"+
 				"    # shellcheck disable=SC2050\n"+
 				"    if [[ \"false\" == \"true\" ]]; then\n"+
-				"        PACKAGE_LIST=\"${PACKAGE_LIST} ${TELEPORT_PACKAGE_NAME}-updater\"\n"+
+				"        PACKAGE_LIST+=\" ${TELEPORT_UPDATER_PIN_VERSION}\"\n"+
 				"    fi\n",
 			)
 		})


### PR DESCRIPTION
We were always installing the latest version available even if the requested version was different

This PR changes the installation command and the version is now pinned to the one received in the `TELEPORT_VERSION` variable.

Tested on a APT and YUM repo:
```
root@tmpubuntu2204:/# curl -fsSL -k https://127.0.0.1.nip.io:3080/scripts/b51fb867634d61aa975d04b885d2e353/install-node.sh > install-node.sh
root@tmpubuntu2204:/# grep 14 install-node.sh 
TELEPORT_VERSION='14.0.0-dev'
root@tmpubuntu2204:/# bash install-node.sh -v 13.0.0       
2023-05-09 12:53:35 UTC [teleport-installer] TELEPORT_VERSION: 13.0.0
...
root@tmpubuntu2204:/# apt show teleport
Package: teleport
Version: 13.0.0
Priority: extra
Section: default
Maintainer: info@goteleport.com
Installed-Size: 436 MB
Provides: teleport
Homepage: https://goteleport.com/docs
License: Apache-2.0
Vendor: Gravitational
Download-Size: 126 MB
APT-Manual-Installed: yes
APT-Sources: https://apt.releases.teleport.dev/ubuntu jammy/stable/v13 amd64 Packages
Description: Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API [64-bit x86 Open source edition]

root@tmpubuntu2204:/#
```
```
[root@tmpcentos7 /]# curl -fsSL -k https://127.0.0.1.nip.io:3080/scripts/b51fb867634d61aa975d04b885d2e353/install-node.sh > install-node.sh
[root@tmpcentos7 /]# grep 14 install-node.sh 
TELEPORT_VERSION='14.0.0-dev'
[root@tmpcentos7 /]# bash install-node.sh -v 13.0.0    
2023-05-09 12:55:31 UTC [teleport-installer] TELEPORT_VERSION: 13.0.0
...
root@tmpcentos7 /]# yum info teleport
Loaded plugins: fastestmirror, ovl
Loading mirror speeds from cached hostfile
 * base: mirrors.up.pt
 * extras: mirrors.up.pt
 * updates: mirrors.up.pt
Installed Packages
Name        : teleport
Arch        : x86_64
Version     : 13.0.0
Release     : 1
Size        : 416 M
Repo        : installed
From repo   : teleport
Summary     : Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API [64-bit x86 Open source
            : edition]
URL         : https://goteleport.com/docs
License     : Apache-2.0
Description : Teleport is a gateway for managing access to clusters of Linux servers via SSH or the Kubernetes API [64-bit x86 Open source
            : edition]

[root@tmpcentos7 /]# 
```

Fixes https://github.com/gravitational/teleport/issues/25867