### PR TITLE
tctl: improve alert ack flows

### DIFF
--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -2602,7 +2602,7 @@ Lists cluster alerts. This command can also be invoked as `tctl alerts ls`.
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--verbose` (`-v`) | false |boolean | If set, display detailed alert info |
+| `--verbose` (`-v`) | false |boolean | If set, display detailed alert info (including acknowledged alerts) |
 | `--labels` | none | Comma-separated strings | A list of labels to filter by |
 
 ### tctl alerts ack

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -2625,7 +2625,7 @@ $ tctl alerts ack [<flags>] <id>
 | - | - | - | - |
 | `--ttl` | 24h | Any duration | Time duration to acknowledge the alert for |
 | `--clear` | none | | Clear an existing alert acknowledgement |
-| `--reason` | none | | An optional reason for suppressing this alert |
+| `--reason` | none | | The reason for suppressing this alert |
 
 #### Examples
 

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -62,7 +62,7 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 	alert := app.Command("alerts", "Manage cluster alerts").Alias("alert")
 
 	c.alertList = alert.Command("list", "List cluster alerts").Alias("ls")
-	c.alertList.Flag("verbose", "Show detailed alert info").Short('v').BoolVar(&c.verbose)
+	c.alertList.Flag("verbose", "Show detailed alert info, including acknowledged alerts").Short('v').BoolVar(&c.verbose)
 	c.alertList.Flag("labels", labelHelp).StringVar(&c.labels)
 
 	c.alertCreate = alert.Command("create", "Create cluster alerts")
@@ -166,7 +166,8 @@ func (c *AlertCommand) List(ctx context.Context, client auth.ClientI) error {
 	}
 
 	alerts, err := client.GetClusterAlerts(ctx, types.GetClusterAlertsRequest{
-		Labels: labels,
+		Labels:           labels,
+		WithAcknowledged: c.verbose,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -26,6 +27,7 @@ import (
 	"github.com/gravitational/kingpin"
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
@@ -44,6 +46,7 @@ type AlertCommand struct {
 	severity string
 	ttl      time.Duration
 
+	format  string
 	verbose bool
 
 	alertList   *kingpin.CmdClause
@@ -64,6 +67,7 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 	c.alertList = alert.Command("list", "List cluster alerts").Alias("ls")
 	c.alertList.Flag("verbose", "Show detailed alert info, including acknowledged alerts").Short('v').BoolVar(&c.verbose)
 	c.alertList.Flag("labels", labelHelp).StringVar(&c.labels)
+	c.alertList.Flag("format", "Output format, 'text' or 'json'").Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 
 	c.alertCreate = alert.Command("create", "Create cluster alerts")
 	c.alertCreate.Arg("message", "Alert body message").Required().StringVar(&c.message)
@@ -181,7 +185,20 @@ func (c *AlertCommand) List(ctx context.Context, client auth.ClientI) error {
 	// sort so that newer/high-severity alerts show up higher.
 	types.SortClusterAlerts(alerts)
 
-	if c.verbose {
+	switch c.format {
+	case teleport.Text:
+		displayAlertsText(alerts, c.verbose)
+		return nil
+	case teleport.JSON:
+		return trace.Wrap(displayAlertsJSON(alerts))
+	default:
+		// technically unreachable since kingpin validates the EnumVar
+		return trace.BadParameter("invalid format %q", c.format)
+	}
+}
+
+func displayAlertsText(alerts []types.ClusterAlert, verbose bool) {
+	if verbose {
 		table := asciitable.MakeTable([]string{"ID", "Severity", "Message", "Created", "Labels"})
 		for _, alert := range alerts {
 			var labelPairs []string
@@ -206,7 +223,14 @@ func (c *AlertCommand) List(ctx context.Context, client auth.ClientI) error {
 		}
 		fmt.Println(table.AsBuffer().String())
 	}
+}
 
+func displayAlertsJSON(alerts []types.ClusterAlert) error {
+	out, err := json.MarshalIndent(alerts, "", "  ")
+	if err != nil {
+		return trace.Wrap(err, "failed to marshal alerts")
+	}
+	fmt.Println(string(out))
 	return nil
 }
 

--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -74,7 +74,7 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 	c.alertAck = alert.Command("ack", "Acknowledge cluster alerts")
 	c.alertAck.Flag("ttl", "Time duration to acknowledge the cluster alert for.").DurationVar(&c.ttl)
 	c.alertAck.Flag("clear", "Clear the acknowledgment for the cluster alert.").BoolVar(&c.clear)
-	c.alertAck.Flag("reason", "The reason for acknowledging the cluster alert.").StringVar(&c.reason)
+	c.alertAck.Flag("reason", "The reason for acknowledging the cluster alert.").Required().StringVar(&c.reason)
 	c.alertAck.Arg("id", "The cluster alert ID.").Required().StringVar(&c.alertID)
 
 	// We add "ack ls" as a command so kingpin shows it in the help dialog - as there is a space, `tctl ack xyz` will always be

--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -63,7 +63,7 @@ func (c *BotsCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	bots := app.Command("bots", "Operate on certificate renewal bots registered with the cluster.")
 
 	c.botsList = bots.Command("ls", "List all certificate renewal bots registered with the cluster.")
-	c.botsList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).StringVar(&c.format)
+	c.botsList.Flag("format", "Output format, 'text' or 'json'").Hidden().Default(teleport.Text).EnumVar(&c.format, teleport.Text, teleport.JSON)
 
 	c.botsAdd = bots.Command("add", "Add a new certificate renewal bot to the cluster.")
 	c.botsAdd.Arg("name", "A name to uniquely identify this bot in the cluster.").Required().StringVar(&c.botName)


### PR DESCRIPTION
This makes several minor usability improvements to the `tctl alerts` family of commands:

1. Mark the `--reason` flag required at the client. The reason was already required by the server, so this just gives us a quicker failure.
2. Include acknowledged alerts when the `-v` flag is provided to `tctl alerts ls`.
3. Add a `--format` flag so alerts can be listed in JSON format.

Demo:

```
teleport on zmb3/alert-ack-reason [$!] 
❯ tctl alerts create 'this is a test'

