### PR TITLE
Improve Kubernetes access test coverage

### DIFF
--- a/lib/cloud/clients.go
+++ b/lib/cloud/clients.go
@@ -964,7 +964,7 @@ func (c *TestCloudClients) GetAzurePostgresClient(subscription string) (azure.DB
 
 // GetAzureKubernetesClient returns an AKS client for the specified subscription
 func (c *TestCloudClients) GetAzureKubernetesClient(subscription string) (azure.AKSClient, error) {
-	if len(c.AzurePostgresPerSub) != 0 {
+	if len(c.AzureAKSClientPerSub) != 0 {
 		return c.AzureAKSClientPerSub[subscription], nil
 	}
 	return c.AzureAKSClient, nil

--- a/lib/cloud/mocks/aws.go
+++ b/lib/cloud/mocks/aws.go
@@ -18,11 +18,15 @@ package mocks
 
 import (
 	"context"
+	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/eks/eksiface"
 	"github.com/aws/aws-sdk-go/service/elasticache"
 	"github.com/aws/aws-sdk-go/service/elasticache/elasticacheiface"
 	"github.com/aws/aws-sdk-go/service/iam"
@@ -44,6 +48,7 @@ import (
 type STSMock struct {
 	stsiface.STSAPI
 	ARN                    string
+	URL                    *url.URL
 	assumedRoleARNs        []string
 	assumedRoleExternalIDs []string
 	mu                     sync.Mutex
@@ -93,6 +98,21 @@ func (m *STSMock) AssumeRoleWithContext(ctx aws.Context, in *sts.AssumeRoleInput
 			SessionToken:    aws.String("token"),
 			Expiration:      &expiry,
 		},
+	}, nil
+}
+
+func (m *STSMock) GetCallerIdentityRequest(req *sts.GetCallerIdentityInput) (*request.Request, *sts.GetCallerIdentityOutput) {
+	return &request.Request{
+		HTTPRequest: &http.Request{
+			Header: http.Header{},
+			URL:    m.URL,
+		},
+		Operation: &request.Operation{
+			Name:       "GetCallerIdentity",
+			HTTPMethod: "POST",
+			HTTPPath:   "/",
+		},
+		Handlers: request.Handlers{},
 	}, nil
 }
 
@@ -208,6 +228,7 @@ func (m *RDSMock) ModifyDBClusterWithContext(ctx aws.Context, input *rds.ModifyD
 	}
 	return nil, trace.NotFound("cluster %v not found", aws.StringValue(input.DBClusterIdentifier))
 }
+
 func (m *RDSMock) DescribeDBProxiesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, options ...request.Option) (*rds.DescribeDBProxiesOutput, error) {
 	if aws.StringValue(input.DBProxyName) == "" {
 		return &rds.DescribeDBProxiesOutput{
@@ -223,6 +244,7 @@ func (m *RDSMock) DescribeDBProxiesWithContext(ctx aws.Context, input *rds.Descr
 	}
 	return nil, trace.NotFound("proxy %v not found", aws.StringValue(input.DBProxyName))
 }
+
 func (m *RDSMock) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, options ...request.Option) (*rds.DescribeDBProxyEndpointsOutput, error) {
 	inputProxyName := aws.StringValue(input.DBProxyName)
 	inputProxyEndpointName := aws.StringValue(input.DBProxyEndpointName)
@@ -252,6 +274,7 @@ func (m *RDSMock) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rd
 	}
 	return &rds.DescribeDBProxyEndpointsOutput{DBProxyEndpoints: endpoints}, nil
 }
+
 func (m *RDSMock) DescribeDBProxyTargetsWithContext(ctx aws.Context, input *rds.DescribeDBProxyTargetsInput, options ...request.Option) (*rds.DescribeDBProxyTargetsOutput, error) {
 	// only mocking to return a port here
 	return &rds.DescribeDBProxyTargetsOutput{
@@ -260,18 +283,21 @@ func (m *RDSMock) DescribeDBProxyTargetsWithContext(ctx aws.Context, input *rds.
 		}},
 	}, nil
 }
+
 func (m *RDSMock) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {
 	fn(&rds.DescribeDBProxiesOutput{
 		DBProxies: m.DBProxies,
 	}, true)
 	return nil
 }
+
 func (m *RDSMock) DescribeDBProxyEndpointsPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, fn func(*rds.DescribeDBProxyEndpointsOutput, bool) bool, options ...request.Option) error {
 	fn(&rds.DescribeDBProxyEndpointsOutput{
 		DBProxyEndpoints: m.DBProxyEndpoints,
 	}, true)
 	return nil
 }
+
 func (m *RDSMock) ListTagsForResourceWithContext(ctx aws.Context, input *rds.ListTagsForResourceInput, options ...request.Option) (*rds.ListTagsForResourceOutput, error) {
 	return &rds.ListTagsForResourceOutput{}, nil
 }
