### PR TITLE
[v11] Replace GetConnectCommandNoAbsPath with os.exec.Cmd.Args

### DIFF
--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -23,7 +23,6 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -77,8 +76,6 @@ type Execer interface {
 	// LookPath returns a full path to a binary if this one is found in system PATH,
 	// error otherwise.
 	LookPath(file string) (string, error)
-	// Command returns the Cmd struct to execute the named program with the given arguments.
-	Command(name string, arg ...string) *exec.Cmd
 }
 
 // SystemExecer implements execer interface by using Go exec module.
@@ -92,11 +89,6 @@ func (s SystemExecer) RunCommand(name string, arg ...string) ([]byte, error) {
 // LookPath is a wrapper for exec.LookPath(...)
 func (s SystemExecer) LookPath(file string) (string, error) {
 	return exec.LookPath(file)
-}
-
-// Command is a wrapper for exec.Command(...)
-func (s SystemExecer) Command(name string, arg ...string) *exec.Cmd {
-	return exec.Command(name, arg...)
 }
 
 // CLICommandBuilder holds data needed to build a CLI command from args passed to NewCmdBuilder.
@@ -216,27 +208,8 @@ func (c *CLICommandBuilder) GetConnectCommandAlternatives() ([]CommandAlternativ
 	return []CommandAlternative{{Description: "default command", Command: cmd}}, nil
 }
 
-// GetConnectCommandNoAbsPath works just like GetConnectCommand, with the only difference being that
-// it guarantees that the command will always be in its base form, never in an absolute path
-// resolved to the binary location. This is useful for situations where the resulting command is
-// meant to be copied and then pasted into an interactive shell, rather than being run directly
-// by a tool like tsh.
-func (c *CLICommandBuilder) GetConnectCommandNoAbsPath() (*exec.Cmd, error) {
-	cmd, err := c.GetConnectCommand()
-
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if filepath.IsAbs(cmd.Path) {
-		cmd.Path = filepath.Base(cmd.Path)
-	}
-
-	return cmd, nil
-}
-
 func (c *CLICommandBuilder) getPostgresCommand() *exec.Cmd {
-	return c.options.exe.Command(postgresBin, c.getPostgresConnString())
+	return exec.Command(postgresBin, c.getPostgresConnString())
 }
 
 func (c *CLICommandBuilder) getCockroachCommand() *exec.Cmd {
@@ -246,7 +219,7 @@ func (c *CLICommandBuilder) getCockroachCommand() *exec.Cmd {
 			cockroachBin, postgresBin, err)
 		return c.getPostgresCommand()
 	}
-	return c.options.exe.Command(cockroachBin, "sql", "--url", c.getPostgresConnString())
+	return exec.Command(cockroachBin, "sql", "--url", c.getPostgresConnString())
 }
 
 // getPostgresConnString returns the connection string for postgres.
@@ -323,7 +296,7 @@ func (c *CLICommandBuilder) getMySQLOracleCommand() (*exec.Cmd, error) {
 	args := c.getMySQLCommonCmdOpts()
 
 	if c.options.noTLS {
-		return c.options.exe.Command(mysqlBin, args...), nil
+		return exec.Command(mysqlBin, args...), nil
 	}
 
 	// defaults-group-suffix must be first.
@@ -347,7 +320,7 @@ func (c *CLICommandBuilder) getMySQLOracleCommand() (*exec.Cmd, error) {
 		args = append(args, fmt.Sprintf("--ssl-mode=%s", mysql.MySQLSSLModeVerifyCA))
 	}
 
-	return c.options.exe.Command(mysqlBin, args...), nil
+	return exec.Command(mysqlBin, args...), nil
 }
 
 // getMySQLCommand returns mariadb command if the binary is on the path. Otherwise,
