### PR TITLE
Terraform guide always recommends Identity Files

### DIFF
--- a/docs/pages/management/guides/terraform-provider.mdx
+++ b/docs/pages/management/guides/terraform-provider.mdx
@@ -122,27 +122,13 @@ $ tctl create terraform-impersonator.yaml
 
 (!docs/pages/includes/add-role-to-user.mdx role="terraform-impersonator"!)
 
-Next, request a signed certificate for the Terraform user:
+Next, request a signed identity file for the Terraform user:
 
-<Tabs>
-  <TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
-```code
-$ tctl auth sign --format=tls --user=terraform --out=auth
-```
-
-This command should result in three PEM-encoded files: `auth.crt`, `auth.key`,
-and `auth.cas` (certificate, private key, and CA certs, respectively).
-
-</TabItem>
-<TabItem label="Teleport Cloud" scope={["cloud"]}>
 ```code
 $ tctl auth sign --user=terraform --out=terraform-identity
 ```
 
-The above sequence should result in one PEM-encoded file: `terraform-identity`.
-
-</TabItem>
-</Tabs>
+This command should result in one file: `terraform-identity`.
 
 ## Step 2/3. Create a Terraform configuration
 
@@ -166,24 +152,10 @@ role using Terraform.
 
 Check the contents of the `teleport-terraform` folder:
 
-<Tabs>
-<TabItem scope={["cloud"]} label="Teleport Cloud">
-
 ```code
 $ ls
 # main.tf  terraform-identity  terraform-impersonator.yaml  terraform.yaml
 ```
-
-</TabItem>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-```code
-$ ls
-# main.tf  auth.crt  auth.key  auth.cas  terraform-impersonator.yaml  terraform.yaml
-```
-
-</TabItem>
-</Tabs>
 
 Init terraform and apply the spec:
 

--- a/examples/resources/terraform/terraform-user-role-self-hosted.tf
+++ b/examples/resources/terraform/terraform-user-role-self-hosted.tf
@@ -9,11 +9,9 @@ terraform {
 
 provider "teleport" {
   # Update addr to point to Teleport Auth/Proxy
-  # addr               = "auth.example.com:3025"
-  addr         = "proxy.example.com:443"
-  cert_path    = "auth.crt"
-  key_path     = "auth.key"
-  root_ca_path = "auth.cas"
+  # addr              = "auth.example.com:3025"
+  addr               = "proxy.example.com:443"
+  identity_file_path = "terraform-identity"
 }
 
 resource "teleport_role" "terraform-test" {


### PR DESCRIPTION
Why should identity files be recommended:

- Contains SSH certificate, which allows the Terraform provider to connect to the auth server more ways. This means it is more likely to succeed
- It's a single file rather than three, users are less likely to forget one of the files/configure the path wrong
- Identity Files are a format we can control, the more users that use these, the more we can transparently introduce new functionality by adding more fields to the identity file

I'm not really sure why we were recommending TLS certs for self-hosted and Identity Files for Cloud. I think potentially something just got mixed up along the way as I can't see any real benefits to TLS certs over identity files for self-hosted setups. It seems to be simpler for us to have one best practice here rather than two.