### PR TITLE
chore: Bump Buf to v1.19.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -298,7 +298,7 @@ RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.18.0" && \
+    VERSION="1.19.0" && \
       curl -fsSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Update to the latest release.

* https://github.com/bufbuild/buf/releases/tag/v1.19.0