### PR TITLE
Speedup OpenSSL build

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 
     cd openssl && \
     [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
     ./config --release --libdir=/usr/local/lib && \
-    make -j$(grep -c processor /proc/cpuinfo) && \
+    make -j"$(nproc)" && \
     make install_sw
 
 # Install libfido2.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -44,7 +44,7 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 
     cd openssl && \
     [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
     ./config --release --libdir=/usr/local/lib && \
-    make && \
+    make -j$(grep -c processor /proc/cpuinfo) && \
     make install_sw
 
 # Install libfido2.

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -81,7 +81,7 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 
     cd openssl && \
     [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
     ./config --release --libdir=/usr/local/lib64 && \
-    make && \
+    make -j$(grep -c processor /proc/cpuinfo) && \
     make install_sw
 # Necessary for libfido2 to find the correct libcrypto.
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -81,7 +81,7 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 
     cd openssl && \
     [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
     ./config --release --libdir=/usr/local/lib64 && \
-    make -j$(grep -c processor /proc/cpuinfo) && \
+    make -j"$(nproc)" && \
     make install_sw
 # Necessary for libfido2 to find the correct libcrypto.
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -73,7 +73,7 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 
     cd openssl && \
     [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
     ./config --release --libdir=/usr/local/lib64 && \
-    make && \
+    make -j$(grep -c processor /proc/cpuinfo) && \
     make install_sw
 # Necessary for libfido2 to find the correct libcrypto.
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -73,7 +73,7 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 
     cd openssl && \
     [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
     ./config --release --libdir=/usr/local/lib64 && \
-    make -j$(grep -c processor /proc/cpuinfo) && \
+    make -j"$(nproc)" && \
     make install_sw
 # Necessary for libfido2 to find the correct libcrypto.
 ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"


### PR DESCRIPTION
Our Docker images build OpenSSL using one job. Running the build using multiple jobs speeds up the process significantly.