### PR TITLE
back compat improvements for label expressions

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -562,6 +562,11 @@ const (
 	// that the discovered resource is owned by. It is used to differentiate resources
 	// that belong to different discovery services that operate on different sets of resources.
 	TeleportInternalDiscoveryGroupName = TeleportInternalLabelPrefix + "discovery-group-name"
+
+	// TeleportDowngradedLabel identifies resources that have been automatically
+	// downgraded before being returned to clients on older versions that do not
+	// support one or more features enabled in that resource.
+	TeleportDowngradedLabel = TeleportInternalLabelPrefix + "downgraded"
 )
 
 // CloudHostnameTag is the name of the tag in a cloud instance used to override a node's hostname.

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -1659,3 +1659,17 @@ func (r *RoleV6) SetLabelMatchers(rct RoleConditionType, kind string, labelMatch
 	}
 	return trace.BadParameter("can't set label matchers for resource kind %q", kind)
 }
+
+// LabelMatcherKinds is the complete list of resource kinds that support label
+// matchers.
+var LabelMatcherKinds = []string{
+	KindRemoteCluster,
+	KindNode,
+	KindKubernetesCluster,
+	KindApp,
+	KindDatabase,
+	KindDatabaseService,
+	KindWindowsDesktop,
+	KindWindowsDesktopService,
+	KindUserGroup,
+}

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/gravitational/roundtrip"
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
@@ -31,6 +32,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/okta"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -3631,6 +3633,11 @@ func (a *ServerWithRoles) UpsertRole(ctx context.Context, role types.Role) error
 		return trace.Wrap(err)
 	}
 
+	if downgradeReason := role.GetMetadata().Labels[types.TeleportDowngradedLabel]; downgradeReason != "" {
+		return trace.BadParameter("refusing to upsert role because %s label is set with reason %q",
+			types.TeleportDowngradedLabel, downgradeReason)
+	}
+
 	// Some options are only available with enterprise subscription
 	if err := checkRoleFeatureSupport(role); err != nil {
 		return trace.Wrap(err)
@@ -3649,6 +3656,18 @@ func (a *ServerWithRoles) UpsertRole(ctx context.Context, role types.Role) error
 		if modules.GetModules().BuildType() != modules.BuildEnterprise {
 			return trace.AccessDenied("Hardware Key support is only available with an enterprise license")
 		}
+	}
+
+	// Note: passing a.authServer.GetInventoryStatus here intentionally bypasses
+	// the authz checks in a.GetInventoryStatus, for these reasons:
+	// - We don't actually return the inventory status result, we're only using
+	//   it internally to check for a misconfiguration and return a generic error.
+	// - We don't want to require users to have new permissions to call UpsertRole.
+	// - GetInventoryStatus currently only supports builtin roles.
+	// - This user already has UpsertRole permissions and could give themselves
+	//   arbitrary permissions if they wanted to.
+	if err := checkInventorySupportsRole(ctx, role, api.Version, a.authServer.GetInventoryStatus); err != nil {
+		return trace.Wrap(err)
 	}
 
 	return a.authServer.UpsertRole(ctx, role)
@@ -3685,6 +3704,91 @@ func checkRoleFeatureSupport(role types.Role) error {
 	default:
 		return nil
 	}
