### PR TITLE
Edit the docs test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1321,6 +1321,10 @@ version switcher.
 
 - [ ] Verify Teleport versions throughout documentation are correct and reflect upcoming release. Check `docs/config.json` for this.
 
+- [ ] Remove any version warnings in the docs that mention a version we no
+  longer support. E.g., if we no longer support version n, remove messages
+  saying "You need at least version n to use this feature."
+
 - [ ] Verify that all necessary documentation for the release was backported to
   the release branch:
   - [ ] Diff between master and release branch and make sure there are no missed

--- a/.github/ISSUE_TEMPLATE/testplan.md
+++ b/.github/ISSUE_TEMPLATE/testplan.md
@@ -1321,9 +1321,10 @@ version switcher.
 
 - [ ] Verify Teleport versions throughout documentation are correct and reflect upcoming release. Check `docs/config.json` for this.
 
-- [ ] Remove any version warnings in the docs that mention a version we no
-  longer support. E.g., if we no longer support version n, remove messages
-  saying "You need at least version n to use this feature."
+- [ ] Remove version warnings in the docs that mention a version we no longer
+  support _except_ for the last EOL version. E.g., if we no longer support
+  version 10, remove messages saying "You need at least version n to use this
+  feature" for all versions before 10, but keep warnings for version 10.
 
 - [ ] Verify that all necessary documentation for the release was backported to
   the release branch:


### PR DESCRIPTION
Add an item to remove version warnings for versions we no longer support. Currently, we remove these version warnings as we encounter them. This change makes this task a regular predictable step when releasing a new major Teleport version.