### PR TITLE
tncon.c: Switch all size variables to `size_t`

### DIFF
--- a/lib/client/tncon/tncon.c
+++ b/lib/client/tncon/tncon.c
@@ -49,7 +49,7 @@
 
 // WriteToBuffer is a dummy function that writes a sequence event rather than
 // to a buffer.
-int
+size_t
 WriteToBuffer(char* source, size_t len)
 {
 	// NOTE: Modified to emit an event to the Go lib rather than mutate a
@@ -78,17 +78,17 @@ DataAvailable(HANDLE hInput, HANDLE hQuitEvent)
 	return FALSE;
 }
 
-int
+size_t
 ReadConsoleForTermEmul(HANDLE hInput, HANDLE hQuitEvent)
 {
 	DWORD dwInput = 0;
 	unsigned char octets[20];
 	INPUT_RECORD inputRecordArray[16];
-	int inputRecordArraySize = sizeof(inputRecordArray) / sizeof(INPUT_RECORD);
+	size_t inputRecordArraySize = sizeof(inputRecordArray) / sizeof(INPUT_RECORD);
 	static WCHAR utf16_surrogatepair[2] = {0,};
-	int n = 0;
+	size_t n = 0;
 
-	int outlen = 0;
+	size_t outlen = 0;
 	while (DataAvailable(hInput, hQuitEvent)) {
 		ReadConsoleInputW(hInput, inputRecordArray, inputRecordArraySize, &dwInput);
 


### PR DESCRIPTION
Previous to this commit there was the risk that calling code could possibly have the size value truncated on a 64bit system.  That was not currently possible from the calling code, but updating these variables to be consistent will be safer long term.

Fixes https://github.com/gravitational/teleport-private/issues/666