### PR TITLE
Assist - Execution web endpoint

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -49,6 +49,9 @@ const (
 
 	// SSHSessionID is the UUID of the current session.
 	SSHSessionID = "SSH_SESSION_ID"
+
+	// EnableNonInteractiveSessionRecording can be used to record non-interactive SSH session.
+	EnableNonInteractiveSessionRecording = "SSH_RECORD_NON_INTERACTIVE"
 )
 
 const (

--- a/constants.go
+++ b/constants.go
@@ -51,7 +51,7 @@ const (
 	SSHSessionID = "SSH_SESSION_ID"
 
 	// EnableNonInteractiveSessionRecording can be used to record non-interactive SSH session.
-	EnableNonInteractiveSessionRecording = "SSH_RECORD_NON_INTERACTIVE"
+	EnableNonInteractiveSessionRecording = "SSH_TELEPORT_RECORD_NON_INTERACTIVE"
 )
 
 const (

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -312,6 +312,10 @@ type Config struct {
 	// SessionID is a session ID to use when opening a new session.
 	SessionID string
 
+	// extraEnvs contains additional environment variables that will be added
+	// to SSH session.
+	extraEnvs map[string]string
+
 	// InteractiveCommand tells tsh to launch a remote exec command in interactive mode,
 	// i.e. attaching the terminal to it.
 	InteractiveCommand bool
@@ -2672,6 +2676,10 @@ func (tc *TeleportClient) newSessionEnv() map[string]string {
 	}
 	if tc.SessionID != "" {
 		env[sshutils.SessionEnvVar] = tc.SessionID
+	}
+
+	for key, val := range tc.extraEnvs {
+		env[key] = val
 	}
 	return env
 }

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1664,6 +1664,15 @@ func (c *NodeClient) RunCommand(ctx context.Context, command []string) error {
 	return nil
 }
 
+// AddEnv add environment variable to SSH session. This method needs to be called
+// before the session is created.
+func (c *NodeClient) AddEnv(key, value string) {
+	if c.TC.extraEnvs == nil {
+		c.TC.extraEnvs = make(map[string]string)
+	}
+	c.TC.extraEnvs[key] = value
+}
+
 func (c *NodeClient) handleGlobalRequests(ctx context.Context, requestCh <-chan *ssh.Request) {
 	for {
 		select {

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -394,8 +394,8 @@ type ServerContext struct {
 	killShellr *os.File
 	killShellw *os.File
 
-	// multiWriter is used by to stream non-interactive session output
-	// to audit log.
+	// multiWriter is used to record non-interactive session output.
+	// Currently, used by Assist.
 	multiWriter io.Writer
 	// recordNonInteractiveSession enables non-interactive session recording. Used by Assist.
 	recordNonInteractiveSession bool

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -394,6 +394,12 @@ type ServerContext struct {
 	killShellr *os.File
 	killShellw *os.File
 
+	// multiWriter is used by to stream non-interactive session output
+	// to audit log.
+	multiWriter io.Writer
+	// recordNonInteractiveSession enables non-interactive session recording. Used by Assist.
+	recordNonInteractiveSession bool
+
 	// ChannelType holds the type of the channel. For example "session" or
 	// "direct-tcpip". Used to create correct subcommand during re-exec.
 	ChannelType string

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -154,7 +154,12 @@ func (e *localExec) Start(ctx context.Context, channel ssh.Channel) (*ExecResult
 
 	// Connect stdout and stderr to the channel so the user can interact with the command.
 	e.Cmd.Stderr = channel.Stderr()
-	e.Cmd.Stdout = channel
+
+	if e.Ctx.recordNonInteractiveSession {
+		e.Cmd.Stdout = io.MultiWriter(e.Ctx.multiWriter, channel)
+	} else {
+		e.Cmd.Stdout = channel
+	}
 
 	// Copy from the channel (client input) into stdin of the process.
 	inputWriter, err := e.Cmd.StdinPipe()

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -276,9 +276,22 @@ func (s *SessionRegistry) OpenSession(ctx context.Context, ch ssh.Channel, scx *
 
 // OpenExecSession opens an non-interactive exec session.
 func (s *SessionRegistry) OpenExecSession(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
-	// Create a new session ID. These sessions can not be joined so no point in
-	// looking for an exisiting one.
-	sessionID := rsession.NewID()
+	var sessionID rsession.ID
+
+	sid, found := scx.GetEnv(sshutils.SessionEnvVar)
+	if !found {
+		// Create a new session ID. These sessions can not be joined
+		sessionID = rsession.NewID()
+	} else {
+		// Use passed session ID. Assist uses this "feature" to record
+		// the execution output.
+		sessionID = rsession.ID(sid)
+	}
+
+	_, found = scx.GetEnv(teleport.EnableNonInteractiveSessionRecording)
+	if found {
+		scx.recordNonInteractiveSession = true
+	}
 
 	// This logic allows concurrent request to create a new session
 	// to fail, what is ok because we should never have this condition.
@@ -1289,6 +1302,12 @@ func newEventOnlyRecorder(s *session, ctx *ServerContext) (events.StreamWriter, 
 }
 
 func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *ServerContext) error {
+	if scx.recordNonInteractiveSession {
+		// enable recording.
+		s.io.AddWriter(sessionRecorderID, utils.WriteCloserWithContext(scx.srv.Context(), s.Recorder()))
+		s.scx.multiWriter = s.io
+	}
+
 	// Emit a session.start event for the exec session.
 	s.emitSessionStartEvent(scx)
 
@@ -1338,6 +1357,10 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 	// Process has been placed in a cgroup, continue execution.
 	execRequest.Continue()
 
+	if scx.recordNonInteractiveSession {
+		s.io.On()
+	}
+
 	// Process is running, wait for it to stop.
 	go func() {
 		result = execRequest.Wait()
@@ -1360,6 +1383,9 @@ func (s *session) startExec(ctx context.Context, channel ssh.Channel, scx *Serve
 
 		s.emitSessionEndEvent()
 		s.Close()
+
+		s.io.Close()
+		close(s.doneCh)
 	}()
 
 	return nil

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2731,8 +2731,9 @@ type hostInfo struct {
 }
 
 // findByQuery returns all hosts matching the given query/predicate.
+// The query is a predicate expression that can be used to filter hosts.
 func findByQuery(ctx context.Context, clt auth.ClientI, query string) ([]hostInfo, error) {
-	resources, err := apiclient.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
+	servers, err := apiclient.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
 		ResourceType:        types.KindNode,
 		Namespace:           apidefaults.Namespace,
 		PredicateExpression: query,
@@ -2741,13 +2742,8 @@ func findByQuery(ctx context.Context, clt auth.ClientI, query string) ([]hostInf
 		return nil, trace.Wrap(err)
 	}
 
-	hosts := make([]hostInfo, 0, len(resources))
-	for _, resource := range resources {
-		server, ok := resource.(types.Server)
-		if !ok {
-			return nil, trace.BadParameter("expected types.Server, got: %T", resource)
-		}
-
+	hosts := make([]hostInfo, 0, len(servers))
+	for _, server := range servers {
 		h := hostInfo{
 			hostName: server.GetHostname(),
 			id:       server.GetName(),

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2680,7 +2680,7 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 
 	host, err := findByHost(ctx, clt, req.Server)
 	if err != nil {
-		return session.Session{}, err
+		return session.Session{}, trace.Wrap(err)
 	}
 
 	accessChecker, err := scx.GetUserAccessChecker()
@@ -2723,14 +2723,14 @@ func (h *Handler) generateCommandSession(host *hostInfo, login, clusterName, own
 	}, nil
 }
 
+// hostInfo is a helper struct used to store host information.
 type hostInfo struct {
 	id       string
 	hostName string
 	port     int
 }
 
-// findByQuery returns all hosts matching the given query/predicate. Allow free query to
-// return all nodes.
+// findByQuery returns all hosts matching the given query/predicate.
 func findByQuery(ctx context.Context, clt auth.ClientI, query string) ([]hostInfo, error) {
 	resources, err := apiclient.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
 		ResourceType:        types.KindNode,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2675,94 +2675,14 @@ func (h *Handler) siteNodeConnect(
 }
 
 func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *TerminalRequest, clusterName string, scx *SessionContext) (session.Session, error) {
-	var (
-		id   string
-		host string
-		port int
-	)
 	owner := scx.cfg.User
 	h.log.Infof("Generating new session for %s\n", clusterName)
 
-	if _, err := uuid.Parse(req.Server); err != nil {
-		// The requested server is either a hostname or an address. Get all
-		// servers that may fuzzily match by populating SearchKeywords
-		servers, err := apiclient.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
-			ResourceType:   types.KindNode,
-			Namespace:      apidefaults.Namespace,
-			SearchKeywords: []string{req.Server},
-		})
-		if err != nil {
-			return session.Session{}, trace.Wrap(err)
-		}
-
-		if len(servers) == 0 {
-			// If we didn't find the resource set host and port,
-			// so we can try direct dial.
-			host, port, err = serverHostPort(req.Server)
-			if err != nil {
-				return session.Session{}, trace.Wrap(err)
-			}
-			id = host
-		}
-
-		matches := 0
-		for _, server := range servers {
-			// match by hostname
-			if server.GetHostname() == req.Server {
-				if matches > 0 {
-					matches++
-					continue
-				}
-
-				host = server.GetHostname()
-				id = server.GetName()
-				port = 0
-
-				matches++
-				continue
-			}
-
-			// exact match by address
-			if server.GetAddr() == req.Server {
-				if matches > 0 {
-					matches++
-					continue
-				}
-
-				host = req.Server
-				id = server.GetName()
-				port = 0
-
-				matches++
-				continue
-			}
-		}
-
-		// there was either at least one partial match or multiple
-		// exact matches on the server. connect with the resolved
-		// host and port of the requested server.
-		if matches > 1 || host == "" && id == "" {
-			host, port, err = serverHostPort(req.Server)
-			if err != nil {
-				return session.Session{}, trace.Wrap(err)
-			}
-			id = req.Server
-		}
-	} else {
-		// Even though the UUID was provided and can be dialed directly, the UI
-		// requires the hostname to populate the title of the session window.
-		// Looking the node up directly by UUID is the most efficient we can be until
-		// the UI is modified to remember the hostname when the connect button is
-		// used to establish a session.
-		server, err := clt.GetNode(ctx, apidefaults.Namespace, req.Server)
-		if err != nil {
-			return session.Session{}, trace.Wrap(err)
-		}
-
-		host = server.GetHostname()
-		port = 0
-		id = req.Server
+	host, err := findByHost(ctx, clt, req.Server)
+	if err != nil {
+		return session.Session{}, err
 	}
+
 	accessChecker, err := scx.GetUserAccessChecker()
 	if err != nil {
 		return session.Session{}, trace.Wrap(err)
@@ -2773,10 +2693,10 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 	return session.Session{
 		Kind:           types.SSHSessionKind,
 		Login:          req.Login,
-		ServerID:       id,
+		ServerID:       host.id,
 		ClusterName:    clusterName,
-		ServerHostname: host,
-		ServerHostPort: port,
+		ServerHostname: host.hostName,
+		ServerHostPort: host.port,
 		Moderated:      accessEvaluator.IsModerated(),
 		ID:             session.NewID(),
 		Created:        time.Now().UTC(),
@@ -2784,6 +2704,146 @@ func (h *Handler) generateSession(ctx context.Context, clt auth.ClientI, req *Te
 		Namespace:      apidefaults.Namespace,
 		Owner:          owner,
 	}, nil
+}
+
+func (h *Handler) generateCommandSession(host *hostInfo, login, clusterName, owner string) (session.Session, error) {
+	h.log.Infof("Generating new session for %s in %s\n", host.hostName, clusterName)
+
+	return session.Session{
+		Login:          login,
+		ServerID:       host.id,
+		ClusterName:    clusterName,
+		ServerHostname: host.hostName,
+		ServerHostPort: host.port,
+		ID:             session.NewID(),
+		Created:        time.Now().UTC(),
+		LastActive:     time.Now().UTC(),
+		Namespace:      apidefaults.Namespace,
+		Owner:          owner,
+	}, nil
+}
+
+type hostInfo struct {
+	id       string
+	hostName string
+	port     int
+}
+
+// findByQuery returns all hosts matching the given query/predicate. Allow free query to
+// return all nodes.
+func findByQuery(ctx context.Context, clt auth.ClientI, query string) ([]hostInfo, error) {
+	resources, err := apiclient.GetResourcesWithFilters(ctx, clt, proto.ListResourcesRequest{
+		ResourceType:        types.KindNode,
+		Namespace:           apidefaults.Namespace,
+		PredicateExpression: query,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	hosts := make([]hostInfo, 0, len(resources))
+	for _, resource := range resources {
+		server, ok := resource.(types.Server)
+		if !ok {
+			return nil, trace.BadParameter("expected types.Server, got: %T", resource)
+		}
+
+		h := hostInfo{
+			hostName: server.GetHostname(),
+			id:       server.GetName(),
+			port:     defaultPort,
+		}
+		hosts = append(hosts, h)
+	}
+
+	return hosts, nil
+}
+
+// findByHost return a host matching by the host name.
+func findByHost(ctx context.Context, clt auth.ClientI, serverName string) (*hostInfo, error) {
+	var host hostInfo
+
+	if _, err := uuid.Parse(serverName); err != nil {
+		// The requested server is either a hostname or an address. Get all
+		// servers that may fuzzily match by populating SearchKeywords
+		servers, err := apiclient.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
+			ResourceType:   types.KindNode,
+			Namespace:      apidefaults.Namespace,
+			SearchKeywords: []string{serverName},
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		if len(servers) == 0 {
+			// If we didn't find the resource set host and port,
+			// so we can try direct dial.
+			host.hostName, host.port, err = serverHostPort(serverName)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			host.id = host.hostName
+		}
+
+		matches := 0
+		for _, server := range servers {
+			// match by hostname
+			if server.GetHostname() == serverName {
+				if matches > 0 {
+					matches++
+					continue
+				}
+
+				host.hostName = server.GetHostname()
+				host.id = server.GetName()
+				host.port = 0
+
+				matches++
+				continue
+			}
+
+			// exact match by address
+			if server.GetAddr() == serverName {
+				if matches > 0 {
+					matches++
+					continue
+				}
+
+				host.hostName = serverName
+				host.id = server.GetName()
+				host.port = 0
+
+				matches++
+				continue
+			}
+		}
+
+		// there was either at least one partial match or multiple
+		// exact matches on the server. connect with the resolved
+		// host and port of the requested server.
+		if matches > 1 || host.hostName == "" && host.id == "" {
+			host.hostName, host.port, err = serverHostPort(serverName)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			host.id = serverName
+		}
+	} else {
+		// Even though the UUID was provided and can be dialed directly, the UI
+		// requires the hostname to populate the title of the session window.
+		// Looking the node up directly by UUID is the most efficient we can be until
+		// the UI is modified to remember the hostname when the connect button is
+		// used to establish a session.
+		server, err := clt.GetNode(ctx, apidefaults.Namespace, serverName)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		host.hostName = server.GetHostname()
+		host.port = 0
+		host.id = serverName
+	}
+	return &host, nil
 }
 
 // fetchExistingSession fetches an active or pending SSH session by the SessionID passed in the TerminalRequest.

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2732,7 +2732,7 @@ type hostInfo struct {
 // findByQuery returns all hosts matching the given query/predicate. Allow free query to
 // return all nodes.
 func findByQuery(ctx context.Context, clt auth.ClientI, query string) ([]hostInfo, error) {
-	resources, err := apiclient.GetResourcesWithFilters(ctx, clt, proto.ListResourcesRequest{
+	resources, err := apiclient.GetAllResources[types.Server](ctx, clt, &proto.ListResourcesRequest{
 		ResourceType:        types.KindNode,
 		Namespace:           apidefaults.Namespace,
 		PredicateExpression: query,

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
+// CommandResultType is the type of Assist message that contains the command execution result.
 const CommandResultType = "COMMAND_RESULT"
 
 type CommandRequest struct {
@@ -74,27 +75,22 @@ type CommandRequest struct {
 
 func (c *CommandRequest) Check() error {
 	if c.Command == "" {
-		return trace.Errorf("missing command")
+		return trace.BadParameter("missing command")
 	}
 
 	if c.Login == "" {
-		return trace.Errorf("missing login")
+		return trace.BadParameter("missing login")
 	}
 
 	if c.ConversationID == "" {
-		return trace.Errorf("missing conversation ID")
+		return trace.BadParameter("missing conversation ID")
 	}
 
 	if c.ExecutionID == "" {
-		return trace.Errorf("missing execution ID")
+		return trace.BadParameter("missing execution ID")
 	}
 
 	return nil
-}
-
-// CommandExecutionResult is a result of a command execution.
-type CommandExecutionResult struct {
-	SessionID string `json:"session_id"`
 }
 
 // executeCommand executes a command on all nodes that match the query.
@@ -112,7 +108,7 @@ func (h *Handler) executeCommand(
 	}
 	var req *CommandRequest
 	if err := json.Unmarshal([]byte(params), &req); err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.BadParameter("failed to read JSON message: %v", err)
 	}
 
 	if err := req.Check(); err != nil {
@@ -373,7 +369,8 @@ type commandHandler struct {
 	// router is used to dial the host
 	router *proxy.Router
 
-	stream *WsStream
+	// stream is the websocket stream to the client.
+	stream *WSStream
 
 	// tracer creates spans
 	tracer oteltrace.Tracer
@@ -385,7 +382,7 @@ type commandHandler struct {
 	// interactiveCommand is a command to execute.
 	interactiveCommand []string
 
-	// ws is the websocket connection to the client.
+	// ws a raw websocket connection to the client.
 	ws WSConn
 }
 

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -243,6 +243,8 @@ func (h *Handler) executeCommand(
 					Type:           CommandResultType,
 					CreatedTime:    timestamppb.New(time.Now().UTC()),
 					Payload:        string(msgPayload),
+					// TODO(jakule): Move username to CreateAssistantMessageRequest.
+					Username: identity.TeleportUser,
 				},
 			})
 

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -170,6 +170,7 @@ func (h *Handler) executeCommand(
 	hosts, err := findByQuery(ctx, clt, req.Query)
 	if err != nil {
 		log.WithError(err).Warn("failed to find nodes by labels")
+		return nil, trace.Wrap(err)
 	}
 
 	if len(hosts) == 0 {
@@ -178,7 +179,7 @@ func (h *Handler) executeCommand(
 		return nil, trace.Errorf(errMsg)
 	}
 
-	h.log.Debugf("found %d hosts", len(hosts))
+	h.log.Debugf("Found %d hosts to run Assist command %q on.", len(hosts), req.Command)
 
 	for _, host := range hosts {
 		err := func() error {

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -232,13 +232,12 @@ func (h *Handler) executeCommand(
 			}
 
 			err = clt.CreateAssistantMessage(ctx, &assist.CreateAssistantMessageRequest{
+				ConversationId: req.ConversationID,
+				Username:       identity.TeleportUser,
 				Message: &assist.AssistantMessage{
-					ConversationId: req.ConversationID,
-					Type:           CommandResultType,
-					CreatedTime:    timestamppb.New(time.Now().UTC()),
-					Payload:        string(msgPayload),
-					// TODO(jakule): Move username to CreateAssistantMessageRequest.
-					Username: identity.TeleportUser,
+					Type:        CommandResultType,
+					CreatedTime: timestamppb.New(time.Now().UTC()),
+					Payload:     string(msgPayload),
 				},
 			})
 
@@ -476,6 +475,8 @@ func (t *commandHandler) streamOutput(ctx context.Context, ws WSConn, tc *client
 	t.log.Debug("Sent close event to web client.")
 }
 
+// Close is no-op as we never want to close the connection to the client.
+// Connection should be closed in the handler when it was created.
 func (t *commandHandler) Close() error {
 	return nil
 }

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -53,6 +53,7 @@ import (
 // CommandResultType is the type of Assist message that contains the command execution result.
 const CommandResultType = "COMMAND_RESULT"
 
+// CommandRequest is a request to execute a command on all nodes that match the query.
 type CommandRequest struct {
 	// Command is the command to be executed on all nodes.
 	Command string `json:"command"`
@@ -66,6 +67,7 @@ type CommandRequest struct {
 	ExecutionID string `json:"execution_id"`
 }
 
+// Check checks if the request is valid.
 func (c *CommandRequest) Check() error {
 	if c.Command == "" {
 		return trace.BadParameter("missing command")
@@ -169,7 +171,7 @@ func (h *Handler) executeCommand(
 
 	hosts, err := findByQuery(ctx, clt, req.Query)
 	if err != nil {
-		log.WithError(err).Warn("failed to find nodes by labels")
+		log.WithError(err).Warn("Failed to find nodes by labels")
 		return nil, trace.Wrap(err)
 	}
 
@@ -281,6 +283,7 @@ func newCommandHandler(ctx context.Context, cfg CommandHandlerConfig) (*commandH
 	}, nil
 }
 
+// CommandHandlerConfig is the configuration for the command handler.
 type CommandHandlerConfig struct {
 	// SessionCtx is the context for the user's web session.
 	SessionCtx *SessionContext
@@ -307,6 +310,7 @@ type CommandHandlerConfig struct {
 	tracer oteltrace.Tracer
 }
 
+// CheckAndSetDefaults checks and sets default values.
 func (t *CommandHandlerConfig) CheckAndSetDefaults() error {
 	// Make sure whatever session is requested is a valid session id.
 	_, err := session.ParseID(t.SessionData.ID.String())
@@ -347,6 +351,7 @@ func (t *CommandHandlerConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
+// commandHandler is a handler for executing commands on a remote node.
 type commandHandler struct {
 	sshBaseHandler
 
@@ -431,12 +436,12 @@ func (t *commandHandler) handler(r *http.Request) {
 	go startPingLoop(r.Context(), t.ws, t.keepAliveInterval, t.log, t.Close)
 
 	// Pump raw terminal in/out and audit events into the websocket.
-	t.streamOutput(r.Context(), t.ws, tc)
+	t.streamOutput(r.Context(), tc)
 }
 
-// streamOutput opens a SSH connection to the remote host and streams
+// streamOutput opens an SSH connection to the remote host and streams
 // events back to the web client.
-func (t *commandHandler) streamOutput(ctx context.Context, ws WSConn, tc *client.TeleportClient) {
+func (t *commandHandler) streamOutput(ctx context.Context, tc *client.TeleportClient) {
 	ctx, span := t.tracer.Start(ctx, "commandHandler/streamOutput")
 	defer span.End()
 

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -20,13 +20,82 @@
 package web
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
 	"net/http"
+	"strconv"
+	"strings"
+	"time"
 
+	"github.com/gogo/protobuf/proto"
+	"github.com/gorilla/websocket"
+	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
+	"github.com/sirupsen/logrus"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/crypto/ssh"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/gravitational/teleport"
+	authproto "github.com/gravitational/teleport/api/client/proto"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/observability/tracing"
+	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
+	"github.com/gravitational/teleport/lib/agentless"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/modules"
+	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnel"
+	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/teleagent"
+	"github.com/gravitational/teleport/lib/utils"
 )
+
+type CommandRequest struct {
+	// Command is the command to be executed on all nodes.
+	Command string `json:"command"`
+	// Login is a Linux username to connect as.
+	Login string `json:"login"`
+	// Query is the predicate query to filter nodes where the command will be executed.
+	Query string `json:"query"`
+	// ConversationID is the conversation context that was used to execute the command.
+	ConversationID string `json:"conversation_id"`
+	// ExecutionID is a unique ID used to identify the command execution.
+	ExecutionID string `json:"execution_id"`
+}
+
+func (c *CommandRequest) Check() error {
+	if c.Command == "" {
+		return trace.Errorf("missing command")
+	}
+
+	if c.Login == "" {
+		return trace.Errorf("missing login")
+	}
+
+	if c.ConversationID == "" {
+		return trace.Errorf("missing conversation ID")
+	}
+
+	if c.ExecutionID == "" {
+		return trace.Errorf("missing execution ID")
+	}
+
+	return nil
+}
+
+type CommandExecutionResult struct {
+	SessionID string `json:"session_id"`
+}
 
 func (h *Handler) executeCommand(
 	w http.ResponseWriter,
@@ -35,5 +104,583 @@ func (h *Handler) executeCommand(
 	sessionCtx *SessionContext,
 	site reversetunnel.RemoteSite,
 ) (any, error) {
-	return nil, trace.NotImplemented("not implemented")
+	q := r.URL.Query()
+	params := q.Get("params")
+	if params == "" {
+		return nil, trace.BadParameter("missing params")
+	}
+	var req *CommandRequest
+	if err := json.Unmarshal([]byte(params), &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := req.Check(); err != nil {
+		return nil, trace.BadParameter("invalid payload: %v", err)
+	}
+
+	clt, err := sessionCtx.GetUserClient(r.Context(), site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	identity, err := createIdentityContext(req.Login, sessionCtx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx, err := h.cfg.SessionControl.AcquireSessionContext(r.Context(), identity, h.cfg.ProxyWebAddr.Addr, r.RemoteAddr)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	authAccessPoint, err := site.CachingAccessPoint()
+	if err != nil {
+		h.log.WithError(err).Debug("Unable to get auth access point.")
+		return nil, trace.Wrap(err)
+	}
+
+	netConfig, err := authAccessPoint.GetClusterNetworkingConfig(ctx)
+	if err != nil {
+		h.log.WithError(err).Debug("Unable to fetch cluster networking config.")
+		return nil, trace.Wrap(err)
+	}
+
+	clusterName := site.GetName()
+
+	upgrader := websocket.Upgrader{
+		ReadBufferSize:  1024,
+		WriteBufferSize: 1024,
+		CheckOrigin:     func(r *http.Request) bool { return true },
+	}
+
+	ws, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		errMsg := "Error upgrading to websocket"
+		h.log.WithError(err).Error(errMsg)
+		http.Error(w, errMsg, http.StatusInternalServerError)
+		return nil, nil
+	}
+
+	defer func() {
+		ws.WriteMessage(websocket.CloseMessage, nil)
+		ws.Close()
+	}()
+
+	keepAliveInterval := netConfig.GetKeepAliveInterval()
+	err = ws.SetReadDeadline(deadlineForInterval(keepAliveInterval))
+	if err != nil {
+		h.log.WithError(err).Error("Error setting websocket readline")
+		return nil, nil
+	}
+
+	hosts, err := findByQuery(ctx, clt, req.Query)
+	if err != nil {
+		log.WithError(err).Warn("failed to find nodes by labels")
+	}
+
+	if len(hosts) == 0 {
+		const errMsg = "no servers found"
+		h.log.Error(errMsg)
+		return nil, trace.Errorf(errMsg)
+	}
+
+	hosts = removeDuplicates(hosts)
+
+	h.log.Debugf("found %d hosts", len(hosts))
+
+	for _, host := range hosts {
+		err := func() error {
+			sessionData, err := h.generateCommandSession(&host, req.Login, clusterName, sessionCtx.cfg.User)
+			if err != nil {
+				h.log.WithError(err).Debug("Unable to generate new ssh session.")
+				return trace.Wrap(err)
+			}
+
+			h.log.Debugf("New command request for server=%s, id=%v, login=%s, sid=%s, websid=%s.",
+				host.hostName, host.id, req.Login, sessionData.ID, sessionCtx.GetSessionID())
+
+			commandHandlerConfig := CommandHandlerConfig{
+				SessionCtx:         sessionCtx,
+				AuthProvider:       clt,
+				SessionData:        sessionData,
+				KeepAliveInterval:  netConfig.GetKeepAliveInterval(),
+				ProxyHostPort:      h.ProxyHostPort(),
+				InteractiveCommand: strings.Split(req.Command, " "),
+				Router:             h.cfg.Router,
+				TracerProvider:     h.cfg.TracerProvider,
+				proxySigner:        h.cfg.PROXYSigner,
+				LocalAuthProvider:  h.auth.accessPoint,
+			}
+
+			handler, err := newCommandHandler(ctx, commandHandlerConfig)
+			if err != nil {
+				h.log.WithError(err).Error("Unable to create terminal.")
+				return trace.Wrap(err)
+			}
+			handler.ws = &noopCloserWS{ws}
+
+			h.userConns.Add(1)
+			defer h.userConns.Add(-1)
+
+			h.log.Infof("Executing command: %#v.", req)
+			httplib.MakeTracingHandler(handler, teleport.ComponentProxy).ServeHTTP(w, r)
+
+			msgPayload, err := json.Marshal(struct {
+				NodeID      string `json:"node_id"`
+				ExecutionID string `json:"execution_id"`
+				SessionID   string `json:"session_id"`
+			}{
+				NodeID:      host.id,
+				ExecutionID: req.ExecutionID,
+				SessionID:   string(sessionData.ID),
+			})
+
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			err = clt.CreateAssistantMessage(ctx, &assist.CreateAssistantMessageRequest{
+				Message: &assist.AssistantMessage{
+					ConversationId: req.ConversationID,
+					Type:           "COMMAND_RESULT",
+					CreatedTime:    timestamppb.New(time.Now().UTC()),
+					Payload:        string(msgPayload),
+				},
+			})
+
+			return trace.Wrap(err)
+		}()
+
+		if err != nil {
+			h.log.WithError(err).Warnf("Failed to start session: %v", host.hostName)
+			continue
+		}
+	}
+
+	return nil, nil
+}
+
+func newCommandHandler(ctx context.Context, cfg CommandHandlerConfig) (*commandHandler, error) {
+	err := cfg.CheckAndSetDefaults()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	_, span := cfg.tracer.Start(ctx, "NewCommand")
+	defer span.End()
+
+	return &commandHandler{
+		log: logrus.WithFields(logrus.Fields{
+			trace.Component: teleport.ComponentWebsocket,
+			"session_id":    cfg.SessionData.ID.String(),
+		}),
+		ctx:                cfg.SessionCtx,
+		authProvider:       cfg.AuthProvider,
+		sessionData:        cfg.SessionData,
+		keepAliveInterval:  cfg.KeepAliveInterval,
+		proxyHostPort:      cfg.ProxyHostPort,
+		interactiveCommand: cfg.InteractiveCommand,
+		router:             cfg.Router,
+		proxySigner:        cfg.proxySigner,
+		localAuthProvider:  cfg.LocalAuthProvider,
+		tracer:             cfg.tracer,
+	}, nil
+}
+
+type CommandHandlerConfig struct {
+	// sctx is the context for the users web session.
+	SessionCtx *SessionContext
+	// authProvider is used to fetch nodes and sessions from the backend.
+	AuthProvider AuthProvider
+	// sessionData is the data to send to the client on the initial session creation.
+	SessionData session.Session
+	// keepAliveInterval is the interval for sending ping frames to web client.
+	// This value is pulled from the cluster network config and
+	// guaranteed to be set to a nonzero value as it's enforced by the configuration.
+	KeepAliveInterval time.Duration
+	// proxyHostPort is the address of the server to connect to.
+	ProxyHostPort string
+	// interactiveCommand is a command to execute.
+	InteractiveCommand []string
+	// Router determines how connections to nodes are created
+	Router *proxy.Router
+	// TracerProvider is used to create the tracer
+	TracerProvider oteltrace.TracerProvider
+	// ProxySigner is used to sign PROXY header and securely propagate client IP information
+	proxySigner multiplexer.PROXYHeaderSigner
+	// LocalAuthProvider is used to fetch user information from the
+	// local cluster when connecting to agentless nodes.
+	LocalAuthProvider agentless.AuthProvider
+	// tracer is used to create spans
+	tracer oteltrace.Tracer
+}
+
+func (t *CommandHandlerConfig) CheckAndSetDefaults() error {
+	// Make sure whatever session is requested is a valid session id.
+	_, err := session.ParseID(t.SessionData.ID.String())
+	if err != nil {
+		return trace.BadParameter("sid: invalid session id")
+	}
+
+	if t.SessionData.Login == "" {
+		return trace.BadParameter("login: missing login")
+	}
+
+	if t.SessionData.ServerID == "" {
+		return trace.BadParameter("server: missing server")
+	}
+
+	if t.AuthProvider == nil {
+		return trace.BadParameter("AuthProvider must be provided")
+	}
+
+	if t.SessionCtx == nil {
+		return trace.BadParameter("SessionCtx must be provided")
+	}
+
+	if t.Router == nil {
+		return trace.BadParameter("Router must be provided")
+	}
+
+	if t.TracerProvider == nil {
+		t.TracerProvider = tracing.DefaultProvider()
+	}
+
+	if t.LocalAuthProvider == nil {
+		return trace.BadParameter("LocalAuthProvider must be provided")
+	}
+
+	t.tracer = t.TracerProvider.Tracer("webcommand")
+
+	return nil
+}
+
+type commandHandler struct {
+	// log holds the structured logger.
+	log *logrus.Entry
+	// ctx is a web session context for the currently logged in user.
+	ctx *SessionContext
+	// authProvider is used to fetch nodes and sessions from the backend.
+	authProvider AuthProvider
+	// proxyHostPort is the address of the server to connect to.
+	proxyHostPort string
+
+	// keepAliveInterval is the interval for sending ping frames to web client.
+	// This value is pulled from the cluster network config and
+	// guaranteed to be set to a nonzero value as it's enforced by the configuration.
+	keepAliveInterval time.Duration
+
+	// The server data for the active session.
+	sessionData session.Session
+
+	// router is used to dial the host
+	router *proxy.Router
+
+	stream *WsStream
+
+	// tracer creates spans
+	tracer oteltrace.Tracer
+
+	// sshSession holds the "shell" SSH channel to the node.
+	sshSession *tracessh.Session
+
+	// ProxySigner is used to sign PROXY header and securely propagate client IP information
+	proxySigner multiplexer.PROXYHeaderSigner
+
+	// localAuthProvider is used to fetch user information from the
+	// local cluster when connecting to agentless nodes.
+	localAuthProvider agentless.AuthProvider
+
+	// interactiveCommand is a command to execute.
+	interactiveCommand []string
+
+	// ws is the websocket connection to the client.
+	ws WSConn
+}
+
+func (t *commandHandler) ServeHTTP(_ http.ResponseWriter, r *http.Request) {
+	// Allow closing websocket if the user logs out before exiting
+	// the session.
+	t.ctx.AddClosers(t)
+	defer t.ctx.RemoveCloser(t)
+
+	sendError := func(errMsg string, err error, ws WSConn) {
+		envelope := &Envelope{
+			Version: defaults.WebsocketVersion,
+			Type:    defaults.WebsocketError,
+			Payload: fmt.Sprintf("%s: %s", errMsg, err.Error()),
+		}
+
+		envelopeBytes, err := proto.Marshal(envelope)
+		if err != nil {
+			t.log.WithError(err).Error("failed to marshal error message")
+		}
+		if err := ws.WriteMessage(websocket.BinaryMessage, envelopeBytes); err != nil {
+			t.log.WithError(err).Error("failed to send error message")
+		}
+	}
+
+	sessionMetadataResponse, err := json.Marshal(siteSessionGenerateResponse{Session: t.sessionData})
+	if err != nil {
+		sendError("unable to marshal session response", err, t.ws)
+		return
+	}
+
+	envelope := &Envelope{
+		Version: defaults.WebsocketVersion,
+		Type:    defaults.WebsocketSessionMetadata,
+		Payload: string(sessionMetadataResponse),
+	}
+
+	envelopeBytes, err := proto.Marshal(envelope)
+	if err != nil {
+		sendError("unable to marshal session data event for web client", err, t.ws)
+		return
+	}
+
+	err = t.ws.WriteMessage(websocket.BinaryMessage, envelopeBytes)
+	if err != nil {
+		sendError("unable to write message to socket", err, t.ws)
+		return
+	}
+
+	t.handler(r)
+}
+
+func (t *commandHandler) handler(r *http.Request) {
+	t.stream = NewWStream(t.ws)
+
+	// Create a Teleport client, if not able to, show the reason to the user in
+	// the terminal.
+	tc, err := t.makeClient(r.Context(), t.ws)
+	if err != nil {
+		t.log.WithError(err).Info("Failed creating a client for session")
+		t.writeError(err)
+		return
+	}
+
+	t.log.Debug("Creating websocket stream")
+
+	// Update the read deadline upon receiving a pong message.
+	t.ws.SetPongHandler(func(_ string) error {
+		t.ws.SetReadDeadline(deadlineForInterval(t.keepAliveInterval))
+		return nil
+	})
+
+	// Start sending ping frames through websocket to the client.
+	go startPingLoop(r.Context(), t.ws, t.keepAliveInterval, t.log, t.Close)
+
+	go t.streamEvents(r.Context(), tc)
+	// Pump raw terminal in/out and audit events into the websocket.
+	t.streamOutput(r.Context(), t.ws, tc)
+}
+
+// streamTerminal opens a SSH connection to the remote host and streams
+// events back to the web client.
+func (t *commandHandler) streamOutput(ctx context.Context, ws WSConn, tc *client.TeleportClient) {
+	ctx, span := t.tracer.Start(ctx, "commandHandler/streamOutput")
+	defer span.End()
+
+	accessChecker, err := t.ctx.GetUserAccessChecker()
+	if err != nil {
+		t.log.WithError(err).Warn("Unable to stream terminal - failed to get access checker")
+		t.writeError(err)
+		return
+	}
+
+	getAgent := func() (teleagent.Agent, error) {
+		return teleagent.NopCloser(tc.LocalAgent()), nil
+	}
+	cert, err := t.ctx.GetSSHCertificate()
+	if err != nil {
+		t.log.WithError(err).Warn("Unable to stream terminal - failed to get certificate")
+		t.writeError(err)
+		return
+	}
+
+	signer := agentless.SignerFromSSHCertificate(cert, t.localAuthProvider, tc.SiteName, tc.Username)
+	conn, _, err := t.router.DialHost(ctx, ws.RemoteAddr(), ws.LocalAddr(), t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort), tc.SiteName, accessChecker, getAgent, signer)
+	if err != nil {
+		t.log.WithError(err).Warn("Unable to stream terminal - failed to dial host.")
+
+		if errors.Is(err, trace.NotFound(teleport.NodeIsAmbiguous)) {
+			const message = "error: ambiguous host could match multiple nodes\n\nHint: try addressing the node by unique id (ex: user@node-id)\n"
+			t.writeError(trace.NotFound(message))
+			return
+		}
+
+		t.writeError(err)
+		return
+	}
+
+	defer func() {
+		if conn == nil {
+			return
+		}
+
+		if err := conn.Close(); err != nil && !utils.IsUseOfClosedNetworkError(err) {
+			t.log.WithError(err).Warn("Failed to close connection to host")
+		}
+	}()
+
+	sshConfig := &ssh.ClientConfig{
+		User:            tc.HostLogin,
+		Auth:            tc.AuthMethods,
+		HostKeyCallback: tc.HostKeyCallback,
+	}
+
+	nc, connectErr := client.NewNodeClient(ctx, sshConfig, conn,
+		net.JoinHostPort(t.sessionData.ServerID, strconv.Itoa(t.sessionData.ServerHostPort)),
+		t.sessionData.ServerHostname,
+		tc, modules.GetModules().IsBoringBinary())
+	switch {
+	case connectErr != nil && !trace.IsAccessDenied(connectErr): // catastrophic error, return it
+		t.log.WithError(connectErr).Warn("Unable to stream terminal - failed to create node client")
+		t.writeError(connectErr)
+		return
+	case connectErr != nil && trace.IsAccessDenied(connectErr): // see if per session mfa would allow access
+		mfaRequiredResp, err := t.authProvider.IsMFARequired(ctx, &authproto.IsMFARequiredRequest{
+			Target: &authproto.IsMFARequiredRequest_Node{
+				Node: &authproto.NodeLogin{
+					Node:  t.sessionData.ServerID,
+					Login: tc.HostLogin,
+				},
+			},
+		})
+		if err != nil {
+			t.log.WithError(err).Warn("Unable to stream terminal - failed to determine if per session mfa is required")
+			// write the original connection error
+			t.writeError(connectErr)
+			return
+		}
+
+		if !mfaRequiredResp.Required {
+			t.log.WithError(connectErr).Warn("Unable to stream terminal - user does not have access to host")
+			// write the original connection error
+			t.writeError(connectErr)
+			return
+		}
+
+		//TODO(jakule): Implement MFA support
+		t.log.Errorf("MFA support is not implemented")
+		t.writeError(errors.New("MFA support is not implemented"))
+		return
+	}
+
+	// Enable session recording
+	nc.AddEnv(teleport.EnableNonInteractiveSessionRecording, "true")
+
+	// Establish SSH connection to the server. This function will block until
+	// either an error occurs or it completes successfully.
+	if err = nc.RunCommand(ctx, t.interactiveCommand); err != nil {
+		t.log.WithError(err).Warn("Unable to stream terminal - failure running interactive shell")
+		t.writeError(err)
+		return
+	}
+
+	if err := t.stream.Close(); err != nil {
+		t.log.WithError(err).Error("Unable to send close event to web client.")
+		return
+	}
+
+	t.log.Debug("Sent close event to web client.")
+}
+
+func (t *commandHandler) Close() error {
+	return nil
+}
+
+// makeClient builds a *client.TeleportClient for the connection.
+func (t *commandHandler) makeClient(ctx context.Context, ws WSConn) (*client.TeleportClient, error) {
+	ctx, span := tracing.DefaultProvider().Tracer("terminal").Start(ctx, "commandHandler/makeClient")
+	defer span.End()
+
+	clientConfig, err := makeTeleportClientConfig(ctx, t.ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	clientConfig.HostLogin = t.sessionData.Login
+	clientConfig.ForwardAgent = client.ForwardAgentLocal
+	clientConfig.Namespace = apidefaults.Namespace
+	clientConfig.Stdout = newPayloadWriter(t.sessionData.ServerID, "stdout", t.stream)
+	clientConfig.Stderr = newPayloadWriter(t.sessionData.ServerID, "stderr", t.stream)
+	clientConfig.Stdin = &bytes.Buffer{} // set stdin to a dummy buffer
+	clientConfig.SiteName = t.sessionData.ClusterName
+	if err := clientConfig.ParseProxyHost(t.proxyHostPort); err != nil {
+		return nil, trace.BadParameter("failed to parse proxy address: %v", err)
+	}
+	clientConfig.Host = t.sessionData.ServerHostname
+	clientConfig.HostPort = t.sessionData.ServerHostPort
+	clientConfig.SessionID = t.sessionData.ID.String()
+	clientConfig.ClientAddr = ws.RemoteAddr().String()
+	clientConfig.Tracer = t.tracer
+
+	tc, err := client.NewClient(clientConfig)
+	if err != nil {
+		return nil, trace.BadParameter("failed to create client: %v", err)
+	}
+
+	// Save the *ssh.Session after the shell has been created. The session is
+	// used to update all other parties window size to that of the web client and
+	// to allow future window changes.
+	tc.OnShellCreated = func(s *tracessh.Session, c *tracessh.Client, _ io.ReadWriteCloser) (bool, error) {
+		t.sshSession = s
+
+		return false, nil
+	}
+
+	return tc, nil
+}
+
+func (t *commandHandler) streamEvents(ctx context.Context, tc *client.TeleportClient) {
+	for {
+		select {
+		// Send push events that come over the events channel to the web client.
+		case event := <-tc.EventsChannel():
+			logger := t.log.WithField("event", event.GetType())
+
+			data, err := json.Marshal(event)
+			if err != nil {
+				logger.WithError(err).Error("Unable to marshal audit event")
+				continue
+			}
+
+			logger.Debug("Sending audit event to web client.")
+
+			if err := t.stream.writeAuditEvent(data); err != nil {
+				if err != nil {
+					if errors.Is(err, websocket.ErrCloseSent) {
+						logger.WithError(err).Debug("Websocket was closed, no longer streaming events")
+						return
+					}
+					logger.WithError(err).Error("Unable to send audit event to web client")
+					continue
+				}
+			}
+
+		// Once the terminal stream is over (and the close envelope has been sent),
+		// close stop streaming envelopes.
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// writeError displays an error in the terminal window.
+func (t *commandHandler) writeError(err error) {
+	out := &outEnvelope{
+		NodeID:  t.sessionData.ServerID,
+		Type:    "teleport-error",
+		Payload: []byte(err.Error()),
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		t.log.WithError(err).Error("failed to marshal error message")
+		return
+	}
+
+	if _, writeErr := t.stream.Write(data); writeErr != nil {
+		t.log.WithError(writeErr).Warnf("Unable to send error to terminal: %v", err)
+	}
 }

--- a/lib/web/command_test.go
+++ b/lib/web/command_test.go
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package web
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/google/uuid"
+	"github.com/gorilla/websocket"
+	"github.com/gravitational/roundtrip"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/session"
+)
+
+func TestExecuteCommand(t *testing.T) {
+	t.Parallel()
+	s := newWebSuite(t)
+
+	ws, _, err := s.makeCommand(t, s.authPack(t, "foo"))
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ws.Close()) })
+
+	stream := NewWStream(ws)
+
+	require.NoError(t, waitForCommandOutput(stream, "teleport"))
+}
+
+func (s *WebSuite) makeCommand(t *testing.T, pack *authPack) (*websocket.Conn, *session.Session, error) {
+	req := CommandRequest{
+		Query:          fmt.Sprintf("name == \"%s\"", s.srvID),
+		Login:          pack.login,
+		ConversationID: uuid.New().String(),
+		ExecutionID:    uuid.New().String(),
+		Command:        "echo txlxport | sed 's/x/e/g'",
+	}
+
+	u := url.URL{
+		Host:   s.url().Host,
+		Scheme: client.WSS,
+		Path:   fmt.Sprintf("/v1/webapi/command/%v/execute", currentSiteShortcut),
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	q := u.Query()
+	q.Set("params", string(data))
+	q.Set(roundtrip.AccessTokenQueryParam, pack.session.Token)
+	u.RawQuery = q.Encode()
+
+	dialer := websocket.Dialer{}
+	dialer.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	header := http.Header{}
+	header.Add("Origin", "http://localhost")
+	for _, cookie := range pack.cookies {
+		header.Add("Cookie", cookie.String())
+	}
+
+	ws, resp, err := dialer.Dial(u.String(), header)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	ty, raw, err := ws.ReadMessage()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	require.Equal(t, websocket.BinaryMessage, ty)
+	var env Envelope
+
+	err = proto.Unmarshal(raw, &env)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	var sessResp siteSessionGenerateResponse
+
+	err = json.Unmarshal([]byte(env.Payload), &sessResp)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	err = resp.Body.Close()
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return ws, &sessResp.Session, nil
+}
+
+func waitForCommandOutput(stream io.Reader, substr string) error {
+	timeoutCh := time.After(10 * time.Second)
+
+	for {
+		select {
+		case <-timeoutCh:
+			return trace.BadParameter("timeout waiting on terminal for output: %v", substr)
+		default:
+		}
+
+		out := make([]byte, 100)
+		n, err := stream.Read(out)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		var env Envelope
+		err = json.Unmarshal(out[:n], &env)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		d, err := base64.StdEncoding.DecodeString(env.Payload)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		data := removeSpace(string(d))
+		if n > 0 && strings.Contains(data, substr) {
+			return nil
+		}
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+}

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -1,0 +1,119 @@
+/*
+
+ Copyright 2023 Gravitational, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+
+*/
+
+package web
+
+import (
+	"encoding/json"
+	"io"
+	"net"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/gravitational/trace"
+)
+
+// WSConn is a gorilla/websocket minimal interface used by our web implementation.
+type WSConn interface {
+	Close() error
+
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+
+	WriteControl(messageType int, data []byte, deadline time.Time) error
+	WriteMessage(messageType int, data []byte) error
+	NextReader() (messageType int, r io.Reader, err error)
+	ReadMessage() (messageType int, p []byte, err error)
+
+	SetReadDeadline(t time.Time) error
+	PingHandler() func(appData string) error
+	SetPingHandler(h func(appData string) error)
+	PongHandler() func(appData string) error
+	SetPongHandler(h func(appData string) error)
+}
+
+// outEnvelope is an envelope used to wrap messages send back to the client connected over WS.
+type outEnvelope struct {
+	NodeID  string `json:"node_id"`
+	Type    string `json:"type"`
+	Payload []byte `json:"payload"`
+}
+
+type payloadWriter struct {
+	nodeID string
+	// output name, can be stdout, stderr or teleport-error.
+	outputName string
+	// stream is the underlying stream.
+	stream io.Writer
+}
+
+func (p *payloadWriter) Write(b []byte) (n int, err error) {
+	out := &outEnvelope{
+		NodeID:  p.nodeID,
+		Type:    p.outputName,
+		Payload: b,
+	}
+	data, err := json.Marshal(out)
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	_, err = p.stream.Write(data)
+	// return the size of the original message as a message send over stream
+	// is larger due to json marshaling and envelope.
+	return len(b), err
+}
+
+func newPayloadWriter(nodeID, outputName string, stream io.Writer) *payloadWriter {
+	return &payloadWriter{
+		nodeID:     nodeID,
+		outputName: outputName,
+		stream:     stream,
+	}
+}
+
+// noopCloserWS is a wrapper around websocket.Conn which does nothing on Close().
+// This struct is used to prevent WS being closed by wrapping stream.
+type noopCloserWS struct {
+	*websocket.Conn
+}
+
+// Close does nothing.
+func (ws *noopCloserWS) Close() error {
+	return nil
+}
+
+func removeDuplicates(hosts []hostInfo) []hostInfo {
+	if len(hosts) <= 1 {
+		return hosts
+	}
+
+	unique := make(map[hostInfo]struct{}, len(hosts))
+	uniqueHosts := make([]hostInfo, 0, len(hosts))
+
+	for _, h := range hosts {
+		if _, ok := unique[h]; ok {
+			continue
+		}
+		unique[h] = struct{}{}
+		uniqueHosts = append(uniqueHosts, h)
+	}
+
+	return uniqueHosts
+}

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -14,7 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 
-
 */
 
 package web

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -77,7 +77,7 @@ func (p *payloadWriter) Write(b []byte) (n int, err error) {
 	_, err = p.stream.Write(data)
 	// return the size of the original message as a message send over stream
 	// is larger due to json marshaling and envelope.
-	return len(b), err
+	return len(b), trace.Wrap(err)
 }
 
 func newPayloadWriter(nodeID, outputName string, stream io.Writer) *payloadWriter {

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -98,22 +98,3 @@ type noopCloserWS struct {
 func (ws *noopCloserWS) Close() error {
 	return nil
 }
-
-func removeDuplicates(hosts []hostInfo) []hostInfo {
-	if len(hosts) <= 1 {
-		return hosts
-	}
-
-	unique := make(map[hostInfo]struct{}, len(hosts))
-	uniqueHosts := make([]hostInfo, 0, len(hosts))
-
-	for _, h := range hosts {
-		if _, ok := unique[h]; ok {
-			continue
-		}
-		unique[h] = struct{}{}
-		uniqueHosts = append(uniqueHosts, h)
-	}
-
-	return uniqueHosts
-}

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -1310,6 +1310,7 @@ func (t *TerminalStream) Read(out []byte) (n int, err error) {
 	}
 }
 
+// Close sends a close message on the web socket and closes the web socket.
 func (t *WSStream) Close() error {
 	// Send close envelope to web terminal upon exit without an error.
 	envelope := &Envelope{


### PR DESCRIPTION
This PR implements the execution endpoint used by Teleport Assist. Command passed in the request is being executed on multiple nodes. Nodes are picked based on the query also passed in the request. The command is being executed as non-interactive SSH command, and the result is being recorded, which is a different behavior rather than calling `tsh ssh command` where the output is not saved.