### PR TITLE
Add missing `dependabot.yml` ignore entries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,9 @@ updates:
       interval: weekly
       day: "sunday"
       time: "09:00" # 9am UTC
+    ignore:
+      # Forked/replaced dependencies
+      - dependency-name: github.com/alecthomas/kingpin/v2
     open-pull-requests-limit: 10
     reviewers:
       - codingllama
@@ -78,6 +81,9 @@ updates:
       interval: weekly
       day: "sunday"
       time: "09:00" # 9am UTC
+    ignore:
+      # Forked/replaced dependencies
+      - dependency-name: github.com/alecthomas/kingpin/v2
     open-pull-requests-limit: 10
     reviewers:
       - codingllama


### PR DESCRIPTION
We replace `alecthomas/kingpin` also in `assets/aws/go.mod` and in `build.assets/tooling/go.mod`, but `dependabot.yml` had an entry only for the main `go.mod`.