### PR TITLE
docs: update kube access for enterprise setting and agent updates

### DIFF
--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -77,7 +77,7 @@ or up to one major version back. You can set the version override with the overr
 (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
 <Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+<TabItem scope={["oss"]} label="Open Source">
 
 Switch `kubectl` to the Kubernetes cluster `cookie` and run the following
 commands, assigning `PROXY_ADDR` to the address of your Auth Service or Proxy
@@ -85,13 +85,49 @@ Service.
 
 ```code
 $ PROXY_ADDR=teleport.example.com:443
-
-# Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
 $ CLUSTER=cookie
+# Create the values.yaml file
+$ cat > values.yaml << EOF
+authToken: "${TOKEN}"
+proxyAddr: "${PROXY_ADDR}"
+roles: "kube"
+joinParams:
+  method: "token"
+  tokenName: "${TOKEN}"
+kubeClusterName: "${CLUSTER}"
+EOF
+# Install the helm chart with the values.yaml setting
 $ helm install teleport-agent teleport/teleport-kube-agent \
-  --set kubeClusterName=${CLUSTER?} \
-  --set proxyAddr=${PROXY_ADDR?} \
-  --set authToken=${TOKEN?} \
+  -f values.yaml \
+  --create-namespace \
+  --namespace=teleport-agent \
+  --version (=teleport.version=)
+```
+
+</TabItem>
+<TabItem scope={["enterprise"]} label="Enterprise">
+
+Switch `kubectl` to the Kubernetes cluster `cookie` and run the following
+commands, assigning `PROXY_ADDR` to the address of your Auth Service or Proxy
+Service.
+
+```code
+$ PROXY_ADDR=teleport.example.com:443
+$ CLUSTER=cookie
+# Create the values.yaml file
+$ cat > values.yaml << EOF
+authToken: "${TOKEN}"
+proxyAddr: "${PROXY_ADDR}"
+roles: "kube"
+joinParams:
+  method: "token"
+  tokenName: "${TOKEN}"
+kubeClusterName: "${CLUSTER}"
+enterprise: true
+EOF
+# Install the helm chart with the values.yaml setting
+$ helm install teleport-agent teleport/teleport-kube-agent \
+  -f values.yaml \
   --create-namespace \
   --namespace=teleport-agent \
   --version (=teleport.version=)
@@ -108,11 +144,20 @@ $ PROXY_ADDR=mytenant.teleport.sh:443
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
 $ CLUSTER=cookie
+# Create the values.yaml file
+$ cat > values.yaml << EOF
+authToken: "${TOKEN}"
+proxyAddr: "${PROXY_ADDR}"
+roles: "kube"
+joinParams:
+  method: "token"
+  tokenName: "${TOKEN}"
+kubeClusterName: "${CLUSTER}"
+enterprise: true
+EOF
 # Run the helm install specifying to match to the Teleport Cloud version of Teleport
 $ helm install teleport-agent teleport/teleport-kube-agent \
-  --set kubeClusterName=${CLUSTER?} \
-  --set proxyAddr=${PROXY_ADDR?} \
-  --set authToken=${TOKEN?} \
+  -f values.yaml \
   --create-namespace \
   --namespace=teleport-agent \
   --version (=cloud.version=)


### PR DESCRIPTION
- Update to show using the `enterprise` value for enterprise and cloud installs
- use `values.yaml` approach which will line up with the agent updates instructions for an upgrade 