### PR TITLE
[v13] Define the "jamf_service" configuration

### DIFF
--- a/api/types/jamf.go
+++ b/api/types/jamf.go
@@ -1,0 +1,93 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+import (
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/slices"
+)
+
+const (
+	// JamfOnMissingNOOP is the textual representation for the NOOP on_missing
+	// action.
+	JamfOnMissingNoop = "NOOP"
+	// JamfOnMissingDelete is the textual representation for the DELETE on_missing
+	// action.
+	JamfOnMissingDelete = "DELETE"
+)
+
+// JamfOnMissingActions is a slice of all textual on_missing representations,
+// excluding the empty string.
+var JamfOnMissingActions = []string{
+	JamfOnMissingNoop,
+	JamfOnMissingDelete,
+}
+
+const (
+	// JamfSyncPeriodPartialDefault is the default value for sync_period_partial
+	// in inventory entries.
+	JamfSyncPeriodPartialDefault = 6 * time.Hour
+	// JamfSyncPeriodFullDefault is the default value for sync_period_full in
+	// inventory entries.
+	JamfSyncPeriodFullDefault = 24 * time.Hour
+)
+
+// ValidateJamfSpecV1 validates a [JamfSpecV1] instance.
+func ValidateJamfSpecV1(s *JamfSpecV1) error {
+	switch {
+	case s == nil:
+		return trace.BadParameter("spec required")
+	case s.Username == "":
+		return trace.BadParameter("username required")
+	case s.Password == "":
+		return trace.BadParameter("password required")
+	}
+
+	switch u, err := url.Parse(s.ApiEndpoint); {
+	case err != nil:
+		return trace.BadParameter("invalid API endpoint: %v", err)
+	case u.Host == "":
+		return trace.BadParameter("invalid API endpoint: missing hostname")
+	}
+
+	for i, e := range s.Inventory {
+		switch {
+		case e == nil:
+			return trace.BadParameter("inventory entry #%v is nil", i)
+		case e.OnMissing != "" && !slices.Contains(JamfOnMissingActions, e.OnMissing):
+			return trace.BadParameter(
+				"inventory[%v]: invalid on_missing action %q (expect empty or one of [%v])",
+				i, e.OnMissing, strings.Join(JamfOnMissingActions, ","))
+		}
+
+		syncPartial := e.SyncPeriodPartial
+		if syncPartial == 0 {
+			syncPartial = Duration(JamfSyncPeriodPartialDefault)
+		}
+		syncFull := e.SyncPeriodFull
+		if syncFull == 0 {
+			syncFull = Duration(JamfSyncPeriodFullDefault)
+		}
+		if syncPartial > syncFull {
+			return trace.BadParameter("inventory[%v]: sync_period_partial is greater than sync_period_full, partial syncs will never happen", i)
+		}
+	}
+
+	return nil
+}

