### PR TITLE
[v11] Add a codegen-focused buildbox

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -992,6 +992,9 @@ enter-root:
 enter/centos7:
 	make -C build.assets enter/centos7
 
+.PHONY:enter/grpcbox
+enter/grpcbox:
+	make -C build.assets enter/grpcbox
 
 BUF := buf
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -245,19 +245,22 @@ RUN helm plugin install https://github.com/vbehar/helm3-unittest && \
     HELM_PLUGINS=/home/ci/.local/share/helm/plugins helm plugin list
 
 # Install JS gRPC tools.
-RUN (npm install --global grpc_tools_node_protoc_ts@5.0.1 grpc-tools@1.12.4)
+ARG NODE_GRPC_TOOLS_VERSION # eg, "1.12.4"
+ARG NODE_PROTOC_TS_VERSION  # eg, "5.0.1"
+RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
 
-# Install protobuf and grpc build tools.
-ARG PROTOC_VER
-ARG GOGO_PROTO_TAG
+# Install protoc.
+ARG PROTOC_VER # eg, "3.20.2"
+RUN VERSION="$PROTOC_VER" && \
+  PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
+  PB_FILE="$(mktemp protoc-XXXXXX.zip)" && \
+  curl -fsSL -o "$PB_FILE" "$PB_REL/download/v$VERSION/protoc-$VERSION-linux-$(if [ "$BUILDARCH" = "amd64" ]; then echo "x86_64"; else echo "aarch_64"; fi).zip"  && \
+  unzip "$PB_FILE" -d /usr/local && \
+  rm -f "$PB_FILE"
 
-RUN (export PROTOC_TARBALL=protoc-${PROTOC_VER}-linux-$(if [ "$BUILDARCH" = "amd64" ]; then echo "x86_64"; else echo "aarch_64"; fi).zip && \
-     curl -fsSL -o /tmp/${PROTOC_TARBALL} https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VER}/${PROTOC_TARBALL} && \
-     cd /tmp && unzip /tmp/${PROTOC_TARBALL} -d /usr/local && \
-     chmod -R a+r /usr/local/include/google/protobuf && \
-     chmod -R a+xr /usr/local/bin/protoc && \
-     rm /tmp/${PROTOC_TARBALL})
-RUN go install github.com/gogo/protobuf/protoc-gen-gogofast@${GOGO_PROTO_TAG}
+# Install protoc-gen-gogofast.
+ARG GOGO_PROTO_TAG # eg, "v1.3.2"
+RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 
 # Install addlicense.
 RUN go install github.com/google/addlicense@v1.0.0
@@ -270,12 +273,11 @@ RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2
     sh -s -- -b "$(go env GOPATH)/bin"
 
 # Install Buf.
