### PR TITLE
fix TestALPNProxyHTTPProxyBasicAuthDial flakiness

### DIFF
--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -1497,11 +1497,18 @@ func TestALPNProxyHTTPProxyBasicAuthDial(t *testing.T) {
 	}()
 	require.ErrorIs(t, authorizer.WaitForRequest(timeout), trace.AccessDenied("bad credentials"))
 	require.Zero(t, ph.Count())
+	// stop the node so it doesn't keep trying to join the cluster with bad credentials.
+	require.NoError(t, rc.StopNodes())
+	require.Error(t, <-startErrC)
 
 	// set the auth credentials to match our environment
 	authorizer.SetCredentials(user, pass)
 
-	// with env set correctly and authorized, the node should register.
+	// with env set correctly and authorized, the node should be able to register.
+	go func() {
+		_, err := rc.StartNode(nodeCfg)
+		startErrC <- err
+	}()
 	require.NoError(t, <-startErrC)
 	require.NoError(t, helpers.WaitForNodeCount(context.Background(), rc, rc.Secrets.SiteName, 1))
 	require.Greater(t, ph.Count(), 0)


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/14143

3rd time's the charm! I think the issue was that the test is setup to intentionally prevent a node from joining through an HTTP basic auth proxy when it has the wrong credentials, but the node only has 10 seconds to successfully join before the test code times it out. This meant it would fail the initial dial attempt, then the test gives it correct credentials and waits for it to join, but it only had 10 seconds to do all of that and join the cluster or the test would fail. I suspect the random failures were coming from backoff/jitter in dial attempts.

So I fixed it by stopping the node after verifying that it was unable to join, then setting correct HTTP basic auth credentials and starting the node again. This should allow the node to join on its first attempt to dial the cluster with good credentials and avoid running out the 10 second timeout due to random backoff/jitter.

I was able to reliably reproduce the original test's flakiness locally by reducing the 10 second timeout to 1 second. With this temporarily reduced timeout, I tried this PR's changes and failed to reproduce a test failure after 100 attempts with and without the race detector enabled. So I think I finally got this one fixed for good.