### PR TITLE
Plugin backend service uses the generic service.

### DIFF
--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -43,7 +43,8 @@ func TestPluginsCRUD(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { mem.Close() })
 
-	service := NewPluginsService(mem)
+	service, err := NewPluginsService(mem)
+	require.NoError(t, err)
 
 	// Define two plugins
 	plugin1 := types.NewPluginV1(types.Metadata{Name: "p1"}, types.PluginSpecV1{
@@ -142,7 +143,8 @@ func TestListPlugins(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { mem.Close() })
 
-	service := NewPluginsService(mem)
+	service, err := NewPluginsService(mem)
+	require.NoError(t, err)
 
 	var insertedPlugins []types.Plugin
 	for i := 0; i < numPlugins; i++ {


### PR DESCRIPTION
The plugin backend service has been adjusted to use the generic service to make upcoming modifications related to static credentials easier.

Associated RFD: https://github.com/gravitational/teleport/blob/master/rfd/0124-plugin-secrets.md