### PR TITLE
Fix `tsh` from a `tsh ssh` session

### DIFF
--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3447,6 +3447,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 		cf.AuthConnector = constants.HeadlessConnector
 	}
 
+	// When using Headless, user must be provided explicitly.
 	if cf.AuthConnector == constants.HeadlessConnector && !cf.ExplicitUsername {
 		return nil, trace.BadParameter("user must be set explicitly for headless login with the --user flag or $TELEPORT_USER env variable")
 	}
@@ -4624,8 +4625,6 @@ func setEnvFlags(cf *CLIConf, getEnv envGetter) {
 			cf.SiteName = clusterName
 		} else if clusterName = getEnv(siteEnvVar); clusterName != "" {
 			cf.SiteName = clusterName
-		} else if clusterName = getEnv(teleport.SSHTeleportClusterName); clusterName != "" {
-			cf.SiteName = clusterName
 		}
 	}
 
@@ -4633,12 +4632,17 @@ func setEnvFlags(cf *CLIConf, getEnv envGetter) {
 		cf.KubernetesCluster = getEnv(kubeClusterEnvVar)
 	}
 
-	if cf.Username == "" {
-		cf.Username = getEnv(teleport.SSHTeleportUser)
-	}
-
-	if cf.Proxy == "" {
-		cf.Proxy = getEnv(teleport.SSHSessionWebproxyAddr)
+	// When using Headless, check for missing proxy/user/cluster values from the teleport session env variables.
+	if cf.Headless || cf.AuthConnector == constants.HeadlessConnector {
+		if cf.Proxy == "" {
+			cf.Proxy = getEnv(teleport.SSHSessionWebproxyAddr)
+		}
+		if cf.Username == "" {
+			cf.Username = getEnv(teleport.SSHTeleportUser)
+		}
+		if cf.SiteName == "" {
+			cf.SiteName = getEnv(teleport.SSHTeleportClusterName)
+		}
 	}
 }
 

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2488,6 +2488,73 @@ func TestEnvFlags(t *testing.T) {
 			},
 		}))
 	})
+
+	t.Run("tsh ssh session env", func(t *testing.T) {
+		t.Run("ignore ssh session env without headless", testEnvFlag(testCase{
+			inCLIConf: CLIConf{
+				Headless: false,
+			},
+			envMap: map[string]string{
+				teleport.SSHSessionWebproxyAddr: "proxy.example.com",
+				teleport.SSHTeleportUser:        "alice",
+				teleport.SSHTeleportClusterName: "root-cluster",
+			},
+			outCLIConf: CLIConf{
+				Headless: false,
+			},
+		}))
+		t.Run("use ssh session env with headless cli flag", testEnvFlag(testCase{
+			inCLIConf: CLIConf{
+				Headless: true,
+			},
+			envMap: map[string]string{
+				teleport.SSHSessionWebproxyAddr: "proxy.example.com",
+				teleport.SSHTeleportUser:        "alice",
+				teleport.SSHTeleportClusterName: "root-cluster",
+			},
+			outCLIConf: CLIConf{
+				Headless: true,
+				Proxy:    "proxy.example.com",
+				Username: "alice",
+				SiteName: "root-cluster",
+			},
+		}))
+		t.Run("use ssh session env with headless auth connector cli flag", testEnvFlag(testCase{
+			inCLIConf: CLIConf{
+				AuthConnector: constants.HeadlessConnector,
+			},
+			envMap: map[string]string{
+				teleport.SSHSessionWebproxyAddr: "proxy.example.com",
+				teleport.SSHTeleportUser:        "alice",
+				teleport.SSHTeleportClusterName: "root-cluster",
+			},
+			outCLIConf: CLIConf{
+				AuthConnector: constants.HeadlessConnector,
+				Proxy:         "proxy.example.com",
+				Username:      "alice",
+				SiteName:      "root-cluster",
+			},
+		}))
+		t.Run("does not overwrite cli flags", testEnvFlag(testCase{
+			inCLIConf: CLIConf{
+				Headless: true,
+				Proxy:    "proxy.example.com",
+				Username: "alice",
+				SiteName: "root-cluster",
+			},
+			envMap: map[string]string{
+				teleport.SSHSessionWebproxyAddr: "other.example.com",
+				teleport.SSHTeleportUser:        "bob",
+				teleport.SSHTeleportClusterName: "leaf-cluster",
+			},
+			outCLIConf: CLIConf{
+				Headless: true,
+				Proxy:    "proxy.example.com",
+				Username: "alice",
+				SiteName: "root-cluster",
+			},
+		}))
+	})
 }
 
 func TestKubeConfigUpdate(t *testing.T) {


### PR DESCRIPTION
https://github.com/gravitational/teleport/issues/24241 was intended for headless use cases, but breaks non headless cases. Specifically, the `SSH_TELEPORT_` env variables would be used in place of the user's active profile, unless they provide the corresponding flags explicitly.

Updates https://github.com/gravitational/teleport/issues/26946
Closes https://github.com/gravitational/teleport/issues/26702