### PR TITLE
ci: build tctl in the build-windows job

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -3,8 +3,8 @@ run-name: Build on Windows
 
 on:
   merge_group:
-    # We only build tsh on Windows so only consider Go code as tsh doesn't
-    # run any Rust.
+    # We only build tsh and tctl on Windows so only consider Go code
+    # (tsh and tctl don't run any Rust)
     paths:
       - '.github/workflows/build-windows.yaml'
       - '**.go'
@@ -41,3 +41,4 @@ jobs:
         run: |
           $Env:OS="windows"
           make build/tsh
+          make build/tctl


### PR DESCRIPTION
We don't officially support tctl on Windows yet, but it does now build and we want to ensure it stays that way.