### PR TITLE
Fix TeleportClient.ConnectToProxy logic error with closed context.

### DIFF
--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -1138,3 +1138,24 @@ func TestLoadTLSConfigForClusters(t *testing.T) {
 		})
 	}
 }
+
+func TestConnectToProxyCancelledContext(t *testing.T) {
+	cfg := MakeDefaultConfig()
+
+	cfg.Agent = &mockAgent{}
+	cfg.AuthMethods = []ssh.AuthMethod{ssh.Password("xyz")}
+	cfg.AddKeysToAgent = AddKeysToAgentNo
+	cfg.WebProxyAddr = "dummy"
+	cfg.KeysDir = t.TempDir()
+	cfg.TLSRoutingEnabled = true
+
+	clt, err := NewClient(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	proxy, err := clt.ConnectToProxy(ctx)
+	require.Nil(t, proxy)
+	require.Error(t, err)
+}


### PR DESCRIPTION
If the context passed to `ConnectToProxy` gets closed, it may end up returning two nil values thanks to this line:

```
	case <-connectContext.Done():
		return proxyClient, trace.Wrap(formatConnectToProxyErr(err))
```

This will lead to `panic` when, down the line, the caller unexpectedly gets a nil client. This happened to me when running a test locally with `-count 100`.