### PR TITLE
tncon: Remove unused return variables

### DIFF
--- a/lib/client/tncon/tncon.c
+++ b/lib/client/tncon/tncon.c
@@ -49,14 +49,12 @@
 
 // WriteToBuffer is a dummy function that writes a sequence event rather than
 // to a buffer.
-size_t
+void
 WriteToBuffer(char* source, size_t len)
 {
 	// NOTE: Modified to emit an event to the Go lib rather than mutate a
 	// global buffer.
 	writeSequence(source, len);
-
-	return len;
 }
 
 // DataAvailable waits for either a new input event, a quit event, or for a
@@ -78,7 +76,7 @@ DataAvailable(HANDLE hInput, HANDLE hQuitEvent)
 	return FALSE;
 }
 
-size_t
+void
 ReadConsoleForTermEmul(HANDLE hInput, HANDLE hQuitEvent)
 {
 	DWORD dwInput = 0;
@@ -88,7 +86,6 @@ ReadConsoleForTermEmul(HANDLE hInput, HANDLE hQuitEvent)
 	static WCHAR utf16_surrogatepair[2] = {0,};
 	size_t n = 0;
 
-	size_t outlen = 0;
 	while (DataAvailable(hInput, hQuitEvent)) {
 		ReadConsoleInputW(hInput, inputRecordArray, inputRecordArraySize, &dwInput);
 
@@ -130,7 +127,7 @@ ReadConsoleForTermEmul(HANDLE hInput, HANDLE hQuitEvent)
 							NULL,
 							NULL);
 
-						outlen += WriteToBuffer((char *)octets, n);
+						WriteToBuffer((char *)octets, n);
 						utf16_surrogatepair[0] = utf16_surrogatepair[1] = L'\0';
 
 						break;
@@ -147,15 +144,13 @@ ReadConsoleForTermEmul(HANDLE hInput, HANDLE hQuitEvent)
 							NULL,
 							NULL);
 
-						outlen += WriteToBuffer((char *)octets, n);
+						WriteToBuffer((char *)octets, n);
 					}
 				}
 				break;
 			}
 		}
 	}
-
-	return outlen;
 }
 
 // ReadInputContinuous reads all console input events until the program exits,


### PR DESCRIPTION
This was originally recommended in this PR: https://github.com/gravitational/teleport/pull/27184/files#r1212402781

In addition there is some potential for this value to overflow (notably on a 32 bit system).  Although it is not used, it is safest to just remove this return value.

Fixes https://github.com/gravitational/teleport-private/issues/667