-RUN BIN="/usr/local/bin" && \
-    VERSION="1.19.0" && \
-      curl -fsSL \
-        "https://github.com/bufbuild/buf/releases/download/v${VERSION}/buf-$(uname -s)-$(uname -m)" \
-        -o "${BIN}/buf" && \
-      chmod +x "${BIN}/buf"
+ARG BUF_VERSION # eg, "1.19.0"
+RUN BIN='/usr/local/bin' && \
+  VERSION="$BUF_VERSION" && \
+  curl -fsSL "https://github.com/bufbuild/buf/releases/download/v$VERSION/buf-$(uname -s)-$(uname -m)" -o "${BIN}/buf" && \
+  chmod +x "$BIN/buf"
 
 # Copy BPF libraries.
 COPY --from=libbpf /usr/include/bpf /usr/include/bpf

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,0 +1,44 @@
+FROM golang:1.20
+
+# Image layers go from less likely to most likely to change.
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+    npm \
+    unzip \
+    && \
+  rm -rf /var/lib/apt/lists/*
+
+# protoc-gen-gogofast
+# Keep in sync with api/proto/buf.yaml (and buf.lock)
+ARG GOGO_PROTO_TAG # eg, "v1.3.2"
+RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
+
+# protoc-gen-js and protoc-gen-ts
+ARG NODE_GRPC_TOOLS_VERSION # eg, "1.12.4"
+ARG NODE_PROTOC_TS_VERSION  # eg, "5.0.1"
+RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
+
+# protoc
+ARG PROTOC_VER # eg, "3.20.2"
+RUN VERSION="$PROTOC_VER" && \
+  PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
+  PB_FILE="$(mktemp protoc-XXXXXX.zip)" && \
+  curl -fsSL -o "$PB_FILE" "$PB_REL/download/v$VERSION/protoc-$VERSION-linux-$(uname -m).zip"  && \
+  unzip "$PB_FILE" -d /usr/local && \
+  rm -f "$PB_FILE"
+
+# buf
+ARG BUF_VERSION # eg, "1.19.0"
+RUN BIN='/usr/local/bin' && \
+  VERSION="$BUF_VERSION" && \
+  curl -fsSL "https://github.com/bufbuild/buf/releases/download/v$VERSION/buf-$(uname -s)-$(uname -m)" -o "${BIN}/buf" && \
+  chmod +x "$BIN/buf"
+
+# Pre-install go-runned binaries.
+# This is meant to be the only step that changes depending on the Teleport
+# branch.
+COPY go.mod go.sum /teleport-module/
+RUN cd /teleport-module; \
+  go install github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go && \
+  go install google.golang.org/grpc/cmd/protoc-gen-go-grpc && \
+  go install google.golang.org/protobuf/cmd/protoc-gen-go

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -23,7 +23,8 @@ ARG PROTOC_VER # eg, "3.20.2"
 RUN VERSION="$PROTOC_VER" && \
   PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
   PB_FILE="$(mktemp protoc-XXXXXX.zip)" && \
-  curl -fsSL -o "$PB_FILE" "$PB_REL/download/v$VERSION/protoc-$VERSION-linux-$(uname -m).zip"  && \
+  ARCH="$(if [ "$(uname -m)" = aarch64 ]; then echo aarch_64; else uname -m; fi)" && \
+  curl -fsSL -o "$PB_FILE" "$PB_REL/download/v$VERSION/protoc-$VERSION-linux-$ARCH.zip"  && \
   unzip "$PB_FILE" -d /usr/local && \
   rm -f "$PB_FILE"
 

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -41,5 +41,5 @@ RUN BIN='/usr/local/bin' && \
 COPY go.mod go.sum /teleport-module/
 RUN cd /teleport-module; \
   go install github.com/bufbuild/connect-go/cmd/protoc-gen-connect-go && \
-  go install google.golang.org/grpc/cmd/protoc-gen-go-grpc && \
+  go install github.com/golang/protobuf/protoc-gen-go && \
   go install google.golang.org/protobuf/cmd/protoc-gen-go

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -33,9 +33,7 @@ BUF_VERSION ?= 1.19.0
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4
 NODE_PROTOC_TS_VERSION ?= 5.0.1
-# Newer version of protoc have removed JS support that breaks our Teleterm build.
-# Related issue: https://github.com/protocolbuffers/protobuf-javascript/issues/105
-PROTOC_VER ?= 3.20.2
+PROTOC_VER ?= 3.20.3
 
 UID := $$(id -u)
 GID := $$(id -g)

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -27,6 +27,16 @@ RUST_VERSION ?= 1.68.0
 LIBBPF_VERSION ?= 0.7.0-teleport
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
+# Protogen related versions.
+BUF_VERSION ?= 1.19.0
+# Keep in sync with api/proto/buf.yaml (and buf.lock)
+GOGO_PROTO_TAG ?= v1.3.2
+NODE_GRPC_TOOLS_VERSION ?= 1.12.4
+NODE_PROTOC_TS_VERSION ?= 5.0.1
+# Newer version of protoc have removed JS support that breaks our Teleterm build.
+# Related issue: https://github.com/protocolbuffers/protobuf-javascript/issues/105
+PROTOC_VER ?= 3.20.2
+
 UID := $$(id -u)
 GID := $$(id -g)
 
@@ -37,14 +47,9 @@ RUNTIME_ARCH_arm64 := arm64
 RUNTIME_ARCH_aarch64 := arm64
 RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
 
-# Newer version of protoc have removed JS support that breaks our Teleterm build.
-# Related issue: https://github.com/protocolbuffers/protobuf-javascript/issues/105
-PROTOC_VER ?= 3.20.3
-# Keep in sync with api/proto/buf.yaml (and buf.lock).
-GOGO_PROTO_TAG ?= v1.3.2
-
 # BUILDBOX_VERSION, BUILDBOX and BUILDBOX_variant variables are included
 include images.mk
+include grpcbox.mk
 
 # These variables are used to dynamically change the name of the buildbox Docker image used by the 'release'
 # target. The other solution was to remove the 'buildbox' dependency from the 'release' target, but this would
@@ -126,9 +131,12 @@ buildbox:
 			--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 			--build-arg RUST_VERSION=$(RUST_VERSION) \
 			--build-arg NODE_VERSION=$(NODE_VERSION) \
-			--build-arg PROTOC_VER=$(PROTOC_VER) \
-			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
+			--build-arg BUF_VERSION=$(BUF_VERSION) \
+			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
+			--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
+			--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
+			--build-arg PROTOC_VER=$(PROTOC_VER) \
 			--cache-from $(BUILDBOX) \
 			--tag $(BUILDBOX) . ; \
 	fi
@@ -164,7 +172,6 @@ buildbox-centos7:
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
-		--build-arg PROTOC_VER=$(PROTOC_VER) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 		--build-arg LIBPCSCLITE_VERSION=$(LIBPCSCLITE_VERSION) \
 		--cache-from $(BUILDBOX_CENTOS7) \
@@ -236,17 +243,13 @@ ui: buildbox
 
 # grpc generates GRPC stubs from inside the buildbox
 .PHONY: grpc
-grpc: buildbox
-	docker run \
-		$(DOCKERFLAGS) -u $(UID):$(GID) -t $(BUILDBOX) \
-		make -C /go/src/github.com/gravitational/teleport grpc/host
+grpc: grpcbox
+	$(GRPCBOX_RUN) make grpc/host
 
 # protos-up-to-date checks if GRPC stubs are up to date from inside the buildbox
 .PHONY: protos-up-to-date
-protos-up-to-date: buildbox
-	docker run \
-		$(DOCKERFLAGS) -t $(BUILDBOX) \
-		make -C /go/src/github.com/gravitational/teleport protos-up-to-date/host
+protos-up-to-date: grpcbox
+	$(GRPCBOX_RUN) make protos-up-to-date/host
 
 # fix-imports runs GCI to sort and re-order Go imports in a deterministic way.
 .PHONY: fix-imports
@@ -358,6 +361,13 @@ enter-root: buildbox
 enter/centos7: buildbox
 	docker run $(DOCKERFLAGS) -ti $(NOROOT) \
 		-e HOME=$(SRCDIR)/build.assets -w $(SRCDIR) $(BUILDBOX_CENTOS7) /bin/bash
+
+#
+# Starts a shell inside the grpcbox.
+#
+.PHONY: enter/grpcbox
+enter/grpcbox: grpcbox
+	$(GRPCBOX_RUN)
 
 #
 # Create a Teleport package using the build container.

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -1,0 +1,33 @@
+# Makefile for grpcbox targets and variables.
+#
+# The grpcbox is a leaner, meaner, faster buildbox meant exclusively for
+# codegen.
+# It is not guaranteed to have tooling parity with the buildbox.
+#
+# See Dockerfile-grpcbox.
+
+GRPCBOX_BASE_NAME ?= teleport-grpcbox
+
+ifeq ($(BUILDBOX_VERSION), "")
+GRPCBOX ?= $(GRPCBOX_BASE_NAME)
+else
+GRPCBOX ?= $(GRPCBOX_BASE_NAME):$(BUILDBOX_VERSION)
+endif
+
+# GRPCBOX_RUN has the necessary invocation to run a command inside the grpcbox.
+# Use this variable to run it from other Makefiles.
+GRPCBOX_RUN := docker run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
+
+# grpcbox builds a codegen-focused buildbox.
+# It's leaner, meaner, faster and not supposed to compile code.
+.PHONY: grpcbox
+grpcbox:
+	DOCKER_BUILDKIT=1 docker build \
+		--build-arg BUF_VERSION=$(BUF_VERSION) \
+		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
+		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
+		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
+		--build-arg PROTOC_VER=$(PROTOC_VER) \
+		-f Dockerfile-grpcbox \
+		-t "$(GRPCBOX)" \
+		../


### PR DESCRIPTION
Backport #26640 and #26758 to branch/v11

Add the "grpcbox", a codegen-focused buildbox. It's meant to cut down build
times for `make grpc` and related commands.

The original buildbox still retains the ability to build protos, as GHA
pipelines require it to run [make protos-up-to-date/host][1]. That could also,
in the future, be changed to rely on the grpcbox instead.

[1]: https://github.com/gravitational/teleport/blob/1296b06955fcc9d2d071aa07bafc8d5c8ba3d853/.github/workflows/lint.yaml#L45