--- a/api/types/jamf_test.go
+++ b/api/types/jamf_test.go
@@ -1,0 +1,177 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestValidateJamfSpecV1(t *testing.T) {
+	validSpec := &types.JamfSpecV1{
+		Enabled:     true,
+		ApiEndpoint: "https://yourtenant.jamfcloud.com",
+		Username:    "llama",
+		Password:    "supersecret!!1!",
+	}
+	validEntry := &types.JamfInventoryEntry{
+		FilterRsql:        "", // no filters
+		SyncPeriodPartial: 0,  // default period
+		SyncPeriodFull:    0,  // default period
+		OnMissing:         "", // same as NOOP
+	}
+
+	modify := func(f func(spec *types.JamfSpecV1)) *types.JamfSpecV1 {
+		spec := proto.Clone(validSpec).(*types.JamfSpecV1)
+		f(spec)
+		return spec
+	}
+
+	tests := []struct {
+		name    string
+		spec    *types.JamfSpecV1
+		wantErr string
+	}{
+		{
+			name: "minimal spec",
+			spec: validSpec,
+		},
+		{
+			name: "spec with inventory",
+			spec: &types.JamfSpecV1{
+				Enabled:     true,
+				ApiEndpoint: "https://yourtenant.jamfcloud.com",
+				Username:    "llama",
+				Password:    "supersecret!!1!",
+				Inventory: []*types.JamfInventoryEntry{
+					{
+						FilterRsql:        `general.remoteManagement.managed==true and general.platform=="Mac"`,
+						SyncPeriodPartial: types.Duration(4 * time.Hour),
+						SyncPeriodFull:    types.Duration(48 * time.Hour),
+						OnMissing:         "DELETE",
+					},
+					{
+						FilterRsql: `general.remoteManagement.managed==false`,
+						OnMissing:  "NOOP",
+					},
+					validEntry,
+				},
+			},
+		},
+		{
+			name: "all fields",
+			spec: &types.JamfSpecV1{
+				Enabled:     true,
+				Name:        "jamf2",
+				SyncDelay:   types.Duration(2 * time.Minute),
+				ApiEndpoint: "https://yourtenant.jamfcloud.com",
+				Username:    "llama",
+				Password:    "supersecret!!1!",
+				Inventory: []*types.JamfInventoryEntry{
+					{
+						FilterRsql:        `general.remoteManagement.managed==true and general.platform=="Mac"`,
+						SyncPeriodPartial: types.Duration(4 * time.Hour),
+						SyncPeriodFull:    types.Duration(48 * time.Hour),
+						OnMissing:         "DELETE",
+					},
+				},
+			},
+		},
+		{
+			name:    "nil spec",
+			spec:    nil,
+			wantErr: "spec required",
+		},
+		{
+			name: "api_endpoint invalid",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.ApiEndpoint = "https://%%"
+			}),
+			wantErr: "API endpoint",
+		},
+		{
+			name: "api_endpoint empty hostname",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.ApiEndpoint = "not a valid URL"
+			}),
+			wantErr: "missing hostname",
+		},
+		{
+			name: "username empty",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Username = ""
+			}),
+			wantErr: "username",
+		},
+		{
+			name: "password empty",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Password = ""
+			}),
+			wantErr: "password",
+		},
+		{
+			name: "inventory nil entry",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Inventory = []*types.JamfInventoryEntry{
+					nil,
+				}
+			}),
+			wantErr: "is nil",
+		},
+		{
+			name: "inventory sync_partial > sync_full",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Inventory = []*types.JamfInventoryEntry{
+					validEntry,
+					{
+						SyncPeriodPartial: types.Duration(12 * time.Hour),
+						SyncPeriodFull:    types.Duration(8 * time.Hour),
+					},
+				}
+			}),
+			wantErr: "greater than sync_period_full",
+		},
+		{
+			name: "inventory on_missing invalid",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Inventory = []*types.JamfInventoryEntry{
+					validEntry,
+					{
+						OnMissing: "BANANA",
+					},
+				}
+			}),
+			wantErr: "on_missing",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := types.ValidateJamfSpecV1(test.spec)
+			if test.wantErr == "" {
+				assert.NoError(t, err, "ValidateJamfSpecV1 failed")
+			} else {
+				assert.ErrorContains(t, err, test.wantErr, "ValidateJamfSpecV1 error mismatch")
+				assert.True(t, trace.IsBadParameter(err), "ValidateJamfSpecV1 returned non-BadParameter error: %T", err)
+			}
+		})
+	}
+}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -94,6 +94,9 @@ type FileConfig struct {
 	// Okta is the "okta_service" section in the Teleport configuration file
 	Okta Okta `yaml:"okta_service,omitempty"`
 
+	// Jamf is the "jamf_service" section in the config file.
+	Jamf JamfService `yaml:"jamf_service,omitempty"`
+
 	// Plugins is the section of the config for configuring the plugin service.
 	Plugins PluginService `yaml:"plugin_service,omitempty"`
 }
