### PR TITLE
[v11] bypass lint and os-compatibility for md and mdx files

### DIFF
--- a/.github/workflows/lint-bypass.yaml
+++ b/.github/workflows/lint-bypass.yaml
@@ -14,10 +14,12 @@ on:
     paths:
       - 'docs/**'
       - 'rfd/**'
+      - '**/*.md*'
   merge_group:
     paths:
       - 'docs/**'
       - 'rfd/**'
+      - '**/*.md*'
 
 jobs:
   lint:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,10 +5,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'rfd/**'
+      - '**/*.md*'
   merge_group:
     paths-ignore:
       - 'docs/**'
       - 'rfd/**'
+      - '**/*.md*'
 
 jobs:
   lint:

--- a/.github/workflows/os-compatibility-test-bypass.yaml
+++ b/.github/workflows/os-compatibility-test-bypass.yaml
@@ -15,11 +15,13 @@ on:
       - 'docs/**'
       - 'web/**'
       - 'rfd/**'
+      - '**/*.md*'
   merge_group:
    paths:
       - 'docs/**'
       - 'web/**'
       - 'rfd/**'
+      - '**/*.md*'
 
 jobs:
   build:

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -6,11 +6,13 @@ on:
       - 'docs/**'
       - 'web/**'
       - 'rfd/**'
+      - '**/*.md*'
   merge_group:
     paths-ignore:
       - 'docs/**'
       - 'web/**'
       - 'rfd/**'
+      - '**/*.md*'
 
 jobs:
   build:


### PR DESCRIPTION
backport #26450 and #26434 to branch/v11