### PR TITLE
Docs: Adjust curl examples

### DIFF
--- a/docs/pages/get-started.mdx
+++ b/docs/pages/get-started.mdx
@@ -178,7 +178,7 @@ Install `tsh` on your local workstation:
 
   <TabItem label="Windows - Powershell">
     ```code
-    $ curl -o teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
+    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
     # Unzip the archive and move `tsh.exe` to your %PATH%
     ```
   </TabItem>

--- a/docs/pages/get-started.mdx
+++ b/docs/pages/get-started.mdx
@@ -178,7 +178,7 @@ Install `tsh` on your local workstation:
 
   <TabItem label="Windows - Powershell">
     ```code
-    $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
+    $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-windows-amd64-bin.zip
     # Unzip the archive and move `tsh.exe` to your %PATH%
     ```
   </TabItem>

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -11,7 +11,7 @@ To install `tsh` on Windows, run the following commands in PowerShell:
   # by default, so you need to convert it to a string
   $ [System.Text.Encoding]::UTF8.getstring($Resp.Content)
   # <checksum> <filename>
-  $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
+  $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-windows-amd64-bin.zip
   $ certUtil -hashfile teleport-v(=teleport.version=)-windows-amd64-bin.zip SHA256
   # SHA256 hash of teleport-v(=teleport.version=)-windows-amd64-bin.zip:
   # <checksum>

--- a/docs/pages/includes/install-windows.mdx
+++ b/docs/pages/includes/install-windows.mdx
@@ -11,7 +11,7 @@ To install `tsh` on Windows, run the following commands in PowerShell:
   # by default, so you need to convert it to a string
   $ [System.Text.Encoding]::UTF8.getstring($Resp.Content)
   # <checksum> <filename>
-  $ curl -o teleport-v(=teleport.version=)-windows-amd64-bin.zip https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
+  $ curl -O https://get.gravitational.com/teleport-v(=teleport.version=)-windows-amd64-bin.zip
   $ certUtil -hashfile teleport-v(=teleport.version=)-windows-amd64-bin.zip SHA256
   # SHA256 hash of teleport-v(=teleport.version=)-windows-amd64-bin.zip:
   # <checksum>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -148,7 +148,7 @@ chart.
   You can also fetch an installer via the command line:
 
   ```code
-  $ curl -o https://cdn.teleport.dev/teleport-(=teleport.version=).pkg
+  $ curl -O https://cdn.teleport.dev/teleport-(=teleport.version=).pkg
   # Installs on Macintosh HD
   $ sudo installer -pkg teleport-(=teleport.version=).pkg -target /
   # Password:


### PR DESCRIPTION
Replaces `-o` with `-O` in example `curl` commands where appropriate. Follow up to #26411 