### PR TITLE
[v13] docs: instruct users to use `apt`/`yum`/`dnf` instead of `dpkg`/`rpm`

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -119,7 +119,7 @@ Alternatively, log in to the Teleport Web Interface at `https://teleport.example
 
 Dive deeper into the topics relevant to your Application Access use-case:
 
-- Learn in more detail about [connecting applications](./guides/connecting-apps.mdx) with Application Access.
+- Learn in more detail about [connecting applications](./guides/connecting-apps.mdx).
 - Learn about integrating with [JWT tokens](./jwt/introduction.mdx) for auth.
 - Learn how to use application access with [RESTful APIs](./guides/api-access.mdx).
 - See full configuration and CLI [reference](./reference.mdx).

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,9 +1,23 @@
 Use the appropriate commands for your environment to install your package.
 
+<Admonition type="note">
+`apt` and `yum` repos don't expose packages for all distribution variants.
+When following installation instructions, you might need to replace `ID` with
+`ID_LIKE` to install packages of the closest supported distribution.
+
+Currently supported distributions (and `ID`) are:
+- RHEL (`rhel`)
+- CentOS (`centos`)
+- Debian (`debian`)
+- Ubuntu (`ubuntu`)
+- AmazonLinux (`amzn`)``
+</Admonition>
+
+
 <Tabs dropdownView dropdownCaption="Teleport Edition">
   <TabItem label="Open Source" scope="oss">
   <Tabs>
-  <TabItem label="Debian/Ubuntu (apt)" scope="oss">
+  <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="oss">
 
   Add the Teleport repository to your repository list:
 
@@ -15,9 +29,6 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
-  # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
   $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
@@ -34,9 +45,6 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
-  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID'
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   $ sudo yum install teleport
   #
@@ -51,9 +59,6 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
-  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID'
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
   # Use the dnf config manager plugin to add the teleport RPM repo
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   
@@ -86,7 +91,7 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="Enterprise" scope="enterprise">
   <Tabs>
-  <TabItem label="Debian/Ubuntu (apt)" scope="enterprise">
+  <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="enterprise">
 
   Add the Teleport repository to your repository list:
 
@@ -98,9 +103,6 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
-  # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
   $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
@@ -123,9 +125,6 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
-  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID'
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   $ sudo yum install teleport-ent
   #
@@ -147,9 +146,6 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
-  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID'
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
   # Use the dnf config manager plugin to add the teleport RPM repo
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   
@@ -199,7 +195,7 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="Cloud" scope="cloud">
   <Tabs>
-  <TabItem label="Debian/Ubuntu (apt)" scope="cloud">
+  <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="cloud">
 
   Add the Teleport repository to your repository list:
 
@@ -209,11 +205,7 @@ Use the appropriate commands for your environment to install your package.
   -o /usr/share/keyrings/teleport-archive-keyring.asc
   # Source variables about OS version
   $ source /etc/os-release
-  # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
-  # file for each major release of Teleport.
-  # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
+  # Add the Teleport apt repository for cloud.
   $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
   https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/cloud" \
   | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
@@ -228,11 +220,7 @@ Use the appropriate commands for your environment to install your package.
   ```code
   # Source variables about OS version
   $ source /etc/os-release
-  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
-  # file for each major release of Teleport.
-  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID'
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  # Add the Teleport yum repository for cloud.
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport.repo")"
   $ sudo yum install teleport-ent
   #
@@ -246,11 +234,7 @@ Use the appropriate commands for your environment to install your package.
   ```code
   # Source variables about OS version
   $ source /etc/os-release
-  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
-  # file for each major release of Teleport.
-  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
-  # and the codename your distro was forked from instead of '$ID'
-  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  # Add the Teleport yum repository for cloud.
   # Use the dnf config manager plugin to add the teleport RPM repo
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport.repo")"
   

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -3,7 +3,7 @@ Use the appropriate commands for your environment to install your package.
 <Tabs dropdownView dropdownCaption="Teleport Edition">
   <TabItem label="Open Source" scope="oss">
   <Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)" scope="oss">
+  <TabItem label="Debian/Ubuntu (apt)" scope="oss">
 
   Add the Teleport repository to your repository list:
 
@@ -27,7 +27,7 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL <= 7 (yum)" scope="oss">
+  <TabItem label="AL 2/RHEL 7- (yum)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -44,7 +44,7 @@ Use the appropriate commands for your environment to install your package.
   # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
   ```
   </TabItem>
