### PR TITLE
teleport-agent helm chart secret should be dynamically generated

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.joinParams.tokenName .Values.authToken }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -11,3 +12,4 @@ type: Opaque
 stringData:
   auth-token: |
     {{ coalesce .Values.joinParams.tokenName .Values.authToken }}
+{{- end }}


### PR DESCRIPTION
When `.Values.joinParams.tokenName` or `.Values.authToken` is not provided, the secret should not be generated, so that it won't conflict with or override the existing secret