### PR TITLE
feat: partial label expression support

### DIFF
--- a/api/types/remotecluster.go
+++ b/api/types/remotecluster.go
@@ -45,6 +45,10 @@ type RemoteCluster interface {
 
 	// Clone performs a deep copy.
 	Clone() RemoteCluster
+
+	// GetLabel retrieves the label with the provided key. If not found value
+	// will be empty and ok will be false.
+	GetLabel(key string) (value string, ok bool)
 }
 
 // NewRemoteCluster is a convenience way to create a RemoteCluster resource.
@@ -163,4 +167,11 @@ func (c *RemoteClusterV3) SetName(e string) {
 // String represents a human readable version of remote cluster settings.
 func (c *RemoteClusterV3) String() string {
 	return fmt.Sprintf("RemoteCluster(%v, %v)", c.Metadata.Name, c.Status.Connection)
+}
+
+// GetLabel retrieves the label with the provided key. If not found value
+// will be empty and ok will be false.
+func (c *RemoteClusterV3) GetLabel(key string) (value string, ok bool) {
+	value, ok = c.Metadata.Labels[key]
+	return value, ok
 }

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -73,10 +73,10 @@ type Role interface {
 
 	// GetLabelMatchers gets the LabelMatchers that match labels of resources of
 	// type [kind] this role is allowed or denied access to.
-	GetLabelMatchers(condition RoleConditionType, kind string) (LabelMatchers, error)
+	GetLabelMatchers(rct RoleConditionType, kind string) (LabelMatchers, error)
 	// SetLabelMatchers sets the LabelMatchers that match labels of resources of
 	// type [kind] this role is allowed or denied access to.
-	SetLabelMatchers(condition RoleConditionType, kind string, labelMatchers LabelMatchers) error
+	SetLabelMatchers(rct RoleConditionType, kind string, labelMatchers LabelMatchers) error
 
 	// GetNodeLabels gets the map of node labels this role is allowed or denied access to.
 	GetNodeLabels(RoleConditionType) Labels
@@ -1580,9 +1580,9 @@ func (l LabelMatchers) Empty() bool {
 
 // GetLabelMatchers gets the LabelMatchers that match labels of resources of
 // type [kind] this role is allowed or denied access to.
-func (r *RoleV6) GetLabelMatchers(condition RoleConditionType, kind string) (LabelMatchers, error) {
+func (r *RoleV6) GetLabelMatchers(rct RoleConditionType, kind string) (LabelMatchers, error) {
 	var cond *RoleConditions
-	if condition {
+	if rct == Allow {
 		cond = &r.Spec.Allow
 	} else {
 		cond = &r.Spec.Deny
@@ -1612,9 +1612,9 @@ func (r *RoleV6) GetLabelMatchers(condition RoleConditionType, kind string) (Lab
 
 // SetLabelMatchers sets the LabelMatchers that match labels of resources of
 // type [kind] this role is allowed or denied access to.
-func (r *RoleV6) SetLabelMatchers(condition RoleConditionType, kind string, labelMatchers LabelMatchers) error {
+func (r *RoleV6) SetLabelMatchers(rct RoleConditionType, kind string, labelMatchers LabelMatchers) error {
 	var cond *RoleConditions
-	if condition {
+	if rct == Allow {
 		cond = &r.Spec.Allow
 	} else {
 		cond = &r.Spec.Deny

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1512,7 +1512,11 @@ func (a *Server) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 	accessInfo := services.AccessInfoFromUser(req.User)
 	roles := make([]types.Role, len(req.Roles))
 	for i := range req.Roles {
-		roles[i] = services.ApplyTraits(req.Roles[i], req.User.GetTraits())
+		var err error
+		roles[i], err = services.ApplyTraits(req.Roles[i], req.User.GetTraits())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	roleSet := services.NewRoleSet(roles...)
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1889,7 +1889,7 @@ func (set RoleSet) CheckAccessToRemoteCluster(rc types.RemoteCluster) error {
 		}
 		if matchLabels {
 			// This condition avoids formatting calls on large scale.
-			debugf("Access to cluster %v denied, deny rule in %v matched; match(label=%v)",
+			debugf("Access to cluster %v denied, deny rule in %v matched; match(%s)",
 				rc.GetName(), role.GetName(), labelsMessage)
 			return trace.AccessDenied("access to cluster denied")
 		}
@@ -1914,7 +1914,7 @@ func (set RoleSet) CheckAccessToRemoteCluster(rc types.RemoteCluster) error {
 			return nil
 		}
 		if isDebugEnabled {
-			deniedError := trace.AccessDenied("role=%v, match(label=%v)",
+			deniedError := trace.AccessDenied("role=%v, match(%s)",
 				role.GetName(), labelsMessage)
 			errs = append(errs, deniedError)
 		}
@@ -2675,7 +2675,7 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 			return trace.Wrap(err)
 		}
 		if matchLabels {
-			debugf("Access to %v %q denied, deny rule in role %q matched; match(namespace=%v, label=%v)",
+			debugf("Access to %v %q denied, deny rule in role %q matched; match(namespace=%v, %s)",
 				r.GetKind(), r.GetName(), role.GetName(), namespaceMessage, labelsMessage)
 			return trace.AccessDenied("access to %v denied. User does not have permissions. %v",
 				r.GetKind(), additionalDeniedMessage)
@@ -2721,7 +2721,7 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 
 		if !matchLabels {
 			if isDebugEnabled {
-				errs = append(errs, trace.AccessDenied("role=%v, match(label=%v)",
+				errs = append(errs, trace.AccessDenied("role=%v, match(%s)",
 					role.GetName(), labelsMessage))
 			}
 			continue
@@ -2844,7 +2844,7 @@ func checkLabelsMatch(
 			return false, "", trace.Wrap(err)
 		}
 		matches = append(matches, match)
-		messages = append(messages, "labels: "+message)
+		messages = append(messages, "label="+message)
 	}
 
 	if len(labelMatchers.Expression) > 0 {
@@ -2853,10 +2853,10 @@ func checkLabelsMatch(
 			return false, "", trace.Wrap(err)
 		}
 		matches = append(matches, match)
-		messages = append(messages, "expression: "+message)
+		messages = append(messages, "expression="+message)
 	}
 
-	message := strings.Join(messages, " ")
+	message := strings.Join(messages, ", ")
 
 	// Deny rules are greedy, if either matched, it's a match.
 	if condition == types.Deny {
@@ -2878,7 +2878,7 @@ func matchLabelExpression(labelExpression string, resource LabelGetter) (bool, s
 		return false, "", trace.Wrap(err, "evaluating label expression %q", labelExpression)
 	}
 	if match {
-		return true, "match", nil
+		return true, "matched", nil
 	}
 	return false, "no match", nil
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1862,17 +1862,14 @@ func (set RoleSet) CheckAccessToRemoteCluster(rc types.RemoteCluster) error {
 	// matchers and the cluster has no labels, assume that the role set has
 	// access to the cluster.
 	usesLabels := false
-outer:
 	for _, role := range set {
-		for _, cond := range []types.RoleConditionType{types.Allow, types.Deny} {
-			labelMatchers, err := role.GetLabelMatchers(cond, types.KindRemoteCluster)
-			if err != nil {
-				return trace.Wrap(err)
-			}
-			if !labelMatchers.Empty() {
-				usesLabels = true
-				break outer
-			}
+		unset, err := labelMatchersUnset(role, types.KindRemoteCluster)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		if !unset {
+			usesLabels = true
+			break
 		}
 	}
 

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -301,23 +301,35 @@ func validateRoleExpressions(r types.Role) error {
 		}
 
 		for _, labels := range []struct {
-			name   string
-			labels types.Labels
+			name string
+			kind string
 		}{
-			{"node_labels", r.GetNodeLabels(condition.condition)},
-			{"app_labels", r.GetAppLabels(condition.condition)},
-			{"kubernetes_labels", r.GetKubernetesLabels(condition.condition)},
-			{"db_labels", r.GetDatabaseLabels(condition.condition)},
-			{"windows_desktop_labels", r.GetWindowsDesktopLabels(condition.condition)},
-			{"cluster_labels", r.GetClusterLabels(condition.condition)},
+			{"cluster_labels", types.KindRemoteCluster},
+			{"node_labels", types.KindNode},
+			{"kubernetes_labels", types.KindKubernetesCluster},
+			{"app_labels", types.KindApp},
+			{"db_labels", types.KindDatabase},
+			{"db_service_labels", types.KindDatabaseService},
+			{"windows_desktop_labels", types.KindWindowsDesktop},
+			{"group_labels", types.KindUserGroup},
 		} {
-			for _, labelValues := range labels.labels {
+			labelMatchers, err := r.GetLabelMatchers(condition.condition, labels.kind)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			for _, labelValues := range labelMatchers.Labels {
 				for _, label := range labelValues {
 					_, err := parse.NewTraitsTemplateExpression(label)
 					if err != nil {
-						err = trace.BadParameter("parsing %s.%s expression: %v", condition.name, labels.name, err)
+						err = trace.BadParameter("parsing %s.%s template expression: %v", condition.name, labels.name, err)
 						errs = append(errs, err)
 					}
+				}
+			}
+			if len(labelMatchers.Expression) > 0 {
+				if _, err := parseLabelExpression(labelMatchers.Expression); err != nil {
+					err = trace.BadParameter("parsing %s.%s_expression: %v", condition.name, labels.name, err)
+					errs = append(errs, err)
 				}
 			}
 		}
@@ -411,8 +423,9 @@ func MatchValidAzureIdentity(identity string) bool {
 
 // ApplyTraits applies the passed in traits to any variables within the role
 // and returns itself.
-func ApplyTraits(r types.Role, traits map[string][]string) types.Role {
+func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 	for _, condition := range []types.RoleConditionType{types.Allow, types.Deny} {
+
 		inLogins := r.GetLogins(condition)
 		outLogins := applyValueTraitsSlice(inLogins, traits, "login")
 		outLogins = filterInvalidUnixLogins(outLogins)
@@ -461,46 +474,27 @@ func ApplyTraits(r types.Role, traits map[string][]string) types.Role {
 		outDbRoles := applyValueTraitsSlice(inDbRoles, traits, "database role")
 		r.SetDatabaseRoles(condition, apiutils.Deduplicate(outDbRoles))
 
-		// apply templates to node labels
-		inLabels := r.GetNodeLabels(condition)
-		if inLabels != nil {
-			r.SetNodeLabels(condition, applyLabelsTraits(inLabels, traits))
-		}
-
-		// apply templates to cluster labels
-		inLabels = r.GetClusterLabels(condition)
-		if inLabels != nil {
-			r.SetClusterLabels(condition, applyLabelsTraits(inLabels, traits))
-		}
-
-		// apply templates to kube labels
-		inLabels = r.GetKubernetesLabels(condition)
-		if inLabels != nil {
-			r.SetKubernetesLabels(condition, applyLabelsTraits(inLabels, traits))
-		}
-
-		// apply templates to app labels
-		inLabels = r.GetAppLabels(condition)
-		if inLabels != nil {
-			r.SetAppLabels(condition, applyLabelsTraits(inLabels, traits))
-		}
-
-		// apply templates to group labels
-		inLabels = r.GetGroupLabels(condition)
-		if inLabels != nil {
-			r.SetGroupLabels(condition, applyLabelsTraits(inLabels, traits))
-		}
-
-		// apply templates to database labels
-		inLabels = r.GetDatabaseLabels(condition)
-		if inLabels != nil {
-			r.SetDatabaseLabels(condition, applyLabelsTraits(inLabels, traits))
-		}
-
-		// apply templates to windows desktop labels
-		inLabels = r.GetWindowsDesktopLabels(condition)
-		if inLabels != nil {
-			r.SetWindowsDesktopLabels(condition, applyLabelsTraits(inLabels, traits))
+		for _, kind := range []string{
+			types.KindRemoteCluster,
+			types.KindNode,
+			types.KindKubernetesCluster,
+			types.KindApp,
+			types.KindDatabase,
+			types.KindDatabaseService,
+			types.KindWindowsDesktop,
+			types.KindUserGroup,
+		} {
+			labelMatchers, err := r.GetLabelMatchers(condition, kind)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			if len(labelMatchers.Labels) == 0 {
+				continue
+			}
+			labelMatchers.Labels = applyLabelsTraits(labelMatchers.Labels, traits)
+			if err := r.SetLabelMatchers(condition, kind, labelMatchers); err != nil {
+				return nil, trace.Wrap(err)
+			}
 		}
 
 		r.SetHostGroups(condition,
@@ -535,7 +529,7 @@ func ApplyTraits(r types.Role, traits map[string][]string) types.Role {
 		r.SetImpersonateConditions(condition, outCond)
 	}
 
-	return r
+	return r, nil
 }
 
 // applyValueTraitsSlice iterates over a slice of input strings, calling
@@ -889,7 +883,11 @@ func FetchRoleList(roleNames []string, access RoleGetter, traits map[string][]st
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		roles = append(roles, ApplyTraits(role, traits))
+		role, err = ApplyTraits(role, traits)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		roles = append(roles, role)
 	}
 
 	return roles, nil
@@ -945,7 +943,10 @@ func FetchAllClusterRoles(ctx context.Context, access CurrentUserRoleGetter, def
 	}
 
 	for i := range roles {
-		roles[i] = ApplyTraits(roles[i], user.GetTraits())
+		roles[i], err = ApplyTraits(roles[i], user.GetTraits())
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 	return NewRoleSet(roles...), nil
 }
@@ -1556,7 +1557,7 @@ func (set RoleSet) CheckDatabaseRoles(database types.Database) (create bool, rol
 	rolesMap := make(map[string]struct{})
 	var matched bool
 	for _, role := range autoCreateRoles {
-		match, _, err := MatchLabels(role.GetDatabaseLabels(types.Allow), database.GetAllLabels())
+		match, _, err := checkRoleLabelsMatch(types.Allow, role, database)
 		if err != nil {
 			return false, nil, trace.Wrap(err)
 		}
@@ -1569,7 +1570,7 @@ func (set RoleSet) CheckDatabaseRoles(database types.Database) (create bool, rol
 		matched = true
 	}
 	for _, role := range autoCreateRoles {
-		match, _, err := MatchLabels(role.GetDatabaseLabels(types.Deny), database.GetAllLabels())
+		match, _, err := checkRoleLabelsMatch(types.Deny, role, database)
 		if err != nil {
 			return false, nil, trace.Wrap(err)
 		}
@@ -1853,13 +1854,21 @@ func (set RoleSet) CheckAccessToRemoteCluster(rc types.RemoteCluster) error {
 
 	rcLabels := rc.GetMetadata().Labels
 
-	// For backwards compatibility, if there is no role in the set with labels and the cluster
-	// has no labels, assume that the role set has access to the cluster.
+	// For backwards compatibility, if there is no role in the set with label
+	// matchers and the cluster has no labels, assume that the role set has
+	// access to the cluster.
 	usesLabels := false
+outer:
 	for _, role := range set {
-		if len(role.GetClusterLabels(types.Allow)) != 0 || len(role.GetClusterLabels(types.Deny)) != 0 {
-			usesLabels = true
-			break
+		for _, cond := range []types.RoleConditionType{types.Allow, types.Deny} {
+			labelMatchers, err := role.GetLabelMatchers(cond, types.KindRemoteCluster)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			if !labelMatchers.Empty() {
+				usesLabels = true
+				break outer
+			}
 		}
 	}
 
@@ -1873,7 +1882,7 @@ func (set RoleSet) CheckAccessToRemoteCluster(rc types.RemoteCluster) error {
 	// the deny role set prohibits access.
 	var errs []error
 	for _, role := range set {
-		matchLabels, labelsMessage, err := MatchLabels(role.GetClusterLabels(types.Deny), rcLabels)
+		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, rc)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -1887,9 +1896,16 @@ func (set RoleSet) CheckAccessToRemoteCluster(rc types.RemoteCluster) error {
 
 	// Check allow rules: label has to match in any role in the role set to be granted access.
 	for _, role := range set {
-		matchLabels, labelsMessage, err := MatchLabels(role.GetClusterLabels(types.Allow), rcLabels)
+		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, rc)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		labelMatchers, err := role.GetLabelMatchers(types.Allow, types.KindRemoteCluster)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 		debugf("Check access to role(%v) rc(%v, labels=%v) matchLabels=%v, msg=%v, err=%v allow=%v rcLabels=%v",
-			role.GetName(), rc.GetName(), rcLabels, matchLabels, labelsMessage, err, role.GetClusterLabels(types.Allow), rcLabels)
+			role.GetName(), rc.GetName(), rcLabels, matchLabels, labelsMessage, err, labelMatchers, rcLabels)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2572,13 +2588,20 @@ func NewKubernetesClusterLabelMatcher(clustersLabels map[string]string) RoleMatc
 
 // Match matches a Kubernetes cluster labels against a role.
 func (l *kubernetesClusterLabelMatcher) Match(role types.Role, typ types.RoleConditionType) (bool, error) {
-	ok, _, err := MatchLabels(l.getKubeLabels(role, typ), l.clusterLabels)
+	labelMatchers, err := l.getKubeLabelMatchers(role, typ)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	ok, _, err := checkLabelsMatch(typ, labelMatchers, mapLabelGetter(l.clusterLabels))
 	return ok, trace.Wrap(err)
 }
 
-// getKubeLabels returns kubernetes_labels based on resource version and role type.
-func (l kubernetesClusterLabelMatcher) getKubeLabels(role types.Role, typ types.RoleConditionType) types.Labels {
-	labels := role.GetKubernetesLabels(typ)
+// getKubeLabelMatchers returns kubernetes_labels based on resource version and role type.
+func (l kubernetesClusterLabelMatcher) getKubeLabelMatchers(role types.Role, typ types.RoleConditionType) (types.LabelMatchers, error) {
+	labelMatchers, err := role.GetLabelMatchers(typ, types.KindKubernetesCluster)
+	if err != nil {
+		return types.LabelMatchers{}, trace.Wrap(err)
+	}
 
 	// After the introduction of https://github.com/gravitational/teleport/pull/9759 the
 	// kubernetes_labels started to be respected. Former role behavior evaluated deny rules
@@ -2587,10 +2610,10 @@ func (l kubernetesClusterLabelMatcher) getKubeLabels(role types.Role, typ types.
 	// Default wildcard rules should be added to  deny.kubernetes_labels if
 	// deny.kubernetes_labels is empty to ensure that deny rule will be evaluated
 	// even if kubernetes_labels are empty.
-	if len(labels) == 0 && typ == types.Deny {
-		return map[string]apiutils.Strings{types.Wildcard: []string{types.Wildcard}}
+	if labelMatchers.Empty() && typ == types.Deny {
+		labelMatchers.Labels = types.Labels{types.Wildcard: []string{types.Wildcard}}
 	}
-	return labels
+	return labelMatchers, nil
 }
 
 // AccessCheckable is the subset of types.Resource required for the RBAC checks.
@@ -2628,32 +2651,15 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 	// Additional message depending on kind of resource
 	// so there's more context on why the user might not have access.
 	additionalDeniedMessage := ""
-
-	var getRoleLabels func(types.Role, types.RoleConditionType) types.Labels
-
 	switch r.GetKind() {
 	case types.KindDatabase:
-		getRoleLabels = types.Role.GetDatabaseLabels
 		additionalDeniedMessage = "Confirm database user and name."
-	case types.KindDatabaseService:
-		getRoleLabels = types.Role.GetDatabaseServiceLabels
-	case types.KindApp:
-		getRoleLabels = types.Role.GetAppLabels
-	case types.KindUserGroup:
-		getRoleLabels = types.Role.GetGroupLabels
 	case types.KindNode:
-		getRoleLabels = types.Role.GetNodeLabels
 		additionalDeniedMessage = "Confirm SSH login."
 	case types.KindKubernetesCluster:
-		getRoleLabels = types.Role.GetKubernetesLabels
 		additionalDeniedMessage = "Confirm Kubernetes user or group."
 	case types.KindWindowsDesktop:
-		getRoleLabels = types.Role.GetWindowsDesktopLabels
 		additionalDeniedMessage = "Confirm Windows user."
-	case types.KindWindowsDesktopService:
-		getRoleLabels = types.Role.GetWindowsDesktopLabels
-	default:
-		return trace.BadParameter("cannot match labels for kind %v", r.GetKind())
 	}
 
 	// Check deny rules.
@@ -2663,7 +2669,7 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 			continue
 		}
 
-		matchLabels, labelsMessage, err := MatchLabelGetter(getRoleLabels(role, types.Deny), r)
+		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Deny, role, r)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2707,7 +2713,7 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 			continue
 		}
 
-		matchLabels, labelsMessage, err := MatchLabelGetter(getRoleLabels(role, types.Allow), r)
+		matchLabels, labelsMessage, err := checkRoleLabelsMatch(types.Allow, role, r)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -2778,6 +2784,102 @@ func (set RoleSet) checkAccess(r AccessCheckable, state AccessState, matchers ..
 	debugf("Access to %v %q denied, no allow rule matched; %v", r.GetKind(), r.GetName(), errs)
 	return trace.AccessDenied("access to %v denied. User does not have permissions. %v",
 		r.GetKind(), additionalDeniedMessage)
+}
+
+// checkRoleLabelsMatch checks if the [role] matches the labels of [resource]
+// for [condition].
+// It considers both the role labels (<kind>_labels) and label expression
+// (<kind>_labels_expression).
+//
+// Returns a match boolean, a debug message, and any unexpected error.
+//
+// If [condition] is types.Deny, the match is greedy, if either one matches it's
+// considered a match.
+//
+// If [condition] is types.Allow, the match is not greedy, if either doesn't
+// match it's not considered a match.
+//
+// If neither is set, it's not a match in either case.
+func checkRoleLabelsMatch(
+	condition types.RoleConditionType,
+	role types.Role,
+	resource AccessCheckable) (bool, string, error) {
+
+	labelMatchers, err := role.GetLabelMatchers(condition, resource.GetKind())
+	if err != nil {
+		return false, "", trace.Wrap(err)
+	}
+	return checkLabelsMatch(condition, labelMatchers, resource)
+}
+
+// checkLabelsMatch checks if the [labelMatchers] match the labels of [resource]
+// for [condition].
+// It considers both [labelMatchers.Labels] and [labelMatchers.Expression].
+//
+// Returns a match boolean, a debug message, and any unexpected error.
+//
+// If [condition] is types.Deny, the match is greedy, if either one matches it's
+// considered a match.
+//
+// If [condition] is types.Allow, the match is not greedy, if either doesn't
+// match it's not considered a match.
+//
+// If neither is set, it's not a match in either case.
+func checkLabelsMatch(
+	condition types.RoleConditionType,
+	labelMatchers types.LabelMatchers,
+	resource LabelGetter,
+) (bool, string, error) {
+	if labelMatchers.Empty() {
+		return false, "no label matchers or label expression", nil
+	}
+
+	var matches []bool
+	var messages []string
+
+	if len(labelMatchers.Labels) > 0 {
+		match, message, err := MatchLabelGetter(labelMatchers.Labels, resource)
+		if err != nil {
+			return false, "", trace.Wrap(err)
+		}
+		matches = append(matches, match)
+		messages = append(messages, "labels: "+message)
+	}
+
+	if len(labelMatchers.Expression) > 0 {
+		match, message, err := matchLabelExpression(labelMatchers.Expression, resource)
+		if err != nil {
+			return false, "", trace.Wrap(err)
+		}
+		matches = append(matches, match)
+		messages = append(messages, "expression: "+message)
+	}
+
+	message := strings.Join(messages, " ")
+
+	// Deny rules are greedy, if either matched, it's a match.
+	if condition == types.Deny {
+		return slices.Contains(matches, true), message, nil
+	}
+	// Allow rules are not greedy, both must match if they are set.
+	return !slices.Contains(matches, false), message, nil
+}
+
+func matchLabelExpression(labelExpression string, resource LabelGetter) (bool, string, error) {
+	parsedExpr, err := parseLabelExpression(labelExpression)
+	if err != nil {
+		return false, "", trace.Wrap(err)
+	}
+	match, err := parsedExpr.Evaluate(labelExpressionEnv{
+		resourceLabelGetter: resource,
+	})
+	if err != nil {
+		return false, "", trace.Wrap(err, "evaluating label expression %q", labelExpression)
+	}
+	if match {
+		return true, "match", nil
+	}
+	return false, "no match", nil
 }
 
 // CanForwardAgents returns true if role set allows forwarding agents.
@@ -2923,9 +3025,8 @@ func (set RoleSet) EnhancedRecordingSet() map[string]bool {
 // DesktopGroups returns the desktop groups a user is allowed to create or an access denied error if a role disallows desktop user creation
 func (set RoleSet) DesktopGroups(s types.WindowsDesktop) ([]string, error) {
 	groups := make(map[string]struct{})
-	labels := s.GetAllLabels()
 	for _, role := range set {
-		result, _, err := MatchLabels(role.GetWindowsDesktopLabels(types.Allow), labels)
+		result, _, err := checkRoleLabelsMatch(types.Allow, role, s)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2944,7 +3045,7 @@ func (set RoleSet) DesktopGroups(s types.WindowsDesktop) ([]string, error) {
 		}
 	}
 	for _, role := range set {
-		result, _, err := MatchLabels(role.GetWindowsDesktopLabels(types.Deny), labels)
+		result, _, err := checkRoleLabelsMatch(types.Deny, role, s)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -2964,7 +3065,6 @@ func (set RoleSet) DesktopGroups(s types.WindowsDesktop) ([]string, error) {
 func (set RoleSet) HostUsers(s types.Server) (*HostUsersInfo, error) {
 	groups := make(map[string]struct{})
 	var sudoers []string
-	serverLabels := s.GetAllLabels()
 
 	roleSet := make([]types.Role, len(set))
 	copy(roleSet, set)
@@ -2974,7 +3074,7 @@ func (set RoleSet) HostUsers(s types.Server) (*HostUsersInfo, error) {
 
 	seenSudoers := make(map[string]struct{})
 	for _, role := range roleSet {
-		result, _, err := MatchLabels(role.GetNodeLabels(types.Allow), serverLabels)
+		result, _, err := checkRoleLabelsMatch(types.Allow, role, s)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3002,7 +3102,7 @@ func (set RoleSet) HostUsers(s types.Server) (*HostUsersInfo, error) {
 
 	var finalSudoers []string
 	for _, role := range roleSet {
-		result, _, err := MatchLabels(role.GetNodeLabels(types.Deny), serverLabels)
+		result, _, err := checkRoleLabelsMatch(types.Deny, role, s)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -3128,7 +3228,7 @@ func (set RoleSet) CheckAccessToRule(ctx RuleContext, namespace string, resource
 // GetKubeResources returns allowed and denied list of Kubernetes Resources configured in the RoleSet.
 func (set RoleSet) GetKubeResources(cluster types.KubeCluster) (allowed, denied []types.KubernetesResource) {
 	for _, role := range set {
-		matchLabels, _, err := MatchLabels(role.GetKubernetesLabels(types.Allow), cluster.GetAllLabels())
+		matchLabels, _, err := checkRoleLabelsMatch(types.Allow, role, cluster)
 		if err != nil || !matchLabels {
 			continue
 		}
@@ -3136,7 +3236,7 @@ func (set RoleSet) GetKubeResources(cluster types.KubeCluster) (allowed, denied 
 	}
 
 	for _, role := range set {
-		matchLabels, _, err := MatchLabels(role.GetKubernetesLabels(types.Deny), cluster.GetAllLabels())
+		matchLabels, _, err := checkRoleLabelsMatch(types.Deny, role, cluster)
 		if err != nil || !matchLabels {
 			continue
 		}

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -488,6 +488,10 @@ func ApplyTraits(r types.Role, traits map[string][]string) (types.Role, error) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
+			// Only labelMatchers.Labels is templated, if empty we can skip
+			// these label matchers. labelMatchers.Expression can reference user
+			// traits later during the access check through the expression
+			// environment, they are not templated in here.
 			if len(labelMatchers.Labels) == 0 {
 				continue
 			}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -45,6 +45,8 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
+const matchAllExpression = `"" == ""`
+
 // TestConnAndSessLimits verifies that role sets correctly calculate
 // a user's MaxConnections and MaxSessions values from multiple
 // roles with different individual values.  These are tested together since
@@ -880,19 +882,59 @@ func TestValidateRole(t *testing.T) {
 				},
 			},
 			expectWarnings: []string{
-				"parsing allow.node_labels expression",
-				"parsing allow.app_labels expression",
-				"parsing allow.kubernetes_labels expression",
-				"parsing allow.db_labels expression",
-				"parsing allow.windows_desktop_labels expression",
-				"parsing allow.cluster_labels expression",
-				"parsing deny.node_labels expression",
-				"parsing deny.app_labels expression",
-				"parsing deny.kubernetes_labels expression",
-				"parsing deny.db_labels expression",
-				"parsing deny.windows_desktop_labels expression",
-				"parsing deny.cluster_labels expression",
+				"parsing allow.node_labels template expression",
+				"parsing allow.app_labels template expression",
+				"parsing allow.kubernetes_labels template expression",
+				"parsing allow.db_labels template expression",
+				"parsing allow.windows_desktop_labels template expression",
+				"parsing allow.cluster_labels template expression",
+				"parsing deny.node_labels template expression",
+				"parsing deny.app_labels template expression",
+				"parsing deny.kubernetes_labels template expression",
+				"parsing deny.db_labels template expression",
+				"parsing deny.windows_desktop_labels template expression",
+				"parsing deny.cluster_labels template expression",
 				"unsupported function: email.localz",
+			},
+		},
+		{
+			name: "unsupported function in labels expression",
+			spec: types.RoleSpecV6{
+				Allow: types.RoleConditions{
+					ClusterLabelsExpression:         `containz(labels["env"], "staging")`,
+					NodeLabelsExpression:            `containz(labels["env"], "staging")`,
+					AppLabelsExpression:             `containz(labels["env"], "staging")`,
+					KubernetesLabelsExpression:      `containz(labels["env"], "staging")`,
+					DatabaseLabelsExpression:        `containz(labels["env"], "staging")`,
+					DatabaseServiceLabelsExpression: `containz(labels["env"], "staging")`,
+					WindowsDesktopLabelsExpression:  `containz(labels["env"], "staging")`,
+					GroupLabelsExpression:           `containz(labels["env"], "staging")`,
+				},
+				Deny: types.RoleConditions{
+					ClusterLabelsExpression:         `containz(labels["env"], "staging")`,
+					NodeLabelsExpression:            `containz(labels["env"], "staging")`,
+					AppLabelsExpression:             `containz(labels["env"], "staging")`,
+					KubernetesLabelsExpression:      `containz(labels["env"], "staging")`,
+					DatabaseLabelsExpression:        `containz(labels["env"], "staging")`,
+					DatabaseServiceLabelsExpression: `containz(labels["env"], "staging")`,
+					WindowsDesktopLabelsExpression:  `containz(labels["env"], "staging")`,
+					GroupLabelsExpression:           `containz(labels["env"], "staging")`,
+				},
+			},
+			expectWarnings: []string{
+				"parsing allow.node_labels_expression",
+				"parsing allow.app_labels_expression",
+				"parsing allow.kubernetes_labels_expression",
+				"parsing allow.db_labels_expression",
+				"parsing allow.windows_desktop_labels_expression",
+				"parsing allow.cluster_labels_expression",
+				"parsing deny.node_labels_expression",
+				"parsing deny.app_labels_expression",
+				"parsing deny.kubernetes_labels_expression",
+				"parsing deny.db_labels_expression",
+				"parsing deny.windows_desktop_labels_expression",
+				"parsing deny.cluster_labels_expression",
+				"unsupported function: containz",
 			},
 		},
 		{
@@ -988,6 +1030,9 @@ func TestValidateRole(t *testing.T) {
 			}
 			require.NoError(t, err, trace.DebugReport(err))
 
+			if len(tc.expectWarnings) == 0 {
+				require.Empty(t, warning)
+			}
 			for _, msg := range tc.expectWarnings {
 				require.ErrorContains(t, warning, msg)
 			}
@@ -1605,6 +1650,21 @@ func TestCheckAccessToServer(t *testing.T) {
 				{server: serverDB, login: "root", hasAccess: true},
 			},
 		},
+		{
+			name: "label expressions",
+			roles: []*types.RoleV6{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.NodeLabels = nil
+					r.Spec.Allow.NodeLabelsExpression = `labels.role == "worker" && labels.status == "follower"`
+					r.Spec.Allow.Logins = []string{"root"}
+				}),
+			},
+			checks: []check{
+				{server: serverNoLabels, login: "root", hasAccess: false},
+				{server: serverWorker, login: "root", hasAccess: true},
+				{server: serverDB, login: "root", hasAccess: false},
+			},
+		},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -1657,6 +1717,9 @@ func TestCheckAccessToRemoteCluster(t *testing.T) {
 			Labels: map[string]string{"role": "db", "status": "follower"},
 		},
 	}
+	require.NoError(t, rcA.CheckAndSetDefaults())
+	require.NoError(t, rcB.CheckAndSetDefaults())
+	require.NoError(t, rcC.CheckAndSetDefaults())
 	testCases := []struct {
 		name   string
 		roles  []types.RoleV6
@@ -1878,6 +1941,19 @@ func TestCheckAccessToRemoteCluster(t *testing.T) {
 				{rc: rcA, hasAccess: false},
 				{rc: rcB, hasAccess: false},
 				{rc: rcC, hasAccess: true},
+			},
+		},
+		{
+			name: "label expressions",
+			roles: []types.RoleV6{
+				*newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.ClusterLabelsExpression = `labels.role == "worker" && labels.status == "follower"`
+				}),
+			},
+			checks: []check{
+				{rc: rcA, hasAccess: false},
+				{rc: rcB, hasAccess: true},
+				{rc: rcC, hasAccess: false},
 			},
 		},
 	}
@@ -3159,7 +3235,8 @@ func TestApplyTraits(t *testing.T) {
 				},
 			}
 
-			outRole := ApplyTraits(role, tt.inTraits)
+			outRole, err := ApplyTraits(role, tt.inTraits)
+			require.NoError(t, err)
 			rules := []struct {
 				condition types.RoleConditionType
 				spec      *rule
@@ -3356,10 +3433,10 @@ func TestCheckAccessToDatabase(t *testing.T) {
 		Version:  types.V3,
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
-				Namespaces:     []string{apidefaults.Namespace},
-				DatabaseLabels: types.Labels{"env": []string{"prod"}},
-				DatabaseNames:  []string{"test"},
-				DatabaseUsers:  []string{"dev"},
+				Namespaces:               []string{apidefaults.Namespace},
+				DatabaseLabelsExpression: `labels["env"] == "prod"`,
+				DatabaseNames:            []string{"test"},
+				DatabaseUsers:            []string{"dev"},
 			},
 		},
 	}
@@ -3566,9 +3643,9 @@ func TestCheckAccessToDatabaseUser(t *testing.T) {
 		Metadata: types.Metadata{Name: "dev-prod", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
-				Namespaces:     []string{apidefaults.Namespace},
-				DatabaseLabels: types.Labels{"env": []string{"prod"}},
-				DatabaseUsers:  []string{"dev"},
+				Namespaces:               []string{apidefaults.Namespace},
+				DatabaseLabelsExpression: `labels["env"] == "prod"`,
+				DatabaseUsers:            []string{"dev"},
 			},
 		},
 	}
@@ -4061,7 +4138,8 @@ func TestCheckDatabaseRoles(t *testing.T) {
 		},
 	}
 
-	// roleB allows auto-user provisioning for production database.
+	// roleB allows auto-user provisioning for production database and uses
+	// label expressions.
 	roleB := &types.RoleV6{
 		Metadata: types.Metadata{Name: "roleB", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
@@ -4069,17 +4147,18 @@ func TestCheckDatabaseRoles(t *testing.T) {
 				CreateDatabaseUser: types.NewBoolOption(true),
 			},
 			Allow: types.RoleConditions{
-				DatabaseLabels: types.Labels{"env": []string{"prod"}},
-				DatabaseRoles:  []string{"reader"},
+				DatabaseLabelsExpression: `labels["env"] == "prod"`,
+				DatabaseRoles:            []string{"reader"},
 			},
 			Deny: types.RoleConditions{
-				DatabaseLabels: types.Labels{"env": []string{"prod"}},
-				DatabaseRoles:  []string{"writer"},
+				DatabaseLabelsExpression: `labels["env"] == "prod"`,
+				DatabaseRoles:            []string{"writer"},
 			},
 		},
 	}
 
-	// roleC allows auto-user provisioning for metrics database.
+	// roleC allows auto-user provisioning for metrics database and uses label
+	// expressions.
 	roleC := &types.RoleV6{
 		Metadata: types.Metadata{Name: "roleC", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
@@ -4295,8 +4374,8 @@ func TestCheckAccessToDatabaseService(t *testing.T) {
 		Metadata: types.Metadata{Name: "dev", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
-				Namespaces:     []string{apidefaults.Namespace},
-				DatabaseLabels: types.Labels{"env": []string{"stage"}},
+				Namespaces:               []string{apidefaults.Namespace},
+				DatabaseLabelsExpression: `labels["env"] == "stage"`,
 			},
 			Deny: types.RoleConditions{
 				Namespaces:     []string{apidefaults.Namespace},
@@ -4407,9 +4486,9 @@ func TestCheckAccessToAWSConsole(t *testing.T) {
 		},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
-				Namespaces:  []string{apidefaults.Namespace},
-				AppLabels:   types.Labels{types.Wildcard: []string{types.Wildcard}},
-				AWSRoleARNs: []string{readOnlyARN},
+				Namespaces:          []string{apidefaults.Namespace},
+				AppLabelsExpression: matchAllExpression,
+				AWSRoleARNs:         []string{readOnlyARN},
 			},
 		},
 	}
@@ -4512,9 +4591,9 @@ func TestCheckAccessToAzureCloud(t *testing.T) {
 		},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
-				Namespaces:      []string{apidefaults.Namespace},
-				AppLabels:       types.Labels{types.Wildcard: []string{types.Wildcard}},
-				AzureIdentities: []string{readOnlyIdentity},
+				Namespaces:          []string{apidefaults.Namespace},
+				AppLabelsExpression: matchAllExpression,
+				AzureIdentities:     []string{readOnlyIdentity},
 			},
 		},
 	}
@@ -4623,9 +4702,9 @@ func TestCheckAccessToGCP(t *testing.T) {
 		},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
-				Namespaces:         []string{apidefaults.Namespace},
-				AppLabels:          types.Labels{types.Wildcard: []string{types.Wildcard}},
-				GCPServiceAccounts: []string{readOnlyAccount, fullAccessAccount},
+				Namespaces:          []string{apidefaults.Namespace},
+				AppLabelsExpression: matchAllExpression,
+				GCPServiceAccounts:  []string{readOnlyAccount, fullAccessAccount},
 			},
 		},
 	}
@@ -5243,11 +5322,8 @@ func TestCheckAccessToKubernetes(t *testing.T) {
 				RequireMFAType: types.RequireMFAType_SESSION,
 			},
 			Allow: types.RoleConditions{
-				Namespaces: []string{apidefaults.Namespace},
-				KubernetesLabels: types.Labels{
-					"foo": apiutils.Strings{"bar"},
-					"baz": apiutils.Strings{"qux"},
-				},
+				Namespaces:                 []string{apidefaults.Namespace},
+				KubernetesLabelsExpression: `labels.foo == "bar" && labels.baz == "qux"`,
 			},
 		},
 	}
@@ -5670,6 +5746,26 @@ func TestCheckAccessToWindowsDesktop(t *testing.T) {
 				{desktop: desktop2012, login: "admin", hasAccess: true},
 			},
 		},
+		{
+			name: "labels expression more permissive than another role",
+			roleSet: RoleSet{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLogins = []string{"admin"}
+					r.Spec.Allow.NodeLabels = types.Labels{"win_version": []string{"2012"}}
+				}),
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = nil
+					r.Spec.Allow.WindowsDesktopLabelsExpression = matchAllExpression
+					r.Spec.Allow.WindowsDesktopLogins = []string{"root", "admin"}
+				}),
+			},
+			checks: []check{
+				{desktop: desktopNoLabels, login: "root", hasAccess: true},
+				{desktop: desktopNoLabels, login: "admin", hasAccess: true},
+				{desktop: desktop2012, login: "root", hasAccess: true},
+				{desktop: desktop2012, login: "admin", hasAccess: true},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			for i, check := range test.checks {
@@ -5757,6 +5853,19 @@ func TestCheckAccessToUserGroups(t *testing.T) {
 				newRole(func(r *types.RoleV6) {
 					r.Spec.Deny.Namespaces = []string{apidefaults.Namespace}
 					r.Spec.Allow.GroupLabels = types.Labels{types.Wildcard: []string{types.Wildcard}}
+				}),
+			},
+			checks: []check{
+				{userGroup: userGroupNoLabels, hasAccess: true},
+				{userGroup: userGroupLabels, hasAccess: true},
+			},
+		},
+		{
+			name: "labels expression, access",
+			roleSet: RoleSet{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Deny.Namespaces = []string{apidefaults.Namespace}
+					r.Spec.Allow.GroupLabelsExpression = matchAllExpression
 				}),
 			},
 			checks: []check{
@@ -6048,11 +6157,9 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 		Metadata: types.Metadata{Name: "roleA", Namespace: apidefaults.Namespace},
 		Spec: types.RoleSpecV6{
 			Allow: types.RoleConditions{
-				KubeGroups: []string{"system:masters"},
-				KubeUsers:  []string{"dev-user"},
-				KubernetesLabels: map[string]apiutils.Strings{
-					"env": []string{"dev"},
-				},
+				KubeGroups:                 []string{"system:masters"},
+				KubeUsers:                  []string{"dev-user"},
+				KubernetesLabelsExpression: `labels["env"] == "dev"`,
 			},
 		},
 	}
@@ -6353,6 +6460,197 @@ func TestCheckKubeGroupsAndUsers(t *testing.T) {
 	}
 }
 
+func TestWindowsDesktopGroups(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		desc          string
+		roles         []types.Role
+		desktopLabels map[string]string
+		expectDenied  bool
+		expectGroups  []string
+	}{
+		{
+			desc: "allow labels",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = types.Labels{"env": {"prod"}}
+					r.Spec.Allow.DesktopGroups = []string{"a", "b", "c"}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+				}),
+			},
+			desktopLabels: map[string]string{"env": "prod"},
+			expectGroups:  []string{"a", "b", "c"},
+		},
+		{
+			desc: "allow expression",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = nil
+					r.Spec.Allow.WindowsDesktopLabelsExpression = `labels["env"] == "prod"`
+					r.Spec.Allow.DesktopGroups = []string{"a", "b", "c"}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+				}),
+			},
+			desktopLabels: map[string]string{"env": "prod"},
+			expectGroups:  []string{"a", "b", "c"},
+		},
+		{
+			desc: "option denied",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = types.Labels{"*": {"*"}}
+					r.Spec.Allow.DesktopGroups = []string{"a", "b", "c"}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+				}),
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = types.Labels{"env": {"prod"}}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(false)
+				}),
+			},
+			desktopLabels: map[string]string{"env": "prod"},
+			expectDenied:  true,
+		},
+		{
+			desc: "irrelevant deny",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = types.Labels{"*": {"*"}}
+					r.Spec.Allow.DesktopGroups = []string{"a", "b", "c"}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+				}),
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = types.Labels{"env": {"prod"}}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(false)
+				}),
+			},
+			desktopLabels: map[string]string{"env": "staging"},
+			expectGroups:  []string{"a", "b", "c"},
+		},
+		{
+			desc: "one group denied",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.WindowsDesktopLabels = types.Labels{"env": {"prod"}}
+					r.Spec.Allow.DesktopGroups = []string{"a", "b", "c"}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+				}),
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Deny.WindowsDesktopLabels = nil
+					r.Spec.Deny.WindowsDesktopLabelsExpression = matchAllExpression
+					r.Spec.Deny.DesktopGroups = []string{"b"}
+					r.Spec.Options.CreateDesktopUser = types.NewBoolOption(true)
+				}),
+			},
+			desktopLabels: map[string]string{"env": "prod"},
+			expectGroups:  []string{"a", "c"},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			desktop := mustMakeTestWindowsDesktop(tc.desktopLabels)
+			set := NewRoleSet(tc.roles...)
+			groups, err := set.DesktopGroups(desktop)
+			if tc.expectDenied {
+				require.True(t, trace.IsAccessDenied(err), "expected access denied error, got %v", err)
+				return
+			}
+			require.NoError(t, err, trace.DebugReport(err))
+			require.ElementsMatch(t, tc.expectGroups, groups)
+		})
+	}
+}
+
+func TestGetKubeResources(t *testing.T) {
+	t.Parallel()
+	podA := types.KubernetesResource{
+		Kind:      types.KindKubePod,
+		Namespace: "test",
+		Name:      "podA",
+	}
+	podB := types.KubernetesResource{
+		Kind:      types.KindKubePod,
+		Namespace: "test",
+		Name:      "podB",
+	}
+	for _, tc := range []struct {
+		desc                        string
+		roles                       []types.Role
+		clusterLabels               map[string]string
+		expectAllowed, expectDenied []types.KubernetesResource
+	}{
+		{
+			desc: "labels allow",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.KubernetesLabels = types.Labels{"env": {"prod"}}
+					r.Spec.Allow.KubernetesResources =
+						[]types.KubernetesResource{podA, podB}
+				}),
+			},
+			clusterLabels: map[string]string{"env": "prod"},
+			expectAllowed: []types.KubernetesResource{podA, podB},
+		},
+		{
+			desc: "labels expression allow",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.KubernetesLabelsExpression = `labels["env"] == "prod"`
+					r.Spec.Allow.KubernetesResources =
+						[]types.KubernetesResource{podA, podB}
+				}),
+			},
+			clusterLabels: map[string]string{"env": "prod"},
+			expectAllowed: []types.KubernetesResource{podA, podB},
+		},
+		{
+			desc: "one denied",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.KubernetesLabelsExpression = `labels["env"] == "prod"`
+					r.Spec.Allow.KubernetesResources =
+						[]types.KubernetesResource{podA, podB}
+				}),
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Deny.KubernetesLabels = types.Labels{"env": {"prod"}}
+					r.Spec.Deny.KubernetesResources =
+						[]types.KubernetesResource{podA}
+				}),
+			},
+			clusterLabels: map[string]string{"env": "prod"},
+			expectAllowed: []types.KubernetesResource{podA, podB},
+			expectDenied:  []types.KubernetesResource{podA},
+		},
+		{
+			desc: "irrelevant deny",
+			roles: []types.Role{
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Allow.KubernetesLabelsExpression = `labels["env"] == "staging"`
+					r.Spec.Allow.KubernetesResources =
+						[]types.KubernetesResource{podA, podB}
+				}),
+				newRole(func(r *types.RoleV6) {
+					r.Spec.Deny.KubernetesLabels = types.Labels{"env": {"prod"}}
+					r.Spec.Deny.KubernetesResources =
+						[]types.KubernetesResource{podA}
+				}),
+			},
+			clusterLabels: map[string]string{"env": "staging"},
+			expectAllowed: []types.KubernetesResource{podA, podB},
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			cluster, err := types.NewKubernetesClusterV3(types.Metadata{
+				Name:   "testcluster",
+				Labels: tc.clusterLabels,
+			}, types.KubernetesClusterSpecV3{})
+			require.NoError(t, err)
+			set := NewRoleSet(tc.roles...)
+			allowed, denied := set.GetKubeResources(cluster)
+			require.ElementsMatch(t, tc.expectAllowed, allowed, "allow list mismatch")
+			require.ElementsMatch(t, tc.expectDenied, denied, "deny list mismatch")
+		})
+	}
+}
+
 func TestSessionRecordingMode(t *testing.T) {
 	tests := map[string]struct {
 		service      constants.SessionRecordingService
@@ -6440,6 +6738,7 @@ func TestHostUsers_getGroups(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6472,6 +6771,7 @@ func TestHostUsers_getGroups(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6511,6 +6811,7 @@ func TestHostUsers_getGroups(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6550,6 +6851,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6598,6 +6900,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6630,6 +6933,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6665,6 +6969,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6716,6 +7021,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6767,6 +7073,7 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6805,6 +7112,7 @@ func TestHostUsers_CanCreateHostUser(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6830,11 +7138,12 @@ func TestHostUsers_CanCreateHostUser(t *testing.T) {
 						CreateHostUser: types.NewBoolOption(false),
 					},
 					Allow: types.RoleConditions{
-						NodeLabels: types.Labels{"success": []string{"abc"}},
+						NodeLabelsExpression: `labels["success"] == "abc"`,
 					},
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -6860,7 +7169,7 @@ func TestHostUsers_CanCreateHostUser(t *testing.T) {
 						CreateHostUser: types.NewBoolOption(true),
 					},
 					Allow: types.RoleConditions{
-						NodeLabels: types.Labels{"success": []string{"abc"}},
+						NodeLabelsExpression: `labels["success"] == "abc"`,
 					},
 				},
 			}, &types.RoleV6{
@@ -6874,6 +7183,7 @@ func TestHostUsers_CanCreateHostUser(t *testing.T) {
 				},
 			}),
 			server: &types.ServerV2{
+				Kind: types.KindNode,
 				Metadata: types.Metadata{
 					Labels: map[string]string{
 						"success": "abc",
@@ -7735,4 +8045,140 @@ func TestKubeResourcesMatcher(t *testing.T) {
 
 func boolsToSlice(v ...bool) []bool {
 	return v
+}
+
+func TestCheckAccessWithLabelExpressions(t *testing.T) {
+	t.Parallel()
+
+	resources := []types.ResourceWithLabels{
+		&types.ServerV2{Kind: types.KindNode},
+		&types.KubernetesClusterV3{Kind: types.KindKubernetesCluster},
+		&types.AppV3{Kind: types.KindApp},
+		&types.DatabaseV3{Kind: types.KindDatabase},
+		&types.DatabaseServiceV1{ResourceHeader: types.ResourceHeader{Kind: types.KindDatabaseService}},
+		&types.WindowsDesktopV3{ResourceHeader: types.ResourceHeader{Kind: types.KindWindowsDesktop}},
+		&types.WindowsDesktopServiceV3{ResourceHeader: types.ResourceHeader{Kind: types.KindWindowsDesktopService}},
+		&types.UserGroupV1{ResourceHeader: types.ResourceHeader{Kind: types.KindUserGroup}},
+	}
+	for _, r := range resources {
+		r.SetStaticLabels(map[string]string{"env": "prod"})
+	}
+	// remoteCluster doesn't implement ResourceWithLabels and access is checked
+	// with CheckAccessToRemoteCluster instead of checkAccess
+	remoteCluster := &types.RemoteClusterV3{
+		Kind: types.KindRemoteCluster,
+		Metadata: types.Metadata{
+			Labels: map[string]string{"env": "prod"},
+		},
+	}
+
+	type option string
+	const (
+		unset   option = "unset"
+		match   option = "match"
+		nomatch option = "nomatch"
+	)
+	allOptions := []option{unset, match, nomatch}
+
+	type testcase struct {
+		allowLabels, allowLabelsExpression, denyLabels, denyLabelsExpression option
+	}
+	var testcases []testcase
+	for _, al := range allOptions {
+		for _, ae := range allOptions {
+			for _, dl := range allOptions {
+				for _, de := range allOptions {
+					testcases = append(testcases, testcase{al, ae, dl, de})
+				}
+			}
+		}
+	}
+
+	matchLabels := types.Labels{"env": {"prod"}}
+	noMatchLabels := types.Labels{"env": {"staging"}}
+	matchExpression := `labels["env"] == "prod"`
+	noMatchExpression := `labels["env"] == "staging"`
+	labelsForOption := func(o option) types.Labels {
+		switch o {
+		case match:
+			return matchLabels
+		case nomatch:
+			return noMatchLabels
+		}
+		return nil
+	}
+	expressionForOption := func(o option) string {
+		switch o {
+		case match:
+			return matchExpression
+		case nomatch:
+			return noMatchExpression
+		}
+		return ""
+	}
+	makeRole := func(tc testcase, kind string) types.Role {
+		role, err := types.NewRole("rolename", types.RoleSpecV6{})
+		require.NoError(t, err)
+		require.NoError(t, role.SetLabelMatchers(types.Allow, kind, types.LabelMatchers{
+			Labels:     labelsForOption(tc.allowLabels),
+			Expression: expressionForOption(tc.allowLabelsExpression),
+		}))
+		require.NoError(t, role.SetLabelMatchers(types.Deny, kind, types.LabelMatchers{
+			Labels:     labelsForOption(tc.denyLabels),
+			Expression: expressionForOption(tc.denyLabelsExpression),
+		}))
+		return role
+	}
+
+	expectDenied := func(tc testcase) bool {
+		return tc.denyLabels == match ||
+			tc.denyLabelsExpression == match ||
+			tc.allowLabels == nomatch ||
+			tc.allowLabelsExpression == nomatch ||
+			(tc.allowLabels == unset && tc.allowLabelsExpression == unset)
+	}
+
+	for _, resource := range resources {
+		resource := resource
+		t.Run(resource.GetKind(), func(t *testing.T) {
+			t.Parallel()
+			for _, tc := range testcases {
+				t.Run(fmt.Sprint(tc), func(t *testing.T) {
+					role := makeRole(tc, resource.GetKind())
+					rs := NewRoleSet(role)
+					accessInfo := &AccessInfo{
+						Roles: []string{role.GetName()},
+					}
+					accessChecker := NewAccessCheckerWithRoleSet(accessInfo, "testcluster", rs)
+					err := accessChecker.CheckAccess(resource, AccessState{})
+					if expectDenied(tc) {
+						require.True(t, trace.IsAccessDenied(err),
+							"expected AccessDenied error, got: %v", err)
+						return
+					}
+					require.NoError(t, err, trace.DebugReport(err))
+				})
+			}
+		})
+	}
+	t.Run("remote cluster", func(t *testing.T) {
+		t.Parallel()
+		for _, tc := range testcases {
+			t.Run(fmt.Sprint(tc), func(t *testing.T) {
+				role := makeRole(tc, types.KindRemoteCluster)
+				rs := NewRoleSet(role)
+				accessInfo := &AccessInfo{
+					Roles: []string{role.GetName()},
+				}
+				accessChecker := NewAccessCheckerWithRoleSet(accessInfo, "testcluster", rs)
+				err := accessChecker.CheckAccessToRemoteCluster(remoteCluster)
+				if expectDenied(tc) {
+					require.True(t, trace.IsAccessDenied(err),
+						"expected AccessDenied error, got: %v", err)
+					return
+				}
+				require.NoError(t, err, trace.DebugReport(err))
+			})
+		}
+	})
 }


### PR DESCRIPTION
This commit implements support for label expressions ([RFD 116](https://github.com/gravitational/teleport/blob/master/rfd/0116-label-expressions.md)) with the exception that user traits can not yet be used in the expressions. The user traits will be made available to the expressions in a following PR.

I double-checked that there's no code left that only checks the role labels (without considering the label expression) by temporarily commenting out all the `Get<Kind>Labels` methods in `types.Role` and making sure everything still built. Everything now goes through `role.GetLabelMatchers`. I didn't want to permanently delete the `Get<Kind>Labels` methods because they are part of our public API package.

I added some new tests, and switched a bunch of the roles in `lib/services/role_test.go` to use label expressions instead of plain labels to get extra coverage.