### PR TITLE
export etcd event processing metrics

### DIFF
--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -30,7 +30,7 @@
 | `etcd_backend_write_requests`                            | counter   | etcd                | Number of write requests to the database.                                                          |
 | `etcd_backend_write_seconds`                             | histogram | etcd                | Latency for etcd write operations.                                                                 |
 | `teleport_etcd_events`                                   | counter   | etcd                | Total number of etcd events processed.                                                             |
-| `teleport_etcd_event_backpressure`                       | counter   | etcd                | Total number times event processing encountered backpressure.                                      |
+| `teleport_etcd_event_backpressure`                       | counter   | etcd                | Total number of times event processing encountered backpressure.                                      |
 | `firestore_events_backend_batch_read_requests`           | counter   | GCP Cloud Firestore | Number of batch read requests to Cloud Firestore events.                                           |
 | `firestore_events_backend_batch_read_seconds`            | histogram | GCP Cloud Firestore | Latency for Cloud Firestore events batch read operations.                                          |
 | `firestore_events_backend_batch_write_requests`          | counter   | GCP Cloud Firestore | Number of batch write requests to Cloud Firestore events.                                          |

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -29,6 +29,8 @@
 | `etcd_backend_tx_seconds`                                | histogram | etcd                | Latency for etcd transaction operations.                                                           |
 | `etcd_backend_write_requests`                            | counter   | etcd                | Number of write requests to the database.                                                          |
 | `etcd_backend_write_seconds`                             | histogram | etcd                | Latency for etcd write operations.                                                                 |
+| `teleport_etcd_events`                                   | counter   | etcd                | Total number of etcd events processed.                                                             |
+| `teleport_etcd_event_backpressure`                       | counter   | etcd                | Total number times event processing encountered backpressure.                                      |
 | `firestore_events_backend_batch_read_requests`           | counter   | GCP Cloud Firestore | Number of batch read requests to Cloud Firestore events.                                           |
 | `firestore_events_backend_batch_read_seconds`            | histogram | GCP Cloud Firestore | Latency for Cloud Firestore events batch read operations.                                          |
 | `firestore_events_backend_batch_write_requests`          | counter   | GCP Cloud Firestore | Number of batch write requests to Cloud Firestore events.                                          |

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -116,20 +116,23 @@ var (
 	)
 	eventCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "etcd_events",
-			Help: "Number of etcd events",
+			Namespace: teleport.MetricNamespace,
+			Name:      "etcd_events",
+			Help:      "Number of etcd events processed",
 		},
 	)
 	eventBackpressure = prometheus.NewCounter(
 		prometheus.CounterOpts{
-			Name: "etcd_event_backpressure",
-			Help: "Number of etcd events that hit backpressure",
+			Namespace: teleport.MetricNamespace,
+			Name:      "etcd_event_backpressure",
+			Help:      "Number of etcd events that hit backpressure",
 		},
 	)
 
 	prometheusCollectors = []prometheus.Collector{
 		writeLatencies, txLatencies, batchReadLatencies,
 		readLatencies, writeRequests, txRequests, batchReadRequests, readRequests,
+		eventCount, eventBackpressure,
 	}
 )
 


### PR DESCRIPTION
Fixes an issue where etcd metrics related to event processing were not actually being exported.