### PR TITLE
[v13] Updated Cloud SQL guides with more info about 'Allow only SSL connections' option

### DIFF
--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -58,11 +58,18 @@ Assign the Service Account the "Cloud SQL Admin" role:
   cloudsql.users.update
   # Used to auto-download the instance's root CA certificate.
   cloudsql.instances.get
-  # Used to generate an ephemeral client certificate when the GCP instance
-  # is configured to "Allow only SSL connections." (optional)
-  cloudsql.sslCerts.createEphemeral
   ```
 </Admonition>
+
+### (Optional) Allow only SSL connections
+
+(!docs/pages/includes/database-access/cloudsql-ssl.mdx!)
+
+In addition, when using Cloud SQL MySQL with "Allow only SSL connections"
+enabled, Teleport connects to the database's Cloud SQL Proxy port `3307`
+instead of the default `3306` as the default Cloud SQL MySQL listener does not
+trust generated ephemeral certificates. For this reason, you should make sure
+to allow port `3307` when using "Allow only SSL connections" with MySQL.
 
 ### Create a key for the service account
 

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -127,12 +127,12 @@ Assign it the "Service Account Token Creator" role:
   iam.serviceAccounts.getAccessToken
   # Used to auto-download the instance's root CA certificate.
   cloudsql.instances.get
-  # Used to generate an ephemeral client certificate when the GCP instance
-  # is configured to "Allow only SSL connections." (optional)
-  cloudsql.sslCerts.createEphemeral
   ```
-
 </Admonition>
+
+### (Optional) Allow only SSL connections
+
+(!docs/pages/includes/database-access/cloudsql-ssl.mdx!)
 
 ### Create a key for the service account
 

--- a/docs/pages/includes/database-access/cloudsql-ssl.mdx
+++ b/docs/pages/includes/database-access/cloudsql-ssl.mdx
@@ -1,0 +1,14 @@
+If you intend to use "Allow only SSL connections" option on your Cloud SQL
+database, the service account must include the following permission to be
+able to generate ephemeral client certificates:
+
+```ini
+cloudsql.sslCerts.createEphemeral
+```
+
+GCP does not currently support granting this permission to custom roles so
+you'd need to assign "Cloud SQL Admin" role to the Teleport service account.
+
+Note that "Allow only SSL connections" setting only forces the client to
+provide a client certificate - all communication between Teleport and the
+database is still over TLS even with this setting disabled.


### PR DESCRIPTION
Backport #27193 to branch/v13