### PR TITLE
[v13] Fix TeleportClient.ConnectToProxy logic error with closed context.

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2922,21 +2922,26 @@ func (tc *TeleportClient) ConnectToProxy(ctx context.Context) (*ProxyClient, err
 	)
 	defer span.End()
 
-	var err error
-	var proxyClient *ProxyClient
+	type result struct {
+		proxyClient *ProxyClient
+		err         error
+	}
+	done := make(chan result)
 
 	// Use connectContext and the cancel function to signal when a response is
 	// returned from connectToProxy.
 	connectContext, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	go func() {
-		defer cancel()
-		proxyClient, err = tc.connectToProxy(connectContext)
+		proxyClient, err := tc.connectToProxy(connectContext)
+		done <- result{proxyClient, err}
 	}()
 
 	select {
 	// connectToProxy returned a result, return that back to the caller.
-	case <-connectContext.Done():
-		return proxyClient, trace.Wrap(formatConnectToProxyErr(err))
+	case r := <-done:
+		return r.proxyClient, trace.Wrap(formatConnectToProxyErr(r.err))
 	// The passed in context timed out. This is often due to the network being
 	// down and the user hitting Ctrl-C.
 	case <-ctx.Done():

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -1138,3 +1138,24 @@ func TestLoadTLSConfigForClusters(t *testing.T) {
 		})
 	}
 }
+
+func TestConnectToProxyCancelledContext(t *testing.T) {
+	cfg := MakeDefaultConfig()
+
+	cfg.Agent = &mockAgent{}
+	cfg.AuthMethods = []ssh.AuthMethod{ssh.Password("xyz")}
+	cfg.AddKeysToAgent = AddKeysToAgentNo
+	cfg.WebProxyAddr = "dummy"
+	cfg.KeysDir = t.TempDir()
+	cfg.TLSRoutingEnabled = true
+
+	clt, err := NewClient(cfg)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	proxy, err := clt.ConnectToProxy(ctx)
+	require.Nil(t, proxy)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Backport #27090 to branch/v13