### PR TITLE
Get rid of unmounted component update in ResultList

### DIFF
--- a/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
+++ b/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx
@@ -59,8 +59,8 @@ export function ResultList<T>(props: ResultListProps<T>) {
   const [activeItemIndex, setActiveItemIndex] = useState(0);
   const pickAndResetActiveItem = useCallback(
     (item: T) => {
-      onPick(item);
       setActiveItemIndex(0);
+      onPick(item);
     },
     [onPick]
   );


### PR DESCRIPTION
Reproduction steps:

1. Start dev version of Connect, open the console.
2. Open the search bar, select a filter.
3. Select an SSH server or a database item.
4. You should see now the leak warning in the console.

Strangely enough, this happen only the first time you do this, not on subsequent calls.

`ResultList` is rendered by `ActionPicker` and `ParameterPicker`. `onPick` on an SSH server or a database calls `changeActivePicker` from `SearchContext` which unmounts `ActionPicker` and mounts `ParameterPicker`.

Still, this doesn't explain how the leak happens. I was under the impression that [React first processes all state updates and only then re-renders the components](https://react.dev/learn/queueing-a-series-of-state-updates).

Well, that's true, but only for React 18. [React 17 does not batch the state updates in certain cases](https://javascript.plainenglish.io/batch-updates-in-react-17-or-earlier-versions-5f76d58e3af1), for example when executing native event listeners.

It just so happens that [`pickAndResetActiveItem` is called from an event listener that is added directly on `window`](https://github.com/gravitational/teleport/blob/cad5633dc9f609b7a7c5a9884c906d16b55cbfd1/web/packages/teleterm/src/ui/Search/pickers/ResultList.tsx#L118-L120) with `addEventListener`.

By calling `setActiveItemIndex` first we make sure that this state update is processed before `onPick` potentially causes `ResultList` to unmount.