@@ -2369,4 +2372,96 @@ type Okta struct {
 
 	// APITokenPath is the path to the Okta API token.
 	APITokenPath string `yaml:"api_token_path,omitempty"`
+}
+
+// JamfService is the yaml representation of jamf_service.
+// Corresponds to [types.JamfSpecV1].
+type JamfService struct {
+	Service `yaml:",inline"`
+	// Name is the name of the sync device source.
+	Name string `yaml:"name,omitempty"`
+	// SyncDelay is the initial sync delay.
+	// Zero means "server default", negative means "immediate".
+	SyncDelay time.Duration `yaml:"sync_delay,omitempty"`
+	// ExitOnSync tells the service to exit immediately after the first sync.
+	ExitOnSync bool `yaml:"exit_on_sync,omitempty"`
+	// APIEndpoint is the Jamf Pro API endpoint.
+	// Example: "https://yourtenant.jamfcloud.com".
+	APIEndpoint string `yaml:"api_endpoint,omitempty"`
+	// Username is the Jamf Pro API username.
+	Username string `yaml:"username,omitempty"`
+	// PasswordFile is a file containing the  Jamf Pro API password.
+	// A single trailing newline is trimmed, anything else is taken literally.
+	PasswordFile string `yaml:"password_file,omitempty"`
+	// Inventory are the entries for inventory sync.
+	Inventory []*JamfInventoryEntry `yaml:"inventory,omitempty"`
+}
+
+// JamfInventoryEntry is the yaml representation of a jamf_service.inventory
+// entry.
+// Corresponds to [types.JamfInventoryEntry].
+type JamfInventoryEntry struct {
+	// FilterRSQL is a Jamf Pro API RSQL filter string.
+	FilterRSQL string `yaml:"filter_rsql,omitempty"`
+	// SyncPeriodPartial is the period for PARTIAL syncs.
+	// Zero means "server default", negative means "disabled".
+	SyncPeriodPartial time.Duration `yaml:"sync_period_partial,omitempty"`
+	// SyncPeriodFull is the period for FULL syncs.
+	// Zero means "server default", negative means "disabled".
+	SyncPeriodFull time.Duration `yaml:"sync_period_full,omitempty"`
+	// OnMissing is the trigger for devices missing from the MDM inventory view.
+	// See [types.JamfInventoryEntry.OnMissing].
+	OnMissing string `yaml:"on_missing,omitempty"`
+}
+
+func (j *JamfService) toJamfSpecV1() (*types.JamfSpecV1, error) {
+	switch {
+	case j == nil:
+		return nil, trace.BadParameter("jamf_service is nil")
+	case j.ListenAddress != "":
+		return nil, trace.BadParameter("jamf listen_addr not supported")
+	case j.PasswordFile == "":
+		return nil, trace.BadParameter("jamf password_file required")
+	}
+
+	// Read password from file.
+	pwdBytes, err := os.ReadFile(j.PasswordFile)
+	if err != nil {
+		return nil, trace.BadParameter("jamf password_file: %v", err)
+	}
+	pwd := string(pwdBytes)
+	if pwd == "" {
+		return nil, trace.BadParameter("jamf password_file is empty")
+	}
+	// Trim trailing \n?
+	if l := len(pwd); pwd[l-1] == '\n' {
+		pwd = pwd[:l-1]
+	}
+
+	// Assemble spec.
+	inventory := make([]*types.JamfInventoryEntry, len(j.Inventory))
+	for i, e := range j.Inventory {
+		inventory[i] = &types.JamfInventoryEntry{
+			FilterRsql:        e.FilterRSQL,
+			SyncPeriodPartial: types.Duration(e.SyncPeriodPartial),
+			SyncPeriodFull:    types.Duration(e.SyncPeriodFull),
+			OnMissing:         e.OnMissing,
+		}
+	}
+	spec := &types.JamfSpecV1{
+		Enabled:     j.Enabled(),
+		Name:        j.Name,
+		SyncDelay:   types.Duration(j.SyncDelay),
+		ApiEndpoint: j.APIEndpoint,
+		Username:    j.Username,
+		Password:    pwd,
+		Inventory:   inventory,
+	}
+
+	// Validate.
+	if err := types.ValidateJamfSpecV1(spec); err != nil {
+		return nil, trace.BadParameter("jamf_service %v", err)
+	}
+
+	return spec, nil
 }

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1181,7 +1181,8 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 
 // enterpriseServicesEnabled will return true of any enterprise services are enabled.
 func (process *TeleportProcess) enterpriseServicesEnabled() bool {
-	return modules.GetModules().BuildType() == modules.BuildEnterprise && (process.Config.Okta.Enabled)
+	return modules.GetModules().BuildType() == modules.BuildEnterprise &&
+		(process.Config.Okta.Enabled || process.Config.Jamf.Enabled())
 }
 
 // notifyParent notifies parent process that this process has started

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -1272,8 +1272,22 @@ func TestEnterpriseServicesEnabled(t *testing.T) {
 			},
 			expected: false,
 		},
