### PR TITLE
Assist UI light theme fixes

### DIFF
--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/Action.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/Action.tsx
@@ -148,6 +148,8 @@ function actionStateToItems(formState: ActionState[]) {
 export function Action(props: ActionProps) {
   const [editing, setEditing] = useState(false);
 
+  const theme = useTheme();
+
   const handleSave = useCallback(
     (state: ActionState[]) => {
       props.onStateUpdate(state);
@@ -173,7 +175,10 @@ export function Action(props: ActionProps) {
       {!editing && (
         <Buttons>
           <EditButton onClick={() => setEditing(true)}>
-            <EditIcon size={18} />
+            <EditIcon
+              size={18}
+              fill={theme.name === 'light' ? 'black' : 'white'}
+            />
           </EditButton>
         </Buttons>
       )}
@@ -287,7 +292,10 @@ export function NodesAndLabels(props: NodesAndLabelsProps) {
       {!editing && !props.disabled && (
         <Buttons>
           <EditButton onClick={() => setEditing(true)}>
-            <EditIcon size={18} />
+            <EditIcon
+              size={18}
+              fill={theme.name === 'light' ? 'black' : 'white'}
+            />
           </EditButton>
         </Buttons>
       )}
@@ -343,7 +351,10 @@ export function Command(props: CommandProps) {
       {!editing && !props.disabled && (
         <Buttons>
           <EditButton onClick={() => setEditing(true)}>
-            <EditIcon size={18} />
+            <EditIcon
+              size={18}
+              fill={theme.name === 'light' ? 'black' : 'white'}
+            />
           </EditButton>
         </Buttons>
       )}

--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/ActionForm.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/ActionForm.tsx
@@ -15,7 +15,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 
 import { UserIcon } from 'design/SVGIcon';
 import { Cross } from 'design/Icon';
@@ -36,7 +36,7 @@ interface ActionFormProps {
 
 const CommandInput = styled.input`
   padding: 10px 15px;
-  background: rgba(255, 255, 255, 0.1);
+  background: ${p => p.theme.colors.spotBackground[0]};
   border-radius: 5px;
   font-size: 16px;
   font-family: SFMono-Regular, Consolas, Liberation Mono, Menlo, Courier,
@@ -62,24 +62,29 @@ const CancelButton = styled.div`
   margin-right: 10px;
 
   &:hover {
-    background: rgba(255, 255, 255, 0.1);
+    background: ${p => p.theme.colors.spotBackground[0]};
   }
 `;
 
 const SaveButton = styled.div`
   margin-top: 10px;
-  background: #5130c9;
+  background: ${p => p.theme.colors.buttons.primary.default};
   font-weight: bold;
+  color: ${p => p.theme.colors.buttons.primary.text};
   border-radius: 5px;
   padding: 5px 15px;
   display: inline-flex;
   align-self: flex-end;
   cursor: pointer;
+
+  &:hover {
+    background: ${p => p.theme.colors.buttons.primary.hover};
+  }
 `;
 
 const LabelForm = styled.div`
   display: flex;
-  background: rgba(255, 255, 255, 0.1);
+  background: ${p => p.theme.colors.spotBackground[0]};
   align-items: center;
   padding: 1px 15px;
   border-radius: 5px;
@@ -101,6 +106,7 @@ const Input = styled.input`
   border: none;
   width: 340px;
   box-sizing: border-box;
+  color: ${p => p.theme.colors.text.main};
 
   &:focus {
     outline: none;
@@ -132,6 +138,8 @@ const As = styled.div`
 `;
 
 export function ActionForm(props: ActionFormProps) {
+  const theme = useTheme();
+
   const currentSelectedUser = props.initialState.find(e => e.type === 'user');
   const [formState, setFormState] = useState<ActionState[]>(props.initialState);
   const [currentUser, setCurrentUser] = useState<string>(
@@ -191,13 +199,15 @@ export function ActionForm(props: ActionFormProps) {
       items.push(
         <LabelForm key={`query-${index}`}>
           <LabelFormContent>
-            <SearchIcon size={16} />
+            <SearchIcon
+              size={16}
+              fill={theme.name === 'light' ? 'black' : 'white'}
+            />
 
             <Input
               key="query"
               value={stateItem.value}
               onChange={event => handleChange(index, event.target.value)}
-              style={{ color: 'white' }}
             />
           </LabelFormContent>
 
@@ -213,14 +223,17 @@ export function ActionForm(props: ActionFormProps) {
         <As key={`as-${index}`}>as</As>,
         <LabelForm key={`user-${index}`}>
           <LabelFormContent>
-            <UserIcon size={16} />
+            <UserIcon
+              size={16}
+              fill={theme.name === 'light' ? 'black' : 'white'}
+            />
             <Select
               onChange={event => handleUserChange(index, event['value'])}
               value={{ value: currentUser, label: currentUser }}
               options={stateItem.value.map(option => {
                 return { label: option, value: option };
               })}
-              css={'width: 20vh; padding: 5px'}
+              css={'width: 20vh; padding: 5px; margin-left: 10px;'}
             />
           </LabelFormContent>
 

--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
@@ -164,9 +164,9 @@ interface NodeOutputProps {
 
 const NodeContainer = styled.div`
   margin-bottom: 20px;
-  background: #0a0e31;
+  background: ${p => p.theme.colors.spotBackground[0]};
   border-radius: 5px;
-  padding: 10px 15px;
+  padding: 10px 15px 10px;
 `;
 
 const NodeTitle = styled.div`
@@ -177,9 +177,10 @@ const NodeTitle = styled.div`
 
 const NodeContent = styled.div`
   background: #020308;
-  margin-bottom: 20px;
+  margin-bottom: 10px;
   border-radius: 5px;
   padding: 1px 20px;
+  color: white;
 `;
 
 const LoadingContainer = styled.div`

--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/common.ts
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/common.ts
@@ -38,6 +38,7 @@ export const Items = styled.div`
   display: flex;
   flex-wrap: wrap;
   margin-top: -10px;
+  align-items: center;
 
   > * {
     margin-top: 10px;

--- a/web/packages/teleport/src/Assist/Icons/EditIcon.tsx
+++ b/web/packages/teleport/src/Assist/Icons/EditIcon.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import type { IconProps } from './types';
 
-export function EditIcon({ size = 24 }: IconProps) {
+export function EditIcon({ size = 24, fill = 'white' }: IconProps) {
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -28,7 +28,7 @@ export function EditIcon({ size = 24 }: IconProps) {
     >
       <path
         d="M 19.171875 2 C 18.448125 2 17.724375 2.275625 17.171875 2.828125 L 16 4 L 20 8 L 21.171875 6.828125 C 22.275875 5.724125 22.275875 3.933125 21.171875 2.828125 C 20.619375 2.275625 19.895625 2 19.171875 2 z M 14.5 5.5 L 5 15 C 5 15 6.005 15.005 6.5 15.5 C 6.995 15.995 6.984375 16.984375 6.984375 16.984375 C 6.984375 16.984375 8.004 17.004 8.5 17.5 C 8.996 17.996 9 19 9 19 L 18.5 9.5 L 14.5 5.5 z M 3.6699219 17 L 3.0136719 20.503906 C 2.9606719 20.789906 3.2100938 21.039328 3.4960938 20.986328 L 7 20.330078 L 3.6699219 17 z"
-        fill="white"
+        fill={fill}
       />
     </svg>
   );

--- a/web/packages/teleport/src/Navigation/AssistTooltip.ts
+++ b/web/packages/teleport/src/Navigation/AssistTooltip.ts
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 import styled from 'styled-components';
 
 import icon from 'teleport/Navigation/teleport-icon.png';


### PR DESCRIPTION
Fixes some issues with the light theme

- Icons are now correctly colored
- Edit command form now respects the theme
- Save button for the form now inherits colors from the primary button
- Command execution text is now correctly colored

<img width="838" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/caa11b28-1135-430b-b6fc-0cccce050822">

<img width="586" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/2e05aa86-ca1b-4f6d-8b4b-2fdcdc712d8c">

I've also added the missing license header here to appease CI