### PR TITLE
Only render the assist sidebar when the feature exists

### DIFF
--- a/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
@@ -59,11 +59,13 @@ export function NavigationCategoryContainer(props: NavigationCategoryProps) {
   if (props.category === NavigationCategory.Assist && items.length) {
     const SidebarComponent = items[0].sidebarComponent;
 
-    return (
-      <Container visible={props.visible}>
-        <SidebarComponent />
-      </Container>
-    );
+    if (SidebarComponent) {
+      return (
+        <Container visible={props.visible}>
+          <SidebarComponent/>
+        </Container>
+      );
+    }
   }
 
   if (props.category === NavigationCategory.Resources) {

--- a/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
@@ -56,7 +56,7 @@ export function NavigationCategoryContainer(props: NavigationCategoryProps) {
     .filter(feature => feature.category === props.category)
     .filter(feature => !feature.parent);
 
-  if (props.category === NavigationCategory.Assist) {
+  if (props.category === NavigationCategory.Assist && items.length) {
     const SidebarComponent = items[0].sidebarComponent;
 
     return (

--- a/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationCategoryContainer.tsx
@@ -62,7 +62,7 @@ export function NavigationCategoryContainer(props: NavigationCategoryProps) {
     if (SidebarComponent) {
       return (
         <Container visible={props.visible}>
-          <SidebarComponent/>
+          <SidebarComponent />
         </Container>
       );
     }


### PR DESCRIPTION
`items` will be empty if the assist feature is disabled for whatever reason, so this adds a check for `items` to have a length before trying to render the first (assist's) route's sidebar component