### PR TITLE
athena audit logs - always pass utc to query

### DIFF
--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -398,11 +398,11 @@ func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error
 }
 
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {
-	return l.querier.SearchEvents(ctx, req.From, req.To, req.EventTypes, req.Limit, req.Order, req.StartKey)
+	return l.querier.SearchEvents(ctx, req)
 }
 
 func (l *Log) SearchSessionEvents(ctx context.Context, req events.SearchSessionEventsRequest) ([]apievents.AuditEvent, string, error) {
-	return l.querier.SearchSessionEvents(ctx, req.From, req.To, req.Limit, req.Order, req.StartKey, req.Cond, req.SessionID)
+	return l.querier.SearchSessionEvents(ctx, req)
 }
 
 func (l *Log) Close() error {


### PR DESCRIPTION
Part of https://github.com/gravitational/teleport.e/issues/894
RFD: https://github.com/gravitational/teleport/blob/master/rfd/0118-scalable-audit-logs.md

Query now enforces UTC time because parquet writer stores files in folders per date and date is UTC there. I believe UTC is not enforced in auth and it's up to client. This way we are sure that athena querier operates on UTC.