### PR TITLE
expose firehose emulator host env in tests

### DIFF
--- a/lib/events/firestoreevents/firestoreevents_test.go
+++ b/lib/events/firestoreevents/firestoreevents_test.go
@@ -46,6 +46,8 @@ func setupFirestoreContext(t *testing.T) *firestoreContext {
 		t.Skip("Firestore emulator is not running, start it with: gcloud beta emulators firestore start --host-port=localhost:8618")
 	}
 
+	require.NoError(t, os.Setenv("FIRESTORE_EMULATOR_HOST", "localhost:8618"))
+
 	fakeClock := clockwork.NewFakeClock()
 
 	config := EventsConfig{}


### PR DESCRIPTION
Firestore client sets emulator credentials only when env is set:
https://github.com/googleapis/google-cloud-go/blob/3a047d2a449b0316a9000539ec9797e47cdd5c91/firestore/client.go#L70-L74

Without it, tests were failing without explicit export. 