### PR TITLE
[v11] chore: Bump OpenSSL to 1.1.1u

### DIFF
--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -31,10 +31,10 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
 # Instal openssl.
 # Pulled from source because repository versions are too old.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1t && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1u && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '830bf8e1e4749ad65c51b6a1d0d769ae689404ba' ] && \
-    ./config --release && \
+    [ "$(git rev-parse HEAD)" = '70c2912f635aac8ab28629a2b5ea0c09740d2bda' ] && \
+    ./config --release --libdir=/usr/local/lib64 && \
     make && \
     make install_sw
 

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -16,8 +16,8 @@ readonly MACOS_VERSION_MIN=10.13
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
-readonly CRYPTO_VERSION=OpenSSL_1_1_1t
-readonly CRYPTO_COMMIT=830bf8e1e4749ad65c51b6a1d0d769ae689404ba
+readonly CRYPTO_VERSION=OpenSSL_1_1_1u
+readonly CRYPTO_COMMIT=70c2912f635aac8ab28629a2b5ea0c09740d2bda
 readonly FIDO2_VERSION=1.12.0
 readonly FIDO2_COMMIT=659a02679f99fd34a44e06e35dce90794f6ecc86
 

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -6,6 +6,6 @@ enginesdir=${libdir}/engines-1.1
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 1.1.1t
+Version: 1.1.1
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Keep up with security releases.

https://www.openssl.org/news/openssl-1.1.1-notes.html