### PR TITLE
Docs: mark Okta application access as preview

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -959,11 +959,11 @@
           ]
         },
         {
-          "title": "Protect Okta Applications and Groups with Teleport",
+          "title": "Protect Okta Applications and Groups (Preview)",
           "slug": "/application-access/okta/",
           "entries": [
             {
-              "title": "Guide",
+              "title": "Okta Service",
               "slug": "/application-access/okta/guide/"
             },
             {

--- a/docs/pages/application-access/okta.mdx
+++ b/docs/pages/application-access/okta.mdx
@@ -3,7 +3,12 @@ title: Okta Integration with Application Access
 description: Guides for using Teleport Okta integration.
 layout: tocless-doc
 ---
+<Admonition type="warning" title="Preview">
+Okta application access is currently in Preview mode.
+</Admonition>
 
-- [Guide](./okta/guide.mdx): A guide for setting up a simple Okta service in Teleport.
+Configure Teleport to import and grant access to Okta applications and user groups.
+
+- [Setting up the Okta Service](./okta/guide.mdx): A guide for setting up a simple Okta service in Teleport.
 - [Architecture](./okta/architecture.mdx): The architecture of the Okta service.
 - [Reference](./okta/reference.mdx): A reference for the Okta service.

--- a/docs/pages/application-access/okta/architecture.mdx
+++ b/docs/pages/application-access/okta/architecture.mdx
@@ -3,6 +3,10 @@ title: Architecture of the Okta Service
 description: An overview of the architecture of the Okta Service.
 ---
 
+<Admonition type="warning" title="Preview">
+Okta application access is currently in Preview mode.
+</Admonition>
+
 This document will go into details on how the Okta Service is organized and how
 it functions.
 

--- a/docs/pages/application-access/okta/guide.mdx
+++ b/docs/pages/application-access/okta/guide.mdx
@@ -19,7 +19,6 @@ configurations to enable it.
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-
 - An Okta organization with an [Okta API token](https://developer.okta.com/docs/guides/create-an-api-token) provisioned.
 - A running Teleport cluster with Okta login configured.
 - An instance where you will run the Okta Service. This can live anywhere

--- a/docs/pages/application-access/okta/guide.mdx
+++ b/docs/pages/application-access/okta/guide.mdx
@@ -34,7 +34,7 @@ provisioned earlier.
 
 To get group IDs:
 
-```
+```code
 $ curl -H "Authorization: SSWS <Var name="okta-api-token" />" <Var name="okta-endpoint-url" />/api/v1/groups | jq '[.[] |  {"id": .id, "label": .profile.name}]'
 ...
 [
@@ -58,7 +58,7 @@ $ curl -H "Authorization: SSWS <Var name="okta-api-token" />" <Var name="okta-en
 ]
 ```
 
-```
+```code
 $ curl -H "Authorization: SSWS <Var name="okta-api-token" />" <Var name="okta-endpoint-url" />/api/v1/apps | jq '[.[] |  {"id": .id, "label": .label}]'
 ...
 [

--- a/docs/pages/application-access/okta/guide.mdx
+++ b/docs/pages/application-access/okta/guide.mdx
@@ -3,6 +3,10 @@ title: Setting up the Okta Service
 description: How to set up the Okta Service with some basic configurations
 ---
 
+<Admonition type="warning" title="Preview">
+Okta application access is currently in Preview mode.
+</Admonition>
+
 Teleport can import and grant access to Okta applications and user groups. Okta applications
 can be accessed through Teleport's application access UI, and access to these applications along
 with user groups can be managed by Teleport's RBAC along with access requests.

--- a/docs/pages/application-access/okta/reference.mdx
+++ b/docs/pages/application-access/okta/reference.mdx
@@ -5,6 +5,10 @@ description: Configuration and CLI reference documentation for Teleport Okta ser
 
 ## Configuration
 
+<Admonition type="warning" title="Preview">
+Okta application access is currently in Preview mode.
+</Admonition>
+
 (!docs/pages/includes/backup-warning.mdx!)
 
 The following snippet shows the full YAML configuration of the Okta Service


### PR DESCRIPTION
Follow-up to #25580

- Adds admonitions that Okta application access is in preview mode.
- Updates titling in ToC and expands section index
- Resolves formatting issue with `Var` components.
