### PR TITLE
Add option to change auth service type

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/service.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/service.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations: {{- toYaml $auth.annotations.service | nindent 4 }}
 {{- end }}
 spec:
+  type: {{ default "ClusterIP" $auth.service.type }}
   ports:
   - name: auth
     port: 3025

--- a/examples/chart/teleport-cluster/templates/auth/service.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/service.yaml
@@ -10,6 +10,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ default "ClusterIP" $auth.service.type }}
+{{- with $auth.service.spec }}
+  {{- toYaml . | nindent 2 }}
+{{- end }}
   ports:
   - name: auth
     port: 3025


### PR DESCRIPTION
The auth service type is currently always a ClusterIP. This means that SSH nodes connecting to the cluster need to go through the proxy. Using the proxy requires having a valid SSL cert. 
When the cluster deployed with the teleport-cluster Helm Chart is a leaf cluster, users shouldn't require to setup a valid SSL cert. Connecting from the SSH nodes to the auth directly using a LoadBalancer service allows to use the leaf cluster without configuring SSL.