### PR TITLE
fix azure db user auth check

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -281,13 +281,18 @@ func TestAccessMySQL(t *testing.T) {
 // TestAccessRedis verifies access scenarios to a Redis database based
 // on the configured RBAC rules.
 func TestAccessRedis(t *testing.T) {
-	ctx := context.Background()
-	testCtx := setupTestContext(ctx, t, withSelfHostedRedis("redis"))
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	testCtx := setupTestContext(ctx, t,
+		withSelfHostedRedis("redis"),
+		withAzureRedis("azure-redis", azureRedisToken))
 	go testCtx.startHandlingConnections()
 
 	tests := []struct {
 		// desc is the test case description.
 		desc string
+		// dbService is the name of the database service to connect to.
+		dbService string
 		// user is the Teleport local username the test will use.
 		user string
 		// role is the Teleport role name to create and assign to the user.
@@ -301,6 +306,7 @@ func TestAccessRedis(t *testing.T) {
 	}{
 		{
 			desc:         "has access to all database users",
+			dbService:    "redis",
 			user:         "alice",
 			role:         "admin",
 			allowDbUsers: []string{types.Wildcard},
@@ -308,6 +314,7 @@ func TestAccessRedis(t *testing.T) {
 		},
 		{
 			desc:         "has access to nothing",
+			dbService:    "redis",
 			user:         "alice",
 			role:         "admin",
 			allowDbUsers: []string{},
@@ -316,6 +323,7 @@ func TestAccessRedis(t *testing.T) {
 		},
 		{
 			desc:         "access allowed to specific user",
+			dbService:    "redis",
 			user:         "alice",
 			role:         "admin",
 			allowDbUsers: []string{"alice"},
@@ -323,11 +331,29 @@ func TestAccessRedis(t *testing.T) {
 		},
 		{
 			desc:         "access denied to specific user",
+			dbService:    "redis",
 			user:         "alice",
 			role:         "admin",
 			allowDbUsers: []string{"alice"},
 			dbUser:       "root",
 			err:          "access to db denied",
+		},
+		{
+			desc:         "azure access allowed to default user",
+			dbService:    "azure-redis",
+			user:         "alice",
+			role:         "admin",
+			allowDbUsers: []string{"default"},
+			dbUser:       "default",
+		},
+		{
+			desc:         "azure access denied to non-default user",
+			dbService:    "azure-redis",
+			user:         "alice",
+			role:         "admin",
+			allowDbUsers: []string{"alice"},
+			dbUser:       "alice",
+			err:          "access denied to non-default db user",
 		},
 	}
 
@@ -336,9 +362,8 @@ func TestAccessRedis(t *testing.T) {
 			// Create user/role with the requested permissions.
 			testCtx.createUserAndRole(ctx, t, test.user, test.role, test.allowDbUsers, []string{types.Wildcard})
 
-			ctx := context.Background()
 			// Try to connect to the database as this user.
-			redisClient, err := testCtx.redisClient(ctx, test.user, "redis", test.dbUser)
+			redisClient, err := testCtx.redisClient(ctx, test.user, test.dbService, test.dbUser)
 			if test.err != "" {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), test.err)

--- a/lib/srv/db/redis/protocol/resp2_test.go
+++ b/lib/srv/db/redis/protocol/resp2_test.go
@@ -146,8 +146,8 @@ func TestMakeUnknownCommandErrorForCmd(t *testing.T) {
 	}{
 		{
 			name:          "HELLO",
-			command:       []interface{}{"HELLO", 3, "user", "TOKEN"},
-			expectedError: "ERR unknown command 'HELLO', with args beginning with: '3' 'user' 'TOKEN'",
+			command:       []interface{}{"HELLO", 3, "AUTH", "user", "TOKEN"},
+			expectedError: "ERR unknown command 'HELLO', with args beginning with: '3' 'AUTH' 'user' 'TOKEN'",
 		},
 		{
 			name:          "no extra args",


### PR DESCRIPTION
This PR fixes Teleport RBAC check for Azure Cache for Redis.

## How
Check that db user matches "default" when connecting to Azure Cache for Redis db before normal running RBAC checks.

### Why
Azure does not support Redis ACL, so we always log in as the "default" user with `AUTH <password>`.

`tsh` will check and set the db username to `"default"` if it's not specified with `--db-user=<someuser>`.

Our Redis engine will also check for a blank db user and set it to `default`.

So `tsh db connect some-redis-db` will automatically use the `default` db user for RBAC checks.

If the user runs an auth command during their interactive session, such as `AUTH "password"`, then we also check that they are using the default user before allowing the command to go through.

However, we do not check for default db user when they initially connect.

### Example problem case:
```
$ tctl get users/martian --format=json | jq '.[] | .spec.traits.db_users'
[
  "alice"
]
[I] [17:19:58] gavin@mac ~  
$ tsh db connect --db-user=alice redis-marek-02
localhost:58350> get x
"1"
localhost:58350> auth ""
(error) ERR Teleport: failed to authenticate as the default user. Please provide the db username when connecting to Redis
localhost:58350> 
```
I logged in as "alice" and Teleport granted me access to the redis instance as the default user. When I tried to re-auth, Teleport caught that I was not the default user and rejected my command.