### PR TITLE
Return errors over Assist WS

### DIFF
--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tiktoken-go/tokenizer/codec"
 )
@@ -107,11 +108,12 @@ func TestChat_Complete(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 
-		require.GreaterOrEqual(t, len(responses), 1, "Unexpected request")
+		// Use assert as require doesn't work when called from a goroutine
+		assert.GreaterOrEqual(t, len(responses), 1, "Unexpected request")
 		dataBytes := responses[0]
 
 		_, err := w.Write(dataBytes)
-		require.NoError(t, err, "Write error")
+		assert.NoError(t, err, "Write error")
 
 		responses = responses[1:]
 	}))

--- a/lib/web/assistant.go
+++ b/lib/web/assistant.go
@@ -378,7 +378,7 @@ func runAssistant(h *Handler, w http.ResponseWriter, r *http.Request,
 			_ = ws.WriteJSON(&assistantMessage{
 				Type:        assist.MessageKindError,
 				Payload:     err.Error(),
-				CreatedTime: h.clock.Now().Format(time.RFC3339),
+				CreatedTime: h.clock.Now().UTC().Format(time.RFC3339),
 			})
 			// Set server error code and message: https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
 			closureReason = websocket.CloseInternalServerErr

--- a/lib/web/assistant_test.go
+++ b/lib/web/assistant_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 
@@ -149,11 +150,12 @@ func Test_runAssistant(t *testing.T) {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "text/event-stream")
 
-				require.GreaterOrEqual(t, len(responses), 1, "Unexpected request")
+				// Use assert as require doesn't work when called from a goroutine
+				assert.GreaterOrEqual(t, len(responses), 1, "Unexpected request")
 				dataBytes := responses[0]
 
 				_, err := w.Write(dataBytes)
-				require.NoError(t, err, "Write error")
+				assert.NoError(t, err, "Write error")
 
 				responses = responses[1:]
 			}))
@@ -233,13 +235,22 @@ func Test_runAssistError(t *testing.T) {
 		// Simulate rate limit error
 		w.WriteHeader(429)
 
-		dataBytes := []byte(`{"error":{` +
-			`"message": "You are sending requests too quickly.",` +
-			`"type":"rate_limit_reached",` +
-			`"param":null,` +
-			`"code":"rate_limit_reached"}}`)
-		_, err := w.Write(dataBytes)
-		require.NoError(t, err, "Write error")
+		errMsg := openai.ErrorResponse{
+			Error: &openai.APIError{
+				Code:           "rate_limit_reached",
+				Message:        "You are sending requests too quickly.",
+				Param:          nil,
+				Type:           "rate_limit_reached",
+				HTTPStatusCode: 429,
+			},
+		}
+
+		dataBytes, err := json.Marshal(errMsg)
+		// Use assert as require doesn't work when called from a goroutine
+		assert.NoError(t, err, "Marshal error")
+
+		_, err = w.Write(dataBytes)
+		assert.NoError(t, err, "Write error")
 	}))
 	t.Cleanup(server.Close)
 
@@ -255,11 +266,20 @@ func Test_runAssistError(t *testing.T) {
 	// Make WS client and start the conversation
 	ws, err := s.makeAssistant(t, authPack, conversationID)
 	require.NoError(t, err)
-	t.Cleanup(func() { require.NoError(t, ws.Close()) })
+	t.Cleanup(func() {
+		// Close should yield an error as the server closes the connection
+		require.Error(t, ws.Close())
+	})
 
 	// verify responses
 	readHelloMsg(ws)
 	readErrorMsg(ws)
+
+	// Check for close message
+	_, _, err = ws.ReadMessage()
+	closeErr, ok := err.(*websocket.CloseError)
+	require.True(t, ok, "Expected close error")
+	require.Equal(t, websocket.CloseInternalServerErr, closeErr.Code, "Expected abnormal closure")
 }
 
 // makeAssistConversation creates a new assist conversation and returns its ID

--- a/lib/web/assistant_test.go
+++ b/lib/web/assistant_test.go
@@ -194,6 +194,74 @@ func Test_runAssistant(t *testing.T) {
 	}
 }
 
+// Test_runAssistError tests that the assistant returns an error message
+// when the OpenAI API returns an error.
+func Test_runAssistError(t *testing.T) {
+	t.Parallel()
+
+	readHelloMsg := func(ws *websocket.Conn) {
+		_, payload, err := ws.ReadMessage()
+		require.NoError(t, err)
+
+		var msg assistantMessage
+		err = json.Unmarshal(payload, &msg)
+		require.NoError(t, err)
+
+		// Expect "hello" message
+		require.Equal(t, assist.MessageKindAssistantMessage, msg.Type)
+		require.Contains(t, msg.Payload, "Hey, I'm Teleport")
+	}
+
+	readErrorMsg := func(ws *websocket.Conn) {
+		err := ws.WriteMessage(websocket.TextMessage, []byte(`{"payload": "show free disk space"}`))
+		require.NoError(t, err)
+
+		_, payload, err := ws.ReadMessage()
+		require.NoError(t, err)
+
+		var msg assistantMessage
+		err = json.Unmarshal(payload, &msg)
+		require.NoError(t, err)
+
+		// Expect OpenAI error message
+		require.Equal(t, assist.MessageKindError, msg.Type)
+		require.Contains(t, msg.Payload, "You are sending requests too quickly")
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Simulate rate limit error
+		w.WriteHeader(429)
+
+		dataBytes := []byte(`{"error":{` +
+			`"message": "You are sending requests too quickly.",` +
+			`"type":"rate_limit_reached",` +
+			`"param":null,` +
+			`"code":"rate_limit_reached"}}`)
+		_, err := w.Write(dataBytes)
+		require.NoError(t, err, "Write error")
+	}))
+	t.Cleanup(server.Close)
+
+	openaiCfg := openai.DefaultConfig("test-token")
+	openaiCfg.BaseURL = server.URL
+	s := newWebSuiteWithConfig(t, webSuiteConfig{OpenAIConfig: &openaiCfg})
+
+	ctx := context.Background()
+	authPack := s.authPack(t, "foo")
+	// Create the conversation
+	conversationID := s.makeAssistConversation(t, ctx, authPack)
+
+	// Make WS client and start the conversation
+	ws, err := s.makeAssistant(t, authPack, conversationID)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, ws.Close()) })
+
+	// verify responses
+	readHelloMsg(ws)
+	readErrorMsg(ws)
+}
+
 // makeAssistConversation creates a new assist conversation and returns its ID
 func (s *WebSuite) makeAssistConversation(t *testing.T, ctx context.Context, authPack *authPack) string {
 	clt := authPack.clt


### PR DESCRIPTION
Return error messages via WebSocket as a message that a client can understand instead of closing the WS without saying what went wrong.

Updates https://github.com/gravitational/teleport.e/issues/1489