### PR TITLE
[v10] Makefile: cache `go env` values

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,8 +72,12 @@ CGOFLAG_TSH = $(CGOFLAG)
 endif
 endif
 
-OS ?= $(shell go env GOOS)
-ARCH ?= $(shell go env GOARCH)
+GO_ENV_OS := $(shell go env GOOS)
+OS ?= $(GO_ENV_OS)
+
+GO_ENV_ARCH := $(shell go env GOARCH)
+ARCH ?= $(GO_ENV_ARCH)
+
 FIPS ?=
 RELEASE = teleport-$(GITTAG)-$(OS)-$(ARCH)-bin
 


### PR DESCRIPTION
Backport #25870 to branch/v10