### PR TITLE
docs: update reference to Teleport systemd

### DIFF
--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -531,7 +531,7 @@ corresponding role permissions with the `create` verb:
 |Database|`*client.Client.CreateDatabase`|`db`|
 |Kubernetes cluster|<nobr>`*client.Client.CreateKubernetesCluster`</nobr>|`kube_cluster`|
 |Windows Desktop|`*client.Client.CreateWindowsDesktop`|<nobr>`windows_desktop`</nobr>|
-Since a server must run an instance of the Teleport SSH Service in order to join
+Since a server must run an instance of the Teleport Service in order to join
 a Teleport cluster, API clients can only register servers by using tokens.
 
 </Details>

--- a/docs/pages/management/admin/daemon.mdx
+++ b/docs/pages/management/admin/daemon.mdx
@@ -66,7 +66,7 @@ any service daemon on systemd, in this case the `teleport` service. The rest of 
   You will see output similar to the following, including the file path (`/lib/systemd/system/teleport.service`) that contains the unit file for the systemd configuration being applied:
 
   ```code
-  ● teleport.service - Teleport SSH Service
+  ● teleport.service - Teleport Service
        Loaded: loaded (/lib/systemd/system/teleport.service; disabled; vendor preset: enabled)
        Active: inactive (dead)
   ```

--- a/docs/pages/management/admin/self-signed-certs.mdx
+++ b/docs/pages/management/admin/self-signed-certs.mdx
@@ -169,7 +169,7 @@ running Teleport: via the `teleport` CLI, using a Helm chart, or via systemd:
     You will see output similar to the following, including the file path (`/lib/systemd/system/teleport.service`) that contains the unit file for the systemd configuration being applied:
 
     ```code
-    ● teleport.service - Teleport SSH Service
+    ● teleport.service - Teleport Service
         Loaded: loaded (/lib/systemd/system/teleport.service; disabled; vendor preset: enabled)
         Active: inactive (dead)
     ```


### PR DESCRIPTION
The service is now called "Teleport Service", not "Teleport SSH Service"