### PR TITLE
[v13] TLS Routing behind ALB: tsh kube subcommands UX (#26305)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -126,6 +126,7 @@ require (
 	github.com/sethvargo/go-diceware v0.3.0
 	github.com/sirupsen/logrus v1.9.0
 	github.com/snowflakedb/gosnowflake v1.6.19
+	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
 	github.com/ucarion/urlpath v0.0.0-20200424170820-7ccc79b76bbb
 	github.com/vulcand/predicate v1.2.0 // replaced
@@ -345,7 +346,6 @@ require (
 	github.com/shabbyrobe/gocovmerge v0.0.0-20190829150210-3e036491d500 // indirect
 	github.com/siddontang/go v0.0.0-20180604090527-bdc77568d726 // indirect
 	github.com/siddontang/go-log v0.0.0-20180807004314-8d05993dda07 // indirect
-	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/thales-e-security/pool v0.0.2 // indirect
 	github.com/tidwall/pretty v1.2.1 // indirect

--- a/lib/client/client_store.go
+++ b/lib/client/client_store.go
@@ -226,33 +226,10 @@ func (s *Store) FullProfileStatus() (*ProfileStatus, []*ProfileStatus, error) {
 // when the store has a lot of keys and when we call the function multiple times in
 // parallel.
 // Although this function speeds up the process since it removes all transversals,
-// it still has to read 3 different files if the proxy is specified, otherwise it also
-// has to read $TSH_HOME/current_profile.
-// - $TSH_HOME/$profile.yaml
+// it still has to read 2 different files:
 // - $TSH_HOME/keys/$PROXY/$USER-kube/$TELEPORT_CLUSTER/$KUBE_CLUSTER-x509.pem
 // - $TSH_HOME/keys/$PROXY/$USER
-func LoadKeysToKubeFromStore(dirPath, proxy, teleportCluster, kubeCluster string) ([]byte, []byte, error) {
-	dirPath = profile.FullProfilePath(dirPath)
-
-	profileStore := NewFSProfileStore(dirPath)
-	// tsh stores the profiles using the proxy host as the profile name.
-	profileName, err := utils.Host(proxy)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-	if profileName == "" {
-		// If no profile name is provided, default to the current profile.
-		profileName, err = profileStore.CurrentProfile()
-		if err != nil {
-			return nil, nil, trace.Wrap(err)
-		}
-	}
-	// Load the desired profile.
-	profile, err := profileStore.GetProfile(profileName)
-	if err != nil {
-		return nil, nil, trace.Wrap(err)
-	}
-
+func LoadKeysToKubeFromStore(profile *profile.Profile, dirPath, teleportCluster, kubeCluster string) ([]byte, []byte, error) {
 	fsKeyStore := NewFSKeyStore(dirPath)
 
 	certPath := fsKeyStore.kubeCertPath(KeyIndex{ProxyHost: profile.SiteName, ClusterName: teleportCluster, Username: profile.Username}, kubeCluster)

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // ProfileStore is a storage interface for client profile data.
@@ -545,4 +546,16 @@ func (p *ProfileStatus) AppNames() (result []string) {
 		result = append(result, app.Name)
 	}
 	return result
+}
+
+// ProfileNameFromProxyAddress converts proxy address to profile name or
+// returns the current profile if the proxyAddr is not set.
+func ProfileNameFromProxyAddress(store ProfileStore, proxyAddr string) (string, error) {
+	if proxyAddr == "" {
+		profileName, err := store.CurrentProfile()
+		return profileName, trace.Wrap(err)
+	}
+
+	profileName, err := utils.Host(proxyAddr)
+	return profileName, trace.Wrap(err)
 }

--- a/lib/client/profile_test.go
+++ b/lib/client/profile_test.go
@@ -84,3 +84,29 @@ func TestProfileStore(t *testing.T) {
 		require.ElementsMatch(t, profiles, retProfiles)
 	})
 }
+
+func TestProfileNameFromProxyAddress(t *testing.T) {
+	t.Parallel()
+
+	store := NewMemProfileStore()
+	require.NoError(t, store.SaveProfile(&profile.Profile{
+		WebProxyAddr: "proxy1.example.com:443",
+		Username:     "test-user",
+		SiteName:     "root",
+	}, true))
+
+	t.Run("current profile", func(t *testing.T) {
+		profileName, err := ProfileNameFromProxyAddress(store, "")
+		require.NoError(t, err)
+		require.Equal(t, "proxy1.example.com", profileName)
+	})
+	t.Run("proxy host", func(t *testing.T) {
+		profileName, err := ProfileNameFromProxyAddress(store, "proxy2.example.com:443")
+		require.NoError(t, err)
+		require.Equal(t, "proxy2.example.com", profileName)
+	})
+	t.Run("invalid proxy address", func(t *testing.T) {
+		_, err := ProfileNameFromProxyAddress(store, ":443")
+		require.Error(t, err)
+	})
+}

--- a/lib/kube/kubeconfig/localproxy.go
+++ b/lib/kube/kubeconfig/localproxy.go
@@ -151,3 +151,36 @@ func LocalProxyClustersFromDefaultConfig(defaultConfig *clientcmdapi.Config, clu
 	}
 	return clusters
 }
+
+// FindTeleportClusterForLocalProxy finds the Teleport kube cluster based on
+// provided cluster address and context name, and prepares a LocalProxyCluster.
+//
+// When the cluster has a ProxyURL set, it means the provided kubeconfig is
+// already pointing to a local proxy through this ProxyURL and thus can be
+// skipped as there is no need to create a new local proxy.
+func FindTeleportClusterForLocalProxy(defaultConfig *clientcmdapi.Config, clusterAddr, contextName string) (LocalProxyCluster, bool) {
+	if contextName == "" {
+		contextName = defaultConfig.CurrentContext
+	}
+
+	context, found := defaultConfig.Contexts[contextName]
+	if !found {
+		return LocalProxyCluster{}, false
+	}
+	cluster, found := defaultConfig.Clusters[context.Cluster]
+	if !found || cluster.Server != clusterAddr || cluster.ProxyURL != "" {
+		return LocalProxyCluster{}, false
+	}
+	auth, found := defaultConfig.AuthInfos[context.AuthInfo]
+	if !found {
+		return LocalProxyCluster{}, false
+	}
+
+	return LocalProxyCluster{
+		TeleportCluster:   context.Cluster,
+		KubeCluster:       KubeClusterFromContext(contextName, context.Cluster),
+		Namespace:         context.Namespace,
+		Impersonate:       auth.Impersonate,
+		ImpersonateGroups: auth.ImpersonateGroups,
+	}, true
+}

--- a/lib/kube/kubeconfig/localproxy_test.go
+++ b/lib/kube/kubeconfig/localproxy_test.go
@@ -50,6 +50,7 @@ func TestLocalProxy(t *testing.T) {
 		KubeClusters:        []string{"kube2"},
 		Credentials:         creds,
 		Exec:                exec,
+		SelectCluster:       "kube2",
 	}, false))
 	require.NoError(t, Update(kubeconfigPath, Values{
 		TeleportClusterName: leafClusterName,
@@ -84,6 +85,63 @@ func TestLocalProxy(t *testing.T) {
 				ImpersonateGroups: []string{"group1", "group2"},
 			},
 		}, clusters)
+	})
+
+	t.Run("FindTeleportClusterForLocalProxy", func(t *testing.T) {
+		inputConfig := configAfterLogins.DeepCopy()
+
+		// Simulate a scenario that kube3 is already pointing to a local proxy
+		// through ProxyURL.
+		inputConfig.Clusters[leafClusterName].ProxyURL = "https://localhost:8443"
+
+		tests := []struct {
+			name          string
+			selectContext string
+			checkResult   require.BoolAssertionFunc
+			wantCluster   LocalProxyCluster
+		}{
+			{
+				name:          "not Teleport cluster",
+				selectContext: "dev",
+				checkResult:   require.False,
+			},
+			{
+				name:          "context not found",
+				selectContext: "not-found",
+				checkResult:   require.False,
+			},
+			{
+				name:          "find Teleport cluster by context name",
+				selectContext: rootClusterName + "-kube1",
+				checkResult:   require.True,
+				wantCluster: LocalProxyCluster{
+					TeleportCluster: rootClusterName,
+					KubeCluster:     "kube1",
+				},
+			},
+			{
+				name:          "find Teleport cluster by current context",
+				selectContext: "",
+				checkResult:   require.True,
+				wantCluster: LocalProxyCluster{
+					TeleportCluster: rootClusterName,
+					KubeCluster:     "kube2",
+				},
+			},
+			{
+				name:          "skip local proxy config",
+				selectContext: leafClusterName + "-kube3",
+				checkResult:   require.False,
+			},
+		}
+
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				cluster, found := FindTeleportClusterForLocalProxy(inputConfig, rootKubeClusterAddr, test.selectContext)
+				test.checkResult(t, found)
+				require.Equal(t, test.wantCluster, cluster)
+			})
+		}
 	})
 
 	t.Run("CreateLocalProxyConfig", func(t *testing.T) {

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -437,17 +437,19 @@ func newKubeExecCommand(parent *kingpin.CmdClause) *kubeExecCommand {
 }
 
 func (c *kubeExecCommand) run(cf *CLIConf) error {
-	var p ExecOptions
-	var err error
+	closeFn, newKubeConfigLocation, err := maybeStartKubeLocalProxy(cf)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	defer closeFn()
 
+	f := c.kubeCmdFactory(newKubeConfigLocation)
+	var p ExecOptions
 	p.IOStreams = genericclioptions.IOStreams{
 		In:     os.Stdin,
 		Out:    os.Stdout,
 		ErrOut: os.Stderr,
 	}
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
-	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
-	f := cmdutil.NewFactory(matchVersionKubeConfigFlags)
 	p.ResourceName = c.target
 	p.ContainerName = c.container
 	p.Quiet = c.quiet
@@ -479,6 +481,17 @@ func (c *kubeExecCommand) run(cf *CLIConf) error {
 
 	p.PodClient = clientset.CoreV1()
 	return trace.Wrap(p.Run(cf.Context))
+}
+
+func (c *kubeExecCommand) kubeCmdFactory(overwriteKubeConfigLocation string) cmdutil.Factory {
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+
+	if overwriteKubeConfigLocation != "" {
+		kubeConfigFlags.KubeConfig = &overwriteKubeConfigLocation
+	}
+
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	return cmdutil.NewFactory(matchVersionKubeConfigFlags)
 }
 
 type kubeSessionsCommand struct {
@@ -582,18 +595,30 @@ func newKubeCredentialsCommand(parent *kingpin.CmdClause) *kubeCredentialsComman
 }
 
 func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
+	profile, err := cf.GetProfile()
+	if err != nil {
+		// Cannot find the profile, continue to c.issueCert for a login.
+		return trace.Wrap(c.issueCert(cf))
+	}
+
+	if err := c.checkLocalProxyRequirement(profile.TLSRoutingConnUpgradeRequired); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// client.LoadKeysToKubeFromStore function is used to speed up the credentials
 	// loading process since Teleport Store transverses the entire store to find the keys.
 	// This operation takes a long time when the store has a lot of keys and when
 	// we call the function multiple times in parallel.
 	// Although client.LoadKeysToKubeFromStore function speeds up the process since
-	// it removes all transversals, it still has to read 3 different files from the disk:
-	// - $TSH_HOME/$profile.yaml
+	// it removes all transversals, it still has to read 2 different files from the disk:
 	// - $TSH_HOME/keys/$PROXY/$USER-kube/$TELEPORT_CLUSTER/$KUBE_CLUSTER-x509.pem
 	// - $TSH_HOME/keys/$PROXY/$USER
+	//
+	// In addition to these files, $TSH_HOME/$profile.yaml is also read from
+	// cf.GetProfile call above.
 	if kubeCert, privKey, err := client.LoadKeysToKubeFromStore(
+		profile,
 		cf.HomePath,
-		cf.Proxy,
 		c.teleportCluster,
 		c.kubeCluster,
 	); err == nil {
@@ -604,8 +629,15 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 		}
 	}
 
+	return trace.Wrap(c.issueCert(cf))
+}
+
+func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 	tc, err := makeClient(cf)
 	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := c.checkLocalProxyRequirement(tc.TLSRoutingConnUpgradeRequired); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -638,6 +670,12 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 
 	ctx, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/RetryWithRelogin")
 	err = client.RetryWithRelogin(ctx, tc, func() error {
+		// The requirement may change after a new login so check again just in
+		// case.
+		if err := c.checkLocalProxyRequirement(tc.TLSRoutingConnUpgradeRequired); err != nil {
+			return trace.Wrap(err)
+		}
+
 		var err error
 		k, err = tc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
 			RouteToCluster:    c.teleportCluster,
@@ -663,6 +701,13 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 	}
 
 	return c.writeKeyResponse(cf.Stdout(), k, c.kubeCluster)
+}
+
+func (c *kubeCredentialsCommand) checkLocalProxyRequirement(connUpgradeRequired bool) error {
+	if connUpgradeRequired {
+		return trace.BadParameter("Cannot connect Kubernetes clients to Teleport Proxy directly. Please use `tsh proxy kube` or `tsh kubectl` instead.")
+	}
+	return nil
 }
 
 // checkIfCertsAreAllowedToAccessCluster evaluates if the new cert created by the user
@@ -1062,12 +1107,44 @@ func (c *kubeLoginCommand) run(cf *CLIConf) error {
 	if err := updateKubeConfig(cf, tc, profileKubeconfigPath, c.overrideContextName); err != nil {
 		return trace.Wrap(err)
 	}
-	if c.kubeCluster != "" {
-		fmt.Printf("Logged into Kubernetes cluster %q. Try 'kubectl version' to test the connection.\n", c.kubeCluster)
-	} else {
-		fmt.Printf("Created kubeconfig with every Kubernetes cluster available. Select a context and try 'kubectl version' to test the connection.\n")
-	}
+
+	c.printUserMessage(cf, tc)
 	return nil
+}
+
+func (c *kubeLoginCommand) printUserMessage(cf *CLIConf, tc *client.TeleportClient) {
+	if c.localProxyRequired(tc) {
+		c.printLocalProxyUserMessage(cf)
+		return
+	}
+
+	if c.kubeCluster != "" {
+		fmt.Fprintf(cf.Stdout(), "Logged into Kubernetes cluster %q. Try 'kubectl version' to test the connection.\n", c.kubeCluster)
+	} else {
+		fmt.Fprintf(cf.Stdout(), "Created kubeconfig with every Kubernetes cluster available. Select a context and try 'kubectl version' to test the connection.\n")
+	}
+}
+
+func (c *kubeLoginCommand) printLocalProxyUserMessage(cf *CLIConf) {
+	switch {
+	case c.kubeCluster != "":
+		fmt.Fprintf(cf.Stdout(), `Logged into Kubernetes cluster %q. Start the local proxy:
+  tsh proxy kube -p 8443
+
+Use the kubeconfig provided by the local proxy, and try 'kubectl version' to test the connection.
+`, c.kubeCluster)
+
+	default:
+		fmt.Fprintf(cf.Stdout(), `Logged into all Kubernetes clusters available. Start the local proxy:
+  tsh proxy kube -p 8443
+
+Use the kubeconfig provided by the local proxy, select a context, and try 'kubectl version' to test the connection.
+`)
+	}
+}
+
+func (c *kubeLoginCommand) localProxyRequired(tc *client.TeleportClient) bool {
+	return tc.TLSRoutingConnUpgradeRequired
 }
 
 func fetchKubeClusters(ctx context.Context, tc *client.TeleportClient) (teleportCluster string, kubeClusters []types.KubeCluster, err error) {

--- a/tool/tsh/kube_proxy.go
+++ b/tool/tsh/kube_proxy.go
@@ -91,10 +91,6 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 	}
 	defer localProxy.Close()
 
-	if err := localProxy.WriteKubeConfig(); err != nil {
-		return trace.Wrap(err)
-	}
-
 	if err := c.printTemplate(cf, localProxy); err != nil {
 		return trace.Wrap(err)
 	}
@@ -260,6 +256,9 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 		return nil, trace.Wrap(err)
 	}
 