+		{
+			name:       "jamf enabled",
+			enterprise: true,
+			config: &servicecfg.Config{
+				Jamf: servicecfg.JamfConfig{
+					Spec: &types.JamfSpecV1{
+						Enabled:     true,
+						ApiEndpoint: "https://example.jamfcloud.com",
+						Username:    "llama",
+						Password:    "supersecret!!1!ONE",
+					},
+				},
+			},
+			expected: true,
+		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			buildType := modules.BuildOSS

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -109,6 +109,9 @@ type Config struct {
 	// Okta defines the okta service configuration.
 	Okta OktaConfig
 
+	// Jamf defines the Jamf MDM service configuration.
+	Jamf JamfConfig
+
 	// Tracing defines the tracing service configuration.
 	Tracing TracingConfig
 
@@ -681,6 +684,7 @@ func verifyEnabledService(cfg *Config) error {
 		cfg.WindowsDesktop.Enabled,
 		cfg.Discovery.Enabled,
 		cfg.Okta.Enabled,
+		cfg.Jamf.Enabled(),
 		cfg.OpenSSH.Enabled,
 	}
 
@@ -691,5 +695,5 @@ func verifyEnabledService(cfg *Config) error {
 	}
 
 	return trace.BadParameter(
-		"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, or okta_service")
+		"config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, okta_service or jamf_service")
 }

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend/lite"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -476,23 +477,23 @@ func TestHostLabelMatching(t *testing.T) {
 
 func TestValidateConfig(t *testing.T) {
 	tests := []struct {
-		desc   string
-		config *Config
-		err    string
+		desc    string
+		config  *Config
+		wantErr string
 	}{
 		{
 			desc: "invalid version",
 			config: &Config{
 				Version: "v1.1",
 			},
-			err: fmt.Sprintf("version must be one of %s", strings.Join(defaults.TeleportConfigVersions, ", ")),
+			wantErr: fmt.Sprintf("version must be one of %s", strings.Join(defaults.TeleportConfigVersions, ", ")),
 		},
 		{
 			desc: "no service enabled",
 			config: &Config{
 				Version: defaults.TeleportConfigVersionV2,
 			},
-			err: "config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, or okta_service",
+			wantErr: "config: enable at least one of auth_service, ssh_service, proxy_service, app_service, database_service, kubernetes_service, windows_desktop_service, discovery_service, okta_service ",
 		},
 		{
 			desc: "no auth_servers or proxy_server specified",
@@ -502,7 +503,7 @@ func TestValidateConfig(t *testing.T) {
 					Enabled: true,
 				},
 			},
-			err: "config: auth_server or proxy_server is required",
+			wantErr: "config: auth_server or proxy_server is required",
 		},
 		{
 			desc: "no auth_servers specified",
@@ -512,7 +513,7 @@ func TestValidateConfig(t *testing.T) {
 					Enabled: true,
 				},
 			},
-			err: "config: auth_servers is required",
+			wantErr: "config: auth_servers is required",
 		},
 		{
 			desc: "specifying proxy_server with the wrong config version",
@@ -523,7 +524,7 @@ func TestValidateConfig(t *testing.T) {
 				},
 				ProxyServer: *utils.MustParseAddr("0.0.0.0"),
 			},
