### PR TITLE
[v12] Okta assignment targets/statuses are human readable in the CLI.

### DIFF
--- a/api/types/okta.go
+++ b/api/types/okta.go
@@ -172,7 +172,9 @@ func (o *OktaImportRuleMatchV1) CheckAndSetDefaults() error {
 	return nil
 }
 
-// OktaAssignment is a representation of an action or set of actions taken by Teleport to assign Okta users to applications or groups.
+// OktaAssignment is a representation of an action or set of actions taken by Teleport to assign Okta users
+// to applications or groups. When modifying this object, please make sure to update
+// tool/tctl/common/oktaassignment to reflect any new fields that were added.
 type OktaAssignment interface {
 	ResourceWithLabels
 

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -37,6 +37,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/tool/tctl/common/loginrule"
+	"github.com/gravitational/teleport/tool/tctl/common/oktaassignment"
 )
 
 type ResourceCollection interface {
@@ -1133,7 +1134,7 @@ type oktaAssignmentCollection struct {
 func (c *oktaAssignmentCollection) resources() []types.Resource {
 	r := make([]types.Resource, len(c.assignments))
 	for i, resource := range c.assignments {
-		r[i] = resource
+		r[i] = oktaassignment.ToResource(resource)
 	}
 	return r
 }

--- a/tool/tctl/common/oktaassignment/resource.go
+++ b/tool/tctl/common/oktaassignment/resource.go
@@ -1,0 +1,78 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oktaassignment
+
+import (
+	"time"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+// Resource is a type to represent on Okta assignment that implements types.Resource
+// and custom YAML marshaling. This is entirely to present a version of the Okta assignment
+// with human readable statuses.
+type Resource struct {
+	// ResourceHeader is embedded to implement types.Resource
+	types.ResourceHeader
+	// Spec is the login rule specification
+	Spec spec `json:"spec"`
+}
+
+// spec holds the Okta assignment spec.
+type spec struct {
+	CleanupTime    time.Time `json:"cleanup_time"`
+	Finalized      bool      `json:"finalized"`
+	LastTransition time.Time `json:"last_transition"`
+	User           string    `json:"user"`
+	Status         string    `json:"status"`
+	Targets        []target  `json:"targets"`
+}
+
+// target holds an Okta assignment target.
+type target struct {
+	ID         string `json:"id"`
+	TargetType string `json:"type"`
+}
+
+// ToResource converts an OktaAssignment into a *Resource which
+// implements types.Resource and can be marshaled to YAML or JSON in a
+// human-friendly format.
+func ToResource(assignment types.OktaAssignment) *Resource {
+	sourceTargets := assignment.GetTargets()
+	resourceTargets := make([]target, len(sourceTargets))
+
+	for i, sourceTarget := range sourceTargets {
+		resourceTargets[i] = target{
+			ID:         sourceTarget.GetID(),
+			TargetType: sourceTarget.GetTargetType(),
+		}
+	}
+
+	return &Resource{
+		ResourceHeader: types.ResourceHeader{
+			Kind:     assignment.GetKind(),
+			Version:  assignment.GetVersion(),
+			Metadata: assignment.GetMetadata(),
+		},
+		Spec: spec{
+			CleanupTime:    assignment.GetCleanupTime(),
+			Finalized:      assignment.IsFinalized(),
+			LastTransition: assignment.GetLastTransition(),
+			User:           assignment.GetUser(),
+			Status:         assignment.GetStatus(),
+			Targets:        resourceTargets,
+		},
+	}
+}

--- a/tool/tctl/common/oktaassignment/resource_test.go
+++ b/tool/tctl/common/oktaassignment/resource_test.go
@@ -1,0 +1,90 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package oktaassignment
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+
+	"github.com/gravitational/teleport/api/constants"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// TestToResource will test that the enum values of the Okta assignment are human readable
+// and make a best effort to ensuring there are no missing fields from the Okta assignment
+// that have not yet been added to this resource.
+func TestToResource(t *testing.T) {
+	assignment, err := types.NewOktaAssignment(types.Metadata{
+		Name: "assignment",
+	}, types.OktaAssignmentSpecV1{
+		User:   "user",
+		Status: types.OktaAssignmentSpecV1_PENDING,
+		Targets: []*types.OktaAssignmentTargetV1{
+			{
+				Id:   "1",
+				Type: types.OktaAssignmentTargetV1_APPLICATION,
+			},
+			{
+				Id:   "2",
+				Type: types.OktaAssignmentTargetV1_GROUP,
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	resource := ToResource(assignment)
+
+	buf := bytes.NewBuffer(nil)
+	require.NoError(t, utils.WriteYAML(buf, assignment))
+	assignmentYAML := buf.Bytes()
+
+	buf = bytes.NewBuffer(nil)
+	require.NoError(t, utils.WriteYAML(buf, resource))
+	resourceYAML := buf.Bytes()
+
+	// Unmarshal these to maps for easier controlled comparison
+	assignmentMap := map[string]interface{}{}
+	require.NoError(t, yaml.Unmarshal(assignmentYAML, &assignmentMap))
+
+	resourceMap := map[string]interface{}{}
+	require.NoError(t, yaml.Unmarshal(resourceYAML, &resourceMap))
+
+	// Test that the enum fields have been properly converted to strings, then
+	// assign the regular enum values to them so that we can do an equivalence
+	// check against the assignment map later.
+	resourceSpec, ok := resourceMap["spec"].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, constants.OktaAssignmentStatusPending, resourceSpec["status"])
+	resourceSpec["status"] = int(types.OktaAssignmentSpecV1_PENDING)
+
+	resourceTargets, ok := resourceSpec["targets"].([]interface{})
+	require.True(t, ok)
+
+	resourceTarget1, ok := resourceTargets[0].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, constants.OktaAssignmentTargetApplication, resourceTarget1["type"])
+	resourceTarget1["type"] = int(types.OktaAssignmentTargetV1_APPLICATION)
+
+	resourceTarget2, ok := resourceTargets[1].(map[string]interface{})
+	require.True(t, ok)
+	require.Equal(t, constants.OktaAssignmentTargetGroup, resourceTarget2["type"])
+	resourceTarget2["type"] = int(types.OktaAssignmentTargetV1_GROUP)
+
+	require.Equal(t, assignmentMap, resourceMap)
+}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/25991 to branch/v12

Note: The docs changes are not in this backport since the Okta docs were not released as part of v12.