### PR TITLE
Add `tsh kubectl` support for tracer exporter

### DIFF
--- a/tool/tsh/kubectl.go
+++ b/tool/tsh/kubectl.go
@@ -143,13 +143,14 @@ func runKubectlCode(cf *CLIConf, args []string) {
 				shutdownCtx, cancel := context.WithTimeout(cf.Context, 1*time.Second)
 				defer cancel()
 				err := provider.Shutdown(shutdownCtx)
-				if err != nil && !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+				if err != nil && !errors.Is(err, context.DeadlineExceeded) {
 					log.WithError(err).Debugf("Failed to shutdown trace provider")
 				}
 			}
 		}
 	}
-
+	// If the user opted to not sample traces, cf.TracingProvider is pre-initialized
+	// with a noop provider.
 	ctx, span := cf.TracingProvider.Tracer("kubectl").Start(cf.Context, "kubectl")
 	closeSpanAndTracer := func() {
 		span.End()

--- a/tool/tsh/kubectl.go
+++ b/tool/tsh/kubectl.go
@@ -132,7 +132,7 @@ func runKubectlCode(cf *CLIConf, args []string) {
 	if cf.SampleTraces {
 		provider, err := newTraceProvider(cf, "", nil)
 		if err != nil {
-			log.WithError(err).Debug("failed to set up span forwarding.")
+			log.WithError(err).Debug("Failed to set up span forwarding")
 		} else {
 			// only update the provider if we successfully set it up
 			cf.TracingProvider = provider

--- a/tool/tsh/kubectl.go
+++ b/tool/tsh/kubectl.go
@@ -144,7 +144,7 @@ func runKubectlCode(cf *CLIConf, args []string) {
 				defer cancel()
 				err := provider.Shutdown(shutdownCtx)
 				if err != nil && !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-					log.WithError(err).Debugf("failed to shutdown trace provider")
+					log.WithError(err).Debugf("Failed to shutdown trace provider")
 				}
 			}
 		}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1073,7 +1073,15 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 
 	// Connect to the span exporter and initialize the trace provider only if
 	// the --trace flag was set.
-	if cf.SampleTraces {
+	// kubectl is a special case because it is the only command that we re-execute
+	// in order to be able to access the exit code and stdout/stderr of the command
+	// that was run and determine if we should create a new access request from
+	// the output data.
+	// We don't want to enable tracing for the master invocation of tsh kubectl
+	// because the data that we would be tracing would be the tsh kubectl command.
+	// Instead, we want to enable tracing for the re-executed kubectl command and
+	// we do that in the kubectl command handler.
+	if cf.SampleTraces && cf.command != kubectl.FullCommand() {
 		// login only needs to be ignored if forwarding to auth
 		var ignored []string
 		if cf.TraceExporter == "" {
@@ -1314,7 +1322,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = deviceCmd.keyget.run(&cf)
 	case kubectl.FullCommand():
 		idx := slices.Index(args, kubectl.FullCommand())
-		err = onKubectlCommand(&cf, args[idx:])
+		err = onKubectlCommand(&cf, args, args[idx:])
 	case approve.FullCommand():
 		err = onHeadlessApprove(&cf)
 	default:


### PR DESCRIPTION
This PR adds support for `--trace` exporter when running `tsh kubectl`.
It allows any user to automatically export traces from `tsh`.

Usage: `tsh --trace --trace-exporter=dir kubectl get pods`