### PR TITLE
Add diagrams to Access Request plugin guides

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -9,6 +9,8 @@ Access Requests. Users can then approve and deny Access Requests from within
 Discord, making it easier to implement security best practices without
 compromising productivity.
 
+(!docs/pages/includes/plugins/diagram.mdx api="Discord" action="Listen for Access Requests" messages="Discord messages" !)
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
@@ -9,6 +9,8 @@ at least some of their communications, Teleport's email plugin makes it
 straightforward to integrate Access Requests into your existing workflows,
 letting you implement security best practices without compromising productivity.
 
+(!docs/pages/includes/plugins/diagram.mdx api="SMTP service" action="Listen for Access Requests" messages="Email messages" !)
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -9,6 +9,8 @@ Access Requests. Users can then approve and deny Access Requests by following th
 message link, making it easier to implement security best practices without
 compromising productivity.
 
+(!docs/pages/includes/plugins/diagram.mdx api="Mattermost" action="Listen for Access Requests" messages="Mattermost messages" !)
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -9,6 +9,8 @@ Access Requests. Users can then approve and deny Access Requests by following th
 message link, making it easier to implement security best practices without
 compromising productivity.
 
+(!docs/pages/includes/plugins/diagram.mdx api="Microsoft Teams" action="Listen for Access Requests" messages="Microsoft Teams messages" !)
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -16,6 +16,8 @@ the on-call team for a service affected by an incident.
 This guide will explain how to set up Teleport's Access Request plugin for
 PagerDuty.
 
+(!docs/pages/includes/plugins/diagram.mdx api="PagerDuty" action="Listen for Access Requests\nModify Access Requests" messages="Send notifications\nGet incident status" !)
+
 ## Prerequisites
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -9,6 +9,8 @@ Access Requests. Users can then approve and deny Access Requests from within
 Slack, making it easier to implement security best practices without
 compromising productivity.
 
+(!docs/pages/includes/plugins/diagram.mdx api="Slack" action="Listen for Access Requests" messages="Slack messages" !)
+
 Here is an example of sending an Access Request via Teleport's Slack plugin:
 
 <video controls>

--- a/docs/pages/includes/plugins/diagram.mdx
+++ b/docs/pages/includes/plugins/diagram.mdx
@@ -1,0 +1,19 @@
+```mermaid
+flowchart LR
+subgraph teleport["Teleport cluster"]
+  direction LR
+  auth["Auth Service"]
+  proxy["Proxy Service"]
+end
+api[{{ api }} API]
+
+subgraph private["Private network"]
+  subgraph plugin[{{ api }} plugin]
+    id["Teleport identity file"]
+  end 
+  plugin<-- "{{ action }}\n(via reverse tunnel)"-->proxy
+end 
+proxy<-- Forward gRPC traffic -->auth
+plugin-- "{{ messages }}" -->api
+```
+


### PR DESCRIPTION
This was mainly an experiment to see how we could use partial parameters with Mermaid diagrams, but also ensures that Access Request plugin docs have a diagram for easier architectural understanding.

(The Jira plugin works a bit differently, so I didn't add the diagram partial.)