### PR TITLE
Always render the portal for the assist title to go into

### DIFF
--- a/web/packages/teleport/src/Assist/ConversationTitle.tsx
+++ b/web/packages/teleport/src/Assist/ConversationTitle.tsx
@@ -29,7 +29,7 @@ export function ConversationTitle() {
     );
 
     if (conversation) {
-      return <> - {conversation.title}</>;
+      return <>{conversation.title}</>;
     }
   }
 

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -72,10 +72,9 @@ export function TopBar() {
       {!hasClusterUrl && (
         <Text fontSize="18px" bold>
           {title}
-
-          <span id="topbar-portal"></span>
         </Text>
       )}
+      <Text fontSize="18px" id="topbar-portal" ml={2}></Text>
       <ClusterSelector
         value={clusterId}
         width="384px"


### PR DESCRIPTION
This always renders the element for the conversation title portal to render into, so we don't run into "Target element doesn't exist" errors.