### PR TITLE
Docs: improve Postgres in GCP

### DIFF
--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -206,6 +206,7 @@ teleport:
   # because the Database Service always connects to the cluster over a reverse
   # tunnel.
   proxy_server: teleport.example.com:3080
+  auth_token: "/tmp/token"
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this
@@ -248,6 +249,7 @@ teleport:
   nodename: test
   # Proxy address to connect to. Use your Teleport Cloud tenant address here.
   proxy_server: mytenant.teleport.sh:443
+  auth_token: "/tmp/token"
 db_service:
   enabled: "yes"
   # This section contains definitions of all databases proxied by this
@@ -307,6 +309,12 @@ earlier.
 
 See [Authenticating as a service account](https://cloud.google.com/docs/authentication/production)
 in the Google Cloud documentation for more details.
+
+If you are using `systemd` to start `teleport`, then you should edit `teleport.service`
+(`/etc/systemd/system/teleport.service`) and add the following into the `[Service]` section:
+```
+Environment=GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+```
 
 ## Step 7/7. Connect
 

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -310,10 +310,10 @@ earlier.
 See [Authenticating as a service account](https://cloud.google.com/docs/authentication/production)
 in the Google Cloud documentation for more details.
 
-If you are using `systemd` to start `teleport`, then you should edit `teleport.service`
-(`/etc/systemd/system/teleport.service`) and add the following into the `[Service]` section:
-```
-Environment=GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json
+If you are using `systemd` to start `teleport`, then you should edit the service's `EnvironmentFile`
+to include the following env var:
+```code
+$ echo 'GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json' | sudo tee -a /etc/default/teleport
 ```
 
 ## Step 7/7. Connect


### PR DESCRIPTION
Add `auth_token` in `teleport.yaml` example.

Show how to set the `GOOGLE_APPLICATION_CREDENTIALS` in a `systemd` env.