### PR TITLE
docs: adds common access plugin install mdx and uses sudo for install

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -29,64 +29,7 @@ in your Teleport cluster.
 
 ## Step 2/8. Install the Teleport Discord plugin
 
-We currently only provide `linux-amd64` binaries. You can also compile these
-plugins from source. You can run the plugin from a remote host or your local
-development machine.
-
-<Notice scope={["enterprise"]} type="tip">
-We recommend installing Teleport plugins on the same host as the Teleport
-Proxy Service. This is an ideal location as plugins have a low memory footprint
-and will require access to both the public internet and the Teleport Auth Service.
-</Notice>
-
-<Tabs>
-<TabItem label="Download">
-  ```code
-  $ curl -L -O https://get.gravitational.com/teleport-access-discord-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-discord-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ ./teleport-access-discord/install
-  ```
-
-  Make sure the binary is installed:
-
-  ```code
-  $ teleport-discord version
-  teleport-discord v(=teleport.plugin.version=) git:teleport-discord-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
-  ```
-</TabItem>
-<TabItem label="From Source">
-  To install from source you need `git` and `go` >= (=teleport.golang=)
-  installed.
-
-  ```code
-  # Check out the teleport-plugins repository
-  $ git clone https://github.com/gravitational/teleport-plugins.git
-  $ cd teleport-plugins/access/discord
-  $ make
-  ```
-
-  Place the `teleport-discord` binary into an appropriate location
-  within the system's `PATH`, e.g., `/usr/local/bin`:
-
-  ```code
-  $ mv ./build/teleport-discord /usr/local/bin
-  ```
-
-  Make sure the binary is installed:
-
-  ```code
-  $ teleport-discord version
-  teleport-discord v(=teleport.plugin.version=) git:teleport-discord-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
-  ```
-
-</TabItem>
-<TabItem label="Helm Chart">
-  ```code
-  $ helm repo add teleport https://charts.releases.teleport.dev/
-  $ helm repo update
-  ```
-</TabItem>
-</Tabs>
+(!docs/pages/includes/plugins/install-access-plugin.mdx plugin="discord"!)
 
 ## Step 3/8. Create a user and role for the plugin
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
@@ -64,41 +64,7 @@ the plugin dials out to the Proxy Service or Auth Service.
 
 </Details>
 
