### PR TITLE
Clean up staticConfig mocks

### DIFF
--- a/web/packages/teleterm/src/staticConfig.ts
+++ b/web/packages/teleterm/src/staticConfig.ts
@@ -29,18 +29,16 @@ interface IStaticConfig {
 
 let staticConfig: IStaticConfig;
 
-if (process.env.NODE_ENV === 'development') {
-  staticConfig = {
-    prehogAddress: 'https://reporting-connect-staging.teleportinfra.dev',
-    feedbackAddress:
-      'https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod',
-  };
-}
-
 if (process.env.NODE_ENV === 'production') {
   staticConfig = {
     prehogAddress: 'https://reporting-connect.teleportinfra.sh',
     feedbackAddress: 'https://usage.teleport.dev',
+  };
+} else {
+  staticConfig = {
+    prehogAddress: 'https://reporting-connect-staging.teleportinfra.dev',
+    feedbackAddress:
+      'https://kcwm2is93l.execute-api.us-west-2.amazonaws.com/prod',
   };
 }
 

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
@@ -29,12 +29,6 @@ import { MockAppContextProvider } from '../fixtures/MockAppContextProvider';
 
 import { useDocumentGateway } from './useDocumentGateway';
 
-jest.mock('teleterm/staticConfig', () => ({
-  staticConfig: {
-    prehogAddress: undefined,
-  },
-}));
-
 beforeEach(() => {
   jest.restoreAllMocks();
 });

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.test.tsx
@@ -42,12 +42,6 @@ import type { IAppContext } from 'teleterm/ui/types';
 import type * as tsh from 'teleterm/services/tshd/types';
 import type * as uri from 'teleterm/ui/uri';
 
-jest.mock('teleterm/staticConfig', () => ({
-  staticConfig: {
-    prehogAddress: undefined,
-  },
-}));
-
 beforeAll(() => {
   Logger.init(new NullService());
 });

--- a/web/packages/teleterm/src/ui/initUi.test.ts
+++ b/web/packages/teleterm/src/ui/initUi.test.ts
@@ -21,12 +21,6 @@ import { Dialog } from 'teleterm/ui/services/modals';
 
 import { initUi } from './initUi';
 
-jest.mock('teleterm/staticConfig', () => ({
-  staticConfig: {
-    prehogAddress: 'localhost',
-  },
-}));
-
 beforeAll(() => {
   Logger.init(new NullService());
 });


### PR DESCRIPTION
staticConfig.ts used to match on "development" and "production" only. In tests, jest sets NODE_ENV to "test" which required us to mock staticConfig.ts.

Since we don't need a separate config for dev and tests, we can reuse dev config for now.