### PR TITLE
Web: Provide accurate actionable steps with duplicate db name error

### DIFF
--- a/web/packages/shared/utils/errorType.ts
+++ b/web/packages/shared/utils/errorType.ts
@@ -24,7 +24,7 @@ export function isPrivateKeyRequiredError(err: Error) {
 // before attempting to access the error message field.
 // Used with try catch blocks, where the error caught
 // may not necessary be of type Error.
-export function getErrMessage(err) {
+export function getErrMessage(err: unknown) {
   let message = 'something went wrong';
   if (err instanceof Error) message = err.message;
 

--- a/web/packages/shared/utils/errorType.ts
+++ b/web/packages/shared/utils/errorType.ts
@@ -19,3 +19,14 @@ import { privateKeyEnablingPolicies } from 'shared/services';
 export function isPrivateKeyRequiredError(err: Error) {
   return privateKeyEnablingPolicies.some(p => err.message.includes(p));
 }
+
+// getErrMessage first checks if the error is of type Error
+// before attempting to access the error message field.
+// Used with try catch blocks, where the error caught
+// may not necessary be of type Error.
+export function getErrMessage(err) {
+  let message = 'something went wrong';
+  if (err instanceof Error) message = err.message;
+
+  return message;
+}

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabase.story.tsx
@@ -68,6 +68,7 @@ const props: State = {
   attempt: { status: '' },
   clearAttempt: () => null,
   registerDatabase: () => null,
+  fetchDatabaseServers: () => null,
   canCreateDatabase: true,
   pollTimeout: Date.now() + 30000,
   dbEngine: DatabaseEngine.Postgres,

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.tsx
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/CreateDatabaseDialog.tsx
@@ -52,7 +52,7 @@ export function CreateDatabaseDialog({
       <>
         <Text mb={5}>
           <Icons.Warning ml={1} mr={2} color="error.main" />
-          Register Failed: {attempt.statusText}
+          {attempt.statusText}
         </Text>
         <Flex>
           <ButtonPrimary mr={3} width="50%" onClick={retry}>
@@ -104,7 +104,7 @@ export function CreateDatabaseDialog({
   return (
     <Dialog disableEscapeKeyDown={false} open={true}>
       <DialogContent
-        width="400px"
+        width="460px"
         alignItems="center"
         mb={0}
         textAlign="center"

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
@@ -16,10 +16,9 @@
 
 import React from 'react';
 
-import { AwsRdsDatabase } from 'teleport/services/integrations';
-
 import { AwsRegionSelector } from './AwsRegionSelector';
 import { DatabaseList } from './RdsDatabaseList';
+import { CheckedAwsRdsDatabase } from './EnrollRdsDatabase';
 
 export default {
   title: 'Teleport/Discover/Database/EnrollRds',
@@ -85,7 +84,7 @@ export const RdsDatabaseListLoading = () => (
   />
 );
 
-const fixtures: AwsRdsDatabase[] = [
+const fixtures: CheckedAwsRdsDatabase[] = [
   {
     name: 'postgres-name',
     engine: 'postgres',
@@ -103,6 +102,7 @@ const fixtures: AwsRdsDatabase[] = [
     status: 'available',
     accountId: '',
     resourceId: '',
+    dbServerExists: true,
   },
   {
     name: 'alpaca',
@@ -137,6 +137,7 @@ const fixtures: AwsRdsDatabase[] = [
     status: 'Unknown' as any,
     accountId: '',
     resourceId: '',
+    dbServerExists: true,
   },
   {
     name: 'llama',

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
@@ -126,11 +126,7 @@ export function EnrollRdsDatabase() {
       const query = resourceIds.join(' || ');
       const { agents: fetchedDbServers } = await fetchDatabaseServers(
         query,
-        // Adding +5 for the corner case possiblity where user
-        // registered the same rds dbs but under a different name.
-        // This was possible before the check for existing db servers
-        // existed.
-        fetchedRdsDbs.length + 5 // limit
+        fetchedRdsDbs.length // limit
       );
 
       const dbServerLookupByResourceId: Record<string, Database> = {};

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
@@ -20,16 +20,17 @@ import { FetchStatus } from 'design/DataTable/types';
 import { Danger } from 'design/Alert';
 
 import useAttempt from 'shared/hooks/useAttemptNext';
+import { getErrMessage } from 'shared/utils/errorType';
 
 import { DbMeta, useDiscover } from 'teleport/Discover/useDiscover';
 import {
   AwsRdsDatabase,
-  ListAwsRdsDatabaseResponse,
   RdsEngineIdentifier,
   Regions,
   integrationService,
 } from 'teleport/services/integrations';
 import { DatabaseEngine } from 'teleport/Discover/SelectResource';
+import { Database } from 'teleport/services/databases';
 
 import { ActionButtons, Header } from '../../Shared';
 
@@ -40,7 +41,7 @@ import { AwsRegionSelector } from './AwsRegionSelector';
 import { DatabaseList } from './RdsDatabaseList';
 
 type TableData = {
-  items: ListAwsRdsDatabaseResponse['databases'];
+  items: CheckedAwsRdsDatabase[];
   fetchStatus: FetchStatus;
   startKey?: string;
   currRegion?: Regions;
@@ -52,6 +53,14 @@ const emptyTableData: TableData = {
   startKey: '',
 };
 
+// CheckedAwsRdsDatabase is a type to describe that a
+// AwsRdsDatabase has been checked (by its resource id)
+// with the backend whether or not a database server already
+// exists for it.
+export type CheckedAwsRdsDatabase = AwsRdsDatabase & {
+  dbServerExists?: boolean;
+};
+
 export function EnrollRdsDatabase() {
   const {
     createdDb,
@@ -60,6 +69,7 @@ export function EnrollRdsDatabase() {
     attempt: registerAttempt,
     clearAttempt: clearRegisterAttempt,
     nextStep,
+    fetchDatabaseServers,
   } = useCreateDatabase();
 
   const { agentMeta, resourceSpec, emitErrorEvent } = useDiscover();
@@ -71,7 +81,7 @@ export function EnrollRdsDatabase() {
     startKey: '',
     fetchStatus: 'disabled',
   });
-  const [selectedDb, setSelectedDb] = useState<AwsRdsDatabase>();
+  const [selectedDb, setSelectedDb] = useState<CheckedAwsRdsDatabase>();
 
   function fetchDatabasesWithNewRegion(region: Regions) {
     // Clear table when fetching with new region.
@@ -87,36 +97,73 @@ export function EnrollRdsDatabase() {
     fetchDatabases({ ...tableData, startKey: '', items: [] });
   }
 
-  function fetchDatabases(data: TableData) {
+  async function fetchDatabases(data: TableData) {
     const integrationName = (agentMeta as DbMeta).integrationName;
 
     setTableData({ ...data, fetchStatus: 'loading' });
     setFetchDbAttempt({ status: 'processing' });
 
-    integrationService
-      .fetchAwsRdsDatabases(
-        integrationName,
-        getRdsEngineIdentifier(resourceSpec.dbMeta?.engine),
-        {
-          region: data.currRegion,
-          nextToken: data.startKey,
+    try {
+      const { databases: fetchedRdsDbs, nextToken } =
+        await integrationService.fetchAwsRdsDatabases(
+          integrationName,
+          getRdsEngineIdentifier(resourceSpec.dbMeta?.engine),
+          {
+            region: data.currRegion,
+            nextToken: data.startKey,
+          }
+        );
+
+      // Check if fetched rds databases have a database
+      // server for it, to prevent user from enrolling
+      // the same db and getting an error from it.
+
+      // Build the predicate string that will query for
+      // all the fetched rds dbs by its resource ids.
+      const resourceIds: string[] = fetchedRdsDbs.map(
+        d => `resource.spec.aws.rds.resource_id == "${d.resourceId}"`
+      );
+      const query = resourceIds.join(' || ');
+      const { agents: fetchedDbServers } = await fetchDatabaseServers(
+        query,
+        // Adding +5 for the corner case possiblity where user
+        // registered the same rds dbs but under a different name.
+        // This was possible before the check for existing db servers
+        // existed.
+        fetchedRdsDbs.length + 5 // limit
+      );
+
+      const dbServerLookupByResourceId: Record<string, Database> = {};
+      fetchedDbServers.forEach(
+        d => (dbServerLookupByResourceId[d.aws.rds.resourceId] = d)
+      );
+
+      // Check for db server matches.
+      const checkedRdsDbs: CheckedAwsRdsDatabase[] = fetchedRdsDbs.map(rds => {
+        const dbServer = dbServerLookupByResourceId[rds.resourceId];
+        if (dbServer) {
+          return {
+            ...rds,
+            dbServerExists: true,
+          };
         }
-      )
-      .then(resp => {
-        setFetchDbAttempt({ status: 'success' });
-        setTableData({
-          currRegion: data.currRegion,
-          startKey: resp.nextToken,
-          fetchStatus: resp.nextToken ? '' : 'disabled',
-          // concat each page fetch.
-          items: [...data.items, ...resp.databases],
-        });
-      })
-      .catch((err: Error) => {
-        setFetchDbAttempt({ status: 'failed', statusText: err.message });
-        setTableData(data); // fallback to previous data
-        emitErrorEvent(`failed to fetch aws rds list: ${err.message}`);
+        return rds;
       });
+
+      setFetchDbAttempt({ status: 'success' });
+      setTableData({
+        currRegion: data.currRegion,
+        startKey: nextToken,
+        fetchStatus: nextToken ? '' : 'disabled',
+        // concat each page fetch.
+        items: [...data.items, ...checkedRdsDbs],
+      });
+    } catch (err) {
+      const errMsg = getErrMessage(err);
+      setFetchDbAttempt({ status: 'failed', statusText: errMsg });
+      setTableData(data); // fallback to previous data
+      emitErrorEvent(`database fetch error: ${errMsg}`);
+    }
   }
 
   function clear() {

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -63,6 +63,7 @@ type EventState = {
 };
 
 type CustomEventInput = {
+  id?: string;
   eventName?: DiscoverEvent;
   eventResourceName?: DiscoverEventResource;
   autoDiscoverResourcesCount?: number;
@@ -116,7 +117,7 @@ export function DiscoverProvider(
       userEventService.captureDiscoverEvent({
         event: custom?.eventName || currEventName,
         eventData: {
-          id,
+          id: id || custom.id,
           resource: custom?.eventResourceName || resourceSpec?.event,
           autoDiscoverResourcesCount: custom?.autoDiscoverResourcesCount,
           selectedResourcesCount: custom?.selectedResourcesCount,
@@ -213,6 +214,7 @@ export function DiscoverProvider(
       {
         eventName: discover.eventState.currEventName,
         eventResourceName: discover.resourceSpec.event,
+        id: discover.eventState.id,
       }
     );
   }

--- a/web/packages/teleport/src/services/api/parseError.ts
+++ b/web/packages/teleport/src/services/api/parseError.ts
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 export default function parseError(json) {
   let msg = '';
 

--- a/web/packages/teleport/src/services/api/parseError.ts
+++ b/web/packages/teleport/src/services/api/parseError.ts
@@ -12,7 +12,9 @@ export default function parseError(json) {
 }
 
 export class ApiError extends Error {
-  constructor(message, response) {
+  response: Response;
+
+  constructor(message, response: Response) {
     message = message || 'Unknown error';
     super(message);
     this.response = response;

--- a/web/packages/teleport/src/services/databases/databases.test.ts
+++ b/web/packages/teleport/src/services/databases/databases.test.ts
@@ -40,6 +40,19 @@ test('correct formatting of database fetch response', async () => {
           { name: 'cluster', value: 'root' },
           { name: 'env', value: 'aws' },
         ],
+        aws: {
+          rds: {
+            resourceId: 'resource-id',
+          },
+        },
+      },
+      {
+        name: 'self-hosted',
+        type: 'Self-hosted PostgreSQL',
+        protocol: 'postgres',
+        names: [],
+        users: [],
+        labels: [],
       },
     ],
     startKey: mockResponse.startKey,
@@ -150,6 +163,7 @@ test('null array fields in database services fetch response', async () => {
 
 const mockResponse = {
   items: [
+    // aws rds
     {
       name: 'aurora',
       desc: 'PostgreSQL 11.6: AWS Aurora',
@@ -160,6 +174,19 @@ const mockResponse = {
         { name: 'cluster', value: 'root' },
         { name: 'env', value: 'aws' },
       ],
+      aws: {
+        rds: {
+          resource_id: 'resource-id',
+        },
+      },
+    },
+    // non-aws self-hosted
+    {
+      name: 'self-hosted',
+      type: 'self-hosted',
+      protocol: 'postgres',
+      uri: 'localhost:5432',
+      labels: [],
     },
   ],
   startKey: 'mockKey',

--- a/web/packages/teleport/src/services/databases/makeDatabase.ts
+++ b/web/packages/teleport/src/services/databases/makeDatabase.ts
@@ -19,9 +19,19 @@ import { formatDatabaseInfo } from 'shared/services/databases';
 import { Database, DatabaseService } from './types';
 
 export function makeDatabase(json: any): Database {
-  const { name, desc, protocol, type } = json;
+  const { name, desc, protocol, type, aws } = json;
 
   const labels = json.labels || [];
+
+  // Only setting RDS fields for now.
+  let rds;
+  if (aws && aws.rds) {
+    rds = {
+      rds: {
+        resourceId: aws.rds.resource_id,
+      },
+    };
+  }
 
   return {
     name,
@@ -32,6 +42,7 @@ export function makeDatabase(json: any): Database {
     names: json.database_names || [],
     users: json.database_users || [],
     hostname: json.hostname,
+    aws: rds,
   };
 }
 

--- a/web/packages/teleport/src/services/databases/types.ts
+++ b/web/packages/teleport/src/services/databases/types.ts
@@ -20,6 +20,10 @@ import { AgentLabel } from 'teleport/services/agents';
 
 import { RdsEngine } from '../integrations';
 
+export type Aws = {
+  rds?: { resourceId: string };
+};
+
 export interface Database {
   name: string;
   description: string;
@@ -29,6 +33,7 @@ export interface Database {
   names?: string[];
   users?: string[];
   hostname: string;
+  aws?: Aws;
 }
 
 export type DatabasesResponse = {


### PR DESCRIPTION
Part of discover work to improve rds flow:

- Before, we gave a user ambiguous "duplicate db name, use a different name and try again". Now we do some tests to provide a user more actionable steps to take depending on if a db server exists for the database or not
- We now pre-check if the rds db's we fetched from aws has already been enrolled and if enrolled, prevent user from re-enrolling by making table row disabled

#### Screenshot

note: the tctl command is actually `tctl rm db/<dbname>` i just took the screenshot before i caught it

Self-hosted, duplicate db with a database server:
<img width="549" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/97bd74c0-6b1d-4a95-bb77-e608a74c0713">

Self-hosted, duplicated db (no db server)
<img width="546" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/cf683fdc-75c1-4e64-8641-f1f4a2b394a9">

aws rds, dup db (no db server)
<img width="543" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/31c7ca26-2269-41ff-ba25-d5224c6739b3">

aws rds, dup db with a db server
<img width="543" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/f3adf985-a4e7-48bd-a0b2-ab700eaac064">

disable row: 
<img width="1440" alt="image" src="https://github.com/gravitational/teleport/assets/43280172/873e3fe7-2ed2-4006-817b-381dcf1e6479">

