### PR TITLE
Properly wait until Lock watcher is stale

### DIFF
--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -607,6 +607,9 @@ func TestInteractiveSessionsNoAuth(t *testing.T) {
 	// force the auth client to return an error when trying to create a session.
 	close(testCtx.closeSessionTrackers)
 
+	require.Eventually(t, func() bool {
+		return testCtx.lockWatcher.IsStale()
+	}, 3*time.Second, time.Millisecond*100, "lock watcher should be stale")
 	tests := []struct {
 		name      string
 		config    *rest.Config

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -205,11 +205,9 @@ func TestMonitorStaleLocks(t *testing.T) {
 	case <-time.After(15 * time.Second):
 		t.Fatal("Timeout waiting for LockWatcher loop check.")
 	}
-	select {
-	case asrv.LockWatcher.StaleC <- struct{}{}:
-	default:
-		t.Fatal("No staleness event should be scheduled yet. This is a bug in the test.")
-	}
+	// StaleC is listened by multiple goroutines, so we need to close to ensure
+	// that all of them are unblocked.
+	close(asrv.LockWatcher.StaleC)
 
 	// ensure ResetC is drained
 	select {


### PR DESCRIPTION
Wait until the lock watcher becomes stale before running the tests.