### PR TITLE
docs: include Enterprise output in tctl enterprise version example

### DIFF
--- a/docs/pages/includes/user-client-prereqs.mdx
+++ b/docs/pages/includes/user-client-prereqs.mdx
@@ -26,7 +26,7 @@
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
 
   $ tsh version
   # Teleport v(=teleport.version=) go(=teleport.golang=)
@@ -46,7 +46,7 @@
 
   ```code
   $ tctl version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
 
   $ tsh version
   # Teleport v(=cloud.version=) go(=teleport.golang=)

--- a/docs/pages/management/admin/self-signed-certs.mdx
+++ b/docs/pages/management/admin/self-signed-certs.mdx
@@ -84,7 +84,7 @@ For example, this Teleport Proxy Service configuration would use self-signed cer
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
   
   $ tsh version
   # Teleport v(=teleport.version=) go(=teleport.golang=)

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -77,7 +77,7 @@ This guide will explain how to:
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
 
   $ tsh version
   # Teleport v(=teleport.version=) go(=teleport.golang=)
@@ -107,7 +107,7 @@ how to set up this cluster, see one of our
 
   ```code
   $ tctl version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
 
   $ tsh version
   # Teleport v(=cloud.version=) go(=teleport.golang=)


### PR DESCRIPTION
Enterprise was missing from `tctl version` for enterprise version.