-  <TabItem label="Amazon Linux 2023/RHEL >= 8 (dnf)" scope="oss">
+  <TabItem label="AL 2023/RHEL 8+ (dnf)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -86,7 +86,7 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="Enterprise" scope="enterprise">
   <Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)" scope="enterprise">
+  <TabItem label="Debian/Ubuntu (apt)" scope="enterprise">
 
   Add the Teleport repository to your repository list:
 
@@ -116,7 +116,7 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL <= 7 (yum)" scope="oss">
+  <TabItem label="AL 2/RHEL 7- (yum)" scope="enterprise">
 
   ```code
   # Source variables about OS version
@@ -140,7 +140,7 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2023/RHEL >= 8 (dnf)" scope="oss">
+  <TabItem label="AL 2023/RHEL 8+ (dnf)" scope="enterprise">
 
   ```code
   # Source variables about OS version
@@ -199,7 +199,7 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="Cloud" scope="cloud">
   <Tabs>
-  <TabItem label="Debian/Ubuntu (DEB)" scope="cloud">
+  <TabItem label="Debian/Ubuntu (apt)" scope="cloud">
 
   Add the Teleport repository to your repository list:
 
@@ -223,7 +223,25 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2023/RHEL >= 8 (dnf)" scope="oss">
+  <TabItem label="AL 2/RHEL 7- (yum)" scope="cloud">
+
+  ```code
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID'
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport.repo")"
+  $ sudo yum install teleport-ent
+  #
+  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+  ```
+
+  </TabItem>
+  <TabItem label="AL 2023/RHEL 8+ (dnf)" scope="oss">
 
   ```code
   # Source variables about OS version

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -5,10 +5,6 @@ Use the appropriate commands for your environment to install your package.
   <Tabs>
   <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="oss">
 
-  Distributions supported by Teleport's `apt` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
-
   ```code
   # Download Teleport's PGP public key
   $ sudo curl https://apt.releases.teleport.dev/gpg \
@@ -28,10 +24,6 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="Amazon Linux 2/RHEL 7 (yum)" scope="oss">
 
-  Distributions supported by Teleport's `yum` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
-
   ```code
   # Source variables about OS version
   $ source /etc/os-release
@@ -45,10 +37,6 @@ Use the appropriate commands for your environment to install your package.
   ```
   </TabItem>
   <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="oss">
-
-  Distributions supported by Teleport's `yum` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Source variables about OS version
@@ -89,10 +77,6 @@ Use the appropriate commands for your environment to install your package.
   <Tabs>
   <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="enterprise">
 
-  Distributions supported by Teleport's `apt` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
-
   ```code
   # Download Teleport's PGP public key
   $ sudo curl https://apt.releases.teleport.dev/gpg \
@@ -118,10 +102,6 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="enterprise">
 
-  Distributions supported by Teleport's `yum` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
-
   ```code
   # Source variables about OS version
   $ source /etc/os-release
@@ -142,10 +122,6 @@ Use the appropriate commands for your environment to install your package.
 
   </TabItem>
   <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="enterprise">
-
-  Distributions supported by Teleport's `yum` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Source variables about OS version
@@ -209,10 +185,6 @@ Use the appropriate commands for your environment to install your package.
 
   Add the Teleport repository to your repository list:
 
-  Distributions supported by Teleport's `apt` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
-
   ```code
   # Download Teleport's PGP public key
   $ sudo curl https://apt.releases.teleport.dev/gpg \
@@ -231,10 +203,6 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="cloud">
 
-  Distributions supported by Teleport's `yum` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
-
   ```code
   # Source variables about OS version
   $ source /etc/os-release
@@ -248,10 +216,6 @@ Use the appropriate commands for your environment to install your package.
 
   </TabItem>
   <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="oss">
