### PR TITLE
Remove privileged APIs from window after app initialization

### DIFF
--- a/web/packages/teleterm/src/ui/appContextProvider.tsx
+++ b/web/packages/teleterm/src/ui/appContextProvider.tsx
@@ -28,8 +28,12 @@ export default AppContextProvider;
 
 export function useAppContext() {
   const ctx = React.useContext(AppReactContext);
-  // For debugging and diagnostic purposes.
-  window['teleterm'] = ctx;
+
+  // Attach the app context to the window for debugging and diagnostic purposes.
+  // Do not do this in the packaged app as this exposes privileged APIs through the window object.
+  if (process.env.NODE_ENV === 'development') {
+    window['teleterm'] = ctx;
+  }
   return ctx;
 }
 

--- a/web/packages/teleterm/src/ui/boot.tsx
+++ b/web/packages/teleterm/src/ui/boot.tsx
@@ -49,23 +49,23 @@ async function boot(): Promise<void> {
 
 /**
  * getElectronGlobals retrieves privileged APIs exposed through the contextBridge from preload.ts.
+ *
  * It also immediately removes them from the window object so that if an attacker gets to execute
  * arbitrary JS on the page, they don't get easy access to those privileged APIs.
- *
- * Technically, each value exposed through the contextBridge gets frozen. [1] Since we expose a
- * promise returning an object however, we can delete properties from that object, effectively
- * removing the APIs from the window object.
- *
- * This behavior might change between Electron or Chromium updates. At the moment we're in the
- * process of investigating how brittle this workaround is. [2]
- *
- * [1] https://www.electronjs.org/docs/latest/api/context-bridge#api
- * [2] https://github.com/electron/electron/issues/38243
  */
 async function getElectronGlobals(): Promise<ElectronGlobals> {
   const globals = await window['electron'];
   const globalsCopy = { ...globals };
 
+  // Technically, each value exposed through the contextBridge gets frozen. [1] Since we expose a
+  // promise returning an object however, we can delete properties from that object, effectively
+  // removing the APIs from the window object.
+  //
+  // We suspect that the semantics of this might change between Electron or Chromium updates.
+  // At the moment we're in the process of investigating how brittle this workaround is. [2]
+  //
+  // [1] https://www.electronjs.org/docs/latest/api/context-bridge#api
+  // [2] https://github.com/electron/electron/issues/38243
   for (const property in globals) {
     delete globals[property];
   }

--- a/web/packages/teleterm/src/ui/boot.tsx
+++ b/web/packages/teleterm/src/ui/boot.tsx
@@ -47,8 +47,30 @@ async function boot(): Promise<void> {
   }
 }
 
+/**
+ * getElectronGlobals retrieves privileged APIs exposed through the contextBridge from preload.ts.
+ * It also immediately removes them from the window object so that if an attacker gets to execute
+ * arbitrary JS on the page, they don't get easy access to those privileged APIs.
+ *
+ * Technically, each value exposed through the contextBridge gets frozen. [1] Since we expose a
+ * promise returning an object however, we can delete properties from that object, effectively
+ * removing the APIs from the window object.
+ *
+ * This behavior might change between Electron or Chromium updates. At the moment we're in the
+ * process of investigating how brittle this workaround is. [2]
+ *
+ * [1] https://www.electronjs.org/docs/latest/api/context-bridge#api
+ * [2] https://github.com/electron/electron/issues/38243
+ */
 async function getElectronGlobals(): Promise<ElectronGlobals> {
-  return await window['electron'];
+  const globals = await window['electron'];
+  const globalsCopy = { ...globals };
+
+  for (const property in globals) {
+    delete globals[property];
+  }
+
+  return globalsCopy;
 }
 
 function renderApp(content: React.ReactElement): void {


### PR DESCRIPTION
Since we only need the privileged APIs during app initialization, we might as well remove them after they're no longer needed.

While by itself this doesn't completely take care of the attack vector described in [TEL-Q322-15](https://github.com/gravitational/teleport-private/issues/176), it greatly reduces the attack surface by making sure that an XSS vulnerability in any random part of the UI doesn't let the attacker access the privileged APIs in a trivial manner.

The privileged APIs are removed from `window` before any UI that the user can interact with is rendered with `ReactDOM.render` a couple of lines below.

---

Another PR will remove the `initCommand` from `DocumentPtySession` which is directly related to the proof of concept included in TEL-Q322-15. However, if an attacker gains access to `ptyServiceClient`, they'll still be able to create a new shell session by creating a new PTY process and writing to it.

We cannot really work around this as creating a new terminal is an essential feature of the app. I suppose this is where the app hardening that we discussed comes into play – splitting the app into multiple layers with `BrowserView` where each layer has different permissions.