### PR TITLE
Update cloud version to 12.4.5

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1683,7 +1683,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "12.4.3",
+      "version": "12.4.5",
       "major_version": "12",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Teleport Cloud will be upgraded to 12.4.5 on 5/31/23. See: https://github.com/gravitational/cloud/issues/4746