### PR TITLE
Initial devbox.

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,28 @@ Why is a specific version of a module imported?
 
 `go mod graph | grep $modname`
 
+### Devbox Build (experimental)
+
+**Note**: Devbox support is still experimental. It's very possible things make not work as intended.
+
+Teleport can be built using [devbox](https://www.jetpack.io/devbox). To use devbox, follow
+the instructions to install devbox [here](https://www.jetpack.io/devbox/docs/quickstart/) and
+then run:
+
+`devbox shell`
+
+This will install Teleport's various build dependencies and drop you into a shell with these
+dependencies. From here, you can build Teleport normally.
+
+#### flake.nix
+
+A nix flake is located in `build.assets/flake` that allows for installation of Teleport's less
+common build tooling. If this flake is updated, run:
+
+`devbox install`
+
+in order to make sure the changes in the flake are reflected in the local devbox shell.
+
 ## Why did We Build Teleport?
 
 The Teleport creators used to work together at Rackspace. We noticed that most cloud computing users struggle with setting up and configuring infrastructure security because popular tools, while flexible, are complex to understand and expensive to maintain. Additionally, most organizations use multiple infrastructure form factors such as several cloud providers, multiple cloud accounts, servers in colocation, and even smart devices. Some of those devices run on untrusted networks, behind third-party firewalls. This only magnifies complexity and increases operational overhead.

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -274,13 +274,11 @@ RUN helm plugin install https://github.com/vbehar/helm3-unittest && \
     HELM_PLUGINS=/home/ci/.local/share/helm/plugins helm plugin list
 
 # Install JS gRPC tools.
-# Keep the version below synced with devbox.json
 ARG NODE_GRPC_TOOLS_VERSION # eg, "1.12.4"
 ARG NODE_PROTOC_TS_VERSION  # eg, "5.0.1"
 RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
 
 # Install protoc.
-# Keep the version below synced with devbox.json
 ARG PROTOC_VER # eg, "3.20.2"
 RUN VERSION="$PROTOC_VER" && \
   PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
@@ -290,7 +288,6 @@ RUN VERSION="$PROTOC_VER" && \
   rm -f "$PB_FILE"
 
 # Install protoc-gen-gogofast.
-# Keep the version below synced with devbox.json
 ARG GOGO_PROTO_TAG # eg, "v1.3.2"
 RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 
@@ -309,7 +306,6 @@ RUN TAG='v1.53.2' && \
     sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
 
 # Install Buf.
-# Keep the version below synced with devbox.json
 ARG BUF_VERSION # eg, "1.19.0"
 RUN BIN='/usr/local/bin' && \
   VERSION="$BUF_VERSION" && \

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -25,6 +25,7 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.2 &&
     make clean
 
 # Install libcbor.
+# Keep the version below synced with devbox.json
 RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     cd libcbor && \
     [ "$(git rev-parse HEAD)" = 'efa6c0886bae46bdaef9b679f61f4b9d8bc296ae' ] && \
@@ -38,6 +39,7 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
+# Keep the version below synced with devbox.json
 RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.9 && \
     cd openssl && \
     [ "$(git rev-parse HEAD)" = 'de90e54bbe82e5be4fb9608b6f5c308bb837d355' ] && \
@@ -47,6 +49,7 @@ RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.9 
 
 # Install libfido2.
 # Depends on libcbor, libcrypto (OpenSSL 3.x), libudev and zlib1g-dev.
+# Keep the version below synced with devbox.json
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.13.0 && \
     cd libfido2 && \
     [ "$(git rev-parse HEAD)" = '486a8f8667e42f55cee2bba301b41433cacec830' ] && \
@@ -238,11 +241,13 @@ RUN make -C /opt/pam_teleport install
 ENV SOFTHSM2_PATH "/usr/lib/softhsm/libsofthsm2.so"
 
 # Install bats.
+# Keep the version below synced with devbox.json
 RUN curl -fsSL https://github.com/bats-core/bats-core/archive/v1.2.1.tar.gz | tar -xz && \
     cd bats-core-1.2.1 && ./install.sh /usr/local && cd .. && \
     rm -r bats-core-1.2.1
 
 # Install shellcheck.
+# Keep the version below synced with devbox.json
 RUN scversion='v0.9.0' && \
     curl -fsSL "https://github.com/koalaman/shellcheck/releases/download/$scversion/shellcheck-$scversion.linux.$(if [ "$BUILDARCH" = "amd64" ]; then echo "x86_64"; else echo "aarch64"; fi).tar.xz" | \
         tar -xJv && \
@@ -250,6 +255,7 @@ RUN scversion='v0.9.0' && \
     shellcheck --version
 
 # Install helm.
+# Keep the version below synced with devbox.json
 RUN mkdir -p helm-tarball && \
     curl -fsSL https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \
     cp helm-tarball/$(go env GOOS)-$(go env GOARCH)/helm /bin/ && \
@@ -268,11 +274,13 @@ RUN helm plugin install https://github.com/vbehar/helm3-unittest && \
     HELM_PLUGINS=/home/ci/.local/share/helm/plugins helm plugin list
 
 # Install JS gRPC tools.
+# Keep the version below synced with devbox.json
 ARG NODE_GRPC_TOOLS_VERSION # eg, "1.12.4"
 ARG NODE_PROTOC_TS_VERSION  # eg, "5.0.1"
 RUN npm install --global "grpc-tools@$NODE_GRPC_TOOLS_VERSION" "grpc_tools_node_protoc_ts@$NODE_PROTOC_TS_VERSION"
 
 # Install protoc.
+# Keep the version below synced with devbox.json
 ARG PROTOC_VER # eg, "3.20.2"
 RUN VERSION="$PROTOC_VER" && \
   PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
@@ -282,21 +290,26 @@ RUN VERSION="$PROTOC_VER" && \
   rm -f "$PB_FILE"
 
 # Install protoc-gen-gogofast.
+# Keep the version below synced with devbox.json
 ARG GOGO_PROTO_TAG # eg, "v1.3.2"
 RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 
 # Install addlicense.
+# Keep the version below synced with devbox.json
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
+# Keep the version below synced with devbox.json
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
+# Keep the version below synced with devbox.json
 RUN TAG='v1.53.2' && \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
 
 # Install Buf.
+# Keep the version below synced with devbox.json
 ARG BUF_VERSION # eg, "1.19.0"
 RUN BIN='/usr/local/bin' && \
   VERSION="$BUF_VERSION" && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -19,15 +19,17 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.20.4
+GOLANG_VERSION ?= go1.20.4 # Sync with devbox.json.
 
-NODE_VERSION ?= 16.18.1
+NODE_VERSION ?= 16.18.1 # Sync with devbox.json.
 
+# Sync any version changes below with devbox.json.
 # run lint-rust check locally before merging code after you bump this
 RUST_VERSION ?= 1.68.0
 LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
+# Sync any version changes below with devbox.json.
 # Protogen related versions.
 BUF_VERSION ?= 1.20.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock)

--- a/build.assets/flake/flake.lock
+++ b/build.assets/flake/flake.lock
@@ -1,0 +1,95 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "helmPkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "libbpfPkgs": {
+      "locked": {
+        "lastModified": 1671056470,
+        "narHash": "sha256-rrcDHjRX9R8qXvkcGvKunsw3mf7zyPJzx1y8TPqjWdM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1678571061,
+        "narHash": "sha256-0gI2FHID8XYD3504kLFRLH3C2GmMCzVMC50APV/kZp8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "helmPkgs": "helmPkgs",
+        "libbpfPkgs": "libbpfPkgs",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/build.assets/flake/flake.lock
+++ b/build.assets/flake/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "batsPkgs": {
+      "locked": {
+        "lastModified": 1614022514,
+        "narHash": "sha256-htMUqRk3r5s3kuixCgojWZX9nwM++xeFfeZU+3xQLCA=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5c1ffb7a9fc96f2d64ed3523c2bdd379bdb7b471",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5c1ffb7a9fc96f2d64ed3523c2bdd379bdb7b471",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -68,6 +84,7 @@
     },
     "root": {
       "inputs": {
+        "batsPkgs": "batsPkgs",
         "flake-utils": "flake-utils",
         "helmPkgs": "helmPkgs",
         "libbpfPkgs": "libbpfPkgs",

--- a/build.assets/flake/flake.nix
+++ b/build.assets/flake/flake.nix
@@ -43,7 +43,7 @@
       (system:
         let
           # These versions are not available from nixpkgs
-          golangciLintVersion = "v1.53.1";
+          golangciLintVersion = "v1.53.2";
           rustVersion = "1.68.0";
           gogoVersion = "v1.3.2";
           helmUnittestVersion = "v1.0.16";
@@ -164,6 +164,22 @@
             protoc-gen-gogo = protoc-gen-gogo;
             grpc-tools = grpc-tools;
             rust = rust;
+
+            default = pkgs.stdenv.mkDerivation {
+              name = "all";
+              dontUnpack = true;
+              buildPhase = ''
+                mkdir "$out"
+              '';
+
+              propagatedBuildInputs = [
+                helm
+                golangci-lint
+                protoc-gen-gogo
+                grpc-tools
+                rust
+              ] ++ conditionalInputs;
+            };
           };
       });
 }

--- a/build.assets/flake/flake.nix
+++ b/build.assets/flake/flake.nix
@@ -27,8 +27,11 @@
     # Linting dependencies
     helmPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # helm 3.11.1
 
-    # Rust and GCC dependencies
+    # libbpf dependencies.
     libbpfPkgs.url = "github:nixos/nixpkgs/79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a"; # libbpf 1.0.1
+
+    # bats dependencies.
+    batsPkgs.url = "github:nixos/nixpkgs/5c1ffb7a9fc96f2d64ed3523c2bdd379bdb7b471"; # bats 1.2.1
   };
 
   outputs = { self,
@@ -36,8 +39,8 @@
               nixpkgs,
 
               helmPkgs,
-
               libbpfPkgs,
+              batsPkgs,
      }:
     flake-utils.lib.eachDefaultSystem
       (system:
@@ -54,6 +57,7 @@
           # The individual package names here have been determined by using
           # https://lazamar.co.uk/nix-versions/
           libbpf = libbpfPkgs.legacyPackages.${system}.libbpf;
+          bats = batsPkgs.legacyPackages.${system}.bats;
 
           # pkgs is an alias for the nixpkgs at the system level. This will be used
           # for general utilities.
@@ -151,7 +155,15 @@
             '';
           };
 
-          conditional = if pkgs.stdenv.isLinux then libbpf else pkgs.hello;
+          conditional = if pkgs.stdenv.isLinux then pkgs.stdenv.mkDerivation {
+            name = "conditional";
+            dontUnpack = true;
+            dontBuild = true;
+            propagatedBuildInputs = [
+              bats
+              libbpf
+            ];
+          } else pkgs.hello;
         in
         {
           packages = {

--- a/build.assets/flake/flake.nix
+++ b/build.assets/flake/flake.nix
@@ -53,7 +53,6 @@
           # Package aliases to make reusing these packages easier.
           # The individual package names here have been determined by using
           # https://lazamar.co.uk/nix-versions/
-
           libbpf = libbpfPkgs.legacyPackages.${system}.libbpf;
 
           # pkgs is an alias for the nixpkgs at the system level. This will be used
@@ -152,34 +151,16 @@
             '';
           };
 
-          conditionalInputs = if pkgs.stdenv.isLinux then
-          [
-            libbpf
-          ] else [];
+          conditional = if pkgs.stdenv.isLinux then libbpf else pkgs.hello;
         in
         {
           packages = {
-            helm = helm;
+            conditional = conditional;
             golangci-lint = golangci-lint;
-            protoc-gen-gogo = protoc-gen-gogo;
             grpc-tools = grpc-tools;
+            helm = helm;
+            protoc-gen-gogo = protoc-gen-gogo;
             rust = rust;
-
-            default = pkgs.stdenv.mkDerivation {
-              name = "all";
-              dontUnpack = true;
-              buildPhase = ''
-                mkdir "$out"
-              '';
-
-              propagatedBuildInputs = [
-                helm
-                golangci-lint
-                protoc-gen-gogo
-                grpc-tools
-                rust
-              ] ++ conditionalInputs;
-            };
           };
       });
 }

