### PR TITLE
[v13] Return a better message on "lacks registered credentials" errors

### DIFF
--- a/lib/auth/webauthncli/api.go
+++ b/lib/auth/webauthncli/api.go
@@ -28,6 +28,12 @@ import (
 	"github.com/gravitational/teleport/lib/auth/webauthnwin"
 )
 
+// ErrUsingNonRegisteredDevice is returned from Login when the user attempts to
+// authenticate with a non-registered security key.
+// The error message is meant to be displayed to end-users, thus it breaks the
+// usual Go error conventions (capitalized sentences, punctuation).
+var ErrUsingNonRegisteredDevice = errors.New("You are using a security key that is not registered with Teleport. Try a different security key.")
+
 // AuthenticatorAttachment allows callers to choose a specific attachment.
 type AuthenticatorAttachment int
 

--- a/lib/auth/webauthncli/fido2.go
+++ b/lib/auth/webauthncli/fido2.go
@@ -726,7 +726,12 @@ func withInteractiveError(filter deviceFilterFunc, cb pinAwareCallbackFunc) pinA
 			// Device not chosen.
 			return false, &nonInteractiveError{filterErr}
 		case errors.Is(waitErr, libfido2.ErrNoCredentials):
-			// Device chosen, error is useful in this case.
+			// Device chosen.
+			// Escalate error to ErrUsingNonRegisteredDevice, if appropriate, so we
+			// send a better message to the user.
+			if errors.Is(filterErr, errNoRegisteredCredentials) {
+				filterErr = ErrUsingNonRegisteredDevice
+			}
 		default:
 			log.Warnf("FIDO2: Device %v: unexpected wait error: %q", info.path, waitErr)
 		}

--- a/lib/auth/webauthncli/fido2_test.go
+++ b/lib/auth/webauthncli/fido2_test.go
@@ -1294,7 +1294,7 @@ func TestFIDO2_LoginRegister_interactionErrors(t *testing.T) {
 			name:            "no registered credential",
 			createAssertion: func() *wanlib.CredentialAssertion { return mfaAssertion },
 			prompt:          notRegistered,
-			wantErr:         "lacks registered credential",
+			wantErr:         wancli.ErrUsingNonRegisteredDevice.Error(),
 		},
 		{
 			// Theoretically could happen, but not something we do today.

--- a/lib/client/mfa_test.go
+++ b/lib/client/mfa_test.go
@@ -1,0 +1,117 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package client_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-webauthn/webauthn/protocol"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	wanpb "github.com/gravitational/teleport/api/types/webauthn"
+	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
+	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/utils/prompt"
+)
+
+// TestPromptMFAChallenge_usingNonRegisteredDevice tests a specific MFA scenario
+// where the user picks a non-registered security key.
+// See api_login_test.go and/or TeleportClient tests for more general
+// authentication tests.
+func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
+	oldPromptWebauthn := *client.PromptWebauthn
+	oldHasPlatformSupport := *client.HasPlatformSupport
+	oldStdin := prompt.Stdin()
+	t.Cleanup(func() {
+		*client.PromptWebauthn = oldPromptWebauthn
+		*client.HasPlatformSupport = oldHasPlatformSupport
+		prompt.SetStdin(oldStdin)
+	})
+
+	// User always picks a non-registered device.
+	*client.PromptWebauthn = func(ctx context.Context, origin string, assertion *wanlib.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+		return nil, "", wancli.ErrUsingNonRegisteredDevice
+	}
+	// Support always enabled.
+	*client.HasPlatformSupport = func() bool {
+		return true
+	}
+
+	const proxyAddr = "example.com"
+	ctx := context.Background()
+
+	// The Webauthn challenge below looks like a typical MFA challenge.
+	challengeWebauthnOnly := &proto.MFAAuthenticateChallenge{
+		WebauthnChallenge: &wanpb.CredentialAssertion{
+			PublicKey: &wanpb.PublicKeyCredentialRequestOptions{
+				Challenge: []byte{1, 2, 3, 4, 5}, // arbitrary
+				RpId:      "example.com",
+				AllowCredentials: []*wanpb.CredentialDescriptor{
+					{
+						Type: string(protocol.PublicKeyCredentialType),
+						Id:   []byte{5, 5, 5, 5, 5}, // arbitrary
+					},
+				},
+				UserVerification: string(protocol.VerificationDiscouraged),
+			},
+		},
+	}
+
+	challengeWebauthnOTP := &proto.MFAAuthenticateChallenge{
+		TOTP:              &proto.TOTPChallenge{}, // non-nil enables OTP prompt
+		WebauthnChallenge: challengeWebauthnOnly.WebauthnChallenge,
+	}
+
+	tests := []struct {
+		name      string
+		challenge *proto.MFAAuthenticateChallenge
+		opts      *client.PromptMFAChallengeOpts
+	}{
+		{
+			name:      "webauthn only",
+			challenge: challengeWebauthnOnly,
+		},
+		{
+			name:      "webauthn and OTP",
+			challenge: challengeWebauthnOTP,
+			opts: &client.PromptMFAChallengeOpts{
+				AllowStdinHijack: true, // required for OTP+WebAuthn prompt.
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// Set a timeout so the test won't block forever.
+			// We don't expect to hit the timeout for any of the test cases.
+			ctx, cancel := context.WithTimeout(ctx, 100000000*time.Second)
+			defer cancel()
+
+			// Prompt never has any input.
+			prompt.SetStdin(prompt.NewFakeReader().AddReply(func(ctx context.Context) (string, error) {
+				<-ctx.Done()
+				return "", ctx.Err()
+			}))
+
+			_, err := client.PromptMFAChallenge(ctx, test.challenge, proxyAddr, test.opts)
+			if !errors.Is(err, wancli.ErrUsingNonRegisteredDevice) {
+				t.Errorf("PromptMFAChallenge returned err=%q, want %q", err, wancli.ErrUsingNonRegisteredDevice)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport #26079 to branch/v13

Return an error message specially crafted to end users in situations where the user picks a non-registered device for MFA ceremonies.

Care is taken to only "escalate" the error in situations where we are 100% about user interaction (pure U2F devices won't see the escalation, unfortunately).

Reproduced by registering only a Touch ID credential in the Web UI, then trying to authenticate using a Yubikey.

Before:

```shell
$ ./tsh login --proxy=zarquon.dev --user=llama
> Enter password for Teleport user llama:
> Tap any security key
*taps non-registered key*
> ERROR: failed to authenticate using all MFA devices, rerun the command with '-d' to see error details for each device
```

("WEBAUTHN authentication failed error: device lacks registered credentials" present in debug logs.)

After:

```shell
$ ./tsh login --proxy=zarquon.dev --user=llama
> Enter password for Teleport user llama:
> Tap any security key
*taps non-registered key*
> ERROR: You are using a security key that is not registered with Teleport. Try a different security key.
```