### PR TITLE
Add `buf breaking` to the CI linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,14 +3,14 @@ run-name: make lint
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
-      - 'rfd/**'
-      - '**/*.md*'
+      - "docs/**"
+      - "rfd/**"
+      - "**/*.md*"
   merge_group:
     paths-ignore:
-      - 'docs/**'
-      - 'rfd/**'
-      - '**/*.md*'
+      - "docs/**"
+      - "rfd/**"
+      - "**/*.md*"
 
 jobs:
   lint:
@@ -40,6 +40,25 @@ jobs:
       - name: Run linter
         run: make lint
 
-      - name: Check if protobufs are up to date
+      - name: Check if protos are up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $(realpath .) && make protos-up-to-date/host
+
+      # The `buf breaking` check is twofold: we always check for compatibility
+      # breaks against the base of the PR, and in backports we check for
+      # compatibility breaks _from_ the tip of master. It's possible to add
+      # fields just to release branches and not master, but it requires
+      # reserving the appropriate field numbers and field names in master (as it
+      # should!).
+
+      # We run a separate fetch because even with a fetch-depth of 0 in
+      # actions/checkout I'm not sure that we're guaranteed to have all the refs
+      # we need (especially the tip of master in backports), but it's a shallow
+      # fetch for a specific tree by hash, so it should be pretty fast.
+
+      - name: Check protos for breakage against parent
+        run: buf breaking . --against "https://github.com/${{ github.repository }}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+
+      - name: Check protos for breakage from master
+        if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
+        run: buf breaking "https://github.com/${{ github.repository }}.git#branch=master" --against .

--- a/Makefile
+++ b/Makefile
@@ -1141,8 +1141,17 @@ protos/lint: buf/installed
 	$(BUF) lint
 	$(BUF) lint --config=api/proto/buf-legacy.yaml api/proto
 
+.PHONY: protos/breaking
+protos/breaking: BASE=origin/master
+protos/breaking: buf/installed
+	@echo Checking compatibility against BASE=$(BASE)
+	buf breaking . --against '.git#branch=$(BASE)'
+
 .PHONY: lint-protos
 lint-protos: protos/lint
+
+.PHONY: lint-breaking
+lint-breaking: protos/breaking
 
 .PHONY: buf/installed
 buf/installed:


### PR DESCRIPTION
This PR runs [`buf breaking`](https://buf.build/docs/breaking/usage), a backwards compatibility check for protobufs, as part of the linting in CI.

Breakage is checked from the head of the PR against the base and - in backports - from the tip of master against the head of the PR. This helps ensure that no incompatibilities can occur when adding or changing fields in the protobuf messages, and that no incompatibilities can be added while backporting said changes.

In addition, this PR adds a Makefile target `lint-breaking` (alias of `protos/breaking`) to use for local development, to check compatibility against a specified ref defaulting to `origin/master`.

Contributes to #26688  