### PR TITLE
Docs: Remove opened var when set to false

### DIFF
--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -99,7 +99,6 @@ with one of the following options:
 
 <Details
   title="Troubleshooting: failed to create a lock?"
-  opened={false}
 >
 
 If your user is missing a lock permission, you will get an error when creating
@@ -149,7 +148,7 @@ $ tctl lock --user=foo@example.com --message="Please come back tomorrow." --ttl=
 ```
 </Admonition>
 
-<Details title="Under the hood: Lock resource and expiration" opened={false}>
+<Details title="Under the hood: Lock resource and expiration">
 Note that without specifying `--ttl` or `--expires`, the created lock remains in
 force until explicitly removed with `tctl rm`.  Refer to `tctl lock --help` for
 the list of all supported parameters.

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -24,7 +24,6 @@ their on-disk Teleport certificates.
 
 <Details
   title="Version warning"
-  opened={false}
   scope={["oss", "enterprise"]}
   scopeOnly={true}
   min="6.1"

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -299,7 +299,7 @@ It is possible to further limit access to
 The examples below illustrate how to restrict session access only for the user
 who created the session.
 
-<Details title="Version Warning: Before 8.1" opened={false}>
+<Details title="Version Warning: Before 8.1">
 Teleport versions prior to 8.1 don't support the roles shown below.
 You may create these roles after upgrading, but in the event of a cluster
 downgrade they will become invalid.

--- a/docs/pages/application-access/guides/dynamodb.mdx
+++ b/docs/pages/application-access/guides/dynamodb.mdx
@@ -96,7 +96,7 @@ spec:
     - arn:aws:iam::123456789000:role/ExampleTeleportDynamoDBRole
 ```
 
