### PR TITLE
docs: update agent updates

### DIFF
--- a/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
+++ b/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
@@ -36,7 +36,7 @@ updates.
 
 <Tabs>
 <TabItem label="Self-hosted">
-- A Teleport Enterprise version agent, either:
+- A Teleport Enterprise agent, either:
   - started via systemd on a distribution using the `apt` or `yum` package managers
   - deployed with the `teleport-kube-agent` Helm chart
 - automatic update infrastructure set up. For Self-Hosted users this means you
@@ -44,7 +44,7 @@ updates.
   know your version server URL and release channel
 </TabItem>
 <TabItem label="Teleport Cloud">
-- A Teleport Enterprise version agent, either:
+- A Teleport Enterprise agent, either:
   - started via systemd on a distribution using the `apt` or `yum` package managers
   - deployed with the `teleport-kube-agent` Helm chart
 - as a Teleport Cloud user, you must check if your Could Tenant is enrolled

--- a/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
+++ b/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
@@ -36,7 +36,7 @@ updates.
 
 <Tabs>
 <TabItem label="Self-hosted">
-- A Teleport agent, either:
+- A Teleport Enterprise version agent, either:
   - started via systemd on a distribution using the `apt` or `yum` package managers
   - deployed with the `teleport-kube-agent` Helm chart
 - automatic update infrastructure set up. For Self-Hosted users this means you
@@ -44,7 +44,7 @@ updates.
   know your version server URL and release channel
 </TabItem>
 <TabItem label="Teleport Cloud">
-- A Teleport agent, either:
+- A Teleport Enterprise version agent, either:
   - started via systemd on a distribution using the `apt` or `yum` package managers
   - deployed with the `teleport-kube-agent` Helm chart
 - as a Teleport Cloud user, you must check if your Could Tenant is enrolled
@@ -56,6 +56,13 @@ updates.
 
 <Tabs dropdownCaption="Cluster Type" dropdownSelected="Self-hosted">
 <TabItem label="systemd" options="Self-hosted">
+
+Confirm you have the Teleport Enterprise version installed.
+
+```code
+$ teleport version
+Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+```
 
 Create the upgrade configuration directory:
 
@@ -69,15 +76,19 @@ Else, you can skip this step:
 
 ```code
 $ sudo touch /etc/teleport-upgrade.d/schedule
-$ sudo chown <your-teleport-user> /etc/teleport-upgrade.d/schedule
+$ sudo chown <Var name="your-teleport-user" /> /etc/teleport-upgrade.d/schedule
 ```
 
 Configure the updater to connect to your custom version server and subscribe
 to the right release channel:
 
 ```code
-$ echo <version-server-url/path>/<release-channel> | sudo tee /etc/teleport-upgrade.d/endpoint
+$ echo <Var name="version-server-url/path" />/<Var name="release-channel" /> | sudo tee /etc/teleport-upgrade.d/endpoint
 ```
+
+<Admonition type="tip" title="Note">
+Make sure not to include `https://` as a prefix to the server address.
+</Admonition>
 
 Install the `teleport-ent-updater` package (note: your teleport agent will be restarted during install):
 
@@ -111,6 +122,9 @@ not be exported yet.
 
 <TabItem label="teleport-kube-agent chart" options="Self-hosted">
 
+Confirm you are using the enterprise image. The `enterprise` value setting
+should have been set to `true` for the helm chart installation.
+
 Add the following chart values to your existing agent `values.yaml`:
 
 ```yaml
@@ -142,6 +156,13 @@ $ kubectl logs <your-agent-release>-updater
 
 </TabItem>
 <TabItem label="systemd " options="Teleport Cloud">
+
+Confirm you have the Teleport Enterprise version installed.
+
+```code
+$ teleport version
+Teleport Enterprise v(=teleport.version=) go(=teleport.golang=)
+```
 
 If you changed the agent user to run as non-root, create
 `/etc/teleport-upgrade.d/schedule` and grant ownership to your Teleport user.
@@ -183,6 +204,9 @@ not be exported yet.
 
 </TabItem>
 <TabItem label="teleport-kube-agent chart " options="Teleport Cloud">
+
+Confirm you are using the enterprise image. The `enterprise` value setting
+should have been set to `true` for the helm chart installation.
 
 Add the following chart values to your existing agent `values.yaml`:
 

--- a/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
+++ b/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
@@ -57,7 +57,7 @@ updates.
 <Tabs dropdownCaption="Cluster Type" dropdownSelected="Self-hosted">
 <TabItem label="systemd" options="Self-hosted">
 
-Confirm you have the Teleport Enterprise version installed.
+Confirm you have the Teleport Enterprise edition installed.
 
 ```code
 $ teleport version
@@ -122,8 +122,8 @@ not be exported yet.
 
 <TabItem label="teleport-kube-agent chart" options="Self-hosted">
 
-Confirm you are using the enterprise image. The `enterprise` value setting
-should have been set to `true` for the helm chart installation.
+Confirm you are using the Teleport Enterprise image. The `enterprise` value setting
+should have been set to `true` for the Helm chart installation.
 
 Add the following chart values to your existing agent `values.yaml`:
 
@@ -157,7 +157,7 @@ $ kubectl logs <your-agent-release>-updater
 </TabItem>
 <TabItem label="systemd " options="Teleport Cloud">
 
-Confirm you have the Teleport Enterprise version installed.
+Confirm you have the Teleport Enterprise edition installed.
 
 ```code
 $ teleport version
@@ -205,8 +205,8 @@ not be exported yet.
 </TabItem>
 <TabItem label="teleport-kube-agent chart " options="Teleport Cloud">
 
-Confirm you are using the enterprise image. The `enterprise` value setting
-should have been set to `true` for the helm chart installation.
+Confirm you are using the Teleport Enterprise image. The `enterprise` value setting
+should have been set to `true` for the Helm chart installation.
 
 Add the following chart values to your existing agent `values.yaml`:
 


### PR DESCRIPTION
Based on recent feedback:
- more explicit on Teleport Enterprise version needed for agent. Wasn't clear the agent needs to be Teleport Enterprise.
- Note to not have `https://` as a prefix for systemd address.
- provide variables where able. 