### PR TITLE
Docs: suggest machine id in plugins partial

### DIFF
--- a/docs/pages/includes/plugins/identity-export.mdx
+++ b/docs/pages/includes/plugins/identity-export.mdx
@@ -25,8 +25,9 @@ You will refer to this file later when configuring the plugin.
 >
 
   By default, `tctl auth sign` produces certificates with a relatively short
-  lifetime. For production deployments, you can use the `--ttl` flag to ensure a
-  more practical certificate lifetime, e.g., `--ttl=8760h` to export a one-year
-  certificate.
+  lifetime. For production deployments, we suggest using [Machine
+  ID](../../machine-id/introduction.mdx) to programmatically issue and renew
+  certificates for your plugin. See our Machine ID [getting started
+  guide](../../machine-id/getting-started.mdx) to learn more.
 
 </Admonition>


### PR DESCRIPTION
This PR resolves #5163 by removing the last remaining instance of a 1-year cert suggestion in our docs. This example was in a partial used in our access request plugin guides. The new form suggests using Machine ID to handle certificate renewal after initial setup.