### PR TITLE
Fix "unnecessary conversion" in lib/devicetrust/native

### DIFF
--- a/lib/devicetrust/native/device_darwin.go
+++ b/lib/devicetrust/native/device_darwin.go
@@ -189,7 +189,7 @@ func getJamfBinaryVersion() (string, error) {
 		return "", fmt.Errorf("unexpected jamf version string: %q", s)
 	}
 
-	return string(tmp[1]), nil
+	return tmp[1], nil
 }
 
 func getMacosEnrollmentProfiles() (string, error) {


### PR DESCRIPTION
It trips the "unconvert" linter.