### PR TITLE
[v13] Do not run the uploader with the MDM role

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2570,12 +2570,12 @@ func (process *TeleportProcess) initUploaderService() error {
 	for _, c := range connectors {
 		// Skip types.RoleMDM, MDM services don't have the necessary permissions to
 		// run the uploader.
-		if c.ServerIdentity != nil && c.ServerIdentity.ID.Role == types.RoleMDM {
+		if c.ClientIdentity != nil && c.ClientIdentity.ID.Role == types.RoleMDM {
 			continue
 		}
 		if c.Client != nil {
 			conn = c
-			log.Debugf("upload completer will use role %v", c.ServerIdentity.ID.Role)
+			log.Debugf("upload completer will use role %v", c.ClientIdentity.ID.Role)
 			break
 		}
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2581,10 +2581,9 @@ func (process *TeleportProcess) initUploaderService() error {
 	}
 
 	// The auth service's upload completer is initialized separately.
-	// The only circumstance in which we would expect not to have found
-	// a connector is if the auth service is the only service running in
-	// this process. In that case, there's nothing to do here and we can
-	// safely return.
+	// The only circumstance in which we would expect not to have found a
+	// connector is if the Auth or MDM service is the only service running in this
+	// process. In that case, there's nothing to do here and we can safely return.
 	if conn == nil {
 		for _, localService := range types.LocalServiceMappings() {
 			if localService != types.RoleAuth && localService != types.RoleMDM && process.instanceRoleExpected(localService) {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2587,6 +2587,7 @@ func (process *TeleportProcess) initUploaderService() error {
 	if conn == nil {
 		for _, localService := range types.LocalServiceMappings() {
 			if localService != types.RoleAuth && localService != types.RoleMDM && process.instanceRoleExpected(localService) {
+				log.Warn("This process will not run an upload completer")
 				return trace.BadParameter("no connectors found")
 			}
 		}


### PR DESCRIPTION
Backport #26491 to branch/v13

Do not run the uploader with the MDM role, MDM service instances don't have the
necessary permissions to write events.

Follow up from #26395.

https://github.com/gravitational/teleport.e/issues/826