### PR TITLE
Don't load ForwardedPorts from the .tsh/profile

### DIFF
--- a/api/profile/profile.go
+++ b/api/profile/profile.go
@@ -71,9 +71,6 @@ type Profile struct {
 	// SiteName is equivalent to the --cluster flag
 	SiteName string `yaml:"cluster,omitempty"`
 
-	// ForwardedPorts is the list of ports to forward to the target node.
-	ForwardedPorts []string `yaml:"forward_ports,omitempty"`
-
 	// DynamicForwardedPorts is a list of ports to use for dynamic port
 	// forwarding (SOCKS5).
 	DynamicForwardedPorts []string `yaml:"dynamic_forward_ports,omitempty"`

--- a/api/profile/profile_test.go
+++ b/api/profile/profile_test.go
@@ -40,7 +40,6 @@ func TestProfileBasics(t *testing.T) {
 		WebProxyAddr:          "proxy:3088",
 		SSHProxyAddr:          "proxy:3023",
 		Username:              "testuser",
-		ForwardedPorts:        []string{"8000:example.com:8000"},
 		DynamicForwardedPorts: []string{"localhost:8080"},
 		Dir:                   dir,
 		SiteName:              "example.com",

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -631,11 +631,6 @@ func (c *Config) LoadProfile(ps ProfileStore, proxyAddr string) error {
 		return trace.BadParameter("unable to parse mfa mode in user profile: %v.", err)
 	}
 
-	c.LocalForwardPorts, err = ParsePortForwardSpec(profile.ForwardedPorts)
-	if err != nil {
-		log.Warnf("Unable to parse port forwarding in user profile: %v.", err)
-	}
-
 	c.DynamicForwardedPorts, err = ParseDynamicPortForwardSpec(profile.DynamicForwardedPorts)
 	if err != nil {
 		log.Warnf("Unable to parse dynamic port forwarding in user profile: %v.", err)
@@ -663,7 +658,6 @@ func (c *Config) SaveProfile(makeCurrent bool) error {
 		PostgresProxyAddr:             c.PostgresProxyAddr,
 		MySQLProxyAddr:                c.MySQLProxyAddr,
 		MongoProxyAddr:                c.MongoProxyAddr,
-		ForwardedPorts:                c.LocalForwardPorts.String(),
 		SiteName:                      c.SiteName,
 		TLSRoutingEnabled:             c.TLSRoutingEnabled,
 		TLSRoutingConnUpgradeRequired: c.TLSRoutingConnUpgradeRequired,


### PR DESCRIPTION
This was leading to unexpected behavior where tsh was implicitly forwarding ports when running `tsh ssh` and would make it so a user could not run `tsh ssh ` multiple times simultaneously due to conflicting ports already being open.

With this change ports to forward must always be explicitly passed via the `-L` flag.

Fix for https://github.com/gravitational/teleport/issues/3094 and https://github.com/gravitational/customer-sensitive-requests/issues/69.