### PR TITLE
Prevent the assist popup showing up again after logout

### DIFF
--- a/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
@@ -27,6 +27,8 @@ import { useHistory } from 'react-router';
 import { useTeleport } from 'teleport';
 import { NavigationCategory } from 'teleport/Navigation/categories';
 
+import { KeysEnum } from 'teleport/services/localStorage';
+
 import {
   TeleportIcon,
   Tooltip,
@@ -139,7 +141,7 @@ export function NavigationSwitcher(props: NavigationSwitcherProps) {
   const ctx = useTeleport();
   const assistEnabled = ctx.getFeatureFlags().assist && ctx.assistEnabled;
   const [showAssist, setShowAssist] = useLocalStorage(
-    'show-assist',
+    KeysEnum.SHOW_ASSIST_POPUP,
     assistEnabled
   );
 

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -21,18 +21,18 @@ import { KeysEnum } from './types';
 
 import type { ThemeOption } from 'design/theme';
 
+// This is an array of local storage `KeysEnum` that are kept when a user logs out
+const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
+  KeysEnum.THEME,
+  KeysEnum.SHOW_ASSIST_POPUP,
+];
+
 const storage = {
   clear() {
-    const themeOption = window.localStorage.getItem(KeysEnum.THEME);
-    window.localStorage.clear();
-    // This is to keep the theme selection in localStorage even when
-    // the rest of it is cleared. This is to prevent theme from
-    // getting reset on logout.
-    window.localStorage.setItem(KeysEnum.THEME, themeOption);
     for (let i = 0; i < window.localStorage.length; i++) {
       const key = window.localStorage.key(i);
 
-      if (key !== 'show-assist') {
+      if (!KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT.includes(key)) {
         window.localStorage.removeItem(key);
       }
     }

--- a/web/packages/teleport/src/services/localStorage/types.ts
+++ b/web/packages/teleport/src/services/localStorage/types.ts
@@ -20,4 +20,5 @@ export const KeysEnum = {
   LAST_ACTIVE: 'grv_teleport_last_active',
   DISCOVER: 'grv_teleport_discover',
   THEME: 'grv_teleport_ui_theme',
+  SHOW_ASSIST_POPUP: 'grv_teleport_show_assist',
 };


### PR DESCRIPTION
This moves the local storage key over to follow conventions and be defined in `KeysEnum`

This also changes the `localStorage.clear()` behaviour to persist the theme and the assist popup status on logout.