### PR TITLE
Install Script: add MacOS ARM64 support

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -679,10 +679,8 @@ elif [[ "${OSTYPE}" == "darwin"* ]]; then
     TELEPORT_BINARY_TYPE="darwin"
     ARCH=$(uname -m)
     log "Detected host: ${OSTYPE}, using Teleport binary type ${TELEPORT_BINARY_TYPE}"
-    if [[ ${ARCH} == "aarch64" || ${ARCH} == "arm64" ]]; then
+    if [[ ${ARCH} == "arm64" ]]; then
         TELEPORT_ARCH="arm64"
-        log_important "Error: detected ${ARCH} but Teleport doesn't build binaries for this architecture yet, exiting"
-        exit 1
     elif [[ ${ARCH} == "x86_64" ]]; then
         TELEPORT_ARCH="amd64"
     else


### PR DESCRIPTION
Adds support for installing Teleport in MacOS with Apple Sillicon

<details>
  <summary>Demo</summary>
  
![image](https://github.com/gravitational/teleport/assets/689271/94d0671f-f7f4-436f-9d5c-59cb28c6868c)
![image](https://github.com/gravitational/teleport/assets/689271/eb8d8368-6735-41b9-bef1-11b71f3020f2)
![image](https://github.com/gravitational/teleport/assets/689271/eceb2fe8-c049-439e-b310-f903ffe7179e)
![image](https://github.com/gravitational/teleport/assets/689271/678eb5cd-5124-44ec-a1bd-3a560041b4ac)
</details>


Related #26490