### PR TITLE
docs: correct faq answer on editions

### DIFF
--- a/docs/pages/faq.mdx
+++ b/docs/pages/faq.mdx
@@ -70,7 +70,7 @@ don't support the SFTP protocol, and it's enabled by default in `tsh` v11.0.0 an
 
 ## How is Open Source different from Enterprise?
 
-Teleport provides three editions:
+Teleport provides four editions:
 
 - Teleport Team
 - Teleport Enterprise


### PR DESCRIPTION
We say three editions and list 4. only required to backport to 12 and 13.