### PR TITLE
Update backends.mdx to remove incorrect comment

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -649,7 +649,7 @@ teleport:
     # Project ID https://support.google.com/googleapi/answer/7014113?hl=en
     project_id: Example_GCP_Project_Name
 
-    # Name of the Firestore table. If it does not exist, Teleport won't start
+    # Name of the Firestore table.
     collection_name: Example_TELEPORT_FIRESTORE_TABLE_NAME
 
     credentials_path: /var/lib/teleport/gcs_creds


### PR DESCRIPTION
remove the comment saying Teleport won't start without the Firestore backend existing.  This is wrong and contradicted by the first bullet point below the example