### PR TITLE
[v11] Add RoleInstance to TestLocalServiceRolesHavePermissionsForUploaderService

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4145,7 +4145,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 				// RoleInstance needs AdditionalSystemRoles, otherwise the setup is the
 				// same.
 				identity = TestIdentity{
-					I: authz.BuiltinRole{
+					I: BuiltinRole{
 						Role: role,
 						AdditionalSystemRoles: []types.SystemRole{
 							types.RoleNode, // Arbitrary, could be any role.
@@ -4157,7 +4157,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 				identity = TestBuiltin(role)
 			}
 
-			authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, identity.I))
+			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, identity.I))
 			require.NoError(t, err)
 
 			s := &ServerWithRoles{

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4130,15 +4130,34 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 	srv, err := NewTestAuthServer(TestAuthServerConfig{Dir: t.TempDir()})
 	require.NoError(t, err)
 
-	for _, role := range types.LocalServiceMappings() {
+	// Test all local service roles, plus RoleInstance.
+	// The latter may also be used to run the uploader.
+	roles := append(types.LocalServiceMappings(), types.RoleInstance)
+	for _, role := range roles {
 		if role == types.RoleAuth {
 			continue
 		}
 		t.Run(role.String(), func(t *testing.T) {
 			ctx := context.Background()
 
-			identity := TestBuiltin(role)
-			authContext, err := srv.Authorizer.Authorize(context.WithValue(ctx, ContextUser, identity.I))
+			var identity TestIdentity
+			if role == types.RoleInstance {
+				// RoleInstance needs AdditionalSystemRoles, otherwise the setup is the
+				// same.
+				identity = TestIdentity{
+					I: authz.BuiltinRole{
+						Role: role,
+						AdditionalSystemRoles: []types.SystemRole{
+							types.RoleNode, // Arbitrary, could be any role.
+						},
+						Username: string(role),
+					},
+				}
+			} else {
+				identity = TestBuiltin(role)
+			}
+
+			authContext, err := srv.Authorizer.Authorize(authz.ContextWithUser(ctx, identity.I))
 			require.NoError(t, err)
 
 			s := &ServerWithRoles{


### PR DESCRIPTION
Backport #26516 to branch/v11

Make sure `RoleInstance` has uploader permissions.