### PR TITLE
Fix link to CA Pinning information

### DIFF
--- a/docs/pages/management/operations/ca-rotation.mdx
+++ b/docs/pages/management/operations/ca-rotation.mdx
@@ -9,13 +9,15 @@ description: How to rotate Teleport's certificate authority
 
 - (!docs/pages/includes/tctl.mdx!)
 
-## Certificate Authority rotation
+## Certificate authority rotation
 
-This section will show you how to implement certificate rotation in practice.
+This section will show you how to rotate Teleport's certificate authority.
 
-If you are using [CA Pinning](../join-services-to-your-cluster/join-token.mdx#obtain-a-ca-pin)
-when adding new nodes, the CA pin will change after the rotation. Make sure you
-use the *new* CA pin when adding nodes after rotation.
+If you are joining Teleport processes to a cluster via the Teleport Auth Service
+using a [join token](../join-services-to-your-cluster/join-token.mdx), each
+Teleport process will need a CA pin to trust the Auth Service. The CA pin will
+change after each CA rotation. Make sure you use the *new* CA pin when adding
+Teleport services after rotation.
 
 <Admonition type="warning" title="Desktop Access">
 Teleport signs Windows Desktop certificates with the user certificate authority.


### PR DESCRIPTION
Closes #26666

The "CA Pinning" link in the CA rotation guide links to an H3 heading within a closed `Details` box, making the link appear broken.

While it is possible to link to a `Details` box using a URL fragment, the docs linter currently flags these links as pointing to a nonexistent heading, since it is not yet aware of the `Details` box navigation logic.

As a result, this change removes this link, describes CA pinning in prose, and links to the general join token guide.