### PR TITLE
[v12] Ignore .swc folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,6 @@ webassets/
 
 # jest --coverage
 coverage
+
+# vite
+.swc


### PR DESCRIPTION
Ignore `.swc` so switching between branches doesn't cause issues.