### PR TITLE
Support ElastiCache Redis IAM auth

### DIFF
--- a/lib/cloud/mocks/aws.go
+++ b/lib/cloud/mocks/aws.go
@@ -550,6 +550,18 @@ func (m *ElastiCacheMock) addTags(arn string, tagsMap map[string]string) {
 	m.TagsByARN[arn] = tags
 }
 
+func (m *ElastiCacheMock) DescribeUsersWithContext(_ aws.Context, input *elasticache.DescribeUsersInput, opts ...request.Option) (*elasticache.DescribeUsersOutput, error) {
+	if input.UserId == nil {
+		return &elasticache.DescribeUsersOutput{Users: m.Users}, nil
+	}
+	for _, user := range m.Users {
+		if aws.StringValue(user.UserId) == aws.StringValue(input.UserId) {
+			return &elasticache.DescribeUsersOutput{Users: []*elasticache.User{user}}, nil
+		}
+	}
+	return nil, trace.NotFound("ElastiCache UserId %v not found", aws.StringValue(input.UserId))
+}
+
 func (m *ElastiCacheMock) DescribeReplicationGroupsWithContext(_ aws.Context, input *elasticache.DescribeReplicationGroupsInput, opts ...request.Option) (*elasticache.DescribeReplicationGroupsOutput, error) {
 	for _, replicationGroup := range m.ReplicationGroups {
 		if aws.StringValue(replicationGroup.ReplicationGroupId) == aws.StringValue(input.ReplicationGroupId) {

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2050,6 +2050,8 @@ type agentParams struct {
 	NoStart bool
 	// GCPSQL defines the GCP Cloud SQL mock to use for GCP API calls.
 	GCPSQL *mocks.GCPSQLAdminClientMock
+	// ElastiCache defines the AWS ElastiCache mock to use for ElastiCache API calls.
+	ElastiCache *mocks.ElastiCacheMock
 	// OnHeartbeat defines a heartbeat function that generates heartbeat events.
 	OnHeartbeat func(error)
 	// CADownloader defines the CA downloader.
@@ -2077,6 +2079,9 @@ func (p *agentParams) setDefaults(c *testContext) {
 			},
 		}
 	}
+	if p.ElastiCache == nil {
+		p.ElastiCache = &mocks.ElastiCacheMock{}
+	}
 	if p.CADownloader == nil {
 		p.CADownloader = &fakeDownloader{
 			cert: []byte(fixtures.TLSCACertPEM),
@@ -2089,7 +2094,7 @@ func (p *agentParams) setDefaults(c *testContext) {
 			RDS:                &mocks.RDSMock{},
 			Redshift:           &mocks.RedshiftMock{},
 			RedshiftServerless: &mocks.RedshiftServerlessMock{},
-			ElastiCache:        &mocks.ElastiCacheMock{},
+			ElastiCache:        p.ElastiCache,
 			MemoryDB:           &mocks.MemoryDBMock{},
 			SecretsManager:     secrets.NewMockSecretsManagerClient(secrets.MockSecretsManagerClientConfig{}),
 			IAM:                &mocks.IAMMock{},
@@ -2592,6 +2597,43 @@ func withSQLServer(name string) withDatabaseOption {
 		require.NoError(t, err)
 		testCtx.sqlServer[name] = testSQLServer{
 			db:       sqlServer,
+			resource: database,
+		}
+		return database
+	}
+}
+
+func withElastiCacheRedis(name string, token, engineVersion string) withDatabaseOption {
+	return func(t *testing.T, ctx context.Context, testCtx *testContext) types.Database {
+		redisServer, err := redis.NewTestServer(t, common.TestServerConfig{
+			Name:       name,
+			AuthClient: testCtx.authClient,
+		}, redis.TestServerPassword(token))
+		require.NoError(t, err)
+
+		database, err := types.NewDatabaseV3(types.Metadata{
+			Name: name,
+			Labels: map[string]string{
+				"engine-version": engineVersion,
+			},
+		}, types.DatabaseSpecV3{
+			Protocol:      defaults.ProtocolRedis,
+			URI:           fmt.Sprintf("rediss://%s", net.JoinHostPort("localhost", redisServer.Port())),
+			DynamicLabels: dynamicLabels,
+			AWS: types.AWS{
+				Region: "us-west-1",
+				ElastiCache: types.ElastiCache{
+					ReplicationGroupID: "example-cluster",
+				},
+			},
+			// Set CA cert to pass cert validation.
+			TLS: types.DatabaseTLS{
+				CACert: string(testCtx.databaseCA.GetActiveKeys().TLS[0].Cert),
+			},
+		})
+		require.NoError(t, err)
+		testCtx.redis[name] = testRedis{
+			db:       redisServer,
 			resource: database,
 		}
 		return database

--- a/lib/srv/db/common/auth.go
+++ b/lib/srv/db/common/auth.go
@@ -23,6 +23,8 @@ import (
 	"crypto/x509/pkix"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -30,6 +32,9 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	v4 "github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/rds/rdsutils"
 	"github.com/aws/aws-sdk-go/service/redshift"
 	"github.com/aws/aws-sdk-go/service/redshiftserverless"
@@ -66,6 +71,8 @@ type Auth interface {
 	GetRedshiftAuthToken(ctx context.Context, sessionCtx *Session) (string, string, error)
 	// GetRedshiftServerlessAuthToken generates Redshift Serverless auth token.
 	GetRedshiftServerlessAuthToken(ctx context.Context, sessionCtx *Session) (string, string, error)
+	// GetElastiCacheRedisToken generates an ElastiCache Redis auth token.
+	GetElastiCacheRedisToken(ctx context.Context, sessionCtx *Session) (string, error)
 	// GetCloudSQLAuthToken generates Cloud SQL auth token.
 	GetCloudSQLAuthToken(ctx context.Context, sessionCtx *Session) (string, error)
 	// GetCloudSQLPassword generates password for a Cloud SQL database user.
@@ -394,6 +401,27 @@ func (a *dbAuth) GetAzureAccessToken(ctx context.Context, sessionCtx *Session) (
 		return "", trace.Wrap(err)
 	}
 	return token.Token, nil
+}
+
+// GetElastiCacheRedisToken generates an ElastiCache Redis auth token.
+func (a *dbAuth) GetElastiCacheRedisToken(ctx context.Context, sessionCtx *Session) (string, error) {
+	meta := sessionCtx.Database.GetAWS()
+	awsSession, err := a.cfg.Clients.GetAWSSession(ctx, meta.Region, cloud.WithAssumeRoleFromAWSMeta(meta))
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	a.cfg.Log.Debugf("Generating ElastiCache Redis auth token for %s.", sessionCtx)
+	tokenReq := &elastiCacheRedisIAMTokenRequest{
+		// For IAM-enabled ElastiCache users, the username and user id properties must be identical.
+		// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-limits
+		userID:             sessionCtx.DatabaseUser,
+		replicationGroupId: meta.ElastiCache.ReplicationGroupID,
+		region:             meta.Region,
+		credentials:        awsSession.Config.Credentials,
+		clock:              a.cfg.Clock,
+	}
+	token, err := tokenReq.toSignedRequestURI()
+	return token, trace.Wrap(err)
 }
 
 // GetAzureCacheForRedisToken retrieves auth token for Azure Cache for Redis.
@@ -842,4 +870,84 @@ func redshiftServerlessUsernameToRoleARN(aws types.AWS, username string) (string
 		return "", trace.BadParameter("expecting name or ARN of an AWS IAM role but got %v", username)
 	}
 	return awsutils.BuildRoleARN(username, aws.Region, aws.AccountID)
+}
+
+// elastiCacheRedisIAMTokenRequest builds an AWS IAM auth token for ElastiCache
+// Redis.
+// Implemented following the AWS example:
+// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-Connecting
+type elastiCacheRedisIAMTokenRequest struct {
+	// userID is the ElastiCache user ID.
+	userID string
+	// replicationGroupId is the ElastiCache replication group ID.
+	replicationGroupId string
+	// region is the AWS region.
+	region string
+	// credentials are used to presign with AWS SigV4.
+	credentials *credentials.Credentials
+	// clock is the clock implementation.
+	clock clockwork.Clock
+}
+
+// checkAndSetDefaults validates config and sets defaults.
+func (r *elastiCacheRedisIAMTokenRequest) checkAndSetDefaults() error {
+	if r.userID == "" {
+		return trace.BadParameter("missing user ID")
+	}
+	if r.replicationGroupId == "" {
+		return trace.BadParameter("missing replication group ID")
+	}
+	if r.region == "" {
+		return trace.BadParameter("missing region")
+	}
+	if r.credentials == nil {
+		return trace.BadParameter("missing credentials")
+	}
+	if r.clock == nil {
+		r.clock = clockwork.NewRealClock()
+	}
+	return nil
+}
+
+// toSignedRequestURI creates a new AWS SigV4 pre-signed request URI.
+// This pre-signed request URI can then be used to authenticate as an
+// ElastiCache Redis user.
+func (r *elastiCacheRedisIAMTokenRequest) toSignedRequestURI() (string, error) {
+	if err := r.checkAndSetDefaults(); err != nil {
+		return "", trace.Wrap(err)
+	}
+	req, err := r.getSignableRequest()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	s := v4.NewSigner(r.credentials)
+	_, err = s.Presign(req, nil, elasticache.ServiceName, r.region, time.Minute*15, r.clock.Now())
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	res := url.URL{
+		Host:     req.URL.Host,
+		Path:     "/",
+		RawQuery: req.URL.RawQuery,
+	}
+	return strings.TrimPrefix(res.String(), "//"), nil
+}
+
+// getSignableRequest creates a new request suitable for pre-signing with SigV4.
+func (r *elastiCacheRedisIAMTokenRequest) getSignableRequest() (*http.Request, error) {
+	query := url.Values{
+		"Action": {"connect"},
+		"User":   {r.userID},
+	}
+	reqURI := url.URL{
+		Scheme:   "http",
+		Host:     r.replicationGroupId,
+		Path:     "/",
+		RawQuery: query.Encode(),
+	}
+	req, err := http.NewRequest(http.MethodGet, reqURI.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return req, nil
 }

--- a/lib/srv/db/common/errors.go
+++ b/lib/srv/db/common/errors.go
@@ -135,6 +135,8 @@ func ConvertConnectError(err error, sessionCtx *Session) error {
 
 	if trace.IsAccessDenied(err) {
 		switch sessionCtx.Database.GetType() {
+		case types.DatabaseTypeElastiCache:
+			return createElastiCacheRedisAccessDeniedError(err, sessionCtx)
 		case types.DatabaseTypeRDS:
 			return createRDSAccessDeniedError(err, sessionCtx)
 		case types.DatabaseTypeRDSProxy:
@@ -145,6 +147,32 @@ func ConvertConnectError(err error, sessionCtx *Session) error {
 	}
 
 	return trace.Wrap(err)
+}
+
+// createElastiCacheRedisAccessDeniedError creates an error with help message
+// to setup IAM auth for ElastiCache Redis.
+func createElastiCacheRedisAccessDeniedError(err error, sessionCtx *Session) error {
+	policy, getPolicyErr := dbiam.GetReadableAWSPolicyDocument(sessionCtx.Database)
+	if getPolicyErr != nil {
+		policy = fmt.Sprintf("failed to generate IAM policy: %v", getPolicyErr)
+	}
+
+	switch sessionCtx.Database.GetProtocol() {
+	case defaults.ProtocolRedis:
+		return trace.AccessDenied(`Could not connect to database:
+
+  %v
+
+Make sure that IAM auth is enabled for ElastiCache user %q and Teleport database
+agent's IAM policy has "elasticache:Connect" permissions (note that IAM changes may
+take a few minutes to propagate):
+
+%v
+`, err, sessionCtx.DatabaseUser, policy)
+
+	default:
+		return trace.Wrap(err)
+	}
 }
 
 // createRDSAccessDeniedError creates an error with help message to setup IAM

--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -21,13 +21,18 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/coreos/go-semver/semver"
 	"github.com/go-redis/redis/v9"
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/api/types"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/db/common"
@@ -62,6 +67,8 @@ type Engine struct {
 	newClient redisClientFactoryFn
 	// redisClient is a current connection to Redis server.
 	redisClient redis.UniversalClient
+	// awsIAMAuthSupported is the saved result of isAWSIAMAuthSupported.
+	awsIAMAuthSupported *bool
 }
 
 // InitializeConnection initializes the database connection.
@@ -166,20 +173,17 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 		return trace.Wrap(err)
 	}
 
-	// If fail to get the initial username or password, return an error right
-	// away without making a connection to the Redis server.
-	username, password, err := e.getInitialUsernameAndPassowrd(ctx, sessionCtx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
 	// Initialize newClient factory function with current connection state.
 	e.newClient, err = e.getNewClientFn(ctx, sessionCtx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	e.redisClient, err = e.newClient(username, password)
+	// Create new client without username or password. Those will be added
+	// when we receive AUTH command (e.g. self-hosted), or they can be
+	// fetched by the OnConnect callback
+	// (e.g. ElastiCache managed users, IAM auth, or Azure access key).
+	e.redisClient, err = e.newClient("", "")
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -198,23 +202,6 @@ func (e *Engine) HandleConnection(ctx context.Context, sessionCtx *common.Sessio
 	}
 
 	return nil
-}
-
-// getInitialUsernameAndPassowrd returns the username and password used for
-// the initial connection.
-func (e *Engine) getInitialUsernameAndPassowrd(ctx context.Context, sessionCtx *common.Session) (string, string, error) {
-	switch {
-	case sessionCtx.Database.IsAzure():
-		// Retrieve the auth token for Azure Cache for Redis. Use default user.
-		password, err := e.Auth.GetAzureCacheForRedisToken(ctx, sessionCtx)
-		return "", password, trace.Wrap(err)
-
-	default:
-		// Create new client without username or password. Those will be added
-		// when we receive AUTH command (e.g. self-hosted), or they can be
-		// fetched by the OnConnect callback (e.g. ElastiCache managed users).
-		return "", "", nil
-	}
 }
 
 // getNewClientFn returns a partial Redis client factory function.
@@ -252,7 +239,7 @@ func (e *Engine) getNewClientFn(ctx context.Context, sessionCtx *common.Session)
 	}
 
 	return func(username, password string) (redis.UniversalClient, error) {
-		onConnect := e.createOnClientConnectFunc(sessionCtx, username, password)
+		onConnect := e.createOnClientConnectFunc(ctx, sessionCtx, username, password)
 
 		redisClient, err := newClient(ctx, connectionOptions, tlsConfig, onConnect)
 		if err != nil {
@@ -265,24 +252,107 @@ func (e *Engine) getNewClientFn(ctx context.Context, sessionCtx *common.Session)
 
 // createOnClientConnectFunc creates a callback function that is called after a
 // successful client connection with the Redis server.
-func (e *Engine) createOnClientConnectFunc(sessionCtx *common.Session, username, password string) onClientConnectFunc {
+func (e *Engine) createOnClientConnectFunc(ctx context.Context, sessionCtx *common.Session, username, password string) onClientConnectFunc {
 	switch {
 	// If password is provided by client.
 	case password != "":
 		return authWithPasswordOnConnect(username, password)
 
-	// If database user is one of managed users.
+	// Azure databases authenticate via access keys.
+	case sessionCtx.Database.IsAzure():
+		credFetchFn := azureAccessKeyFetchFunc(sessionCtx, e.Auth)
+		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn)
+
+	// If database user is one of managed users (AWS only).
 	//
 	// Teleport managed users can have their passwords rotated during a
 	// database session. Fetching an user's password on each new connection
 	// ensures the correct password is used for each shard connection when
 	// Redis is in cluster mode.
 	case slices.Contains(sessionCtx.Database.GetManagedUsers(), sessionCtx.DatabaseUser):
-		return fetchUserPasswordOnConnect(sessionCtx, e.Users, e.Audit)
+		credFetchFn := managedUserCredFetchFunc(sessionCtx, e.Auth, e.Users)
+		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn)
+
+	// AWS ElastiCache has limited support for IAM authentication.
+	// See: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-limits
+	// So we must check that the database supports IAM auth and that the
+	// ElastiCache user has IAM auth enabled.
+	case e.isAWSIAMAuthSupported(ctx, sessionCtx):
+		credFetchFn := elasticacheIAMTokenFetchFunc(sessionCtx, e.Auth)
+		return fetchCredentialsOnConnect(e.Context, sessionCtx, e.Audit, credFetchFn)
 
 	default:
 		return nil
 	}
+}
+
+// isAWSIAMAuthSupported returns whether AWS IAM auth is supported for the
+// database and the database user.
+func (e *Engine) isAWSIAMAuthSupported(ctx context.Context, sessionCtx *common.Session) (res bool) {
+	if e.awsIAMAuthSupported != nil {
+		return *e.awsIAMAuthSupported
+	}
+	defer func() {
+		// cache result to avoid API calls on each new instance connection.
+		e.awsIAMAuthSupported = &res
+	}()
+	// check if the db supports IAM auth. If we get an error, assume the db does
+	// support IAM auth. False positives just incur an extra API call.
+	if ok, err := checkDBSupportsIAMAuth(sessionCtx.Database); err != nil {
+		e.Log.WithError(err).Debugf("Assuming database %s supports IAM auth.",
+			sessionCtx.Database.GetName())
+	} else if !ok {
+		return false
+	}
+	awsMeta := sessionCtx.Database.GetAWS()
+	dbUser := sessionCtx.DatabaseUser
+	ok, err := checkUserIAMAuthIsEnabled(ctx, e.CloudClients, awsMeta, dbUser)
+	if err != nil {
+		e.Log.WithError(err).Debugf("Assuming IAM auth is not enabled for user %s.",
+			dbUser)
+		return false
+	}
+	return ok
+}
+
+// checkDBSupportsIAMAuth returns whether the given database supports IAM auth.
+// AWS ElastiCache Redis supports IAM auth for redis version 7+.
+func checkDBSupportsIAMAuth(database types.Database) (bool, error) {
+	if !database.IsElastiCache() {
+		return false, nil
+	}
+	version, ok := database.GetLabel("engine-version")
+	if !ok {
+		return false, trace.NotFound("database missing engine-version label")
+	}
+	v, err := semver.NewVersion(strings.TrimPrefix(version, "v"))
+	if err != nil {
+		return false, trace.Wrap(err, "failed to parse engine-version")
+	}
+	return v.Major >= 7, nil
+}
+
+// checkUserIAMAuthIsEnabled returns whether a given ElastiCache user has IAM auth
+// enabled.
+func checkUserIAMAuthIsEnabled(ctx context.Context, clients cloud.Clients, awsMeta types.AWS, username string) (bool, error) {
+	client, err := clients.GetAWSElastiCacheClient(ctx, awsMeta.Region,
+		cloud.WithAssumeRoleFromAWSMeta(awsMeta))
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	// For IAM-enabled ElastiCache users, the username and user id properties
+	// must be identical.
+	// https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-limits
+	input := elasticache.DescribeUsersInput{UserId: aws.String(username)}
+	out, err := client.DescribeUsersWithContext(ctx, &input)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	if len(out.Users) < 1 || out.Users[0].Authentication == nil {
+		return false, nil
+	}
+	authType := aws.StringValue(out.Users[0].Authentication.Type)
+	return elasticache.AuthenticationTypeIam == authType, nil
 }
 
 // reconnect closes the current Redis server connection and creates a new one pre-authenticated
@@ -317,7 +387,7 @@ func (e *Engine) process(ctx context.Context, sessionCtx *common.Session) error 
 		// Function below maps errors that should be returned to the
 		// client as value or return them as err if we should terminate
 		// the session.
-		value, err := processServerResponse(cmd, err, sessionCtx)
+		value, err := e.processServerResponse(cmd, err, sessionCtx)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -348,7 +418,7 @@ func (e *Engine) readClientCmd(ctx context.Context) (*redis.Cmd, error) {
 // "terminal" errors as second value (connection should be terminated when this happens)
 // or returns error/value as the first value. Then value should be sent back to
 // the client without terminating the connection.
-func processServerResponse(cmd *redis.Cmd, err error, sessionCtx *common.Session) (interface{}, error) {
+func (e *Engine) processServerResponse(cmd *redis.Cmd, err error, sessionCtx *common.Session) (interface{}, error) {
 	value, cmdErr := cmd.Result()
 	if err == nil {
 		// If the server didn't return any error use cmd.Err() as server error.
@@ -356,6 +426,8 @@ func processServerResponse(cmd *redis.Cmd, err error, sessionCtx *common.Session
 	}
 
 	switch {
+	case e.isIAMAuthError(err):
+		return common.ConvertConnectError(trace.AccessDenied(err.Error()), sessionCtx), nil
 	case isRedisError(err):
 		// Redis errors should be returned to the client.
 		return err, nil
@@ -388,6 +460,14 @@ func processServerResponse(cmd *redis.Cmd, err error, sessionCtx *common.Session
 		// Return value and the error. If the error is not nil we will close the connection.
 		return value, common.ConvertConnectError(err, sessionCtx)
 	}
+}
+
+// isIAMAuthError detects an ElastiCache IAM auth error.
+func (e *Engine) isIAMAuthError(err error) bool {
+	if err == nil || e.awsIAMAuthSupported == nil || !*e.awsIAMAuthSupported {
+		return false
+	}
+	return strings.Contains(err.Error(), "WRONGPASS")
 }
 
 // isRedisError returns true is error comes from Redis, ex, nil, bad command, etc.


### PR DESCRIPTION
Issue: https://github.com/gravitational/teleport/issues/18550

This PR adds support for ElastiCache IAM auth.

I tested the implementation manually as well, and confirmed that the secrets manager method still works when some Redis users are managed users and others are using IAM auth method.

It works by "pre-signing" an http request with AWS sigv4, to generate a URI that can be used as an auth token, as described here: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth-iam.html#auth-iam-Connecting

The token is rebuilt on reconnect, which should handle the 12 hour time limit as well, although my manual test for that is still running due to an unfortunate internet outage for me this morning.

Stacked this PR on top of https://github.com/gravitational/teleport/pull/25959 for an unrelated Azure redis auth issue.

### TODO
* docs update for AWS elasticache redis guide and AWS policy reference.
* update configurator to add `elasticache: Connect` permissions