### PR TITLE
[v13] Pin golangci-lint to `v1.53.1` and upgrade `depguard` config to `v2`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,16 +33,23 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: denylist
-    include-go-root: true # check against stdlib
-    packages-with-error-message:
-      - io/ioutil: 'use "io" or "os" packages instead'
-      - github.com/golang/protobuf: 'use "google.golang.org/protobuf"'
-      - github.com/hashicorp/go-uuid: 'use "github.com/google/uuid" instead'
-      - github.com/pborman/uuid: 'use "github.com/google/uuid" instead'
-      - github.com/siddontang/go-log/log: 'use "github.com/sirupsen/logrus" instead'
-      - github.com/siddontang/go/log: 'use "github.com/sirupsen/logrus" instead'
-      - go.uber.org/atomic: 'use "sync/atomic" instead'
+    rules:
+      main:
+        deny:
+          - pkg: io/ioutil
+            desc: 'use "io" or "os" packages instead'
+          - pkg: github.com/golang/protobuf
+            desc: 'use "google.golang.org/protobuf"'
+          - pkg: github.com/hashicorp/go-uuid
+            desc: 'use "github.com/google/uuid" instead'
+          - pkg: github.com/pborman/uuid
+            desc: 'use "github.com/google/uuid" instead'
+          - pkg: github.com/siddontang/go-log/log
+            desc: 'use "github.com/sirupsen/logrus" instead'
+          - pkg: github.com/siddontang/go/log
+            desc: 'use "github.com/sirupsen/logrus" instead'
+          - pkg: go.uber.org/atomic
+            desc: 'use "sync/atomic" instead'
   gci:
     sections:
       - standard # Standard section: captures all standard packages.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -296,7 +296,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-RUN TAG='v1.53.0' && \
+RUN TAG='v1.53.1' && \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -296,10 +296,9 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-ARG GOLANGCI_VERSION # eg, "1.53.0"
-RUN TAG="v$GOLANGCI_VERSION" && \
+RUN TAG='v1.53.0' && \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
-    sh -s -- -b $(go env GOPATH)/bin $TAG
+    sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
 
 # Install Buf.
 ARG BUF_VERSION # eg, "1.19.0"

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -296,7 +296,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/v1.52.2/install.sh" | \
+RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/v1.53.0/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin"
 
 # Install Buf.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -296,8 +296,10 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/v1.53.0/install.sh" | \
-    sh -s -- -b "$(go env GOPATH)/bin"
+ARG GOLANGCI_VERSION # eg, "1.53.0"
+RUN TAG="v$GOLANGCI_VERSION" && \
+    curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
+    sh -s -- -b $(go env GOPATH)/bin $TAG
 
 # Install Buf.
 ARG BUF_VERSION # eg, "1.19.0"

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -28,9 +28,6 @@ RUST_VERSION ?= 1.68.0
 LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
-# pin golangci-lint version to avoid breaking changes
-GOLANGCI_VERSION ?= 1.53.0
-
 # Protogen related versions.
 BUF_VERSION ?= 1.19.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
@@ -141,7 +138,6 @@ buildbox:
 			--build-arg NODE_VERSION=$(NODE_VERSION) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 			--build-arg BUF_VERSION=$(BUF_VERSION) \
-			--build-arg GOLANGCI_VERSION=$(GOLANGCI_VERSION) \
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 			--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -28,6 +28,9 @@ RUST_VERSION ?= 1.68.0
 LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
+# pin golangci-lint version to avoid breaking changes
+GOLANGCI_VERSION ?= 1.53.0
+
 # Protogen related versions.
 BUF_VERSION ?= 1.19.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
@@ -138,6 +141,7 @@ buildbox:
 			--build-arg NODE_VERSION=$(NODE_VERSION) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
 			--build-arg BUF_VERSION=$(BUF_VERSION) \
+			--build-arg GOLANGCI_VERSION=$(GOLANGCI_VERSION) \
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 			--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \


### PR DESCRIPTION
Backport #27264 to branch/v13