### PR TITLE
[Web] Fix scrolling in Node list in web terminal

### DIFF
--- a/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.tsx
+++ b/web/packages/teleport/src/Console/DocumentNodes/DocumentNodes.tsx
@@ -128,6 +128,7 @@ const Container = styled(Box)`
   display: flex;
   flex: 1;
   max-width: 1024px;
+  height: fit-content;
   ::after {
     content: ' ';
     padding-bottom: 24px;

--- a/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -739,6 +739,7 @@ exports[`render DocumentNodes 1`] = `
   display: flex;
   flex: 1;
   max-width: 1024px;
+  height: fit-content;
 }
 
 .c2::after {

--- a/web/packages/teleport/src/Sessions/SessionList/SessionJoinBtn.tsx
+++ b/web/packages/teleport/src/Sessions/SessionList/SessionJoinBtn.tsx
@@ -35,8 +35,14 @@ export const SessionJoinBtn = ({
   participantModes: ParticipantMode[];
   showCTA: boolean;
 }) => {
+  const [anchorEl, setAnchorEl] = useState<HTMLElement>(null);
+
+  function closeMenu() {
+    setAnchorEl(null);
+  }
+
   return (
-    <JoinMenu>
+    <JoinMenu anchorEl={anchorEl} setAnchorEl={setAnchorEl}>
       {showCTA && (
         <Box mx="12px" my="3">
           <ButtonLockedFeature
@@ -56,6 +62,7 @@ export const SessionJoinBtn = ({
         participantMode="observer"
         key="observer"
         showCTA={showCTA}
+        closeMenu={closeMenu}
       />
       <JoinMenuItem
         title="As a Moderator"
@@ -65,6 +72,7 @@ export const SessionJoinBtn = ({
         participantMode="moderator"
         key="moderator"
         showCTA={showCTA}
+        closeMenu={closeMenu}
       />
       <JoinMenuItem
         title="As a Peer"
@@ -74,14 +82,21 @@ export const SessionJoinBtn = ({
         participantMode="peer"
         key="peer"
         showCTA={showCTA}
+        closeMenu={closeMenu}
       />
     </JoinMenu>
   );
 };
 
-function JoinMenu({ children }: { children: React.ReactNode }) {
-  const [anchorEl, setAnchorEl] = useState<HTMLElement>(null);
-
+function JoinMenu({
+  children,
+  anchorEl,
+  setAnchorEl,
+}: {
+  children: React.ReactNode;
+  anchorEl: HTMLElement;
+  setAnchorEl: React.Dispatch<React.SetStateAction<HTMLElement>>;
+}) {
   const handleClickListItem = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -122,6 +137,7 @@ function JoinMenuItem({
   participantMode,
   url,
   showCTA,
+  closeMenu,
 }: {
   title: string;
   description: string;
@@ -129,6 +145,7 @@ function JoinMenuItem({
   participantMode: ParticipantMode;
   url: string;
   showCTA: boolean;
+  closeMenu: () => void;
 }) {
   if (hasAccess && !showCTA) {
     return (
@@ -136,6 +153,7 @@ function JoinMenuItem({
         as="a"
         href={url}
         target="_blank"
+        onClick={closeMenu}
         css={`
           text-decoration: none;
           padding: 8px 12px;

--- a/web/packages/teleport/src/Sessions/SessionList/SessionList.tsx
+++ b/web/packages/teleport/src/Sessions/SessionList/SessionList.tsx
@@ -112,7 +112,7 @@ const renderJoinCell = ({
   showActiveSessionsCTA,
 }: renderJoinCellProps) => {
   const { joinable } = kinds[kind];
-  if (!joinable || participantModes.length === 0) {
+  if (!joinable) {
     return <Cell align="right" height="26px" />;
   }
 


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/26604

Fixes the scrolling on the Nodes list in the web terminal.

Also, for active sessions, makes it so the participant mode menu closes after joining a session rather than staying open.