### PR TITLE
Fix agent forwarding with `--add-keys-to-agent=no`

### DIFF
--- a/lib/client/session.go
+++ b/lib/client/session.go
@@ -270,7 +270,7 @@ func selectKeyAgent(tc *TeleportClient) agent.ExtendedAgent {
 	switch tc.ForwardAgent {
 	case ForwardAgentYes:
 		log.Debugf("Selecting system key agent.")
-		return tc.localAgent.systemAgent
+		return connectToSSHAgent()
 	case ForwardAgentLocal:
 		log.Debugf("Selecting local Teleport key agent.")
 		return tc.localAgent.ExtendedAgent


### PR DESCRIPTION
Fix bug where the system agent is not forwarded in combination with `--add-keys-to-agent=no`.

Note: unit test added in https://github.com/gravitational/teleport/pull/26862