### PR TITLE
[v12] Update docs version to 12.3.3

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1449,16 +1449,16 @@
     },
     "teleport": {
       "major_version": "12",
-      "version": "12.3.1",
+      "version": "12.3.3",
       "golang": "1.20",
       "plugin": {
         "version": "12.3.1"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
-      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:12.3.1",
-      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.3.1",
-      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:12.3.1",
-      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.3.1"
+      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:12.3.3",
+      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.3.3",
+      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:12.3.3",
+      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.3.3"
     },
     "terraform": {
       "version": "1.0.0"


### PR DESCRIPTION
Teleport 12.3.3 is now the latest 12.x version.

Required by https://github.com/gravitational/teleport/pull/26166