### PR TITLE
Assist bug fixes

### DIFF
--- a/web/packages/shared/package.json
+++ b/web/packages/shared/package.json
@@ -24,7 +24,6 @@
     "react-router": "5.1.1",
     "react-router-dom": "5.1.1",
     "react-select": "^3.0.8",
-    "react-use-websocket": "^4.3.1",
     "tslib": "^2.4.0",
     "whatwg-fetch": "^3.0.0",
     "@gravitational/design": "1.0.0"

--- a/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
+++ b/web/packages/teleport/src/Assist/Chat/ChatItem/Action/RunAction.tsx
@@ -259,6 +259,10 @@ const LoadingContainer = styled.div`
   margin: 30px 0 20px;
 `;
 
+const Output = styled.pre`
+  overflow-x: auto;
+`;
+
 function NodeOutput(props: NodeOutputProps) {
   return (
     <NodeContainer>
@@ -275,7 +279,7 @@ function NodeOutput(props: NodeOutputProps) {
           'Empty output.'
         ) : (
           <NodeContent>
-            <pre>{props.state.stdout}</pre>
+            <Output>{props.state.stdout}</Output>
           </NodeContent>
         ))}
     </NodeContainer>

--- a/web/packages/teleport/src/Assist/contexts/messages.test.ts
+++ b/web/packages/teleport/src/Assist/contexts/messages.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { sortLoginsWithRootLoginsLast } from './messages';
+
+describe('assist messages', () => {
+  it('should sort logins alphabetically', () => {
+    const logins = ['test', 'login1', 'awesome', 'random', 'login2'];
+
+    const sorted = sortLoginsWithRootLoginsLast(logins);
+
+    expect(sorted).toEqual(['awesome', 'login1', 'login2', 'random', 'test']);
+  });
+
+  it('should put root logins last', () => {
+    const logins = [
+      'root',
+      'admin',
+      'test',
+      'login1',
+      'awesome',
+      'random',
+      'login2',
+    ];
+
+    const sorted = sortLoginsWithRootLoginsLast(logins);
+
+    expect(sorted).toEqual([
+      'awesome',
+      'login1',
+      'login2',
+      'random',
+      'test',
+      'admin',
+      'root',
+    ]);
+  });
+});

--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -110,6 +110,15 @@ const convertToQuery = (cmd: ExecuteRemoteCommandPayload): string => {
   return query;
 };
 
+const ROOT_LOGINS = ['root', 'ec2-user', 'ubuntu', 'admin', 'centos'];
+
+// findPreferredLogin tries to find a login that is not a root login.
+function findPreferredLogin(logins: string[]): string | undefined {
+  const login = logins.find(l => !ROOT_LOGINS.includes(l));
+
+  return login || logins[0];
+}
+
 export const remoteCommandToMessage = async (
   execCmd: ExecuteRemoteCommandContent,
   clusterId: string
@@ -144,12 +153,12 @@ export const remoteCommandToMessage = async (
     let avLogin = execCmd.selectedLogin;
     if (!avLogin) {
       // If the login has not been selected, use the first one.
-      avLogin = availableLogins ? availableLogins[0] : '';
+      avLogin = availableLogins ? findPreferredLogin(availableLogins) : '';
     } else {
       // If the login has been selected, check if it is available.
       // Updated query could have changed the available logins.
       if (!availableLogins.includes(avLogin)) {
-        avLogin = availableLogins ? availableLogins[0] : '';
+        avLogin = availableLogins ? findPreferredLogin(availableLogins) : '';
       }
     }
 

--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -416,7 +416,7 @@ export function MessagesContextProvider(
 
     // refresh the websocket connection every 10 minutes to avoid
     // session timeouts
-    const id = window.setInterval(setupWebSocket, TEN_MINUTES);
+    const id = window.setInterval(setupWebSocket, TEN_MINUTES * 0.8);
 
     return () => {
       window.clearInterval(id);

--- a/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
+++ b/web/packages/teleport/src/Navigation/NavigationSwitcher.tsx
@@ -166,11 +166,17 @@ export function NavigationSwitcher(props: NavigationSwitcherProps) {
 
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
+      // prevent the dropdown from closing when the assist tooltip is visible
+      // this prevents the switcher from closing when the user closes the discover modal
+      if (showAssist) {
+        return;
+      }
+
       if (ref.current && !ref.current.contains(event.target as HTMLElement)) {
         setOpen(false);
       }
     },
-    [ref.current]
+    [showAssist, ref.current]
   );
 
   useEffect(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12465,11 +12465,6 @@ react-transition-group@^4.3.0, react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
-react-use-websocket@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/react-use-websocket/-/react-use-websocket-4.3.1.tgz#13cd2fd2e0fb90010482ab2858f8ae81f2ce85c2"
-  integrity sha512-zHPLWrgcqydJaak2O5V9hiz4q2dwkwqNQqpgFVmSuPxLZdsZlnDs8DVHy3WtHH+A6ms/8aHIyX7+7ulOcrnR0Q==
-
 react@16.14.0, react@^16.8.4:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"


### PR DESCRIPTION
This removes `react-use-websocket` in favour of keeping a normal `WebSocket` connection in a ref. This also has a rudimentary fix for the session expiring - it renews the websocket connection every 10 minutes. Should hopefully fix https://github.com/gravitational/teleport.e/issues/1496.

Added a scrollbar to the command output if the text overflows. Fixes https://github.com/gravitational/teleport.e/issues/1456.

Implements the idea from @klizhentas around selecting a login that isn't root/ubuntu/centos, etc. This is half of it - we should still add the remember feature to remember the last selected login.

Also fixes https://github.com/gravitational/teleport.e/issues/1461 - the navigation switcher now can't close whilst the assist tooltip is open.