-
-  Distributions supported by Teleport's `yum` repository [are listed here
-  ](../installation.mdx#feature-support). If your distribution `$ID` is not
-  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Source variables about OS version

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -10,7 +10,8 @@ Currently supported distributions (and `ID`) are:
 - CentOS (`centos`)
 - Debian (`debian`)
 - Ubuntu (`ubuntu`)
-- AmazonLinux (`amzn`)``
+- AmazonLinux (`amzn`)
+
 </Admonition>
 
 
@@ -38,7 +39,7 @@ Currently supported distributions (and `ID`) are:
   ```
 
   </TabItem>
-  <TabItem label="AL 2/RHEL 7 (yum)" scope="oss">
+  <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -52,7 +53,7 @@ Currently supported distributions (and `ID`) are:
   # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
   ```
   </TabItem>
-  <TabItem label="AL 2023/RHEL 8+ (dnf)" scope="oss">
+  <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -118,7 +119,7 @@ Currently supported distributions (and `ID`) are:
   ```
 
   </TabItem>
-  <TabItem label="AL 2/RHEL 7 (yum)" scope="enterprise">
+  <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="enterprise">
 
   ```code
   # Source variables about OS version
@@ -139,7 +140,7 @@ Currently supported distributions (and `ID`) are:
   ```
 
   </TabItem>
-  <TabItem label="AL 2023/RHEL 8+ (dnf)" scope="enterprise">
+  <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="enterprise">
 
   ```code
   # Source variables about OS version
@@ -164,6 +165,10 @@ Currently supported distributions (and `ID`) are:
 
   </TabItem>
   <TabItem label="Tarball" scope="enterprise">
+
+  In the example commands below, update `$SYSTEM_ARCH` with the appropriate
+  value (`amd64`, `arm64`, or `arm`). All example commands using this variable
+  will update after one is filled out.
 
   ```code
   $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz.sha256
@@ -215,7 +220,7 @@ Currently supported distributions (and `ID`) are:
   ```
 
   </TabItem>
-  <TabItem label="AL 2/RHEL 7 (yum)" scope="cloud">
+  <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="cloud">
 
   ```code
   # Source variables about OS version
@@ -229,7 +234,7 @@ Currently supported distributions (and `ID`) are:
   ```
 
   </TabItem>
-  <TabItem label="AL 2023/RHEL 8+ (dnf)" scope="oss">
+  <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -247,6 +252,10 @@ Currently supported distributions (and `ID`) are:
 
   </TabItem>
   <TabItem label="Tarball" scope="cloud">
+
+  In the example commands below, update `$SYSTEM_ARCH` with the appropriate
+  value (`amd64`, `arm64`, or `arm`). All example commands using this variable
+  will update after one is filled out.
 
   ```code
   $ curl https://get.gravitational.com/teleport-ent-v(=cloud.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz.sha256

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,26 +1,13 @@
 Use the appropriate commands for your environment to install your package.
 
-<Admonition type="note">
-`apt` and `yum` repos don't expose packages for all distribution variants.
-When following installation instructions, you might need to replace `ID` with
-`ID_LIKE` to install packages of the closest supported distribution.
-
-Currently supported distributions (and `ID`) are:
-- RHEL >= 7 (`rhel`)
-- CentOS >= 7 (`centos`)
-- Debian >= 8 (`debian`)
-- Ubuntu >= 16.04 (`ubuntu`)
-- Amazon Linux 2 and 2023 (`amzn`)
-
-</Admonition>
-
-
 <Tabs dropdownView dropdownCaption="Teleport Edition">
   <TabItem label="Open Source" scope="oss">
   <Tabs>
   <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="oss">
 
-  Add the Teleport repository to your repository list:
+  Distributions supported by Teleport's `apt` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Download Teleport's PGP public key
@@ -41,6 +28,10 @@ Currently supported distributions (and `ID`) are:
   </TabItem>
   <TabItem label="Amazon Linux 2/RHEL 7 (yum)" scope="oss">
 
+  Distributions supported by Teleport's `yum` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
+
   ```code
   # Source variables about OS version
   $ source /etc/os-release
@@ -54,6 +45,10 @@ Currently supported distributions (and `ID`) are:
   ```
   </TabItem>
   <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="oss">
+
+  Distributions supported by Teleport's `yum` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Source variables about OS version
@@ -94,7 +89,9 @@ Currently supported distributions (and `ID`) are:
   <Tabs>
   <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="enterprise">
 
-  Add the Teleport repository to your repository list:
+  Distributions supported by Teleport's `apt` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Download Teleport's PGP public key
@@ -121,6 +118,10 @@ Currently supported distributions (and `ID`) are:
   </TabItem>
   <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="enterprise">
 
+  Distributions supported by Teleport's `yum` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
+
   ```code
   # Source variables about OS version
   $ source /etc/os-release
@@ -141,6 +142,10 @@ Currently supported distributions (and `ID`) are:
 
   </TabItem>
   <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="enterprise">
+
+  Distributions supported by Teleport's `yum` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Source variables about OS version
@@ -204,6 +209,10 @@ Currently supported distributions (and `ID`) are:
 
   Add the Teleport repository to your repository list:
 
+  Distributions supported by Teleport's `apt` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
+
   ```code
   # Download Teleport's PGP public key
   $ sudo curl https://apt.releases.teleport.dev/gpg \
@@ -222,6 +231,10 @@ Currently supported distributions (and `ID`) are:
   </TabItem>
   <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="cloud">
 
+  Distributions supported by Teleport's `yum` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
+
   ```code
   # Source variables about OS version
   $ source /etc/os-release
@@ -235,6 +248,10 @@ Currently supported distributions (and `ID`) are:
 
   </TabItem>
   <TabItem label="AmazonLinux 2023/RHEL 8+ (dnf)" scope="oss">
+
+  Distributions supported by Teleport's `yum` repository [are listed here
+  ](../installation.mdx#feature-support). If your distribution `$ID` is not
+  supported, you can use `$ID_LIKE` instead.
 
   ```code
   # Source variables about OS version

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -66,17 +66,17 @@ Use the appropriate commands for your environment to install your package.
   </TabItem>
   <TabItem label="Tarball" scope="oss">
 
-  In the example commands below, update `$SYSTEM-ARCH` with the appropriate
+  In the example commands below, update `$SYSTEM_ARCH` with the appropriate
   value (`amd64`, `arm64`, or `arm`). All example commands using this variable
   will update after one is filled out.
 
   ```code
-  $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH" description="The CPU architecture of the system Teleport will be installed on"/>-bin.tar.gz.sha256
+  $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH" description="The CPU architecture of the system Teleport will be installed on"/>-bin.tar.gz.sha256
   # <checksum> <filename>
-  $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
-  $ shasum -a 256 teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
+  $ shasum -a 256 teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
   # Verify that the checksums match
-  $ tar -xvf teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ tar -xvf teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
   $ cd teleport
   $ sudo ./install
   ```
@@ -170,12 +170,12 @@ Use the appropriate commands for your environment to install your package.
   <TabItem label="Tarball" scope="enterprise">
 
   ```code
-  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
+  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz.sha256
   # <checksum> <filename>
-  $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
-  $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
+  $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
   # Verify that the checksums match
-  $ tar -xvf teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz
+  $ tar -xvf teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
   $ cd teleport-ent
   $ sudo ./install
   ```
@@ -184,12 +184,12 @@ Use the appropriate commands for your environment to install your package.
   will be slightly different:
 
   ```code
-  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz.sha256
+  $ curl https://get.gravitational.com/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz.sha256
   # <checksum> <filename>
-  $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
-  $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
+  $ curl -O https://cdn.teleport.dev/teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
+  $ shasum -a 256 teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
   # Verify that the checksums match
-  $ tar -xvf teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM-ARCH"/>-fips-bin.tar.gz
+  $ tar -xvf teleport-ent-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-fips-bin.tar.gz
   $ cd teleport-ent
   $ sudo ./install
   ```
@@ -265,7 +265,7 @@ Use the appropriate commands for your environment to install your package.
   <TabItem label="Tarball" scope="cloud">
 
   ```code
-  $ curl https://get.gravitational.com/teleport-ent-v(=cloud.version=)-linux-<Var name="$SYSTEM-ARCH"/>-bin.tar.gz.sha256
+  $ curl https://get.gravitational.com/teleport-ent-v(=cloud.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz.sha256
   # <checksum> <filename>
   $ curl -O https://cdn.teleport.dev/teleport-ent-v(=cloud.version=)-linux-amd64-bin.tar.gz
   $ shasum -a 256 teleport-ent-v(=cloud.version=)-linux-amd64-bin.tar.gz

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -6,11 +6,11 @@ When following installation instructions, you might need to replace `ID` with
 `ID_LIKE` to install packages of the closest supported distribution.
 
 Currently supported distributions (and `ID`) are:
-- RHEL (`rhel`)
-- CentOS (`centos`)
-- Debian (`debian`)
-- Ubuntu (`ubuntu`)
-- AmazonLinux (`amzn`)
+- RHEL >= 7 (`rhel`)
+- CentOS >= 7 (`centos`)
+- Debian >= 8 (`debian`)
+- Ubuntu >= 16.04 (`ubuntu`)
+- Amazon Linux 2 and 2023 (`amzn`)
 
 </Admonition>
 
@@ -39,7 +39,7 @@ Currently supported distributions (and `ID`) are:
   ```
 
   </TabItem>
-  <TabItem label="AmazonLinux 2/RHEL 7 (yum)" scope="oss">
+  <TabItem label="Amazon Linux 2/RHEL 7 (yum)" scope="oss">
 
   ```code
   # Source variables about OS version

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -27,7 +27,7 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="AL 2/RHEL 7- (yum)" scope="oss">
+  <TabItem label="AL 2/RHEL 7 (yum)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -116,7 +116,7 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="AL 2/RHEL 7- (yum)" scope="enterprise">
+  <TabItem label="AL 2/RHEL 7 (yum)" scope="enterprise">
 
   ```code
   # Source variables about OS version
@@ -223,7 +223,7 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="AL 2/RHEL 7- (yum)" scope="cloud">
+  <TabItem label="AL 2/RHEL 7 (yum)" scope="cloud">
 
   ```code
   # Source variables about OS version

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,16 +1,3 @@
-<ScopedBlock scope={["enterprise"]}>
-
-Visit your [Teleport account](https://teleport.sh) and select the URL for your package of choice.
-
-</ScopedBlock>
-
-<ScopedBlock scope={["cloud"]}>
-
-Visit the [Downloads Page](/docs/choose-an-edition/teleport-cloud/downloads.mdx)
-and select the URL for your package of choice.
-
-</ScopedBlock>
-
 Use the appropriate commands for your environment to install your package.
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
@@ -40,7 +27,7 @@ Use the appropriate commands for your environment to install your package.
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="oss">
+  <TabItem label="Amazon Linux 2/RHEL <= 7 (yum)" scope="oss">
 
   ```code
   # Source variables about OS version
@@ -50,28 +37,32 @@ Use the appropriate commands for your environment to install your package.
   # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
   # and the codename your distro was forked from instead of '$ID'
   # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
-  $ sudo yum-config-manager --add-repo $(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")
+  $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   $ sudo yum install teleport
   #
   # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
   # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
-  #
-  # Optional:  Use DNF on newer distributions
-  # $ sudo dnf config-manager --add-repo https://rpm.releases.teleport.dev/teleport.repo
-  # $ sudo dnf install teleport
   ```
-
-  <Admonition type="warning" title="Amazon Linux 2023 Installations">
-  Amazon Linux 2023 users should utilize the tarball or RPM file to install Teleport.
-  You can download the matching RPM architecture for your instance
-  from the [Teleport Downloads page](https://goteleport.com/download) and install with the example command below.
+  </TabItem>
+  <TabItem label="Amazon Linux 2023/RHEL >= 8 (dnf)" scope="oss">
 
   ```code
-  # Replace <arch> with the architecture type (amd64, arm64,...)
-  $ rpm -i teleport-(=teleport.version=)-1.<arch>.rpm
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID'
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  # Use the dnf config manager plugin to add the teleport RPM repo
+  $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+  
+  # Install teleport
+  $ sudo dnf install teleport
+  
+  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
   ```
-  </Admonition>
-
   </TabItem>
   <TabItem label="Tarball" scope="oss">
 
@@ -94,34 +85,85 @@ Use the appropriate commands for your environment to install your package.
   </Tabs>
   </TabItem>
   <TabItem label="Enterprise" scope="enterprise">
-
-  In the example commands below, update `$SYSTEM-ARCH` with the appropriate
-  value (`amd64`, `arm64`, or `arm`). All example commands using this variable
-  will update after one is filled out.
-
   <Tabs>
   <TabItem label="Debian/Ubuntu (DEB)" scope="enterprise">
 
-  After Downloading the `.deb` file for your system architecture, install it with
-  `dpkg`. The example below assumes the `root` user:
+  Add the Teleport repository to your repository list:
 
   ```code
-  $ dpkg -i ~/Downloads/teleport-ent_(=teleport.version=)_<Var name="$SYSTEM-ARCH" description="The CPU architecture of the system Teleport will be installed on"/>.deb
-  Selecting previously unselected package teleport-ent.
-  (Reading database ... 30810 files and directories currently installed.)
-  Preparing to unpack teleport-ent_(=teleport.version=)_$SYSTEM_ARCH.deb ...
-  Unpacking teleport-ent (=teleport.version=) ...
-  Setting up teleport-ent (=teleport.version=) ...
+  # Download Teleport's PGP public key
+  $ sudo curl https://apt.releases.teleport.dev/gpg \
+  -o /usr/share/keyrings/teleport-archive-keyring.asc
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
+  $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
+  | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+
+  $ sudo apt-get update
+  $ sudo apt-get install teleport-ent
+  ```
+
+  For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+  ```code
+  $ sudo apt-get install teleport-ent-fips
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="enterprise">
-
-  After Downloading the `.rpm` file for your system architecture, install it with `rpm`:
+  <TabItem label="Amazon Linux 2/RHEL <= 7 (yum)" scope="oss">
 
   ```code
-  $ rpm -i ~/Downloads/teleport-ent-(=teleport.version=).<Var name="$SYSTEM-ARCH"/>.rpm
-  warning: teleport-ent-(=teleport.version=).$SYSTEM-ARCH.rpm: Header V4 RSA/SHA512 Signature, key ID 6282c411: NOKEY
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID'
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+  $ sudo yum install teleport-ent
+  #
+  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+  ```
+
+  For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+  ```code
+  $ sudo yum install teleport-ent-fips
+  ```
+
+  </TabItem>
+  <TabItem label="Amazon Linux 2023/RHEL >= 8 (dnf)" scope="oss">
+
+  ```code
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID'
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  # Use the dnf config manager plugin to add the teleport RPM repo
+  $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
+  
+  # Install teleport
+  $ sudo dnf install teleport-ent
+  
+  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
+  ```
+
+  For FedRAMP/FIPS-compliant installations, install the `teleport-ent-fips` package instead:
+
+  ```code
+  $ sudo dnf install teleport-ent-fips
   ```
 
   </TabItem>
@@ -156,34 +198,49 @@ Use the appropriate commands for your environment to install your package.
   </Tabs>
   </TabItem>
   <TabItem label="Cloud" scope="cloud">
-
-  In the example commands below, update `$SYSTEM-ARCH` with the appropriate
-  value (`amd64`, `arm64`, or `arm`). All example commands using this variable
-  will update after one is filled out.
-
   <Tabs>
   <TabItem label="Debian/Ubuntu (DEB)" scope="cloud">
 
-  After Downloading the `.deb` file for your system architecture, install it with
-  `dpkg`. The example below assumes the `root` user:
+  Add the Teleport repository to your repository list:
 
   ```code
-  $ dpkg -i ~/Downloads/teleport-ent_(=cloud.version=)_<Var name="$SYSTEM-ARCH"/>.deb
-  Selecting previously unselected package teleport-ent.
-  (Reading database ... 30810 files and directories currently installed.)
-  Preparing to unpack teleport-ent_(=cloud.version=)_$SYSTEM_ARCH.deb ...
-  Unpacking teleport-ent (=cloud.version=) ...
-  Setting up teleport-ent (=cloud.version=) ...
+  # Download Teleport's PGP public key
+  $ sudo curl https://apt.releases.teleport.dev/gpg \
+  -o /usr/share/keyrings/teleport-archive-keyring.asc
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of Debian or Ubuntu you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID' and '$VERSION_CODENAME'.
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L42-L67
+  $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
+  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/cloud" \
+  | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
+
+  $ sudo apt-get update
+  $ sudo apt-get install teleport-ent
   ```
 
   </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL (RPM)" scope="cloud">
-
-  After Downloading the `.rpm` file for your system architecture, install it with `rpm`:
+  <TabItem label="Amazon Linux 2023/RHEL >= 8 (dnf)" scope="oss">
 
   ```code
-  $ rpm -i ~/Downloads/teleport-ent-(=cloud.version=).<Var name="$SYSTEM-ARCH"/>.rpm
-  warning: teleport-ent-(=cloud.version=).$SYSTEM-ARCH.rpm: Header V4 RSA/SHA512 Signature, key ID 6282c411: NOKEY
+  # Source variables about OS version
+  $ source /etc/os-release
+  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
+  # file for each major release of Teleport.
+  # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
+  # and the codename your distro was forked from instead of '$ID'
+  # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  # Use the dnf config manager plugin to add the teleport RPM repo
+  $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport.repo")"
+  
+  # Install teleport
+  $ sudo dnf install teleport-ent
+  
+  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
+  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
   ```
 
   </TabItem>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -12,7 +12,7 @@ including:
 - `tctl`
 - `tbot`
 
-If you are new to Teleport, we recommend following our [getting started
+If you are new to Teleport, we recommend following our [ge[installation.mdx](installation.mdx)tting started
 guide](./get-started.mdx).
 
 For best results, Teleport clients (`tsh`, `tctl`, `tbot`) should be the same major
@@ -49,6 +49,19 @@ supports most features on Windows 10 and later.*
 ## Linux
 
 All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
+
+### Feature Support
+
+Some Teleport features have additional requirements:
+
+| Feature                                                                        | Requirement   | Debian                   | Ubuntu   | CentOS/RHEL | AmazonLinux            |
+|--------------------------------------------------------------------------------|---------------|--------------------------|----------|-------------|------------------------|
+| [Enhanced Session Recording](./server-access/guides/bpf-session-recording.mdx) | Kernel  v5.8+ | 11, or 10 with backports | 20.04.2+ | 9+          | 2 (post 11/2021), 2023 |
+| Easy node enrollment through the web UI                                        | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
+| Automatic Updates                                                              | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
+| Installation through apt/yum repos                                             | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
+
+### Installation instructions
 
 (!docs/pages/includes/permission-warning.mdx!)
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -50,7 +50,7 @@ supports most features on Windows 10 and later.*
 
 All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
 
-### Feature Support
+### Feature support
 
 Some Teleport features have additional requirements:
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -12,7 +12,7 @@ including:
 - `tctl`
 - `tbot`
 
-If you are new to Teleport, we recommend following our [ge[installation.mdx](installation.mdx)tting started
+If you are new to Teleport, we recommend following our [getting started
 guide](./get-started.mdx).
 
 For best results, Teleport clients (`tsh`, `tctl`, `tbot`) should be the same major
@@ -57,7 +57,6 @@ Some Teleport features have additional requirements:
 | Feature                                                                        | Requirement   | Debian                   | Ubuntu   | CentOS/RHEL | AmazonLinux            |
 |--------------------------------------------------------------------------------|---------------|--------------------------|----------|-------------|------------------------|
 | [Enhanced Session Recording](./server-access/guides/bpf-session-recording.mdx) | Kernel  v5.8+ | 11, or 10 with backports | 20.04.2+ | 9+          | 2 (post 11/2021), 2023 |
-| Easy node enrollment through the web UI                                        | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
 | Automatic Updates                                                              | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
 | Installation through apt/yum repos                                             | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
 

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -60,6 +60,21 @@ Some Teleport features have additional requirements:
 | Automatic Updates                                                              | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
 | Installation through apt/yum repos                                             | systemd-based | 8+                       | 16.04+   | 7+          | 2, 2023                |
 
+<Admonition type="note">
+`apt` and `yum` repos don't expose packages for all distribution variants.
+When following installation instructions, you might need to replace `ID` with
+`ID_LIKE` to install packages of the closest supported distribution.
+
+Currently supported distributions (and `ID`) are:
+- RHEL >= 7 (`rhel`)
+- CentOS >= 7 (`centos`)
+- Debian >= 8 (`debian`)
+- Ubuntu >= 16.04 (`ubuntu`)
+- Amazon Linux 2 and 2023 (`amzn`)
+
+</Admonition>
+
+
 ### Installation instructions
 
 (!docs/pages/includes/permission-warning.mdx!)


### PR DESCRIPTION
Backport #25700 to branch/v13