### PR TITLE
User os.UserHomeDir where possible

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -313,7 +313,15 @@ func FullProfilePath(dir string) string {
 
 // defaultProfilePath retrieves the default path of the TSH profile.
 func defaultProfilePath() string {
-	home := os.TempDir()
+	// start with UserHomeDir, which is the fastest option as it
+	// relies only on environment variables and does not perform
+	// a user lookup (which can be very slow on large AD environments)
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		return home
+	}
+
+	home = os.TempDir()
 	if u, err := utils.CurrentUser(); err == nil && u.HomeDir != "" {
 		home = u.HomeDir
 	}

--- a/lib/client/db/mysql/optionfile.go
+++ b/lib/client/db/mysql/optionfile.go
@@ -17,6 +17,7 @@ limitations under the License.
 package mysql
 
 import (
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -44,11 +45,16 @@ type OptionFile struct {
 
 func DefaultConfigPath() (string, error) {
 	// Default location is .my.cnf file in the user's home directory.
-	usr, err := utils.CurrentUser()
-	if err != nil {
-		return "", trace.ConvertSystemError(err)
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		usr, err := utils.CurrentUser()
+		if err != nil {
+			return "", trace.ConvertSystemError(err)
+		}
+		home = usr.HomeDir
 	}
-	return filepath.Join(usr.HomeDir, mysqlOptionFile), nil
+
+	return filepath.Join(home, mysqlOptionFile), nil
 }
 
 // Load loads MySQL option file from the default location.

--- a/lib/client/db/postgres/servicefile.go
+++ b/lib/client/db/postgres/servicefile.go
@@ -17,6 +17,7 @@ limitations under the License.
 package postgres
 
 import (
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -46,11 +47,16 @@ type ServiceFile struct {
 func Load() (*ServiceFile, error) {
 	// Default location is .pg_service.conf file in the user's home directory.
 	// TODO(r0mant): Check PGSERVICEFILE and PGSYSCONFDIR env vars as well.
-	user, err := utils.CurrentUser()
-	if err != nil {
-		return nil, trace.ConvertSystemError(err)
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		user, err := utils.CurrentUser()
+		if err != nil {
+			return nil, trace.ConvertSystemError(err)
+		}
+		home = user.HomeDir
 	}
-	return LoadFromPath(filepath.Join(user.HomeDir, pgServiceFile))
+
+	return LoadFromPath(filepath.Join(home, pgServiceFile))
 }
 
 // LoadFromPath loads Posrtgres connection service file from the specified path.


### PR DESCRIPTION
In #24156 we removed a lot of unnecessary calls to user.Current, which can take a long time in Active Directory environments.

This commit removes a few other uses of user.Current where we were doing a full user lookup only to find the user's home directory, which is usually more readily available via the environment.

Updates #25014