### PR TITLE
[v12] chore: Bump Buf to v1.19.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -286,7 +286,7 @@ RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2
 
 # Install Buf.
 RUN BIN="/usr/local/bin" && \
-    VERSION="1.18.0" && \
+    VERSION="1.19.0" && \
       curl -fsSL \
         "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
         -o "${BIN}/buf" && \


### PR DESCRIPTION
Backport #26634 to branch/v12

Update to the latest release.

* https://github.com/bufbuild/buf/releases/tag/v1.19.0