### PR TITLE
Docs: patch Enhanced Session recording

### DIFF
--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -81,6 +81,8 @@ library preloading, and environment variables may not be captured in session rec
 
 ### Linux distributions and supported kernels
 
+Teleport supports enhanced session recording with BPF on `amd64` and `arm64` architectures.
+
 | Distro name             | Distro version | Kernel Version |
 |:------------------------|:---------------|:---------------|
 | Ubuntu "Groovy Gorilla" | 20.10          | 5.8+           |


### PR DESCRIPTION
Closes #7156

Specifies supported architectures for BPF.