### PR TITLE
cache parsed role template expressions

### DIFF
--- a/lib/services/label_expressions.go
+++ b/lib/services/label_expressions.go
@@ -15,13 +15,9 @@
 package services
 
 import (
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/gravitational/trace"
-	lru "github.com/hashicorp/golang-lru/v2"
-	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/lib/utils"
@@ -36,53 +32,18 @@ type labelExpressionEnv struct {
 	userTraits          map[string][]string
 }
 
+var labelExpressionParser = mustNewLabelExpressionParser()
+
 func parseLabelExpression(expr string) (labelExpression, error) {
-	if parsedExpr, ok := labelExpressionCache.Get(expr); ok {
-		return parsedExpr, nil
-	}
 	parsedExpr, err := labelExpressionParser.Parse(expr)
 	if err != nil {
 		return nil, trace.Wrap(err, "parsing label expression")
-	}
-	if evicted := labelExpressionCache.Add(expr, parsedExpr); evicted {
-		log.Info("Evicting entry from label expression cache")
 	}
 	return parsedExpr, nil
 
 }
 
-var (
-	labelExpressionCache  = mustNewLabelExpressionCache()
-	labelExpressionParser = mustNewLabelExpressionParser()
-)
-
-const (
-	cacheSizeEnvVar  = "TELEPORT_EXPRESSION_CACHE_SIZE"
-	defaultCacheSize = 1000
-)
-
-func mustNewLabelExpressionCache() *lru.Cache[string, labelExpression] {
-	cache, err := newLabelExpressionCache()
-	if err != nil {
-		panic(trace.Wrap(err, "initializing label expression cache"))
-	}
-	return cache
-}
-
-func newLabelExpressionCache() (*lru.Cache[string, labelExpression], error) {
-	cacheSize := defaultCacheSize
-	if env := os.Getenv(cacheSizeEnvVar); env != "" {
-		if envCacheSize, err := strconv.ParseUint(env, 10, 31); err != nil {
-			log.WithError(err).Warn("Parsing " + cacheSizeEnvVar)
-		} else {
-			cacheSize = int(envCacheSize)
-		}
-	}
-	cache, err := lru.New[string, labelExpression](cacheSize)
-	return cache, trace.Wrap(err)
-}
-
-func mustNewLabelExpressionParser() *typical.Parser[labelExpressionEnv, bool] {
+func mustNewLabelExpressionParser() *typical.CachedParser[labelExpressionEnv, bool] {
 	parser, err := newLabelExpressionParser()
 	if err != nil {
 		panic(trace.Wrap(err, "failed to create label expression parser (this is a bug)"))
@@ -90,8 +51,8 @@ func mustNewLabelExpressionParser() *typical.Parser[labelExpressionEnv, bool] {
 	return parser
 }
 
-func newLabelExpressionParser() (*typical.Parser[labelExpressionEnv, bool], error) {
-	parser, err := typical.NewParser[labelExpressionEnv, bool](typical.ParserSpec{
+func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool], error) {
+	parser, err := typical.NewCachedParser[labelExpressionEnv, bool](typical.ParserSpec{
 		Variables: map[string]typical.Variable{
 			"user.spec.traits": typical.DynamicVariable(
 				func(env labelExpressionEnv) (map[string][]string, error) {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -996,7 +996,6 @@ func TestValidateRole(t *testing.T) {
 }
 
 // BenchmarkValidateRole benchmarks the performance of ValidateRole.
-// The current bottleneck is validateRule and specifically predicate.GetFieldByTag.
 //
 // $ go test ./lib/services -bench BenchmarkValidateRole -v -run xxx
 // goos: darwin
@@ -1034,9 +1033,9 @@ func BenchmarkValidateRole(b *testing.B) {
 			ClusterLabels:        types.Labels{"env": {`{{regexp.replace(external["allow-envs"], "^env-(.*)$", "$1")}}`}},
 			Rules: []types.Rule{
 				{
-					Resources: []string{"role"},
-					Verbs:     []string{"read", "list"},
-					Where:     "contains(user.spec.traits[\"groups\"], \"prod\")",
+					Resources: []string{types.KindRole},
+					Verbs:     []string{types.VerbRead, types.VerbList},
+					Where:     `contains(user.spec.traits["groups"], "prod")`,
 				},
 				{
 					Resources: []string{types.KindSession},
@@ -1047,6 +1046,7 @@ func BenchmarkValidateRole(b *testing.B) {
 		},
 	})
 	require.NoError(b, err)
+	require.NoError(b, ValidateRole(role))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -1003,9 +1003,9 @@ func TestValidateRole(t *testing.T) {
 // pkg: github.com/gravitational/teleport/lib/services
 // cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
 // BenchmarkValidateRole
-// BenchmarkValidateRole-16           14752             83120 ns/op
+// BenchmarkValidateRole-16           14630             80205 ns/op
 // PASS
-// ok      github.com/gravitational/teleport/lib/services  3.064s
+// ok      github.com/gravitational/teleport/lib/services  3.030s
 func BenchmarkValidateRole(b *testing.B) {
 	role, err := types.NewRole("test", types.RoleSpecV6{
 		Allow: types.RoleConditions{
@@ -1046,11 +1046,10 @@ func BenchmarkValidateRole(b *testing.B) {
 		},
 	})
 	require.NoError(b, err)
-	require.NoError(b, ValidateRole(role))
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		ValidateRole(role)
+		require.NoError(b, ValidateRole(role))
 	}
 }
 

--- a/lib/utils/parse/parse.go
+++ b/lib/utils/parse/parse.go
@@ -136,7 +136,7 @@ func parseTraitsTemplateExpression(exprString string) (traitsTemplateExpression,
 	return expr, trace.Wrap(err)
 }
 
-func mustNewTraitsTemplateParser() *typical.Parser[traitsTemplateEnv, []string] {
+func mustNewTraitsTemplateParser() *typical.CachedParser[traitsTemplateEnv, []string] {
 	parser, err := newTraitsTemplateParser()
 	if err != nil {
 		panic(trace.Wrap(err, "failed to create template parser (this is a bug)"))
@@ -144,7 +144,7 @@ func mustNewTraitsTemplateParser() *typical.Parser[traitsTemplateEnv, []string] 
 	return parser
 }
 
-func newTraitsTemplateParser() (*typical.Parser[traitsTemplateEnv, []string], error) {
+func newTraitsTemplateParser() (*typical.CachedParser[traitsTemplateEnv, []string], error) {
 	traitsVariable := func(name string) typical.Variable {
 		return typical.DynamicMapFunction(func(e traitsTemplateEnv, key string) ([]string, error) {
 			if e.traitValidator != nil {
@@ -160,7 +160,7 @@ func newTraitsTemplateParser() (*typical.Parser[traitsTemplateEnv, []string], er
 		})
 	}
 
-	parser, err := typical.NewParser[traitsTemplateEnv, []string](typical.ParserSpec{
+	parser, err := typical.NewCachedParser[traitsTemplateEnv, []string](typical.ParserSpec{
 		Variables: map[string]typical.Variable{
 			"external": traitsVariable("external"),
 			"internal": traitsVariable("internal"),
@@ -330,7 +330,7 @@ func parseMatcherExpression(raw string) (Matcher, error) {
 	return matcher, trace.Wrap(err, "evaluating match expression")
 }
 
-func mustNewMatcherParser() *typical.Parser[matcherEnv, Matcher] {
+func mustNewMatcherParser() *typical.CachedParser[matcherEnv, Matcher] {
 	parser, err := newMatcherParser()
 	if err != nil {
 		panic(trace.Wrap(err, "failed to create match parser (this is a bug)"))
@@ -338,8 +338,8 @@ func mustNewMatcherParser() *typical.Parser[matcherEnv, Matcher] {
 	return parser
 }
 
-func newMatcherParser() (*typical.Parser[matcherEnv, Matcher], error) {
-	parser, err := typical.NewParser[matcherEnv, Matcher](typical.ParserSpec{
+func newMatcherParser() (*typical.CachedParser[matcherEnv, Matcher], error) {
+	parser, err := typical.NewCachedParser[matcherEnv, Matcher](typical.ParserSpec{
 		Functions: map[string]typical.Function{
 			RegexpMatchFnName:    typical.UnaryFunction[matcherEnv](regexpMatch),
 			RegexpNotMatchFnName: typical.UnaryFunction[matcherEnv](regexpNotMatch),

--- a/lib/utils/typical/cached_parser.go
+++ b/lib/utils/typical/cached_parser.go
@@ -1,0 +1,71 @@
+package typical
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/gravitational/trace"
+	lru "github.com/hashicorp/golang-lru/v2"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	cacheSizeEnvVar  = "TELEPORT_EXPRESSION_CACHE_SIZE"
+	defaultCacheSize = 1000
+)
+
+// newExpressionCache returns a new LRU cache meant to hold parsed expressions.
+// The size of the cache defaults to 1000 but can be overridden with the
+// TELEPORT_EXPRESSION_CACHE_SIZE environment variable. Each expression type
+// will have its own unique cache with its own size.
+func newExpressionCache[TExpr any]() (*lru.Cache[string, TExpr], error) {
+	cacheSize := defaultCacheSize
+	if env := os.Getenv(cacheSizeEnvVar); env != "" {
+		if envCacheSize, err := strconv.ParseUint(env, 10, 31); err != nil {
+			return nil, trace.Wrap(err)
+		} else {
+			cacheSize = int(envCacheSize)
+		}
+	}
+	cache, err := lru.New[string, TExpr](cacheSize)
+	return cache, trace.Wrap(err)
+}
+
+// CachedParser is a Parser that caches each parsed expression.
+type CachedParser[TEnv, TResult any] struct {
+	Parser[TEnv, TResult]
+	cache *lru.Cache[string, Expression[TEnv, TResult]]
+}
+
+// NewCachedParser creates a cached predicate expression parser with the given specification.
+func NewCachedParser[TEnv, TResult any](spec ParserSpec, opts ...ParserOption) (*CachedParser[TEnv, TResult], error) {
+	parser, err := NewParser[TEnv, TResult](spec, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	cache, err := newExpressionCache[Expression[TEnv, TResult]]()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &CachedParser[TEnv, TResult]{
+		Parser: *parser,
+		cache:  cache,
+	}, nil
+}
+
+// Parse checks if [expression] is already present in the cache and returns the
+// cached version if present, or else parses the expression to produce an
+// Expression[TEnv, TResult] which is stored in the cache and returned.
+func (c *CachedParser[TEnv, TResult]) Parse(expression string) (Expression[TEnv, TResult], error) {
+	if parsedExpr, ok := c.cache.Get(expression); ok {
+		return parsedExpr, nil
+	}
+	parsedExpr, err := c.Parser.Parse(expression)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if evicted := c.cache.Add(expression, parsedExpr); evicted {
+		logrus.Info("Evicting entry from expression cache")
+	}
+	return parsedExpr, nil
+}

--- a/lib/utils/typical/cached_parser.go
+++ b/lib/utils/typical/cached_parser.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package typical
 
 import (

--- a/lib/utils/typical/cached_parser_test.go
+++ b/lib/utils/typical/cached_parser_test.go
@@ -1,0 +1,101 @@
+package typical
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testLogger struct {
+	loggedCount int
+}
+
+func (t *testLogger) Infof(msg string, args ...any) {
+	t.loggedCount++
+}
+
+func TestCachedParser(t *testing.T) {
+	// A simple cached parser with no environment that always returns an int.
+	p, err := NewCachedParser[struct{}, int](ParserSpec{
+		Functions: map[string]Function{
+			"inc": UnaryFunction[struct{}](func(i int) (int, error) {
+				return i + 1, nil
+			}),
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	var logger testLogger
+	p.logger = &logger
+
+	// Sanity check we still get errors.
+	_, err = p.Parse(`"hello"`)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "expected type int, got value (hello) with type (string)")
+
+	// Parse $defaultCacheSize unique expressions to fill the cache.
+	for i := 0; i < defaultCacheSize; i++ {
+		expr := fmt.Sprintf("inc(%d)", i)
+
+		parsed, err := p.Parse(expr)
+		require.NoError(t, err)
+
+		// Sanity check the expression evaluates correctly.
+		result, err := parsed.Evaluate(struct{}{})
+		require.NoError(t, err)
+		require.Equal(t, i+1, result)
+
+		// Make sure the cache len matches what we expect.
+		require.Equal(t, i+1, p.cache.Len())
+
+		// Make sure the cache len doesn't increase after parsing the same
+		// expression again.
+		_, err = p.Parse(expr)
+		require.NoError(t, err)
+		require.Equal(t, i+1, p.cache.Len())
+	}
+
+	// Parse $logAfterEvictions-1 unique expressions to cause
+	// $logAfterEvictions-1 cache evictions
+	for i := 0; i < logAfterEvictions-1; i++ {
+		expr := fmt.Sprintf("inc(%d)", defaultCacheSize+i)
+
+		parsed, err := p.Parse(expr)
+		require.NoError(t, err)
+
+		// Sanity check the expression evaluates correctly.
+		result, err := parsed.Evaluate(struct{}{})
+		require.NoError(t, err)
+		require.Equal(t, defaultCacheSize+i+1, result)
+
+		// Make sure the cache len matches what we expect.
+		require.Equal(t, defaultCacheSize, p.cache.Len())
+
+		// Check that each new parsed expression results in an eviction.
+		require.Equal(t, uint32(i+1), p.evictedCount.Load())
+
+		// Check that no log was printed
+		require.Equal(t, 0, logger.loggedCount)
+	}
+
+	// Parse one more expression
+	expr := fmt.Sprintf("inc(%d)", defaultCacheSize+logAfterEvictions)
+	_, err = p.Parse(expr)
+	require.NoError(t, err)
+
+	// Check a log was printed once after $logAfterEvictions evictions.
+	require.Equal(t, 1, logger.loggedCount)
+
+	// Parse another $logAfterEvictions unique expressions to cause
+	// another $logAfterEvictions cache evictions and one more log
+	for i := 0; i < logAfterEvictions; i++ {
+		expr := fmt.Sprintf("inc(%d)", defaultCacheSize+logAfterEvictions+i+1)
+		_, err := p.Parse(expr)
+		require.NoError(t, err)
+	}
+
+	// Check a log was printed twice after 2*$logAfterEvictions evictions.
+	require.Equal(t, 2, logger.loggedCount)
+}

--- a/lib/utils/typical/cached_parser_test.go
+++ b/lib/utils/typical/cached_parser_test.go
@@ -1,3 +1,17 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package typical
 
 import (


### PR DESCRIPTION
This PR adds caching for parsed role template expressions and matcher expressions. The motivation is [this](https://github.com/gravitational/teleport/issues/27228) issue which shows that `ValidateRole` has become a performance bottleneck for clusters with large numbers of roles.

Adding caching is pretty simple since the parser was converted to use `typical.Parser` in https://github.com/gravitational/teleport/pull/26313, but that PR also added extra validation which I'm concerned could cause further performance problems like those linked in #27228 (that issue is seen on v12 without any of the changes from #26313).

I added a benchmark and this change speeds up `ValidateRole` by ~45%, and decreases the amount of time spent in `parse.parseTraitsTemplateExpression` from 35.8% to 0.5%. The bottleneck is still `services.validateRule` which uses the uncached `services.NewWhereParser` and takes 63.9% of the benchmark execution time. Most of the remaining time is spent in `regexp.FindStringSubmatch`.

`services.NewWhereParser` can't be trivially converted to `typical.CachedParser` because it's tricky to emulate `predicate.GetFieldByTag` which allows the nested json struct references and is the actual bottleneck here.