### PR TITLE
RFD 129: Avoid Discovery Resource Name Collisions

### DIFF
--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -408,7 +408,23 @@ No security concerns I can think of.
 
 ### Backward Compatibility
 
-No concerns I can think of.
+
+If the Teleport Discovery service is upgraded, but `tsh` is not, then
+we may break backwards compatibility with user automation scripts, and/or
+frustrate users with long names they must type fully, since their `tsh` does
+not have the UX improvements.
+
+Solution: backport `tsh` UX changes to prior versions and reserve changes to 
+the Teleport Discovery naming schema for v14.
+This way users can continue to type the old names of discovered resources and
+connect by prefix match.
+
+`tsh` UX changes will add a new predicate expression `hasPrefix` to the
+server-side predicate resource parser.
+If a user has a newer `tsh` version than the server, then `hasPrefix` may not
+be supported by the server and `tsh` will get an error.
+To avoid issues, we can make `tsh` fallback to listing resources without a
+predicate expression and filter the results by matching prefix name.
 
 ### Audit Events
 

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -298,12 +298,17 @@ argument. These commands shall support
 `tsh <sub-command> [--labels keys=val1,key2=val2,...] [--query <predicate>] [name | prefix]` syntax:
 
 - `tsh db login`
+- `tsh db logout`
 - `tsh db connect`
 - `tsh db env`
 - `tsh db config`
+- `tsh kube login`
+- `tsh app login`
+- `tsh app logout`
+- `tsh app config`
 - `tsh proxy db`
 - `tsh proxy kube`
-- `tsh kube login`
+- `tsh proxy app`
 
 To support prefix names, we add a new predicate expression function
 `hasPrefix`, and change the `tsh` API calls to use `hasPrefix(name, "<prefix>")`

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -107,7 +107,7 @@ For each cloud metadata type, we can make available the corresponding
 `api/types` protobufs:
 
 - `api/types.AWS`
-- `api/types.GCP`
+- `api/types.GCPCloudSQL`
 - `api/types.Azure`
 
 Doing this would couple our cloud metadata protobufs to the supported template

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -314,8 +314,8 @@ $ tsh db connect --db-user=alice --db-name-postgres foo
 # ambiguous prefix name is an error
 $ tsh db connect --db-user=alice --db-name-postgres bar
 error: ambiguous database name could match multiple databases:
