### PR TITLE
[v12] chore: Bump golangci-lint to v1.52.2

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -281,7 +281,8 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-RUN go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.51.2
+RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2/install.sh" | \
+    sh -s -- -b "$(go env GOPATH)/bin"
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \


### PR DESCRIPTION
Backport #26524 to branch/v12

Update to the latest release.

I've changed the install method from `go install` to the preferred "curl
install.sh". They recommend not using `go install`.

References:
* https://github.com/golangci/golangci-lint/releases/tag/v1.52.2
* https://golangci-lint.run/usage/install/#other-ci
* https://golangci-lint.run/usage/install/#install-from-source