### PR TITLE
docs: add note about curl on Windows

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -46,11 +46,25 @@ to your Windows system, and prepare it for passwordless access through Teleport.
 
 ### Import the Teleport root certificate
 
-Export the Teleport user certificate authority by running the following from your Windows system:
+Export the Teleport user certificate authority by running the following from
+`cmd.exe` on your Windows system:
 
 ```code
 $ curl 'https://teleport-proxy.example.com:443/webapi/auth/export?type=windows' > teleport.cer
 ```
+
+<Admonition type="warning" title="PowerShell">
+Be sure to run the above command in `cmd.exe`. In PowerShell, `curl` is an alias for
+[`Invoke-WebRequest`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.3)
+which has different semantics.
+
+If you must use PowerShell, remove the alias before running curl with the
+following command:
+
+```
+> Remove-Item alias:curl
+```
+</Admonition>
 
 ### Install the Teleport service for Windows
 

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -57,7 +57,6 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/installers"
 	"github.com/gravitational/teleport/api/utils"
-	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/auth/mocku2f"
 	"github.com/gravitational/teleport/lib/auth/testauthority"
@@ -1867,7 +1866,7 @@ func TestIsMFARequiredUnauthorized(t *testing.T) {
 	roleOpt := role.GetOptions()
 	roleOpt.RequireMFAType = types.RequireMFAType_SESSION
 	role.SetOptions(roleOpt)
-	role.SetNodeLabels(types.Allow, map[string]apiutils.Strings{"a": []string{"c"}})
+	role.SetNodeLabels(types.Allow, map[string]utils.Strings{"a": []string{"c"}})
 	err = srv.Auth().UpsertRole(ctx, role)
 	require.NoError(t, err)
 


### PR DESCRIPTION
PowerShell tricks you into thinking you're running curl when you're not.

Also lump in a fix for a duplicate import that was tripping up the linter.

Closes #24502