### PR TITLE
Do not run the uploader with the MDM role

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2573,12 +2573,12 @@ func (process *TeleportProcess) initUploaderService() error {
 	for _, c := range connectors {
 		// Skip types.RoleMDM, MDM services don't have the necessary permissions to
 		// run the uploader.
-		if c.ServerIdentity != nil && c.ServerIdentity.ID.Role == types.RoleMDM {
+		if c.ClientIdentity != nil && c.ClientIdentity.ID.Role == types.RoleMDM {
 			continue
 		}
 		if c.Client != nil {
 			conn = c
-			log.Debugf("upload completer will use role %v", c.ServerIdentity.ID.Role)
+			log.Debugf("upload completer will use role %v", c.ClientIdentity.ID.Role)
 			break
 		}
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2584,10 +2584,9 @@ func (process *TeleportProcess) initUploaderService() error {
 	}
 
 	// The auth service's upload completer is initialized separately.
-	// The only circumstance in which we would expect not to have found
-	// a connector is if the auth service is the only service running in
-	// this process. In that case, there's nothing to do here and we can
-	// safely return.
+	// The only circumstance in which we would expect not to have found a
+	// connector is if the Auth or MDM service is the only service running in this
+	// process. In that case, there's nothing to do here and we can safely return.
 	if conn == nil {
 		for _, localService := range types.LocalServiceMappings() {
 			if localService != types.RoleAuth && localService != types.RoleMDM && process.instanceRoleExpected(localService) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2590,6 +2590,7 @@ func (process *TeleportProcess) initUploaderService() error {
 	if conn == nil {
 		for _, localService := range types.LocalServiceMappings() {
 			if localService != types.RoleAuth && localService != types.RoleMDM && process.instanceRoleExpected(localService) {
+				log.Warn("This process will not run an upload completer")
 				return trace.BadParameter("no connectors found")
 			}
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2568,11 +2568,14 @@ func (process *TeleportProcess) initUploaderService() error {
 		return trace.Wrap(err)
 	}
 
-	log.Infof("starting upload completer service")
-
 	connectors := process.getConnectors()
 	var conn *Connector
 	for _, c := range connectors {
+		// Skip types.RoleMDM, MDM services don't have the necessary permissions to
+		// run the uploader.
+		if c.ServerIdentity != nil && c.ServerIdentity.ID.Role == types.RoleMDM {
+			continue
+		}
 		if c.Client != nil {
 			conn = c
 			log.Debugf("upload completer will use role %v", c.ServerIdentity.ID.Role)
@@ -2587,12 +2590,13 @@ func (process *TeleportProcess) initUploaderService() error {
 	// safely return.
 	if conn == nil {
 		for _, localService := range types.LocalServiceMappings() {
-			if localService != types.RoleAuth && process.instanceRoleExpected(localService) {
+			if localService != types.RoleAuth && localService != types.RoleMDM && process.instanceRoleExpected(localService) {
 				return trace.BadParameter("no connectors found")
 			}
 		}
 		return nil
 	}
+	log.Info("starting upload completer service")
 
 	// create folder for uploads
 	uid, gid, err := adminCreds()


### PR DESCRIPTION
Do not run the uploader with the MDM role, MDM service instances don't have the necessary permissions to write events.

Follow up from #26395.

https://github.com/gravitational/teleport.e/issues/826