### PR TITLE
Add new role defaults to allow requesting and reviewing user groups.

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -2660,6 +2660,7 @@ message SessionJoinPolicy {
 
 // AccessRequestConditions is a matcher for allow/deny restrictions on
 // access-requests.
+// Please remember to update IsEmpty when updating this message.
 message AccessRequestConditions {
   // Roles is the name of roles which will match the request rule.
   repeated string Roles = 1 [(gogoproto.jsontag) = "roles,omitempty"];
@@ -2704,6 +2705,7 @@ message AccessRequestConditions {
 
 // AccessReviewConditions is a matcher for allow/deny restrictions on
 // access reviews.
+// Please remember to update IsEmpty when updating this message.
 message AccessReviewConditions {
   // Roles is the name of roles which may be reviewed.
   repeated string Roles = 1 [(gogoproto.jsontag) = "roles,omitempty"];

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -1539,3 +1539,21 @@ func validateKubeResources(kubeResources []KubernetesResource) error {
 func (k *KubernetesResource) ClusterResource() string {
 	return k.Namespace + "/" + k.Name
 }
+
+// IsEmpty will return true if the condition is empty.
+func (a AccessRequestConditions) IsEmpty() bool {
+	return len(a.Annotations) == 0 &&
+		len(a.ClaimsToRoles) == 0 &&
+		len(a.Roles) == 0 &&
+		len(a.SearchAsRoles) == 0 &&
+		len(a.SuggestedReviewers) == 0 &&
+		len(a.Thresholds) == 0
+}
+
+// IsEmpty will return true if the condition is empty.
+func (a AccessReviewConditions) IsEmpty() bool {
+	return len(a.ClaimsToRoles) == 0 &&
+		len(a.PreviewAsRoles) == 0 &&
+		len(a.Roles) == 0 &&
+		len(a.Where) == 0
+}

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -1,0 +1,145 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/wrappers"
+)
+
+func TestAccessRequestConditionsIsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		arc      AccessRequestConditions
+		expected bool
+	}{
+		{
+			name:     "empty",
+			arc:      AccessRequestConditions{},
+			expected: true,
+		},
+		{
+			name: "annotations",
+			arc: AccessRequestConditions{
+				Annotations: wrappers.Traits{
+					"test": []string{"test"},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "claims to roles",
+			arc: AccessRequestConditions{
+				ClaimsToRoles: []ClaimMapping{
+					{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "roles",
+			arc: AccessRequestConditions{
+				Roles: []string{"test"},
+			},
+			expected: false,
+		},
+		{
+			name: "search as roles",
+			arc: AccessRequestConditions{
+				SearchAsRoles: []string{"test"},
+			},
+			expected: false,
+		},
+		{
+			name: "suggested reviewers",
+			arc: AccessRequestConditions{
+				SuggestedReviewers: []string{"test"},
+			},
+			expected: false,
+		},
+		{
+			name: "thresholds",
+			arc: AccessRequestConditions{
+				Thresholds: []AccessReviewThreshold{
+					{
+						Name: "test",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, test.arc.IsEmpty())
+		})
+	}
+}
+
+func TestAccessReviewConditionsIsEmpty(t *testing.T) {
+	tests := []struct {
+		name     string
+		arc      AccessReviewConditions
+		expected bool
+	}{
+		{
+			name:     "empty",
+			arc:      AccessReviewConditions{},
+			expected: true,
+		},
+		{
+			name: "claims to roles",
+			arc: AccessReviewConditions{
+				ClaimsToRoles: []ClaimMapping{
+					{},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "preview as roles",
+			arc: AccessReviewConditions{
+				PreviewAsRoles: []string{"test"},
+			},
+			expected: false,
+		},
+		{
+			name: "roles",
+			arc: AccessReviewConditions{
+				Roles: []string{"test"},
+			},
+			expected: false,
+		},
+		{
+			name: "where",
+			arc: AccessReviewConditions{
+				Where: "test",
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, test.arc.IsEmpty())
+		})
+	}
+}

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -6751,6 +6751,7 @@ var xxx_messageInfo_SessionJoinPolicy proto.InternalMessageInfo
 
 // AccessRequestConditions is a matcher for allow/deny restrictions on
 // access-requests.
+// Please remember to update IsEmpty when updating this message.
 type AccessRequestConditions struct {
 	// Roles is the name of roles which will match the request rule.
 	Roles []string `protobuf:"bytes,1,rep,name=Roles,proto3" json:"roles,omitempty"`
@@ -6816,6 +6817,7 @@ var xxx_messageInfo_AccessRequestConditions proto.InternalMessageInfo
 
 // AccessReviewConditions is a matcher for allow/deny restrictions on
 // access reviews.
+// Please remember to update IsEmpty when updating this message.
 type AccessReviewConditions struct {
 	// Roles is the name of roles which may be reviewed.
 	Roles []string `protobuf:"bytes,1,rep,name=Roles,proto3" json:"roles,omitempty"`

--- a/constants.go
+++ b/constants.go
@@ -615,7 +615,7 @@ const (
 
 	// PresetGroupAccessRoleName is a name of a preset role that allows
 	// access to all user groups.
-	PresetGroupAccessRoleName = "group_access"
+	PresetGroupAccessRoleName = "group-access"
 )
 
 var PresetRoles = []string{PresetEditorRoleName, PresetAccessRoleName, PresetAuditorRoleName}

--- a/constants.go
+++ b/constants.go
@@ -612,6 +612,10 @@ const (
 	// PresetAuditorRoleName is a name of a preset role that allows
 	// reading cluster events and playing back session records.
 	PresetAuditorRoleName = "auditor"
+
+	// PresetGroupAccessRoleName is a name of a preset role that allows
+	// access to all user groups.
+	PresetGroupAccessRoleName = "group_access"
 )
 
 var PresetRoles = []string{PresetEditorRoleName, PresetAccessRoleName, PresetAuditorRoleName}

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -614,6 +614,7 @@ type PresetRoleManager interface {
 // createPresets creates preset resources (eg, roles).
 func createPresets(ctx context.Context, rm PresetRoleManager) error {
 	roles := []types.Role{
+		services.NewPresetGroupAccessRole(),
 		services.NewPresetEditorRole(),
 		services.NewPresetAccessRole(),
 		services.NewPresetAuditorRole(),
@@ -630,7 +631,7 @@ func createPresets(ctx context.Context, rm PresetRoleManager) error {
 				return trace.Wrap(err)
 			}
 
-			role, err := services.AddDefaultAllowConditions(currentRole)
+			role, err := services.AddRoleDefaults(currentRole)
 			if trace.IsAlreadyExists(err) {
 				continue
 			}

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -614,7 +614,7 @@ func TestPresets(t *testing.T) {
 	})
 
 	t.Run("Does not upsert roles if nothing changes", func(t *testing.T) {
-		presetRoleCount := 3
+		presetRoleCount := 4
 
 		roleManager := &mockRoleManager{
 			roles: make(map[string]types.Role, presetRoleCount),

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -32,6 +32,7 @@ import (
 // NewPresetEditorRole returns a new pre-defined role for cluster
 // editors who can edit cluster configuration resources.
 func NewPresetEditorRole() types.Role {
+	enterprise := modules.GetModules().BuildType() == modules.BuildEnterprise
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
 		Version: types.V6,
@@ -93,7 +94,7 @@ func NewPresetEditorRole() types.Role {
 					// Please see defaultAllowRules when adding a new rule.
 				},
 				// By default, allow editors to approve any user group access requests.
-				ReviewRequests: defaultAllowAccessReviewConditions()[teleport.PresetEditorRoleName],
+				ReviewRequests: defaultAllowAccessReviewConditions(enterprise)[teleport.PresetEditorRoleName],
 			},
 		},
 	}
@@ -103,6 +104,7 @@ func NewPresetEditorRole() types.Role {
 // NewPresetAccessRole creates a role for users who are allowed to initiate
 // interactive sessions.
 func NewPresetAccessRole() types.Role {
+	enterprise := modules.GetModules().BuildType() == modules.BuildEnterprise
 	role := &types.RoleV6{
 		Kind:    types.KindRole,
 		Version: types.V6,
@@ -149,7 +151,7 @@ func NewPresetAccessRole() types.Role {
 					// Please see defaultAllowRules when adding a new rule.
 				},
 				// By default, allow users with the access role to request any user group.
-				Request: defaultAllowAccessRequestConditions()[teleport.PresetAccessRoleName],
+				Request: defaultAllowAccessRequestConditions(enterprise)[teleport.PresetAccessRoleName],
 			},
 		},
 	}
@@ -270,8 +272,8 @@ func defaultAllowLabels() map[string]types.RoleConditions {
 
 // defaultAllowAccessRequestConditions has the access request conditions that should be set as default when they were
 // not explicitly defined.
-func defaultAllowAccessRequestConditions() map[string]*types.AccessRequestConditions {
-	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+func defaultAllowAccessRequestConditions(enterprise bool) map[string]*types.AccessRequestConditions {
+	if enterprise {
 		return map[string]*types.AccessRequestConditions{
 			teleport.PresetAccessRoleName: {
 				SearchAsRoles: []string{
@@ -286,8 +288,8 @@ func defaultAllowAccessRequestConditions() map[string]*types.AccessRequestCondit
 
 // defaultAllowAccessReviewConditions has the access review conditions that should be set as default when they were
 // not explicitly defined.
-func defaultAllowAccessReviewConditions() map[string]*types.AccessReviewConditions {
-	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+func defaultAllowAccessReviewConditions(enterprise bool) map[string]*types.AccessReviewConditions {
+	if enterprise {
 		return map[string]*types.AccessReviewConditions{
 			teleport.PresetEditorRoleName: {
 				PreviewAsRoles: []string{
@@ -339,8 +341,10 @@ func AddRoleDefaults(role types.Role) (types.Role, error) {
 		}
 	}
 
+	enterprise := modules.GetModules().BuildType() == modules.BuildEnterprise
+
 	if role.GetAccessRequestConditions(types.Allow).IsEmpty() {
-		arc := defaultAllowAccessRequestConditions()[role.GetName()]
+		arc := defaultAllowAccessRequestConditions(enterprise)[role.GetName()]
 		if arc != nil {
 			role.SetAccessRequestConditions(types.Allow, *arc)
 			changed = true
@@ -348,7 +352,7 @@ func AddRoleDefaults(role types.Role) (types.Role, error) {
 	}
 
 	if role.GetAccessReviewConditions(types.Allow).IsEmpty() {
-		arc := defaultAllowAccessReviewConditions()[role.GetName()]
+		arc := defaultAllowAccessReviewConditions(enterprise)[role.GetName()]
 		if arc != nil {
 			role.SetAccessReviewConditions(types.Allow, *arc)
 			changed = true

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 // NewPresetEditorRole returns a new pre-defined role for cluster
@@ -270,28 +271,36 @@ func defaultAllowLabels() map[string]types.RoleConditions {
 // defaultAllowAccessRequestConditions has the access request conditions that should be set as default when they were
 // not explicitly defined.
 func defaultAllowAccessRequestConditions() map[string]*types.AccessRequestConditions {
-	return map[string]*types.AccessRequestConditions{
-		teleport.PresetAccessRoleName: {
-			SearchAsRoles: []string{
-				teleport.PresetGroupAccessRoleName,
+	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+		return map[string]*types.AccessRequestConditions{
+			teleport.PresetAccessRoleName: {
+				SearchAsRoles: []string{
+					teleport.PresetGroupAccessRoleName,
+				},
 			},
-		},
+		}
 	}
+
+	return map[string]*types.AccessRequestConditions{}
 }
 
 // defaultAllowAccessReviewConditions has the access review conditions that should be set as default when they were
 // not explicitly defined.
 func defaultAllowAccessReviewConditions() map[string]*types.AccessReviewConditions {
-	return map[string]*types.AccessReviewConditions{
-		teleport.PresetEditorRoleName: {
-			PreviewAsRoles: []string{
-				teleport.PresetGroupAccessRoleName,
+	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+		return map[string]*types.AccessReviewConditions{
+			teleport.PresetEditorRoleName: {
+				PreviewAsRoles: []string{
+					teleport.PresetGroupAccessRoleName,
+				},
+				Roles: []string{
+					teleport.PresetGroupAccessRoleName,
+				},
 			},
-			Roles: []string{
-				teleport.PresetGroupAccessRoleName,
-			},
-		},
+		}
 	}
+
+	return map[string]*types.AccessReviewConditions{}
 }
 
 // AddRoleDefaults adds default role attributes to a preset role.

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -20,12 +20,12 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/modules"
-	"github.com/gravitational/trace"
 )
 
 func TestAddRoleDefaults(t *testing.T) {

--- a/lib/services/presets_test.go
+++ b/lib/services/presets_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestAddRoleDefaults(t *testing.T) {
+	noChange := func(t require.TestingT, err error, i ...interface{}) {
+		require.ErrorIs(t, err, trace.AlreadyExists("no change"))
+	}
+
+	tests := []struct {
+		name        string
+		role        types.Role
+		expectedErr require.ErrorAssertionFunc
+		expected    types.Role
+	}{
+		{
+			name:        "nothing added",
+			role:        &types.RoleV6{},
+			expectedErr: noChange,
+			expected:    nil,
+		},
+		{
+			name: "editor",
+			role: &types.RoleV6{
+				Metadata: types.Metadata{
+					Name: teleport.PresetEditorRoleName,
+				},
+			},
+			expectedErr: require.NoError,
+			expected: &types.RoleV6{
+				Metadata: types.Metadata{
+					Name: teleport.PresetEditorRoleName,
+				},
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Rules:          defaultAllowRules()[teleport.PresetEditorRoleName],
+						ReviewRequests: defaultAllowAccessReviewConditions()[teleport.PresetEditorRoleName],
+					},
+				},
+			},
+		},
+		{
+			name: "editor (existing rules)",
+			role: &types.RoleV6{
+				Metadata: types.Metadata{
+					Name: teleport.PresetEditorRoleName,
+				},
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Rules: []types.Rule{
+							{
+								Resources: []string{"test"},
+								Verbs:     []string{"test"},
+							},
+						},
+					},
+				},
+			},
+			expectedErr: require.NoError,
+			expected: &types.RoleV6{
+				Metadata: types.Metadata{
+					Name: teleport.PresetEditorRoleName,
+				},
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Rules: append([]types.Rule{
+							{
+								Resources: []string{"test"},
+								Verbs:     []string{"test"},
+							},
+						}, defaultAllowRules()[teleport.PresetEditorRoleName]...),
+						ReviewRequests: defaultAllowAccessReviewConditions()[teleport.PresetEditorRoleName],
+					},
+				},
+			},
+		},
+		{
+			name: "editor (existing review requests, identical rules)",
+			role: &types.RoleV6{
+				Metadata: types.Metadata{
+					Name: teleport.PresetEditorRoleName,
+				},
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Rules: defaultAllowRules()[teleport.PresetEditorRoleName],
+						ReviewRequests: &types.AccessReviewConditions{
+							Where: "test",
+						},
+					},
+				},
+			},
+			expectedErr: noChange,
+			expected:    nil,
+		},
+		{
+			name: "access (access review, db labels, identical rules)",
+			role: &types.RoleV6{
+				Metadata: types.Metadata{
+					Name: teleport.PresetAccessRoleName,
+				},
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						Rules: defaultAllowRules()[teleport.PresetAccessRoleName],
+					},
+				},
+			},
+			expectedErr: require.NoError,
+			expected: &types.RoleV6{
+				Metadata: types.Metadata{
+					Name: teleport.PresetAccessRoleName,
+				},
+				Spec: types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						DatabaseServiceLabels: defaultAllowLabels()[teleport.PresetAccessRoleName].DatabaseServiceLabels,
+						DatabaseRoles:         defaultAllowLabels()[teleport.PresetAccessRoleName].DatabaseRoles,
+						Rules:                 defaultAllowRules()[teleport.PresetAccessRoleName],
+						Request:               defaultAllowAccessRequestConditions()[teleport.PresetAccessRoleName],
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			role, err := AddRoleDefaults(test.role)
+			test.expectedErr(t, err)
+
+			require.Empty(t, cmp.Diff(role, test.expected))
+		})
+	}
+}


### PR DESCRIPTION
User groups are now default requestable by the access role and default reviewable by the editor role. This will make the onboarding experience for the Okta service much easier, as there will be no need to set up new roles to support it.

A new role called group_access has also been added to support it, which allows read access to all groups.