### PR TITLE
tctl: allow creating desktops from YAML file

### DIFF
--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -127,6 +127,7 @@ func (rc *ResourceCommand) Initialize(app *kingpin.Application, config *servicec
 		types.KindDevice:                   rc.createDevice,
 		types.KindOktaImportRule:           rc.createOktaImportRule,
 		types.KindIntegration:              rc.createIntegration,
+		types.KindWindowsDesktop:           rc.createWindowsDesktop,
 	}
 	rc.config = config
 
@@ -598,6 +599,20 @@ func (rc *ResourceCommand) createNetworkRestrictions(ctx context.Context, client
 		return trace.Wrap(err)
 	}
 	fmt.Printf("network restrictions have been updated\n")
+	return nil
+}
+
+func (rc *ResourceCommand) createWindowsDesktop(ctx context.Context, client auth.ClientI, raw services.UnknownResource) error {
+	wd, err := services.UnmarshalWindowsDesktop(raw.Raw)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := client.UpsertWindowsDesktop(ctx, wd); err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Printf("windows desktop %q has been updated\n", wd.GetName())
 	return nil
 }
 


### PR DESCRIPTION
To date: we have supported registering desktops in a few ways:

1. By discovering them from LDAP
2. By listing "static hosts" in the configuration file
3. Via our API https://github.com/gravitational/teleport/tree/master/examples/desktop-registration

This extends tctl to support creating a desktop from a YAML resource definition, which provides an alternative for those who want more control over the name and labels of their desktops, but don't want to write and maintain an integration using our API.

Note: this also makes it possible to `tctl edit` an existing desktop, but we do not recommend doing so if the desktop was created via methods 1 or 2 above, as any changes will be overwritten on the next heartbeat.

Closes #27106