### PR TITLE
WebPublicAddr includes user specified port.

### DIFF
--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -644,3 +644,46 @@ func TestVerifyEnabledService(t *testing.T) {
 		})
 	}
 }
+
+func TestWebPublicAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   ProxyConfig
+		expected string
+	}{
+		{
+			name:     "no public address specified",
+			expected: "https://<proxyhost>:3080",
+		},
+		{
+			name: "default port",
+			config: ProxyConfig{
+				PublicAddrs: []utils.NetAddr{
+					{Addr: "0.0.0.0", AddrNetwork: "tcp"},
+				},
+			},
+			expected: "https://0.0.0.0:3080",
+		},
+		{
+			name: "non-default port",
+			config: ProxyConfig{
+				PublicAddrs: []utils.NetAddr{
+					{Addr: "0.0.0.0:443", AddrNetwork: "tcp"},
+				},
+			},
+			expected: "https://0.0.0.0:443",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := test.config.WebPublicAddr()
+			require.NoError(t, err)
+
+			require.Equal(t, test.expected, out)
+		})
+	}
+}

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -141,16 +141,18 @@ type ProxyConfig struct {
 // WebPublicAddr returns the address for the web endpoint on this proxy that
 // can be reached by clients.
 func (c ProxyConfig) WebPublicAddr() (string, error) {
-	return c.getDefaultAddr(c.WebAddr.Port(defaults.HTTPListenPort)), nil
+	return c.getDefaultAddr(c.WebAddr.Port(defaults.HTTPListenPort), true), nil
 }
 
-func (c ProxyConfig) getDefaultAddr(port int) string {
+func (c ProxyConfig) getDefaultAddr(port int, usePublicAddrPort bool) string {
 	host := "<proxyhost>"
 	// Try to guess the hostname from the HTTP public_addr.
 	if len(c.PublicAddrs) > 0 {
 		publicAddr := c.PublicAddrs[0]
 		host = publicAddr.Host()
-		port = publicAddr.Port(port)
+		if usePublicAddrPort {
+			port = publicAddr.Port(port)
+		}
 	}
 
 	u := url.URL{
@@ -170,7 +172,7 @@ func (c ProxyConfig) KubeAddr() (string, error) {
 		return fmt.Sprintf("https://%s", c.Kube.PublicAddrs[0].Addr), nil
 	}
 
-	return c.getDefaultAddr(c.Kube.ListenAddr.Port(defaults.KubeListenPort)), nil
+	return c.getDefaultAddr(c.Kube.ListenAddr.Port(defaults.KubeListenPort), false), nil
 }
 
 // PublicPeerAddr attempts to returns the public address the proxy advertises

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -148,7 +148,9 @@ func (c ProxyConfig) getDefaultAddr(port int) string {
 	host := "<proxyhost>"
 	// Try to guess the hostname from the HTTP public_addr.
 	if len(c.PublicAddrs) > 0 {
-		host = c.PublicAddrs[0].Host()
+		publicAddr := c.PublicAddrs[0]
+		host = publicAddr.Host()
+		port = publicAddr.Port(port)
 	}
 
 	u := url.URL{

--- a/lib/service/servicecfg/proxy.go
+++ b/lib/service/servicecfg/proxy.go
@@ -141,8 +141,6 @@ type ProxyConfig struct {
 // WebPublicAddr returns the address for the web endpoint on this proxy that
 // can be reached by clients.
 func (c ProxyConfig) WebPublicAddr() (string, error) {
-	port := c.WebAddr.Port(defaults.HTTPListenPort)
-
 	// Use the port from the first public address if possible.
 	if len(c.PublicAddrs) > 0 {
 		publicAddr := c.PublicAddrs[0]
@@ -153,6 +151,7 @@ func (c ProxyConfig) WebPublicAddr() (string, error) {
 		return u.String(), nil
 	}
 
+	port := c.WebAddr.Port(defaults.HTTPListenPort)
 	return c.getDefaultAddr(port), nil
 }
 


### PR DESCRIPTION
The WebPublicAddr function did not include the user specified port for public addresses, which could potentially yield a public address that does not exist. This was impacting the SAML identity provider, which uses this function for determining the public address of the identity provider.