+}
+
+type inventoryGetter func(context.Context, proto.InventoryStatusRequest) proto.InventoryStatusSummary
+
+// checkInventorySupportsRole returns an error if any connected servers found in
+// the inventory do not support some features enabled in [role]. This is only a
+// best-effort check meant to prevent common user errors, since some unsupported
+// servers may not be connected to this auth, or they may connect later.
+func checkInventorySupportsRole(ctx context.Context, role types.Role, authVersion string, getInventory inventoryGetter) error {
+	minRequiredVersion, msg, err := minRequiredVersionForRole(role)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if safeToSkipInventoryCheck(*semver.New(authVersion), minRequiredVersion) {
+		return nil
+	}
+
+	inventoryStatus := getInventory(ctx, proto.InventoryStatusRequest{Connected: true})
+	for _, hello := range inventoryStatus.Connected {
+		version, err := semver.NewVersion(hello.Version)
+		if err != nil {
+			log.Warnf("Connected server %q has unparseable version %q", hello.ServerID, hello.Version)
+			continue
+		}
+		if version.LessThan(minRequiredVersion) {
+			return trace.BadParameter(msg)
+		}
+	}
+	return nil
+}
+
+func minRequiredVersionForRole(role types.Role) (semver.Version, string, error) {
+	// DELETE IN 15.0.0
+	// The label expression checks can be deleted in 15.0.0 since all servers
+	// that don't support label expressions are on 13.x or older. If no other
+	// feature checks have been added at that time, checkInventorySupportsRole
+	// can be deleted entirely.
+	for _, kind := range types.LabelMatcherKinds {
+		for _, rct := range []types.RoleConditionType{types.Allow, types.Deny} {
+			labelMatchers, err := role.GetLabelMatchers(rct, kind)
+			if err != nil {
+				return semver.Version{}, "", trace.Wrap(err)
+			}
+			if len(labelMatchers.Expression) != 0 {
+				return minSupportedLabelExpressionVersion, fmt.Sprintf(
+					"one or more connected servers is running a Teleport version "+
+						"older than %s which does not support the label expressions used "+
+						"in this role.", minSupportedLabelExpressionVersion), nil
+			}
+		}
+	}
+	// Return the zero version to indicate all server versions are supported.
+	return semver.Version{}, "", nil
+}
+
+// safeToSkipInventoryCheck returns true if all possible versions *less than*
+// [minRequiredVersion] are more than one major version behind [authVersion].
+//
+// In this case, any servers older than [minRequiredVersion] are already
+// unsupported and shouldn't be connected, so it's safe to skip the inventory
+// check as an optimization.
+//
+// This also covers the case where minRequiredVersionForRole returned
+// the zero version.
+//
+// Examples:
+// - (15.x.x, 13.1.0) -> true (anything older than 13.1.0 is >1 major behind v15)
+// - (14.x.x, 13.1.0) -> false (13.0.9 is within one major of v14)
+// - (14.x.x, 13.0.0) -> true (anything older than 13.0.0 is >1 major behind v14)
+func safeToSkipInventoryCheck(authVersion, minRequiredVersion semver.Version) bool {
+	return authVersion.Major > roundToNextMajor(minRequiredVersion)
+}
+
+// roundToNextMajor returns the next major version that is *not less than* [v].
+//
+// Examples:
+// - 13.1.0 -> 14.0.0
+// - 13.0.0 -> 13.0.0
+// - 13.0.0-alpha -> 13.0.0
+func roundToNextMajor(v semver.Version) int64 {
+	if (semver.Version{Major: v.Major}).LessThan(v) {
+		return v.Major + 1
+	}
+	return v.Major
 }
 
 // GetRole returns role by name

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -25,6 +25,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
@@ -35,6 +36,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
@@ -5244,4 +5246,151 @@ func createSessionTestUsers(t *testing.T, authServer *Server) (string, string, s
 	})
 	require.NoError(t, err)
 	return "alice", "bob", "admin"
