### PR TITLE
Docs: Cleanup SSO Navigation subtree

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -335,23 +335,6 @@
           ],
           "entries": [
             {
-              "title": "GitHub SSO",
-              "slug": "/access-controls/sso/github-sso/",
-              "forScopes": [
-                "enterprise",
-                "cloud",
-                "oss"
-              ]
-            },
-            {
-              "title": "Azure Active Directory (AD)",
-              "slug": "/access-controls/sso/azuread/",
-              "forScopes": [
-                "enterprise",
-                "cloud"
-              ]
-            },
-            {
               "title": "Active Directory (ADFS)",
               "slug": "/access-controls/sso/adfs/",
               "forScopes": [
@@ -360,11 +343,20 @@
               ]
             },
             {
-              "title": "Google Workspace",
-              "slug": "/access-controls/sso/google-workspace/",
+              "title": "Azure Active Directory",
+              "slug": "/access-controls/sso/azuread/",
               "forScopes": [
                 "enterprise",
                 "cloud"
+              ]
+            },
+            {
+              "title": "GitHub",
+              "slug": "/access-controls/sso/github-sso/",
+              "forScopes": [
+                "enterprise",
+                "cloud",
+                "oss"
               ]
             },
             {
@@ -376,8 +368,8 @@
               ]
             },
             {
-              "title": "OneLogin",
-              "slug": "/access-controls/sso/one-login/",
+              "title": "Google Workspace",
+              "slug": "/access-controls/sso/google-workspace/",
               "forScopes": [
                 "enterprise",
                 "cloud"
@@ -394,6 +386,14 @@
             {
               "title": "Okta",
               "slug": "/access-controls/sso/okta/",
+              "forScopes": [
+                "enterprise",
+                "cloud"
+              ]
+            },
+            {
+              "title": "OneLogin",
+              "slug": "/access-controls/sso/one-login/",
               "forScopes": [
                 "enterprise",
                 "cloud"


### PR DESCRIPTION
- Moves the list from sort of alphabetical to actually alphabetical. I understand that GitHub was probably first because it's the only non-local option for OSS, but putting it first doesn't mean that to someone who doesn't already know it, and we have markings for the scope of each page.
- Removes `SSO` from the GitHub entry, because they're all SSO guides and the parent title is "Single Sign-On (SSO)".
- Removes (AD) from "Azure Active Directory" so it doesn't spill into a second line.

Before:
![image](https://github.com/gravitational/teleport/assets/2349184/a4affe9c-1c89-48a6-8808-3dc35b2adb7e)

After:

![image](https://github.com/gravitational/teleport/assets/2349184/868b6cd7-0de2-4e13-a898-41302b18a365)

