### PR TITLE
Ignore ENOENT error on group check

### DIFF
--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -274,7 +274,7 @@ func (u *HostUserManagement) doWithUserLock(f func(types.SemaphoreLease) error) 
 
 func (u *HostUserManagement) createGroupIfNotExist(group string) error {
 	_, err := u.backend.LookupGroup(group)
-	if err != nil && err != user.UnknownGroupError(group) {
+	if err != nil && !isUnknownGroupError(err, group) {
 		return trace.Wrap(err)
 	}
 	err = u.backend.CreateGroup(group)
@@ -287,10 +287,13 @@ func (u *HostUserManagement) createGroupIfNotExist(group string) error {
 // isUnknownGroupError returns whether the error from LookupGroup is an unknown group error.
 //
 // LookupGroup is supposed to return an UnknownGroupError, but due to an existing issue
-// may instead return a generic "no such file or directory" error when sssd is installed.
+// may instead return a generic "no such file or directory" error when sssd is installed
+// or "no such process" as Go std library just forwards errors returned by getgrpnam_r.
 // See github issue - https://github.com/golang/go/issues/40334
 func isUnknownGroupError(err error, groupName string) bool {
-	return errors.Is(err, user.UnknownGroupError(groupName)) || strings.HasSuffix(err.Error(), syscall.ENOENT.Error())
+	return errors.Is(err, user.UnknownGroupError(groupName)) ||
+		strings.HasSuffix(err.Error(), syscall.ENOENT.Error()) ||
+		strings.HasSuffix(err.Error(), syscall.ESRCH.Error())
 }
 
 // DeleteAllUsers deletes all host users in the teleport service group.


### PR DESCRIPTION
As described here https://github.com/golang/go/issues/40334 incorrect system configuration can lead user.LookupGroup to return ENOENT. We've already added a workaround https://github.com/gravitational/teleport/issues/18981, but this one place seems to be forgotten. I also added ESRCH to ignored errors as newer glibc returns it.

The error was exposed after updating our docker image to Ubuntu 20.04 https://github.com/gravitational/teleport/pull/26905 which includes newer Glibc.