### PR TITLE
TLS Routing behind ALB: access request Kube Pod search

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -48,11 +48,13 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/gravitational/teleport/api/breaker"
+	kubeproto "github.com/gravitational/teleport/api/gen/proto/go/teleport/kube/v1"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -441,23 +443,28 @@ func mustClosePostgresClient(t *testing.T, client *pgconn.PgConn) {
 	require.NoError(t, err)
 }
 
+const (
+	kubeClusterName             = "gke_project_europecentral2a_cluster1"
+	kubeClusterDefaultNamespace = "default"
+	kubePodName                 = "firstcontainer-66b6c48dd-bqmwk"
+)
+
 func k8ClientConfig(serverAddr, sni string) clientcmdapi.Config {
-	const clusterName = "gke_project_europecentral2a_cluster1"
 	return clientcmdapi.Config{
 		Clusters: map[string]*clientcmdapi.Cluster{
-			clusterName: {
+			kubeClusterName: {
 				Server:                serverAddr,
 				InsecureSkipTLSVerify: true,
 				TLSServerName:         sni,
 			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
-			clusterName: {
-				Cluster:  clusterName,
-				AuthInfo: clusterName,
+			kubeClusterName: {
+				Cluster:  kubeClusterName,
+				AuthInfo: kubeClusterName,
 			},
 		},
-		CurrentContext: clusterName,
+		CurrentContext: kubeClusterName,
 	}
 }
 
@@ -470,7 +477,8 @@ func mkPodList() *v1.PodList {
 		Items: []v1.Pod{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "firstcontainer-66b6c48dd-bqmwk",
+					Name:      kubePodName,
+					Namespace: kubeClusterDefaultNamespace,
 				},
 			},
 		},
@@ -780,4 +788,22 @@ func mustRegisterUsingIAMMethod(t *testing.T, proxyAddr utils.NetAddr, token str
 		PublicSSHKey: []byte(fixtures.SSHCAPublicKey),
 	})
 	require.NoError(t, err, trace.DebugReport(err))
+}
+
+func mustFindKubePod(t *testing.T, tc *client.TeleportClient) {
+	t.Helper()
+
+	serviceClient, err := tc.NewKubernetesServiceClient(context.Background(), tc.SiteName)
+	require.NoError(t, err)
+
+	response, err := serviceClient.ListKubernetesResources(context.Background(), &kubeproto.ListKubernetesResourcesRequest{
+		ResourceType:        types.KindKubePod,
+		KubernetesCluster:   kubeClusterName,
+		KubernetesNamespace: kubeClusterDefaultNamespace,
+		TeleportCluster:     tc.SiteName,
+	})
+	require.NoError(t, err)
+	require.Len(t, response.Resources, 1)
+	require.Equal(t, types.KindKubePod, response.Resources[0].Kind)
+	require.Equal(t, kubePodName, response.Resources[0].GetName())
 }

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4738,6 +4738,8 @@ func (tc *TeleportClient) NewKubernetesServiceClient(ctx context.Context, cluste
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
+		ALPNConnUpgradeRequired:  tc.TLSRoutingConnUpgradeRequired,
+		InsecureAddressDiscovery: tc.InsecureSkipVerify,
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Related PR
- #21870

Test
```
$ tsh request search --kind pod --kube-cluster minikube --kube-namespace default
```