### PR TITLE
feat: extend label expression syntax

### DIFF
--- a/api/types/remotecluster.go
+++ b/api/types/remotecluster.go
@@ -49,6 +49,9 @@ type RemoteCluster interface {
 	// GetLabel retrieves the label with the provided key. If not found value
 	// will be empty and ok will be false.
 	GetLabel(key string) (value string, ok bool)
+
+	// GetAllLabels returns all labels for the remote cluster
+	GetAllLabels() map[string]string
 }
 
 // NewRemoteCluster is a convenience way to create a RemoteCluster resource.
@@ -174,4 +177,10 @@ func (c *RemoteClusterV3) String() string {
 func (c *RemoteClusterV3) GetLabel(key string) (value string, ok bool) {
 	value, ok = c.Metadata.Labels[key]
 	return value, ok
+}
+
+// GetAllLabels returns all labels for the remote cluster. Remote clusters only
+// have static labels.
+func (c *RemoteClusterV3) GetAllLabels() map[string]string {
+	return c.Metadata.Labels
 }

--- a/lib/services/label_expressions.go
+++ b/lib/services/label_expressions.go
@@ -65,10 +65,13 @@ func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool]
 				}),
 		},
 		Functions: map[string]typical.Function{
+			"labels_matching": typical.UnaryFunctionWithEnv(labelsMatching),
 			"contains": typical.BinaryFunction[labelExpressionEnv](
 				func(list []string, item string) (bool, error) {
 					return slices.Contains(list, item), nil
 				}),
+			"contains_any": typical.BinaryFunction[labelExpressionEnv](containsAny),
+			"contains_all": typical.BinaryFunction[labelExpressionEnv](containsAll),
 			"regexp.match": typical.BinaryFunction[labelExpressionEnv](
 				func(list []string, re string) (bool, error) {
 					match, err := utils.RegexMatchesAny(list, re)
@@ -77,9 +80,10 @@ func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool]
 					}
 					return match, nil
 				}),
-			// Use regexp.replace from lib/utils/parse to get behavior identical
+			// Use regexp.replace and email.local from lib/utils/parse to get behavior identical
 			// to role templates.
 			"regexp.replace": typical.TernaryFunction[labelExpressionEnv](parse.RegexpReplace),
+			"email.local":    typical.UnaryFunction[labelExpressionEnv](parse.EmailLocal),
 			"strings.upper": typical.UnaryFunction[labelExpressionEnv](
 				func(list []string) ([]string, error) {
 					out := make([]string, len(list))
@@ -99,4 +103,57 @@ func newLabelExpressionParser() (*typical.CachedParser[labelExpressionEnv, bool]
 		},
 	})
 	return parser, trace.Wrap(err)
