### PR TITLE
Add Assist to the access role

### DIFF
--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -634,7 +634,7 @@ func TestPresets(t *testing.T) {
 		err = createPresets(ctx, roleManager)
 		require.NoError(t, err)
 
-		require.Equal(t, 0, roleManager.upsertRoleCallsCount, "unexpected call to UpsertRole")
+		require.Zero(t, roleManager.upsertRoleCallsCount, "unexpected call to UpsertRole")
 		require.Equal(t, presetRoleCount, roleManager.getRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.getRoleCallsCount)
 		require.Equal(t, presetRoleCount, roleManager.createRoleCallsCount, "unexpected number of calls to CreateRole, got %d calls", roleManager.createRoleCallsCount)
 

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -148,6 +148,7 @@ func NewPresetAccessRole() types.Role {
 						Where:     "contains(session.participants, user.metadata.name)",
 					},
 					types.NewRule(types.KindInstance, RO()),
+					types.NewRule(types.KindAssistant, append(RW(), types.VerbUse)),
 					// Please see defaultAllowRules when adding a new rule.
 				},
 				// By default, allow users with the access role to request any user group.

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -254,6 +254,11 @@ func defaultAllowRules() map[string][]types.Rule {
 			types.NewRule(types.KindBilling, RW()),
 			types.NewRule(types.KindAssistant, append(RW(), types.VerbUse)),
 		},
+		teleport.PresetAccessRoleName: {
+			// Allow assist access to access role. This role only allow access
+			// to the assist console, not any other cluster resources.
+			types.NewRule(types.KindAssistant, append(RW(), types.VerbUse)),
+		},
 	}
 }
 


### PR DESCRIPTION
Per our latest conversation, we want to add Teleport Assist access to everyone with the built-in access role.