### PR TITLE
Build change for when go caching should be used

### DIFF
--- a/.github/workflows/assign.yaml
+++ b/.github/workflows/assign.yaml
@@ -41,7 +41,7 @@ jobs:
           path: .github/shared-workflows
           ref: main
       - name: Installing Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: .github/shared-workflows/bot/go.mod
         # Run "check" subcommand on bot.

--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -38,7 +38,7 @@ jobs:
           path: .github/shared-workflows
           ref: main
       - name: Installing Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: .github/shared-workflows/bot/go.mod
         # Run "check" subcommand on bot.

--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -33,8 +33,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          cache: false
           # use the version declared in API's go.mod
           go-version-file: api/go.mod
 

--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -35,9 +35,9 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          cache: false
           # use the version declared in API's go.mod
           go-version-file: api/go.mod
+          cache-dependency-path: api/go.sum
 
       - name: Init workspace
         run: go work init . ./api/

--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -52,8 +52,9 @@ jobs:
           corepack enable yarn
 
       - name: Install Go Toolchain
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: ${{ env.GOLANG_VERSION }}
 
       - name: Configure Rust Toolchain

--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -33,8 +33,9 @@ jobs:
         run: echo "go-version=$(make --no-print-directory print-go-version | tr -d '\n')" >> $GITHUB_OUTPUT
 
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
+          cache: false
           go-version: ${{ steps.go-version.outputs.go-version }}
 
       - name: Build

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -49,7 +49,7 @@ jobs:
           path: .github/shared-workflows
           ref: main
       - name: Installing Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: .github/shared-workflows/bot/go.mod
         # Run "check" subcommand on bot.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        cache-dependency-path: '**/go.sum'
+        cache: false
       if: ${{ matrix.language == 'go' }}
 
     - name: Initialize the CodeQL tools for scanning

--- a/.github/workflows/dismiss.yaml
+++ b/.github/workflows/dismiss.yaml
@@ -45,7 +45,7 @@ jobs:
           path: .github/shared-workflows
           ref: main
       - name: Installing Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: .github/shared-workflows/bot/go.mod
         # Run "dismiss" subcommand on bot.

--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -41,7 +41,7 @@ jobs:
           path: .github/shared-workflows
           ref: main
       - name: Installing Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version-file: .github/shared-workflows/bot/go.mod
         # Run "check" subcommand on bot.


### PR DESCRIPTION
This PR does the following:
* Updates all `setup-go` actions to use `v4` (which has caching enabled by default)
* For `shared-workflow` jobs caching is left enabled due to the presumed small size
* For `teleport` jobs caching is now disabled due to the size exceeding the cache limit

This should make all of the mentioned jobs a little faster.