### PR TITLE
Only set responding to false when the server indicates the last message

### DIFF
--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -324,13 +324,17 @@ export function MessagesContextProvider(
   useEffect(() => {
     if (lastMessage !== null) {
       const value = JSON.parse(lastMessage.data) as ServerMessage;
+
+      if (value.type === 'CHAT_PARTIAL_MESSAGE_ASSISTANT_FINALIZE') {
+        setResponding(false);
+      }
+
       convertServerMessage(value, clusterId).then(res => {
         setMessages(prev => {
           const curr = [...prev];
           res(curr);
           return curr;
         });
-        setResponding(false);
       });
     }
   }, [lastMessage, setMessages, conversationId]);


### PR DESCRIPTION
This makes it so you can't send messages whilst ChatGPT is streaming back to you.