### PR TITLE
Web: Fix local storage clearing

### DIFF
--- a/web/packages/teleport/src/services/localStorage/localStorage.test.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ls from './localStorage';
+import { KeysEnum } from './types';
+
+describe('localStorage', () => {
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('deletes all keys', () => {
+    // add a few keys
+    localStorage.setItem('key1', 'val1');
+    localStorage.setItem('key2', 'val2');
+    localStorage.setItem('key3', 'val3');
+    expect(localStorage).toHaveLength(3);
+
+    ls.clear();
+    expect(localStorage).toHaveLength(0);
+  });
+
+  test('does not delete keys under KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT', () => {
+    // add a few keys
+    localStorage.setItem('key1', 'val1');
+    localStorage.setItem(KeysEnum.THEME, '');
+    localStorage.setItem('key2', 'val2');
+    localStorage.setItem(KeysEnum.SHOW_ASSIST_POPUP, '');
+    localStorage.setItem('key3', 'val3');
+    localStorage.setItem(KeysEnum.LAST_ACTIVE, '');
+
+    expect(localStorage).toHaveLength(6);
+
+    ls.clear();
+    expect(localStorage).toHaveLength(2);
+    expect(localStorage.key(0)).toBe(KeysEnum.THEME);
+    expect(localStorage.key(1)).toBe(KeysEnum.SHOW_ASSIST_POPUP);
+  });
+
+  test('delete on empty length is not an error', () => {
+    expect(localStorage).toHaveLength(0);
+    ls.clear();
+    expect(localStorage).toHaveLength(0);
+  });
+});

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -29,13 +29,15 @@ const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
 
 const storage = {
   clear() {
+    const keys = [];
     for (let i = 0; i < window.localStorage.length; i++) {
-      const key = window.localStorage.key(i);
-
+      keys.push(window.localStorage.key(i));
+    }
+    keys.forEach(key => {
       if (!KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT.includes(key)) {
         window.localStorage.removeItem(key);
       }
-    }
+    });
   },
 
   subscribe(fn) {

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -29,11 +29,7 @@ const KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT = [
 
 const storage = {
   clear() {
-    const keys = [];
-    for (let i = 0; i < window.localStorage.length; i++) {
-      keys.push(window.localStorage.key(i));
-    }
-    keys.forEach(key => {
+    Object.keys(window.localStorage).forEach(key => {
       if (!KEEP_LOCALSTORAGE_KEYS_ON_LOGOUT.includes(key)) {
         window.localStorage.removeItem(key);
       }


### PR DESCRIPTION
fixes https://github.com/gravitational/teleport/issues/27254

fixes a bug where upon logout, the local storage was not getting cleared as expected. 

i'm not sure if i am explaining this right, but the previous code, as we were deleting keys, the next index value did not necessarily meant it was the `next key`. if the previous key was deleted, then the next index value may refer to next next key (or out of bounds). so depending on the order of keys, it was a delete or miss, which is why users were having `inconsistent` issues with login/logouts

the incident was: when a user logged in, the user got logged right back out, and it was because the local storage key `LAST_ACTIVE: 'grv_teleport_last_active'` was not getting deleted, so it kept the old expired value.

this bug was introduced (backported) starting from `12.4.0`

when i wrote the test, i tested it against the old code first, which failed

i was also able to replicate the issue where my local storage wasn't getting cleared

re @zac about https://github.com/gravitational/teleport/blob/dbcb8a890aa68d87a641e0558fef58a62a24761b/web/packages/teleport/src/components/Authenticated/Authenticated.tsx#L76, i think we do need this check to handle a case where user just closes tabs (but not the browser) which does not clear the storage, so user can step away, and someone else could go load the website and resume the user's session. granted i only tested this with idle time set to 1min...  