-<Details title="Templating aws_role_arns" opened={false}>
+<Details title="Templating aws_role_arns">
 The `aws_role_arns` field supports template variables so they can be populated
 dynamically based on your users' identity provider attributes. See [Role
 Templates](../../access-controls/guides/role-templates.mdx) for details.

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -411,7 +411,7 @@ $ tsh ls os=osx
 
 [CLI Docs -tsh ls](../reference/cli.mdx#tsh-ls)
 
-<Details title="Not seeing Nodes?" opened={false}>
+<Details title="Not seeing Nodes?">
 
 (!docs/pages/includes/node-logins.mdx!)
 

--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -79,7 +79,7 @@ $ curl -u elastic:your_elasticsearch_password -X POST "https://elasticsearch.exa
 '
 ```
 
-<Details title="Role Mapping with wildcards" opened={false}>
+<Details title="Role Mapping with wildcards">
 
 In a scenario where Teleport is using [single sign-on](../../access-controls/sso.mdx) you may want to define a mapping for all users to a role:
 

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -161,7 +161,7 @@ databases:
 Redis in cluster mode does not support the following commands. If one of the listed commands above is called Teleport
 returns the <nobr>`ERR Teleport: command not supported`</nobr> error.
 
-<Details title="Unsupported commands" opened={false}>
+<Details title="Unsupported commands">
 - `ACL`
 - `ASKING`
 - `CLIENT`

--- a/docs/pages/database-access/reference/aws.mdx
+++ b/docs/pages/database-access/reference/aws.mdx
@@ -399,7 +399,7 @@ IAM policies with the required permissions are shown below.
 To connect to an RDS database, the Database Service instance's IAM identity
 needs to have `rds-db:connect` permissions for it:
 
-<Details title="Example IAM policy document" opened={false}>
+<Details title="Example IAM policy document">
 ```json
 {
    "Version": "2012-10-17",
@@ -446,7 +446,7 @@ Redshift databases.
 In order to authorize Teleport to generate temporary IAM tokens, create an IAM
 role with the `GetClusterCredentials` permission:
 
-<Details title="Example IAM policy document" opened={false}>
+<Details title="Example IAM policy document">
 ```json
 {
     "Version": "2012-10-17",

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -191,7 +191,7 @@ allow:
 
 ### Automatic User Creation
 
-<Details title="Version Warning: Before 12.3" opened={false}>
+<Details title="Version Warning: Before 12.3">
 Teleport versions prior to 12.3 don't support the options shown below.
 </Details>
 

--- a/docs/pages/includes/database-access/aws-troubleshooting-max-policy-size.mdx
+++ b/docs/pages/includes/database-access/aws-troubleshooting-max-policy-size.mdx
@@ -15,7 +15,7 @@ or 100 RDS databases.
 One way to work around this is to manually manage the IAM policy used for database
 connections, and use a wildcard `"*"` for `"Resource"` to reduce the policy size:
 
-<Details title="use a wildcard policy" opened={false}>
+<Details title="use a wildcard policy">
 
 Attach a policy with the following permissions to the IAM user or role:
 

--- a/docs/pages/includes/diagnostics/diag-addr-prereqs-tabs.mdx
+++ b/docs/pages/includes/diagnostics/diag-addr-prereqs-tabs.mdx
@@ -31,10 +31,7 @@ them via:
     </TabItem>
 </Tabs>
 
-<Details
-    title="Ensure you can connect to the diagnostic endpoint"
-    opened={false}
->
+<Details title="Ensure you can connect to the diagnostic endpoint">
 
     Verify that Teleport is now serving the diagnostics endpoint:
 

--- a/docs/pages/includes/dns.mdx
+++ b/docs/pages/includes/dns.mdx
@@ -3,11 +3,11 @@ Set up two `A` DNS records: `tele.example.com` for all traffic and
 that your domain name is `example.com`. Use your own subdomain instead of
 `tele`.
 
-<Details opened={false} title="Why are we using wildcard subdomains for application access?">
+<Details title="Why are we using wildcard subdomains for application access?">
 (!docs/pages/includes/dns-app-access.mdx!)
 </Details>
 
-<Details title="DNS instructions for cloud providers" opened={false}>
+<Details title="DNS instructions for cloud providers">
 
 Execute the following commands on the host where you are running the Teleport Proxy
 Service:

--- a/docs/pages/includes/permission-warning.mdx
+++ b/docs/pages/includes/permission-warning.mdx
@@ -1,4 +1,4 @@
-<Details title="Before you begin: read security tips" opened={false}>
+<Details title="Before you begin: read security tips">
 
   When running Teleport in production, we recommend that you follow the
   practices below to avoid security incidents. These practices may differ from

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -264,7 +264,7 @@ Node Name Address        Labels
 node-name  127.0.0.1:3022 arch=x86_64,group=api-servers
 ```
 
-<Details title="Not seeing Nodes?" opened={false}>
+<Details title="Not seeing Nodes?">
 
 (!docs/pages/includes/node-logins.mdx!)
 

--- a/docs/pages/machine-id/guides/ansible.mdx
+++ b/docs/pages/machine-id/guides/ansible.mdx
@@ -64,7 +64,7 @@ $ # Replace ".example.com" below with the name of your cluster.
 $ tsh ls --format=json | jq -r '.[].spec.hostname + ".example.com"' > hosts
 ```
 
-<Details title="Not seeing Nodes?" opened={false}>
+<Details title="Not seeing Nodes?">
 
 (!docs/pages/includes/node-logins.mdx!)
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -165,7 +165,7 @@ Node Name    Address    Labels
 bdcb47b87ad6 ⟵ Tunnel environment=dev
 ```
 
-<Details title="Don't see your Node?" opened={false}>
+<Details title="Don't see your Node?">
 
 First, check the logs for your Node to ensure the SSH Service is running. Your logs should resemble the following:
 
@@ -248,7 +248,7 @@ you run `tsh ls`.
 
 </Details>
 
-<Details title="Hidden labels" opened={false}>
+<Details title="Hidden labels">
 
 If you wish to use labels for RBAC purposes but don't want to see the labels
 in the UI, you can put them in the hidden namespace by prefixing the label's

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -322,7 +322,7 @@ Token                                                            Type           
 (=presets.tokens.first=)                                 trusted_cluster          28 Apr 22 19:19 UTC (4m48s)
 ```
 
-<Details title="Revoking join tokens" opened={false}>
+<Details title="Revoking join tokens">
 
 You can revoke a join token with the following command:
 
@@ -568,7 +568,7 @@ Create the Trusted Cluster:
 $ tctl create trusted_cluster.yaml
 ```
 
-<Details title="Creating Trusted Clusters via the Web UI" opened={false}>
+<Details title="Creating Trusted Clusters via the Web UI">
 
 You can easily configure leaf nodes using the Teleport Web UI.
 

--- a/docs/pages/management/admin/upgrading-the-teleport-binary.mdx
+++ b/docs/pages/management/admin/upgrading-the-teleport-binary.mdx
@@ -58,7 +58,7 @@ $ pidof teleport
 
 In our example, `235276` is a PID of the child process, and `235119` is a PID of the parent.
 
-<Details type="tip" opened={false} title="Not sure which process is the parent?">
+<Details type="tip" title="Not sure which process is the parent?">
 
 You can use the following command, which prints the parent for each PID returned
 by `pidof`:

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -838,7 +838,7 @@ List cluster nodes:
 $ tsh ls [<flags>] [<label>]
 ```
 
-<Details title="Not seeing Nodes?" opened={false}>
+<Details title="Not seeing Nodes?">
 
 (!docs/pages/includes/node-logins.mdx!)
 

--- a/docs/pages/reference/helm-reference/teleport-cluster.mdx
+++ b/docs/pages/reference/helm-reference/teleport-cluster.mdx
@@ -806,7 +806,7 @@ to inject your custom configuration.
 
 ## `persistence`
 
-<Details title="Read this if using Kubernetes 1.23+ on EKS" opened={false}>
+<Details title="Read this if using Kubernetes 1.23+ on EKS">
 
 Changes in Kubernetes 1.23+ mean that persistent volumes will not automatically be provisioned in AWS EKS clusters
 without additional configuration.

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -202,7 +202,7 @@ Events emitted via Enhanced Session Recording will include the
 If your Teleport cluster uses a file-based event log, you can examine your audit
 log on the Teleport Auth Service host.
 
-<Details title="Is my cluster using a file-based event log?" opened={false}>
+<Details title="Is my cluster using a file-based event log?">
 
 Teleport's session recordings backend is configured via the
 `teleport.storage.audit_sessions_uri` field. If a provided URI includes a scheme

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -147,7 +147,7 @@ host.
 
 ### Issue a host certificate
 
-<Details title="Find your node's UUID" opened={false}>
+<Details title="Find your node's UUID">
 
 When you created a `node` resource and if you didn't set the `metadata.name` field earlier,
 the Teleport Auth Service generated a universal unique identifier (UUID) for that node.
@@ -358,7 +358,7 @@ authenticate the host via the certificate we generated earlier.
 
 </Details>
 
-<Details title="Using PowerShell on Windows?" opened={false}>
+<Details title="Using PowerShell on Windows?">
 
   If using PowerShell on Windows, note that normal shell redirection may write
   the file with the incorrect encoding. To ensure it's written properly, try the


### PR DESCRIPTION
Follow-up to https://github.com/gravitational/docs/pull/290

Removed the `opened` var when set to `false`, as the presence of the var implies true.