### PR TITLE
Fix SEO issues

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -2775,6 +2775,11 @@
       "source": "/adopters/",
       "destination": "/",
       "permanent": true
+    },
+    {
+      "source": "/choose-an-edition/teleport-cloud/",
+      "destination": "/choose-an-edition/teleport-cloud/introduction/",
+      "permanent": true
     }
   ]
 }

--- a/docs/pages/choose-an-edition/teleport-team.mdx
+++ b/docs/pages/choose-an-edition/teleport-team.mdx
@@ -237,5 +237,5 @@ Connect](../connect-your-client/teleport-connect.mdx).
 ### Subscribe
 
 After you finish your free trial, Teleport Team will charge based on usage.
-Check the [pricing page](https://goteleport.com/teleport-pricing/) for detailed
+Check the [pricing page](https://goteleport.com/pricing/) for detailed
 billing information.

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -142,11 +142,16 @@ access see the [RBAC](../database-access/rbac.mdx) documentation.
 
 When TLS Routing is disable by default, the Teleport Proxy Service returns `8.0.0-Teleport` as the MySQL server version. In some cases, like connecting with a GUI Client, this can result in obtaining an `Unknown system variable 'query_cache_size'` error that indicates that MySQL capabilities were not properly negotiated between the MySQL client and server.
 
-One way to solve this issue is to [use the TLS Routing feature](../management/operations/tls-routing.mdx), where the Teleport Proxy Service propagates the correct MySQL server version via TLS Routing extensions.
+One way to solve this issue is to [use the TLS Routing
+feature](../management/operations/tls-routing.mdx), where the Teleport Proxy
+Service propagates the correct MySQL server version via TLS Routing extensions.
 
-If migration to TLS Routing is not possible, another way to bypass this error is to use the [Teleport local proxy command](../connect-your-client/gui-clients.mdx#get-connection-information), which allows you to establish a TLS Routing connection to the Teleport Proxy Service even if TLS Routing was not enabled on the Teleport cluster.
+If migration to TLS Routing is not possible, another way to bypass this error is
+to use the [Teleport local proxy
+command](../connect-your-client/gui-clients.mdx#get-connection-information),
+which allows you to establish a TLS Routing connection to the Teleport Proxy
+Service even if TLS Routing was not enabled on the Teleport cluster.
 
-Another possibility is to overwrite the default MySQL server version (8.0.0-Teleport) returned by the Teleport Proxy Service. To do this, assign the `mysql_server_version` field in the `proxy_service` configuration block on your Teleport Proxy Service instances:
 ```yaml
 proxy_service:
   mysql_server_version: "8.0.4"


### PR DESCRIPTION
- Add a missing redirect from `choose-an-edition/teleport-cloud` to the introduction page of the "Teleport Cloud" docs subsection
- Fix broken links