### PR TITLE
[v11] Propagate proxy public addr in Web UI ssh session

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -95,6 +95,11 @@ type NodeClient struct {
 
 	mu      sync.Mutex
 	closers []io.Closer
+
+	// ProxyPublicAddr is the web proxy public addr, as opposed to the local proxy
+	// addr set in TC.WebProxyAddr. This is needed to report the correct address
+	// to SSH_TELEPORT_WEBPROXY_ADDR used by some features like "teleport status".
+	ProxyPublicAddr string
 }
 
 // AddCloser adds an [io.Closer] that will be closed when the
@@ -1794,11 +1799,14 @@ func (c *NodeClient) RunInteractiveShell(ctx context.Context, mode types.Session
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
 	env[teleport.EnvSSHSessionInvited] = string(encoded)
 	for key, value := range c.TC.Env {
 		env[key] = value
 	}
+
+	// Overwrite "SSH_SESSION_WEBPROXY_ADDR" with the public addr reported by the proxy. Otherwise,
+	// this would be set to the localhost addr (tc.WebProxyAddr) used for Web UI client connections.
+	env[teleport.SSHSessionWebproxyAddr] = c.ProxyPublicAddr
 
 	nodeSession, err := newSession(ctx, c, sessToJoin, env, c.TC.Stdin, c.TC.Stdout, c.TC.Stderr, c.TC.EnableEscapeSequences)
 	if err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2534,6 +2534,7 @@ func (h *Handler) siteNodeConnect(
 		SessionData:        sessionData,
 		KeepAliveInterval:  netConfig.GetKeepAliveInterval(),
 		ProxyHostPort:      h.ProxyHostPort(),
+		ProxyPublicAddr:    h.PublicProxyAddr(),
 		InteractiveCommand: req.InteractiveCommand,
 		Router:             h.cfg.Router,
 		TracerProvider:     h.cfg.TracerProvider,

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -120,6 +120,7 @@ func NewTerminal(ctx context.Context, cfg TerminalHandlerConfig) (*TerminalHandl
 		sessionData:        cfg.SessionData,
 		keepAliveInterval:  cfg.KeepAliveInterval,
 		proxyHostPort:      cfg.ProxyHostPort,
+		proxyPublicAddr:    cfg.ProxyPublicAddr,
 		interactiveCommand: cfg.InteractiveCommand,
 		term:               cfg.Term,
 		router:             cfg.Router,
@@ -147,7 +148,9 @@ type TerminalHandlerConfig struct {
 	KeepAliveInterval time.Duration
 	// proxyHostPort is the address of the server to connect to.
 	ProxyHostPort string
-	// interactiveCommand is a command to execute.
+	// ProxyPublicAddr is the public web proxy address.
+	ProxyPublicAddr string
+	// InteractiveCommand is a command to execute.
 	InteractiveCommand []string
 	// Router determines how connections to nodes are created
 	Router *proxy.Router
@@ -233,6 +236,9 @@ type TerminalHandler struct {
 
 	// proxyHostPort is the address of the server to connect to.
 	proxyHostPort string
+
+	// proxyPublicAddr is the public web proxy address.
+	proxyPublicAddr string
 
 	// interactiveCommand is a command to execute.
 	interactiveCommand []string
@@ -784,6 +790,8 @@ func (t *TerminalHandler) connectToNode(ctx context.Context, ws *websocket.Conn,
 		return nil, trace.NewAggregate(err, conn.Close())
 	}
 
+	clt.ProxyPublicAddr = t.proxyPublicAddr
+
 	return clt, nil
 }
 
@@ -815,6 +823,8 @@ func (t *TerminalHandler) connectToNodeWithMFA(ctx context.Context, ws *websocke
 	if err != nil {
 		return nil, trace.NewAggregate(err, conn.Close())
 	}
+
+	nc.ProxyPublicAddr = t.proxyPublicAddr
 
 	return nc, nil
 }


### PR DESCRIPTION
backport https://github.com/gravitational/teleport/pull/27058 to branch/v11