### PR TITLE
[v12][Assist] Fix 'React is not defined' error

### DIFF
--- a/web/packages/teleport/src/Assist/Dots.tsx
+++ b/web/packages/teleport/src/Assist/Dots.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react'
+import React from 'react';
 import styled, { keyframes } from 'styled-components';
 
 const loader = keyframes`

--- a/web/packages/teleport/src/Assist/Dots.tsx
+++ b/web/packages/teleport/src/Assist/Dots.tsx
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import React from 'react'
 import styled, { keyframes } from 'styled-components';
 
 const loader = keyframes`


### PR DESCRIPTION
This PR fixes the below error
<img width="1511" alt="Screenshot 2023-05-14 at 1 04 55 PM" src="https://github.com/gravitational/teleport/assets/13811785/82bd3d58-215e-4c2d-84c3-7efbb3500dda">

This is not a backport, and I assume that this error is an effect of different tooling/dependencies between master and v12 that happened after backporting code from master.