### PR TITLE
[v13] feat: label expression parser

### DIFF
--- a/lib/services/label_expressions.go
+++ b/lib/services/label_expressions.go
@@ -1,0 +1,141 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/gravitational/trace"
+	lru "github.com/hashicorp/golang-lru/v2"
+	log "github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/parse"
+	"github.com/gravitational/teleport/lib/utils/typical"
+)
+
+type labelExpression typical.Expression[labelExpressionEnv, bool]
+
+type labelExpressionEnv struct {
+	resourceLabelGetter LabelGetter
+	userTraits          map[string][]string
+}
+
+func parseLabelExpression(expr string) (labelExpression, error) {
+	if parsedExpr, ok := labelExpressionCache.Get(expr); ok {
+		return parsedExpr, nil
+	}
+	parsedExpr, err := labelExpressionParser.Parse(expr)
+	if err != nil {
+		return nil, trace.Wrap(err, "parsing label expression")
+	}
+	if evicted := labelExpressionCache.Add(expr, parsedExpr); evicted {
+		log.Info("Evicting entry from label expression cache")
+	}
+	return parsedExpr, nil
+
+}
+
+var (
+	labelExpressionCache  = mustNewLabelExpressionCache()
+	labelExpressionParser = mustNewLabelExpressionParser()
+)
+
+const (
+	cacheSizeEnvVar  = "TELEPORT_EXPRESSION_CACHE_SIZE"
+	defaultCacheSize = 1000
+)
+
+func mustNewLabelExpressionCache() *lru.Cache[string, labelExpression] {
+	cache, err := newLabelExpressionCache()
+	if err != nil {
+		panic(trace.Wrap(err, "initializing label expression cache"))
+	}
+	return cache
+}
+
+func newLabelExpressionCache() (*lru.Cache[string, labelExpression], error) {
+	cacheSize := defaultCacheSize
+	if env := os.Getenv(cacheSizeEnvVar); env != "" {
+		if envCacheSize, err := strconv.ParseUint(env, 10, 31); err != nil {
+			log.WithError(err).Warn("Parsing " + cacheSizeEnvVar)
+		} else {
+			cacheSize = int(envCacheSize)
+		}
+	}
+	cache, err := lru.New[string, labelExpression](cacheSize)
+	return cache, trace.Wrap(err)
+}
+
+func mustNewLabelExpressionParser() *typical.Parser[labelExpressionEnv, bool] {
+	parser, err := newLabelExpressionParser()
+	if err != nil {
+		panic(trace.Wrap(err, "failed to create label expression parser (this is a bug)"))
+	}
+	return parser
+}
+
+func newLabelExpressionParser() (*typical.Parser[labelExpressionEnv, bool], error) {
+	parser, err := typical.NewParser[labelExpressionEnv, bool](typical.ParserSpec{
+		Variables: map[string]typical.Variable{
+			"user.spec.traits": typical.DynamicVariable(
+				func(env labelExpressionEnv) (map[string][]string, error) {
+					return env.userTraits, nil
+				}),
+			"labels": typical.DynamicMapFunction(
+				func(env labelExpressionEnv, key string) (string, error) {
+					label, _ := env.resourceLabelGetter.GetLabel(key)
+					return label, nil
+				}),
+		},
+		Functions: map[string]typical.Function{
+			"contains": typical.BinaryFunction[labelExpressionEnv](
+				func(list []string, item string) (bool, error) {
+					return slices.Contains(list, item), nil
+				}),
+			"regexp.match": typical.BinaryFunction[labelExpressionEnv](
+				func(list []string, re string) (bool, error) {
+					match, err := utils.RegexMatchesAny(list, re)
+					if err != nil {
+						return false, trace.Wrap(err, "invalid regular expression %q", re)
+					}
+					return match, nil
+				}),
+			// Use regexp.replace from lib/utils/parse to get behavior identical
+			// to role templates.
+			"regexp.replace": typical.TernaryFunction[labelExpressionEnv](parse.RegexpReplace),
+			"strings.upper": typical.UnaryFunction[labelExpressionEnv](
+				func(list []string) ([]string, error) {
+					out := make([]string, len(list))
+					for i, s := range list {
+						out[i] = strings.ToUpper(s)
+					}
+					return out, nil
+				}),
+			"strings.lower": typical.UnaryFunction[labelExpressionEnv](
+				func(list []string) ([]string, error) {
+					out := make([]string, len(list))
+					for i, s := range list {
+						out[i] = strings.ToLower(s)
+					}
+					return out, nil
+				}),
+		},
+	})
+	return parser, trace.Wrap(err)
+}

