### PR TITLE
warn about v13 repos not containing v14 Teleport

### DIFF
--- a/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
+++ b/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
@@ -12,6 +12,16 @@ description: How to enroll an agent into automatic updates
 >
   Automatic agent update is available starting from Teleport `13.0`.
 </Details>
+  <Details
+  title="Version warning"
+  opened={true}
+  scope={["cloud"]}
+  scopeOnly={true}
+  min="13.0"
+>
+Automatic agent update is available starting from Teleport `13.0`.
+Teleport Cloud does not run Teleport 13 yet.
+</Details>
 
 Teleport supports automatic agent updates for
 systemd-based Linux distributions using `apt` or `yum` package managers,

--- a/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
+++ b/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
@@ -12,15 +12,15 @@ description: How to enroll an agent into automatic updates
 >
   Automatic agent update is available starting from Teleport `13.0`.
 </Details>
-  <Details
+<Details
   title="Version warning"
   opened={true}
   scope={["cloud"]}
   scopeOnly={true}
   min="13.0"
 >
-Automatic agent update is available starting from Teleport `13.0`.
-Teleport Cloud does not run Teleport 13 yet.
+  Automatic agent update is available starting from Teleport `13.0`.
+  Teleport Cloud does not run Teleport 13 yet.
 </Details>
 
 Teleport supports automatic agent updates for

--- a/docs/pages/management/operations/self-hosted-automatic-agent-updates.mdx
+++ b/docs/pages/management/operations/self-hosted-automatic-agent-updates.mdx
@@ -23,6 +23,19 @@ This guide covers how to set up the automatic update infrastructure. If this is
 already done, or you are a Teleport Cloud user, you can directly
 [enroll agents into automatic updates](./enroll-agent-into-automatic-updates.mdx).
 
+<Admonition type="warning">
+Agents enrolled into automatic updates can only install versions present in
+their package repositories. As Teleport 14 won't be published to `stable/v13`,
+those agents will require manual intervention to be updated to the next major
+version (adding a new apt/yum repo for `stable/v14`).
+
+This limitation will be fixed before Teleport 14. We'll provide a rolling
+update channel for agents to be able to automatically update from one major
+to another. When this will happen, you will have to update the repos of the
+existing agents to point to the new repo.
+
+</Admonition>
+
 ## Requirements
 
 - Self-hosted Teleport cluster running.

--- a/docs/pages/management/operations/self-hosted-automatic-agent-updates.mdx
+++ b/docs/pages/management/operations/self-hosted-automatic-agent-updates.mdx
@@ -24,10 +24,10 @@ already done, or you are a Teleport Cloud user, you can directly
 [enroll agents into automatic updates](./enroll-agent-into-automatic-updates.mdx).
 
 <Admonition type="warning">
-Agents enrolled into automatic updates can only install versions present in
-their package repositories. As Teleport 14 won't be published to `stable/v13`,
-those agents will require manual intervention to be updated to the next major
-version (adding a new apt/yum repo for `stable/v14`).
+Systemd agents enrolled into automatic updates can only install versions
+present in their package repositories. As Teleport 14 won't be published to
+`stable/v13`, those agents will require manual intervention to be updated to
+the next major version (adding a new apt/yum repo for `stable/v14`).
 
 This limitation will be fixed before Teleport 14. We'll provide a rolling
 update channel for agents to be able to automatically update from one major


### PR DESCRIPTION
(Urgent) As discussed with @fheinecke @fspmarshall and @r0mant, we won't offer a rolling update channel until we have refactored the repo pipelines and can make sure this won't affect our ability to release versions.

Due to this limitation, we must warn users they will have some manual intervention to do before v14.