-We currently only provide Linux amd64 binaries. You can also compile the plugin
-from source.
-
-<Tabs>
-<TabItem label="Download">
-  ```code
-  $ curl -L https://get.gravitational.com/teleport-access-email-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-email-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ cd teleport-access-email
-  $ ./install
-  ```
-</TabItem>
-<TabItem label="From Source">
-
-  To install from source you need `git` and `go` installed. If you do not have
-  Go installed, visit the Go [downloads page](https://go.dev/dl/).
-
-  ```code
-  # Checkout teleport-plugins
-  $ git clone https://github.com/gravitational/teleport-plugins.git
-  $ cd teleport-plugins/access/email
-  $ make
-  ```
-
-  Move the `teleport-email` binary from `teleport-plugins/access/email/build`
-  into a directory in your `PATH`.
-
-</TabItem>
-</Tabs>
-
-Ensure that the plugin is installed correctly:
-
-```code
-$ teleport-email version
-```
+(!docs/pages/includes/plugins/install-access-plugin.mdx plugin="email"!)
 
 ## Step 3/7. Create a user and role for the plugin
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-jira.mdx
@@ -70,39 +70,7 @@ In the webhook settings page, make sure that the webhook will only send Issue Up
 
 ## Step 4/6. Install the plugin
 
-We recommend installing Teleport plugins alongside the Teleport Proxy. This is an ideal
-location as plugins have a low memory footprint, and will require both public internet access
-and Teleport Auth Service access.
-
-<Tabs>
-<TabItem label="Download">
-  ```code
-  $ curl -L -O https://get.gravitational.com/teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-jira-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ cd teleport-access-jira
-  $ ./install
-  ```
-</TabItem>
-<TabItem label="From Source">
-  To install from source you need `git` and `go` installed. If you do not have Go installed, visit the Go [downloads page](https://go.dev/dl/).
-
-  ```code
-  # Checkout teleport-plugins
-  $ git clone https://github.com/gravitational/teleport-plugins.git
-  $ cd teleport-plugins/access/jira
-  $ make
-  ```
-Run `./install` from `teleport-jira` or place the executable in `/usr/bin` or `/usr/local/bin` on the server installation.
-</TabItem>
-<TabItem label="Docker">
-  ```code
-  $ docker pull public.ecr.aws/gravitational/teleport-plugin-jira:(=teleport.plugin.version=)
-  ```
-</TabItem>
-<TabItem label="Helm Chart">
-  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
-</TabItem>
-</Tabs>
+(!docs/pages/includes/plugins/install-access-plugin.mdx plugin="jira"!)
 
 ## Step 5/6. Configure the plugin
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -29,50 +29,7 @@ Requests in the Proxy or Auth Service.
 
 ## Step 2/8. Install the Teleport Mattermost plugin
 
-<ScopedBlock scope={["enterprise", "oss"]}>
-
-We recommend installing Teleport plugins on the same host as the Teleport Proxy
-Service. This is an ideal location as plugins have a low memory footprint, and
-will require both public internet access and Teleport Auth Service access.
-
-</ScopedBlock>
-
-<ScopedBlock scope="cloud">
-
-Install the Teleport Mattermost plugin on a host that can access both your
-Teleport Proxy Service and your Mattermost deployment.
-
-</ScopedBlock>
-
-<Tabs>
-<TabItem label="Download">
-  ```code
-  $ curl -L -O https://get.gravitational.com/teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-mattermost-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ cd teleport-access-mattermost
-  $ ./install
-  ```
-</TabItem>
-<TabItem label="From Source">
-  To install from source you need `git` and `go` installed. If you do not have Go installed, visit the Go [downloads page](https://go.dev/dl/).
-
-  ```code
-  # Checkout teleport-plugins
-  $ git clone https://github.com/gravitational/teleport-plugins.git
-  $ cd teleport-plugins/access/mattermost
-  $ make
-  ```
-Run `./install` from `teleport-mattermost` or place the executable in the appropriate `/usr/bin` or `/usr/local/bin` on the server installation.
-</TabItem>
-<TabItem label="Docker">
-  ```code
-  $ docker pull public.ecr.aws/gravitational/teleport-plugin-mattermost:(=teleport.plugin.version=)
-  ```
-</TabItem>
-<TabItem label="Helm Chart">
-(!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
-</TabItem>
-</Tabs>
+(!docs/pages/includes/plugins/install-access-plugin.mdx plugin="mattermost"!)
 
 ## Step 3/8. Create a user and role for the plugin
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -50,7 +50,7 @@ and will require access to both the public internet and the Teleport Auth Servic
   ```code
   $ curl -L -O https://get.gravitational.com/teleport-access-msteams-v(=teleport.version=)-linux-amd64-bin.tar.gz
   $ tar -xzf teleport-access-msteams-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ ./teleport-access-msteams/install
+  $ sudo ./teleport-access-msteams/install
   ```
 </TabItem>
 <TabItem label="From Source">

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -373,45 +373,7 @@ Teleport cluster.
 
 ## Step 3/8. Install the Teleport PagerDuty plugin
 
-We currently only provide `linux-amd64` binaries. You can also compile these
-plugins from source. You can run the plugin from a remote host or your local
-development machine.
-
-<Tabs>
-<TabItem label="Download">
-  ```code
-  $ curl -L -O https://get.gravitational.com/teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-pagerduty-v(=teleport.plugin.version=)-linux-amd64-bin.tar.gz
-  $ cd teleport-access-pagerduty
-  $ sudo ./install
-  Teleport PagerDuty Plugin binaries have been copied to /usr/local/bin
-  You can run teleport-pagerduty configure > /etc/teleport-pagerduty.toml to
-  bootstrap your config file.
-  ```
-</TabItem>
-<TabItem label="From Source">
-  To install from source you need `git` and `go` installed. If you do not have
-  Go installed, visit the Go [downloads page](https://go.dev/dl/).
-
-  ```code
-  # Checkout teleport-plugins
-  $ git clone https://github.com/gravitational/teleport-plugins.git
-  $ cd teleport-plugins/access/pagerduty
-  $ make
-  ```
-
-Run `./install` from `teleport-pagerduty`.
-
-</TabItem>
-<TabItem label="Docker">
-  ```code
-  $ docker pull public.ecr.aws/gravitational/teleport-plugin-pagerduty:(=teleport.plugin.version=)
-  ```
-</TabItem>
-<TabItem label="Helm Chart">
-  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
-</TabItem>
-</Tabs>
+(!docs/pages/includes/plugins/install-access-plugin.mdx plugin="pagerduty"!)
 
 ## Step 4/8. Export the access plugin identity
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -47,61 +47,7 @@ in your Teleport cluster.
 
 ## Step 2/8. Install the Teleport Slack plugin
 
-We currently only provide `linux-amd64` binaries. You can also compile these
-plugins from source. You can run the plugin from a remote host or your local
-development machine.
-
-<Notice scope={["enterprise"]} type="tip">
-We recommend installing Teleport plugins on the same host as the Teleport
-Proxy Service. This is an ideal location as plugins have a low memory footprint
-and will require access to both the public internet and the Teleport Auth Service.
-</Notice>
-
-<Tabs>
-<TabItem label="Download">
-  ```code
-  $ curl -L -O https://get.gravitational.com/teleport-access-slack-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ tar -xzf teleport-access-slack-v(=teleport.version=)-linux-amd64-bin.tar.gz
-  $ ./teleport-access-slack/install
-  ```
-
-  Make sure the binary is installed:
-
-  ```code
-  $ teleport-slack version
-  teleport-slack v(=teleport.plugin.version=) git:teleport-slack-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
-  ```
-</TabItem>
-<TabItem label="From Source">
-  To install from source you need `git` and `go` >= (=teleport.golang=)
-  installed.
-
-  ```code
-  # Check out the teleport-plugins repository
-  $ git clone https://github.com/gravitational/teleport-plugins.git
-  $ cd teleport-plugins/access/slack
-  $ make
-  ```
-
-  Place the `teleport-slack` binary into an appropriate location
-  within the system's `PATH`, e.g., `/usr/local/bin`:
-
-  ```code
-  $ mv ./build/teleport-slack /usr/local/bin
-  ```
-
-  Make sure the binary is installed:
-
-  ```code
-  $ teleport-slack version
-  teleport-slack v(=teleport.plugin.version=) git:teleport-slack-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
-  ```
-
-</TabItem>
-<TabItem label="Helm Chart">
-  (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
-</TabItem>
-</Tabs>
+(!docs/pages/includes/plugins/install-access-plugin.mdx plugin="slack"!)
 
 ## Step 3/8. Create a user and role for the plugin
 

--- a/docs/pages/includes/plugins/install-access-plugin.mdx
+++ b/docs/pages/includes/plugins/install-access-plugin.mdx
@@ -1,0 +1,58 @@
+We currently only provide `linux-amd64` binaries. You can also compile these
+plugins from source. You can run the plugin from a remote host or your local
+development machine.
+
+<Notice scope={["enterprise"]} type="tip">
+We recommend installing Teleport plugins on the same host as the Teleport
+Proxy Service. This is an ideal location as plugins have a low memory footprint
+and will require access to both the public internet and the Teleport Auth Service.
+</Notice>
+
+<Tabs>
+<TabItem label="Download">
+  ```code
+  $ curl -L -O https://get.gravitational.com/teleport-access-{{ plugin }}-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ tar -xzf teleport-access-{{ plugin }}-v(=teleport.version=)-linux-amd64-bin.tar.gz
+  $ sudo ./teleport-access-{{ plugin }}/install
+  ```
+
+  Make sure the binary is installed:
+
+  ```code
+  $ teleport-{{ plugin }} version
+  teleport-{{ plugin }} v(=teleport.plugin.version=) git:teleport-{{ plugin }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+  ```
+</TabItem>
+<TabItem label="From Source">
+  To install from source you need `git` and `go` >= (=teleport.golang=)
+  installed.
+
+  ```code
+  # Check out the teleport-plugins repository
+  $ git clone https://github.com/gravitational/teleport-plugins.git
+  $ cd teleport-plugins/access/{{ plugin }}
+  $ make
+  ```
+
+  Place the `teleport-{{ plugin }}` binary into an appropriate location
+  within the system's `PATH`, e.g., `/usr/local/bin`:
+
+  ```code
+  $ mv ./build/teleport-{{ plugin }} /usr/local/bin
+  ```
+
+  Make sure the binary is installed:
+
+  ```code
+  $ teleport-{{ plugin }} version
+  teleport-{{ plugin }} v(=teleport.plugin.version=) git:teleport-{{ plugin }}-v(=teleport.plugin.version=)-fffffffff go(=teleport.golang=)
+  ```
+
+</TabItem>
+<TabItem label="Helm Chart">
+  ```code
+  $ helm repo add teleport https://charts.releases.teleport.dev/
+  $ helm repo update
+  ```
+</TabItem>
+</Tabs>


### PR DESCRIPTION
- Uses `sudo` for the install command as this would fail if you aren't root or using `sudo`
- Uses a common install include so it's repeatable
- Left msteams for now as it does't have a helm example built yet