--- a/build.assets/flake/flake.nix
+++ b/build.assets/flake/flake.nix
@@ -1,0 +1,169 @@
+# Copyright 2023 Gravitational, Inc.
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# This file contains the dependencies for the Teleport nix shell, which contains
+# all of the utilities for building and linting Teleport.
+#
+
+{
+  description = "Teleport shell dependencies";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # general packages
+
+    # Linting dependencies
+    helmPkgs.url = "github:nixos/nixpkgs/8ad5e8132c5dcf977e308e7bf5517cc6cc0bf7d8"; # helm 3.11.1
+
+    # Rust and GCC dependencies
+    libbpfPkgs.url = "github:nixos/nixpkgs/79b3d4bcae8c7007c9fd51c279a8a67acfa73a2a"; # libbpf 1.0.1
+  };
+
+  outputs = { self,
+              flake-utils,
+              nixpkgs,
+
+              helmPkgs,
+
+              libbpfPkgs,
+     }:
+    flake-utils.lib.eachDefaultSystem
+      (system:
+        let
+          # These versions are not available from nixpkgs
+          golangciLintVersion = "v1.53.1";
+          rustVersion = "1.68.0";
+          gogoVersion = "v1.3.2";
+          helmUnittestVersion = "v1.0.16";
+          nodeProtocTsVersion = "5.0.1";
+          grpcToolsVersion = "1.12.4";
+
+          # Package aliases to make reusing these packages easier.
+          # The individual package names here have been determined by using
+          # https://lazamar.co.uk/nix-versions/
+
+          libbpf = libbpfPkgs.legacyPackages.${system}.libbpf;
+
+          # pkgs is an alias for the nixpkgs at the system level. This will be used
+          # for general utilities.
+          pkgs = nixpkgs.legacyPackages.${system};
+
+          # The helm unittest plugin.
+          helm-unittest = pkgs.buildGoModule rec {
+            name = "helm-unittest";
+          
+            src = pkgs.fetchFromGitHub {
+              owner = "vbehar";
+              repo = "helm3-unittest";
+              rev = helmUnittestVersion;
+              sha256 = "sha256-2UfQimIlA+hb1CpQrWfMh5iBEvgdnrkCGYaTJC3Bzpo=";
+            };
+
+            vendorSha256 = null;
+          
+            postInstall = ''
+              install -Dm644 plugin.yaml $out/helm-unittest/plugin.yaml
+              mkdir "$out/helm-unittest/bin"
+              mv $out/bin/helm3-unittest $out/helm-unittest/bin/unittest
+            '';
+          
+            doCheck = false;
+          };
+
+          # Wrap helm with the unittest plugin.
+          helm = (pkgs.wrapHelm helmPkgs.legacyPackages.${system}.kubernetes-helm {plugins = [helm-unittest];});
+
+          # Install golangci-lint
+          golangci-lint = pkgs.stdenv.mkDerivation {
+            name = "golangci-lint";
+            buildInputs = [
+              pkgs.cacert
+              pkgs.curl
+            ];
+            dontUnpack = true;
+            buildPhase = ''
+              curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $out/bin ${golangciLintVersion}
+            '';
+          };
+
+          # Compile protoc-gen-gogo for golang protobuf compilation.
+          protoc-gen-gogo = pkgs.stdenv.mkDerivation {
+            name = "protoc-gen-gogo";
+            src = pkgs.fetchFromGitHub {
+              owner = "gogo";
+              repo = "protobuf";
+              rev = gogoVersion;
+              sha256 = "sha256-CoUqgLFnLNCS9OxKFS7XwjE17SlH6iL1Kgv+0uEK2zU=";
+            };
+            buildInputs = [
+              pkgs.cacert
+              pkgs.go
+            ];
+            buildPhase = ''
+              export GOBIN="$out/bin"
+              export GOCACHE="$(mktemp -d)"
+              make install
+              cp -R protobuf "$out/protobuf"
+            '';
+          };
+
+          # Compile grpc-tools for nodejs protobuf compilation.
+          grpc-tools = pkgs.stdenv.mkDerivation {
+            name = "grpc-tools";
+            dontUnpack = true;
+            buildInputs = [
+              pkgs.nodejs-16_x
+            ];
+            buildPhase = ''
+              export HOME="$(mktemp -d)"
+              export TEMPDIR="$(mktemp -d)"
+              npm install --prefix "$TEMPDIR" grpc_tools_node_protoc_ts@${nodeProtocTsVersion} grpc-tools@${grpcToolsVersion}
+              mv "$TEMPDIR" "$out"
+              mkdir "$out/bin"
+              cd "$out/bin"
+              ln -s ../node_modules/.bin/* "$out/bin/"
+            '';
+          };
+
+          # Rust and cargo binaries.
+          rust = pkgs.stdenv.mkDerivation {
+            name = "rust";
+            dontUnpack = true;
+            buildInputs = [
+              pkgs.cacert
+              pkgs.curl
+            ];
+            buildPhase = ''
+              export RUSTUP_HOME="$out"
+              export CARGO_HOME="$out"
+              curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --no-modify-path --default-toolchain "${rustVersion}"
+            '';
+          };
+
+          conditionalInputs = if pkgs.stdenv.isLinux then
+          [
+            libbpf
+          ] else [];
+        in
+        {
+          packages = {
+            helm = helm;
+            golangci-lint = golangci-lint;
+            protoc-gen-gogo = protoc-gen-gogo;
+            grpc-tools = grpc-tools;
+            rust = rust;
+          };
+      });
+}

--- a/devbox.json
+++ b/devbox.json
@@ -1,10 +1,11 @@
 {
   "packages": [
-    "bash@5.2-p15",
+    "bash",
+    "git",
     "github:nixos/nixpkgs/757a0d107c238d031652a8c09d1f6bf1b6f523a3#go",
     "nodejs@16.18.1",
     "git@2.40.1",
-    "gcc@12.2.0",
+    "clang@11.1.0",
     "libiconvReal@1.16",
     "libfido2@1.13.0",
     "gci@0.9.1",
@@ -14,7 +15,6 @@
     "python@3.11.2",
     "yarn@1.22.19",
     "protobuf3_20@3.20.3",
-    "protoc-gen-go@1.28.1",
     "patchelf@0.15.0",
     "path:build.assets/flake#helm",
     "path:build.assets/flake#golangci-lint",

--- a/devbox.json
+++ b/devbox.json
@@ -2,6 +2,8 @@
   "packages": [
     "addlicense@1.0.0",
     "bash",
+    "bats@1.3.0",
+    "github:nixos/nixpkgs/757a0d107c238d031652a8c09d1f6bf1b6f523a3#buf",
     "clang@11.1.0",
     "gci@0.9.1",
     "git",
@@ -9,6 +11,7 @@
     "libiconvReal@1.16",
     "libfido2@1.13.0",
     "nodejs@16.18.1",
+    "github:nixos/nixpkgs/b39bfdc033e1d79f2b58e1630530e5d54b19e698#openssl",
     "patchelf@0.15.0",
     "protobuf3_20@3.20.3",
     "python@3.11.2",

--- a/devbox.json
+++ b/devbox.json
@@ -20,10 +20,11 @@
     "path:build.assets/flake#golangci-lint",
     "path:build.assets/flake#protoc-gen-gogo",
     "path:build.assets/flake#grpc-tools",
-    "path:build.assets/flake#rust"
+    "path:build.assets/flake#rust",
+    "gotestsum@latest"
   ],
   "shell": {
-    "init_hook": null
+    "init_hook": "export TELEPORT_DEVBOX=1"
   },
   "nixpkgs": {
     "commit": "f91ee3065de91a3531329a674a45ddcb3467a650"

--- a/devbox.json
+++ b/devbox.json
@@ -6,7 +6,6 @@
     "gci@0.9.1",
     "git",
     "github:nixos/nixpkgs/757a0d107c238d031652a8c09d1f6bf1b6f523a3#go",
-    "gotestsum@latest",
     "libiconvReal@1.16",
     "libfido2@1.13.0",
     "nodejs@16.18.1",

--- a/devbox.json
+++ b/devbox.json
@@ -1,27 +1,26 @@
 {
   "packages": [
+    "addlicense@1.0.0",
     "bash",
+    "clang@11.1.0",
+    "gci@0.9.1",
     "git",
     "github:nixos/nixpkgs/757a0d107c238d031652a8c09d1f6bf1b6f523a3#go",
-    "nodejs@16.18.1",
-    "git@2.40.1",
-    "clang@11.1.0",
+    "gotestsum@latest",
     "libiconvReal@1.16",
     "libfido2@1.13.0",
-    "gci@0.9.1",
-    "yamllint@1.28.0",
-    "addlicense@1.0.0",
-    "shellcheck@0.9.0",
-    "python@3.11.2",
-    "yarn@1.22.19",
-    "protobuf3_20@3.20.3",
+    "nodejs@16.18.1",
     "patchelf@0.15.0",
+    "protobuf3_20@3.20.3",
+    "python@3.11.2",
+    "shellcheck@0.9.0",
+    "yamllint@1.28.0",
+    "yarn@1.22.19",
     "path:build.assets/flake#helm",
     "path:build.assets/flake#golangci-lint",
     "path:build.assets/flake#protoc-gen-gogo",
     "path:build.assets/flake#grpc-tools",
-    "path:build.assets/flake#rust",
-    "gotestsum@latest"
+    "path:build.assets/flake#rust"
   ],
   "shell": {
     "init_hook": "export TELEPORT_DEVBOX=1"

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,31 @@
+{
+  "packages": [
+    "bash@5.2-p15",
+    "github:nixos/nixpkgs/757a0d107c238d031652a8c09d1f6bf1b6f523a3#go",
+    "nodejs@16.18.1",
+    "git@2.40.1",
+    "gcc@12.2.0",
+    "libiconvReal@1.16",
+    "libfido2@1.13.0",
+    "gci@0.9.1",
+    "yamllint@1.28.0",
+    "addlicense@1.0.0",
+    "shellcheck@0.9.0",
+    "python@3.11.2",
+    "yarn@1.22.19",
+    "protobuf3_20@3.20.3",
+    "protoc-gen-go@1.28.1",
+    "patchelf@0.15.0",
+    "path:build.assets/flake#helm",
+    "path:build.assets/flake#golangci-lint",
+    "path:build.assets/flake#protoc-gen-gogo",
+    "path:build.assets/flake#grpc-tools",
+    "path:build.assets/flake#rust"
+  ],
+  "shell": {
+    "init_hook": null
+  },
+  "nixpkgs": {
+    "commit": "f91ee3065de91a3531329a674a45ddcb3467a650"
+  }
+}

--- a/devbox.json
+++ b/devbox.json
@@ -15,10 +15,11 @@
     "shellcheck@0.9.0",
     "yamllint@1.28.0",
     "yarn@1.22.19",
+    "path:build.assets/flake#conditional",
     "path:build.assets/flake#helm",
     "path:build.assets/flake#golangci-lint",
-    "path:build.assets/flake#protoc-gen-gogo",
     "path:build.assets/flake#grpc-tools",
+    "path:build.assets/flake#protoc-gen-gogo",
     "path:build.assets/flake#rust"
   ],
   "shell": {

--- a/devbox.lock
+++ b/devbox.lock
@@ -6,6 +6,9 @@
       "resolved": "github:NixOS/nixpkgs/d3248619647234b5dc74a6921bcdf6dd8323eb22#addlicense",
       "version": "1.0.0"
     },
+    "bash": {
+      "resolved": "github:NixOS/nixpkgs/f91ee3065de91a3531329a674a45ddcb3467a650#bash"
+    },
     "bash@5.2-p15": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#bash",
@@ -13,6 +16,11 @@
     },
     "bash_5": {
       "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#bash_5"
+    },
+    "clang@11.1.0": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#clang",
+      "version": "11.1.0"
     },
     "gcc@12.2.0": {
       "last_modified": "2023-05-01T16:53:22Z",
@@ -23,6 +31,9 @@
       "last_modified": "2023-02-28T22:11:13Z",
       "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#gci",
       "version": "0.9.1"
+    },
+    "git": {
+      "resolved": "github:NixOS/nixpkgs/f91ee3065de91a3531329a674a45ddcb3467a650#git"
     },
     "git@2.40.1": {
       "last_modified": "2023-05-01T16:53:22Z",

--- a/devbox.lock
+++ b/devbox.lock
@@ -17,6 +17,11 @@
     "bash_5": {
       "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#bash_5"
     },
+    "bats@1.3.0": {
+      "last_modified": "2021-09-01T12:51:06Z",
+      "resolved": "github:NixOS/nixpkgs/6cc260cfd60f094500b79e279069b499806bf6d8#bats",
+      "version": "1.3.0"
+    },
     "clang@11.1.0": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#clang",

--- a/devbox.lock
+++ b/devbox.lock
@@ -48,6 +48,11 @@
     "go_1_20": {
       "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#go_1_20"
     },
+    "gotestsum@latest": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#gotestsum",
+      "version": "1.10.0"
+    },
     "kubernetes-helm@3.11.1": {
       "last_modified": "2023-02-28T22:11:13Z",
       "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#kubernetes-helm",

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,106 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "addlicense@1.0.0": {
+      "last_modified": "2022-06-30T00:42:12Z",
+      "resolved": "github:NixOS/nixpkgs/d3248619647234b5dc74a6921bcdf6dd8323eb22#addlicense",
+      "version": "1.0.0"
+    },
+    "bash@5.2-p15": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#bash",
+      "version": "5.2-p15"
+    },
+    "bash_5": {
+      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#bash_5"
+    },
+    "gcc@12.2.0": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#gcc12",
+      "version": "12.2.0"
+    },
+    "gci@0.9.1": {
+      "last_modified": "2023-02-28T22:11:13Z",
+      "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#gci",
+      "version": "0.9.1"
+    },
+    "git@2.40.1": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#git",
+      "version": "2.40.1"
+    },
+    "go@1.20.3": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#go",
+      "version": "1.20.3"
+    },
+    "go_1_20": {
+      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#go_1_20"
+    },
+    "kubernetes-helm@3.11.1": {
+      "last_modified": "2023-02-28T22:11:13Z",
+      "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#kubernetes-helm",
+      "version": "3.11.1"
+    },
+    "libfido2@1.13.0": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#libfido2",
+      "version": "1.13.0"
+    },
+    "libiconvReal@1.16": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#libiconvReal",
+      "version": "1.16"
+    },
+    "nodejs": {
+      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#nodejs"
+    },
+    "nodejs@16.18.1": {
+      "last_modified": "2023-01-02T04:31:48Z",
+      "resolved": "github:NixOS/nixpkgs/a4379d2b0deefedc8dba360897557707ea9ee9a7#nodejs-16_x",
+      "version": "16.18.1"
+    },
+    "patchelf@0.15.0": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#patchelf",
+      "version": "0.15.0"
+    },
+    "path:build.assets/flake": {},
+    "path:build.assets/flake#helm": {},
+    "protobuf3_20@3.20.3": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#protobuf3_20",
+      "version": "3.20.3"
+    },
+    "protoc-gen-go@1.28.1": {
+      "last_modified": "2023-02-28T22:11:13Z",
+      "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#protoc-gen-go",
+      "version": "1.28.1"
+    },
+    "python@3.11.2": {
+      "last_modified": "2023-03-31T22:52:29Z",
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#python311",
+      "version": "3.11.2"
+    },
+    "rustup": {
+      "plugin_version": "0.0.1",
+      "resolved": "github:NixOS/nixpkgs/f80ac848e3d6f0c12c52758c0f25c10c97ca3b62#rustup"
+    },
+    "shellcheck@0.9.0": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#shellcheck",
+      "version": "0.9.0"
+    },
+    "yamllint@1.28.0": {
+      "last_modified": "2023-02-28T22:11:13Z",
+      "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#yamllint",
+      "version": "1.28.0"
+    },
+    "yarn@1.22.19": {
+      "last_modified": "2023-05-01T16:53:22Z",
+      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#yarn",
+      "version": "1.22.19"
+    }
+  }
+}


### PR DESCRIPTION
As devbox has added in version pinning, it seems like a viable way for maintaining consistent tooling across devboxes. This is an initial pass at using devbox in Teleport.

This requires devbox `0.5.4`. To test, run:
* `curl -fsSL https://get.jetpack.io/devbox | bash`
* `devbox shell`

If you're trying this out and `devbox.json` changes, you can update your shell with `devbox install`.