--- a/lib/services/label_expressions_test.go
+++ b/lib/services/label_expressions_test.go
@@ -1,0 +1,191 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package services
+
+import (
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type labelExpressionTestResource struct {
+	labels map[string]string
+}
+
+func (t labelExpressionTestResource) GetLabel(key string) (string, bool) {
+	label, ok := t.labels[key]
+	return label, ok
+}
+
+func TestLabelExpressions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		desc                string
+		expr                string
+		resourceLabels      map[string]string
+		userTraits          map[string][]string
+		expectParseError    []string
+		expectEvaluateError []string
+		expectMatch         bool
+	}{
+		{
+			desc: "label equality",
+			expr: `labels["env"] == "staging"`,
+			resourceLabels: map[string]string{
+				"env": "staging",
+			},
+			expectMatch: true,
+		},
+		{
+			desc: "label inequality",
+			expr: `labels["env"] != "production"`,
+			resourceLabels: map[string]string{
+				"env": "production",
+			},
+			expectMatch: false,
+		},
+		{
+			desc: "wrong type",
+			expr: `user.spec.traits["allow-env"] == "staging"`,
+			expectParseError: []string{
+				"parsing lhs of (==) operator",
+				"expected type string, got expression returning type ([]string)",
+			},
+		},
+		{
+			desc: "contains match",
+			expr: `contains(user.spec.traits["allow-env"], labels["env"])`,
+			userTraits: map[string][]string{
+				"allow-env": {"dev", "staging"},
+			},
+			resourceLabels: map[string]string{
+				"env": "staging",
+			},
+			expectMatch: true,
+		},
+		{
+			desc: "contains not match",
+			expr: `contains(user.spec.traits["allow-env"], labels["env"])`,
+			userTraits: map[string][]string{
+				"allow-env": {"dev", "staging"},
+			},
+			resourceLabels: map[string]string{
+				"env": "production",
+			},
+			expectMatch: false,
+		},
+		{
+			desc: "contains wrong type",
+			expr: `contains(labels, "env")`,
+			resourceLabels: map[string]string{
+				"env": "staging",
+			},
+			expectParseError: []string{
+				"parsing first argument to (contains)",
+				"expected type []string",
+			},
+		},
+		{
+			desc: "boolean logic",
+			expr: `contains(user.spec.traits["allow-env"], labels["env"]) &&
+				   contains(user.spec.traits["groups"], labels["group"]) ||
+				   contains(user.spec.traits["groups"], "super-admin")`,
+			userTraits: map[string][]string{
+				"allow-env": {"dev", "staging", "production"},
+				"groups":    {"devs", "security"},
+			},
+			resourceLabels: map[string]string{
+				"env":   "staging",
+				"group": "devs",
+			},
+			expectMatch: true,
+		},
+		{
+			desc: "regexp.match",
+			expr: `regexp.match(labels["owner"], "dev-*") &&
+                  !regexp.match(labels["env"], "^prod.*$")`,
+			resourceLabels: map[string]string{
+				"owner": "dev-123",
+				"env":   "staging",
+			},
+			expectMatch: true,
+		},
+		{
+			desc: "regexp.replace",
+			expr: `
+			contains(
+			    // call with list
+				regexp.replace(user.spec.traits["groups"], "^team-(.*)$", "$1"),
+				labels["team"]) &&
+			contains(
+			    // call with single string
+				regexp.replace(labels["env"], "^(.*)$", "env-$1"),
+				"env-staging")`,
+			resourceLabels: map[string]string{
+				"team": "security",
+				"env":  "staging",
+			},
+			userTraits: map[string][]string{
+				"groups": {"team-security"},
+			},
+			expectMatch: true,
+		},
+		{
+			desc: "string helpers",
+			expr: `
+			contains(strings.lower(user.spec.traits["logins"]), "name") &&
+			contains(strings.upper(labels["env"]), "STAGING")`,
+			resourceLabels: map[string]string{
+				"env": "staging",
+			},
+			userTraits: map[string][]string{
+				"logins": {"test", "Name"},
+			},
+			expectMatch: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			parsedExpr, err := parseLabelExpression(tc.expr)
+			for _, msg := range tc.expectParseError {
+				assert.ErrorContains(t, err, msg, "parse error doesn't include expected message")
+			}
+			if len(tc.expectParseError) > 0 {
+				return
+			}
+			require.NoError(t, err, trace.DebugReport(err))
+
+			env := labelExpressionEnv{
+				resourceLabelGetter: labelExpressionTestResource{
+					labels: tc.resourceLabels,
+				},
+				userTraits: tc.userTraits,
+			}
+
+			match, err := parsedExpr.Evaluate(env)
+			for _, msg := range tc.expectEvaluateError {
+				assert.ErrorContains(t, err, msg, "evaluate error doesn't include expected message")
+			}
+			if len(tc.expectEvaluateError) > 0 {
+				return
+			}
+			require.NoError(t, err, trace.DebugReport(err))
+
+			require.Equal(t, tc.expectMatch, match)
+		})
+	}
+}

