### PR TITLE
Deflake `TestMonitorStaleLocks`

### DIFF
--- a/lib/services/watcher.go
+++ b/lib/services/watcher.go
@@ -242,6 +242,11 @@ func (p *resourceWatcher) runWatchLoop() {
 		case <-p.ctx.Done():
 			p.Log.Debug("Closed, returning from watch loop.")
 			return
+		case <-p.StaleC:
+			// Used for testing that the watch routine is waiting for the
+			// next restart attempt. We don't want to wait for the full
+			// retry period in tests so we trigger the restart immediately.
+			p.Log.Debug("Stale view, continue watch loop.")
 		}
 		if err != nil {
 			p.Log.Warningf("Restart watch on error: %v.", err)


### PR DESCRIPTION
This PR deflakes `TestMonitorStaleLocks` because it ends up waiting for the retry time to pass and timeout.

This PR enforces the loop continuation by adding the test `StaleC` channel into the wait select.

Fixes #26866