### PR TITLE
lib/kube/proxy/server.go: Fix potential mutex deadlock on error

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -25,7 +25,7 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
-	logrus "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/maps"
 	"golang.org/x/net/http2"
 
@@ -291,10 +291,11 @@ func (t *TLSServer) Serve(listener net.Listener) error {
 
 	t.mu.Lock()
 	t.listener = mux.TLS()
-	if err = http2.ConfigureServer(t.Server, &http2.Server{}); err != nil {
+	err = http2.ConfigureServer(t.Server, &http2.Server{})
+	t.mu.Unlock()
+	if err != nil {
 		return trace.Wrap(err)
 	}
-	t.mu.Unlock()
 
 	// startStaticClusterHeartbeats starts the heartbeat process for static clusters.
 	// static clusters can be specified via kubeconfig or clusterName for Teleport agent

--- a/lib/kube/proxy/server_test.go
+++ b/lib/kube/proxy/server_test.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/http"
 	"sort"
 	"testing"
 	"time"
@@ -45,6 +46,18 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
+
+func TestServeConfigureError(t *testing.T) {
+	srv := &TLSServer{Server: &http.Server{TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12, CipherSuites: []uint16{}}}}
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	err = srv.Serve(listener)
+	require.Error(t, err) // expected due to incompatible ciphers
+
+	require.True(t, srv.mu.TryLock()) // verify that lock was released despite error
+}
 
 func TestMTLSClientCAs(t *testing.T) {
 	ap := &mockAccessPoint{


### PR DESCRIPTION
This commit fixes a potential condition where the mutex is not unlocked in the case where `Serve` returns an error configuring the server.  This is not currently possible because if an error occurs the TLSServer struct is not attempt to be reused, but this PR is still provided for technical correctness.

Fixes https://github.com/gravitational/teleport-private/issues/663