### PR TITLE
Okta Import Rules use Teleport style regexes.

### DIFF
--- a/lib/services/local/okta.go
+++ b/lib/services/local/okta.go
@@ -18,7 +18,6 @@ package local
 
 import (
 	"context"
-	"regexp"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -29,6 +28,7 @@ import (
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/services/local/generic"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -123,7 +123,7 @@ func validateOktaImportRuleRegexes(importRule types.OktaImportRule) error {
 		for _, match := range mapping.GetMatches() {
 			if ok, regexes := match.GetAppNameRegexes(); ok {
 				for _, regex := range regexes {
-					if _, err := regexp.Compile(regex); err != nil {
+					if _, err := utils.CompileExpression(regex); err != nil {
 						errs = append(errs, err)
 					}
 				}
@@ -131,7 +131,7 @@ func validateOktaImportRuleRegexes(importRule types.OktaImportRule) error {
 
 			if ok, regexes := match.GetGroupNameRegexes(); ok {
 				for _, regex := range regexes {
-					if _, err := regexp.Compile(regex); err != nil {
+					if _, err := utils.CompileExpression(regex); err != nil {
 						errs = append(errs, err)
 					}
 				}

--- a/lib/services/local/okta_test.go
+++ b/lib/services/local/okta_test.go
@@ -252,7 +252,7 @@ func TestValidateOktaImportRuleRegexes(t *testing.T) {
 			spec: types.OktaImportRuleSpecV1{
 				Mappings: []*types.OktaImportRuleMappingV1{
 					{
-						Match:     []*types.OktaImportRuleMatchV1{createRegexMatch("(bad", ".*")},
+						Match:     []*types.OktaImportRuleMatchV1{createRegexMatch("^(bad$", ".*")},
 						AddLabels: map[string]string{"label1": "value1"},
 					},
 					{
@@ -274,7 +274,7 @@ func TestValidateOktaImportRuleRegexes(t *testing.T) {
 						AddLabels: map[string]string{"label1": "value1"},
 					},
 					{
-						Match:     []*types.OktaImportRuleMatchV1{createRegexMatch(".*", "(bad")},
+						Match:     []*types.OktaImportRuleMatchV1{createRegexMatch(".*", "^(bad$")},
 						AddLabels: map[string]string{"label1": "value1"},
 					},
 				},

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -89,7 +89,7 @@ type RegexpConfig struct {
 
 // KubeResourceMatchesRegex checks whether the input matches any of the given
 // expressions.
-// This function returns as soon as it finds the first match or when matchString
+// This function returns as soon as it finds the first match or when MatchString
 // returns an error.
 // This function supports regex expressions in the Name and Namespace fields,
 // but not for the Kind field.
@@ -101,13 +101,13 @@ func KubeResourceMatchesRegex(input types.KubernetesResource, resources []types.
 		if input.Kind != resource.Kind {
 			continue
 		}
-		switch ok, err := matchString(input.Name, resource.Name); {
+		switch ok, err := MatchString(input.Name, resource.Name); {
 		case err != nil:
 			return false, trace.Wrap(err)
 		case !ok:
 			continue
 		}
-		if ok, err := matchString(input.Namespace, resource.Namespace); err != nil || ok {
+		if ok, err := MatchString(input.Namespace, resource.Namespace); err != nil || ok {
 			return ok, trace.Wrap(err)
 		}
 	}
@@ -119,7 +119,7 @@ func KubeResourceMatchesRegex(input types.KubernetesResource, resources []types.
 // match is always evaluated as a regex either an exact match or regexp.
 func SliceMatchesRegex(input string, expressions []string) (bool, error) {
 	for _, expression := range expressions {
-		result, err := matchString(input, expression)
+		result, err := MatchString(input, expression)
 		if err != nil || result {
 			return result, trace.Wrap(err)
 		}
@@ -158,14 +158,15 @@ func mustCache[K comparable, V any](size int) *lru.Cache[K, V] {
 	return cache
 }
 
-// exprCache interns compiled regular expressions created in matchString
+// exprCache interns compiled regular expressions created in MatchString
 // to improve performance.
 var exprCache = mustCache[string, *regexp.Regexp](1000)
 
-func matchString(input, expression string) (bool, error) {
+// MatchString will match an input against the given expression. The expression is cached for later use.
+func MatchString(input, expression string) (bool, error) {
 	expr, err := compileRegexCached(expression)
 	if err != nil {
-		return false, trace.Wrap(err)
+		return false, trace.BadParameter(err.Error())
 	}
 
 	// Since the expression is always surrounded by ^ and $ this is an exact
@@ -174,12 +175,9 @@ func matchString(input, expression string) (bool, error) {
 	return expr.MatchString(input), nil
 }
 
-func compileRegexCached(expression string) (*regexp.Regexp, error) {
-	if expr, ok := exprCache.Get(expression); ok {
-		return expr, nil
-	}
-
-	original := expression
+// CompileExpression compiles the given regex expression with Teleport's custom globbing
+// and quoting logic.
+func CompileExpression(expression string) (*regexp.Regexp, error) {
 	if !strings.HasPrefix(expression, "^") || !strings.HasSuffix(expression, "$") {
 		// replace glob-style wildcards with regexp wildcards
 		// for plain strings, and quote all characters that could
@@ -192,7 +190,20 @@ func compileRegexCached(expression string) (*regexp.Regexp, error) {
 		return nil, trace.BadParameter(err.Error())
 	}
 
-	exprCache.Add(original, expr)
+	return expr, nil
+}
+
+func compileRegexCached(expression string) (*regexp.Regexp, error) {
+	if expr, ok := exprCache.Get(expression); ok {
+		return expr, nil
+	}
+
+	expr, err := CompileExpression(expression)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	exprCache.Add(expression, expr)
 	return expr, nil
 }
 


### PR DESCRIPTION
Okta Import Rules will now use Teleport style regexes as opposed to raw regexp. This will maintain parity with the way the rest of Teleport handles matching.