+}
+
+func TestCheckInventorySupportsRole(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	emptyRole, err := types.NewRole("empty", types.RoleSpecV6{})
+	require.NoError(t, err)
+
+	roleWithLabelExpressions, err := types.NewRole("expressions", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			NodeLabelsExpression: `contains(user.spec.traits["allow-env"], labels["env"])`,
+		},
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		desc                   string
+		role                   types.Role
+		authVersion            string
+		inventoryVersions      []string
+		assertErr              require.ErrorAssertionFunc
+		expectNoInventoryCheck bool
+	}{
+		{
+			desc:                   "basic",
+			role:                   emptyRole,
+			authVersion:            api.Version,
+			inventoryVersions:      []string{"12.1.2", "13.0.0", api.Version},
+			assertErr:              require.NoError,
+			expectNoInventoryCheck: true,
+		},
+		{
+			desc:              "label expressions supported",
+			role:              roleWithLabelExpressions,
+			authVersion:       "14.0.0-dev",
+			inventoryVersions: []string{minSupportedLabelExpressionVersion.String(), "13.2.3"},
+			assertErr:         require.NoError,
+		},
+		{
+			desc:              "unparseable server version doesn't break UpsertRole",
+			role:              roleWithLabelExpressions,
+			authVersion:       "14.0.0-dev",
+			inventoryVersions: []string{"Not a version"},
+			assertErr:         require.NoError,
+		},
+		{
+			desc:              "block upsert with unsupported nodes in v13",
+			role:              roleWithLabelExpressions,
+			authVersion:       "13.2.3",
+			inventoryVersions: []string{minSupportedLabelExpressionVersion.String(), "13.0.0-unsupported", "13.2.3"},
+			assertErr: func(t require.TestingT, err error, args ...any) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
+				require.ErrorContains(t, err, "does not support the label expressions used in this role")
+			},
+		},
+		{
+			desc:              "block upsert with unsupported nodes in v14",
+			role:              roleWithLabelExpressions,
+			authVersion:       "14.1.2",
+			inventoryVersions: []string{minSupportedLabelExpressionVersion.String(), "13.0.0-unsupported", "13.2.3"},
+			assertErr: func(t require.TestingT, err error, args ...any) {
+				require.Error(t, err)
+				require.True(t, trace.IsBadParameter(err), "expected bad parameter error, got %v", err)
+				require.ErrorContains(t, err, "does not support the label expressions used in this role")
+			},
+		},
+		{
+			desc:                   "skip inventory check in 15",
+			role:                   roleWithLabelExpressions,
+			authVersion:            "15.0.0-dev",
+			inventoryVersions:      []string{"14.0.0", "15.0.0"},
+			assertErr:              require.NoError,
+			expectNoInventoryCheck: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			getInventory := func(context.Context, proto.InventoryStatusRequest) proto.InventoryStatusSummary {
+				if tc.expectNoInventoryCheck {
+					require.Fail(t, "getInventory called when the inventory check should have been skipped")
+				}
+
+				hellos := make([]proto.UpstreamInventoryHello, 0, len(tc.inventoryVersions))
+				for _, v := range tc.inventoryVersions {
+					hellos = append(hellos, proto.UpstreamInventoryHello{
+						Version: v,
+					})
+				}
+				return proto.InventoryStatusSummary{
+					Connected: hellos,
+				}
+			}
+
+			err := checkInventorySupportsRole(ctx, tc.role, tc.authVersion, getInventory)
+			tc.assertErr(t, err)
+		})
+	}
+}
+
+func TestSafeToSkipInventoryCheck(t *testing.T) {
+	for _, tc := range []struct {
+		desc               string
+		authVersion        string
+		minRequiredVersion string
+		safeToSkip         bool
+	}{
+		{
+			desc:               "auth two majors ahead of required minor release",
+			authVersion:        "15.0.0",
+			minRequiredVersion: "13.1.0",
+			safeToSkip:         true,
+		},
+		{
+			desc:               "auth within one major of required minor release",
+			authVersion:        "14.0.0",
+			minRequiredVersion: "13.1.0",
+			safeToSkip:         false,
+		},
+		{
+			desc:               "auth one major greater than required major release",
+			authVersion:        "14.0.0",
+			minRequiredVersion: "13.0.0",
+			safeToSkip:         true, // anything older than 13.0.0 is >1 major behind 14.0.0
+		},
+		{
+			desc:               "auth within one major of required major release",
+			authVersion:        "13.3.12",
+			minRequiredVersion: "13.0.0",
+			safeToSkip:         false,
+		},
+		{
+			desc:               "matching releases",
+			authVersion:        "13.2.0",
+			minRequiredVersion: "13.2.0",
+			safeToSkip:         false,
+		},
+		{
+			desc:               "skip for zero version",
+			authVersion:        "13.2.0",
+			minRequiredVersion: "0.0.0",
+			safeToSkip:         true,
+		},
+	} {
+		require.Equal(t, tc.safeToSkip,
+			safeToSkipInventoryCheck(*semver.New(tc.authVersion), *semver.New(tc.minRequiredVersion)))
+	}
 }

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
@@ -49,6 +50,7 @@ import (
 	integrationpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/integration/v1"
 	oktapb "github.com/gravitational/teleport/api/gen/proto/go/teleport/okta/v1"
 	trustpb "github.com/gravitational/teleport/api/gen/proto/go/teleport/trust/v1"
+	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/api/types/installers"
@@ -379,6 +381,13 @@ func (g *GRPCServer) WatchEvents(watch *proto.Watch, stream proto.AuthService_Wa
 		case <-watcher.Done():
 			return watcher.Error()
 		case event := <-watcher.Events():
+			if role, ok := event.Resource.(*types.RoleV6); ok {
+				downgraded, err := maybeDowngradeRole(stream.Context(), role)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				event.Resource = downgraded
+			}
 			out, err := client.EventToGRPC(event)
 			if err != nil {
 				return trace.Wrap(err)
@@ -1917,6 +1926,71 @@ func (g *GRPCServer) DeleteAllKubernetesServers(ctx context.Context, req *proto.
 	return &emptypb.Empty{}, nil
 }
 
+// maybeDowngradeRole tests the client version passed through the GRPC metadata,
+// and if the client version is unknown or less than the minimum supported
+// version for some features of the role returns a shallow copy of the given
+// role downgraded for compatibility with the older version.
+func maybeDowngradeRole(ctx context.Context, role *types.RoleV6) (*types.RoleV6, error) {
+	clientVersionString, ok := metadata.ClientVersionFromContext(ctx)
+	if !ok {
+		// This client is not reporting its version via gRPC metadata. Teleport
+		// clients have been reporting their version for long enough that older
+		// clients won't even support v6 roles at all, so this is likely a
+		// third-party client, and we shouldn't assume that downgrading the role
+		// will do more good than harm.
+		return role, nil
+	}
+
+	clientVersion, err := semver.NewVersion(clientVersionString)
+	if err != nil {
+		return nil, trace.BadParameter("unrecognized client version: %s is not a valid semver", clientVersionString)
+	}
+
+	role, err = maybeDowngradeRoleLabelExpressions(ctx, role, clientVersion)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return role, nil
+}
+
+var minSupportedLabelExpressionVersion = semver.Version{Major: 13, Minor: 2}
+
+func maybeDowngradeRoleLabelExpressions(ctx context.Context, role *types.RoleV6, clientVersion *semver.Version) (*types.RoleV6, error) {
+	if !clientVersion.LessThan(minSupportedLabelExpressionVersion) {
+		return role, nil
+	}
+	hasLabelExpression := false
+	for _, kind := range types.LabelMatcherKinds {
+		allowLabelMatchers, err := role.GetLabelMatchers(types.Allow, kind)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		denyLabelMatchers, err := role.GetLabelMatchers(types.Deny, kind)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if len(allowLabelMatchers.Expression) == 0 && len(denyLabelMatchers.Expression) == 0 {
+			continue
+		}
+		hasLabelExpression = true
+		denyLabelMatchers.Labels = types.Labels{types.Wildcard: {types.Wildcard}}
+		role.SetLabelMatchers(types.Deny, kind, denyLabelMatchers)
+	}
+	if hasLabelExpression {
+		reason := fmt.Sprintf(
+			"client version %q does not support label expressions, wildcard deny labels have been added for all resource kinds with configured label expressions",
+			clientVersion)
+		if role.Metadata.Labels == nil {
+			role.Metadata.Labels = make(map[string]string, 1)
+		}
+		role.Metadata.Labels[types.TeleportDowngradedLabel] = reason
+		log.Debugf(`Downgrading role %q before returning it to the client: %s`,
+			role.GetName(), reason)
+	}
+	return role, nil
+}
+
 // GetRole retrieves a role by name.
 func (g *GRPCServer) GetRole(ctx context.Context, req *proto.GetRoleRequest) (*types.RoleV6, error) {
 	auth, err := g.authenticate(ctx)
@@ -1932,7 +2006,12 @@ func (g *GRPCServer) GetRole(ctx context.Context, req *proto.GetRoleRequest) (*t
 		return nil, trace.Errorf("encountered unexpected role type: %T", role)
 	}
 
-	return roleV6, nil
+	downgraded, err := maybeDowngradeRole(ctx, roleV6)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return downgraded, nil
 }
 
 // GetRoles retrieves all roles.
@@ -1951,7 +2030,11 @@ func (g *GRPCServer) GetRoles(ctx context.Context, _ *emptypb.Empty) (*proto.Get
 		if !ok {
 			return nil, trace.BadParameter("unexpected type %T", r)
 		}
-		rolesV6 = append(rolesV6, role)
+		downgraded, err := maybeDowngradeRole(ctx, role)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		rolesV6 = append(rolesV6, downgraded)
 	}
 	return &proto.GetRolesResponse{
 		Roles: rolesV6,

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -50,10 +50,12 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/internalutils/stream"
+	"github.com/gravitational/teleport/api/metadata"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/installers"
@@ -4173,6 +4175,198 @@ func TestGRPCServer_GetInstallers(t *testing.T) {
 			}
 
 			require.Equal(t, tc.expectedInstallers, outputInstallers)
+		})
+	}
+}
+
+func TestRoleVersions(t *testing.T) {
+	t.Parallel()
+	srv := newTestTLSServer(t)
+
+	wildcardLabels := types.Labels{types.Wildcard: {types.Wildcard}}
+
+	newRole := func(spec types.RoleSpecV6) types.Role {
+		role, err := types.NewRole("test_rule", spec)
+		require.NoError(t, err)
+		return role
+	}
+
+	role := newRole(types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			NodeLabels:               wildcardLabels,
+			AppLabels:                wildcardLabels,
+			AppLabelsExpression:      `labels["env"] == "staging"`,
+			DatabaseLabelsExpression: `labels["env"] == "staging"`,
+			Rules: []types.Rule{
+				types.NewRule(types.KindRole, services.RW()),
+			},
+		},
+		Deny: types.RoleConditions{
+			KubernetesLabels:               types.Labels{"env": {"prod"}},
+			ClusterLabels:                  types.Labels{"env": {"prod"}},
+			ClusterLabelsExpression:        `labels["env"] == "prod"`,
+			WindowsDesktopLabelsExpression: `labels["env"] == "prod"`,
+		},
+	})
+
+	user, err := CreateUser(srv.Auth(), "user", role)
+	require.NoError(t, err)
+
+	client, err := srv.NewClient(TestUser(user.GetName()))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		desc             string
+		clientVersions   []string
+		expectError      bool
+		expectedRole     types.Role
+		expectDowngraded bool
+	}{
+		{
+			desc: "up to date",
+			clientVersions: []string{
+				minSupportedLabelExpressionVersion.String(), "13.3.0", "14.0.0-alpha.1", "15.1.2", api.Version, "",
+			},
+			expectedRole: role,
+		},
+		{
+			desc:           "bad client versions",
+			clientVersions: []string{"Not a version", "13", "13.1"},
+			expectError:    true,
+		},
+		{
+			desc:           "label expressions downgraded",
+			clientVersions: []string{"13.0.11", "12.4.3", "6.0.0"},
+			expectedRole: newRole(
+				types.RoleSpecV6{
+					Allow: types.RoleConditions{
+						// None of the allow labels change
+						NodeLabels:               wildcardLabels,
+						AppLabels:                wildcardLabels,
+						AppLabelsExpression:      `labels["env"] == "staging"`,
+						DatabaseLabelsExpression: `labels["env"] == "staging"`,
+						Rules: []types.Rule{
+							types.NewRule(types.KindRole, services.RW()),
+						},
+					},
+					Deny: types.RoleConditions{
+						// These fields don't change
+						KubernetesLabels:               types.Labels{"env": {"prod"}},
+						ClusterLabelsExpression:        `labels["env"] == "prod"`,
+						WindowsDesktopLabelsExpression: `labels["env"] == "prod"`,
+						// These all get set to wildcard deny because there is
+						// either an allow or deny label expression for them.
+						AppLabels:            wildcardLabels,
+						DatabaseLabels:       wildcardLabels,
+						ClusterLabels:        wildcardLabels,
+						WindowsDesktopLabels: wildcardLabels,
+					},
+				}),
+			expectDowngraded: true,
+		},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			for _, clientVersion := range tc.clientVersions {
+				t.Run(clientVersion, func(t *testing.T) {
+					// setup client metadata
+					ctx := context.Background()
+					if clientVersion == "" {
+						ctx = context.WithValue(ctx, metadata.DisableInterceptors{}, struct{}{})
+					} else {
+						ctx = metadata.AddMetadataToContext(ctx, map[string]string{
+							metadata.VersionKey: clientVersion,
+						})
+					}
+
+					checkRole := func(gotRole types.Role) {
+						t.Helper()
+						if tc.expectError {
+							return
+						}
+						require.Empty(t, cmp.Diff(tc.expectedRole, gotRole,
+							cmpopts.IgnoreFields(types.RoleV6{}, "Metadata.ID", "Metadata.Labels")))
+						// The downgraded label value won't match exactly because it
+						// includes the client version, so just check it's not empty
+						// and ignore it in the role diff.
+						if tc.expectDowngraded {
+							require.NotEmpty(t, gotRole.GetMetadata().Labels[types.TeleportDowngradedLabel])
+						}
+					}
+					checkErr := func(err error) {
+						t.Helper()
+						if tc.expectError {
+							require.Error(t, err)
+						} else {
+							require.NoError(t, err)
+						}
+					}
+
+					// Test GetRole
+					gotRole, err := client.GetRole(ctx, role.GetName())
+					checkErr(err)
+					checkRole(gotRole)
+
+					// Test GetRoles
+					gotRoles, err := client.GetRoles(ctx)
+					checkErr(err)
+					if !tc.expectError {
+						foundTestRole := false
+						for _, gotRole := range gotRoles {
+							if gotRole.GetName() != role.GetName() {
+								continue
+							}
+							checkRole(gotRole)
+							foundTestRole = true
+							break
+						}
+						require.True(t, foundTestRole, "GetRoles result does not include expected role")
+					}
+
+					ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+					defer cancel()
+
+					// Test WatchEvents
+					watcher, err := client.NewWatcher(ctx, types.Watch{Name: "roles", Kinds: []types.WatchKind{{Kind: types.KindRole}}})
+					require.NoError(t, err)
+					defer watcher.Close()
+
+					// Swallow the init event
+					e := <-watcher.Events()
+					require.Equal(t, types.OpInit, e.Type)
+
+					// Re-upsert the role so that the watcher sees it, do this
+					// on the auth server directly to avoid the
+					// TeleportDowngradedLabel check in ServerWithRoles
+					require.NoError(t, srv.Auth().UpsertRole(ctx, role))
+
+					gotRole, err = func() (types.Role, error) {
+						for {
+							select {
+							case <-watcher.Done():
+								return nil, watcher.Error()
+							case e := <-watcher.Events():
+								if gotRole, ok := e.Resource.(types.Role); ok && gotRole.GetName() == role.GetName() {
+									return gotRole, nil
+								}
+							}
+						}
+					}()
+					checkErr(err)
+					checkRole(gotRole)
+
+					if !tc.expectError {
+						// Try to re-upsert the role we got. If it was
+						// downgraded, it should be rejected due to the
+						// TeleportDowngradedLabel
+						err = client.UpsertRole(ctx, gotRole)
+						if tc.expectDowngraded {
+							require.Error(t, err)
+						} else {
+							require.NoError(t, err)
+						}
+					}
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
The PR is a follow-up the the label expressions implementation https://github.com/gravitational/teleport/pull/26638 which adds 2 features to improve compatibility with any connected servers on older version that do not yet support label expressions.

The motivation for these features is best described by @fspmarshall's comment:
> I'm concerned about the back-combat story here. Typically when we add a new feature to roles, it allows something that wasn't previously possible, so it's not a huge deal if an older agent doesn't understand the new field. Or, worst case, it imposes a new kind of limit (e.g. ip pinning) that it is reasonable to expect might not be consistently enforced until all agents are updated.
>
> This feature could cause older agents to make more permissive decisions than intended. An older agent might fail to deny an action that would have been denied by the expression, or spuriously treat an action as allowed when the allow expression doesn't actually match. On its own that isn't so different from new limits not being enforced by old agents, but IMO its more serious than that since we're talking about a top-level access decision. Furthermore, I wouldn't necessarily expect a user to even know that ultimate access is often decided by individual agents rather than the control plane.

Some [options](https://github.com/gravitational/teleport/pull/26638#issuecomment-1564661318) for mitigation were discussed on that PR, and this PR implements two of those features:

1. `UpsertRole` will (if label expressions are present) do a best-effort inventory check for services of the relevant Kind on versions older than 13.1.0, and if any are found block the role creation with a helpful error message. This is only a best-effort attempt to warn users as early as possibly of the misconfiguration and prevent most cases of (2).
2. `GetRole` and equivalents will downgrade the role for any clients on versions < 13.1.0. To "downgrade" a role is to insert wildcard deny labels for all resource kinds with any label expression set. A message will be logged at DEBUG level. This will catch all servers that may have been missed by (1) and makes sure we always apply a more-restrictive access decision  when necessary.

The `maybeDowngradeRole` logic is heavily inspired by code that used to exist for downgrading v4,v5,v6 roles to v3,v4,v5 but has since been deleted, and is already being re-added in the role v7 PR https://github.com/gravitational/teleport/pull/26583. Whoever merges second will have to resolve the conflicts :)

Note: I will edit `minSupportedLabelExpressionVersion` when it becomes clear which release this will make it out in. It should be fine if `minSupportedLabelExpressionVersion` is too high, but we don't want it to be too low.