+}
+
+// labelsMatching returns the aggregate of all label values for all keys that
+// match keyExpr. It supports globs or full regular expressions and must find
+// a complete match for the key.
+func labelsMatching(env labelExpressionEnv, keyExpr string) ([]string, error) {
+	allLabels := env.resourceLabelGetter.GetAllLabels()
+	var matchingLabelValues []string
+	for key, value := range allLabels {
+		match, err := utils.MatchString(key, keyExpr)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		if match {
+			matchingLabelValues = append(matchingLabelValues, value)
+		}
+	}
+	return matchingLabelValues, nil
+}
+
+// containsAny returns true if [list] contains any element of [items].
+func containsAny(list []string, items []string) (bool, error) {
+	s := set(list)
+	for _, item := range items {
+		if _, ok := s[item]; ok {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// containsAny returns true if [list] contains every element of [items]. If
+// [items] is empty, it returns false, to avoid matching resources that
+// otherwise appear unrelated to the expression.
+func containsAll(list []string, items []string) (bool, error) {
+	if len(items) == 0 {
+		return false, nil
+	}
+	s := set(list)
+	for _, item := range items {
+		if _, ok := s[item]; !ok {
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+func set(list []string) map[string]struct{} {
+	m := make(map[string]struct{}, len(list))
+	for _, l := range list {
+		m[l] = struct{}{}
+	}
+	return m
 }

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1084,9 +1084,12 @@ func MatchLabels(selector types.Labels, target map[string]string) (bool, string,
 	return MatchLabelGetter(selector, mapLabelGetter(target))
 }
 
-// LabelGetter allows retrieving a particular label by name.
+// LabelGetter allows retrieving a particular label by name or retreiving all
+// labels at once. Prefer to use GetLabel when possible to avoid unnecessary
+// copies.
 type LabelGetter interface {
 	GetLabel(key string) (value string, ok bool)
+	GetAllLabels() map[string]string
 }
 
 type mapLabelGetter map[string]string
@@ -1094,6 +1097,10 @@ type mapLabelGetter map[string]string
 func (m mapLabelGetter) GetLabel(key string) (value string, ok bool) {
 	v, ok := m[key]
 	return v, ok
+}
+
+func (m mapLabelGetter) GetAllLabels() map[string]string {
+	return map[string]string(m)
 }
 
 // MatchLabelGetter matches selector against labelGetter. Empty selector matches
@@ -2300,6 +2307,7 @@ type AccessCheckable interface {
 	GetName() string
 	GetMetadata() types.Metadata
 	GetLabel(key string) (value string, ok bool)
+	GetAllLabels() map[string]string
 }
 
 // rbacDebugLogger creates a debug logger for Teleport's RBAC component.

--- a/rfd/0116-label-expressions.md
+++ b/rfd/0116-label-expressions.md
@@ -138,10 +138,10 @@ Label expressions can appear in `allow` or `deny` role conditions.
 
 Label expressions will have access to the following context:
 
-| Syntax             | Type                  | Description |
-|--------------------|-----------------------|-------------|
-| `labels`           | `map[string]string`   | Combined static and dynamic labels of the resource (node, app, db, etc.) being accessed |
-| `user.spec.traits` | `map[string][]string` | `external` or `internal` traits of the user accessing the resource |
+| Syntax             | Type                    | Description |
+|--------------------|-------------------------|-------------|
+| `user.spec.traits` | `map[string][]string`   | `external` or `internal` traits of the user accessing the resource |
+| `labels`           | `map[string]string`     | Combined static and dynamic labels of the resource (node, app, db, etc.) being accessed |
 
 #### Helper functions
 
@@ -155,10 +155,14 @@ resource label or a string literal).
 | Syntax | Return type | Description | Example |
 |--------|-------------|-------------|---------|
 | `contains(list, item)` | Boolean | Returns true if `list` contains an exact match for `item` | `contains(user.spec.traits[teams], labels["team"])` |
+| `contains_any(list, items)` | Boolean | Returns true if `list` contains an exact match for any element of `items` | `contains_any(user.spec.traits["projects"], labels_matching("project-*"))` |
+| `contains_all(list, items)` | Boolean | Returns true if `list` contains an exact match for all elements of `items` | `contains_all(user.spec.traits["projects"], labels_matching("project-*"))` |
 | `regexp.match(list, re)` | Boolean | Returns true if `list` contains a match for `re` | `regexp.match(labels["team"], "dev-team-\d+$")` |
 | `regexp.replace(list, re, replacement)` | `[]string` | Replaces all matches of `re` with replacement for all items in `list` | `contains(regexp.replace(user.spec.traits["allowed-env"], "^env-(.*)$", "$1"), labels["env"])`
+| `email.local(list)` | `[]string` | Returns the local part of each email in `list`, or an error if any email fails to parse | `contains(email.local(user.spec.traits["email"]), labels["owner"])`
 | `strings.upper(list)` | `[]string` | Converts all items of the list to uppercase | `contains(strings.upper(user.spec.traits["username"]), labels["owner"])`
 | `strings.lower(list)` | `[]string` | Converts all items of the list to lowercase | `contains(strings.lower(user.spec.traits["username"]), labels["owner"])`
+| `labels_matching(re)` | `[]string` | Returns the aggregate of all label values with keys matching `re`, which can be a glob or a regular expression. | `contains(labels_matching("^project-(team|label)$"), "skunkworks")`
 
 #### Operators
 


### PR DESCRIPTION
This commit adds the new function `labels_matching` to the label expression syntax. It accepts a Teleport-style glob or regular expression, and returns the aggregate of all values for keys matching that expression.

Since it is now more likely for users to want to compare two slices, I've also added the `contains_any` and `contains_all` functions to complement the existing `contains` function.

This commit also adds the `email.local` function that is already available in role templates and should be useful.

Some examples are included in the new test cases.

This should address https://github.com/gravitational/teleport/issues/10233