### PR TITLE
Allow overriding docker in `make grpc`

### DIFF
--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM docker.io/golang:1.20
 
 # Image layers go from less likely to most likely to change.
 RUN apt-get update && \
@@ -10,16 +10,16 @@ RUN apt-get update && \
 
 # protoc-gen-gogofast
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
-ARG GOGO_PROTO_TAG # eg, "v1.3.2"
+ARG GOGO_PROTO_TAG
 RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 
 # protoc-gen-js and protoc-gen-ts
-ARG NODE_GRPC_TOOLS_VERSION # eg, "1.12.4"
-ARG NODE_PROTOC_TS_VERSION  # eg, "5.0.1"
+ARG NODE_GRPC_TOOLS_VERSION
+ARG NODE_PROTOC_TS_VERSION
 RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
 
 # protoc
-ARG PROTOC_VER # eg, "3.20.2"
+ARG PROTOC_VER
 RUN VERSION="$PROTOC_VER" && \
   PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
   PB_FILE="$(mktemp protoc-XXXXXX.zip)" && \
@@ -29,7 +29,7 @@ RUN VERSION="$PROTOC_VER" && \
   rm -f "$PB_FILE"
 
 # buf
-ARG BUF_VERSION # eg, "1.19.0"
+ARG BUF_VERSION
 RUN BIN='/usr/local/bin' && \
   VERSION="$BUF_VERSION" && \
   curl -fsSL "https://github.com/bufbuild/buf/releases/download/v$VERSION/buf-$(uname -s)-$(uname -m)" -o "${BIN}/buf" && \

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -15,7 +15,9 @@ ARG GOGO_PROTO_TAG
 RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 
 # protoc-gen-js and protoc-gen-ts
+# eg, "1.12.4"
 ARG NODE_GRPC_TOOLS_VERSION
+# eg, "5.0.1"
 ARG NODE_PROTOC_TS_VERSION
 RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
 

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -10,6 +10,7 @@ RUN apt-get update && \
 
 # protoc-gen-gogofast
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
+# eg, "v1.3.2"
 ARG GOGO_PROTO_TAG
 RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 
@@ -19,6 +20,7 @@ ARG NODE_PROTOC_TS_VERSION
 RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
 
 # protoc
+# eg, "3.20.2"
 ARG PROTOC_VER
 RUN VERSION="$PROTOC_VER" && \
   PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
@@ -29,6 +31,7 @@ RUN VERSION="$PROTOC_VER" && \
   rm -f "$PB_FILE"
 
 # buf
+# eg, "1.19.0"
 ARG BUF_VERSION
 RUN BIN='/usr/local/bin' && \
   VERSION="$BUF_VERSION" && \

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -14,13 +14,8 @@ else
 GRPCBOX ?= $(GRPCBOX_BASE_NAME):$(BUILDBOX_VERSION)
 endif
 
+# Allow overriding the docker implementation to use for ex. podman.
 DOCKER := docker
-UNAME := $(shell uname)
-
-ifeq ($(UNAME), Linux)
-# Use podman on linux.
-DOCKER = podman
-endif
 
 # GRPCBOX_RUN has the necessary invocation to run a command inside the grpcbox.
 # Use this variable to run it from other Makefiles.

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -14,9 +14,14 @@ else
 GRPCBOX ?= $(GRPCBOX_BASE_NAME):$(BUILDBOX_VERSION)
 endif
 
+# UID and GID are used to run the grpcbox as the current user.
+UID := $$(id -u)
+GID := $$(id -g)
+
 # GRPCBOX_RUN has the necessary invocation to run a command inside the grpcbox.
 # Use this variable to run it from other Makefiles.
-GRPCBOX_RUN := docker run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
+# Set XDG_CACHE_HOME to let non-root user cache dependencies: https://github.com/bufbuild/buf/blob/f38ba9455c6650947b0b710327f9acb708da1196/private/pkg/app/app_unix.go#LL70C18-L70C32
+GRPCBOX_RUN := docker run -it --rm -u $(UID):$(GID) -e XDG_CACHE_HOME="/tmp/.cache" -v "$$(pwd)/../:/workdir" -w /workdir $(GRPCBOX)
 
 # grpcbox builds a codegen-focused buildbox.
 # It's leaner, meaner, faster and not supposed to compile code.

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -15,7 +15,7 @@ GRPCBOX ?= $(GRPCBOX_BASE_NAME):$(BUILDBOX_VERSION)
 endif
 
 # Allow overriding the docker implementation to use for ex. podman.
-DOCKER := docker
+DOCKER ?= docker
 
 # GRPCBOX_RUN has the necessary invocation to run a command inside the grpcbox.
 # Use this variable to run it from other Makefiles.


### PR DESCRIPTION
Our `make grpc` doesn't allow overriding the `docker` CLI tool, which stops us from using alternative docker implementations as `podman`. This change allows overriding the docker binary name by using `make grpc DOCKER=podman`. The grpc dockerfile is also converted to work with podman.