### PR TITLE
Fix `TestKube/Join` data race

### DIFF
--- a/lib/client/kubesession.go
+++ b/lib/client/kubesession.go
@@ -65,7 +65,7 @@ func NewKubeSession(ctx context.Context, tc *TeleportClient, meta types.SessionT
 
 	fmt.Printf("Joining session with participant mode: %v. \n\n", mode)
 
-	ws, resp, err := dialer.Dial(joinEndpoint, nil)
+	ws, resp, err := dialer.DialContext(ctx, joinEndpoint, nil)
 	if resp != nil && resp.Body != nil {
 		defer resp.Body.Close()
 	}
@@ -236,7 +236,7 @@ func (s *KubeSession) pipeInOut(stdout io.Writer, enableEscapeSequences bool, mo
 
 // Wait waits for the session to finish.
 func (s *KubeSession) Wait() {
-	<-s.ctx.Done()
+	// Wait for the session to copy everything into stdout
 	s.wg.Wait()
 }
 
@@ -246,7 +246,6 @@ func (s *KubeSession) Close() error {
 		return trace.Wrap(err)
 	}
 
-	<-s.ctx.Done()
 	s.wg.Wait()
 	return trace.Wrap(s.Detach())
 }


### PR DESCRIPTION
PR #26168 extended the inital Kube Join test to add more observers using different upgrade logic.
While extending it, it also introduced the following dataraces

```
==================
WARNING: DATA RACE
Read at 0x00c00139d548 by goroutine 64284:
  bytes.(*Buffer).String()
      /opt/go/src/bytes/buffer.go:65 +0x252
  github.com/gravitational/teleport/integration.testKubeJoin.func7()
      /__w/teleport/teleport/integration/kube_integration_test.go:1702 +0x245
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47

Previous write at 0x00c00139d548 by goroutine 63051:
  bytes.(*Buffer).grow()
      /opt/go/src/bytes/buffer.go:145 +0x3c4
  bytes.(*Buffer).Write()
      /opt/go/src/bytes/buffer.go:170 +0xcd
  github.com/gravitational/teleport/lib/utils.(*SyncWriter).Write()
      /__w/teleport/teleport/lib/utils/sync_writer.go:38 +0x109
  io.copyBuffer()
      /opt/go/src/io/io.go:429 +0x2de
  io.Copy()
      /opt/go/src/io/io.go:386 +0xc5
  github.com/gravitational/teleport/lib/client.(*KubeSession).pipeInOut.func1()
      /__w/teleport/teleport/lib/client/kubesession.go:208 +0x8d

Goroutine 64284 (running) created at:
  testing.(*T).Run()
      /opt/go/src/testing/testing.go:1629 +0x805
  github.com/gravitational/teleport/integration.testKubeJoin()
      /__w/teleport/teleport/integration/kube_integration_test.go:1691 +0x2b79
  github.com/gravitational/teleport/integration.(*KubeSuite).bind.func1()
      /__w/teleport/teleport/integration/kube_integration_test.go:152 +0x118
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47

Goroutine 63051 (running) created at:
  github.com/gravitational/teleport/lib/client.(*KubeSession).pipeInOut()
      /__w/teleport/teleport/lib/client/kubesession.go:206 +0xea
  github.com/gravitational/teleport/lib/client.NewKubeSession()
      /__w/teleport/teleport/lib/client/kubesession.go:120 +0x12cb
  github.com/gravitational/teleport/integration.kubeJoin()
      /__w/teleport/teleport/integration/kube_integration_test.go:1518 +0x12a
  github.com/gravitational/teleport/integration.kubeJoinObserverWithSNISet()
      /__w/teleport/teleport/integration/kube_integration_test.go:1750 +0x34b
  github.com/gravitational/teleport/integration.kubeJoinByALBAddr()
      /__w/teleport/teleport/integration/kube_integration_test.go:1740 +0x249
  github.com/gravitational/teleport/integration.testKubeJoin.func5()
      /__w/teleport/teleport/integration/kube_integration_test.go:1663 +0x14e
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c00139d530 by goroutine 64284:
  bytes.(*Buffer).String()
      /opt/go/src/bytes/buffer.go:65 +0x268
  github.com/gravitational/teleport/integration.testKubeJoin.func7()
      /__w/teleport/teleport/integration/kube_integration_test.go:1702 +0x245
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47

Previous write at 0x00c00139d530 by goroutine 63051:
  bytes.(*Buffer).grow()
      /opt/go/src/bytes/buffer.go:142 +0x2d6
  bytes.(*Buffer).Write()
      /opt/go/src/bytes/buffer.go:170 +0xcd
  github.com/gravitational/teleport/lib/utils.(*SyncWriter).Write()
      /__w/teleport/teleport/lib/utils/sync_writer.go:38 +0x109
  io.copyBuffer()
      /opt/go/src/io/io.go:429 +0x2de
  io.Copy()
      /opt/go/src/io/io.go:386 +0xc5
  github.com/gravitational/teleport/lib/client.(*KubeSession).pipeInOut.func1()
      /__w/teleport/teleport/lib/client/kubesession.go:208 +0x8d

Goroutine 64284 (running) created at:
  testing.(*T).Run()
      /opt/go/src/testing/testing.go:1629 +0x805
  github.com/gravitational/teleport/integration.testKubeJoin()
      /__w/teleport/teleport/integration/kube_integration_test.go:1691 +0x2b79
  github.com/gravitational/teleport/integration.(*KubeSuite).bind.func1()
      /__w/teleport/teleport/integration/kube_integration_test.go:152 +0x118
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47

Goroutine 63051 (running) created at:
  github.com/gravitational/teleport/lib/client.(*KubeSession).pipeInOut()
      /__w/teleport/teleport/lib/client/kubesession.go:206 +0xea
  github.com/gravitational/teleport/lib/client.NewKubeSession()
      /__w/teleport/teleport/lib/client/kubesession.go:120 +0x12cb
  github.com/gravitational/teleport/integration.kubeJoin()
      /__w/teleport/teleport/integration/kube_integration_test.go:1518 +0x12a
  github.com/gravitational/teleport/integration.kubeJoinObserverWithSNISet()
      /__w/teleport/teleport/integration/kube_integration_test.go:1750 +0x34b
  github.com/gravitational/teleport/integration.kubeJoinByALBAddr()
      /__w/teleport/teleport/integration/kube_integration_test.go:1740 +0x249
  github.com/gravitational/teleport/integration.testKubeJoin.func5()
      /__w/teleport/teleport/integration/kube_integration_test.go:1663 +0x14e
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c0023c2d00 by goroutine 64284:
  runtime.slicebytetostring()
      /opt/go/src/runtime/string.go:81 +0x0
  bytes.(*Buffer).String()
      /opt/go/src/bytes/buffer.go:65 +0x2a6
  github.com/gravitational/teleport/integration.testKubeJoin.func7()
      /__w/teleport/teleport/integration/kube_integration_test.go:1702 +0x245
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47

Previous write at 0x00c0023c2d00 by goroutine 63051:
  runtime.slicecopy()
      /opt/go/src/runtime/slice.go:310 +0x0
  bytes.growSlice()
      /opt/go/src/bytes/buffer.go:241 +0x14d
  bytes.(*Buffer).grow()
      /opt/go/src/bytes/buffer.go:142 +0x2ba
  bytes.(*Buffer).Write()
      /opt/go/src/bytes/buffer.go:170 +0xcd
  github.com/gravitational/teleport/lib/utils.(*SyncWriter).Write()
      /__w/teleport/teleport/lib/utils/sync_writer.go:38 +0x109
  io.copyBuffer()
      /opt/go/src/io/io.go:429 +0x2de
  io.Copy()
      /opt/go/src/io/io.go:386 +0xc5
  github.com/gravitational/teleport/lib/client.(*KubeSession).pipeInOut.func1()
      /__w/teleport/teleport/lib/client/kubesession.go:208 +0x8d

Goroutine 64284 (running) created at:
  testing.(*T).Run()
      /opt/go/src/testing/testing.go:1629 +0x805
  github.com/gravitational/teleport/integration.testKubeJoin()
      /__w/teleport/teleport/integration/kube_integration_test.go:1691 +0x2b79
  github.com/gravitational/teleport/integration.(*KubeSuite).bind.func1()
      /__w/teleport/teleport/integration/kube_integration_test.go:152 +0x118
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47

Goroutine 63051 (running) created at:
  github.com/gravitational/teleport/lib/client.(*KubeSession).pipeInOut()
      /__w/teleport/teleport/lib/client/kubesession.go:206 +0xea
  github.com/gravitational/teleport/lib/client.NewKubeSession()
      /__w/teleport/teleport/lib/client/kubesession.go:120 +0x12cb
  github.com/gravitational/teleport/integration.kubeJoin()
      /__w/teleport/teleport/integration/kube_integration_test.go:1518 +0x12a
  github.com/gravitational/teleport/integration.kubeJoinObserverWithSNISet()
      /__w/teleport/teleport/integration/kube_integration_test.go:1750 +0x34b
  github.com/gravitational/teleport/integration.kubeJoinByALBAddr()
      /__w/teleport/teleport/integration/kube_integration_test.go:1740 +0x249
  github.com/gravitational/teleport/integration.testKubeJoin.func5()
      /__w/teleport/teleport/integration/kube_integration_test.go:1663 +0x14e
  testing.tRunner()
      /opt/go/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/go/src/testing/testing.go:1629 +0x47
==================
    testing.go:1446: race detected during execution of test
```

Fixes #26652