### PR TITLE
Fix flaky test `TestLoadConfigFromProfile`

### DIFF
--- a/tool/tsh/tctl_test.go
+++ b/tool/tsh/tctl_test.go
@@ -80,11 +80,6 @@ func TestLoadConfigFromProfile(t *testing.T) {
 				TeleportHome: "some/dir/that/does/not/exist",
 			},
 			want: trace.NotFound("profile is not found"),
-		}, {
-			name: "teleportHome is not specified",
-			ccf:  &common.GlobalCLIFlags{},
-			cfg:  &servicecfg.Config{},
-			want: trace.NotFound("profile is not found"),
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Removes a test case in `TestLoadConfigFromProfile` which uses your local `~/.tsh` profile. This causes the test to fail or panic under certain conditions.

Closes https://github.com/gravitational/teleport/issues/20004