### PR TITLE
docs: add troubleshooting step for standard RDP security

### DIFF
--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -79,16 +79,16 @@ remain at the login screen even though the smart card was detected.
 
 **Solution:** ensure that group policy allows specifying credentials during
  RDP connection establishment. This setting can be found under:
- 
+
  ```text
  Computer Configuration > Administrative Templates > Windows Components > Remote Desktop Services > Remote Desktop Session Host > Security
  ```
- 
+
  Right click `Always prompt for password upon connection` and select **Disabled**.
- 
+
  Note: despite mention of passwords in the name of this policy, no passwords are sent
  on the wire. This mechanism is used only to send the smart card PIN.
- 
+
 ## New session "hangs"
 
 ### Host unreachable
@@ -254,6 +254,33 @@ $ certutil -pulse
 ```
 
 ## Connection attempts fail
+
+### RDP server only uses Standard RDP Security
+
+Attempts to connect to a desktop fail, and the logs show an error similar to:
+
+```
+Rdp(RdpError(RdpError { kind: ProtocolNegFailure, message: "Error during negotiation step: the server is configured to only use standard RDP security mechanisms and does not support external security protocols" }))
+```
+
+**Solution:** Enable Enhanced RDP security
+
+Standard RDP Security is based on RC4 encryption and is the least secure way
+to connect to a Windows host over RDP. Teleport's RDP client requires enhanced
+RDP security with TLS.
+
+Enhanced RDP Security is typically enabled by default, but your environment may
+be configured to require the legacy security methods.
+
+This configuration is available via group policy at:
+
+```text
+Computer Configuration > Administrative Templates > Windows Components > Remote Desktop Services > Remote Desktop Session Host > Security
+```
+
+Look for the "Require use of a specific security layer for remote (RDP)
+connections" setting. The setting should be set to **Negotiate** or **SSL**, not
+**RDP**.
 
 ### Enhanced RDP security with CredSSP required
 


### PR DESCRIPTION
Teleport does not support connecting to desktops that require the use of "standard RDP security" (it's the least secure option).

Add a section to the troubleshooting guide showing the error that occurs when standard security is required with steps to fix it.

Closes #27061