### PR TITLE
Connect: Enable dev-related tools only in dev mode

### DIFF
--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -295,10 +295,24 @@ export default class MainProcess {
   private _setAppMenu() {
     const isMac = this.settings.platform === 'darwin';
 
+    // Enable actions like reload or toggle dev tools only in dev mode.
+    const viewMenuTemplate: MenuItemConstructorOptions = this.settings.dev
+      ? { role: 'viewMenu' }
+      : {
+          label: 'View',
+          submenu: [
+            { role: 'resetZoom' },
+            { role: 'zoomIn' },
+            { role: 'zoomOut' },
+            { type: 'separator' },
+            { role: 'togglefullscreen' },
+          ],
+        };
+
     const macTemplate: MenuItemConstructorOptions[] = [
       { role: 'appMenu' },
       { role: 'editMenu' },
-      { role: 'viewMenu' },
+      viewMenuTemplate,
       {
         label: 'Window',
         submenu: [{ role: 'minimize' }, { role: 'zoom' }],
@@ -312,7 +326,7 @@ export default class MainProcess {
     const otherTemplate: MenuItemConstructorOptions[] = [
       { role: 'fileMenu' },
       { role: 'editMenu' },
-      { role: 'viewMenu' },
+      viewMenuTemplate,
       { role: 'windowMenu' },
       {
         role: 'help',


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/26246

The following menu items:
```
{ role: 'reload' },
{ role: 'forceReload' },
{ role: 'toggleDevTools' },
```
should be shown only in dev mode. Hiding menu items also disables the keyboard shortcuts associated with them.
