### PR TITLE
Assign module experts in Dependabot reviews

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,7 @@ updates:
       - codingllama
       - jentfoo
       - rosstimothy
+      - tcsc
       - zmb3
 
   - package-ecosystem: gomod
@@ -81,6 +82,7 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - codingllama
+      - fheinecke
       - jentfoo
       - rosstimothy
       - zmb3
@@ -94,6 +96,7 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - codingllama
+      - hugoShaka
       - jentfoo
       - rosstimothy
       - zmb3
@@ -107,6 +110,7 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - codingllama
+      - ibeckermayer
       - jentfoo
       - rosstimothy
       - zmb3
@@ -120,6 +124,7 @@ updates:
     open-pull-requests-limit: 10
     reviewers:
       - codingllama
+      - ibeckermayer
       - jentfoo
       - rosstimothy
       - zmb3


### PR DESCRIPTION
Assign module experts, in addition to the usual suspects, for dependabot reviews.