### PR TITLE
integrations/operator: Use a dedicated scheme in tests

### DIFF
--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -50,16 +50,16 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
-// Scheme is our own test-specific scheme to avoid using the global
+// scheme is our own test-specific scheme to avoid using the global
 // unprotected scheme.Scheme that triggers the race detector
-var Scheme = apiruntime.NewScheme()
+var scheme = apiruntime.NewScheme()
 
 func init() {
-	utilruntime.Must(v1.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv1.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv2.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv3.AddToScheme(Scheme))
-	utilruntime.Must(resourcesv5.AddToScheme(Scheme))
+	utilruntime.Must(v1.AddToScheme(scheme))
+	utilruntime.Must(resourcesv1.AddToScheme(scheme))
+	utilruntime.Must(resourcesv2.AddToScheme(scheme))
+	utilruntime.Must(resourcesv3.AddToScheme(scheme))
+	utilruntime.Must(resourcesv5.AddToScheme(scheme))
 }
 
 func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
@@ -178,7 +178,7 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	}
 
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{
-		Scheme:             Scheme,
+		Scheme:             scheme,
 		MetricsBindAddress: "0",
 	})
 	require.NoError(t, err)
@@ -277,7 +277,7 @@ func SetupTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	k8sClient, err := kclient.New(cfg, kclient.Options{Scheme: Scheme})
+	k8sClient, err := kclient.New(cfg, kclient.Options{Scheme: scheme})
 	require.NoError(t, err)
 	require.NotNil(t, k8sClient)
 

--- a/integrations/operator/controllers/resources/testlib/env.go
+++ b/integrations/operator/controllers/resources/testlib/env.go
@@ -28,9 +28,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	core "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/rest"
-	"k8s.io/kubectl/pkg/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	kclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -47,6 +49,18 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
+
+// Scheme is our own test-specific scheme to avoid using the global
+// unprotected scheme.Scheme that triggers the race detector
+var Scheme = apiruntime.NewScheme()
+
+func init() {
+	utilruntime.Must(v1.AddToScheme(Scheme))
+	utilruntime.Must(resourcesv1.AddToScheme(Scheme))
+	utilruntime.Must(resourcesv2.AddToScheme(Scheme))
+	utilruntime.Must(resourcesv3.AddToScheme(Scheme))
+	utilruntime.Must(resourcesv5.AddToScheme(Scheme))
+}
 
 func createNamespaceForTest(t *testing.T, kc kclient.Client) *core.Namespace {
 	ns := &core.Namespace{
@@ -164,7 +178,7 @@ func (s *TestSetup) StartKubernetesOperator(t *testing.T) {
 	}
 
 	k8sManager, err := ctrl.NewManager(s.K8sRestConfig, ctrl.Options{
-		Scheme:             scheme.Scheme,
+		Scheme:             Scheme,
 		MetricsBindAddress: "0",
 	})
 	require.NoError(t, err)
@@ -263,19 +277,7 @@ func SetupTestEnv(t *testing.T, opts ...TestOption) *TestSetup {
 	require.NoError(t, err)
 	require.NotNil(t, cfg)
 
-	err = resourcesv1.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
-	err = resourcesv5.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
-	err = resourcesv2.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
-	err = resourcesv3.AddToScheme(scheme.Scheme)
-	require.NoError(t, err)
-
-	k8sClient, err := kclient.New(cfg, kclient.Options{Scheme: scheme.Scheme})
+	k8sClient, err := kclient.New(cfg, kclient.Options{Scheme: Scheme})
 	require.NoError(t, err)
 	require.NotNil(t, k8sClient)
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/26753

Relying on a global scheme can cause race-conditions when registering schema in multiple tests. This commit does two things in an attempt to fix https://github.com/gravitational/teleport/issues/26753:

- use a separate Scheme for tests to avoid being affected by what others might be doing with the scheme
- initiate the Scheme only once during import