### PR TITLE
docs: Fix link to standalone Windows auth service

### DIFF
--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -69,7 +69,7 @@ following command:
 ### Install the Teleport service for Windows
 
 From the Windows system, download the [Teleport Windows Auth
-Setup](https://github.com/gravitational/teleport/releases/tag/v12.1.1-passwordless-windows).
+Setup](https://cdn.teleport.dev/teleport-windows-auth-setup-v(=teleport.version=)-amd64.exe).
 Extract the `.exe` file from the archive and run it. When prompted, select the
 Teleport certificate file from the previous step. Once complete, reboot the system.
 


### PR DESCRIPTION
The old link to the releases page is no longer valid as of 12.3.3 and 13..0.0, so we should just link directly to the CDN instead.

Depends on https://github.com/gravitational/teleport/pull/26167 to update the version on `branch/v12`