### PR TITLE
Set the correct file permission on make grpc

### DIFF
--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -14,9 +14,14 @@ else
 GRPCBOX ?= $(GRPCBOX_BASE_NAME):$(BUILDBOX_VERSION)
 endif
 
+# UID and GID are used to run the grpcbox as the current user.
+UID := $$(id -u)
+GID := $$(id -g)
+
 # GRPCBOX_RUN has the necessary invocation to run a command inside the grpcbox.
 # Use this variable to run it from other Makefiles.
-GRPCBOX_RUN := docker run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
+# Set XDG_CACHE_HOME to let non-root user cache dependencies: https://github.com/bufbuild/buf/blob/f38ba9455c6650947b0b710327f9acb708da1196/private/pkg/app/app_unix.go#LL70C18-L70C32
+GRPCBOX_RUN := docker run -it --rm -u $(UID):$(GID) -e XDG_CACHE_HOME="/tmp/.cache" -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
 
 # grpcbox builds a codegen-focused buildbox.
 # It's leaner, meaner, faster and not supposed to compile code.


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/26640 introduced the new GRPC buildbox. The new Docker image uses the default user (root) which changes the generated files owner on all generates files. This PR changes the user to the current OS user, so files should preserve the same owner and group.

Note: This is mainly Linux issue, as MacOS does not change the owner of modified files in mounted volumes.