### PR TITLE
docs: update fluentd output and correct docs link

### DIFF
--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -48,7 +48,7 @@ secret so the Helm chart can mount them to their appropriate path.
 You'll see the following output:
 
 ```txt
-Teleport event handler 0.0.1 07617b0ad0829db043fe779faf1669defdc8d84e
+Teleport event handler (=teleport.version=)
 
 [1] mTLS Fluentd certificates generated and saved to ca.crt, ca.key, server.crt, server.key, client.crt, client.key
 [2] Generated sample teleport-event-handler role and user file teleport-event-handler-role.yaml
@@ -57,7 +57,7 @@ Teleport event handler 0.0.1 07617b0ad0829db043fe779faf1669defdc8d84e
 
 Follow-along with our getting started guide:
 
-https://goteleport.com/setup/guides/fluentd
+https://goteleport.com/docs/management/export-audit-events/
 ```
 
 The plugin generates several setup files:

--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -57,7 +57,7 @@ Teleport event handler (=teleport.version=)
 
 Follow-along with our getting started guide:
 
-https://goteleport.com/docs/management/export-audit-events/
+https://goteleport.com/docs/management/export-audit-events/fluentd/
 ```
 
 The plugin generates several setup files:


### PR DESCRIPTION
- had hard-coded version number
- incorrect docs link in example
- separately submitted redirect request for the old link