### PR TITLE
[v11] fix github url formatting backport

### DIFF
--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -980,7 +980,7 @@ func (c *githubAPIClient) get(page string) ([]byte, string, error) {
 
 // formatGithubURL is a helper for formatting github api request URLs.
 func formatGithubURL(host string, path string) string {
-	return fmt.Sprintf("https://%s/%s", host, strings.TrimPrefix(path, "/"))
+	return fmt.Sprintf("https://api.%s/%s", host, strings.TrimPrefix(path, "/"))
 }
 
 const (

--- a/lib/auth/github_test.go
+++ b/lib/auth/github_test.go
@@ -543,17 +543,17 @@ func TestGithubURLFormat(t *testing.T) {
 		{
 			host:   "example.com",
 			path:   "foo/bar",
-			expect: "https://example.com/foo/bar",
+			expect: "https://api.example.com/foo/bar",
 		},
 		{
 			host:   "example.com",
 			path:   "/foo/bar?spam=eggs",
-			expect: "https://example.com/foo/bar?spam=eggs",
+			expect: "https://api.example.com/foo/bar?spam=eggs",
 		},
 		{
 			host:   "example.com",
 			path:   "/foo/bar",
-			expect: "https://example.com/foo/bar",
+			expect: "https://api.example.com/foo/bar",
 		},
 	}
 


### PR DESCRIPTION
Fixes an issue introduced by a bad backport (https://github.com/gravitational/teleport/pull/25110).  This backport was based on logic that included https://github.com/gravitational/teleport/pull/23200, but that PR was never included in v11, so v11 still relies on the `api` prefix being hard-coded in GitHub url formatting.