### PR TITLE
[v11] docs: mention missing delete permission for GCS buckets

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -111,7 +111,7 @@ and user records will be stored.
 To configure Teleport for using etcd as a storage backend:
 
 - Make sure you are using **etcd versions 3.3** or newer.
-- Follow [etcd's cluster hardware recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/). In particular, leverage 
+- Follow [etcd's cluster hardware recommendations](https://etcd.io/docs/v3.5/op-guide/hardware/). In particular, leverage
   SSD or high-performance virtualized block device storage for best performance.
 - Install etcd and configure peer and client TLS authentication using the [etcd
   security guide](https://etcd.io/docs/v3.5/op-guide/security/).
@@ -617,6 +617,10 @@ Replace the following variables in the above example with your own values:
   - `storage.objects.get`
   - `storage.objects.list`
   - `storage.objects.update`
+  - `storage.objects.delete`
+
+  `storage.objects.delete` is required in order to clean up multipart files
+  after they have been assembled into the final blob.
 
   If the bucket does not exist, please also ensure that the `storage.buckets.create` permission is granted.
 
@@ -686,8 +690,8 @@ teleport:
 - The GCP authentication setting above can be omitted if the machine itself is
   running on a GCE instance with a Service Account that has access to the
   Firestore table.
-- Audit log settings above are optional. If specified, Teleport will store the audit log in Firestore 
-  and the session recordings **must** be stored in a GCS bucket, i.e. both `audit_xxx` settings must 
+- Audit log settings above are optional. If specified, Teleport will store the audit log in Firestore
+  and the session recordings **must** be stored in a GCS bucket, i.e. both `audit_xxx` settings must
   be present. If they are not set, Teleport will default to a local filesystem for the audit log, i.e.
   `/var/lib/teleport/log` on an auth server.
 


### PR DESCRIPTION
GCS does not implement the S3 multipart API, so we emulate it by uploading parts manually and "completing" the upload. The delete permission is necessary to remove the individual parts after the upload is completed.

Manual backport of #26506 