-Name                           Description               Protocol Type URI                                                     Allowed Users Labels                                                                                                                                    Connect 
------------------------------- ------------------------- -------- ---- ------------------------------------------------------- ------------- ----------------------------------------------------------------------------------------------------------------------------------------- ------- 
+Name                           Description               Protocol Type URI                                                   Allowed Users Labels                                                                                                                                    Connect 
+------------------------------ ------------------------- -------- ---- ----------------------------------------------------- ------------- ----------------------------------------------------------------------------------------------------------------------------------------- ------- 
 bar-rds-us-west-1-123456789012 RDS instance in us-west-1 postgres rds  bar.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432 [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=dev,region=us-west-1,teleport.dev/origin=dynamic          
 bar-rds-us-west-2-123456789012 RDS instance in us-west-2 postgres rds  bar.abcdefghijklmnop.us-west-2.rds.amazonaws.com:5432 [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=dev,region=us-west-2,teleport.dev/origin=dynamic          
 
@@ -333,10 +333,10 @@ $ tsh db connect --db-user=alice --db-name-postgres region=us-west-2
 # ambiguous label(s) match is also an error
 $ tsh db connect --db-user=alice --db-name-postgres region=us-west-1 
 error: ambiguous database labels could match multiple databases:
-Name                           Description               Protocol Type URI                                                     Allowed Users Labels                                                                                                                                    Connect 
------------------------------- ------------------------- -------- ---- ------------------------------------------------------- ------------- ----------------------------------------------------------------------------------------------------------------------------------------- ------- 
+Name                           Description               Protocol Type URI                                                   Allowed Users Labels                                                                                                                                    Connect 
+------------------------------ ------------------------- -------- ---- ----------------------------------------------------- ------------- ----------------------------------------------------------------------------------------------------------------------------------------- ------- 
 bar-rds-us-west-1-123456789012 RDS instance in us-west-1 postgres rds  bar.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432 [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=dev,region=us-west-1,teleport.dev/origin=dynamic          
-foo-rds-us-west-1-123456789012 RDS instance in us-west-1 postgres rds  foo.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432   [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=prod,region=us-west-1,teleport.dev/origin=dynamic         
+foo-rds-us-west-1-123456789012 RDS instance in us-west-1 postgres rds  foo.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432 [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=prod,region=us-west-1,teleport.dev/origin=dynamic         
 
 Hint: try addressing the database by its full name or by matching its labels (ex: tsh db connect key1=value1,key2=value2).
 Hint: use `tsh db ls -v` or `tsh db ls --format=[yaml | json]` to list all databases with verbose details.

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -60,25 +60,25 @@ discovery_service:
   enabled: true
   aws:
     - types: ["rds"]
-      regions: ["us-west-1"]
+      regions: ["us-west-1", "us-west-2"]
       resource_name_template: "teleport-dev-{{.Name}}-{{.AWS.AccountID}}-{{.AWS.Region}}"
       tags:
         "*": "*"
 ```
 
 In this example, the discovery agent will discover AWS RDS databases in the
-us-west-1 AWS region.
+us-west-1 and us-west-2 AWS regions.
 
 Each database discovered by the matcher will have the prefix "teleport-dev-"
 followed by the discovered database's name, AWS account ID, and AWS region.
 
 For instance, if a database named `foo` is discovered in AWS account ID
-`0123456789012`, the rewritten name will be
+`0123456789012` in region `us-west-1`, the rewritten name will be
 `teleport-dev-foo-012345689012-us-west-1`.
 This would disambiguate the database name from other databases in other regions
 and other AWS accounts.
 
-Since the full template syntax is available, you could modify this to use
+Since the full template syntax is available, a user could modify this to use
 available template builtin functions to shorten the account ID portion:
 `resource_name_template: 'teleport-dev-{{printf "%s-%.4s-%s" .Name .AWS.AccountID .AWS.Region}}'`
 results in: `teleport-dev-foo-0123-us-west-1`

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -1,0 +1,211 @@
+---
+authors: Gavin Frazar (gavin.frazar@goteleport.com)
+state: draft
+---
+
+# RFD 0129 - Discovery Resource Name Templates
+
+Related RFDs:
+- [RFD 0125 - Dynamic Auto-Discovery Configuration](./0125-dynamic-auto-discovery-config.md)
+
+## Required Approvers
+
+- Engineering: `@r0mant && @smallinsky && @tigrato`
+- Product: `@klizhentas || @xinding33`
+- Security: `@reedloden || @jentfoo`
+
+## What
+
+Auto-Discovery service can be configured to dynamically name discovered
+resources using a template string that can reference a subset of resource
+metadata. The choice of what metadata to make available is the main motivation
+for this RFD.
+
+## Why
+
+Multiple discovery agents can discover resources with identical names.
+For example, this happened when customers had databases in different AWS
+regions or accounts with the same name. When a name collision occurs, only one
+of the databases can be accessed by users.
+
+Resource name templates can be used to avoid naming collisions by renaming
+discovered resources with a prefix/suffix specific to a discovery agent, or by
+using other available metadata such as AWS region or account ID.
+
+See:
+- https://github.com/gravitational/teleport/issues/22438
+
+## Details
+
+There will be a new optional configuration string in Discovery service matchers,
+`resource_name_template`, that will be parsed as a
+[Go Template](https://pkg.go.dev/text/template) to rename resources discovered
+using that matcher.
+
+This setting will be made available in both static config and the upcoming
+dynamic discovery config from RFD 125.
+
+### `resource_name_template`
+
+This template string is just a Go text/template, so the template syntax is the
+same.
+
+Using Go templates is not uncommon, so this UX should not be surprising.
+A few examples of software that supports using Go templates: `helm`, `gh`
+(GitHub CLI), `docker`.
+
+### Example config:
+```yaml
+discovery_service:
+  enabled: true
+  aws:
+    - types: ["rds"]
+      regions: ["us-west-1"]
+      resource_name_template: "teleport-dev-{{.Name}}-{{.AWS.AccountID}}-{{.AWS.Region}}"
+      tags:
+        "*": "*"
+```
+
+In this example, the discovery agent will discover AWS RDS databases in the
+us-west-1 AWS region.
+
+Each database discovered by the matcher will have the prefix "teleport-dev-"
+followed by the discovered database's name, AWS account ID, and AWS region.
+
+For instance, if a database named `foo` is discovered in AWS account ID
+`0123456789012`, the rewritten name will be
+`teleport-dev-foo-012345689012-us-west-1`.
+This would disambiguate the database name from other databases in other regions
+and other AWS accounts.
+
+Since the full template syntax is available, you could modify this to use
+available template builtin functions to shorten the account ID portion:
+`resource_name_template: 'teleport-dev-{{printf "%s-%.4s-%s" .Name .AWS.AccountID .AWS.Region}}'`
+results in: `teleport-dev-foo-0123-us-west-1`
+
+### Available template variables
+
+We must decide which variables to make available for templating.
+
+The supported variables must be sufficient to disambiguate cloud resources to
+avoid name collisions, therefore I think, at a minimum, the supported variables
+should include:
+
+- the original discovered resource name: `.Name`
+- cloud metadata: `.AWS`, `.GCP`, `.Azure`
+  - each of these should only be available for the corresponding matcher
+    type: `aws:`, `gcp:`, `azure:`.
+- the region/location of the resource: `.Region` or `.Location`
+  - this is already included in AWS metadata, but not Azure nor GCP.
+  - rather than a protobuf update, we can just expose this template data
+    variable separately: `.Region` for AWS/Azure and `.Location` for GCP, for
+    consistency with the naming conventions chosen for our discovery matcher
+    config - AWS/Azure matchers use `regions:` and GCP matchers use
+    `locations:`.
+
+For each cloud metadata type, we can make available the corresponding
+`api/types` protobufs:
+
+- `api/types.AWS`
+- `api/types.GCP`
+- `api/types.Azure`
+
+Doing this would couple our cloud metadata protobufs to the supported template
+variables, however it would simplify the implementation and ensure that any new
+cloud metadata is available for templating.
+
+For whatever choice of supported variables, we must document the supported
+template variables in our docs reference.
+
+We should also print a friendly user message that lists the supported
+variables if a user provides a template string that references an unsupported
+variable.
+
+We can check the user provided template when file config is applied,
+or when a dynamic discovery config is created, by executing the template with
+stub data input, or by walking the template parse tree.
+
+### Security
+
+This configuration setting will only be available to Teleport cluster admins,
+which limits the potential for intentional abuse. I'm not aware of any
+unintentional security concerns, since we control the available supported
+template variables and none of them are secrets.
+
+I was concerned about the potential for resource exhaustion if a
+self-referencing template makes it into a running discovery agent:
+`{{template "ResourceNameTemplate" .}}` - this is self-referencing and looks
+like it will evaluate infinitely.
+What will actually happen is text/template terminates the recursion at 100,000
+depth with an error (not a panic).
+
+We could alternatively catch the invocation of `{{template}} "name" .` actions 
+by writing a visitor to walk the template parse tree. We could use this parse
+tree walking for further template restrictions if we need to.
+
+We can check for invocations of the template action on agent startup from static
+config, or server-side when a dynamic discovery config is created.
+
+### UX
+
+#### `discovery_service` new service configuration properties
+
+Users need to ensure the `resource_name_template` option is set to a template
+string for each discovery matcher to enable resource name rewriting.
+
+Example:
+```yaml
+discovery_service:
+  enabled: true
+  aws:
+    - types: ["ec2", "rds"]
+      regions: ["us-west-1"]
+      resource_name_template: "{{.Name}}-{{.Region}}-{{.AWS.AccountID}}"
+      tags:
+        "*": "*"
+  azure:
+    - types: ["aks"]
+      resource_name_template: "{{.Name}}-{{.Region}}"
+      regions: ["eastus", "westus"]
+      subscriptions: ["11111111-2222-3333-4444-555555555555"]
+      resource_groups: ["group1", "group2"]
+      tags:
+        "*": "*"
+  gcp:
+    - types: ["gke"]
+      resource_name_template: "{{.Name}}-{{.GCP.ProjectID}}-{{.Location}}"
+      locations: ["*"]
+      tags:
+        "*": "*"
+       project_ids: ["myproject"]
+```
+
+Likewise, use `resource_name_template` in matchers for `DiscoveryConfig`
+from RFD 125 using `tctl`.
+
+### Proto Specification
+
+When RFD 125 is implemented, we will need to update the proto messages for
+`DiscoveryConfig` to add a string `resource_name_template` field to each of
+AWS/Azure/GCP matcher messages.
+
+### Backward Compatibility
+
+No concerns I can think of.
+
+### Audit Events
+
+N/A
+
+### Test Plan
+
+We should test discovering multiple resources with identical names do not suffer
+a name collision when using templates to disambiguate them.
+
+For instance, setup identically named RDS databases in different AWS regions
+and a discovery agent to discover them with this template:
+`resource_name_template: '{{.Name}}-{{.Region}}'`
+
+Check that the databases are both present and differentiated by region in their
+name using `tsh db ls`.
+

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -283,7 +283,70 @@ And a similar message specific to the matcher type: AWS/Azure/GCP.
 
 When RFD 125 is implemented, we will need to update the proto messages for
 `DiscoveryConfig` to add a string `resource_name_template` field to each of
-AWS/Azure/GCP matcher messages.
+AWS/Azure/GCP matcher messages:
+
+```proto
+// AWSMatcher matches AWS EC2 instances and AWS Databases
+message AWSMatcher {
+  // Types are AWS database types to match, "ec2", "rds", "redshift", "elasticache",
+	// or "memorydb".
+  repeated string Types = 1;
+  // Regions are AWS regions to query for databases.
+	repeated string Regions = 2;
+	// AssumeRoleARN is the AWS role to assume for database discovery.
+	string AssumeRoleARN = 3;
+	// ExternalID is the AWS external ID to use when assuming a role for
+	// database discovery in an external AWS account.
+	string ExternalID = 4;
+	// Tags are AWS tags to match.
+  wrappers.LabelValues Tags = 5;
+	// InstallParams sets the join method when installing on
+	// discovered EC2 nodes
+	MatcherInstallParams InstallParams = 6;
+	// SSM provides options to use when sending a document command to
+	// an EC2 node
+	AWSSSM SSM = 7;
+	// ResourceNameTemplate rewrites matching resources according to a template
+	// string.
+	ResourceNameTemplate string = 7;
+}
+
+// AzureMatcher matches Azure resources.
+// It defines which resource types, filters and some configuration params.
+message AzureMatcher {
+	// Subscriptions are Azure subscriptions to query for resources.
+	repeated string Subscriptions = 1;
+	// ResourceGroups are Azure resource groups to query for resources.
+	repeated string ResourceGroups = 2;
+	// Types are Azure types to match: "mysql", "postgres", "aks", "vm"
+	repeated string Types = 3;
+	// Regions are Azure locations to match for databases.
+	repeated string Regions = 4;
+	// ResourceTags are Azure tags on resources to match.
+  wrappers.LabelValues ResourceTags = 5;
+	// InstallParams sets the join method when installing on
+	// discovered Azure nodes.
+	MatcherInstallParams InstallParams = 6;
+	// ResourceNameTemplate rewrites matching resources according to a template
+	// string.
+	ResourceNameTemplate string = 7;
+}
+
+// GCPMatcher matches GCP resources.
+message GCPMatcher {
+	// Types are GKE resource types to match: "gke".
+	repeated string Types = 1;
+	// Locations are GKE locations to search resources for.
+	repeated string Locations = 2;
+	// Tags are GCP labels to match.
+	wrappers.LabelValues Tags = 3;
+	// ProjectIDs are the GCP project ID where the resources are deployed.
+	repeated string ProjectIDs = 4;
+	// ResourceNameTemplate rewrites matching resources according to a template
+	// string.
+	ResourceNameTemplate string = 5;
+}
+```
 
 ### Backward Compatibility
 

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -269,7 +269,7 @@ usage error:
 
 ```shell
 $ tctl create ~/discovery_config.yaml 
-ERROR: failed to parse Teleport configuration: discovery service AWS resource_name_template variable ".Thing" is not supported, supported template variables types are:
+ERROR: DiscoveryConfig "example" AWS resource_name_template variable ".Thing" is not supported, supported template variables types are:
 .Name
 .Region
 .AWS

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -39,7 +39,8 @@ Name collisions can be avoided with the addition of other resource metadata
 in the resource name.
 
 Since discovered resource names will be longer and more tedious to use, we
-should support resource name prefixes and label matching in `tsh` for better UX.
+should support resource name prefixes and label matching in `tsh`, Teleport
+Connect, and the web UI for better UX.
 
 Relevant issue:
 - https://github.com/gravitational/teleport/issues/22438
@@ -343,6 +344,28 @@ $ tsh db connect --db-user=alice --db-name-postgres foo region=us-west-1
 $ tsh db connect --db-user=alice --db-name-postgres region=us-west-1,env=prod
 #...connects to "foo-rds-us-west-1-0123456789012" by multiple labels...
 ```
+
+### Web UI and Teleport Connect UX
+
+Both the web UI and Teleport Connect already support searching for substrings
+in resource names and labels.
+
+Searching by substring is a "fuzzier" kind of search than prefix-based name
+search (like this RFD proposed prefix-based search for `tsh`) - it's more
+likely to match more than one resource.
+However, GUI UX is fundamentally different from CLI - users can search and then
+interactively select from multiple matching resources.
+So this kind of search is appropriate for the web UI and Teleport Connect, but
+not for `tsh`.
+
+Both web UI and Teleport Connect also support label-based searching with
+the predicate language, e.g.:
+
+```
+labels["env"] == "dev" && labels["region"] == "us-west-1"
+```
+
+Therefore, no UX changes are required for these user interfaces.
 
 ### Security
 

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -290,7 +290,6 @@ argument. These commands shall support
 - `tsh db env`
 - `tsh db config`
 - `tsh proxy db`
-- `tsh proxy app`
 - `tsh proxy kube`
 - `tsh kube login`
 

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -183,6 +183,36 @@ discovery_service:
 Likewise, use `resource_name_template` in matchers for `DiscoveryConfig`
 from RFD 125 using `tctl`.
 
+#### `teleport` and `tctl` template errors
+
+Print a user-friendly message that lists supported template variables
+when a user tries to use an unsupported template variable:
+
+config file:
+```yaml
+discovery_service:
+  enabled: true
+  aws:
+    - types: ["ec2", "rds"]
+      regions: ["us-west-1"]
+      resource_name_template: "{{.Thing}}-{{.Region}}-{{.AWS.AccountID}}"
+      tags:
+        "*": "*"
+```
+
+usage:
+```shell
+$ teleport start
+ERROR: failed to parse Teleport configuration: discovery service AWS resource_name_template variable ".Thing" is not supported, supported template variables types are:
+.Name
+.Region
+.AWS
+  .AccountID
+  ...
+```
+
+And a similar message specific to the matcher type: AWS/Azure/GCP.
+
 ### Proto Specification
 
 When RFD 125 is implemented, we will need to update the proto messages for

--- a/rfd/0129-discovery-name-templating.md
+++ b/rfd/0129-discovery-name-templating.md
@@ -303,46 +303,49 @@ To illustrate the new UX for `tsh` sub-commands, here is an example using
 $ tsh db ls
 Name   Description         Allowed Users       Labels                      Connect 
 ------ ------------------- ------------------- --------------------------- ------- 
-foo-rds-us-west-1-0123456789012 RDS instance in ... [*] account-id=0123456789012,region=us-west-1,env=prod,...
-bar-rds-us-west-1-0123456789012 RDS instance in ... [*] account-id=0123456789012,region=us-west-1,env=dev,...
-bar-rds-us-west-2-0123456789012 RDS instance in ... [*] account-id=0123456789012,region=us-west-2,env=dev,...
+bar    RDS instance in ... [*] account-id=123456789012,region=us-west-1,env=dev,...
+bar    RDS instance in ... [*] account-id=123456789012,region=us-west-2,env=dev,...
+foo    RDS instance in ... [*] account-id=123456789012,region=us-west-1,env=prod,...
 
 # connect by prefix name
 $ tsh db connect --db-user=alice --db-name-postgres foo
-#...connects to "foo-rds-us-west-1-0123456789012" by prefix...
+#...connects to "foo-rds-us-west-1-123456789012" by prefix...
 
 # ambiguous prefix name is an error
 $ tsh db connect --db-user=alice --db-name-postgres bar
 error: ambiguous database name could match multiple databases:
-Name   Description         Allowed Users       Labels                      Connect 
------- ------------------- ------------------- --------------------------- ------- 
-bar-rds-us-west-1-0123456789012 RDS instance in ... [*] account-id=0123456789012,region=us-west-1,env=dev,...
-bar-rds-us-west-2-0123456789012 RDS instance in ... [*] account-id=0123456789012,region=us-west-2,env=dev,...
+Name                           Description               Protocol Type URI                                                     Allowed Users Labels                                                                                                                                    Connect 
+------------------------------ ------------------------- -------- ---- ------------------------------------------------------- ------------- ----------------------------------------------------------------------------------------------------------------------------------------- ------- 
+bar-rds-us-west-1-123456789012 RDS instance in us-west-1 postgres rds  bar.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432 [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=dev,region=us-west-1,teleport.dev/origin=dynamic          
+bar-rds-us-west-2-123456789012 RDS instance in us-west-2 postgres rds  bar.abcdefghijklmnop.us-west-2.rds.amazonaws.com:5432 [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=dev,region=us-west-2,teleport.dev/origin=dynamic          
 
-Hint: try addressing the database by its full name or by matching its labels.
-Hint: use `tsh db ls -v` to list all databases with verbose detail.
+Hint: try addressing the database by its full name or by matching its labels (ex: tsh db connect key1=value1,key2=value2).
+Hint: use `tsh db ls -v` or `tsh db ls --format=[yaml | json]` to list all databases with verbose details.
 
 # resolve the error by connecting with an unambiguous prefix 
 $ tsh db connect --db-user=alice --db-name-postgres bar-rds-us-west-2
-#...connects to "bar-rds-us-west-2-0123456789012" by prefix...
+#...connects to "bar-rds-us-west-2-123456789012" by prefix...
 
 # or connect by label(s)
 $ tsh db connect --db-user=alice --db-name-postgres region=us-west-2 
-#...connects to "bar-rds-us-west-2-0123456789012" by matching region label...
+#...connects to "bar-rds-us-west-2-123456789012" by matching region label...
 
 # ambiguous label(s) match is also an error
 $ tsh db connect --db-user=alice --db-name-postgres region=us-west-1 
 error: ambiguous database labels could match multiple databases:
-Name   Description         Allowed Users       Labels                      Connect 
------- ------------------- ------------------- --------------------------- ------- 
-foo-rds-us-west-1-0123456789012 RDS instance in ... [*] account-id=0123456789012,region=us-west-1,env=prod,...
-bar-rds-us-west-1-0123456789012 RDS instance in ... [*] account-id=0123456789012,region=us-west-1,env=dev,...
+Name                           Description               Protocol Type URI                                                     Allowed Users Labels                                                                                                                                    Connect 
+------------------------------ ------------------------- -------- ---- ------------------------------------------------------- ------------- ----------------------------------------------------------------------------------------------------------------------------------------- ------- 
+bar-rds-us-west-1-123456789012 RDS instance in us-west-1 postgres rds  bar.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432 [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=dev,region=us-west-1,teleport.dev/origin=dynamic          
+foo-rds-us-west-1-123456789012 RDS instance in us-west-1 postgres rds  foo.abcdefghijklmnop.us-west-1.rds.amazonaws.com:5432   [*]           account-id=123456789012,endpoint-type=instance,engine-version=13.10,engine=postgres,env=prod,region=us-west-1,teleport.dev/origin=dynamic         
+
+Hint: try addressing the database by its full name or by matching its labels (ex: tsh db connect key1=value1,key2=value2).
+Hint: use `tsh db ls -v` or `tsh db ls --format=[yaml | json]` to list all databases with verbose details.
 
 # resolve the error by using either more specific labels or adding a prefix name
 $ tsh db connect --db-user=alice --db-name-postgres foo region=us-west-1 
-#...connects to "foo-rds-us-west-1-0123456789012" by prefix and label...
+#...connects to "foo-rds-us-west-1-123456789012" by prefix and label...
 $ tsh db connect --db-user=alice --db-name-postgres region=us-west-1,env=prod
-#...connects to "foo-rds-us-west-1-0123456789012" by multiple labels...
+#...connects to "foo-rds-us-west-1-123456789012" by multiple labels...
 ```
 
 ### Web UI and Teleport Connect UX


### PR DESCRIPTION
Rendered:
- [RFD 129 - Discovery Resource Name Templates](https://github.com/gravitational/teleport/blob/master/rfd/0129-discovery-name-templating.md)

~I have prototyped this idea for AWS databases and the implementation was straightforward (and works to solve the name collision issue). This RFD is mostly to discuss:~

~1. should we use Go templates instead of some custom templating like we do in Teleport RBAC or a simpler alternative like name rewriting to just add a prefix/suffix?~
~2. if we like the Go template solution, what template variables/functionality should we expose?~

Reworked RFD to discuss a discovery resource naming convention and `tsh` UX to make working with longer resource names less tedious.