### PR TITLE
check for empty name part in role arn

### DIFF
--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -415,7 +415,7 @@ func checkRoleARN(parsed *arn.ARN) error {
 	if parts[0] != "role" || parsed.Service != iam.ServiceName {
 		return trace.BadParameter("%q is not an AWS IAM role ARN", parsed)
 	}
-	if len(parts) < 2 {
+	if len(parts) < 2 || len(parts[len(parts)-1]) == 0 {
 		return trace.BadParameter("%q is missing AWS IAM role name", parsed)
 	}
 	if err := apiawsutils.IsValidAccountID(parsed.AccountID); err != nil {

--- a/lib/utils/aws/aws_test.go
+++ b/lib/utils/aws/aws_test.go
@@ -282,8 +282,16 @@ func TestParseRoleARN(t *testing.T) {
 			arn:             "arn:aws:iam::123456789012:user/test-user",
 			wantErrContains: "not an AWS IAM role",
 		},
-		"iam role arn is missing role name": {
+		"iam role arn is missing role name section": {
 			arn:             "arn:aws:iam::123456789012:role",
+			wantErrContains: "missing AWS IAM role name",
+		},
+		"iam role arn is missing role name": {
+			arn:             "arn:aws:iam::123456789012:role/",
+			wantErrContains: "missing AWS IAM role name",
+		},
+		"service role arn is missing role name": {
+			arn:             "arn:aws:iam::123456789012:role/aws-service-role/redshift.amazonaws.com/",
 			wantErrContains: "missing AWS IAM role name",
 		},
 	}
@@ -292,7 +300,7 @@ func TestParseRoleARN(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			got, err := ParseRoleARN(tt.arn)
 			if tt.wantErrContains != "" {
-				require.Error(t, err, err.Error())
+				require.Error(t, err)
 				require.ErrorContains(t, err, tt.wantErrContains)
 				return
 			}


### PR DESCRIPTION
This PR fixes a minor issue where the role arn checking doesn't check if the role name is `""` (empty).

We were checking if the role arn resource had at least 2 parts separated by `"/"`, but we didn't check if the last part is empty.
`strings.Split("role/", "/")) == []string{"role", ""}`

This was a minor inconvenience I ran into recently. Instead of catching my typo early, the db service was trying to assume the invalid role and returning a less helpful error message from the failed assume role call.