teleport on zmb3/alert-ack-reason [$!] 
➜ tctl alerts ls
Severity Message          
-------- ---------------- 
LOW      "this is a test" 


teleport on zmb3/alert-ack-reason [$!] 
➜ tctl alerts ls --format=json
[
  {
    "kind": "cluster_alert",
    "version": "v1",
    "metadata": {
      "name": "cff2d19e-06f5-4b9d-893c-8959444ef01e",
      "labels": {
        "teleport.internal/alert-on-login": "yes",
        "teleport.internal/alert-permit-all": "yes"
      },
      "expires": "2023-05-11T20:21:46.028354Z"
    },
    "spec": {
      "severity": 0,
      "message": "this is a test",
      "created": "2023-05-10T20:21:46.028354Z"
    }
  }
]                                                                                                                                                                                                          

teleport on zmb3/alert-ack-reason [$!] 
➜ tctl alerts ack cff2d19e-06f5-4b9d-893c-8959444ef01e --reason testing
Successfully acknowledged alert 'cff2d19e-06f5-4b9d-893c-8959444ef01e'. Alerts with this ID won't be pushed for 24h0m0s.

teleport on zmb3/alert-ack-reason [$!] 
➜ tctl alerts ls
no alerts

teleport on zmb3/alert-ack-reason [$!] 
➜ tctl alerts ls -v
ID                                   Severity Message          Created             Labels                                                                       
------------------------------------ -------- ---------------- ------------------- ---------------------------------------------------------------------------- 
cff2d19e-06f5-4b9d-893c-8959444ef01e LOW      "this is a test" 10 May 23 20:21 UTC teleport.internal/alert-on-login=yes, teleport.internal/alert-permit-all=yes 

```