### PR TITLE
docs: mention missing delete permission for GCS buckets

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -112,7 +112,7 @@ and user records will be stored.
 To configure Teleport for using etcd as a storage backend:
 
 - Make sure you are using **etcd versions 3.3** or newer.
-- Follow [etcd's cluster hardware recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/). In particular, leverage 
+- Follow [etcd's cluster hardware recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/). In particular, leverage
   SSD or high-performance virtualized block device storage for best performance.
 - Install etcd and configure peer and client TLS authentication using the [etcd
   security guide](https://etcd.io/docs/v3.5/op-guide/security/).
@@ -196,7 +196,7 @@ version of a recording.
 ### Authenticating to AWS
 
 The Teleport Auth Service must be able to read AWS credentials in order to
-authenticate to S3. 
+authenticate to S3.
 
 (!docs/pages/includes/aws-credentials.mdx service="the Teleport Auth Service"!)
 
@@ -410,12 +410,12 @@ Teleport uses DynamoDB and DynamoDB Streams endpoints for its storage
 back-end management.
 
 DynamoDB cannot store the recorded sessions. You are advised to use AWS S3 for
-that as shown above. 
+that as shown above.
 
 ### Authenticating to AWS
 
 The Teleport Auth Service must be able to read AWS credentials in order to
-authenticate to DynamoDB. 
+authenticate to DynamoDB.
 
 (!docs/pages/includes/aws-credentials.mdx service="the Teleport Auth Service"!)
 
@@ -605,6 +605,10 @@ Replace the following variables in the above example with your own values:
   - `storage.objects.get`
   - `storage.objects.list`
   - `storage.objects.update`
+  - `storage.objects.delete`
+
+  `storage.objects.delete` is required in order to clean up multipart files after they have been assembled
+  into the final blob.
 
   If the bucket does not exist, please also ensure that the `storage.buckets.create` permission is granted.
 
@@ -674,8 +678,8 @@ teleport:
 - The GCP authentication setting above can be omitted if the machine itself is
   running on a GCE instance with a Service Account that has access to the
   Firestore table.
-- Audit log settings above are optional. If specified, Teleport will store the audit log in Firestore 
-  and the session recordings **must** be stored in a GCS bucket, i.e. both `audit_xxx` settings must 
+- Audit log settings above are optional. If specified, Teleport will store the audit log in Firestore
+  and the session recordings **must** be stored in a GCS bucket, i.e. both `audit_xxx` settings must
   be present. If they are not set, Teleport will default to a local filesystem for the audit log, i.e.
   `/var/lib/teleport/log` on an auth server.
 


### PR DESCRIPTION
GCS does not implement the S3 multipart API, so we emulate it by uploading parts and manually "completing" the upload. The delete permissions is required in order to assemble the individual parts.