### PR TITLE
add styles to tooltip for team pages

### DIFF
--- a/web/packages/design/src/theme/darkTheme.ts
+++ b/web/packages/design/src/theme/darkTheme.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import { fonts } from './fonts';
 import { getContrastRatio, lighten } from './utils/colorManipulator';
-import { lightBlue, blueGrey, yellow } from './palette';
+import { blueGrey, lightBlue, yellow } from './palette';
 import typography, { fontSizes, fontWeights } from './typography';
 import { sharedStyles } from './sharedStyles';
 
@@ -25,15 +25,15 @@ const contrastThreshold = 3;
 
 const colors = {
   /*
-  Colors in `levels` are used to reflect the perceived depth of elements in the UI.
-  The further back an element is, the more "sunken" it is, and the more forwards it is, the more "elevated" it is (think CSS z-index).
+    Colors in `levels` are used to reflect the perceived depth of elements in the UI.
+    The further back an element is, the more "sunken" it is, and the more forwards it is, the more "elevated" it is (think CSS z-index).
 
-  A `sunken` color would be used to represent something like the background of the app.
-  While `surface` would be the color of the primary surface where most content is located (such as tables).
-  Any colors more "elevated" than that would be used for things such as popovers, menus, and dialogs.
+    A `sunken` color would be used to represent something like the background of the app.
+    While `surface` would be the color of the primary surface where most content is located (such as tables).
+    Any colors more "elevated" than that would be used for things such as popovers, menus, and dialogs.
 
-  For more information on this concept: https://m3.material.io/styles/elevation/applying-elevation
- */
+    For more information on this concept: https://m3.material.io/styles/elevation/applying-elevation
+   */
   levels: {
     deep: '#000000',
 
@@ -112,6 +112,10 @@ const colors = {
       hover: '#33B1FF',
       active: '#66C5FF',
     },
+  },
+
+  tooltip: {
+    background: '#212B2F',
   },
 
   progressBarColor: '#00BFA5',

--- a/web/packages/design/src/theme/lightTheme.ts
+++ b/web/packages/design/src/theme/lightTheme.ts
@@ -110,6 +110,10 @@ const colors = {
     },
   },
 
+  tooltip: {
+    background: '#F0F2F4',
+  },
+
   progressBarColor: '#007D6B',
 
   dark: '#000000',

--- a/web/packages/shared/components/FieldInput/__snapshots__/FieldInput.test.tsx.snap
+++ b/web/packages/shared/components/FieldInput/__snapshots__/FieldInput.test.tsx.snap
@@ -149,6 +149,7 @@ exports[`snapshot tests 1`] = `
       </span>
       <span
         class="c5"
+        role="icon"
       >
         <span
           class="c6 icon icon-info_outline "
@@ -186,6 +187,7 @@ exports[`snapshot tests 1`] = `
       </span>
       <span
         class="c5"
+        role="icon"
       >
         <span
           class="c6 icon icon-info_outline "

--- a/web/packages/shared/components/ToolTip/ToolTip.tsx
+++ b/web/packages/shared/components/ToolTip/ToolTip.tsx
@@ -17,7 +17,7 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-import { Text, Popover } from 'design';
+import { Popover, Text } from 'design';
 import * as Icons from 'design/Icon';
 
 export const ToolTipInfo: React.FC = ({ children }) => {
@@ -35,6 +35,7 @@ export const ToolTipInfo: React.FC = ({ children }) => {
   return (
     <>
       <span
+        role="icon"
         aria-owns={open ? 'mouse-over-popover' : undefined}
         onMouseEnter={handlePopoverOpen}
         onMouseLeave={handlePopoverClose}
@@ -76,7 +77,7 @@ const modalCss = () => `
 `;
 
 const StyledOnHover = styled(Text)`
-  background-color: white;
-  color: black;
+  color: ${props => props.theme.colors.text.main};
+  background-color: ${props => props.theme.colors.tooltip.background};
   max-width: 350px;
 `;


### PR DESCRIPTION
As per the Team design session, this updates the colors and padding on tooltips according to [Figma](https://www.figma.com/file/Gpjs9vjhzUKF1GDbeG9JGE/Application-Design-System?type=design&node-id=997-2807&t=sgJQFU92pAxiGGAe-0). Does not include "speech bubble arrow"

![Screenshot 2023-06-05 at 2 06 12 PM](https://github.com/gravitational/teleport/assets/11967646/daad345e-0352-4fd7-8d06-c0b74ed3da85)

![Screenshot 2023-06-05 at 2 05 22 PM](https://github.com/gravitational/teleport/assets/11967646/4880e894-c7ab-4a50-855d-d9d82903dc32)


supports https://github.com/gravitational/cloud/issues/4712