### PR TITLE
[v11] Don't unmount `cgroup2` when restarting

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -189,16 +189,21 @@ func New(config *Config) (BPF, error) {
 }
 
 // Close will stop any running BPF programs. Note this is only for a graceful
-// shutdown, from the man page for BPF: "Generally, eBPF programs are loaded
-// by the user process and automatically unloaded when the process exits."
-func (s *Service) Close() error {
+// shutdown, from the man page for BPF: "Generally, eBPF programs are loaded by
+// the user process and automatically unloaded when the process exits". The
+// restarting parameter indicates that Teleport is shutting down because of a
+// restart, and thus we should skip any deinitialization that would interfere
+// with the new Teleport instance.
+func (s *Service) Close(restarting bool) error {
 	// Unload the BPF programs.
 	s.exec.close()
 	s.open.close()
 	s.conn.close()
 
-	// Close cgroup service.
-	s.cgroup.Close()
+	// Close cgroup service. We should not unmount the cgroup filesystem if
+	// we're restarting.
+	skipCgroupUnmount := restarting
+	s.cgroup.Close(skipCgroupUnmount)
 
 	// Signal to the loop pulling events off the perf buffer to shutdown.
 	s.closeFunc()

--- a/lib/bpf/bpf_test.go
+++ b/lib/bpf/bpf_test.go
@@ -71,7 +71,8 @@ func TestRootWatch(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Cleanup(func() {
-		require.NoError(t, service.Close())
+		const restarting = false
+		require.NoError(t, service.Close(restarting))
 	})
 
 	// Create a fake audit log that can be used to capture the events emitted.
@@ -465,7 +466,8 @@ func moveIntoCgroup(t *testing.T, pid int) (uint64, error) {
 		return 0, trace.Wrap(err)
 	}
 	t.Cleanup(func() {
-		require.NoError(t, cgroupSrv.Close())
+		const skipUnmount = false
+		require.NoError(t, cgroupSrv.Close(skipUnmount))
 	})
 
 	sessionID := uuid.New().String()

--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -40,7 +40,7 @@ type BPF interface {
 	CloseSession(ctx *SessionContext) error
 
 	// Close will stop any running BPF programs.
-	Close() error
+	Close(restarting bool) error
 }
 
 // SessionContext contains all the information needed to track and emit
@@ -125,7 +125,7 @@ type NOP struct {
 }
 
 // Close closes the NOP service. Note this function does nothing.
-func (s *NOP) Close() error {
+func (s *NOP) Close(bool) error {
 	return nil
 }
 

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -92,11 +92,17 @@ func New(config *Config) (*Service, error) {
 	return s, nil
 }
 
-// Close will unmount the cgroup filesystem.
-func (s *Service) Close() error {
+// Close will clean up the session cgroups and unmount the cgroup2 filesystem,
+// unless otherwise requested.
+func (s *Service) Close(skipUnmount bool) error {
 	err := s.cleanupHierarchy()
 	if err != nil {
 		return trace.Wrap(err)
+	}
+
+	if skipUnmount {
+		log.Debugf("Cleaned up Teleport session hierarchy at: %v.", s.teleportRoot)
+		return nil
 	}
 
 	err = s.unmount()

--- a/lib/cgroup/cgroup_test.go
+++ b/lib/cgroup/cgroup_test.go
@@ -71,7 +71,8 @@ func TestRootCreate(t *testing.T) {
 	require.NoDirExists(t, cgroupPath)
 
 	// Close the cgroup service, this should unmound the cgroup filesystem.
-	err = service.Close()
+	const skipUnmount = false
+	err = service.Close(skipUnmount)
 	require.NoError(t, err)
 
 	// Make sure the cgroup filesystem has been unmounted.
@@ -96,7 +97,8 @@ func TestRootCleanup(t *testing.T) {
 		MountPath: dir,
 	})
 	require.NoError(t, err)
-	defer service.Close()
+	const skipUnmount = false
+	defer service.Close(skipUnmount)
 
 	// Create fake session ID and cgroup.
 	sessionID := uuid.New().String()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2137,6 +2137,12 @@ func (process *TeleportProcess) initSSH() error {
 	proxyGetter := reversetunnel.NewConnectedProxyGetter()
 
 	process.RegisterCriticalFunc("ssh.node", func() error {
+		// restartingOnGracefulShutdown will be set to true before the function
+		// exits if the function is exiting because Teleport is gracefully
+		// shutting down as a consequence of internally-triggered reloading or
+		// being signaled to restart.
+		var restartingOnGracefulShutdown bool
+
 		conn, err := process.waitForConnector(SSHIdentityEvent, log)
 		if conn == nil {
 			return trace.Wrap(err)
@@ -2189,7 +2195,7 @@ func (process *TeleportProcess) initSSH() error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		defer func() { warnOnErr(ebpf.Close(), log) }()
+		defer func() { warnOnErr(ebpf.Close(restartingOnGracefulShutdown), log) }()
 
 		// Start access control programs. This is blocking and if the BPF programs fail to
 		// load, the node will not start. If access control is not enabled, this will simply
@@ -2396,7 +2402,9 @@ func (process *TeleportProcess) initSSH() error {
 			warnOnErr(s.Close(), log)
 		} else {
 			log.Infof("Shutting down gracefully.")
-			warnOnErr(s.Shutdown(payloadContext(event.Payload, log)), log)
+			ctx := payloadContext(event.Payload, log)
+			restartingOnGracefulShutdown = services.IsProcessReloading(ctx) || services.HasProcessForked(ctx)
+			warnOnErr(s.Shutdown(ctx), log)
 		}
 
 		s.Wait()


### PR DESCRIPTION
Backport #26610 to branch/v11