### PR TITLE
billing banner appears on application load

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -14,7 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Suspense, useEffect, useMemo } from 'react';
+import React, {
+  ReactNode,
+  Suspense,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import styled from 'styled-components';
 import { Indicator } from 'design';
 import { Failed } from 'design/CardError';
@@ -51,8 +57,9 @@ import type { LockedFeatures, TeleportFeature } from 'teleport/types';
 
 interface MainProps {
   initialAlerts?: ClusterAlert[];
-  customBanners?: React.ReactNode[];
+  customBanners?: ReactNode[];
   features: TeleportFeature[];
+  billingBanners?: ReactNode[];
 }
 
 export function Main(props: MainProps) {
@@ -79,7 +86,7 @@ export function Main(props: MainProps) {
 
   const { alerts, dismissAlert } = useAlerts(props.initialAlerts);
 
-  const [showOnboardDiscover, setShowOnboardDiscover] = React.useState(true);
+  const [showOnboardDiscover, setShowOnboardDiscover] = useState(true);
 
   if (attempt.status === 'failed') {
     return <Failed message={attempt.statusText} />;
@@ -148,6 +155,7 @@ export function Main(props: MainProps) {
       <BannerList
         banners={banners}
         customBanners={props.customBanners}
+        billingBanners={featureFlags.billing && props.billingBanners}
         onBannerDismiss={dismissAlert}
       >
         <MainContainer>

--- a/web/packages/teleport/src/components/BannerList/BannerList.tsx
+++ b/web/packages/teleport/src/components/BannerList/BannerList.tsx
@@ -23,13 +23,14 @@ import { MainContainer } from 'teleport/Main/MainContainer';
 
 import { Banner } from './Banner';
 
-import type { ReactNode } from 'react';
 import type { Severity } from './Banner';
+import type { ReactNode } from 'react';
 
 export const BannerList = ({
   banners = [],
   children,
   customBanners = [],
+  billingBanners = [],
   onBannerDismiss = () => {},
 }: Props) => {
   const [bannerData, setBannerData] = useState<{ [id: string]: BannerType }>(
@@ -68,6 +69,7 @@ export const BannerList = ({
         />
       ))}
       {customBanners}
+      {billingBanners}
       {children}
     </Wrapper>
   );
@@ -89,6 +91,7 @@ type Props = {
   children?: ReactNode;
   customBanners?: ReactNode[];
   onBannerDismiss?: (string) => void;
+  billingBanners?: ReactNode[];
 };
 
 export type BannerType = {


### PR DESCRIPTION
**Before** the billing banner was not displaying on application load, would show up on subsequent updates (page view, tab change).

**Cause** We need to check two values to determine if the billing banner should display: `cfg.oss.isUsageBasedBilling` and `ctx.getFeatureFlags().billing`. in e/Main `ctx.getFeatureFlags().billing` was returning false on load. This is because we call `ctx.init` in ./Main (a child component)

**Solution** 
- e/Main now checks `cfg.oss.isUsageBasedBilling` and if that is true, passes billing banner to ./Main
- ./Main now checks `ctx.getFeatureFlags().billing` and if that is true, passes the billing banner to the banner list


Teleport.e implementation: https://github.com/gravitational/teleport.e/pull/1356
supports: https://github.com/gravitational/cloud/issues/3536