### PR TITLE
Ignore K8S dependencies until K8S API v0.27.2 is released

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,20 @@ updates:
       - dependency-name: github.com/sirupsen/logrus
       - dependency-name: github.com/vulcand/predicate
       - dependency-name: golang.org/x/crypto
+      # kubernetes-sigs/controller-runtime is holding the k8s deps upgrade because it requires
+      # a new API version v0.27.2 which includes some required fixes.
+      # Until released, we must hold k8s deps upgrade otherwise we break operators.
+      # TODO(tigrato): remove once https://github.com/gravitational/teleport/pull/25136
+      # merges.
+      - dependency-name: k8s.io/api
+      - dependency-name: k8s.io/apiextensions-apiserver
+      - dependency-name: k8s.io/apimachinery
+      - dependency-name: k8s.io/apiserver
+      - dependency-name: k8s.io/cli-runtime
+      - dependency-name: k8s.io/client-go
+      - dependency-name: k8s.io/component-base
+      - dependency-name: k8s.io/kubectl
+      - dependency-name: k8s.io/utils
     open-pull-requests-limit: 10
     reviewers:
       - codingllama


### PR DESCRIPTION
This PR adds K8S dependencies to the dependabot ignore list.

We can revert this PR after
https://github.com/gravitational/teleport/pull/25136 merges to master.

`sigs.k8s.io/controller-runtime` is holding the K8S deps update because it does not support K8S API 0.27.1. `controller-runtime` will release a new version once `k8s.io/api@v0.27.2` is released.