### PR TITLE
Plugin static credentials RFD.

### DIFF
--- a/rfd/0124-plugin-secrets.md
+++ b/rfd/0124-plugin-secrets.md
@@ -1,0 +1,134 @@
+---
+authors: Michael Wilson (michael.wilson@goteleport.com)
+state: draft
+---
+
+# RFD 124 - Plugin static credentials
+
+### Required Approvers
+
+* Engineering @r0mant, @justinas
+* Security @reed
+* Product: @klizhentas
+
+## What
+
+Allow storage of plugin static credentials within Teleport in a safe and secure way.
+
+## Why
+
+As we grow our plugin support, we have discovered that the various services we
+hope to integrate do not offer a uniform mechanism for configuration. For instance,
+Slack uses oauth2, but Okta requires an API token, and Jamf requires a username and
+password.
+
+Today, the plugin houses a credentials object that allows for this sort of storage.
+However, unlike oauth tokens, static credentials pose a much greater risk of exposure,
+and rotating credentials can be a time consuming process.  To reduce the risks associated
+with storing static credentials within Teleport and to allow for easier credentials rotation,
+we would like to create a new resource within Teleport that is handled in an explicitly secure
+way.
+
+## Details
+
+### The `PluginStaticCredentials` object
+
+A new object will be needed to house static credentials. At present it will support:
+
+- API tokens
+- Usernames and passwords
+
+It should be noted that this object should *only* be readable by the auth service to prevent
+exfiltration of these credentials.
+
+```yaml
+kind: plugin_static_credentials
+version: v1
+metadata:
+  name: plugin-name
+spec:
+  lastRotated: "2023-05-09T16:50:52.497874Z"
+  credentials:
+    # Only one of these credential types must be defined at a time.
+    api_token: example-token
+    basic_auth:
+      username: example-user
+      password: example-password
+```
+
+If a plugin requires static credentials, there is a 1-to-1 mapping between `Plugin`
+objects and `PluginStaticCredentials` objects. If a `Plugin` is using oauth, however,
+it will not need a `PluginStaticCredentials` and none will be created. The object will
+inherit the same name as its associated plugin.
+
+### Lifecycle of the `PluginStaticCredentials` object
+
+#### Creation
+
+A `PluginStaticCredentials` object can be created after a `Plugin` object has been
+created. If a `Plugin` is marked as needing static credentials, the `Plugin` won't
+start until these have been provided.
+
+#### Rotation
+
+A `PluginStaticCredentials` object can be updated, which we'll refer to as rotation.
+When the credentils are rotated, the `Plugin` associated with the credentials will be
+restarted with the new credentials.
+
+#### Deletion
+
+`PluginStaticCredentials` objects can be deleted. On deletion, the associated `Plugin`
+will be stopped. Additionally, `PluginStaticCredentials` objects will be deleted when
+deleting its associated plugin.
+
+### UX
+
+#### Web UI
+
+The web UI will remain largely the same with respect to entering credentials for specific
+plugins. This will largely depend on the specific application.
+
+#### Teleport CLI
+
+* Creation of plugin credentials will be done with `tctl plugins create plugin_static_credentials.yaml`.
+* Rotation of plugin credentials will be done with `tctl plugins rotate plugin_static_credentials.yaml`
+* Plugins can be deleted with `tctl plugins rm plugin_static_credentials/plugin-name`
+
+### Audit events
+
+A number of new audit events will be created as part of this effort:
+
+| Event Name | Description |
+|------------|-------------|
+| `PLUGIN_CREDENTIALS_CREATED` | Emitted when plugin credentials have been created. |
+| `PLUGIN_CREDENTIALS_ROTATED` | Emitted when plugin credentials have been rotated. |
+| `PLUGIN_CREDENTIALS_DELETED` | Emitted when plugin credentials have been deleted. |
+
+### Security
+
+* Only the auth server is able to read plugin credentials. Users will be able to create
+  credentials, rotate, and delete credentials, but not read them.
+
+### Implementation plan
+
+#### `PluginStaticCredentials` object
+
+The new `PluginStaticCredentials` object should be created with any backend and gRPC modifications
+required.
+
+#### Implement `PluginStaticCredentials` permissions
+
+Proper permissions for the `PluginStaticCredentials` objects should be added.
+
+#### Implement `PluginStaticCredentials` CLI tooling
+
+CLI tooling for the `PluginStaticCredentials` should be implemented.
+
+#### Integrate `PluginStaticCredentials` with enterprise plugin manager
+
+The plugin manager should be able to look up the `PluginStaticCredentials` objects as needed. This
+may require some additional modifications to the `Plugin` object.
+
+#### Add audit events
+
+Audit events for the various user facing operations should be added.

--- a/rfd/0124-plugin-secrets.md
+++ b/rfd/0124-plugin-secrets.md
@@ -43,20 +43,7 @@ This object has very strict access control requirements that will be explained i
 in the **Access Control** section. On creation, the plugin and static credentials will
 receive a UUID called the `plugin-label`. The static credentials will have an internal
 label that receives this value. Additionally, one plugin may have _many_ credentials
