### PR TITLE
docs: include Teleport Enterprise Cloud in SSO feature faq ?

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -113,7 +113,8 @@ Please refer to our [Networking](./reference/networking.mdx) guide.
 
 ## Does Teleport support authentication via OAuth, SAML, or Active Directory?
 
-Teleport offers this feature for the [Enterprise versions of Teleport](choose-an-edition/teleport-enterprise/introduction.mdx).
+Teleport offers this feature for the Teleport Enterprise and Teleport Enterprise Cloud editions.
+See [comparing the editions](choose-an-edition/introduction.mdx#access-controls) for more details.
 
 ## Why do I see an alert that some agents are out of date?
 


### PR DESCRIPTION
FAQ answer only mentioned enterprise self-hosted and linked to enterprise self-hosted.