### PR TITLE
Add elasticache:Connect AWS permission to auto-IAM

### DIFF
--- a/lib/cloud/mocks/aws.go
+++ b/lib/cloud/mocks/aws.go
@@ -562,6 +562,8 @@ func (m *IAMErrorMock) PutUserPolicyWithContext(ctx aws.Context, input *iam.PutU
 // ElastiCache mocks AWS ElastiCache API.
 type ElastiCacheMock struct {
 	elasticacheiface.ElastiCacheAPI
+	// Unauth set to true will make API calls return unauthorized errors.
+	Unauth bool
 
 	ReplicationGroups []*elasticache.ReplicationGroup
 	Users             []*elasticache.User
@@ -589,6 +591,9 @@ func (m *ElastiCacheMock) addTags(arn string, tagsMap map[string]string) {
 }
 
 func (m *ElastiCacheMock) DescribeUsersWithContext(_ aws.Context, input *elasticache.DescribeUsersInput, opts ...request.Option) (*elasticache.DescribeUsersOutput, error) {
+	if m.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
 	if input.UserId == nil {
 		return &elasticache.DescribeUsersOutput{Users: m.Users}, nil
 	}
@@ -601,6 +606,9 @@ func (m *ElastiCacheMock) DescribeUsersWithContext(_ aws.Context, input *elastic
 }
 
 func (m *ElastiCacheMock) DescribeReplicationGroupsWithContext(_ aws.Context, input *elasticache.DescribeReplicationGroupsInput, opts ...request.Option) (*elasticache.DescribeReplicationGroupsOutput, error) {
+	if m.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
 	for _, replicationGroup := range m.ReplicationGroups {
 		if aws.StringValue(replicationGroup.ReplicationGroupId) == aws.StringValue(input.ReplicationGroupId) {
 			return &elasticache.DescribeReplicationGroupsOutput{
@@ -612,6 +620,9 @@ func (m *ElastiCacheMock) DescribeReplicationGroupsWithContext(_ aws.Context, in
 }
 
 func (m *ElastiCacheMock) DescribeReplicationGroupsPagesWithContext(_ aws.Context, _ *elasticache.DescribeReplicationGroupsInput, fn func(*elasticache.DescribeReplicationGroupsOutput, bool) bool, _ ...request.Option) error {
+	if m.Unauth {
+		return trace.AccessDenied("unauthorized")
+	}
 	fn(&elasticache.DescribeReplicationGroupsOutput{
 		ReplicationGroups: m.ReplicationGroups,
 	}, true)
@@ -619,6 +630,9 @@ func (m *ElastiCacheMock) DescribeReplicationGroupsPagesWithContext(_ aws.Contex
 }
 
 func (m *ElastiCacheMock) DescribeUsersPagesWithContext(_ aws.Context, _ *elasticache.DescribeUsersInput, fn func(*elasticache.DescribeUsersOutput, bool) bool, _ ...request.Option) error {
+	if m.Unauth {
+		return trace.AccessDenied("unauthorized")
+	}
 	fn(&elasticache.DescribeUsersOutput{
 		Users: m.Users,
 	}, true)
@@ -626,14 +640,23 @@ func (m *ElastiCacheMock) DescribeUsersPagesWithContext(_ aws.Context, _ *elasti
 }
 
 func (m *ElastiCacheMock) DescribeCacheClustersPagesWithContext(aws.Context, *elasticache.DescribeCacheClustersInput, func(*elasticache.DescribeCacheClustersOutput, bool) bool, ...request.Option) error {
-	return trace.AccessDenied("unauthorized")
+	if m.Unauth {
+		return trace.AccessDenied("unauthorized")
+	}
+	return trace.NotImplemented("elasticache:DescribeCacheClustersPagesWithContext is not implemented")
 }
 
 func (m *ElastiCacheMock) DescribeCacheSubnetGroupsPagesWithContext(aws.Context, *elasticache.DescribeCacheSubnetGroupsInput, func(*elasticache.DescribeCacheSubnetGroupsOutput, bool) bool, ...request.Option) error {
-	return trace.AccessDenied("unauthorized")
+	if m.Unauth {
+		return trace.AccessDenied("unauthorized")
+	}
+	return trace.NotImplemented("elasticache:DescribeCacheSubnetGroupsPagesWithContext is not implemented")
 }
 
 func (m *ElastiCacheMock) ListTagsForResourceWithContext(_ aws.Context, input *elasticache.ListTagsForResourceInput, _ ...request.Option) (*elasticache.TagListMessage, error) {
+	if m.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
 	if m.TagsByARN == nil {
 		return nil, trace.NotFound("no tags")
 	}
@@ -649,6 +672,9 @@ func (m *ElastiCacheMock) ListTagsForResourceWithContext(_ aws.Context, input *e
 }
 
 func (m *ElastiCacheMock) ModifyUserWithContext(_ aws.Context, input *elasticache.ModifyUserInput, opts ...request.Option) (*elasticache.ModifyUserOutput, error) {
+	if m.Unauth {
+		return nil, trace.AccessDenied("unauthorized")
+	}
 	for _, user := range m.Users {
 		if aws.StringValue(user.UserId) == aws.StringValue(input.UserId) {
 			return &elasticache.ModifyUserOutput{}, nil

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -188,6 +188,8 @@ var (
 			"elasticache:ModifyUser",
 		},
 		requireSecretsManager: true,
+		boundary:              []string{"elasticache:Connect"},
+		requireIAMEdit:        true,
 	}
 	// memoryDBActions contains IAM actions for services.AWSMatcherMemoryDB.
 	memoryDBActions = databaseActions{

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -282,6 +282,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
@@ -291,6 +294,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					"elasticache:DescribeCacheSubnetGroups",
 					"elasticache:DescribeUsers",
 					"elasticache:ModifyUser",
+					"elasticache:Connect",
 				}},
 				{
 					Effect: awslib.EffectAllow,
@@ -302,6 +306,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 					},
 					Resources: []string{"arn:aws:secretsmanager:*:123456789012:secret:teleport/*"},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 		},
 		"ElastiCache static database": {
@@ -358,6 +365,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 						"arn:aws:kms:*:123456789012:key/my-kms-id",
 					},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 			boundaryStatements: []*awslib.Statement{
 				{Effect: awslib.EffectAllow, Resources: []string{"*"}, Actions: []string{
@@ -367,6 +377,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 					"elasticache:DescribeCacheSubnetGroups",
 					"elasticache:DescribeUsers",
 					"elasticache:ModifyUser",
+					"elasticache:Connect",
 				}},
 				{
 					Effect: "Allow",
@@ -388,6 +399,9 @@ func TestAWSIAMDocuments(t *testing.T) {
 						"arn:aws:kms:*:123456789012:key/my-kms-id",
 					},
 				},
+				{Effect: awslib.EffectAllow, Resources: []string{roleTarget.String()}, Actions: []string{
+					"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy",
+				}},
 			},
 		},
 		"MemoryDB auto discovery": {

--- a/lib/srv/db/cloud/iam_test.go
+++ b/lib/srv/db/cloud/iam_test.go
@@ -115,6 +115,20 @@ func TestAWSIAM(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	elasticache, err := types.NewDatabaseV3(types.Metadata{
+		Name: "aws-elasticache",
+	}, types.DatabaseSpecV3{
+		Protocol: "redis",
+		URI:      "clustercfg.my-redis-cluster.xxxxxx.cac1.cache.amazonaws.com:6379",
+		AWS: types.AWS{
+			AccountID: "123456789012",
+			ElastiCache: types.ElastiCache{
+				ReplicationGroupID: "some-group",
+			},
+		},
+	})
+	require.NoError(t, err)
+
 	// Make configurator.
 	taskChan := make(chan struct{})
 	waitForTaskProcessed := func(t *testing.T) {
@@ -184,6 +198,13 @@ func TestAWSIAM(t *testing.T) {
 			wantPolicyContains: redshiftDatabase.GetAWS().Redshift.ClusterID,
 			getIAMAuthEnabled: func() bool {
 				return true // it always is for redshift.
+			},
+		},
+		"ElastiCache": {
+			database:           elasticache,
+			wantPolicyContains: elasticache.GetAWS().ElastiCache.ReplicationGroupID,
+			getIAMAuthEnabled: func() bool {
+				return true // it always is for ElastiCache.
 			},
 		},
 	}
@@ -291,6 +312,19 @@ func TestAWSIAMNoPermissions(t *testing.T) {
 			meta: types.AWS{Region: "localhost", AccountID: "123456789012", Redshift: types.Redshift{ClusterID: "redshift-cluster-1"}},
 			clients: &clients.TestCloudClients{
 				Redshift: &mocks.RedshiftMockUnauth{},
+				IAM: &mocks.IAMErrorMock{
+					Error: trace.AccessDenied("unauthorized"),
+				},
+				STS: stsClient,
+			},
+		},
+		{
+			name: "ElastiCache",
+			meta: types.AWS{Region: "localhost", AccountID: "123456789012", ElastiCache: types.ElastiCache{ReplicationGroupID: "some-group"}},
+			clients: &clients.TestCloudClients{
+				// As of writing this API won't be called by the configurator anyway,
+				// but might as well provide it in case that changes.
+				ElastiCache: &mocks.ElastiCacheMock{Unauth: true},
 				IAM: &mocks.IAMErrorMock{
 					Error: trace.AccessDenied("unauthorized"),
 				},

--- a/lib/srv/db/common/iam/aws_test.go
+++ b/lib/srv/db/common/iam/aws_test.go
@@ -67,6 +67,12 @@ func TestGetAWSPolicyDocument(t *testing.T) {
 	}, types.DatabaseSpecV3{
 		Protocol: "redis",
 		URI:      "clustercfg.my-redis-cluster.xxxxxx.cac1.cache.amazonaws.com:6379",
+		AWS: types.AWS{
+			AccountID: "123456789012",
+			ElastiCache: types.ElastiCache{
+				ReplicationGroupID: "some-group",
+			},
+		},
 	})
 	require.NoError(t, err)
 
@@ -122,7 +128,19 @@ func TestGetAWSPolicyDocument(t *testing.T) {
 		},
 		{
 			inputDatabase: elasticache,
-			expectError:   true,
+			expectPolicyDocument: `{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": "elasticache:Connect",
+            "Resource": [
+                "arn:aws:elasticache:ca-central-1:123456789012:replicationgroup:some-group",
+                "arn:aws:elasticache:ca-central-1:123456789012:user:*"
+            ]
+        }
+    ]
+}`,
 		},
 	}
 


### PR DESCRIPTION
Adds the last code change needed for ElastiCache Redis IAM auth: https://github.com/gravitational/teleport/issues/18550

This PR auto-adds the `elasticache:Connect` permission to the db agent's identity permissions, and updates the boundary policy set by `teleport db configure ...` commands to include it as well.

example inline policy statement attached:
```json
        {
            "Effect": "Allow",
            "Action": "elasticache:Connect",
            "Resource": [
                "arn:aws:elasticache:us-west-1:123456789012:replicationgroup:gavin-redis",
                "arn:aws:elasticache:us-west-1:123456789012:user:*"
            ]
        }
```

Tested manually:
- inline policies for elasticache connect permissions are added
- bootstrap commands set the boundary policy with the added permission as well.

TODO in follow-up PR:
- update elasticache docs to explain IAM auth flow