### PR TITLE
Use the one-liner in install-linux.mdx

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -199,7 +199,7 @@ if you weren't already authenticated.
 
 ## Next steps
 
-Dive deeper into the topics relevant to your Application Access use-case:
+Dive deeper into protecting applications with Teleport:
 
 - Learn in more detail about [connecting applications](./guides/connecting-apps.mdx).
 - Learn about integrating with [JWT tokens](./jwt/introduction.mdx) for auth.

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,80 +1,12 @@
-Use the appropriate commands for your environment to install your package.
+Use the appropriate commands for your environment to install your package:
 
 <Tabs dropdownView dropdownCaption="Teleport Edition">
   <TabItem label="Open Source" scope="oss">
-  <Tabs>
-  <TabItem label="Debian 8+/Ubuntu 16.04+ (apt)" scope="oss">
 
   ```code
-  # Download Teleport's PGP public key
-  $ sudo curl https://apt.releases.teleport.dev/gpg \
-  -o /usr/share/keyrings/teleport-archive-keyring.asc
-  # Source variables about OS version
-  $ source /etc/os-release
-  # Add the Teleport APT repository for v(=teleport.major_version=). You'll need to update this
-  # file for each major release of Teleport.
-  $ echo "deb [signed-by=/usr/share/keyrings/teleport-archive-keyring.asc] \
-  https://apt.releases.teleport.dev/${ID?} ${VERSION_CODENAME?} stable/v(=teleport.major_version=)" \
-  | sudo tee /etc/apt/sources.list.d/teleport.list > /dev/null
-
-  $ sudo apt-get update
-  $ sudo apt-get install teleport
+  $ curl https://goteleport.com/static/install.sh | bash -s (=teleport.version=)
   ```
 
-  </TabItem>
-  <TabItem label="Amazon Linux 2/RHEL 7 (yum)" scope="oss">
-
-  ```code
-  # Source variables about OS version
-  $ source /etc/os-release
-  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
-  # file for each major release of Teleport.
-  # First, get the major version from $VERSION_ID so this fetches the correct
-  # package version.
-  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
-  $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
-  $ sudo yum install teleport
-  #
-  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
-  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
-  ```
-  </TabItem>
-  <TabItem label="Amazon Linux 2023/RHEL 8+ (dnf)" scope="oss">
-
-  ```code
-  # Source variables about OS version
-  $ source /etc/os-release
-  # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
-  # file for each major release of Teleport.
-  # Use the dnf config manager plugin to add the teleport RPM repo
-  $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
-  
-  # Install teleport
-  $ sudo dnf install teleport
-  
-  # Tip: Add /usr/local/bin to path used by sudo (so 'sudo tctl users add' will work as per the docs)
-  # echo "Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin" > /etc/sudoers.d/secure_path
-  ```
-  </TabItem>
-  <TabItem label="Tarball" scope="oss">
-
-  In the example commands below, update `$SYSTEM_ARCH` with the appropriate
-  value (`amd64`, `arm64`, or `arm`). All example commands using this variable
-  will update after one is filled out.
-
-  ```code
-  $ curl https://get.gravitational.com/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH" description="The CPU architecture of the system Teleport will be installed on"/>-bin.tar.gz.sha256
-  # <checksum> <filename>
-  $ curl -O https://cdn.teleport.dev/teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
-  $ shasum -a 256 teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
-  # Verify that the checksums match
-  $ tar -xvf teleport-v(=teleport.version=)-linux-<Var name="$SYSTEM_ARCH"/>-bin.tar.gz
-  $ cd teleport
-  $ sudo ./install
-  ```
-
-  </TabItem>
-  </Tabs>
   </TabItem>
   <TabItem label="Enterprise" scope="enterprise">
   <Tabs>


### PR DESCRIPTION
Closes #25505

We now have a one-line installation command for Teleport Community Edition. Since the script the command runs already checks the user's OS and attempts to use the appropriate package manager, there is no need for the tabbed installation instructions in the Community Edition tab of `install-linux.mdx`.