### PR TITLE
Remove Read permission to SAML IdP CA from proxy.

### DIFF
--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1880,12 +1880,12 @@ func TestGetCertAuthority(t *testing.T) {
 	_, err = proxyClt.GetCertAuthority(ctx, hostCAID, true)
 	require.True(t, trace.IsAccessDenied(err))
 
-	// proxy can fetch SAML IdP CA with secrets
+	// proxy can't fetch SAML IdP CA with secrets
 	_, err = proxyClt.GetCertAuthority(ctx, types.CertAuthID{
 		DomainName: tt.server.ClusterName(),
 		Type:       types.SAMLIDPCA,
 	}, true)
-	require.NoError(t, err)
+	require.True(t, trace.IsAccessDenied(err))
 
 	// proxy can't fetch anything else with secrets
 	_, err = proxyClt.GetCertAuthority(ctx, types.CertAuthID{

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -601,18 +601,6 @@ func roleSpecForProxy(clusterName string) types.RoleSpecV6 {
 						),
 					).String(),
 				},
-				// this rule allows the local proxy to read the local SAML IdP CA.
-				{
-					Resources: []string{types.KindCertAuthority},
-					Verbs:     []string{types.VerbRead},
-					Where: builder.And(
-						builder.Equals(services.CertAuthorityTypeExpr, builder.String(string(types.SAMLIDPCA))),
-						builder.Equals(
-							services.ResourceNameExpr,
-							builder.String(clusterName),
-						),
-					).String(),
-				},
 			},
 		},
 	}


### PR DESCRIPTION
Now that the proxy does not sign SAML IdP responses, the proxy does not need the Read permission to the SAML IdP CA. The existing ReadWithNoSecrets is sufficient.