### PR TITLE
Edit the docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -4,11 +4,17 @@ about: Report errors or suggest improvements to Teleport's documentation.
 labels: documentation
 ---
 ## Applies To
+
 <!-- List the URL(s) for existing docs this issue relates to. If this is a proposal for a new doc, you can suggest a path and title here. -->
 
 ## Details
-Describe the documentation improvements you wish to see.
+
+<!-- Describe the documentation improvements you wish to see. -->
+
+## How will we know this is resolved?
+
+<!-- Briefly describe a test we can carry out. Scope this as narrowly as possible. -->
 
 ## Related Issues
 
-<!-- If an existing issue relates to this one, please include it here for reference. -->
+<!-- Please make an effort to find related issues on GitHub and list them here. This makes a big difference in how we prioritize and schedule work. -->


### PR DESCRIPTION
- Add an item to define a scope for resolving the issue to avoid scope creep and make it easier to close issues.
- Make a stronger plea for "Related Issues" items, since these are often not included.