### PR TITLE
Document lack of stability of lib/teleterm gRPC API

### DIFF
--- a/gen/proto/js/teleport/lib/teleterm/v1/service_grpc_pb.js
+++ b/gen/proto/js/teleport/lib/teleterm/v1/service_grpc_pb.js
@@ -534,7 +534,12 @@ function deserialize_teleport_lib_teleterm_v1_UpdateTshdEventsServerAddressRespo
 }
 
 
-// TerminalService describes Teleterm service
+// TerminalService is used by the Electron app to communicate with the tsh daemon.
+//
+// While we aim to preserve backwards compatibility in order to satisfy CI checks and follow the
+// proto practices used within the company, this service is not guaranteed to be stable across
+// versions. The packaging process of Teleport Connect ensures that the server and the client use
+// the same version of the service.
 var TerminalServiceService = exports.TerminalServiceService = {
   // UpdateTshdEventsServerAddress lets the Electron app update the address the tsh daemon is
 // supposed to use when connecting to the tshd events gRPC service. This RPC needs to be made

--- a/proto/teleport/lib/teleterm/v1/service.proto
+++ b/proto/teleport/lib/teleterm/v1/service.proto
@@ -27,7 +27,12 @@ import "teleport/lib/teleterm/v1/usage_events.proto";
 
 option go_package = "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1;teletermv1";
 
-// TerminalService describes Teleterm service
+// TerminalService is used by the Electron app to communicate with the tsh daemon.
+//
+// While we aim to preserve backwards compatibility in order to satisfy CI checks and follow the
+// proto practices used within the company, this service is not guaranteed to be stable across
+// versions. The packaging process of Teleport Connect ensures that the server and the client use
+// the same version of the service.
 service TerminalService {
   // UpdateTshdEventsServerAddress lets the Electron app update the address the tsh daemon is
   // supposed to use when connecting to the tshd events gRPC service. This RPC needs to be made


### PR DESCRIPTION
[As suggested by Edoardo](https://github.com/gravitational/teleport/pull/26441#issuecomment-1557260886), this PR documents the fact that the gRPC API of lib/teleterm should not be considered to be stable across versions.