### PR TITLE
Update rbac.mdx to add AD Host clarification

### DIFF
--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -202,7 +202,7 @@ Windows users upon login.
 
 <Admonition type="warning" title="Local users only">
 Automatic user provisioning is only supported for local users, and does
-not take effect in Active Directory environments.
+not take effect in Active Directory environments. Windows hosts joined using Active directory are not supported. 
 </Admonition>
 
 This feature is disabled by default, and can be enabled by setting the

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -202,7 +202,7 @@ Windows users upon login.
 
 <Admonition type="warning" title="Local users only">
 Automatic user provisioning is only supported for local users, and does
-not take effect in Active Directory environments. Windows hosts joined using Active directory are not supported. 
+not take effect in Active Directory environments. Windows hosts joined using Active Directory are not supported. 
 </Admonition>
 
 This feature is disabled by default, and can be enabled by setting the


### PR DESCRIPTION
The existing entry is a bit vague and doesn't clearly state that hosts joined using our older AD method will not support automatic user creation. Adding clarity.