@@ -356,7 +329,7 @@ func (c *CLICommandBuilder) getMySQLCommand() (*exec.Cmd, error) {
 	// Check if mariadb client is available. Prefer it over mysql client even if connecting to MySQL server.
 	if c.isMariaDBBinAvailable() {
 		args := c.getMariaDBArgs()
-		return c.options.exe.Command(mariadbBin, args...), nil
+		return exec.Command(mariadbBin, args...), nil
 	}
 
 	// Check for mysql binary. In case the caller doesn't tolerate a missing CLI client, return with
@@ -374,7 +347,7 @@ func (c *CLICommandBuilder) getMySQLCommand() (*exec.Cmd, error) {
 	mySQLMariaDBFlavor, err := c.isMySQLBinMariaDBFlavor()
 	if mySQLMariaDBFlavor && err == nil {
 		args := c.getMariaDBArgs()
-		return c.options.exe.Command(mysqlBin, args...), nil
+		return exec.Command(mysqlBin, args...), nil
 	}
 
 	// Either we failed to check the flavor or binary comes from Oracle. Regardless return mysql/Oracle command.
@@ -472,11 +445,11 @@ func (c *CLICommandBuilder) getMongoCommand() *exec.Cmd {
 
 	// use `mongosh` if available
 	if hasMongosh {
-		return c.options.exe.Command(mongoshBin, args...)
+		return exec.Command(mongoshBin, args...)
 	}
 
 	// fall back to `mongo` if `mongosh` isn't found
-	return c.options.exe.Command(mongoBin, args...)
+	return exec.Command(mongoBin, args...)
 }
 
 func (c *CLICommandBuilder) getMongoAddress() string {
@@ -539,7 +512,7 @@ func (c *CLICommandBuilder) getRedisCommand() *exec.Cmd {
 		args = append(args, []string{"-n", c.db.Database}...)
 	}
 
-	return c.options.exe.Command(redisBin, args...)
+	return exec.Command(redisBin, args...)
 }
 
 func (c *CLICommandBuilder) getSQLServerCommand() *exec.Cmd {
@@ -556,7 +529,7 @@ func (c *CLICommandBuilder) getSQLServerCommand() *exec.Cmd {
 		args = append(args, "-d", c.db.Database)
 	}
 
-	return c.options.exe.Command(mssqlBin, args...)
+	return exec.Command(mssqlBin, args...)
 }
 
 func (c *CLICommandBuilder) getSnowflakeCommand() *exec.Cmd {
@@ -591,7 +564,7 @@ func (c *CLICommandBuilder) getCassandraCommand() (*exec.Cmd, error) {
 // getElasticsearchCommand returns a command to connect to Elasticsearch. We support `elasticsearch-sql-cli`, but only in non-TLS scenario.
 func (c *CLICommandBuilder) getElasticsearchCommand() (*exec.Cmd, error) {
 	if c.options.noTLS {
-		return c.options.exe.Command(elasticsearchSQLBin, fmt.Sprintf("http://%v:%v/", c.host, c.port)), nil
+		return exec.Command(elasticsearchSQLBin, fmt.Sprintf("http://%v:%v/", c.host, c.port)), nil
 	}
 	return nil, trace.BadParameter("%v interactive command is only supported in --tunnel mode.", elasticsearchSQLBin)
 }
@@ -606,7 +579,7 @@ func (c *CLICommandBuilder) getElasticsearchAlternativeCommands() []CommandAlter
 
 	var curlCommand *exec.Cmd
 	if c.options.noTLS {
-		curlCommand = c.options.exe.Command(curlBin, fmt.Sprintf("http://%v:%v/", c.host, c.port))
+		curlCommand = exec.Command(curlBin, fmt.Sprintf("http://%v:%v/", c.host, c.port))
 	} else {
 		args := []string{
 			fmt.Sprintf("https://%v:%v/", c.host, c.port),
@@ -628,7 +601,7 @@ func (c *CLICommandBuilder) getElasticsearchAlternativeCommands() []CommandAlter
 			args = append(args, "--http1.1")
 		}
 
-		curlCommand = c.options.exe.Command(curlBin, args...)
+		curlCommand = exec.Command(curlBin, args...)
 	}
 	commands = append(commands, CommandAlternative{Description: "run single request with curl", Command: curlCommand})
 

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -16,9 +16,7 @@ package dbcmd
 
 import (
 	"errors"
-	"os"
-	"os/exec"
-	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -32,24 +30,11 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-type commandPathBehavior = int
-
-const (
-	system commandPathBehavior = iota
-	forceAbsolutePath
-	forceBasePath
-)
-
 // fakeExec implements execer interface for mocking purposes.
 type fakeExec struct {
 	// execOutput maps binary name and output that should be returned on RunCommand().
 	// Map is also being used to check if a binary exist. Command line args are not supported.
 	execOutput map[string][]byte
-	// commandPathBehavior controls what kind of path will be returned from fakeExec.Command:
-	// * system just calls exec.Command
-	// * forceAbsolutePath guarantees that the returned cmd.Path will be absolute
-	// * forceBasePath guarantees that the returned cmd.Path will be just the binary name
-	commandPathBehavior commandPathBehavior
 }
 
 func (f fakeExec) RunCommand(cmd string, _ ...string) ([]byte, error) {
@@ -66,28 +51,6 @@ func (f fakeExec) LookPath(path string) (string, error) {
 		return "", nil
 	}
 	return "", trace.NotFound("not found")
-}
-
-func (f fakeExec) Command(name string, arg ...string) *exec.Cmd {
-	switch f.commandPathBehavior {
-	case system:
-		return exec.Command(name, arg...)
-	case forceAbsolutePath:
-		path, err := os.Getwd()
-		if err != nil {
-			panic(err)
-		}
-
-		absolutePath := filepath.Join(path, name)
-		cmd := exec.Command(absolutePath, arg...)
-
-		return cmd
-	case forceBasePath:
-		cmd := exec.Command(name, arg...)
-		cmd.Path = filepath.Base(cmd.Path)
-		return cmd
-	}
-	panic("Unknown commandPathBehavior")
 }
 
 func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
@@ -699,84 +662,6 @@ func TestCLICommandBuilderGetConnectCommandAlternatives(t *testing.T) {
 	}
 }
 
-func TestGetConnectCommandNoAbsPathConvertsAbsolutePathToRelative(t *testing.T) {
-	conf := &client.Config{
-		HomePath:     t.TempDir(),
-		Host:         "localhost",
-		WebProxyAddr: "localhost",
-		SiteName:     "db.example.com",
-		Tracer:       tracing.NoopProvider().Tracer("test"),
-	}
-
-	tc, err := client.NewClient(conf)
-	require.NoError(t, err)
-
-	profile := &client.ProfileStatus{
-		Name:     "example.com",
-		Username: "bob",
-		Dir:      "/tmp",
-	}
-
-	database := &tlsca.RouteToDatabase{
-		Protocol:    defaults.ProtocolPostgres,
-		Database:    "mydb",
-		Username:    "myUser",
-		ServiceName: "postgres",
-	}
-
-	opts := []ConnectCommandFunc{
-		WithLocalProxy("localhost", 12345, ""),
-		WithNoTLS(),
-		WithExecer(&fakeExec{commandPathBehavior: forceAbsolutePath}),
-	}
-
-	c := NewCmdBuilder(tc, profile, database, "root", opts...)
-	c.uid = utils.NewFakeUID()
-
-	got, err := c.GetConnectCommandNoAbsPath()
-	require.NoError(t, err)
-	require.Equal(t, "psql postgres://myUser@localhost:12345/mydb", got.String())
-}
-
-func TestGetConnectCommandNoAbsPathIsNoopWhenGivenRelativePath(t *testing.T) {
-	conf := &client.Config{
-		HomePath:     t.TempDir(),
-		Host:         "localhost",
-		WebProxyAddr: "localhost",
-		SiteName:     "db.example.com",
-		Tracer:       tracing.NoopProvider().Tracer("test"),
-	}
-
-	tc, err := client.NewClient(conf)
-	require.NoError(t, err)
-
-	profile := &client.ProfileStatus{
-		Name:     "example.com",
-		Username: "bob",
-		Dir:      "/tmp",
-	}
-
-	database := &tlsca.RouteToDatabase{
-		Protocol:    defaults.ProtocolPostgres,
-		Database:    "mydb",
-		Username:    "myUser",
-		ServiceName: "postgres",
-	}
-
-	opts := []ConnectCommandFunc{
-		WithLocalProxy("localhost", 12345, ""),
-		WithNoTLS(),
-		WithExecer(&fakeExec{commandPathBehavior: forceBasePath}),
-	}
-
-	c := NewCmdBuilder(tc, profile, database, "root", opts...)
-	c.uid = utils.NewFakeUID()
-
-	got, err := c.GetConnectCommandNoAbsPath()
-	require.NoError(t, err)
-	require.Equal(t, "psql postgres://myUser@localhost:12345/mydb", got.String())
-}
-
 func TestConvertCommandError(t *testing.T) {
 	t.Parallel()
 	homePath := t.TempDir()
@@ -800,6 +685,7 @@ func TestConvertCommandError(t *testing.T) {
 	tests := []struct {
 		desc       string
 		dbProtocol string
+		execer     *fakeExec
 		stderr     []byte
 		wantBin    string
 		wantStdErr string
@@ -807,6 +693,11 @@ func TestConvertCommandError(t *testing.T) {
 		{
 			desc:       "converts access denied to helpful message",
 			dbProtocol: defaults.ProtocolMySQL,
+			execer: &fakeExec{
+				execOutput: map[string][]byte{
+					"mysql": []byte("Ver 8.0.27-0ubuntu0.20.04.1 for Linux on x86_64 ((Ubuntu))"),
+				},
+			},
 			stderr:     []byte("access to db denied"),
 			wantBin:    mysqlBin,
 			wantStdErr: "see your available logins, or ask your Teleport administrator",
@@ -814,6 +705,7 @@ func TestConvertCommandError(t *testing.T) {
 		{
 			desc:       "converts unrecognized redis error to helpful message",
 			dbProtocol: defaults.ProtocolRedis,
+			execer:     &fakeExec{},
 			stderr:     []byte("Unrecognized option or bad number of args for"),
 			wantBin:    redisBin,
 			wantStdErr: "Please make sure 'redis-cli' with version 6.2 or newer is installed",
@@ -835,12 +727,7 @@ func TestConvertCommandError(t *testing.T) {
 			opts := []ConnectCommandFunc{
 				WithLocalProxy("localhost", 12345, ""),
 				WithNoTLS(),
-				WithExecer(&fakeExec{
-					commandPathBehavior: forceBasePath,
-					execOutput: map[string][]byte{
-						tt.wantBin: tt.stderr,
-					},
-				}),
+				WithExecer(tt.execer),
 			}
 			c := NewCmdBuilder(tc, profile, database, "root", opts...)
 			c.uid = utils.NewFakeUID()
@@ -849,13 +736,10 @@ func TestConvertCommandError(t *testing.T) {
 			require.NoError(t, err)
 
 			// make sure the expected test bin is the command bin we got
-			require.Equal(t, cmd.Path, tt.wantBin)
-
-			out, err := c.options.exe.RunCommand(cmd.Path)
-			require.NoError(t, err, "fakeExec.execOutput is not configured for bin %v", tt.wantBin)
+			require.True(t, strings.HasSuffix(cmd.Path, tt.wantBin))
 
 			peakStderr := utils.NewCaptureNBytesWriter(PeakStderrSize)
-			_, peakErr := peakStderr.Write(out)
+			_, peakErr := peakStderr.Write(tt.stderr)
 			require.NoError(t, peakErr, "CaptureNBytesWriter should never return error")
 
 			convertedErr := ConvertCommandError(cmd, nil, string(peakStderr.Bytes()))

--- a/lib/teleterm/clusters/dbcmd_cli_command_provider_test.go
+++ b/lib/teleterm/clusters/dbcmd_cli_command_provider_test.go
@@ -124,9 +124,9 @@ func TestDbcmdCLICommandProviderGetCommand(t *testing.T) {
 			command, err := dbcmdCLICommandProvider.GetCommand(gateway)
 
 			require.NoError(t, err)
-			require.NotEmpty(t, command)
-			require.Contains(t, command, tc.targetSubresourceName)
-			require.Contains(t, command, gateway.LocalPort())
+			require.NotEmpty(t, command.Args)
+			require.Contains(t, command.Args[1], tc.targetSubresourceName)
+			require.Contains(t, command.Args[1], gateway.LocalPort())
 		})
 	}
 }

--- a/lib/teleterm/daemon/gateway_cert_reissuer_test.go
+++ b/lib/teleterm/daemon/gateway_cert_reissuer_test.go
@@ -17,6 +17,8 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -184,9 +186,12 @@ func (r *mockDBCertReissuer) ReissueDBCerts(context.Context, tlsca.RouteToDataba
 
 type mockCLICommandProvider struct{}
 
-func (m mockCLICommandProvider) GetCommand(gateway *gateway.Gateway) (string, error) {
-	command := fmt.Sprintf("%s/%s", gateway.TargetName(), gateway.TargetSubresourceName())
-	return command, nil
+func (m mockCLICommandProvider) GetCommand(gateway *gateway.Gateway) (*exec.Cmd, error) {
+	// Use a relative path to make exec.Command avoid unnecessarily calling exec.LookPath.
+	path := filepath.Join("foo", gateway.Protocol())
+	arg := fmt.Sprintf("%s/%s", gateway.TargetName(), gateway.TargetSubresourceName())
+	cmd := exec.Command(path, arg)
+	return cmd, nil
 }
 
 type mockTSHDEventsClient struct {

--- a/lib/teleterm/gateway/gateway.go
+++ b/lib/teleterm/gateway/gateway.go
@@ -21,7 +21,9 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os/exec"
 	"strconv"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -223,13 +225,20 @@ func (g *Gateway) LocalPortInt() int {
 }
 
 // CLICommand returns a command which launches a CLI client pointed at the given gateway.
+// It needs to return a relative command as it will be executed from a terminal in Connect, so we
+// should let user's env resolve the command rather than depending on os.exec.
 func (g *Gateway) CLICommand() (string, error) {
-	cliCommand, err := g.cfg.CLICommandProvider.GetCommand(g)
+	cmd, err := g.cfg.CLICommandProvider.GetCommand(g)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
 
-	return cliCommand, nil
+	cmdString := strings.TrimSpace(
+		fmt.Sprintf("%s %s",
+			strings.Join(cmd.Env, " "),
+			strings.Join(cmd.Args, " ")))
+
+	return cmdString, nil
 }
 
 // RouteToDatabase returns tlsca.RouteToDatabase based on the config of the gateway.
@@ -296,7 +305,7 @@ type Gateway struct {
 
 // CLICommandProvider provides a CLI command for gateways which support CLI clients.
 type CLICommandProvider interface {
-	GetCommand(gateway *Gateway) (string, error)
+	GetCommand(gateway *Gateway) (*exec.Cmd, error)
 }
 
 type TCPPortAllocator interface {

--- a/lib/teleterm/gateway/gateway_test.go
+++ b/lib/teleterm/gateway/gateway_test.go
@@ -19,6 +19,9 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -30,7 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-func TestCLICommandUsesCLICommandProvider(t *testing.T) {
+func TestCLICommandReturnsRelativeCommand(t *testing.T) {
 	gateway := Gateway{
 		cfg: &Config{
 			TargetName:            "foo",
@@ -44,7 +47,9 @@ func TestCLICommandUsesCLICommandProvider(t *testing.T) {
 	command, err := gateway.CLICommand()
 	require.NoError(t, err)
 
-	require.Equal(t, "foo/bar", command)
+	args := strings.Split(command, " ")
+	path := args[0]
+	require.True(t, filepath.IsLocal(path), "Not a local path: %q", path)
 }
 
 func TestGatewayStart(t *testing.T) {
@@ -141,9 +146,22 @@ func TestNewWithLocalPortReturnsErrorIfNewPortEqualsOldPort(t *testing.T) {
 
 type mockCLICommandProvider struct{}
 
-func (m mockCLICommandProvider) GetCommand(gateway *Gateway) (string, error) {
-	command := fmt.Sprintf("%s/%s", gateway.TargetName(), gateway.TargetSubresourceName())
-	return command, nil
+func (m mockCLICommandProvider) GetCommand(gateway *Gateway) (*exec.Cmd, error) {
+	absPath, err := filepath.Abs(gateway.Protocol())
+	if err != nil {
+		return nil, err
+	}
+	arg := fmt.Sprintf("%s/%s", gateway.TargetName(), gateway.TargetSubresourceName())
+	// Call exec.Command with a relative path so that cmd.Args[0] is a relative path.
+	// Then replace cmd.Path with an absolute path to simulate gateway.Protocol() being resolved to
+	// an absolute path. This way we can later verify that gateway.CLICommand doesn't use the absolute
+	// path.
+	//
+	// This also ensures that exec.Command behaves the same way on different devices, no matter
+	// whether a command like postgres is installed on the system or not.
+	cmd := exec.Command(gateway.Protocol(), arg)
+	cmd.Path = absPath
+	return cmd, nil
 }
 
 func createAndServeGateway(t *testing.T, tcpPortAllocator TCPPortAllocator) *Gateway {


### PR DESCRIPTION
Backport #26121