### PR TITLE
docs: fix invalid characters in kubernetes service example in discovery troubleshooting

### DIFF
--- a/docs/pages/kubernetes-access/discovery/includes/troubleshooting.mdx
+++ b/docs/pages/kubernetes-access/discovery/includes/troubleshooting.mdx
@@ -15,7 +15,7 @@ If the `tctl get kube_cluster` command returns the discovered clusters, but the
 
 ```yaml
 kubernetes_service:
-  enabled: `yes`
+  enabled: "yes"
   resources:
   - tags:
       "env": "prod"


### PR DESCRIPTION

Not a valid config to use "`":

```yaml
kubernetes_service:
  enabled: `yes`
  resources:
  - tags:
      "env": "prod"
```