### PR TITLE
Get locks in tctl get all

### DIFF
--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -362,13 +362,12 @@ func itemFromLock(l types.Lock) (*backend.Item, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	item := &backend.Item{
+	return &backend.Item{
 		Key:     backend.Key(locksPrefix, l.GetName()),
 		Value:   value,
 		Expires: l.Expiry(),
 		ID:      l.GetResourceID(),
-	}
-	return item, nil
+	}, nil
 }
 
 // TODO: convert username/suffix ops to work on bytes by default; string/byte conversion

--- a/lib/services/local/resource.go
+++ b/lib/services/local/resource.go
@@ -101,6 +101,8 @@ func itemsFromResource(resource types.Resource) ([]backend.Item, error) {
 		item, err = itemFromSAMLConnector(r)
 	case types.ProvisionToken:
 		item, err = itemFromProvisionToken(r)
+	case types.Lock:
+		item, err = itemFromLock(r)
 	default:
 		return nil, trace.NotImplemented("cannot itemFrom resource of type %T", resource)
 	}
@@ -348,6 +350,25 @@ func itemsFromLocalAuthSecrets(user string, auth types.LocalAuthSecrets) ([]back
 		})
 	}
 	return items, nil
+}
+
+// itemFromLock attempts to encode the supplied lock as an
+// instance of `backend.Item` suitable for storage.
+func itemFromLock(l types.Lock) (*backend.Item, error) {
+	if err := l.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	value, err := services.MarshalLock(l)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	item := &backend.Item{
+		Key:     backend.Key(locksPrefix, l.GetName()),
+		Value:   value,
+		Expires: l.Expiry(),
+		ID:      l.GetResourceID(),
+	}
+	return item, nil
 }
 
 // TODO: convert username/suffix ops to work on bytes by default; string/byte conversion

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/protobuf/testing/protocmp"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
@@ -247,5 +248,5 @@ func TestBootstrapLock(t *testing.T) {
 
 	l, err := tt.suite.Access.GetLock(ctx, "test")
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(nl, l))
+	require.Empty(t, cmp.Diff(nl, l, protocmp.Transform()))
 }

--- a/lib/services/local/resource_test.go
+++ b/lib/services/local/resource_test.go
@@ -230,3 +230,22 @@ func newUserTestCase(t *testing.T, name string, roles []string, withSecrets bool
 	}
 	return &user
 }
+
+func TestBootstrapLock(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	tt := setupServicesContext(ctx, t)
+
+	nl, err := types.NewLock("test", types.LockSpecV2{
+		Target: types.LockTarget{
+			User: "user",
+		},
+		Message: "lock test",
+	})
+	require.NoError(t, err)
+	require.NoError(t, CreateResources(ctx, tt.bk, nl))
+
+	l, err := tt.suite.Access.GetLock(ctx, "test")
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(nl, l))
+}

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -554,6 +554,24 @@ func init() {
 		}
 		return token, nil
 	})
+	RegisterResourceMarshaler(types.KindLock, func(resource types.Resource, opts ...MarshalOption) ([]byte, error) {
+		lock, ok := resource.(types.Lock)
+		if !ok {
+			return nil, trace.BadParameter("expected lock, got %T", resource)
+		}
+		bytes, err := MarshalLock(lock, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return bytes, nil
+	})
+	RegisterResourceUnmarshaler(types.KindLock, func(bytes []byte, opts ...MarshalOption) (types.Resource, error) {
+		lock, err := UnmarshalLock(bytes, opts...)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return lock, nil
+	})
 }
 
 // MarshalResource attempts to marshal a resource dynamically, returning NotImplementedError


### PR DESCRIPTION
- Get locked resources in `tctl get all`
- Bootstrap locked resource when starting teleport with `--bootstrap="backup.yml"` flag.

Fixes https://github.com/gravitational/teleport/issues/23765