### PR TITLE
wait for kube watcher to init in tests

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -8140,6 +8140,8 @@ func startKubeWithoutCleanup(ctx context.Context, t *testing.T, cfg startKubeOpt
 		}
 		errChan <- err
 	}()
+	// wait for the watcher to init or it may race with test cleanup.
+	require.NoError(t, watcher.WaitInitialization())
 
 	// Waits for len(clusters) heartbeats to start
 	heartbeatsToExpect := len(cfg.clusters)


### PR DESCRIPTION
This PR fixes various flaky tests in `lib/web` that depend on a web test suite setup, by waiting for the kube server watcher to init before returning from test suite setup code.

### Details
I think this change https://github.com/gravitational/teleport/pull/24554 introduced the test flakiness. I haven’t seen it fail in CI, but it does cause test failures frequently when I run  `go test -v -count=1 ./lib/web` locally. Reason I suspect that PR is because the failure looks like this:
```
--- FAIL: TestForwardingTraces (0.12s)
    apiserver_test.go:8002: 
                Error Trace:    /Users/gavin/work/teleport/lib/web/apiserver_test.go:8002
                                                        /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1150
                                                        /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1328
                                                        /opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1570
                Error:          Received unexpected error:
                                ResourceWatcher kube_server failed to initialize.
                Test:           TestForwardingTraces
```
which comes from here:
https://github.com/gravitational/teleport/blob/448c4051fe14cef3d514c20cfbe3d346617ea516/lib/services/watcher.go#L181-L188

and in tests, if the test finishes before the watcher can initialize, then the test cleanup closes the server, which cancels the watcher’s context and so kubeServer.Serve(listener) return the error from this goroutine:
https://github.com/gravitational/teleport/blob/448c4051fe14cef3d514c20cfbe3d346617ea516/lib/web/apiserver_test.go#L7995-L8003

(and this test code path was introduced by that PR)