### PR TITLE
Add UI `node` lock to use `server_id` instead

### DIFF
--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Nodes.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Nodes.tsx
@@ -54,12 +54,14 @@ export function Nodes(props: ServerSideListProps & { nodes: Node[] }) {
         {
           altKey: 'action-btn',
           render: agent =>
-            renderActionCell(Boolean(selectedResources.node[agent.id]), () =>
-              toggleSelectResource({
-                kind: 'node',
-                targetValue: agent.id,
-                friendlyName: agent.hostname,
-              })
+            renderActionCell(
+              Boolean(selectedResources.server_id[agent.id]),
+              () =>
+                toggleSelectResource({
+                  kind: 'server_id',
+                  targetValue: agent.id,
+                  friendlyName: agent.hostname,
+                })
             ),
         },
       ]}

--- a/web/packages/teleport/src/LocksV2/NewLock/common.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/common.tsx
@@ -45,6 +45,7 @@ export type LockResourceKind =
   | 'role'
   | 'login'
   | 'node'
+  | 'server_id'
   | 'mfa_device'
   | 'windows_desktop'
   | 'access_request'
@@ -69,6 +70,7 @@ export function getEmptyResourceMap(): LockResourceMap {
     login: {},
     access_request: {},
     device: {},
+    server_id: {},
   };
 }
 
@@ -116,7 +118,7 @@ export const baseResourceKindOpts: LockResourceOption[] = [
     listKind: 'logins',
   },
   {
-    value: 'node',
+    value: 'server_id',
     label: 'Servers',
     listKind: 'server-side',
   },


### PR DESCRIPTION
PR #27018 generalized locks to other roles besides `RoleNode` by adding a new field `server_id` that forbids the agent to connect to the cluster independently of the roles it has associated.

This PR converts the UI lock of nodes from `node` to the new `server_id` field.

![screenshot_2023-06-05_18:05:31_selection](https://github.com/gravitational/teleport/assets/3629062/f7c52d83-a412-4e81-a160-777f71da8b8d)


