### PR TITLE
Update the README to mention Teleport Team

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,23 +87,20 @@ implementation. It is _fully compatible with OpenSSH_,
 
 ## Installing and Running
 
-| Follow the [Installation](https://goteleport.com/docs/installation/) Guide
+To set up a single-instance Teleport cluster, follow our [getting started
+guide](https://goteleport.com/docs/get-started). You can then register your
+servers, Kubernetes clusters, and other infrastructure with your Teleport
+cluster.
 
-Download the [latest binary release](https://goteleport.com/download),
-unpack the .tar.gz and run `sudo ./install`. This will copy Teleport binaries into
-`/usr/local/bin`.
+You can also get started with Teleport Team, a managed Teleport deployment that
+makes it easier for small organizations to enable secure access to their
+infrastructure.
 
-Then you can run Teleport as a single-node cluster:
+[Sign up for a free trial](https://goteleport.com/signup) of Teleport Team.
 
-```bash
-sudo teleport start
-```
-
-In a production environment, Teleport must run as `root`. For testing or non-production environments, run it as the `$USER`:
-
-`chown $USER /var/lib/teleport`
-
-* In this case, you will not be able to log in as another user.
+Follow our guide to [registering your first
+server](https://goteleport.com/docs/choose-an-edition/teleport-team/) with
+Teleport Team
 
 ## Docker
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ implementation. It is _fully compatible with OpenSSH_,
 |---|----
 | [Teleport Website](https://goteleport.com/) | The official website of the project. |
 | [Documentation](https://goteleport.com/docs/) | Admin guide, user manual and more. |
-| [Demo Video](https://www.youtube.com/watch?v=b1WHFW0NIoM) | 3-minute video overview of Teleport. |
 | [Blog](https://goteleport.com/blog/) | Our blog where we publish Teleport news. |
 | [Forum](https://github.com/gravitational/teleport/discussions) | Ask us a setup question, post your tutorial, feedback, or idea on our forum. |
 | [Slack](https://goteleport.com/slack) | Need help with your setup? Ping us in our Slack channel. |
@@ -103,8 +102,6 @@ server](https://goteleport.com/docs/choose-an-edition/teleport-team/) with
 Teleport Team
 
 ## Docker
-
-| Follow the Docker-Compose [Getting Started](https://goteleport.com/docs/setup/guides/docker-compose/) Guide
 
 ### Deploy Teleport
 


### PR DESCRIPTION
Mention Teleport Team in the section related to installing and running Teleport. Also replace the current instructions with a link to the Getting Started guide, which contains up-to-date information.