### PR TITLE
[v11] WebPublicAddr includes user specified port.

### DIFF
--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -530,7 +530,18 @@ type KeyPairPath struct {
 // WebPublicAddr returns the address for the web endpoint on this proxy that
 // can be reached by clients.
 func (c ProxyConfig) WebPublicAddr() (string, error) {
-	return c.getDefaultAddr(c.WebAddr.Port(defaults.HTTPListenPort)), nil
+	// Use the port from the first public address if possible.
+	if len(c.PublicAddrs) > 0 {
+		publicAddr := c.PublicAddrs[0]
+		u := url.URL{
+			Scheme: "https",
+			Host:   net.JoinHostPort(publicAddr.Host(), strconv.Itoa(publicAddr.Port(defaults.HTTPListenPort))),
+		}
+		return u.String(), nil
+	}
+
+	port := c.WebAddr.Port(defaults.HTTPListenPort)
+	return c.getDefaultAddr(port), nil
 }
 
 func (c ProxyConfig) getDefaultAddr(port int) string {

--- a/lib/service/cfg_test.go
+++ b/lib/service/cfg_test.go
@@ -445,3 +445,46 @@ func TestHostLabelMatching(t *testing.T) {
 		})
 	}
 }
+
+func TestWebPublicAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   ProxyConfig
+		expected string
+	}{
+		{
+			name:     "no public address specified",
+			expected: "https://<proxyhost>:3080",
+		},
+		{
+			name: "default port",
+			config: ProxyConfig{
+				PublicAddrs: []utils.NetAddr{
+					{Addr: "0.0.0.0", AddrNetwork: "tcp"},
+				},
+			},
+			expected: "https://0.0.0.0:3080",
+		},
+		{
+			name: "non-default port",
+			config: ProxyConfig{
+				PublicAddrs: []utils.NetAddr{
+					{Addr: "0.0.0.0:443", AddrNetwork: "tcp"},
+				},
+			},
+			expected: "https://0.0.0.0:443",
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := test.config.WebPublicAddr()
+			require.NoError(t, err)
+
+			require.Equal(t, test.expected, out)
+		})
+	}
+}


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/27269 to branch/v11