### PR TITLE
Correctly set `SSH_SESSION_WEBPROXY_ADDR` in Web UI ssh sessions

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -92,6 +92,11 @@ type NodeClient struct {
 
 	mu      sync.Mutex
 	closers []io.Closer
+
+	// ProxyPublicAddr is the web proxy public addr, as opposed to the local proxy
+	// addr set in TC.WebProxyAddr. This is needed to report the correct address
+	// to SSH_TELEPORT_WEBPROXY_ADDR used by some features like "teleport status".
+	ProxyPublicAddr string
 }
 
 // AddCloser adds an [io.Closer] that will be closed when the
@@ -1604,8 +1609,11 @@ func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.Session
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	env[teleport.EnvSSHSessionInvited] = string(encoded)
+
+	// Overwrite "SSH_SESSION_WEBPROXY_ADDR" with the public addr reported by the proxy. Otherwise,
+	// this would be set to the localhost addr (tc.WebProxyAddr) used for Web UI client connections.
+	env[teleport.SSHSessionWebproxyAddr] = c.ProxyPublicAddr
 
 	nodeSession, err := newSession(ctx, c, sessToJoin, env, c.TC.Stdin, c.TC.Stdout, c.TC.Stderr, c.TC.EnableEscapeSequences)
 	if err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2684,6 +2684,7 @@ func (h *Handler) siteNodeConnect(
 		SessionData:        sessionData,
 		KeepAliveInterval:  netConfig.GetKeepAliveInterval(),
 		ProxyHostPort:      h.ProxyHostPort(),
+		ProxyPublicAddr:    h.PublicProxyAddr(),
 		InteractiveCommand: req.InteractiveCommand,
 		Router:             h.cfg.Router,
 		TracerProvider:     h.cfg.TracerProvider,

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -121,6 +121,7 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 			sessionData:        cfg.SessionData,
 			keepAliveInterval:  cfg.KeepAliveInterval,
 			proxyHostPort:      cfg.ProxyHostPort,
+			proxyPublicAddr:    cfg.ProxyPublicAddr,
 			interactiveCommand: cfg.InteractiveCommand,
 			router:             cfg.Router,
 			tracer:             cfg.tracer,
@@ -154,6 +155,8 @@ type TerminalHandlerConfig struct {
 	KeepAliveInterval time.Duration
 	// ProxyHostPort is the address of the server to connect to.
 	ProxyHostPort string
+	// ProxyPublicAddr is the public web proxy address.
+	ProxyPublicAddr string
 	// InteractiveCommand is a command to execute.
 	InteractiveCommand []string
 	// Router determines how connections to nodes are created
@@ -223,6 +226,8 @@ type sshBaseHandler struct {
 	authProvider AuthProvider
 	// proxyHostPort is the address of the server to connect to.
 	proxyHostPort string
+	// proxyPublicAddr is the public web proxy address.
+	proxyPublicAddr string
 	// keepAliveInterval is the interval for sending ping frames to a web client.
 	// This value is pulled from the cluster network config and
 	// guaranteed to be set to a nonzero value as it's enforced by the configuration.
@@ -776,6 +781,8 @@ func (t *sshBaseHandler) connectToNode(ctx context.Context, ws WSConn, tc *clien
 		return nil, trace.NewAggregate(err, conn.Close())
 	}
 
+	clt.ProxyPublicAddr = t.proxyPublicAddr
+
 	return clt, nil
 }
 
@@ -813,6 +820,8 @@ func (t *sshBaseHandler) connectToNodeWithMFABase(ctx context.Context, ws WSConn
 	if err != nil {
 		return nil, trace.NewAggregate(err, conn.Close())
 	}
+
+	nc.ProxyPublicAddr = t.proxyPublicAddr
 
 	return nc, nil
 }


### PR DESCRIPTION
The Web UI client uses `proxy_service.web_addr` rather than `proxy_service.public_addr`, but 
`SSH_SESSION_WEBPROXY_ADDR` needs to be set to the public addr. This PR propagates the public address separately to fix this without impacting existing functionality.

Closes https://github.com/gravitational/teleport/issues/26946