--- a/lib/utils/replace.go
+++ b/lib/utils/replace.go
@@ -128,6 +128,25 @@ func SliceMatchesRegex(input string, expressions []string) (bool, error) {
 	return false, nil
 }
 
+// RegexMatchesAny returns true if [expression] matches any element of
+// [inputs]. [expression] support globbing ("env-*") or normal regexp syntax if
+// surrounded with ^$ ("^env-.*$").
+func RegexMatchesAny(inputs []string, expression string) (bool, error) {
+	expr, err := compileRegexCached(expression)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+	for _, input := range inputs {
+		// Since the expression is always surrounded by ^ and $ this is an exact
+		// match for either a plain string (for example ^hello$) or for a regexp
+		// (for example ^hel*o$).
+		if expr.MatchString(input) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // mustCache initializes a new [lru.Cache] with the provided size.
 // A panic will be triggered if the creation of the cache fails.
 func mustCache[K comparable, V any](size int) *lru.Cache[K, V] {

--- a/rfd/0116-label-expressions.md
+++ b/rfd/0116-label-expressions.md
@@ -138,10 +138,10 @@ Label expressions can appear in `allow` or `deny` role conditions.
 
 Label expressions will have access to the following context:
 
-| Syntax | Alias | Type | Description | 
-|--------|-------|------|-------------|
-| `resource.metadata.labels` | `labels` | `map[string]string` | Labels of the resource (node, app, db, etc.) being accessed |
-| `user.spec.traits` | | `map[string][]string` | `external` or `internal` traits of the user accessing the resource |
+| Syntax             | Type                  | Description |
+|--------------------|-----------------------|-------------|
+| `labels`           | `map[string]string`   | Combined static and dynamic labels of the resource (node, app, db, etc.) being accessed |
+| `user.spec.traits` | `map[string][]string` | `external` or `internal` traits of the user accessing the resource |
 
 #### Helper functions
 


### PR DESCRIPTION
Backport #26176 to branch/v13

This PR builds on https://github.com/gravitational/teleport/pull/26177 to implement the label expression parser as defined in [RFD 116](https://github.com/gravitational/teleport/blob/master/rfd/0116-label-expressions.md#expression-syntax).