### PR TITLE
[v12] Fix `NewHeadlessAuthenticationWatcher` prevents Auth initialization when the backend is unavailable

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -360,6 +360,9 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if err := headlessAuthenticationWatcher.WaitInit(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	srv.AuthServer.SetHeadlessAuthenticationWatcher(headlessAuthenticationWatcher)
 
 	srv.Authorizer, err = authz.NewAuthorizer(authz.AuthorizerOpts{

--- a/lib/services/local/headlessauthn_watcher.go
+++ b/lib/services/local/headlessauthn_watcher.go
@@ -116,14 +116,16 @@ func NewHeadlessAuthenticationWatcher(ctx context.Context, cfg HeadlessAuthentic
 
 	go h.runWatchLoop(ctx)
 
-	// Wait for the watch loop to initialize before returning.
+	return h, nil
+}
+
+// WaitInit waits for the watch loop to initialize.
+func (h *HeadlessAuthenticationWatcher) WaitInit(ctx context.Context) error {
 	select {
 	case <-h.running:
 	case <-ctx.Done():
-		return nil, trace.Wrap(ctx.Err())
 	}
-
-	return h, nil
+	return trace.Wrap(ctx.Err())
 }
 
 // Done returns a channel that's closed when the watcher is closed.

--- a/lib/services/local/headlessauthn_watcher_test.go
+++ b/lib/services/local/headlessauthn_watcher_test.go
@@ -49,6 +49,10 @@ func newHeadlessAuthenticationWatcherTestEnv(t *testing.T, clock clockwork.Clock
 	})
 	require.NoError(t, err)
 
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	require.NoError(t, w.WaitInit(ctx))
+
 	return &headlessAuthenticationWatcherTestEnv{
 		watcher:       w,
 		watcherCancel: watcherCancel,


### PR DESCRIPTION
Backport #27059 to branch/v12