### PR TITLE
use uri path for config dump

### DIFF
--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -735,7 +735,7 @@ func dumpConfigFile(outputURI, contents, comment string) (string, error) {
 			return "", trace.BadParameter("please use absolute path for file %v", uri.Path)
 		}
 
-		configDir := path.Dir(outputURI)
+		configDir := path.Dir(uri.Path)
 		err := os.MkdirAll(configDir, 0o755)
 		err = trace.ConvertSystemError(err)
 		if err != nil {


### PR DESCRIPTION
Tiny one line fix for https://github.com/gravitational/teleport/issues/26979

We just needed to use the parsed file path instead of the unparsed output uri. This prevents the creation of a phantom `file:` directory after running `go test ./tool/teleport/common -run TestConfigure` and also fixes a UX problem where it would sometimes try to output the config file to the wrong path and error out.