### PR TITLE
Remove initCommand from DocumentPtySession and PtyProcess

### DIFF
--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -93,7 +93,6 @@ export function getPtyProcessOptions(
         args: [],
         cwd: cmd.cwd,
         env,
-        initCommand: cmd.initCommand,
       };
     }
 

--- a/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/ptyHostClient.ts
@@ -43,10 +43,6 @@ export function createPtyHostClient(
         request.setCwd(ptyOptions.cwd);
       }
 
-      if (ptyOptions.initCommand) {
-        request.setInitCommand(ptyOptions.initCommand);
-      }
-
       return new Promise<string>((resolve, reject) => {
         client.createPtyProcess(request, (error, response) => {
           if (error) {

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -41,7 +41,6 @@ export type PtyServiceClient = {
 export type ShellCommand = PtyCommandBase & {
   kind: 'pty.shell';
   cwd?: string;
-  initCommand?: string;
 };
 
 export type TshLoginCommand = PtyCommandBase & {

--- a/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
+++ b/web/packages/teleterm/src/sharedProcess/api/proto/ptyHostService.proto
@@ -33,7 +33,8 @@ message PtyCreate {
   string path = 3;
   repeated string args = 4;
   string cwd = 5;
-  optional string init_command = 6;
+  reserved 6;
+  reserved "init_command";
   google.protobuf.Struct env = 7;
 }
 

--- a/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.d.ts
+++ b/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.d.ts
@@ -53,11 +53,6 @@ export class PtyCreate extends jspb.Message {
     getCwd(): string;
     setCwd(value: string): PtyCreate;
 
-    hasInitCommand(): boolean;
-    clearInitCommand(): void;
-    getInitCommand(): string | undefined;
-    setInitCommand(value: string): PtyCreate;
-
     hasEnv(): boolean;
     clearEnv(): void;
     getEnv(): google_protobuf_struct_pb.Struct | undefined;
@@ -78,7 +73,6 @@ export namespace PtyCreate {
         path: string,
         argsList: Array<string>,
         cwd: string,
-        initCommand?: string,
         env?: google_protobuf_struct_pb.Struct.AsObject,
     }
 }

--- a/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.js
+++ b/web/packages/teleterm/src/sharedProcess/api/protogen/ptyHostService_pb.js
@@ -439,7 +439,6 @@ proto.PtyCreate.toObject = function(includeInstance, msg) {
     path: jspb.Message.getFieldWithDefault(msg, 3, ""),
     argsList: (f = jspb.Message.getRepeatedField(msg, 4)) == null ? undefined : f,
     cwd: jspb.Message.getFieldWithDefault(msg, 5, ""),
-    initCommand: jspb.Message.getFieldWithDefault(msg, 6, ""),
     env: (f = msg.getEnv()) && google_protobuf_struct_pb.Struct.toObject(includeInstance, f)
   };
 
@@ -488,10 +487,6 @@ proto.PtyCreate.deserializeBinaryFromReader = function(msg, reader) {
     case 5:
       var value = /** @type {string} */ (reader.readString());
       msg.setCwd(value);
-      break;
-    case 6:
-      var value = /** @type {string} */ (reader.readString());
-      msg.setInitCommand(value);
       break;
     case 7:
       var value = new google_protobuf_struct_pb.Struct;
@@ -545,13 +540,6 @@ proto.PtyCreate.serializeBinaryToWriter = function(message, writer) {
   if (f.length > 0) {
     writer.writeString(
       5,
-      f
-    );
-  }
-  f = /** @type {string} */ (jspb.Message.getField(message, 6));
-  if (f != null) {
-    writer.writeString(
-      6,
       f
     );
   }
@@ -636,42 +624,6 @@ proto.PtyCreate.prototype.getCwd = function() {
  */
 proto.PtyCreate.prototype.setCwd = function(value) {
   return jspb.Message.setProto3StringField(this, 5, value);
-};
-
-
-/**
- * optional string init_command = 6;
- * @return {string}
- */
-proto.PtyCreate.prototype.getInitCommand = function() {
-  return /** @type {string} */ (jspb.Message.getFieldWithDefault(this, 6, ""));
-};
-
-
-/**
- * @param {string} value
- * @return {!proto.PtyCreate} returns this
- */
-proto.PtyCreate.prototype.setInitCommand = function(value) {
-  return jspb.Message.setField(this, 6, value);
-};
-
-
-/**
- * Clears the field making it undefined.
- * @return {!proto.PtyCreate} returns this
- */
-proto.PtyCreate.prototype.clearInitCommand = function() {
-  return jspb.Message.setField(this, 6, undefined);
-};
-
-
-/**
- * Returns whether this field is set.
- * @return {boolean}
- */
-proto.PtyCreate.prototype.hasInitCommand = function() {
-  return jspb.Message.getField(this, 6) != null;
 };
 
 

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyHostService.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyHostService.ts
@@ -36,7 +36,6 @@ export function createPtyHostService(): IPtyHostServer {
           path: ptyOptions.path,
           args: ptyOptions.argsList,
           cwd: ptyOptions.cwd,
-          initCommand: ptyOptions.initCommand,
           ptyId,
           env: call.request.getEnv()?.toJavaScript() as Record<string, string>,
         });

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/ptyProcess.ts
@@ -78,10 +78,6 @@ export class PtyProcess extends EventEmitter implements IPtyProcess {
 
     this._process.onData(data => this._handleData(data));
     this._process.onExit(ev => this._handleExit(ev));
-
-    if (this.options.initCommand) {
-      this._process.write(this.options.initCommand + '\r');
-    }
   }
 
   write(data: string) {

--- a/web/packages/teleterm/src/sharedProcess/ptyHost/types.ts
+++ b/web/packages/teleterm/src/sharedProcess/ptyHost/types.ts
@@ -19,7 +19,6 @@ export type PtyProcessOptions = {
   path: string;
   args: string[];
   cwd?: string;
-  initCommand?: string;
 };
 
 export type IPtyProcess = {

--- a/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/useDocumentTerminal.ts
@@ -251,24 +251,10 @@ async function setUpPtyProcess(
     });
   };
 
-  const removeInitCommand = () => {
-    if (doc.kind !== 'doc.terminal_shell') {
-      return;
-    }
-    // The initCommand has to be launched only once, not every time we recreate the document from
-    // the state.
-    //
-    // Imagine that someone creates a new terminal document with `rm -rf /tmp` as initCommand.
-    // We'd execute the command each time the document gets recreated from the state, which is not
-    // what the user would expect.
-    documentsService.update(doc.uri, { initCommand: undefined });
-  };
-
   // We don't need to clean up the listeners added on ptyProcess in this function. The effect which
   // calls setUpPtyProcess automatically disposes of the process on cleanup, removing all listeners.
   ptyProcess.onOpen(() => {
     refreshTitle();
-    removeInitCommand();
   });
 
   // TODO(ravicious): Refactor runOnce to not use the `n` variable. Otherwise runOnce subtracts 1
@@ -409,6 +395,5 @@ function createCmd(
     proxyHost,
     clusterName,
     cwd: doc.cwd,
-    initCommand: doc.initCommand,
   };
 }

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -21,7 +21,6 @@ import {
   CreateAccessRequestDocumentOpts,
   CreateClusterDocumentOpts,
   CreateGatewayDocumentOpts,
-  CreateNewTerminalOpts,
   CreateTshKubeDocumentOptions,
   Document,
   DocumentAccessRequests,
@@ -182,7 +181,7 @@ export class DocumentsService {
     };
   }
 
-  openNewTerminal(opts: CreateNewTerminalOpts) {
+  openNewTerminal(opts: { rootClusterId: string; leafClusterId?: string }) {
     const doc = ((): Document => {
       const activeDocument = this.getActive();
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -148,7 +148,6 @@ export interface DocumentAccessRequests extends DocumentBase {
 export interface DocumentPtySession extends DocumentBase {
   kind: 'doc.terminal_shell';
   cwd?: string;
-  initCommand?: string;
   rootClusterId?: string;
   leafClusterId?: string;
 }
@@ -211,9 +210,3 @@ export type CreateAccessRequestDocumentOpts = {
 };
 
 export type AccessRequestDocumentState = 'browsing' | 'creating' | 'reviewing';
-
-export type CreateNewTerminalOpts = {
-  initCommand?: string;
-  rootClusterId: string;
-  leafClusterId?: string;
-};


### PR DESCRIPTION
`initCommand` was our (admittedly hacky) solution to opening a shell session and executing a specific command when it starts. It has been used for two features which are no longer existing:

* Launching an arbitrary command from the command bar.
   * The command bar was replaced with the search bar in v13.
* Opening a new terminal tab and running a gateway CLI client.
   * This was removed by #26441.

Since it's no longer used, we can remove it. Documents are persisted to disk, so we have to be careful about modifying their fields. However, removing fields is generally safe. On top that, `initCommand` was removed from the state as soon as the tab got opened. If by any chance there's a user with a doc with `initCommand` in the state (for example, we failed to spawn the PTY and they closed the app), this document will become a regular terminal tab.

It doesn't get rid of the problems raised in [TEL-Q322-15](https://github.com/gravitational/teleport-private/issues/176) (see the description of #26057), but it does get rid of an attack vector.