### PR TITLE
[v13] build: Scope RUST_VERSION var to single target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,6 @@ TARBINS = $(addprefix teleport/,$(BINS))
 CHECK_CARGO := $(shell cargo --version 2>/dev/null)
 CHECK_RUST := $(shell rustc --version 2>/dev/null)
 
-RUST_VERSION ?= $(shell make --no-print-directory -C build.assets print-rust-version)
 RUST_TARGET_ARCH ?= $(CARGO_TARGET_$(OS)_$(ARCH))
 
 # Have cargo use sparse crates.io protocol:
@@ -1331,6 +1330,7 @@ docker-ui:
 # defined in build.assets/Makefile. It assumes that `rustup` is already
 # installed for managing the rust toolchain.
 .PHONY: rustup-install-target-toolchain
+rustup-install-target-toolchain: RUST_VERSION := $(shell $(MAKE) --no-print-directory -C build.assets print-rust-version)
 rustup-install-target-toolchain:
 	rustup override set $(RUST_VERSION)
 	rustup target add $(RUST_TARGET_ARCH)


### PR DESCRIPTION
Backport #25960 to branch/v13

Scope the `RUST_VERSION` variable to the single
`rustup-install-target-toolchain` target that needs it. Setting it at
the top-level causes a strange interaction between the top-level
Makefile and the one in `build.assets/` that causes `make fix-imports`
(and presumably any other target that chains to `build.assets/Makefile`
and uses `RUST_VERSION`) to get an empty `RUST_VERSION`.

We use `:=` when setting `RUST_VERSION` otherwise the same problem is
present but just for the `rustup-install-target-toolchain` target.

Backport: https://github.com/gravitational/teleport/pull/25960