### PR TITLE
Add one-liner to get an RFD number

### DIFF
--- a/rfd/0000-rfds.md
+++ b/rfd/0000-rfds.md
@@ -55,37 +55,29 @@ Use this RFD as an example.
 Here's the process from and RFD idea in your head to a working implementation
 in the main Teleport branch.
 
-1. pick the RFD number
+1. Pick the RFD number. RFD numbers are claimed by pushing a branch named
+   `rfd/$number-title`.
 
-   check [submitted](https://github.com/gravitational/teleport/tree/master/rfd)
-   and
-   [pending](https://github.com/gravitational/teleport/pulls?q=is%3Apr+is%3Aopen+label%3Arfd)
-   RFDs and pick the next available number.
-
-   For example, you're writing an RFD titled 'Teleport IRC Access' and end up
-   with number 18.
-
-   Use this one-liner to get the highest-numbered RFD that is currently part of
-   a pull request. This command requires the [`gh` CLI
-   tool](https://github.com/cli/cli):
+   Use this one-liner to get the highest-numbered RFD branch that's been pushed:
 
    ```bash
-   gh pr list --label rfd | awk '{print $1}' | xargs -I{} gh pr diff {} --name-only | grep "^rfd" | sed -E "s|rfd/([0-9]+)?.*|\1|" | sort -n | tail -n 1
+   git fetch --quiet && git branch -r -v | grep origin/rfd/ | awk '{print $1}' | sort | tail -n 1
    ```
 
 1. make a branch off of `master` called `rfd/$number-your-title`
 
-   In our example, it'll be branch `rfd/0018-irc-access`.
+   For example, you're writing an RFD titled 'Teleport IRC Access' and end up
+   with number 18 - your branch would be called `rfd/0018-irc-access`.
 
 1. write your RFD under `/rfd/$number-your-title.md`
 
    Our example RFD is in `/rfd/0018-irc-access.md`.
 
-1. submit a PR titled `RFD $number: Your Title` and tag it with the `rfd` label
+1. submit a PR titled `RFD $number: Your Title`
 
    Our example RFD title: `RFD 18: IRC Access`
 
-1. iterated on the RFD based on reviewer feedback and get approvals
+1. iterate on the RFD based on reviewer feedback and get approvals
 
    Note: it's OK to use meetings or chat to discuss the RFD, but please write
    down the outcome in PR comments. A future reader will be grateful!
@@ -93,7 +85,7 @@ in the main Teleport branch.
 1. merge the PR and start implementing
 
 1. once implemented, make another PR changing the `state` to `implemented` and
-   updating any details that changed during implementation
+   updating any details that changed during implementation.
 
 If an RFD is eventually deprecated (e.g. a feature is removed), make a PR
 changing the `state` to `deprecated` and optionally link to the replacement RFD

--- a/rfd/0000-rfds.md
+++ b/rfd/0000-rfds.md
@@ -65,6 +65,14 @@ in the main Teleport branch.
    For example, you're writing an RFD titled 'Teleport IRC Access' and end up
    with number 18.
 
+   Use this one-liner to get the highest-numbered RFD that is currently part of
+   a pull request. This command requires the [`gh` CLI
+   tool](https://github.com/cli/cli):
+
+   ```bash
+   gh pr list --label rfd | awk '{print $1}' | xargs -I{} gh pr diff {} --name-only | grep "^rfd" | sed -E "s|rfd/([0-9]+)?.*|\1|" | sort -n | tail -n 1
+   ```
+
 1. make a branch off of `master` called `rfd/$number-your-title`
 
    In our example, it'll be branch `rfd/0018-irc-access`.


### PR DESCRIPTION
It can be a little tricky/friction-inducing to find the next available RFD number within current PRs. Add a command to our RFD instructions for finding the highest-numbered RFD within a PR that uses the `rfd` label.