@@ -379,6 +405,7 @@ func (m *RedshiftMock) GetClusterCredentialsWithContext(aws.Context, *redshift.G
 	}
 	return m.GetClusterCredentialsOutput, nil
 }
+
 func (m *RedshiftMock) DescribeClustersWithContext(ctx aws.Context, input *redshift.DescribeClustersInput, options ...request.Option) (*redshift.DescribeClustersOutput, error) {
 	if aws.StringValue(input.ClusterIdentifier) == "" {
 		return &redshift.DescribeClustersOutput{
@@ -430,12 +457,15 @@ func (m *RDSMockUnauth) DescribeDBInstancesPagesWithContext(ctx aws.Context, inp
 func (m *RDSMockUnauth) DescribeDBClustersPagesWithContext(aws aws.Context, input *rds.DescribeDBClustersInput, fn func(*rds.DescribeDBClustersOutput, bool) bool, options ...request.Option) error {
 	return trace.AccessDenied("unauthorized")
 }
+
 func (m *RDSMockUnauth) DescribeDBProxiesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, options ...request.Option) (*rds.DescribeDBProxiesOutput, error) {
 	return nil, trace.AccessDenied("unauthorized")
 }
+
 func (m *RDSMockUnauth) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, options ...request.Option) (*rds.DescribeDBProxyEndpointsOutput, error) {
 	return nil, trace.AccessDenied("unauthorized")
 }
+
 func (m *RDSMockUnauth) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {
 	return trace.AccessDenied("unauthorized")
 }
@@ -451,9 +481,11 @@ type RDSMockByDBType struct {
 func (m *RDSMockByDBType) DescribeDBInstancesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, options ...request.Option) (*rds.DescribeDBInstancesOutput, error) {
 	return m.DBInstances.DescribeDBInstancesWithContext(ctx, input, options...)
 }
+
 func (m *RDSMockByDBType) ModifyDBInstanceWithContext(ctx aws.Context, input *rds.ModifyDBInstanceInput, options ...request.Option) (*rds.ModifyDBInstanceOutput, error) {
 	return m.DBInstances.ModifyDBInstanceWithContext(ctx, input, options...)
 }
+
 func (m *RDSMockByDBType) DescribeDBInstancesPagesWithContext(ctx aws.Context, input *rds.DescribeDBInstancesInput, fn func(*rds.DescribeDBInstancesOutput, bool) bool, options ...request.Option) error {
 	return m.DBInstances.DescribeDBInstancesPagesWithContext(ctx, input, fn, options...)
 }
@@ -461,18 +493,23 @@ func (m *RDSMockByDBType) DescribeDBInstancesPagesWithContext(ctx aws.Context, i
 func (m *RDSMockByDBType) DescribeDBClustersWithContext(ctx aws.Context, input *rds.DescribeDBClustersInput, options ...request.Option) (*rds.DescribeDBClustersOutput, error) {
 	return m.DBClusters.DescribeDBClustersWithContext(ctx, input, options...)
 }
+
 func (m *RDSMockByDBType) ModifyDBClusterWithContext(ctx aws.Context, input *rds.ModifyDBClusterInput, options ...request.Option) (*rds.ModifyDBClusterOutput, error) {
 	return m.DBClusters.ModifyDBClusterWithContext(ctx, input, options...)
 }
+
 func (m *RDSMockByDBType) DescribeDBClustersPagesWithContext(aws aws.Context, input *rds.DescribeDBClustersInput, fn func(*rds.DescribeDBClustersOutput, bool) bool, options ...request.Option) error {
 	return m.DBClusters.DescribeDBClustersPagesWithContext(aws, input, fn, options...)
 }
+
 func (m *RDSMockByDBType) DescribeDBProxiesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, options ...request.Option) (*rds.DescribeDBProxiesOutput, error) {
 	return m.DBProxies.DescribeDBProxiesWithContext(ctx, input, options...)
 }
+
 func (m *RDSMockByDBType) DescribeDBProxyEndpointsWithContext(ctx aws.Context, input *rds.DescribeDBProxyEndpointsInput, options ...request.Option) (*rds.DescribeDBProxyEndpointsOutput, error) {
 	return m.DBProxies.DescribeDBProxyEndpointsWithContext(ctx, input, options...)
 }
+
 func (m *RDSMockByDBType) DescribeDBProxiesPagesWithContext(ctx aws.Context, input *rds.DescribeDBProxiesInput, fn func(*rds.DescribeDBProxiesOutput, bool) bool, options ...request.Option) error {
 	return m.DBProxies.DescribeDBProxiesPagesWithContext(ctx, input, fn, options...)
 }
@@ -535,6 +572,7 @@ func (m *ElastiCacheMock) AddMockUser(user *elasticache.User, tagsMap map[string
 	m.Users = append(m.Users, user)
 	m.addTags(aws.StringValue(user.ARN), tagsMap)
 }
+
 func (m *ElastiCacheMock) addTags(arn string, tagsMap map[string]string) {
 	if m.TagsByARN == nil {
 		m.TagsByARN = make(map[string][]*elasticache.Tag)
@@ -572,12 +610,14 @@ func (m *ElastiCacheMock) DescribeReplicationGroupsWithContext(_ aws.Context, in
 	}
 	return nil, trace.NotFound("ElastiCache %v not found", aws.StringValue(input.ReplicationGroupId))
 }
+
 func (m *ElastiCacheMock) DescribeReplicationGroupsPagesWithContext(_ aws.Context, _ *elasticache.DescribeReplicationGroupsInput, fn func(*elasticache.DescribeReplicationGroupsOutput, bool) bool, _ ...request.Option) error {
 	fn(&elasticache.DescribeReplicationGroupsOutput{
 		ReplicationGroups: m.ReplicationGroups,
 	}, true)
 	return nil
 }
+
 func (m *ElastiCacheMock) DescribeUsersPagesWithContext(_ aws.Context, _ *elasticache.DescribeUsersInput, fn func(*elasticache.DescribeUsersOutput, bool) bool, _ ...request.Option) error {
 	fn(&elasticache.DescribeUsersOutput{
 		Users: m.Users,
@@ -588,9 +628,11 @@ func (m *ElastiCacheMock) DescribeUsersPagesWithContext(_ aws.Context, _ *elasti
 func (m *ElastiCacheMock) DescribeCacheClustersPagesWithContext(aws.Context, *elasticache.DescribeCacheClustersInput, func(*elasticache.DescribeCacheClustersOutput, bool) bool, ...request.Option) error {
 	return trace.AccessDenied("unauthorized")
 }
+
 func (m *ElastiCacheMock) DescribeCacheSubnetGroupsPagesWithContext(aws.Context, *elasticache.DescribeCacheSubnetGroupsInput, func(*elasticache.DescribeCacheSubnetGroupsOutput, bool) bool, ...request.Option) error {
 	return trace.AccessDenied("unauthorized")
 }
+
 func (m *ElastiCacheMock) ListTagsForResourceWithContext(_ aws.Context, input *elasticache.ListTagsForResourceInput, _ ...request.Option) (*elasticache.TagListMessage, error) {
 	if m.TagsByARN == nil {
 		return nil, trace.NotFound("no tags")
@@ -605,6 +647,7 @@ func (m *ElastiCacheMock) ListTagsForResourceWithContext(_ aws.Context, input *e
 		TagList: tags,
 	}, nil
 }
+
 func (m *ElastiCacheMock) ModifyUserWithContext(_ aws.Context, input *elasticache.ModifyUserInput, opts ...request.Option) (*elasticache.ModifyUserOutput, error) {
 	for _, user := range m.Users {
 		if aws.StringValue(user.UserId) == aws.StringValue(input.UserId) {
@@ -627,6 +670,7 @@ func (m *MemoryDBMock) AddMockUser(user *memorydb.User, tagsMap map[string]strin
 	m.Users = append(m.Users, user)
 	m.addTags(aws.StringValue(user.ARN), tagsMap)
 }
+
 func (m *MemoryDBMock) addTags(arn string, tagsMap map[string]string) {
 	if m.TagsByARN == nil {
 		m.TagsByARN = make(map[string][]*memorydb.Tag)
@@ -641,11 +685,12 @@ func (m *MemoryDBMock) addTags(arn string, tagsMap map[string]string) {
 	}
 	m.TagsByARN[arn] = tags
 }
+
 func (m *MemoryDBMock) DescribeSubnetGroupsWithContext(aws.Context, *memorydb.DescribeSubnetGroupsInput, ...request.Option) (*memorydb.DescribeSubnetGroupsOutput, error) {
 	return nil, trace.AccessDenied("unauthorized")
 }
-func (m *MemoryDBMock) DescribeClustersWithContext(_ aws.Context, input *memorydb.DescribeClustersInput, _ ...request.Option) (*memorydb.DescribeClustersOutput, error) {
 
+func (m *MemoryDBMock) DescribeClustersWithContext(_ aws.Context, input *memorydb.DescribeClustersInput, _ ...request.Option) (*memorydb.DescribeClustersOutput, error) {
 	if aws.StringValue(input.ClusterName) == "" {
 		return &memorydb.DescribeClustersOutput{
 			Clusters: m.Clusters,
@@ -661,6 +706,7 @@ func (m *MemoryDBMock) DescribeClustersWithContext(_ aws.Context, input *memoryd
 	}
 	return nil, trace.NotFound("cluster %v not found", aws.StringValue(input.ClusterName))
 }
+
 func (m *MemoryDBMock) ListTagsWithContext(_ aws.Context, input *memorydb.ListTagsInput, _ ...request.Option) (*memorydb.ListTagsOutput, error) {
 	if m.TagsByARN == nil {
 		return nil, trace.NotFound("no tags")
@@ -675,11 +721,13 @@ func (m *MemoryDBMock) ListTagsWithContext(_ aws.Context, input *memorydb.ListTa
 		TagList: tags,
 	}, nil
 }
+
 func (m *MemoryDBMock) DescribeUsersWithContext(aws.Context, *memorydb.DescribeUsersInput, ...request.Option) (*memorydb.DescribeUsersOutput, error) {
 	return &memorydb.DescribeUsersOutput{
 		Users: m.Users,
 	}, nil
 }
+
 func (m *MemoryDBMock) UpdateUserWithContext(_ aws.Context, input *memorydb.UpdateUserInput, opts ...request.Option) (*memorydb.UpdateUserOutput, error) {
 	for _, user := range m.Users {
 		if aws.StringValue(user.Name) == aws.StringValue(input.UserName) {
@@ -777,4 +825,23 @@ func RedshiftGetClusterCredentialsOutput(user, password string, clock clockwork.
 		DbPassword: aws.String(password),
 		Expiration: aws.Time(clock.Now().Add(15 * time.Minute)),
 	}
+}
+
+// EKSMock is a mock EKS client.
+type EKSMock struct {
+	eksiface.EKSAPI
+	Clusters []*eks.Cluster
+	Notify   chan struct{}
+}
+
+func (e *EKSMock) DescribeClusterWithContext(_ aws.Context, req *eks.DescribeClusterInput, _ ...request.Option) (*eks.DescribeClusterOutput, error) {
+	defer func() {
+		e.Notify <- struct{}{}
+	}()
+	for _, cluster := range e.Clusters {
+		if aws.StringValue(req.Name) == aws.StringValue(cluster.Name) {
+			return &eks.DescribeClusterOutput{Cluster: cluster}, nil
+		}
+	}
+	return nil, trace.NotFound("cluster %v not found", aws.StringValue(req.Name))
 }

--- a/lib/cloud/mocks/azure.go
+++ b/lib/cloud/mocks/azure.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mocks
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"k8s.io/client-go/rest"
+
+	"github.com/gravitational/teleport/lib/cloud/azure"
+)
+
+// AKSClusterEntry is an entry in the AKSMock.Clusters list.
+type AKSClusterEntry struct {
+	azure.ClusterCredentialsConfig
+	Config *rest.Config
+	TTL    time.Duration
+}
+
+// AKSMock implements the azure.AKSClient interface for tests.
+type AKSMock struct {
+	azure.AKSClient
+	Clusters []AKSClusterEntry
+	Notify   chan struct{}
+	Clock    clockwork.Clock
+}
+
+func (a *AKSMock) ClusterCredentials(ctx context.Context, cfg azure.ClusterCredentialsConfig) (*rest.Config, time.Time, error) {
+	defer func() {
+		a.Notify <- struct{}{}
+	}()
+	for _, cluster := range a.Clusters {
+		if cluster.ClusterCredentialsConfig.ResourceGroup == cfg.ResourceGroup &&
+			cluster.ClusterCredentialsConfig.ResourceName == cfg.ResourceName &&
+			cluster.ClusterCredentialsConfig.TenantID == cfg.TenantID {
+			return cluster.Config, a.Clock.Now().Add(cluster.TTL), nil
+		}
+	}
+	return nil, time.Now(), trace.NotFound("cluster not found")
+}

--- a/lib/kube/grpc/grpc_test.go
+++ b/lib/kube/grpc/grpc_test.go
@@ -419,7 +419,7 @@ func initGRPCServer(t *testing.T, testCtx *kubeproxy.TestContext, listener net.L
 			Signer:        proxyAuthClient,
 			AccessPoint:   proxyAuthClient,
 			Emitter:       testCtx.Emitter,
-			KubeProxyAddr: testCtx.KubeServiceAddress(),
+			KubeProxyAddr: testCtx.KubeProxyAddress(),
 			Authz:         testCtx.Authz,
 		},
 	)

--- a/lib/kube/proxy/exec_test.go
+++ b/lib/kube/proxy/exec_test.go
@@ -185,7 +185,7 @@ func TestExecKubeService(t *testing.T) {
 
 			req, err := generateExecRequest(
 				generateExecRequestConfig{
-					addr:          testCtx.KubeServiceAddress(),
+					addr:          testCtx.KubeProxyAddress(),
 					podName:       podName,
 					podNamespace:  podNamespace,
 					containerName: podContainerName,

--- a/lib/kube/proxy/kube_creds_test.go
+++ b/lib/kube/proxy/kube_creds_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/aws/aws-sdk-go/service/eks/eksiface"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	authztypes "k8s.io/client-go/kubernetes/typed/authorization/v1"
+	"k8s.io/client-go/rest"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/cloud/gcp"
+	"github.com/gravitational/teleport/lib/fixtures"
+)
+
+func Test_DynamicKubeCreds(t *testing.T) {
+	t.Parallel()
+	log := logrus.New()
+	log.SetOutput(io.Discard)
+	awsKube, err := types.NewKubernetesClusterV3(
+		types.Metadata{
+			Name: "aws",
+		},
+		types.KubernetesClusterSpecV3{
+			AWS: types.KubeAWS{
+				Region:    "us-west-2",
+				AccountID: "1234567890",
+				Name:      "eks",
+			},
+		},
+	)
+	require.NoError(t, err)
+	gkeKube, err := types.NewKubernetesClusterV3(
+		types.Metadata{
+			Name: "gke",
+		},
+		types.KubernetesClusterSpecV3{
+			GCP: types.KubeGCP{
+				Location:  "us-west-2",
+				ProjectID: "1234567890",
+				Name:      "eks",
+			},
+		},
+	)
+	require.NoError(t, err)
+	aksKube, err := types.NewKubernetesClusterV3(
+		types.Metadata{
+			Name: "aks",
+		},
+		types.KubernetesClusterSpecV3{
+			Azure: types.KubeAzure{
+				TenantID:       "id",
+				ResourceGroup:  "1234567890",
+				ResourceName:   "eks",
+				SubscriptionID: "12345",
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// mock sts client
+	stsMock := &stsMockClient{
+		// u is used to presign the request
+		// here we just verify the pre-signed request includes this url.
+		u: &url.URL{
+			Scheme: "https",
+			Host:   "sts.amazonaws.com",
+			Path:   "/?Action=GetCallerIdentity&Version=2011-06-15",
+		},
+	}
+
+	// mock clients
+	cloudclients := &cloud.TestCloudClients{
+		STS: stsMock,
+		EKS: &eksMockClient{
+			cluster: awsKube,
+			t:       t,
+		},
+		GCPGKE: &gkeMockCLient{kube: gkeKube, t: t},
+		AzureAKSClientPerSub: map[string]azure.AKSClient{
+			"12345": &azureMockCLient{
+				kube: aksKube,
+				t:    t,
+			},
+		},
+	}
+
+	type args struct {
+		cluster             types.KubeCluster
+		client              dynamicCredsClient
+		validateBearerToken func(string) error
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantAddr string
+	}{
+		{
+			name: "aws eks cluster",
+			args: args{
+				cluster: awsKube,
+				client:  getAWSClientRestConfig(cloudclients),
+				validateBearerToken: func(token string) error {
+					if token == "" {
+						return trace.BadParameter("missing bearer token")
+					}
+					tokens := strings.Split(token, ".")
+					if len(tokens) != 2 {
+						return trace.BadParameter("invalid bearer token")
+					}
+					if tokens[0] != "k8s-aws-v1" {
+						return trace.BadParameter("token must start with k8s-aws-v1")
+					}
+					dec, err := base64.RawStdEncoding.DecodeString(tokens[1])
+					if err != nil {
+						return trace.Wrap(err)
+					}
+					if string(dec) != stsMock.u.String() {
+						return trace.BadParameter("invalid token payload")
+					}
+					return nil
+				},
+			},
+			wantAddr: "api.eks.us-west-2.amazonaws.com:443",
+		},
+		{
+			name: "gcp gke cluster",
+			args: args{
+				cluster:             gkeKube,
+				client:              gcpRestConfigClient(cloudclients),
+				validateBearerToken: func(_ string) error { return nil },
+			},
+			wantAddr: "api.gke.google.com:443",
+		},
+		{
+			name: "azure aks cluster",
+			args: args{
+				cluster:             aksKube,
+				client:              azureRestConfigClient(cloudclients),
+				validateBearerToken: func(_ string) error { return nil },
+			},
+			wantAddr: "api.aks.microsoft.com:443",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClock := clockwork.NewFakeClock()
+			got, err := newDynamicKubeCreds(
+				context.Background(),
+				dynamicCredsConfig{
+					clock: fakeClock,
+					checker: func(_ context.Context, _ string,
+						_ authztypes.SelfSubjectAccessReviewInterface,
+					) error {
+						return nil
+					},
+					log:         log,
+					kubeCluster: tt.args.cluster,
+					client:      tt.args.client,
+				},
+			)
+			require.NoError(t, err)
+			require.Equal(t, got.getKubeRestConfig().CAData, []byte(fixtures.TLSCACertPEM))
+			require.NoError(t, tt.args.validateBearerToken(got.getKubeRestConfig().BearerToken))
+			require.Equal(t, got.getTargetAddr(), tt.wantAddr)
+			require.NoError(t, got.close())
+		})
+	}
+}
+
+type eksMockClient struct {
+	eksiface.EKSAPI
+	cluster types.KubeCluster
+	t       *testing.T
+}
+
+func (e *eksMockClient) DescribeClusterWithContext(_ aws.Context, req *eks.DescribeClusterInput, _ ...request.Option) (*eks.DescribeClusterOutput, error) {
+	require.Equal(e.t, e.cluster.GetAWSConfig().Name, *req.Name)
+	return &eks.DescribeClusterOutput{
+		Cluster: &eks.Cluster{
+			Endpoint: aws.String("https://api.eks.us-west-2.amazonaws.com"),
+			Name:     req.Name,
+			CertificateAuthority: &eks.Certificate{
+				Data: aws.String(base64.RawStdEncoding.EncodeToString([]byte(fixtures.TLSCACertPEM))),
+			},
+		},
+	}, nil
+}
+
+type stsMockClient struct {
+	stsiface.STSAPI
+	u *url.URL
+}
+
+func (s *stsMockClient) GetCallerIdentityRequest(req *sts.GetCallerIdentityInput) (*request.Request, *sts.GetCallerIdentityOutput) {
+	return &request.Request{
+		HTTPRequest: &http.Request{
+			Header: http.Header{},
+			URL:    s.u,
+		},
+		Operation: &request.Operation{},
+		Handlers:  request.Handlers{},
+	}, nil
+}
+
+type gkeMockCLient struct {
+	gcp.GKEClient
+	kube types.KubeCluster
+	t    *testing.T
+}
+
+func (g *gkeMockCLient) GetClusterRestConfig(ctx context.Context, cfg gcp.ClusterDetails) (*rest.Config, time.Time, error) {
+	require.Equal(g.t, g.kube.GetGCPConfig().Name, cfg.Name)
+	require.Equal(g.t, g.kube.GetGCPConfig().ProjectID, cfg.ProjectID)
+	require.Equal(g.t, g.kube.GetGCPConfig().Location, cfg.Location)
+	return &rest.Config{
+		Host: "https://api.gke.google.com",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: []byte(fixtures.TLSCACertPEM),
+		},
+	}, time.Now(), nil
+}
+
+type azureMockCLient struct {
+	azure.AKSClient
+	kube types.KubeCluster
+	t    *testing.T
+}
+
+func (a *azureMockCLient) ClusterCredentials(ctx context.Context, cfg azure.ClusterCredentialsConfig) (*rest.Config, time.Time, error) {
+	require.Equal(a.t, a.kube.GetAzureConfig().ResourceName, cfg.ResourceName)
+	require.Equal(a.t, a.kube.GetAzureConfig().ResourceGroup, cfg.ResourceGroup)
+	require.Equal(a.t, a.kube.GetAzureConfig().TenantID, cfg.TenantID)
+
+	return &rest.Config{
+		Host: "https://api.aks.microsoft.com",
+		TLSClientConfig: rest.TLSClientConfig{
+			CAData: []byte(fixtures.TLSCACertPEM),
+		},
+	}, time.Now(), nil
+}

--- a/lib/kube/proxy/kube_creds_test.go
+++ b/lib/kube/proxy/kube_creds_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Gravitational, Inc.
+Copyright 2023 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,19 +19,13 @@ package proxy
 import (
 	"context"
 	"encoding/base64"
-	"io"
-	"net/http"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/eks"
-	"github.com/aws/aws-sdk-go/service/eks/eksiface"
-	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -43,13 +37,24 @@ import (
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/azure"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
+	"github.com/gravitational/teleport/lib/cloud/mocks"
 	"github.com/gravitational/teleport/lib/fixtures"
 )
 
+// Test_DynamicKubeCreds tests the dynamic kube credrentials generator for
+// AWS, GCP, and Azure clusters accessed using their respective IAM credentials.
+// This test mocks the cloud provider clients and the STS client to generate
+// rest.Config objects for each cluster. It also tests the renewal of the
+// credentials when they expire.
 func Test_DynamicKubeCreds(t *testing.T) {
 	t.Parallel()
-	log := logrus.New()
-	log.SetOutput(io.Discard)
+	var (
+		fakeClock = clockwork.NewFakeClock()
+		log       = logrus.New()
+		notify    = make(chan struct{}, 1)
+		ttl       = 14 * time.Minute
+	)
+
 	awsKube, err := types.NewKubernetesClusterV3(
 		types.Metadata{
 			Name: "aws",
@@ -71,7 +76,7 @@ func Test_DynamicKubeCreds(t *testing.T) {
 			GCP: types.KubeGCP{
 				Location:  "us-west-2",
 				ProjectID: "1234567890",
-				Name:      "eks",
+				Name:      "gke",
 			},
 		},
 	)
@@ -84,7 +89,7 @@ func Test_DynamicKubeCreds(t *testing.T) {
 			Azure: types.KubeAzure{
 				TenantID:       "id",
 				ResourceGroup:  "1234567890",
-				ResourceName:   "eks",
+				ResourceName:   "aks-name",
 				SubscriptionID: "12345",
 			},
 		},
@@ -92,28 +97,70 @@ func Test_DynamicKubeCreds(t *testing.T) {
 	require.NoError(t, err)
 
 	// mock sts client
-	stsMock := &stsMockClient{
-		// u is used to presign the request
-		// here we just verify the pre-signed request includes this url.
-		u: &url.URL{
-			Scheme: "https",
-			Host:   "sts.amazonaws.com",
-			Path:   "/?Action=GetCallerIdentity&Version=2011-06-15",
-		},
+	u := &url.URL{
+		Scheme: "https",
+		Host:   "sts.amazonaws.com",
+		Path:   "/?Action=GetCallerIdentity&Version=2011-06-15",
 	}
-
 	// mock clients
 	cloudclients := &cloud.TestCloudClients{
-		STS: stsMock,
-		EKS: &eksMockClient{
-			cluster: awsKube,
-			t:       t,
+		STS: &mocks.STSMock{
+			// u is used to presign the request
+			// here we just verify the pre-signed request includes this url.
+			URL: u,
 		},
-		GCPGKE: &gkeMockCLient{kube: gkeKube, t: t},
+		EKS: &mocks.EKSMock{
+			Notify: notify,
+			Clusters: []*eks.Cluster{
+				{
+					Endpoint: aws.String("https://api.eks.us-west-2.amazonaws.com"),
+					Name:     aws.String(awsKube.GetAWSConfig().Name),
+					CertificateAuthority: &eks.Certificate{
+						Data: aws.String(base64.RawStdEncoding.EncodeToString([]byte(fixtures.TLSCACertPEM))),
+					},
+				},
+			},
+		},
+		GCPGKE: &mocks.GKEMock{
+			Notify: notify,
+			Clock:  fakeClock,
+			Clusters: []mocks.GKEClusterEntry{
+				{
+					Config: &rest.Config{
+						Host: "https://api.gke.google.com",
+						TLSClientConfig: rest.TLSClientConfig{
+							CAData: []byte(fixtures.TLSCACertPEM),
+						},
+					},
+					ClusterDetails: gcp.ClusterDetails{
+						Name:      gkeKube.GetGCPConfig().Name,
+						ProjectID: gkeKube.GetGCPConfig().ProjectID,
+						Location:  gkeKube.GetGCPConfig().Location,
+					},
+					TTL: ttl,
+				},
+			},
+		},
 		AzureAKSClientPerSub: map[string]azure.AKSClient{
-			"12345": &azureMockCLient{
-				kube: aksKube,
-				t:    t,
+			"12345": &mocks.AKSMock{
+				Notify: notify,
+				Clock:  fakeClock,
+				Clusters: []mocks.AKSClusterEntry{
+					{
+						Config: &rest.Config{
+							Host: "https://api.aks.microsoft.com",
+							TLSClientConfig: rest.TLSClientConfig{
+								CAData: []byte(fixtures.TLSCACertPEM),
+							},
+						},
+						TTL: ttl,
+						ClusterCredentialsConfig: azure.ClusterCredentialsConfig{
+							ResourceName:  aksKube.GetAzureConfig().ResourceName,
+							ResourceGroup: aksKube.GetAzureConfig().ResourceGroup,
+							TenantID:      aksKube.GetAzureConfig().TenantID,
+						},
+					},
+				},
 			},
 		},
 	}
@@ -132,7 +179,7 @@ func Test_DynamicKubeCreds(t *testing.T) {
 			name: "aws eks cluster",
 			args: args{
 				cluster: awsKube,
-				client:  getAWSClientRestConfig(cloudclients),
+				client:  getAWSClientRestConfig(cloudclients, fakeClock),
 				validateBearerToken: func(token string) error {
 					if token == "" {
 						return trace.BadParameter("missing bearer token")
@@ -148,7 +195,7 @@ func Test_DynamicKubeCreds(t *testing.T) {
 					if err != nil {
 						return trace.Wrap(err)
 					}
-					if string(dec) != stsMock.u.String() {
+					if string(dec) != u.String() {
 						return trace.BadParameter("invalid token payload")
 					}
 					return nil
@@ -177,7 +224,6 @@ func Test_DynamicKubeCreds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			fakeClock := clockwork.NewFakeClock()
 			got, err := newDynamicKubeCreds(
 				context.Background(),
 				dynamicCredsConfig{
@@ -187,88 +233,34 @@ func Test_DynamicKubeCreds(t *testing.T) {
 					) error {
 						return nil
 					},
-					log:         log,
-					kubeCluster: tt.args.cluster,
-					client:      tt.args.client,
+					log:                  log,
+					kubeCluster:          tt.args.cluster,
+					client:               tt.args.client,
+					initialRenewInterval: ttl / 2,
 				},
 			)
 			require.NoError(t, err)
-			require.Equal(t, got.getKubeRestConfig().CAData, []byte(fixtures.TLSCACertPEM))
-			require.NoError(t, tt.args.validateBearerToken(got.getKubeRestConfig().BearerToken))
-			require.Equal(t, got.getTargetAddr(), tt.wantAddr)
+			select {
+			case <-notify:
+			case <-time.After(5 * time.Second):
+				t.Fatalf("timeout waiting for cluster to be ready")
+			}
+			for i := 0; i < 10; i++ {
+				require.Equal(t, got.getKubeRestConfig().CAData, []byte(fixtures.TLSCACertPEM))
+				require.NoError(t, tt.args.validateBearerToken(got.getKubeRestConfig().BearerToken))
+				require.Equal(t, got.getTargetAddr(), tt.wantAddr)
+				fakeClock.BlockUntil(1)
+				fakeClock.Advance(ttl / 2)
+				// notify receives a signal when the cloud client is invoked.
+				// this is used to test that the credentials are refreshed each time
+				// they are about to expire.
+				select {
+				case <-notify:
+				case <-time.After(5 * time.Second):
+					t.Fatalf("timeout waiting for cluster to be ready, i=%d", i)
+				}
+			}
 			require.NoError(t, got.close())
 		})
 	}
-}
-
-type eksMockClient struct {
-	eksiface.EKSAPI
-	cluster types.KubeCluster
-	t       *testing.T
-}
-
-func (e *eksMockClient) DescribeClusterWithContext(_ aws.Context, req *eks.DescribeClusterInput, _ ...request.Option) (*eks.DescribeClusterOutput, error) {
-	require.Equal(e.t, e.cluster.GetAWSConfig().Name, *req.Name)
-	return &eks.DescribeClusterOutput{
-		Cluster: &eks.Cluster{
-			Endpoint: aws.String("https://api.eks.us-west-2.amazonaws.com"),
-			Name:     req.Name,
-			CertificateAuthority: &eks.Certificate{
-				Data: aws.String(base64.RawStdEncoding.EncodeToString([]byte(fixtures.TLSCACertPEM))),
-			},
-		},
-	}, nil
-}
-
-type stsMockClient struct {
-	stsiface.STSAPI
-	u *url.URL
-}
-
-func (s *stsMockClient) GetCallerIdentityRequest(req *sts.GetCallerIdentityInput) (*request.Request, *sts.GetCallerIdentityOutput) {
-	return &request.Request{
-		HTTPRequest: &http.Request{
-			Header: http.Header{},
-			URL:    s.u,
-		},
-		Operation: &request.Operation{},
-		Handlers:  request.Handlers{},
-	}, nil
-}
-
-type gkeMockCLient struct {
-	gcp.GKEClient
-	kube types.KubeCluster
-	t    *testing.T
-}
-
-func (g *gkeMockCLient) GetClusterRestConfig(ctx context.Context, cfg gcp.ClusterDetails) (*rest.Config, time.Time, error) {
-	require.Equal(g.t, g.kube.GetGCPConfig().Name, cfg.Name)
-	require.Equal(g.t, g.kube.GetGCPConfig().ProjectID, cfg.ProjectID)
-	require.Equal(g.t, g.kube.GetGCPConfig().Location, cfg.Location)
-	return &rest.Config{
-		Host: "https://api.gke.google.com",
-		TLSClientConfig: rest.TLSClientConfig{
-			CAData: []byte(fixtures.TLSCACertPEM),
-		},
-	}, time.Now(), nil
-}
-
-type azureMockCLient struct {
-	azure.AKSClient
-	kube types.KubeCluster
-	t    *testing.T
-}
-
-func (a *azureMockCLient) ClusterCredentials(ctx context.Context, cfg azure.ClusterCredentialsConfig) (*rest.Config, time.Time, error) {
-	require.Equal(a.t, a.kube.GetAzureConfig().ResourceName, cfg.ResourceName)
-	require.Equal(a.t, a.kube.GetAzureConfig().ResourceGroup, cfg.ResourceGroup)
-	require.Equal(a.t, a.kube.GetAzureConfig().TenantID, cfg.TenantID)
-
-	return &rest.Config{
-		Host: "https://api.aks.microsoft.com",
-		TLSClientConfig: rest.TLSClientConfig{
-			CAData: []byte(fixtures.TLSCACertPEM),
-		},
-	}, time.Now(), nil
 }

--- a/lib/kube/proxy/moderated_sessions_test.go
+++ b/lib/kube/proxy/moderated_sessions_test.go
@@ -268,7 +268,7 @@ func TestModeratedSessions(t *testing.T) {
 			}
 			req, err := generateExecRequest(
 				generateExecRequestConfig{
-					addr:          testCtx.KubeServiceAddress(),
+					addr:          testCtx.KubeProxyAddress(),
 					podName:       podName,
 					podNamespace:  podNamespace,
 					containerName: podContainerName,
@@ -653,7 +653,7 @@ func TestInteractiveSessionsNoAuth(t *testing.T) {
 			}
 			req, err := generateExecRequest(
 				generateExecRequestConfig{
-					addr:          testCtx.KubeServiceAddress(),
+					addr:          testCtx.KubeProxyAddress(),
 					podName:       podName,
 					podNamespace:  podNamespace,
 					containerName: podContainerName,


### PR DESCRIPTION
This PR improves the Kubernetes Access test coverage from 61% to >73%.

There are some other code paths that require special attention such as watching with filtering but those require more work.