### PR TITLE
Search bar: Take cluster filter into account when listing offline clusters

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
@@ -126,6 +126,64 @@ describe('getActionPickerStatus', () => {
         status.inputState === 'some-input' && status;
       expect([...clustersWithExpiredCerts]).toEqual(['/clusters/foo']);
     });
+
+    describe('when there are no results', () => {
+      it('lists only the filtered offline cluster if a cluster filter is selected and the filtered cluster is offline', () => {
+        const filteredCluster = makeRootCluster({
+          connected: false,
+          uri: '/clusters/filtered-cluster',
+        });
+        const otherOfflineCluster = makeRootCluster({
+          connected: false,
+          uri: '/clusters/other-offline-cluster',
+        });
+        const status = getActionPickerStatus({
+          inputValue: 'foo',
+          filters: [{ filter: 'cluster', clusterUri: filteredCluster.uri }],
+          filterActionsAttempt: makeSuccessAttempt([]),
+          allClusters: [filteredCluster, otherOfflineCluster],
+          actionAttempts: [makeSuccessAttempt([])],
+          resourceSearchAttempt: makeSuccessAttempt({
+            errors: [],
+            results: [],
+            search: 'foo',
+          }),
+        });
+
+        expect(status.inputState).toBe('some-input');
+        const { clustersWithExpiredCerts } =
+          status.inputState === 'some-input' && status;
+        expect([...clustersWithExpiredCerts]).toEqual([filteredCluster.uri]);
+      });
+
+      it('does not list offline clusters if a cluster filter is selected and that cluster is online and there are no results', () => {
+        const filteredCluster = makeRootCluster({
+          connected: true,
+          uri: '/clusters/filtered-cluster',
+        });
+        const otherOfflineCluster = makeRootCluster({
+          connected: false,
+          uri: '/clusters/other-offline-cluster',
+        });
+        const status = getActionPickerStatus({
+          inputValue: 'foo',
+          filters: [{ filter: 'cluster', clusterUri: filteredCluster.uri }],
+          filterActionsAttempt: makeSuccessAttempt([]),
+          allClusters: [filteredCluster, otherOfflineCluster],
+          actionAttempts: [makeSuccessAttempt([])],
+          resourceSearchAttempt: makeSuccessAttempt({
+            errors: [],
+            results: [],
+            search: 'foo',
+          }),
+        });
+
+        expect(status.inputState).toBe('some-input');
+        const { clustersWithExpiredCerts } =
+          status.inputState === 'some-input' && status;
+        expect([...clustersWithExpiredCerts]).toHaveLength(0);
+      });
+    });
   });
 
   describe('no-input search mode', () => {

--- a/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
+++ b/web/packages/teleterm/src/ui/Search/pickers/ActionPicker.test.ts
@@ -22,142 +22,148 @@ import { ResourceSearchError } from 'teleterm/ui/services/resources';
 import { getActionPickerStatus } from './ActionPicker';
 
 describe('getActionPickerStatus', () => {
-  it('partitions resource search errors into clusters with expired certs and non-retryable errors', () => {
-    const retryableError = new ResourceSearchError(
-      '/clusters/foo',
-      'server',
-      new Error('ssh: cert has expired')
-    );
-
-    const nonRetryableError = new ResourceSearchError(
-      '/clusters/bar',
-      'database',
-      new Error('whoops')
-    );
-
-    const status = getActionPickerStatus({
-      inputValue: 'foo',
-      filters: [],
-      filterActionsAttempt: makeSuccessAttempt([]),
-      allClusters: [],
-      actionAttempts: [makeSuccessAttempt([])],
-      resourceSearchAttempt: makeSuccessAttempt({
-        errors: [retryableError, nonRetryableError],
-        results: [],
-        search: 'foo',
-      }),
-    });
-
-    expect(status.inputState).toBe('some-input');
-
-    const { clustersWithExpiredCerts, nonRetryableResourceSearchErrors } =
-      status.inputState === 'some-input' && status;
-
-    expect([...clustersWithExpiredCerts]).toEqual([retryableError.clusterUri]);
-    expect(nonRetryableResourceSearchErrors).toEqual([nonRetryableError]);
-  });
-
-  it('merges non-connected clusters with clusters that returned retryable errors', () => {
-    const offlineCluster = makeRootCluster({ connected: false });
-    const retryableError = new ResourceSearchError(
-      '/clusters/foo',
-      'server',
-      new Error('ssh: cert has expired')
-    );
-
-    const status = getActionPickerStatus({
-      inputValue: 'foo',
-      filters: [],
-      filterActionsAttempt: makeSuccessAttempt([]),
-      allClusters: [offlineCluster],
-      actionAttempts: [makeSuccessAttempt([])],
-      resourceSearchAttempt: makeSuccessAttempt({
-        errors: [retryableError],
-        results: [],
-        search: 'foo',
-      }),
-    });
-
-    expect(status.inputState).toBe('some-input');
-    const { clustersWithExpiredCerts } =
-      status.inputState === 'some-input' && status;
-
-    expect(clustersWithExpiredCerts.size).toBe(2);
-    expect(clustersWithExpiredCerts).toContain(offlineCluster.uri);
-    expect(clustersWithExpiredCerts).toContain(retryableError.clusterUri);
-  });
-
-  it('includes a cluster with expired cert only once even if multiple requests fail with retryable errors', () => {
-    const retryableErrors = [
-      new ResourceSearchError(
+  describe('some-input search mode', () => {
+    it('partitions resource search errors into clusters with expired certs and non-retryable errors', () => {
+      const retryableError = new ResourceSearchError(
         '/clusters/foo',
         'server',
         new Error('ssh: cert has expired')
-      ),
-      new ResourceSearchError(
-        '/clusters/foo',
+      );
+
+      const nonRetryableError = new ResourceSearchError(
+        '/clusters/bar',
         'database',
-        new Error('ssh: cert has expired')
-      ),
-      new ResourceSearchError(
-        '/clusters/foo',
-        'kube',
-        new Error('ssh: cert has expired')
-      ),
-    ];
-    const status = getActionPickerStatus({
-      inputValue: 'foo',
-      filters: [],
-      filterActionsAttempt: makeSuccessAttempt([]),
-      allClusters: [],
-      actionAttempts: [makeSuccessAttempt([])],
-      resourceSearchAttempt: makeSuccessAttempt({
-        errors: retryableErrors,
-        results: [],
-        search: 'foo',
-      }),
+        new Error('whoops')
+      );
+
+      const status = getActionPickerStatus({
+        inputValue: 'foo',
+        filters: [],
+        filterActionsAttempt: makeSuccessAttempt([]),
+        allClusters: [],
+        actionAttempts: [makeSuccessAttempt([])],
+        resourceSearchAttempt: makeSuccessAttempt({
+          errors: [retryableError, nonRetryableError],
+          results: [],
+          search: 'foo',
+        }),
+      });
+
+      expect(status.inputState).toBe('some-input');
+
+      const { clustersWithExpiredCerts, nonRetryableResourceSearchErrors } =
+        status.inputState === 'some-input' && status;
+
+      expect([...clustersWithExpiredCerts]).toEqual([
+        retryableError.clusterUri,
+      ]);
+      expect(nonRetryableResourceSearchErrors).toEqual([nonRetryableError]);
     });
 
-    expect(status.inputState).toBe('some-input');
-    const { clustersWithExpiredCerts } =
-      status.inputState === 'some-input' && status;
-    expect([...clustersWithExpiredCerts]).toEqual(['/clusters/foo']);
-  });
-
-  it('returns non-retryable errors when fetching a preview after selecting a filter fails', () => {
-    const nonRetryableError = new ResourceSearchError(
-      '/clusters/bar',
-      'server',
-      new Error('non-retryable error')
-    );
-    const resourceSearchErrors = [
-      new ResourceSearchError(
+    it('merges non-connected clusters with clusters that returned retryable errors', () => {
+      const offlineCluster = makeRootCluster({ connected: false });
+      const retryableError = new ResourceSearchError(
         '/clusters/foo',
         'server',
         new Error('ssh: cert has expired')
-      ),
-      nonRetryableError,
-    ];
-    const status = getActionPickerStatus({
-      inputValue: '',
-      filters: [{ filter: 'resource-type', resourceType: 'servers' }],
-      filterActionsAttempt: makeSuccessAttempt([]),
-      allClusters: [],
-      actionAttempts: [makeSuccessAttempt([])],
-      resourceSearchAttempt: makeSuccessAttempt({
-        errors: resourceSearchErrors,
-        results: [],
-        search: 'foo',
-      }),
+      );
+
+      const status = getActionPickerStatus({
+        inputValue: 'foo',
+        filters: [],
+        filterActionsAttempt: makeSuccessAttempt([]),
+        allClusters: [offlineCluster],
+        actionAttempts: [makeSuccessAttempt([])],
+        resourceSearchAttempt: makeSuccessAttempt({
+          errors: [retryableError],
+          results: [],
+          search: 'foo',
+        }),
+      });
+
+      expect(status.inputState).toBe('some-input');
+      const { clustersWithExpiredCerts } =
+        status.inputState === 'some-input' && status;
+
+      expect(clustersWithExpiredCerts.size).toBe(2);
+      expect(clustersWithExpiredCerts).toContain(offlineCluster.uri);
+      expect(clustersWithExpiredCerts).toContain(retryableError.clusterUri);
     });
 
-    expect(status.inputState).toBe('no-input');
+    it('includes a cluster with expired cert only once even if multiple requests fail with retryable errors', () => {
+      const retryableErrors = [
+        new ResourceSearchError(
+          '/clusters/foo',
+          'server',
+          new Error('ssh: cert has expired')
+        ),
+        new ResourceSearchError(
+          '/clusters/foo',
+          'database',
+          new Error('ssh: cert has expired')
+        ),
+        new ResourceSearchError(
+          '/clusters/foo',
+          'kube',
+          new Error('ssh: cert has expired')
+        ),
+      ];
+      const status = getActionPickerStatus({
+        inputValue: 'foo',
+        filters: [],
+        filterActionsAttempt: makeSuccessAttempt([]),
+        allClusters: [],
+        actionAttempts: [makeSuccessAttempt([])],
+        resourceSearchAttempt: makeSuccessAttempt({
+          errors: retryableErrors,
+          results: [],
+          search: 'foo',
+        }),
+      });
 
-    const { searchMode } = status.inputState === 'no-input' && status;
-    expect(searchMode.kind).toBe('preview');
+      expect(status.inputState).toBe('some-input');
+      const { clustersWithExpiredCerts } =
+        status.inputState === 'some-input' && status;
+      expect([...clustersWithExpiredCerts]).toEqual(['/clusters/foo']);
+    });
+  });
 
-    const { nonRetryableResourceSearchErrors } =
-      searchMode.kind === 'preview' && searchMode;
-    expect(nonRetryableResourceSearchErrors).toEqual([nonRetryableError]);
+  describe('no-input search mode', () => {
+    it('returns non-retryable errors when fetching a preview after selecting a filter fails', () => {
+      const nonRetryableError = new ResourceSearchError(
+        '/clusters/bar',
+        'server',
+        new Error('non-retryable error')
+      );
+      const resourceSearchErrors = [
+        new ResourceSearchError(
+          '/clusters/foo',
+          'server',
+          new Error('ssh: cert has expired')
+        ),
+        nonRetryableError,
+      ];
+      const status = getActionPickerStatus({
+        inputValue: '',
+        filters: [{ filter: 'resource-type', resourceType: 'servers' }],
+        filterActionsAttempt: makeSuccessAttempt([]),
+        allClusters: [],
+        actionAttempts: [makeSuccessAttempt([])],
+        resourceSearchAttempt: makeSuccessAttempt({
+          errors: resourceSearchErrors,
+          results: [],
+          search: '',
+        }),
+      });
+
+      expect(status.inputState).toBe('no-input');
+
+      const { searchMode } = status.inputState === 'no-input' && status;
+      expect(searchMode.kind).toBe('preview');
+
+      const { nonRetryableResourceSearchErrors } =
+        searchMode.kind === 'preview' && searchMode;
+      expect(nonRetryableResourceSearchErrors).toEqual([nonRetryableError]);
+    });
   });
 });


### PR DESCRIPTION
When a cluster filter was selected, the search bar ignored it when listing offline clusters, leading to a situations like this one:

![offline clusters](https://user-images.githubusercontent.com/27113/231132555-a4f6a0b9-e5e0-48a9-8b81-b2b79d391d72.png)

Here the cluster filter limits the search only to the teleport-local cluster. But the message below says that the other cluster was excluded from the search due to having an expired cert.

This PR takes care of that by making sure that we only list a single offline cluster if the cluster filter is selected.