### PR TITLE
flaky test detector: pass --skip flag in all jobs, skip new tests

### DIFF
--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -85,35 +85,35 @@ jobs:
       - name: Run libfido2 difftest
         uses: ./.github/actions/difftest
         with:
-          flags: --include "lib/auth/webauthncli/**/*"
+          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "lib/auth/webauthncli/**/*"
           target: test-go-libfido2
 
       - name: Run touch-id difftest
         uses: ./.github/actions/difftest
         with:
-          flags: --include "lib/auth/touchid/**/*"
+          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "lib/auth/touchid/**/*"
           target: test-go-touch-id
 
       - name: Run tsh difftest
         uses: ./.github/actions/difftest
         with:
-          flags: --include "tool/tsh/**/*"
+          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "tool/tsh/**/*"
           target: test-go-tsh
 
       - name: Run api difftest
         uses: ./.github/actions/difftest
         with:
-          flags: --include "api/**/*" --relative "api"
+          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "api/**/*" --relative "api"
           target: test-api
 
       - name: Run kube-agent-updater difftest
         uses: ./.github/actions/difftest
         with:
-          flags: --include "integrations/kube-agent-updater/**/*" --relative "integrations/kube-agent-updater"
+          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "integrations/kube-agent-updater/**/*" --relative "integrations/kube-agent-updater"
           target: test-kube-agent-updater
 
       - name: Run teleport-usage difftest
         uses: ./.github/actions/difftest
         with:
-          flags: --include "examples/teleport-usage/**/*" --relative "examples/teleport-usage"
+          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" --include "examples/teleport-usage/**/*" --relative "examples/teleport-usage"
           target: test-teleport-usage

--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -169,6 +169,10 @@ func test(repoPath string, ref string, changedFiles []string) {
 		}
 
 		for _, n := range r.New {
+			if slices.Contains(testsToSkip, n.RefName) {
+				log.Printf("-skipping %q (%s)\n", n.RefName, dir)
+				continue
+			}
 			methods = append(methods, "^"+n.RefName+dollarSign)
 			dirs[dir] = struct{}{}
 		}


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/26542 `--skip` was added to the `Run base difftest` job. This PR adds this flag to other `difftest` invocations.

Additionally, a change in `difftest` itself extends the coverage of `--skip` to new tests.