### PR TITLE
[v13] Add and map the MDM system role

### DIFF
--- a/api/types/system_role.go
+++ b/api/types/system_role.go
@@ -72,6 +72,11 @@ const (
 	RoleDiscovery SystemRole = "Discovery"
 	// RoleOkta is a role for Okta nodes in the cluster
 	RoleOkta SystemRole = "Okta"
+	// RoleMDM is the role for MDM services in the cluster.
+	// An MDM service, like Jamf Service, has the powers to manage the cluster's
+	// device inventory.
+	// Device Trust requires Teleport Enteprise.
+	RoleMDM SystemRole = "MDM"
 )
 
 // roleMappings maps a set of allowed lowercase system role names
@@ -97,6 +102,7 @@ var roleMappings = map[string]SystemRole{
 	"instance":        RoleInstance,
 	"discovery":       RoleDiscovery,
 	"okta":            RoleOkta,
+	"mdm":             RoleMDM,
 }
 
 // localServiceMappings is the subset of role mappings which happen to be true
@@ -112,6 +118,7 @@ var localServiceMappings = map[SystemRole]struct{}{
 	RoleWindowsDesktop: {},
 	RoleDiscovery:      {},
 	RoleOkta:           {},
+	RoleMDM:            {},
 }
 
 // LocalServiceMappings returns the subset of role mappings which happen

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -3827,7 +3827,9 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, role := range types.LocalServiceMappings() {
-		if role == types.RoleAuth {
+		// RoleMDM services don't create events by themselves, instead they rely on
+		// Auth to issue events.
+		if role == types.RoleAuth || role == types.RoleMDM {
 			continue
 		}
 		t.Run(role.String(), func(t *testing.T) {

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -890,6 +890,17 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 					},
 				},
 			})
+	case types.RoleMDM:
+		return services.RoleFromSpec(
+			role.String(),
+			types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					Namespaces: []string{types.Wildcard},
+					Rules: []types.Rule{
+						types.NewRule(types.KindDevice, services.RW()),
+					},
+				},
+			})
 	}
 
 	return nil, trace.NotFound("builtin role %q is not recognized", role.String())

--- a/lib/authz/permissions_test.go
+++ b/lib/authz/permissions_test.go
@@ -621,6 +621,36 @@ func TestAuthorizeWithVerbs(t *testing.T) {
 	}
 }
 
+func TestRoleSetForBuiltinRoles(t *testing.T) {
+	tests := []struct {
+		name          string
+		clusterName   string
+		recConfig     types.SessionRecordingConfig
+		roles         []types.SystemRole
+		assertRoleSet func(t *testing.T, rs services.RoleSet)
+	}{
+		{
+			name:        "RoleMDM is mapped",
+			clusterName: clusterName,
+			roles:       []types.SystemRole{types.RoleMDM},
+			assertRoleSet: func(t *testing.T, rs services.RoleSet) {
+				for i, r := range rs {
+					assert.NotEmpty(t, r.GetNamespaces(types.Allow), "RoleSetForBuiltinRoles: rs[%v]: role has no namespaces", i)
+					assert.NotEmpty(t, r.GetRules(types.Allow), "RoleSetForBuiltinRoles: rs[%v]: role has no rules", i)
+				}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rs, err := RoleSetForBuiltinRoles(test.clusterName, test.recConfig, test.roles...)
+			require.NoError(t, err, "RoleSetForBuiltinRoles failed")
+			assert.NotEmpty(t, rs, "RoleSetForBuiltinRoles returned a nil RoleSet")
+			test.assertRoleSet(t, rs)
+		})
+	}
+}
+
 // fakeCtxUser is used for auth.Context tests.
 type fakeCtxUser struct {
 	types.User

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -52,7 +52,7 @@ Use this token to add an MDM service to Teleport.
 > teleport start \
    --token={{.token}} \{{range .ca_pins}}
    --ca-pin={{.}} \{{end}}
-   -c=/path/to/mdm_service.yaml
+   -c=/path/to/teleport.yaml
 
 `))
 


### PR DESCRIPTION
Backport #26395 to branch/v13

Add the `MDM` system role and code the necessary mappings.

The PR also specializes the output for "mdm" tokens in `tctl tokens add`.

For example:

```shell
$ tctl tokens add --type=mdm
> The invite token: 3aca68eaccb13571cf0fb19b41fd31bd
> This token will expire in 30 minutes.
> 
> Use this token to add an MDM service to Teleport.
> 
> > teleport start \
>    --token=3aca68eaccb13571cf0fb19b41fd31bd \
>    --ca-pin=sha256:4b32d9c54b2b3332019d5f0720b8f9a603de03ace07d308bcd743465eee1f200 \
>    -c=/path/to/mdm_service.yaml
```

This PR is part of the groundwork necessary for the new "MDM service".

https://github.com/gravitational/teleport.e/issues/826