### PR TITLE
Go Version Sync to 1.20

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/api
 
-go 1.19
+go 1.20
 
 require (
 	github.com/coreos/go-semver v0.3.1

--- a/assets/aws/go.mod
+++ b/assets/aws/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport-ami-update
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.3.2 // replaced

--- a/assets/backport/go.mod
+++ b/assets/backport/go.mod
@@ -1,6 +1,6 @@
 module github.com/teleport/assets/backport
 
-go 1.18
+go 1.20
 
 require (
 	github.com/google/go-github/v41 v41.0.0

--- a/build.assets/tooling/go.mod
+++ b/build.assets/tooling/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/build.assets/tooling
 
-go 1.18
+go 1.20
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.3.2 // replaced

--- a/examples/api-sync-roles/go.mod
+++ b/examples/api-sync-roles/go.mod
@@ -1,6 +1,6 @@
 module sync-roles
 
-go 1.19
+go 1.20
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20230320182000-4099bf7d2364

--- a/examples/desktop-registration/go.mod
+++ b/examples/desktop-registration/go.mod
@@ -1,6 +1,6 @@
 module teleport-desktop-registration
 
-go 1.19
+go 1.20
 
 require github.com/gravitational/teleport/api v0.0.0-20230202160043-2f3df9127981
 

--- a/examples/go-client/go.mod
+++ b/examples/go-client/go.mod
@@ -1,6 +1,6 @@
 module go-client
 
-go 1.18
+go 1.20
 
 require (
 	github.com/google/uuid v1.1.2

--- a/examples/service-discovery-api-client/go.mod
+++ b/examples/service-discovery-api-client/go.mod
@@ -1,6 +1,6 @@
 module register-app-service
 
-go 1.19
+go 1.20
 
 require (
 	github.com/docker/docker v23.0.6+incompatible

--- a/examples/teleport-usage/go.mod
+++ b/examples/teleport-usage/go.mod
@@ -1,6 +1,6 @@
 module usage-script
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.224

--- a/examples/workflows/go.mod
+++ b/examples/workflows/go.mod
@@ -1,6 +1,6 @@
 module workflows
 
-go 1.18
+go 1.20
 
 require (
 	github.com/gravitational/teleport/api v0.0.0-20220330155827-83a32f49e14e

--- a/integrations/kube-agent-updater/go.mod
+++ b/integrations/kube-agent-updater/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/teleport/integrations/kube-agent-updater
 
-go 1.19
+go 1.20
 
 require (
 	github.com/Masterminds/sprig/v3 v3.2.3

--- a/web/.cloudbuild/scripts/go.mod
+++ b/web/.cloudbuild/scripts/go.mod
@@ -1,6 +1,6 @@
 module github.com/gravitational/webapps/.cloudbuild/scripts
 
-go 1.17
+go 1.20
 
 require github.com/gravitational/trace v1.1.15
 


### PR DESCRIPTION
This commit updates all `go.mod` files in the repo to match the 1.20 version already present in the root level `go.mod`.

This is currently only planned to be backported to v13 since v12 still has 1.19 as the root level Go Version.  That said this is probably safe if there is a preference to backport further.