### PR TITLE
Teleport Connect Kube gateway POC

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -515,7 +515,7 @@ func mustCreateKubeLocalProxyListener(t *testing.T, teleportCluster string, caCe
 	ca, err := tls.X509KeyPair(caCert, caKey)
 	require.NoError(t, err)
 
-	listener, err := alpnproxy.NewKubeListener(map[string]tls.Certificate{
+	listener, err := alpnproxy.NewKubeListenerWithRandomPort(map[string]tls.Certificate{
 		teleportCluster: ca,
 	})
 	require.NoError(t, err)
@@ -563,7 +563,7 @@ func mustStartALPNLocalProxyWithConfig(t *testing.T, config alpnproxy.LocalProxy
 func mustStartKubeForwardProxy(t *testing.T, lpAddr string) *alpnproxy.ForwardProxy {
 	t.Helper()
 
-	fp, err := alpnproxy.NewKubeForwardProxy(context.Background(), "", lpAddr)
+	fp, err := alpnproxy.NewKubeForwardProxyWithPort(context.Background(), "", lpAddr)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		fp.Close()

--- a/lib/client/profile.go
+++ b/lib/client/profile.go
@@ -510,6 +510,15 @@ func (p *ProfileStatus) KubeConfigPath(name string) string {
 	return keypaths.KubeConfigPath(p.Dir, p.Name, p.Username, p.Cluster, name)
 }
 
+// TODO
+func (p *ProfileStatus) KubeCertPath(name string) string {
+	if path, ok := p.virtualPathFromEnv(VirtualPathKubernetes, VirtualPathKubernetesParams(name)); ok {
+		return path
+	}
+
+	return keypaths.KubeCertPath(p.Dir, p.Name, p.Username, p.Cluster, name)
+}
+
 // DatabaseServices returns a list of database service names for this profile.
 func (p *ProfileStatus) DatabaseServices() (result []string) {
 	for _, db := range p.Databases {

--- a/lib/teleterm/api/uri/uri.go
+++ b/lib/teleterm/api/uri/uri.go
@@ -29,6 +29,8 @@ var pathServers = urlpath.New("/clusters/:cluster/servers/:serverUUID")
 var pathLeafServers = urlpath.New("/clusters/:cluster/leaves/:leaf/servers/:serverUUID")
 var pathDbs = urlpath.New("/clusters/:cluster/dbs/:dbName")
 var pathLeafDbs = urlpath.New("/clusters/:cluster/leaves/:leaf/dbs/:dbName")
+var pathKubes = urlpath.New("/clusters/:cluster/kubes/:kubeName")
+var pathLeafKubes = urlpath.New("/clusters/:cluster/leaves/:leaf/kubes/:kubeName")
 
 // New creates an instance of ResourceURI
 func New(path string) ResourceURI {
@@ -111,6 +113,21 @@ func (r ResourceURI) GetDbName() string {
 	return ""
 }
 
+// GetKubeName extracts the kube name from r. Returns an empty string if path is not a kube URI.
+func (r ResourceURI) GetKubeName() string {
+	result, ok := pathKubes.Match(r.path)
+	if ok {
+		return result.Params["kubeName"]
+	}
+
+	result, ok = pathLeafKubes.Match(r.path)
+	if ok {
+		return result.Params["kubeName"]
+	}
+
+	return ""
+}
+
 // GetServerUUID extracts the server UUID from r. Returns an empty string if path is not a server URI.
 func (r ResourceURI) GetServerUUID() string {
 	result, ok := pathServers.Match(r.path)
@@ -176,4 +193,14 @@ func (r ResourceURI) AppendAccessRequest(id string) ResourceURI {
 // String returns string representation of the Resource URI
 func (r ResourceURI) String() string {
 	return r.path
+}
+
+// TODO
+func IsDB(resourceURI string) bool {
+	return New(resourceURI).GetDbName() != ""
+}
+
+// TODO
+func IsKube(resourceURI string) bool {
+	return New(resourceURI).GetKubeName() != ""
 }

--- a/lib/teleterm/api/uri/uri_test.go
+++ b/lib/teleterm/api/uri/uri_test.go
@@ -130,6 +130,52 @@ func TestGetDbName(t *testing.T) {
 	}
 }
 
+func TestGetKubeName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   uri.ResourceURI
+		out  string
+	}{
+		{
+			name: "returns root cluster kube name",
+			in:   uri.NewClusterURI("foo").AppendKube("k8s"),
+			out:  "k8s",
+		},
+		{
+			name: "returns leaf cluster kube name",
+			in:   uri.NewClusterURI("foo").AppendLeafCluster("bar").AppendKube("k8s"),
+			out:  "k8s",
+		},
+		{
+			name: "returns empty string when given root cluster URI",
+			in:   uri.NewClusterURI("foo"),
+			out:  "",
+		},
+		{
+			name: "returns empty string when given leaf cluster URI",
+			in:   uri.NewClusterURI("foo").AppendLeafCluster("bar"),
+			out:  "",
+		},
+		{
+			name: "returns empty string when given root cluster non-kube resource URI",
+			in:   uri.NewClusterURI("foo").AppendDB("postgres"),
+			out:  "",
+		},
+		{
+			name: "returns empty string when given leaf cluster non-kube resource URI",
+			in:   uri.NewClusterURI("foo").AppendLeafCluster("bar").AppendDB("postgres"),
+			out:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := tt.in.GetKubeName()
+			require.Equal(t, tt.out, out)
+		})
+	}
+}
+
 func TestGetServerUUID(t *testing.T) {
 	tests := []struct {
 		name string

--- a/lib/teleterm/clusters/kube_cli_command_provider.go
+++ b/lib/teleterm/clusters/kube_cli_command_provider.go
@@ -1,0 +1,34 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clusters
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/teleterm/gateway"
+)
+
+// TODO
+type KubeCLICommandProvider struct {
+}
+
+func (p KubeCLICommandProvider) GetCommand(gateway *gateway.Gateway) (*exec.Cmd, error) {
+	// Use kubectl version as placeholders. Only env should be used.
+	cmd := exec.Command("kubectl", "version")
+	cmd.Env = []string{fmt.Sprintf("%v=%v", teleport.EnvKubeConfig, gateway.KubeconfigPath())}
+	return cmd, nil
+}

--- a/lib/teleterm/daemon/gateway_cert_reissuer_test.go
+++ b/lib/teleterm/daemon/gateway_cert_reissuer_test.go
@@ -184,6 +184,10 @@ func (r *mockDBCertReissuer) ReissueDBCerts(context.Context, tlsca.RouteToDataba
 	return err
 }
 
+func (r *mockDBCertReissuer) ReissueKubeCerts(context.Context, string) error {
+	return nil
+}
+
 type mockCLICommandProvider struct{}
 
 func (m mockCLICommandProvider) GetCommand(gateway *gateway.Gateway) (*exec.Cmd, error) {

--- a/lib/teleterm/gateway/config.go
+++ b/lib/teleterm/gateway/config.go
@@ -42,6 +42,8 @@ type Config struct {
 	TargetURI string
 	// TargetUser is the target user name
 	TargetUser string
+	// TargetGroups is a list of target groups
+	TargetGroups []string
 	// TargetSubresourceName points at a subresource of the remote resource, for example a database
 	// name on a database server. It is used only for generating the CLI command.
 	TargetSubresourceName string
@@ -58,6 +60,8 @@ type Config struct {
 	KeyPath string
 	// Insecure
 	Insecure bool
+	// ClusterName
+	ClusterName string
 	// WebProxyAddr
 	WebProxyAddr string
 	// Log is a component logger
@@ -125,6 +129,10 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.CLICommandProvider == nil {
 		return trace.BadParameter("missing CLICommandProvider")
+	}
+
+	if c.OnExpiredCert == nil {
+		return trace.BadParameter("missing OnExpiredCert")
 	}
 
 	if c.TCPPortAllocator == nil {

--- a/lib/teleterm/gateway/db.go
+++ b/lib/teleterm/gateway/db.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+// RouteToDatabase returns tlsca.RouteToDatabase based on the config of the gateway.
+//
+// The tlsca.RouteToDatabase.Database field is skipped, as it's an optional field and gateways can
+// change their Config.TargetSubresourceName at any moment.
+func (g *Gateway) RouteToDatabase() tlsca.RouteToDatabase {
+	return g.cfg.RouteToDatabase()
+}
+
+func (g *Gateway) makeLocalProxyForDB(listener net.Listener) error {
+	tlsCert, err := keys.LoadX509KeyPair(g.cfg.CertPath, g.cfg.KeyPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := checkCertSubject(tlsCert, g.RouteToDatabase()); err != nil {
+		return trace.Wrap(err,
+			"database certificate check failed, try restarting the database connection")
+	}
+
+	localProxyConfig := alpnproxy.LocalProxyConfig{
+		InsecureSkipVerify:      g.cfg.Insecure,
+		RemoteProxyAddr:         g.cfg.WebProxyAddr,
+		Listener:                listener,
+		ParentContext:           g.closeContext,
+		Certs:                   []tls.Certificate{tlsCert},
+		Clock:                   g.cfg.Clock,
+		ALPNConnUpgradeRequired: g.cfg.TLSRoutingConnUpgradeRequired,
+	}
+
+	if g.cfg.OnExpiredCert != nil {
+		localProxyConfig.Middleware = &dbMiddleware{
+			log:     g.cfg.Log,
+			dbRoute: g.cfg.RouteToDatabase(),
+			onExpiredCert: func(ctx context.Context) error {
+				err := g.cfg.OnExpiredCert(ctx, g)
+				return trace.Wrap(err)
+			},
+		}
+	}
+
+	localProxy, err := alpnproxy.NewLocalProxy(localProxyConfig,
+		alpnproxy.WithDatabaseProtocol(g.cfg.Protocol),
+		alpnproxy.WithClusterCAsIfConnUpgrade(g.closeContext, g.cfg.RootClusterCACertPoolFunc),
+	)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	g.localProxy = localProxy
+	g.certReloader = g.reloadDBCert
+	return nil
+}
+
+func (g *Gateway) reloadDBCert(tlsCert tls.Certificate) error {
+	if err := checkCertSubject(tlsCert, g.RouteToDatabase()); err != nil {
+		return trace.Wrap(err,
+			"database certificate check failed, try restarting the database connection")
+	}
+
+	g.localProxy.SetCerts([]tls.Certificate{tlsCert})
+	return nil
+}

--- a/lib/teleterm/gateway/db_middleware.go
+++ b/lib/teleterm/gateway/db_middleware.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-type localProxyMiddleware struct {
+type dbMiddleware struct {
 	onExpiredCert func(context.Context) error
 	log           *logrus.Entry
 	dbRoute       tlsca.RouteToDatabase
@@ -39,7 +39,7 @@ type localProxyMiddleware struct {
 //
 // In the future, DBCertChecker is going to be extended so that it's used by both tsh and Connect
 // and this middleware will be removed.
-func (m *localProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy, conn net.Conn) error {
+func (m *dbMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy, conn net.Conn) error {
 	err := lp.CheckDBCerts(m.dbRoute)
 	if err == nil {
 		return nil
@@ -58,6 +58,6 @@ func (m *localProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpn.Loc
 // OnStart is a noop. client.DBCertChecker.OnStart checks cert validity too. However in Connect
 // there's no flow which would allow the user to create a local proxy without valid
 // certs.
-func (m *localProxyMiddleware) OnStart(context.Context, *alpn.LocalProxy) error {
+func (m *dbMiddleware) OnStart(context.Context, *alpn.LocalProxy) error {
 	return nil
 }

--- a/lib/teleterm/gateway/db_middleware_test.go
+++ b/lib/teleterm/gateway/db_middleware_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
 
-func TestLocalProxyMiddleware_OnNewConnection(t *testing.T) {
+func TestDBMiddleware_OnNewConnection(t *testing.T) {
 	testCert, err := cert.GenerateSelfSignedCert([]string{"localhost"})
 	require.NoError(t, err)
 	tlsCert, err := keys.X509KeyPair(testCert.Cert, testCert.PrivateKey)
@@ -103,7 +103,7 @@ func TestLocalProxyMiddleware_OnNewConnection(t *testing.T) {
 
 			hasCalledOnExpiredCert := false
 
-			middleware := &localProxyMiddleware{
+			middleware := &dbMiddleware{
 				onExpiredCert: func(context.Context) error {
 					hasCalledOnExpiredCert = true
 					return nil

--- a/lib/teleterm/gateway/gateway.go
+++ b/lib/teleterm/gateway/gateway.go
@@ -70,55 +70,25 @@ func New(cfg Config) (*Gateway, error) {
 
 	cfg.LocalPort = port
 
-	tlsCert, err := keys.LoadX509KeyPair(cfg.CertPath, cfg.KeyPath)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if err := checkCertSubject(tlsCert, cfg.RouteToDatabase()); err != nil {
-		return nil, trace.Wrap(err,
-			"database certificate check failed, try restarting the database connection")
-	}
-
-	localProxyConfig := alpn.LocalProxyConfig{
-		InsecureSkipVerify:      cfg.Insecure,
-		RemoteProxyAddr:         cfg.WebProxyAddr,
-		Listener:                listener,
-		ParentContext:           closeContext,
-		Certs:                   []tls.Certificate{tlsCert},
-		Clock:                   cfg.Clock,
-		ALPNConnUpgradeRequired: cfg.TLSRoutingConnUpgradeRequired,
-	}
-
-	localProxyMiddleware := &localProxyMiddleware{
-		log:     cfg.Log,
-		dbRoute: cfg.RouteToDatabase(),
-	}
-
-	if cfg.OnExpiredCert != nil {
-		localProxyConfig.Middleware = localProxyMiddleware
-	}
-
-	localProxy, err := alpn.NewLocalProxy(localProxyConfig,
-		alpn.WithDatabaseProtocol(cfg.Protocol),
-		alpn.WithClusterCAsIfConnUpgrade(closeContext, cfg.RootClusterCACertPoolFunc),
-	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
 	gateway := &Gateway{
 		cfg:          &cfg,
 		closeContext: closeContext,
 		closeCancel:  closeCancel,
-		localProxy:   localProxy,
 	}
 
-	if cfg.OnExpiredCert != nil {
-		localProxyMiddleware.onExpiredCert = func(ctx context.Context) error {
-			err := cfg.OnExpiredCert(ctx, gateway)
-			return trace.Wrap(err)
+	switch {
+	case uri.IsDB(cfg.TargetURI):
+		if err := gateway.makeLocalProxyForDB(listener); err != nil {
+			return nil, trace.Wrap(err)
 		}
+
+	case uri.IsKube(cfg.TargetURI):
+		if err := gateway.makeLocalProxiesForKube(listener); err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+	default:
+		return nil, trace.NotImplemented("gateway not supported for %v", cfg.TargetURI)
 	}
 
 	ok = true
@@ -143,24 +113,48 @@ func NewWithLocalPort(gateway *Gateway, port string) (*Gateway, error) {
 func (g *Gateway) Close() error {
 	g.closeCancel()
 
-	if err := g.localProxy.Close(); err != nil {
-		return trace.Wrap(err)
+	errs := []error{
+		g.localProxy.Close(),
 	}
 
-	return nil
+	if g.forwardProxy != nil {
+		errs = append(errs, g.forwardProxy.Close())
+	}
+
+	return trace.NewAggregate(errs...)
 }
 
 // Serve starts the underlying ALPN proxy. Blocks until closeContext is canceled.
 func (g *Gateway) Serve() error {
 	g.cfg.Log.Info("Gateway is open.")
+	defer g.cfg.Log.Info("Gateway has closed.")
 
-	if err := g.localProxy.Start(g.closeContext); err != nil {
-		return trace.Wrap(err)
+	if g.forwardProxy != nil {
+		return trace.Wrap(g.serveLocalProxies())
 	}
 
-	g.cfg.Log.Info("Gateway has closed.")
+	return trace.Wrap(g.localProxy.Start(g.closeContext))
+}
 
-	return nil
+func (g *Gateway) serveLocalProxies() error {
+	errChan := make(chan error, 2)
+	go func() {
+		if err := g.forwardProxy.Start(); err != nil {
+			errChan <- err
+		}
+	}()
+	go func() {
+		if err := g.localProxy.StartHTTPAccessProxy(g.closeContext); err != nil {
+			errChan <- err
+		}
+	}()
+
+	select {
+	case err := <-errChan:
+		return trace.Wrap(err)
+	case <-g.closeContext.Done():
+		return nil
+	}
 }
 
 func (g *Gateway) URI() uri.ResourceURI {
@@ -236,20 +230,16 @@ func (g *Gateway) CLICommand() (*api.GatewayCLICommand, error) {
 	}, nil
 }
 
-// RouteToDatabase returns tlsca.RouteToDatabase based on the config of the gateway.
-//
-// The tlsca.RouteToDatabase.Database field is skipped, as it's an optional field and gateways can
-// change their Config.TargetSubresourceName at any moment.
-func (g *Gateway) RouteToDatabase() tlsca.RouteToDatabase {
-	return g.cfg.RouteToDatabase()
-}
-
 // ReloadCert loads the key pair from cfg.CertPath & cfg.KeyPath and updates the cert of the running
 // local proxy. This is typically done after the cert is reissued and saved to disk.
 //
 // In the future, we're probably going to make this method accept the cert as an arg rather than
 // reading from disk.
 func (g *Gateway) ReloadCert() error {
+	if g.certReloader == nil {
+		return nil
+	}
+
 	g.cfg.Log.Debug("Reloading cert")
 
 	tlsCert, err := keys.LoadX509KeyPair(g.cfg.CertPath, g.cfg.KeyPath)
@@ -257,14 +247,7 @@ func (g *Gateway) ReloadCert() error {
 		return trace.Wrap(err)
 	}
 
-	if err := checkCertSubject(tlsCert, g.RouteToDatabase()); err != nil {
-		return trace.Wrap(err,
-			"database certificate check failed, try restarting the database connection")
-	}
-
-	g.localProxy.SetCerts([]tls.Certificate{tlsCert})
-
-	return nil
+	return trace.Wrap(g.certReloader(tlsCert))
 }
 
 // checkCertSubject checks if the cert subject matches the expected db route.
@@ -290,8 +273,10 @@ func checkCertSubject(tlsCert tls.Certificate, dbRoute tlsca.RouteToDatabase) er
 //
 // In the future if Gateway becomes more complex it might be worthwhile to add an RWMutex to it.
 type Gateway struct {
-	cfg        *Config
-	localProxy *alpn.LocalProxy
+	cfg          *Config
+	localProxy   *alpn.LocalProxy
+	forwardProxy *alpn.ForwardProxy
+	certReloader func(tls.Certificate) error
 	// closeContext and closeCancel are used to signal to any waiting goroutines
 	// that the local proxy is now closed and to release any resources.
 	closeContext context.Context

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -1,0 +1,170 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/pem"
+	"net"
+	"sync/atomic"
+
+	"github.com/gravitational/trace"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+
+	"github.com/gravitational/teleport/api/utils/keys"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// TODO do better
+func (g *Gateway) KubeconfigPath() string {
+	return g.cfg.CertPath + ".kubeconfig"
+}
+
+func (g *Gateway) makeLocalProxiesForKube(listener net.Listener) error {
+	// A key is required here for generating local CAs. It can be any key.
+	// Reading the provided key path to avoid generating a new one.
+	key, err := keys.LoadPrivateKey(g.cfg.KeyPath)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	cas, err := alpnproxy.CreateKubeLocalCAs(key, []string{g.cfg.ClusterName})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := g.makeALPNLocalProxyForKube(cas); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := g.makeForwardProxyForKube(listener); err != nil {
+		return trace.NewAggregate(err, g.Close())
+	}
+
+	if err := g.makeKubeConfig(key, cas); err != nil {
+		return trace.NewAggregate(err, g.Close())
+	}
+	return nil
+}
+
+func (g *Gateway) makeALPNLocalProxyForKube(cas map[string]tls.Certificate) error {
+	// Create a random port listener for g.localProxy.
+	innerListener, err := g.cfg.TCPPortAllocator.Listen(g.cfg.LocalAddress, "")
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	listener, err := alpnproxy.NewKubeListener(innerListener, cas)
+	if err != nil {
+		return trace.NewAggregate(err, innerListener.Close())
+	}
+
+	middleware, err := g.makeKubeMiddleware()
+	if err != nil {
+		return trace.NewAggregate(err, innerListener.Close())
+	}
+
+	g.localProxy, err = alpnproxy.NewLocalProxy(alpnproxy.LocalProxyConfig{
+		InsecureSkipVerify:      g.cfg.Insecure,
+		RemoteProxyAddr:         g.cfg.WebProxyAddr,
+		Listener:                listener,
+		ParentContext:           g.closeContext,
+		Clock:                   g.cfg.Clock,
+		ALPNConnUpgradeRequired: g.cfg.TLSRoutingConnUpgradeRequired,
+	},
+		alpnproxy.WithHTTPMiddleware(middleware),
+		alpnproxy.WithSNI(client.GetKubeTLSServerName(g.cfg.WebProxyAddr)),
+		alpnproxy.WithClusterCAs(g.closeContext, g.cfg.RootClusterCACertPoolFunc),
+	)
+	if err != nil {
+		return trace.NewAggregate(err, innerListener.Close())
+	}
+	return nil
+}
+
+func (g *Gateway) makeKubeMiddleware() (alpnproxy.LocalProxyHTTPMiddleware, error) {
+	cert, err := keys.LoadX509KeyPair(g.cfg.CertPath, g.cfg.KeyPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var certUpdate atomic.Value
+	certUpdate.Store(cert)
+
+	certReissuer := func(ctx context.Context, teleportCluster, kubeCluster string) (tls.Certificate, error) {
+		if err := g.cfg.OnExpiredCert(g.closeContext, g); err != nil {
+			return tls.Certificate{}, trace.Wrap(err)
+		}
+		return certUpdate.Load().(tls.Certificate), nil
+	}
+
+	g.certReloader = func(newCert tls.Certificate) error {
+		// TODO tsh does checkIfCertsAreAllowedToAccessCluster for new certs.
+		// should it be checked here as well?
+		certUpdate.Store(newCert)
+		return nil
+	}
+
+	certs := make(alpnproxy.KubeClientCerts)
+	certs.Add(g.cfg.ClusterName, g.cfg.TargetName, cert)
+	return alpnproxy.NewKubeMiddleware(certs, certReissuer, g.cfg.Clock, g.cfg.Log), nil
+}
+
+func (g *Gateway) makeForwardProxyForKube(listener net.Listener) (err error) {
+	// Use provided listener with user configured port for the forward proxy.
+	g.forwardProxy, err = alpnproxy.NewKubeForwardProxy(g.closeContext, listener, g.localProxy.GetAddr())
+	return trace.Wrap(err)
+}
+
+func (g *Gateway) makeKubeConfig(key *keys.PrivateKey, cas map[string]tls.Certificate) error {
+	ca, ok := cas[g.cfg.ClusterName]
+	if !ok {
+		return trace.BadParameter("CA for teleport cluster %q is missing", g.cfg.ClusterName)
+	}
+
+	x509Cert, err := utils.TLSCertLeaf(ca)
+	if err != nil {
+		return trace.BadParameter("could not parse CA certificate for cluster %q", g.cfg.ClusterName)
+	}
+
+	values := &kubeconfig.LocalProxyValues{
+		// Ideally tc.KubeClusterAddr() should be used as it matches what tsh
+		// kube login sets in the kubeconfig. In this case it is not a big deal
+		// since this ephemeral config has only a single kube cluster. Also
+		// tc.KubeClusterAddr() is likely the same as WebProxyAddr anyway.
+		TeleportKubeClusterAddr: "https://" + g.cfg.WebProxyAddr,
+		LocalProxyURL:           "http://" + g.forwardProxy.GetAddr(),
+		ClientKeyData:           key.PrivateKeyPEM(),
+		Clusters: []kubeconfig.LocalProxyCluster{{
+			TeleportCluster:   g.cfg.ClusterName,
+			KubeCluster:       g.cfg.TargetName,
+			Impersonate:       g.cfg.TargetUser,
+			ImpersonateGroups: g.cfg.TargetGroups,
+			Namespace:         g.cfg.TargetSubresourceName,
+		}},
+		LocalProxyCAs: map[string][]byte{
+			g.cfg.ClusterName: pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: x509Cert.Raw}),
+		},
+	}
+
+	// TODO remove kubeconfigPath on close.
+	config := kubeconfig.CreateLocalProxyConfig(clientcmdapi.NewConfig(), values)
+	return trace.Wrap(kubeconfig.Save(g.KubeconfigPath(), *config))
+}

--- a/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
+++ b/web/packages/teleterm/src/services/pty/ptyHost/buildPtyOptions.ts
@@ -148,6 +148,14 @@ export function getPtyProcessOptions(
       };
     }
 
+    case 'pty.gateway-kube': {
+      return {
+        path: settings.defaultShell,
+        args: [],
+        env: { ...env, ...cmd.env },
+      };
+    }
+
     default:
       assertUnreachable(cmd);
   }

--- a/web/packages/teleterm/src/services/pty/types.ts
+++ b/web/packages/teleterm/src/services/pty/types.ts
@@ -78,6 +78,11 @@ export type GatewayCliClientCommand = PtyCommandBase & {
   env: Record<string, string>;
 };
 
+export type GatewayKubeCommand = PtyCommandBase & {
+  kind: 'pty.gateway-kube';
+  env: Record<string, string>;
+};
+
 type PtyCommandBase = {
   proxyHost: string;
   clusterName: string;
@@ -87,4 +92,5 @@ export type PtyCommand =
   | ShellCommand
   | TshLoginCommand
   | TshKubeLoginCommand
-  | GatewayCliClientCommand;
+  | GatewayCliClientCommand
+  | GatewayKubeCommand;

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -46,7 +46,7 @@ export interface Server extends apiServer.Server.AsObject {
 
 export interface Gateway extends apiGateway.Gateway.AsObject {
   uri: uri.GatewayUri;
-  targetUri: uri.DatabaseUri;
+  targetUri: uri.GatewayTargetUri;
   // The type of gatewayCliCommand was repeated here just to refer to the type with the JSDoc.
   gatewayCliCommand: GatewayCLICommand;
 }
@@ -261,7 +261,7 @@ export interface LoginPasswordlessParams extends LoginParamsBase {
 }
 
 export type CreateGatewayParams = {
-  targetUri: uri.DatabaseUri;
+  targetUri: uri.GatewayTargetUri;
   port?: string;
   user: string;
   subresource_name?: string;

--- a/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/useDocumentGateway.test.tsx
@@ -28,6 +28,7 @@ import { WorkspaceContextProvider } from '../Documents';
 import { MockAppContextProvider } from '../fixtures/MockAppContextProvider';
 
 import { useDocumentGateway } from './useDocumentGateway';
+import { DatabaseUri } from 'teleterm/ui/uri';
 
 beforeEach(() => {
   jest.restoreAllMocks();
@@ -113,7 +114,7 @@ const testSetup = () => {
     uri: '/docs/1',
     kind: 'doc.gateway',
     targetName: gateway.targetName,
-    targetUri: gateway.targetUri,
+    targetUri: gateway.targetUri as DatabaseUri,
     targetUser: gateway.targetUser,
     targetSubresourceName: gateway.targetSubresourceName,
     gatewayUri: gateway.uri,

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/DocumentGatewayKube.tsx
@@ -1,0 +1,160 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { Flex, Text, ButtonPrimary } from 'design';
+import { useAsync } from 'shared/hooks/useAsync';
+
+import Document from 'teleterm/ui/Document';
+import * as types from 'teleterm/ui/services/workspacesService';
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { useWorkspaceContext } from 'teleterm/ui/Documents';
+import { DocumentTerminal } from 'teleterm/ui/DocumentTerminal';
+import { connectToKube } from 'teleterm/ui/services/workspacesService';
+import { retryWithRelogin } from 'teleterm/ui/utils';
+import { routing } from 'teleterm/ui/uri';
+
+export const DocumentGatewayKube = (props: {
+  visible: boolean;
+  doc: types.DocumentGatewayKube;
+}) => {
+  const { clustersService } = useAppContext();
+  clustersService.useState();
+
+  const { doc, visible } = props;
+  const [hasRenderedTerminal, setHasRenderedTerminal] = useState(false);
+
+  // TODO support user, groups, namespace
+  const gateway = clustersService.findGatewayByConnectionParams(
+    doc.targetUri,
+    ''
+  );
+
+  if (gateway || hasRenderedTerminal) {
+    if (!hasRenderedTerminal) {
+      setHasRenderedTerminal(true);
+    }
+
+    return <DocumentTerminal doc={doc} visible={visible} />;
+  }
+
+  return <WaitingForGateway doc={doc} visible={visible} />;
+};
+
+const TIMEOUT_SECONDS = 10;
+
+const WaitingForGateway = (props: {
+  doc: types.DocumentGatewayKube;
+  visible: boolean;
+}) => {
+  const { doc, visible } = props;
+  const ctx = useAppContext();
+  const { documentsService } = useWorkspaceContext();
+  // If we depended on doc.status for hasTimedOut instead of using a separate state, then on reopen
+  // the doc would have status set to 'connected' on 'error' and it'd be updated from useEffect,
+  // meaning that there would be a brief flash of old state.
+  const [hasTimedOut, setHasTimedOut] = useState(false);
+  const [connectAttempt, createGateway] = useAsync(async () => {
+    const gw = await retryWithRelogin(ctx, doc.targetUri, () =>
+      // TODO support user, groups, namespace
+      ctx.clustersService.createGateway({
+        targetUri: doc.targetUri,
+        user: '',
+      })
+    );
+
+    documentsService.update(doc.uri, {
+      gatewayUri: gw.uri,
+      port: gw.localPort,
+    });
+  });
+  const { params } = routing.parseKubeUri(doc.targetUri);
+
+  useEffect(() => {
+    // Update the doc state to make the progress bar show up in the tab bar.
+    // Once DocumentTerminal is mounted, it is going to update the status to 'connected' or 'error'.
+    documentsService.update(doc.uri, { status: 'connecting' });
+
+    if (connectAttempt.status === '') {
+      createGateway();
+    }
+
+    const timeoutId = setTimeout(() => {
+      setHasTimedOut(true);
+      documentsService.update(doc.uri, { status: 'error' });
+    }, TIMEOUT_SECONDS * 1000);
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const openConnection = () => {
+    connectToKube(
+      ctx,
+      {
+        uri: doc.targetUri,
+      },
+      { origin: 'reopened_session' }
+    );
+  };
+
+  return (
+    <Document visible={visible} px={2}>
+      <WaitingForGatewayContent
+        kubeId={params.kubeId}
+        hasTimedOut={hasTimedOut}
+        openConnection={openConnection}
+      />
+    </Document>
+  );
+};
+
+export const WaitingForGatewayContent = ({
+  kubeId,
+  hasTimedOut,
+  openConnection,
+}: {
+  kubeId: string;
+  hasTimedOut: boolean;
+  openConnection: () => void;
+}) => (
+  <Flex gap={4} flexDirection="column" mx="auto" alignItems="center" mt={100}>
+    {hasTimedOut ? (
+      <div>
+        <StyledText>
+          A connection to <strong>{kubeId}</strong> has not been opened up
+          within {TIMEOUT_SECONDS} seconds.
+        </StyledText>
+        <StyledText>Please try to open the connection manually.</StyledText>
+      </div>
+    ) : (
+      <StyledText>
+        Waiting for a kube connection to <strong>{kubeId}</strong> to be opened
+        up.
+      </StyledText>
+    )}
+
+    <ButtonPrimary onClick={openConnection}>Open the connection</ButtonPrimary>
+  </Flex>
+);
+
+const StyledText = styled(Text).attrs({
+  typography: 'h5',
+  textAlign: 'center',
+})``;

--- a/web/packages/teleterm/src/ui/DocumentGatewayKube/index.ts
+++ b/web/packages/teleterm/src/ui/DocumentGatewayKube/index.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export { DocumentGatewayKube } from './DocumentGatewayKube';

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Reconnect.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Reconnect.tsx
@@ -71,6 +71,7 @@ function getReconnectCopy(docKind: types.DocumentTerminal['kind']) {
       };
     }
     case 'doc.gateway_cli_client':
+    case 'doc.gateway_kube':
     case 'doc.terminal_shell':
     case 'doc.terminal_tsh_kube': {
       return {

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -31,6 +31,7 @@ import {
 } from 'teleterm/ui/services/workspacesService';
 import DocumentCluster from 'teleterm/ui/DocumentCluster';
 import DocumentGateway from 'teleterm/ui/DocumentGateway';
+import { DocumentGatewayKube } from 'teleterm/ui/DocumentGatewayKube';
 import { DocumentTerminal } from 'teleterm/ui/DocumentTerminal';
 
 import Document from 'teleterm/ui/Document';
@@ -98,6 +99,8 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
         return <DocumentCluster doc={doc} visible={visible} />;
       case 'doc.gateway':
         return <DocumentGateway doc={doc} visible={visible} />;
+      case 'doc.gateway_kube':
+        return <DocumentGatewayKube doc={doc} visible={visible} />;
       case 'doc.gateway_cli_client':
         return <DocumentGatewayCliClient doc={doc} visible={visible} />;
       case 'doc.terminal_shell':

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsFilterableList/ConnectionItem.tsx
@@ -144,6 +144,7 @@ function getKindName(kind: ExtendedTrackedConnection['kind']): string {
       return 'DB';
     case 'connection.server':
       return 'SSH';
+    case 'connection.gateway_kube':
     case 'connection.kube':
       return 'KUBE';
     default:

--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -411,7 +411,7 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
   }
 
   findGatewayByConnectionParams(
-    targetUri: uri.DatabaseUri,
+    targetUri: uri.GatewayTargetUri,
     targetUser: string
   ) {
     let found: Gateway;

--- a/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/trackedConnectionUtils.ts
@@ -16,6 +16,7 @@
 
 import {
   DocumentGateway,
+  DocumentGatewayKube,
   DocumentTshKube,
   DocumentTshNode,
   DocumentTshNodeWithServerId,
@@ -25,6 +26,7 @@ import { unique } from 'teleterm/ui/utils/uid';
 
 import {
   TrackedGatewayConnection,
+  TrackedGatewayKubeConnection,
   TrackedKubeConnection,
   TrackedServerConnection,
 } from './types';
@@ -58,6 +60,20 @@ export function getGatewayDocumentByConnection(
     i.targetUser === connection.targetUser;
 }
 
+export function getGatewayKubeDocumentByConnection(
+  connection: TrackedGatewayKubeConnection
+) {
+  return (i: DocumentGatewayKube) =>
+    i.kind === 'doc.gateway_kube' && i.targetUri === connection.targetUri;
+}
+
+export function getGatewayKubeConnectionByDocument(
+  document: DocumentGatewayKube
+) {
+  return (i: TrackedGatewayKubeConnection) =>
+    i.kind === 'connection.gateway_kube' && i.targetUri === document.targetUri;
+}
+
 export function getKubeDocumentByConnection(connection: TrackedKubeConnection) {
   return (i: DocumentTshKube) =>
     i.kind === 'doc.terminal_tsh_kube' && i.kubeUri === connection.kubeUri;
@@ -86,6 +102,20 @@ export function createGatewayConnection(
     targetUser: document.targetUser,
     targetName: document.targetName,
     targetSubresourceName: document.targetSubresourceName,
+    gatewayUri: document.gatewayUri,
+  };
+}
+
+export function createGatewayKubeConnection(
+  document: DocumentGatewayKube
+): TrackedGatewayKubeConnection {
+  return {
+    kind: 'connection.gateway_kube',
+    connected: true,
+    id: unique(),
+    title: document.title,
+    port: document.port,
+    targetUri: document.targetUri,
     gatewayUri: document.gatewayUri,
   };
 }

--- a/web/packages/teleterm/src/ui/services/connectionTracker/types.ts
+++ b/web/packages/teleterm/src/ui/services/connectionTracker/types.ts
@@ -39,6 +39,13 @@ export interface TrackedGatewayConnection extends TrackedConnectionBase {
   targetSubresourceName?: string;
 }
 
+export interface TrackedGatewayKubeConnection extends TrackedConnectionBase {
+  kind: 'connection.gateway_kube';
+  targetUri: KubeUri;
+  port?: string;
+  gatewayUri: GatewayUri;
+}
+
 export interface TrackedKubeConnection extends TrackedConnectionBase {
   kind: 'connection.kube';
   kubeConfigRelativePath: string;
@@ -48,6 +55,7 @@ export interface TrackedKubeConnection extends TrackedConnectionBase {
 export type TrackedConnection =
   | TrackedServerConnection
   | TrackedGatewayConnection
+  | TrackedGatewayKubeConnection
   | TrackedKubeConnection;
 
 export type ExtendedTrackedConnection = TrackedConnection & {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -21,11 +21,13 @@ import {
   CreateAccessRequestDocumentOpts,
   CreateClusterDocumentOpts,
   CreateGatewayDocumentOpts,
+  CreateGatewayKubeDocumentOpts,
   CreateTshKubeDocumentOptions,
   Document,
   DocumentAccessRequests,
   DocumentCluster,
   DocumentGateway,
+  DocumentGatewayKube,
   DocumentGatewayCliClient,
   DocumentOrigin,
   DocumentTshKube,
@@ -148,6 +150,26 @@ export class DocumentsService {
       targetSubresourceName,
       gatewayUri,
       title,
+      port,
+      origin,
+    };
+  }
+
+  createGatewayKubeDocument(
+    opts: CreateGatewayKubeDocumentOpts
+  ): DocumentGatewayKube {
+    const { targetUri, port, gatewayUri, origin } = opts;
+    const uri = routing.getDocUri({ docId: unique() });
+    const { params } = routing.parseKubeUri(targetUri);
+
+    return {
+      uri,
+      kind: 'doc.gateway_kube',
+      rootClusterId: params.rootClusterId,
+      leafClusterId: params.leafClusterId,
+      targetUri,
+      gatewayUri,
+      title: `${params.kubeId}`,
       port,
       origin,
     };

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -34,6 +34,7 @@ export function getResourceUri(
     case 'doc.cluster':
       return document.clusterUri;
     case 'doc.gateway':
+    case 'doc.gateway_kube':
     case 'doc.gateway_cli_client':
       return document.targetUri;
     case 'doc.terminal_tsh_node':

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -105,6 +105,18 @@ export interface DocumentGateway extends DocumentBase {
   origin: DocumentOrigin;
 }
 
+export interface DocumentGatewayKube extends DocumentBase {
+  kind: 'doc.gateway_kube';
+  // rootClusterId and leafClusterId are tech debt. They could be read from targetUri, but
+  // useDocumentTerminal expects these fields to be set on the doc.
+  rootClusterId: string;
+  leafClusterId: string | undefined;
+  gatewayUri?: uri.GatewayUri;
+  targetUri: uri.KubeUri;
+  port?: string;
+  origin: DocumentOrigin;
+}
+
 /**
  * DocumentGatewayCliClient is the tab that opens a CLI tool which targets the given gateway.
  *
@@ -122,7 +134,7 @@ export interface DocumentGatewayCliClient extends DocumentBase {
   //
   // targetUri and targetUser are also needed to find a gateway providing the connection to the
   // target.
-  targetUri: tsh.Gateway['targetUri'];
+  targetUri: uri.DatabaseUri;
   targetUser: tsh.Gateway['targetUser'];
   targetName: tsh.Gateway['targetName'];
   targetProtocol: tsh.Gateway['protocol'];
@@ -154,6 +166,7 @@ export interface DocumentPtySession extends DocumentBase {
 
 export type DocumentTerminal =
   | DocumentPtySession
+  | DocumentGatewayKube
   | DocumentGatewayCliClient
   | DocumentTshNode
   | DocumentTshKube;
@@ -187,6 +200,14 @@ export type CreateGatewayDocumentOpts = {
   targetName: string;
   targetUser: string;
   targetSubresourceName?: string;
+  title?: string;
+  port?: string;
+  origin: DocumentOrigin;
+};
+
+export type CreateGatewayKubeDocumentOpts = {
+  gatewayUri?: uri.GatewayUri;
+  targetUri: uri.KubeUri;
   title?: string;
   port?: string;
   origin: DocumentOrigin;

--- a/web/packages/teleterm/src/ui/uri.ts
+++ b/web/packages/teleterm/src/ui/uri.ts
@@ -67,6 +67,7 @@ export type ServerUri = RootClusterServerUri | LeafClusterServerUri;
 export type KubeUri = RootClusterKubeUri | LeafClusterKubeUri;
 export type DatabaseUri = RootClusterDatabaseUri | LeafClusterDatabaseUri;
 export type ClusterOrResourceUri = ResourceUri | ClusterUri;
+export type GatewayTargetUri = KubeUri | DatabaseUri;
 
 type DocumentId = string;
 export type DocumentUri = `/docs/${DocumentId}`;


### PR DESCRIPTION
Related PR #26836

Note this is a POC only. Code will be better written, tested, and broken to proper PRs once POC concept is approved.

POC overview:
1. UI flow is almost the same as the current kube flow, with a new `DocumentGatewayKube` (mostly copied from `DocumentGatewayCLICommand`):
   - Calls daemon to create gateway on mount
   - Wait screen (copied from `DocumentGatewayCLICommand`) while the gateway is creating
   - Then opens a terminal, with `KUBECONFIG` set
   - Can have multiple kube terminals that SHARES the gateway/local proxy.
2. On daemon side
   - No change to CreateGateway API, daemon creates a local proxy based on `targetURI`.
   - Kube Gateway returns a `KUBECONFIG=<path-to-kubeconfig-for-local-proxy>` env var for pty terminal to use. The path is based on the kube user cert path so uniq per kube resource and maintained by the gateway, so it can be shared between kube terminals.
   - Some changes to the gateway object to support forward proxy, different ways to reload cert etc.