### PR TITLE
Fix display of Assist command executions with empty output

### DIFF
--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
@@ -93,7 +93,7 @@ class assistClient extends EventEmitterWebAuthnSender {
     this.ws = new WebSocket(url);
     this.ws.binaryType = 'arraybuffer';
 
-    this.ws.onclose = event => {
+    this.ws.onclose = () => {
       setState(state => {
         return state.map(n => ({
           ...n,

--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
@@ -271,7 +271,7 @@ function NodeOutput(props: NodeOutputProps) {
       )}
 
       {props.state.stdout !== undefined &&
-        (props.state.stdout == '' ? (
+        (props.state.stdout === '' ? (
           'Empty output.'
         ) : (
           <NodeContent>

--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
@@ -75,6 +75,10 @@ interface RawPayload {
   payload: string;
 }
 
+interface SessionData {
+  session: { server_id: string };
+}
+
 class assistClient extends EventEmitterWebAuthnSender {
   private readonly ws: WebSocket;
   readonly proto: Protobuf = new Protobuf();
@@ -89,11 +93,32 @@ class assistClient extends EventEmitterWebAuthnSender {
     this.ws = new WebSocket(url);
     this.ws.binaryType = 'arraybuffer';
 
+    this.ws.onclose = event => {
+      setState(state => {
+        return state.map(n => ({
+          ...n,
+          stdout: n.stdout || '',
+          status: RunActionStatus.Finished,
+        }));
+      });
+    };
+
     this.ws.onmessage = event => {
       const uintArray = new Uint8Array(event.data);
       const msg = this.proto.decode(uintArray);
 
       switch (msg.type) {
+        case MessageTypeEnum.SESSION_DATA:
+          const sessionData = JSON.parse(msg.payload) as SessionData;
+          setState(state => {
+            state.push({
+              nodeId: sessionData.session.server_id,
+              status: RunActionStatus.Connecting,
+            });
+            return state;
+          });
+          break;
+
         case MessageTypeEnum.RAW:
           const data = JSON.parse(msg.payload) as RawPayload;
           const payload = atob(data.payload);
@@ -245,11 +270,14 @@ function NodeOutput(props: NodeOutputProps) {
         </LoadingContainer>
       )}
 
-      {props.state.stdout && (
-        <NodeContent>
-          <pre>{props.state.stdout}</pre>
-        </NodeContent>
-      )}
+      {props.state.stdout !== undefined &&
+        (props.state.stdout == '' ? (
+          'Empty output.'
+        ) : (
+          <NodeContent>
+            <pre>{props.state.stdout}</pre>
+          </NodeContent>
+        ))}
     </NodeContainer>
   );
 }

--- a/web/packages/teleport/src/Assist/Chat/ChatItem/ChatItem.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/ChatItem.tsx
@@ -251,6 +251,8 @@ export function ChatItem(props: ChatItemProps) {
               </MachineName>
               {props.message.content.errorMsg ? (
                 <ErrorMessage>{props.message.content.errorMsg}</ErrorMessage>
+              ) : props.message.content.payload === '' ? (
+                <p>Empty output.</p>
               ) : (
                 <Output>{props.message.content.payload}</Output>
               )}

--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -169,6 +169,10 @@ export const remoteCommandToMessage = async (
   }
 };
 
+function isExecEvent(e: SessionEvent): e is ExecEvent {
+  return e.event == EventType.EXEC;
+}
+
 async function convertServerMessage(
   message: ServerMessage,
   clusterId: string
@@ -234,10 +238,6 @@ async function convertServerMessage(
     const eventsData = (await eventsResp.json()) as {
       events: SessionEvent[];
     };
-
-    function isExecEvent(e: SessionEvent): e is ExecEvent {
-      return e.event == EventType.EXEC;
-    }
     const execEvent = eventsData.events.find(isExecEvent);
 
     let msg;

--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -221,16 +221,25 @@ async function convertServerMessage(
       sid: payload.session_id,
     });
 
-    // The offset here is set base on A/B test that was run between me, myself and I.
-    const resp = await api.fetch(sessionUrl + '/stream?offset=0&bytes=4096', {
-      Accept: 'text/plain',
-      'Content-Type': 'text/plain; charset=utf-8',
-    });
+    const sessionResp = await api.fetch(sessionUrl + '/events');
+    const sessionExists = sessionResp.status === 200;
 
     let msg;
     let errorMsg;
-    if (resp.status === 200) {
-      msg = await resp.text();
+    if (sessionExists) {
+      // The offset here is set base on A/B test that was run between me, myself and I.
+      const stream = await api.fetch(
+        sessionUrl + '/stream?offset=0&bytes=4096',
+        {
+          Accept: 'text/plain',
+          'Content-Type': 'text/plain; charset=utf-8',
+        }
+      );
+      if (stream.status === 200) {
+        msg = await stream.text();
+      } else {
+        msg = ''; // Empty output, handled in <Output>
+      }
     } else {
       errorMsg = 'No session recording. The command execution failed.';
     }

--- a/web/packages/teleport/src/lib/term/enums.ts
+++ b/web/packages/teleport/src/lib/term/enums.ts
@@ -18,6 +18,7 @@ export enum EventType {
   START = 'session.start',
   JOIN = 'session.join',
   END = 'session.end',
+  EXEC = 'exec',
   PRINT = 'print',
   RESIZE = 'resize',
   FILE_TRANSFER_REQUEST = 'file_transfer_request',


### PR DESCRIPTION
Partially addresses https://github.com/gravitational/teleport.e/issues/1454 .

After live execution

<img width="644" alt="Screenshot 2023-05-26 at 16 43 07" src="https://github.com/gravitational/teleport/assets/662666/19475440-271d-4010-b44c-be56e69590a6">

Coming back to the conversation (when history is fetched)

<img width="676" alt="Screenshot 2023-05-26 at 16 34 26" src="https://github.com/gravitational/teleport/assets/662666/8437fb54-0fcd-44de-a4c7-b6bb213d5670">

Now also improved to display when the command exited with a status code (previously said "no output" with no indication that the command failed). This only applies when returning to a previous conversation.
<img width="644" alt="Screenshot 2023-05-29 at 15 26 25" src="https://github.com/gravitational/teleport/assets/662666/53025419-6062-4099-9815-8cd75cacbf32">
