### PR TITLE
[v12] docs: mention locking as an alternative to CA rotation for revoking access

### DIFF
--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -16,7 +16,7 @@ We've outlined these reasons in [OpenSSH vs Teleport SSH for Servers?](https://g
 
 - OpenSSH version 6.9 or above on your local machine. View your OpenSSH version
   with the command:
-  
+
   ```code
   $ ssh -V
   ```
@@ -150,10 +150,10 @@ myhost-cert.pub:
         Key ID: ""
         Serial: 0
         Valid: after 2022-04-22T11:14:16
-        Principals: 
+        Principals:
                 203.0.113.0
         Critical Options: (none)
-        Extensions: 
+        Extensions:
                 x-teleport-authority UNKNOWN OPTION (len 33)
                 x-teleport-role UNKNOWN OPTION (len 8)
 ```
@@ -305,12 +305,12 @@ authenticate the host via the certificate we generated earlier.
 
 ### Proxy Jump
 
-In the generated OpenSSH client configuration, the `ProxyCommand` for each leaf 
+In the generated OpenSSH client configuration, the `ProxyCommand` for each leaf
 cluster connects through the root cluster's Proxy Service. In scenarios where
 leaf cluster Proxy Services are reachable by SSH client, you might prefer to
 connect directly through the leaf proxies for lower latency.
 
-To enable direct connections to a Proxy Service in a leaf cluster, open the 
+To enable direct connections to a Proxy Service in a leaf cluster, open the
 SSH configuration file you generated earlier and update the `ProxyCommand`
 of the leaf cluster's configuration block to use the leaf Proxy Service as
 a jumphost, using the `-J` flag.
@@ -345,9 +345,9 @@ proxy_templates:
   proxy: "$2:443"
 ```
 
-`tsh proxy ssh -J {{proxy}}` will attempt to match the host server address `%h:%p` with the 
+`tsh proxy ssh -J {{proxy}}` will attempt to match the host server address `%h:%p` with the
 configured templates. If there is a match, then the jump proxy address `{{proxy}}` will
-be replaced using the template's `proxy` field and the host server address `%h:%p` will be 
+be replaced using the template's `proxy` field and the host server address `%h:%p` will be
 replaced using the template's `host` field if set.
 
 | Field      | Description |
@@ -494,6 +494,24 @@ $ ssh -F ssh_config_teleport ${USER?}@node2.leafcluster.${CLUSTER}
 
 ## Revoke an SSH certificate
 
-To revoke the current Teleport CA and generate a new one, run `tctl auth rotate`. Unless you've highly automated your
-infrastructure, we would suggest you proceed with caution as this will invalidate the user
-and host CAs, meaning that the new CAs will need to be exported to every OpenSSH-based machine again using `curl .../auth/export` as above.
+Teleport's approach to using short-lived certificates for all infrastructure
+access means that it can generate large numbers of certificates every day. For
+this reason, Teleport does not support traditional certificate revocation. There
+are two options available for revoking access: CA rotations, and Teleport locks.
+
+ ### CA Rotations
+
+ To generate a new certificate authority and invalidate user certificates issued
+ by the current CA, run `tctl auth rotate --type-user`. This process will
+ require that the newly generated CA certificate is uploaded to your entire
+ fleet of OpenSSH servers. This can be a disruptive change, especially in
+ environments that lack automation, so proceed with caution.
+
+ ### Locks
+
+ Teleport locks allow you to permanently or temporarily revoke access to a
+ number of different "targets". Supported lock targets include: specific users,
+ roles, servers, desktops, or MFA devices. When a lock is created any existing
+ sessions where the lock applies will be terminated, and new sessions will be
+ rejected while the lock remains in force. For more information, read our
+ [Session and Identity Locking Guide](../../access-controls/guides/locking.mdx).


### PR DESCRIPTION
Backports #27160 