### PR TITLE
updates bitflags from 2.2.1 to 2.3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,9 +121,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
 
 [[package]]
 name = "block-buffer"
@@ -1210,7 +1210,7 @@ dependencies = [
 name = "rdp-client"
 version = "0.1.0"
 dependencies = [
- "bitflags 2.2.1",
+ "bitflags 2.3.1",
  "byteorder",
  "cbindgen",
  "env_logger",

--- a/lib/srv/desktop/rdp/rdpclient/Cargo.toml
+++ b/lib/srv/desktop/rdp/rdpclient/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 crate-type = ["staticlib"]
 
 [dependencies]
-bitflags = "2.2.1"
+bitflags = "2.3.1"
 byteorder = "1.4.3"
 env_logger = "0.10.0"
 iso7816 = "0.1.0"


### PR DESCRIPTION
[Bitflags deprecated the `BitFlags` trait in favor of `Flags` trait](https://github.com/bitflags/bitflags/releases/tag/2.3.0), however because nothing in our codebase depended on the `BitFlags` trait itself, this is just a standard minor version update for us.

Closes https://github.com/gravitational/teleport/issues/26711