### PR TITLE
Docs: remove confusing variable delineation

### DIFF
--- a/docs/pages/access-controls/sso/azuread.mdx
+++ b/docs/pages/access-controls/sso/azuread.mdx
@@ -109,8 +109,8 @@ spec:
   # The last segment of the URL must be identical to the connector metadata name.
   acs: https://teleport.example.com:3080/v1/webapi/saml/acs/azure-saml
   attributes_to_roles:
-    - {name: "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups", value: "<group id 930210...>", roles: ["editor"]}
-    - {name: "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups", value: "<group id 93b110...>", roles: ["dev"]}
+    - {name: "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups", value: "930210...", roles: ["editor"]}
+    - {name: "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups", value: "93b110...", roles: ["dev"]}
   # Populate entity_descriptor with the federator data xml or set entity_descriptor_url to automatically load from the SSO
   entity_descriptor: |
     <federationmedata.xml contents>


### PR DESCRIPTION
Closes #8465 by removing extraneous content from our example group ID values.