### PR TITLE
[v12] gh-trigger-workflow: Retry transient server errors

### DIFF
--- a/build.assets/tooling/cmd/gh-trigger-workflow/main.go
+++ b/build.assets/tooling/cmd/gh-trigger-workflow/main.go
@@ -57,6 +57,7 @@ import (
 	ghapi "github.com/google/go-github/v41/github"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 
 	"github.com/gravitational/teleport/build.assets/tooling/lib/github"
 )
@@ -78,7 +79,7 @@ func main() {
 		log.Fatalf("Failed to fetch installation ID for app #%d on account %s: %s", args.appID, args.owner, err)
 	}
 
-	tx, err := ghinst.New(http.DefaultTransport, args.appID, installationID, args.appKey)
+	tx, err := ghinst.New(&retryablehttp.RoundTripper{}, args.appID, installationID, args.appKey)
 	if err != nil {
 		log.Fatalf("Failed creating authenticated transport: %s", err)
 	}
@@ -159,7 +160,7 @@ func lookupInstallationID(ctx context.Context, args args) (int64, error) {
 	// Because we don't know the Installtion ID yet (otherwise we wouldn't be
 	// here at all) we have to uses a special, short-lived github client that
 	// can authenticate without it.
-	tx, err := ghinst.NewAppsTransport(http.DefaultTransport, args.appID, args.appKey)
+	tx, err := ghinst.NewAppsTransport(&retryablehttp.RoundTripper{}, args.appID, args.appKey)
 	if err != nil {
 		return 0, trace.Wrap(err, "Failed creating authenticated transport")
 	}

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -25,10 +25,10 @@ require (
 	github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 // indirect
 	github.com/fatih/color v1.7.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v0.9.3-0.20191025211905-234833755cb2 // indirect
 	github.com/hashicorp/go-multierror v1.0.0 // indirect
-	github.com/hashicorp/go-retryablehttp v0.6.3 // indirect
+	github.com/hashicorp/go-retryablehttp v0.7.2 // indirect
 	github.com/mattn/go-colorable v0.1.4 // indirect
 	github.com/mattn/go-isatty v0.0.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/build.assets/tooling/go.sum
+++ b/build.assets/tooling/go.sum
@@ -48,6 +48,8 @@ github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/U
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.3-0.20191025211905-234833755cb2 h1:STV8OvzphW1vlhPFxcG8d6OIilzBSKRAoWFJt+Onu10=
 github.com/hashicorp/go-hclog v0.9.3-0.20191025211905-234833755cb2/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
@@ -55,6 +57,8 @@ github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uP
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-retryablehttp v0.6.3 h1:tuulM+WnToeqa05z83YLmKabZxrySOmJAd4mJ+s2Nfg=
 github.com/hashicorp/go-retryablehttp v0.6.3/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/hcl/v2 v2.0.0/go.mod h1:oVVDG71tEinNGYCxinCYadcmKU9bglqW9pV3txagJ90=
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf h1:FtEj8sfIcaaBfAKrE1Cwb61YDtYq9JxChK1c7AKce7s=
 github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf/go.mod h1:yrqSXGoD/4EKfF26AOGzscPOgTTJcyAwM2rpixWT+t4=


### PR DESCRIPTION
Retry GitHub API requests on transient server errors, using
`github.com/hashicorp/retryablehttp-go`. We get the occasional 502 error
which breaks the whole drone pipeline run:

    Failed to start workflow run Failed polling workflow jobs
      Failed to fetch workflow jobs
          GET https://api.github.com/repos/gravitational/teleport.e/actions/runs/4858067495/jobs: 502 Server Error []

Backport: https://github.com/gravitational/teleport/pull/25868