-			err: "config: proxy_server is supported from config version v3 onwards",
+			wantErr: "config: proxy_server is supported from config version v3 onwards",
 		},
 		{
 			desc: "specifying auth_server when app_service is enabled",
@@ -535,7 +536,7 @@ func TestValidateConfig(t *testing.T) {
 				DataDir:     "/",
 				authServers: []utils.NetAddr{*utils.MustParseAddr("0.0.0.0")},
 			},
-			err: "config: when app_service is enabled, proxy_server must be specified instead of auth_server",
+			wantErr: "config: when app_service is enabled, proxy_server must be specified instead of auth_server",
 		},
 		{
 			desc: "specifying auth_server when db_service is enabled",
@@ -547,17 +548,17 @@ func TestValidateConfig(t *testing.T) {
 				DataDir:     "/",
 				authServers: []utils.NetAddr{*utils.MustParseAddr("0.0.0.0")},
 			},
-			err: "config: when db_service is enabled, proxy_server must be specified instead of auth_server",
+			wantErr: "config: when db_service is enabled, proxy_server must be specified instead of auth_server",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
 			err := ValidateConfig(test.config)
-			if test.err == "" {
+			if test.wantErr == "" {
 				require.NoError(t, err)
 			} else {
-				require.EqualError(t, err, test.err)
+				require.ErrorContains(t, err, test.wantErr)
 			}
 		})
 	}
@@ -615,10 +616,24 @@ func TestVerifyEnabledService(t *testing.T) {
 			errAssertionFunc: require.NoError,
 		},
 		{
+			desc: "jamf enabled",
+			config: &Config{
+				Jamf: JamfConfig{
+					Spec: &types.JamfSpecV1{
+						Enabled:     true,
+						ApiEndpoint: "https://example.jamfcloud.com",
+						Username:    "llama",
+						Password:    "supersecret!!1!ONE",
+					},
+				},
+			},
+			errAssertionFunc: require.NoError,
+		},
+		{
 			desc:   "nothing enabled",
 			config: &Config{},
-			errAssertionFunc: func(tt require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsBadParameter(err))
+			errAssertionFunc: func(t require.TestingT, err error, _ ...interface{}) {
+				require.True(t, trace.IsBadParameter(err), "err is not a BadParameter error: %T", err)
 			},
 		},
 	}

--- a/lib/service/servicecfg/jamf.go
+++ b/lib/service/servicecfg/jamf.go
@@ -1,0 +1,30 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package servicecfg
+
+import "github.com/gravitational/teleport/api/types"
+
+// JamfConfig is the configuration for the Jamf MDM service.
+type JamfConfig struct {
+	// Spec is the configuration spec.
+	Spec *types.JamfSpecV1
+	// ExitOnSync controls whether the service performs a single sync operation
+	// before exiting.
+	ExitOnSync bool
+}
+
+func (j *JamfConfig) Enabled() bool {
+	return j != nil && j.Spec != nil && j.Spec.Enabled
+}


### PR DESCRIPTION
Backport #26478 to branch/v13

Add the "jamf_service" stanza to fileconf and the corresponding entry to
`servicecfg`.

Changes on `servicecfg`, `enterpriseServicesEnabled` and `ApplyFileConfig` are
part of the groundwork for the Jamf MDM service, as is the configuration itself.

https://github.com/gravitational/teleport.e/issues/826