### PR TITLE
Add pprof diagnostics endpoints to `tbot`

### DIFF
--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -160,6 +160,10 @@ type CLIConf struct {
 	// - Restrict TLS / SSH cipher suites and TLS version
 	// - RSA2048 should be used for private key generation
 	FIPS bool
+
+	// DiagAddr is the address the diagnostics http service should listen on.
+	// If not set, no diagnostics listener is created.
+	DiagAddr string
 }
 
 // AzureOnboardingConfig holds configuration relevant to the "azure" join method.
@@ -243,6 +247,9 @@ type BotConfig struct {
 	// - Restrict TLS / SSH cipher suites and TLS version
 	// - RSA2048 should be used for private key generation
 	FIPS bool `yaml:"fips"`
+	// DiagAddr is the address the diagnostics http service should listen on.
+	// If not set, no diagnostics listener is created.
+	DiagAddr string `yaml:"diag_addr,omitempty"`
 }
 
 func (conf *BotConfig) CipherSuites() []uint16 {
@@ -463,6 +470,13 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 
 	if cf.FIPS {
 		config.FIPS = cf.FIPS
+	}
+
+	if cf.DiagAddr != "" {
+		if config.DiagAddr != "" {
+			log.Warnf("CLI parameters are overriding diagnostics address configured in %s", cf.ConfigPath)
+		}
+		config.DiagAddr = cf.DiagAddr
 	}
 
 	if err := config.CheckAndSetDefaults(); err != nil {

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -56,6 +56,8 @@ func TestConfigCLIOnlySample(t *testing.T) {
 		Token:          "foo",
 		CAPins:         []string{"abc123"},
 		AuthServer:     "auth.example.com",
+		DiagAddr:       "127.0.0.1:1337",
+		Debug:          true,
 	}
 	cfg, err := FromCLIConf(&cf)
 	require.NoError(t, err)
@@ -91,6 +93,8 @@ func TestConfigCLIOnlySample(t *testing.T) {
 	require.True(t, ok)
 
 	require.Equal(t, cf.DestinationDir, destImplReal.Path)
+	require.Equal(t, cf.Debug, cfg.Debug)
+	require.Equal(t, cf.DiagAddr, cfg.DiagAddr)
 }
 
 func TestConfigFile(t *testing.T) {
@@ -130,6 +134,9 @@ func TestConfigFile(t *testing.T) {
 	destImplReal, ok := destImpl.(*DestinationDirectory)
 	require.True(t, ok)
 	require.Equal(t, "/tmp/foo", destImplReal.Path)
+
+	require.True(t, cfg.Debug)
+	require.Equal(t, "127.0.0.1:1337", cfg.DiagAddr)
 }
 
 func TestLoadTokenFromFile(t *testing.T) {
@@ -149,6 +156,8 @@ func TestLoadTokenFromFile(t *testing.T) {
 const exampleConfigFile = `
 auth_server: auth.example.com
 renewal_interval: 5m
+debug: true
+diag_addr: 127.0.0.1:1337
 onboarding:
   token: %s
   ca_pins:

--- a/tool/tbot/main.go
+++ b/tool/tbot/main.go
@@ -85,6 +85,7 @@ func Run(args []string, stdout io.Writer) error {
 	startCmd.Flag("renewal-interval", "Interval at which short-lived certificates are renewed; must be less than the certificate TTL.").DurationVar(&cf.RenewalInterval)
 	startCmd.Flag("join-method", "Method to use to join the cluster. "+joinMethodList).Default(config.DefaultJoinMethod).EnumVar(&cf.JoinMethod, config.SupportedJoinMethods...)
 	startCmd.Flag("oneshot", "If set, quit after the first renewal.").BoolVar(&cf.Oneshot)
+	startCmd.Flag("diag-addr", "If set and the bot is in debug mode, a diagnostics service will listen on specified address.").StringVar(&cf.DiagAddr)
 
 	initCmd := app.Command("init", "Initialize a certificate destination directory for writes from a separate bot user.")
 	initCmd.Flag("destination-dir", "Directory to write short-lived machine certificates to.").StringVar(&cf.DestinationDir)


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/26087

When `-d --diag-addr 127.0.0.1:1337` a HTTP server is set to listen with the pprof debug handlers mounted.