### PR TITLE
[v13] skip rdpclient build in integration tests

### DIFF
--- a/.github/workflows/integration-tests-non-root.yaml
+++ b/.github/workflows/integration-tests-non-root.yaml
@@ -72,4 +72,4 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 40
-        run: runuser -u ci -g ci make rdpclient integration
+        run: runuser -u ci -g ci make integration RDPCLIENT_SKIP_BUILD=1

--- a/.github/workflows/integration-tests-root.yaml
+++ b/.github/workflows/integration-tests-root.yaml
@@ -50,4 +50,4 @@ jobs:
       - name: Run tests
         timeout-minutes: 40
         run: |
-          make rdpclient integration-root
+          make integration-root RDPCLIENT_SKIP_BUILD=1

--- a/.github/workflows/kube-integration-tests-non-root.yaml
+++ b/.github/workflows/kube-integration-tests-non-root.yaml
@@ -84,4 +84,4 @@ jobs:
       - name: Run tests
         timeout-minutes: 40
         run: |
-          runuser -u ci -g ci make rdpclient integration-kube
+          runuser -u ci -g ci make integration-kube RDPCLIENT_SKIP_BUILD=1

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,6 @@ RUST_TARGET_ARCH ?= $(CARGO_TARGET_$(OS)_$(ARCH))
 # TODO: Delete when it becomes default in Rust 1.70.0
 export CARGO_REGISTRIES_CRATES_IO_PROTOCOL=sparse
 
-with_rdpclient := no
-RDPCLIENT_MESSAGE := without-Windows-RDP-client
-
 CARGO_TARGET_darwin_amd64 := x86_64-apple-darwin
 CARGO_TARGET_darwin_arm64 := aarch64-apple-darwin
 CARGO_TARGET_linux_arm64 := aarch64-unknown-linux-gnu
@@ -112,6 +109,14 @@ CARGO_TARGET_linux_amd64 := x86_64-unknown-linux-gnu
 
 CARGO_TARGET := --target=${CARGO_TARGET_${OS}_${ARCH}}
 
+# If set to 1, Windows RDP client is not built.
+RDPCLIENT_SKIP_BUILD ?= 0
+
+# Enable Windows RDP client build?
+with_rdpclient := no
+RDPCLIENT_MESSAGE := without-Windows-RDP-client
+
+ifeq ($(RDPCLIENT_SKIP_BUILD),0)
 ifneq ($(CHECK_RUST),)
 ifneq ($(CHECK_CARGO),)
 
@@ -124,6 +129,7 @@ RDPCLIENT_TAG := desktop_access_rdp
 endif
 endif
 
+endif
 endif
 endif
 


### PR DESCRIPTION
backport #26492 to branch/v13.

* add RDPCLIENT_SKIP_BUILD opt to makefile
* skip rdpclient build in go integration tests