-that are disambiguated with arbitrary additional labels. These will allow plugin authors
-to refer to multiple static credentials if needed.
-
-```mermaid
-flowchart LR
-  Plugin
-  Okta[Okta Credentials]
-  Slack[Slack Credentials]
-  OpsGenie[OpsGenie Credentials]
-
-  Plugin-->|label "type: okta"|Okta
-  Plugin-->|label "type: slack"|Slack
-  Plugin-->|label "type: opsgenie"|OpsGenie
-```
+for the purposes of credentials rotation.
 
 ```yaml
 kind: plugin_static_credentials
@@ -64,12 +51,12 @@ version: v1
 metadata:
   name: credentials-name
   labels:
-    # this is a unique plugin label generated randomly at plugin creation.
+    # This is a unique plugin label generated randomly at plugin creation.
+    # It cannot be modified by the user.
     teleport.internal/plugin-label: 48398071-9860-4be6-9f29-ca6ca5bc7155
     # additional labels to uniquely identify the credentials.
-    label1: value1 # additional labels
+    label1: value1
     type: slack
-    teleport.internal/plugin-credentials-type
 spec:
   credentials:
     # Only one of these credential types must be defined at a time. All values in this
@@ -89,14 +76,16 @@ If a `Plugin` is using the oauth authorization code flow, however, it will not n
 ### Changes to the `Plugin` object
 
 The `Plugin` object's `Credentials` field will have a new type of credential called
-`PluginStaticCredentialsRefs` that contains a UUID and additional aribitrary labels.
+`PluginStaticCredentialsRef` that contains a reference to a static plugin label. More than
+one static credential may match this label, in which case when starting the plugin, the most
+recently created credential will be used.
 
 ```yaml
-plugin_static_credentials_refs:
-  # this label is the same label generated at plugin creation. It cannot be modified
-  # by users in any way.
-  plugin-label: 48398071-9860-4be6-9f29-ca6ca5bc7155
+plugin_static_credentials_ref:
   labels:
+    # This label is the same label generated at plugin creation. This field will be
+    # injected by Teleport at creation.
+    teleport.dev/plugin-label: 48398071-9860-4be6-9f29-ca6ca5bc7155
     env: prod
     type: slack
 ```

--- a/rfd/0124-plugin-secrets.md
+++ b/rfd/0124-plugin-secrets.md
@@ -53,7 +53,7 @@ metadata:
   labels:
     # This is a unique plugin label generated randomly at plugin creation.
     # It cannot be modified by the user.
-    teleport.internal/plugin-label: 48398071-9860-4be6-9f29-ca6ca5bc7155
+    teleport.internal/plugin: 48398071-9860-4be6-9f29-ca6ca5bc7155
     # additional labels to uniquely identify the credentials.
     label1: value1
     type: slack
@@ -76,16 +76,16 @@ If a `Plugin` is using the oauth authorization code flow, however, it will not n
 ### Changes to the `Plugin` object
 
 The `Plugin` object's `Credentials` field will have a new type of credential called
-`PluginStaticCredentialsRef` that contains a reference to a static plugin label. More than
+`CredentialsRef` that contains a reference to a static plugin label. More than
 one static credential may match this label, in which case when starting the plugin, the most
 recently created credential will be used.
 
 ```yaml
-plugin_static_credentials_ref:
+credentials_ref:
   labels:
     # This label is the same label generated at plugin creation. This field will be
     # injected by Teleport at creation.
-    teleport.dev/plugin-label: 48398071-9860-4be6-9f29-ca6ca5bc7155
+    teleport.internal/plugin: 48398071-9860-4be6-9f29-ca6ca5bc7155
     env: prod
     type: slack
 ```

--- a/rfd/0124-plugin-secrets.md
+++ b/rfd/0124-plugin-secrets.md
@@ -71,7 +71,8 @@ metadata:
 spec:
   credentials:
     # Only one of these credential types must be defined at a time. All values in this
-    # are string literals and not file locations.
+    # are string literals and not file locations, though its up to the plugin how
+    # to interpret the value of the literal.
     api_token: example-token
     basic_auth:
       username: example-user
@@ -109,7 +110,9 @@ able to actually read the static credentials.
 
 The one exception here is Teleport Assist, which runs in the proxy. The proxy will be
 able to read plugin credentials with the name of `openai-default`, which is the name of
-the Assist plugin.
+the Assist plugin. The Teleport Assist static credentials object API token must be interpreted
+as a file location, however, to avoid leaking the API key to unintended proxies joined to a
+Teleport cluster.
 
 ### Lifecycle of the `PluginStaticCredentials` object
 

--- a/rfd/0124-plugin-secrets.md
+++ b/rfd/0124-plugin-secrets.md
@@ -60,7 +60,8 @@ metadata:
 spec:
   credentials:
     # Only one of these credential types must be defined at a time. All values in this
-    # are string literals and not file locations.
+    # are string literals and not file locations. None of the existing credentials objects
+    # will be used for this, and all new objects will be created.
     api_token: example-token
     basic_auth:
       username: example-user

--- a/rfd/0124-plugin-secrets.md
+++ b/rfd/0124-plugin-secrets.md
@@ -71,8 +71,7 @@ metadata:
 spec:
   credentials:
     # Only one of these credential types must be defined at a time. All values in this
-    # are string literals and not file locations, though its up to the plugin how
-    # to interpret the value of the literal.
+    # are string literals and not file locations.
     api_token: example-token
     basic_auth:
       username: example-user
@@ -110,9 +109,7 @@ able to actually read the static credentials.
 
 The one exception here is Teleport Assist, which runs in the proxy. The proxy will be
 able to read plugin credentials with the name of `openai-default`, which is the name of
-the Assist plugin. The Teleport Assist static credentials object API token must be interpreted
-as a file location, however, to avoid leaking the API key to unintended proxies joined to a
-Teleport cluster.
+the Assist plugin.
 
 ### Lifecycle of the `PluginStaticCredentials` object
 


### PR DESCRIPTION
The RFD for supporting plugin static credentials has been created. This RFD describes how static credentials such as API tokens and username/passwords should be stored within Teleport.

[Rendered](https://github.com/gravitational/teleport/blob/mike.wilson/plugin-secrets-rfd/rfd/0124-plugin-secrets.md)