+	if err := kubeProxy.WriteKubeConfig(); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return kubeProxy, nil
 }
 

--- a/tool/tsh/kubectl_test.go
+++ b/tool/tsh/kubectl_test.go
@@ -1,0 +1,284 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"path"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gravitational/teleport/api/profile"
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+)
+
+func Test_maybeStartKubeLocalProxy(t *testing.T) {
+	t.Parallel()
+
+	tshHome := t.TempDir()
+	kubeCluster := "kube1"
+	kubeconfigLocation := mustSetupKubeconfig(t, tshHome, kubeCluster)
+
+	tests := []struct {
+		name             string
+		inputProfile     *profile.Profile
+		inputArgs        []string
+		wantLocalProxy   bool
+		wantKubeClusters kubeconfig.LocalProxyClusters
+	}{
+		{
+			name:           "no profile",
+			inputArgs:      []string{"kubectl", "--kubeconfig", kubeconfigLocation, "version"},
+			wantLocalProxy: false,
+		},
+		{
+			name: "ALPN conn upgrade not required",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:  "localhost:443",
+				KubeProxyAddr: "localhost:443",
+			},
+			inputArgs:      []string{"kubectl", "--kubeconfig", kubeconfigLocation, "version"},
+			wantLocalProxy: false,
+		},
+		{
+			name: "skip kubectl config",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:                  "localhost:443",
+				KubeProxyAddr:                 "localhost:443",
+				TLSRoutingConnUpgradeRequired: true,
+			},
+			inputArgs:      []string{"kubectl", "--kubeconfig", kubeconfigLocation, "config"},
+			wantLocalProxy: false,
+		},
+		{
+			name: "no Teleport cluster selected",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:                  "localhost:443",
+				KubeProxyAddr:                 "localhost:443",
+				TLSRoutingConnUpgradeRequired: true,
+			},
+			inputArgs:      []string{"kubectl", "--context=not-found", "--kubeconfig", kubeconfigLocation, "version"},
+			wantLocalProxy: false,
+		},
+		{
+			name: "use local proxy",
+			inputProfile: &profile.Profile{
+				WebProxyAddr:                  "localhost:443",
+				KubeProxyAddr:                 "localhost:443",
+				TLSRoutingConnUpgradeRequired: true,
+			},
+			inputArgs:      []string{"kubectl", "--kubeconfig", kubeconfigLocation, "version"},
+			wantLocalProxy: true,
+			wantKubeClusters: kubeconfig.LocalProxyClusters{{
+				TeleportCluster: "localhost",
+				KubeCluster:     kubeCluster,
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.inputProfile != nil {
+				err := client.NewFSProfileStore(tshHome).SaveProfile(test.inputProfile, true)
+				require.NoError(t, err)
+			}
+
+			cf := &CLIConf{
+				HomePath: tshHome,
+				Proxy:    "localhost",
+			}
+
+			var localProxyCreated bool
+			var loadedKubeClusters kubeconfig.LocalProxyClusters
+			wantLocalProxyKubeConfigLocation := path.Join(tshHome, uuid.NewString())
+
+			closeFn, actualKubeConfigLocation, err := maybeStartKubeLocalProxy(cf,
+				withKubectlArgs(test.inputArgs),
+				func(o *kubeLocalProxyOpts) {
+					// Fake makeAndStartKubeLocalProxyFunc instead of making a
+					// real kube local proxy.
+					o.makeAndStartKubeLocalProxyFunc = func(_ *CLIConf, _ *clientcmdapi.Config, clusters kubeconfig.LocalProxyClusters) (func(), string, error) {
+						localProxyCreated = true
+						loadedKubeClusters = clusters
+						return func() {}, wantLocalProxyKubeConfigLocation, nil
+					}
+				},
+			)
+			require.NoError(t, err)
+			defer closeFn()
+
+			require.Equal(t, test.wantLocalProxy, localProxyCreated)
+			if test.wantLocalProxy {
+				require.ElementsMatch(t, test.wantKubeClusters, loadedKubeClusters)
+				require.Equal(t, wantLocalProxyKubeConfigLocation, actualKubeConfigLocation)
+			}
+		})
+	}
+}
+
+func Test_isKubectlConfigCommand(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		inputArgs   []string
+		checkResult require.BoolAssertionFunc
+	}{
+		{
+			name:        "no args",
+			inputArgs:   nil,
+			checkResult: require.False,
+		},
+		{
+			name:        "not kubectl",
+			inputArgs:   []string{"aaa", "config"},
+			checkResult: require.False,
+		},
+		{
+			name:        "kubectl config",
+			inputArgs:   []string{"kubectl", "--kubeconfig", "path", "config", "use-context", "some-context"},
+			checkResult: require.True,
+		},
+		{
+			name:        "kubectl get pod",
+			inputArgs:   []string{"kubectl", "get", "pod", "-n", "config"},
+			checkResult: require.False,
+		},
+	}
+
+	command := makeKubectlCobraCommand()
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.checkResult(t, isKubectlConfigCommand(command, test.inputArgs))
+		})
+	}
+}
+
+func Test_extractKubeConfigAndContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		inputArgs      []string
+		wantKubeconfig string
+		wantContext    string
+	}{
+		{
+			name:           "not enough args",
+			inputArgs:      []string{"kubectl"},
+			wantKubeconfig: "",
+			wantContext:    "",
+		},
+		{
+			name:           "args before subcommand",
+			inputArgs:      []string{"kubectl", "--kubeconfig", "test-path", "--context=test-context", "get", "po", "--all-namespaces"},
+			wantKubeconfig: "test-path",
+			wantContext:    "test-context",
+		},
+		{
+			name:        "args after subcommand",
+			inputArgs:   []string{"kubectl", "get", "po", "-A", "--context", "test-context"},
+			wantContext: "test-context",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualKubeconfig, actualContext := extractKubeConfigAndContext(test.inputArgs)
+			require.Equal(t, test.wantKubeconfig, actualKubeconfig)
+			require.Equal(t, test.wantContext, actualContext)
+		})
+	}
+}
+
+func Test_overwriteKubeconfigFlagInArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		inputPath  string
+		inputArgs  []string
+		expectArgs []string
+	}{
+		{
+			name:       "no kubeconfig flag",
+			inputPath:  "newpath",
+			inputArgs:  []string{"kubectl", "version"},
+			expectArgs: []string{"kubectl", "version"},
+		},
+		{
+			name:       "kubeconfig flag",
+			inputPath:  "newpath",
+			inputArgs:  []string{"kubectl", "--kubeconfig", "oldpath", "version"},
+			expectArgs: []string{"kubectl", "--kubeconfig", "newpath", "version"},
+		},
+		{
+			name:       "kubeconfig equal flag",
+			inputPath:  "newpath",
+			inputArgs:  []string{"--debug", "kubectl", "version", "--kubeconfig=oldpath"},
+			expectArgs: []string{"--debug", "kubectl", "version", "--kubeconfig=newpath"},
+		},
+	}
+
+	for _, test := range tests {
+		outputArgs := overwriteKubeconfigFlagInArgs(test.inputArgs, test.inputPath)
+		require.Equal(t, test.expectArgs, outputArgs)
+	}
+}
+
+func Test_overwriteKubeconfigFlagInEnv(t *testing.T) {
+	t.Parallel()
+
+	inputEnv := []string{
+		"foo=bar",
+		"KUBECONFIG=old-path",
+		"bar=foo",
+	}
+	wantEnv := []string{
+		"foo=bar",
+		"bar=foo",
+		"KUBECONFIG=new-path",
+	}
+	require.Equal(t, wantEnv, overwriteKubeconfigInEnv(inputEnv, "new-path"))
+}
+
+func mustSetupKubeconfig(t *testing.T, tshHome, kubeCluster string) string {
+	kubeconfigLocation := path.Join(tshHome, "kubeconfig")
+	priv, err := keys.ParsePrivateKey([]byte(fixtures.SSHCAPrivateKey))
+	require.NoError(t, err)
+	err = kubeconfig.Update(kubeconfigLocation, kubeconfig.Values{
+		TeleportClusterName: "localhost",
+		ClusterAddr:         "https://localhost:443",
+		KubeClusters:        []string{kubeCluster},
+		Credentials: &client.Key{
+			PrivateKey: priv,
+			TLSCert:    []byte(fixtures.TLSCACertPEM),
+			TrustedCerts: []auth.TrustedCerts{{
+				TLSCertificates: [][]byte{[]byte(fixtures.TLSCACertPEM)},
+			}},
+		},
+		SelectCluster: kubeCluster,
+	}, false)
+	require.NoError(t, err)
+	return kubeconfigLocation
+}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -57,6 +57,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/wrappers"
@@ -3676,6 +3677,22 @@ func (c *CLIConf) ListProfiles() ([]*client.ProfileStatus, error) {
 	}
 
 	return profiles, nil
+}
+
+// GetProfile loads user profile.
+func (c *CLIConf) GetProfile() (*profile.Profile, error) {
+	store, err := initClientStore(c, c.Proxy)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	profileName, err := client.ProfileNameFromProxyAddress(store, c.Proxy)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	profile, err := store.GetProfile(profileName)
+	return profile, trace.Wrap(err)
 }
 
 type mfaModeOpts struct {


### PR DESCRIPTION
backport of #26305

only one minor conflict in `go.mod` (master has newer packages).