### PR TITLE
don't emit session recording audit events when session recording is disabled

### DIFF
--- a/api/types/events/api.go
+++ b/api/types/events/api.go
@@ -82,6 +82,13 @@ type Emitter interface {
 type Stream interface {
 	// Emitter allows stream to emit audit event in the context of the event stream
 	Emitter
+	// StreamManager allows the stream to be managed
+	StreamManager
+}
+
+// SteamManager is used to manage a continuous ordered sequence of events
+// associated with a session.
+type StreamManager interface {
 	// Status returns channel broadcasting updates about the stream state:
 	// last event index that was uploaded and the upload ID
 	Status() <-chan StreamStatus

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -412,7 +412,7 @@ func (s *Service) emitCommandEvent(eventBytes []byte) {
 			Path:       argv[0],
 			Argv:       argv[1:],
 		}
-		if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionCommandEvent); err != nil {
+		if err := ctx.Emitter.EmitSessionRecordingEvent(ctx.Context, sessionCommandEvent); err != nil {
 			log.WithError(err).Warn("Failed to emit command event.")
 		}
 
@@ -470,7 +470,7 @@ func (s *Service) emitDiskEvent(eventBytes []byte) {
 		ReturnCode: event.ReturnCode,
 	}
 	// Logs can be DoS by event failures here
-	_ = ctx.Emitter.EmitAuditEvent(ctx.Context, sessionDiskEvent)
+	_ = ctx.Emitter.EmitSessionRecordingEvent(ctx.Context, sessionDiskEvent)
 }
 
 // emit4NetworkEvent will parse and emit IPv4 events to the Audit Log.
@@ -532,7 +532,7 @@ func (s *Service) emit4NetworkEvent(eventBytes []byte) {
 		SrcAddr:    srcAddr.String(),
 		TCPVersion: 4,
 	}
-	if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
+	if err := ctx.Emitter.EmitSessionRecordingEvent(ctx.Context, sessionNetworkEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit network event.")
 	}
 }
@@ -602,7 +602,7 @@ func (s *Service) emit6NetworkEvent(eventBytes []byte) {
 		SrcAddr:    srcAddr.String(),
 		TCPVersion: 6,
 	}
-	if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
+	if err := ctx.Emitter.EmitSessionRecordingEvent(ctx.Context, sessionNetworkEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit network event.")
 	}
 }

--- a/lib/bpf/common.go
+++ b/lib/bpf/common.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
-	apievents "github.com/gravitational/teleport/api/types/events"
+	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -73,7 +73,7 @@ type SessionContext struct {
 	PID int
 
 	// Emitter is used to record events for a particular session
-	Emitter apievents.Emitter
+	Emitter events.SessionEmitter
 
 	// Events is the set of events (command, disk, or network) to record for
 	// this session.
@@ -81,8 +81,7 @@ type SessionContext struct {
 }
 
 // NOP is used on either non-Linux systems or when BPF support is not enabled.
-type NOP struct {
-}
+type NOP struct{}
 
 // Close closes the NOP service. Note this function does nothing.
 func (s *NOP) Close(bool) error {

--- a/lib/events/api.go
+++ b/lib/events/api.go
@@ -799,17 +799,45 @@ type UploadMetadataGetter interface {
 	GetUploadMetadata(sid session.ID) UploadMetadata
 }
 
+// SessionEmitter is for emitters that need to emit session recording events.
+type SessionEmitter interface {
+	// EmitSessionRecordingEvent emits a single audit event if session recording is enabled.
+	EmitSessionRecordingEvent(ctx context.Context, event apievents.AuditEvent) error
+}
+
+// SessionEmitter is for emitters that need to emit audit and session
+// recording events.
+type AuditSessionEmitter interface {
+	apievents.Emitter
+	SessionEmitter
+}
+
 // StreamWriter implements io.Writer to be plugged into the multi-writer
-// associated with every session. It forwards session stream to the audit log
+// associated with every session. It forwards session stream to the audit log.
 type StreamWriter interface {
 	io.Writer
-	apievents.Stream
+	SessionEmitter
+	apievents.StreamManager
+}
+
+// AuditStreamWriter is a StreamWriter that can also emit audit events.
+type AuditStreamWriter interface {
+	apievents.Emitter
+	StreamWriter
 }
 
 // StreamEmitter supports submitting single events and streaming
-// session events
+// session events.
 type StreamEmitter interface {
 	apievents.Emitter
+	Streamer
+}
+
+// SessionStreamEmitter supports submitting single session or audit
+// events and streaming session events.
+type SessionStreamEmitter interface {
+	apievents.Emitter
+	SessionEmitter
 	Streamer
 }
 

--- a/lib/events/auditwriter.go
+++ b/lib/events/auditwriter.go
@@ -173,8 +173,8 @@ func bytesToSessionPrintEvents(b []byte) []apievents.AuditEvent {
 	return result
 }
 
-// AuditWriter wraps session stream
-// and writes audit events to it
+// AuditWriter wraps a session stream and writes session-related audit events to it.
+// A different emitter should be used for non-session events.
 type AuditWriter struct {
 	mtx            sync.Mutex
 	cfg            AuditWriterConfig
@@ -281,7 +281,15 @@ func (a *AuditWriter) maybeSetBackoff(backoffUntil time.Time) bool {
 	}
 }
 
-// EmitAuditEvent emits audit event
+// EmitSessionRecordingEvent emits a session recording event if session recording is enabled.
+func (a *AuditWriter) EmitSessionRecordingEvent(ctx context.Context, event apievents.AuditEvent) error {
+	if !a.cfg.RecordOutput {
+		return nil
+	}
+
+	return a.EmitAuditEvent(ctx, event)
+}
+
 func (a *AuditWriter) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	// Event modification is done under lock and in the same goroutine
 	// as the caller to avoid data races and event copying

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -105,6 +105,11 @@ func (*DiscardStream) EmitAuditEvent(ctx context.Context, event apievents.AuditE
 	return nil
 }
 
+// EmitSessionRecordingEvent discards audit event
+func (d *DiscardStream) EmitSessionRecordingEvent(ctx context.Context, event apievents.AuditEvent) error {
+	return d.EmitAuditEvent(ctx, event)
+}
+
 // NewDiscardEmitter returns a no-op discard emitter
 func NewDiscardEmitter() *DiscardEmitter {
 	return &DiscardEmitter{}
@@ -122,6 +127,11 @@ func (*DiscardEmitter) EmitAuditEvent(ctx context.Context, event apievents.Audit
 		"event_index": event.GetIndex(),
 	}).Debugf("Discarding event")
 	return nil
+}
+
+// EmitSessionRecordingEvent discards audit event
+func (d *DiscardEmitter) EmitSessionRecordingEvent(ctx context.Context, event apievents.AuditEvent) error {
+	return d.EmitAuditEvent(ctx, event)
 }
 
 // CreateAuditStream creates a stream that discards all events

--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -239,8 +239,7 @@ func NewLoggingEmitter() *LoggingEmitter {
 }
 
 // LoggingEmitter logs all events with info level
-type LoggingEmitter struct {
-}
+type LoggingEmitter struct{}
 
 // EmitAuditEvent logs audit event, skips session print events, session
 // disk events and app session request events, because they are very verbose.
@@ -291,10 +290,19 @@ func (m *MultiEmitter) EmitAuditEvent(ctx context.Context, event apievents.Audit
 	return trace.NewAggregate(errors...)
 }
 
-// StreamerAndEmitter combines streamer and emitter to create stream emitter
+// StreamerAndEmitter combines a streamer and an emitter to create stream emitter
 type StreamerAndEmitter struct {
 	Streamer
 	apievents.Emitter
+	EmitSessionRecordings bool
+}
+
+func (s *StreamerAndEmitter) EmitSessionRecordingEvent(ctx context.Context, event apievents.AuditEvent) error {
+	if !s.EmitSessionRecordings {
+		return nil
+	}
+
+	return s.EmitAuditEvent(ctx, event)
 }
 
 // CheckingStreamerConfig provides parameters for streamer

--- a/lib/events/eventstest/channel.go
+++ b/lib/events/eventstest/channel.go
@@ -50,6 +50,10 @@ func (e *ChannelEmitter) EmitAuditEvent(ctx context.Context, event events.AuditE
 	}
 }
 
+func (e *ChannelEmitter) EmitSessionRecordingEvent(ctx context.Context, event events.AuditEvent) error {
+	return e.EmitAuditEvent(ctx, event)
+}
+
 func (e *ChannelEmitter) C() <-chan events.AuditEvent {
 	return e.events
 }

--- a/lib/events/eventstest/mock_emitter.go
+++ b/lib/events/eventstest/mock_emitter.go
@@ -38,6 +38,10 @@ func (e *MockEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEven
 	return nil
 }
 
+func (e *MockEmitter) EmitSessionRecordingEvent(ctx context.Context, event events.AuditEvent) error {
+	return e.EmitAuditEvent(ctx, event)
+}
+
 // LastEvent returns the last emitted event.
 func (e *MockEmitter) LastEvent() events.AuditEvent {
 	e.mu.RLock()

--- a/lib/events/filesessions/fileasync.go
+++ b/lib/events/filesessions/fileasync.go
@@ -140,7 +140,7 @@ func (u *Uploader) writeSessionError(sessionID session.ID, err error) error {
 		return trace.BadParameter("missing session ID")
 	}
 	path := u.sessionErrorFilePath(sessionID)
-	return trace.ConvertSystemError(os.WriteFile(path, []byte(err.Error()), 0600))
+	return trace.ConvertSystemError(os.WriteFile(path, []byte(err.Error()), 0o600))
 }
 
 func (u *Uploader) checkSessionError(sessionID session.ID) (bool, error) {
@@ -405,7 +405,7 @@ func (u *Uploader) startUpload(ctx context.Context, fileName string) error {
 		file:         sessionFile,
 		fileUnlockFn: unlock,
 	}
-	upload.checkpointFile, err = os.OpenFile(u.checkpointFilePath(sessionID), os.O_RDWR|os.O_CREATE, 0600)
+	upload.checkpointFile, err = os.OpenFile(u.checkpointFilePath(sessionID), os.O_RDWR|os.O_CREATE, 0o600)
 	if err != nil {
 		if err := upload.Close(); err != nil {
 			u.log.WithError(err).Warningf("Failed to close upload.")

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -124,7 +124,7 @@ type ForwarderConfig struct {
 	CachingAuthClient auth.ReadKubernetesAccessPoint
 	// StreamEmitter is used to create audit streams
 	// and emit audit events
-	StreamEmitter events.StreamEmitter
+	StreamEmitter events.SessionStreamEmitter
 	// DataDir is a data dir to store logs
 	DataDir string
 	// Namespace is a namespace of the proxy server (not a K8s namespace)
@@ -1495,7 +1495,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 		SessionRecording: ctx.recordingConfig.GetMode(),
 	}
 
-	if err := f.cfg.StreamEmitter.EmitAuditEvent(f.ctx, sessionStartEvent); err != nil {
+	if err := f.cfg.StreamEmitter.EmitSessionRecordingEvent(f.ctx, sessionStartEvent); err != nil {
 		f.log.WithError(err).Warn("Failed to emit event.")
 	}
 
@@ -1516,7 +1516,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 	}
 
 	defer func() {
-		if err := f.cfg.StreamEmitter.EmitAuditEvent(f.ctx, execEvent); err != nil {
+		if err := f.cfg.StreamEmitter.EmitSessionRecordingEvent(f.ctx, execEvent); err != nil {
 			f.log.WithError(err).Warn("Failed to emit exec event.")
 		}
 
@@ -1539,7 +1539,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 			SessionRecording:          ctx.recordingConfig.GetMode(),
 		}
 
-		if err := f.cfg.StreamEmitter.EmitAuditEvent(f.ctx, sessionEndEvent); err != nil {
+		if err := f.cfg.StreamEmitter.EmitSessionRecordingEvent(f.ctx, sessionEndEvent); err != nil {
 			f.log.WithError(err).Warn("Failed to emit session end event.")
 		}
 	}()
@@ -1800,7 +1800,7 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 		if !success {
 			portForward.Code = events.PortForwardFailureCode
 		}
-		if err := f.cfg.StreamEmitter.EmitAuditEvent(f.ctx, portForward); err != nil {
+		if err := f.cfg.StreamEmitter.EmitSessionRecordingEvent(f.ctx, portForward); err != nil {
 			f.log.WithError(err).Warn("Failed to emit event.")
 		}
 	}

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -329,7 +329,7 @@ type session struct {
 
 	recorder events.StreamWriter
 
-	emitter apievents.Emitter
+	emitter events.SessionEmitter
 
 	podName string
 
@@ -562,7 +562,7 @@ func (s *session) launch() error {
 		SessionRecording:          s.ctx.recordingConfig.GetMode(),
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionStartEvent); err != nil {
+	if err := s.emitter.EmitSessionRecordingEvent(s.forwarder.ctx, sessionStartEvent); err != nil {
 		s.forwarder.log.WithError(err).Warn("Failed to emit event.")
 	}
 
@@ -661,7 +661,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 
 			// Report the updated window size to the event log (this is so the sessions
 			// can be replayed correctly).
-			if err := s.recorder.EmitAuditEvent(s.forwarder.ctx, resizeEvent); err != nil {
+			if err := s.recorder.EmitSessionRecordingEvent(s.forwarder.ctx, resizeEvent); err != nil {
 				s.forwarder.log.WithError(err).Warn("Failed to emit terminal resize event.")
 			}
 		}
@@ -779,7 +779,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 
 		}
 
-		if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, execEvent); err != nil {
+		if err := s.emitter.EmitSessionRecordingEvent(s.forwarder.ctx, execEvent); err != nil {
 			s.forwarder.log.WithError(err).Warn("Failed to emit exec event.")
 		}
 
@@ -799,7 +799,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 			BytesReceived: s.io.CountWritten(),
 		}
 
-		if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionDataEvent); err != nil {
+		if err := s.emitter.EmitSessionRecordingEvent(s.forwarder.ctx, sessionDataEvent); err != nil {
 			s.forwarder.log.WithError(err).Warn("Failed to emit session data event.")
 		}
 
@@ -823,7 +823,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 			SessionRecording:          s.ctx.recordingConfig.GetMode(),
 		}
 
-		if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionEndEvent); err != nil {
+		if err := s.emitter.EmitSessionRecordingEvent(s.forwarder.ctx, sessionEndEvent); err != nil {
 			s.forwarder.log.WithError(err).Warn("Failed to emit session end event.")
 		}
 	}, nil
@@ -881,7 +881,7 @@ func (s *session) join(p *party) error {
 		},
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionJoinEvent); err != nil {
+	if err := s.emitter.EmitSessionRecordingEvent(s.forwarder.ctx, sessionJoinEvent); err != nil {
 		s.forwarder.log.WithError(err).Warn("Failed to emit event.")
 	}
 
@@ -1017,7 +1017,7 @@ func (s *session) unlockedLeave(id uuid.UUID) (bool, error) {
 		},
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionLeaveEvent); err != nil {
+	if err := s.emitter.EmitSessionRecordingEvent(s.forwarder.ctx, sessionLeaveEvent); err != nil {
 		s.forwarder.log.WithError(err).Warn("Failed to emit event.")
 	}
 

--- a/lib/restrictedsession/restricted.go
+++ b/lib/restrictedsession/restricted.go
@@ -41,13 +41,11 @@ var log = logrus.WithFields(logrus.Fields{
 	trace.Component: teleport.ComponentRestrictedSession,
 })
 
-var (
-	lostRestrictedEvents = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: teleport.MetricLostRestrictedEvents,
-			Help: "Number of lost restricted events.",
-		},
-	)
+var lostRestrictedEvents = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: teleport.MetricLostRestrictedEvents,
+		Help: "Number of lost restricted events.",
+	},
 )
 
 //go:embed bytecode
@@ -292,7 +290,7 @@ func (l *auditEventLoop) loop() {
 			continue
 		}
 
-		if err = ctx.Emitter.EmitAuditEvent(ctx.Context, event); err != nil {
+		if err = ctx.Emitter.EmitSessionRecordingEvent(ctx.Context, event); err != nil {
 			log.WithError(err).Warn("Failed to emit network event.")
 		}
 	}

--- a/lib/service/kubernetes.go
+++ b/lib/service/kubernetes.go
@@ -206,9 +206,16 @@ func (process *TeleportProcess) initKubernetesService(log *logrus.Entry, conn *C
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	recConfig, err := accessPoint.GetSessionRecordingConfig(process.ExitContext())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
 	streamEmitter := &events.StreamerAndEmitter{
-		Emitter:  asyncEmitter,
-		Streamer: streamer,
+		Emitter:               asyncEmitter,
+		Streamer:              streamer,
+		EmitSessionRecordings: recConfig.GetMode() != types.RecordOff,
 	}
 
 	var publicAddr string

--- a/lib/srv/app/common/audit.go
+++ b/lib/srv/app/common/audit.go
@@ -51,7 +51,7 @@ type Audit interface {
 // AuditConfig is the audit events emitter configuration.
 type AuditConfig struct {
 	// Emitter is used to emit audit events.
-	Emitter apievents.Emitter
+	Emitter events.SessionEmitter
 }
 
 // Check validates the config.
@@ -215,7 +215,7 @@ func (a *audit) OnDynamoDBRequest(ctx context.Context, sessionCtx *SessionContex
 
 // EmitEvent emits the provided audit event.
 func (a *audit) EmitEvent(ctx context.Context, event apievents.AuditEvent) error {
-	return trace.Wrap(a.cfg.Emitter.EmitAuditEvent(ctx, event))
+	return trace.Wrap(a.cfg.Emitter.EmitSessionRecordingEvent(ctx, event))
 }
 
 // MakeAppMetadata returns common server metadata for database session.

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1049,14 +1049,23 @@ func (s *Server) newHTTPServer(clusterName string) *http.Server {
 
 // newTCPServer creates a server that proxies TCP applications.
 func (s *Server) newTCPServer() (*tcpServer, error) {
-	audit, err := common.NewAudit(common.AuditConfig{
-		Emitter: s.c.Emitter,
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 	return &tcpServer{
-		audit:  audit,
+		newEmitter: func(sessionID string) (common.Audit, error) {
+			// Audit stream is using server context, not session context,
+			// to make sure that session is uploaded even after it is closed.
+			streamWriter, err := s.newStreamWriter(s.closeContext, sessionID)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+			audit, err := common.NewAudit(common.AuditConfig{
+				Emitter: streamWriter,
+			})
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			return audit, nil
+		},
 		hostID: s.c.HostID,
 		log:    s.log,
 	}, nil

--- a/lib/srv/app/tcpserver.go
+++ b/lib/srv/app/tcpserver.go
@@ -31,9 +31,9 @@ import (
 )
 
 type tcpServer struct {
-	audit  common.Audit
-	hostID string
-	log    logrus.FieldLogger
+	newEmitter func(sessionID string) (common.Audit, error)
+	hostID     string
+	log        logrus.FieldLogger
 }
 
 // handleConnection handles connection from a TCP application.
@@ -52,14 +52,20 @@ func (s *tcpServer) handleConnection(ctx context.Context, clientConn net.Conn, i
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := s.audit.OnSessionStart(ctx, s.hostID, identity, app); err != nil {
+
+	emitter, err := s.newEmitter(identity.RouteToApp.SessionID)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if err := emitter.OnSessionStart(ctx, s.hostID, identity, app); err != nil {
 		return trace.Wrap(err)
 	}
 	defer func() {
-		if err := s.audit.OnSessionEnd(ctx, s.hostID, identity, app); err != nil {
+		if err := emitter.OnSessionEnd(ctx, s.hostID, identity, app); err != nil {
 			s.log.WithError(err).Warnf("Failed to emit session end event for app %v.", app.GetName())
 		}
 	}()
+
 	err = utils.ProxyConn(ctx, clientConn, serverConn)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -977,7 +977,7 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 	if !c.srv.UseTunnel() {
 		sessionDataEvent.ConnectionMetadata.LocalAddr = c.ServerConn.LocalAddr().String()
 	}
-	if err := c.GetServer().EmitAuditEvent(c.GetServer().Context(), sessionDataEvent); err != nil {
+	if err := c.EmitSessionRecordingEvent(c.GetServer().Context(), sessionDataEvent); err != nil {
 		c.WithError(err).Warn("Failed to emit session data event.")
 	}
 
@@ -1343,4 +1343,12 @@ func (c *ServerContext) GetExecRequest() (Exec, error) {
 		return nil, trace.NotFound("execRequest has not been set")
 	}
 	return c.execRequest, nil
+}
+
+func (c *ServerContext) EmitSessionRecordingEvent(ctx context.Context, event apievents.AuditEvent) error {
+	if c.SessionRecordingConfig.GetMode() == types.RecordOff {
+		return nil
+	}
+
+	return c.GetServer().EmitAuditEvent(ctx, event)
 }

--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -54,7 +54,7 @@ type Query struct {
 // AuditConfig is the audit events emitter configuration.
 type AuditConfig struct {
 	// Emitter is used to emit audit events.
-	Emitter events.Emitter
+	Emitter libevents.SessionEmitter
 }
 
 // Check validates the config.
@@ -155,7 +155,7 @@ func (a *audit) OnQuery(ctx context.Context, session *Session, query Query) {
 
 // EmitEvent emits the provided audit event using configured emitter.
 func (a *audit) EmitEvent(ctx context.Context, event events.AuditEvent) {
-	if err := a.cfg.Emitter.EmitAuditEvent(ctx, event); err != nil {
+	if err := a.cfg.Emitter.EmitSessionRecordingEvent(ctx, event); err != nil {
 		a.log.WithError(err).Errorf("Failed to emit audit event: %s - %s.", event.GetType(), event.GetID())
 	}
 }

--- a/lib/srv/db/sqlserver/engine_test.go
+++ b/lib/srv/db/sqlserver/engine_test.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"io"
 	"net"
-	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -34,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/events"
 	libevents "github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/db/common"
 	"github.com/gravitational/teleport/lib/srv/db/sqlserver/protocol"
@@ -151,7 +151,7 @@ func TestHandleConnectionAuditEvents(t *testing.T) {
 
 			_, err = b.Write(tc.packet)
 			require.NoError(t, err)
-			emitterMock := &mockEmitter{}
+			emitterMock := &eventstest.MockEmitter{}
 			audit, err := common.NewAudit(common.AuditConfig{Emitter: emitterMock})
 			require.NoError(t, err)
 
@@ -177,7 +177,7 @@ func TestHandleConnectionAuditEvents(t *testing.T) {
 				Database: &types.DatabaseV3{},
 			})
 			for _, ch := range tc.checks {
-				ch(t, err, emitterMock.emittedEvents)
+				ch(t, err, emitterMock.Events())
 			}
 		})
 	}
@@ -191,23 +191,12 @@ type mockConn struct {
 func (o *mockConn) Read(p []byte) (n int, err error) {
 	return o.buff.Read(p)
 }
+
 func (o *mockConn) Write(p []byte) (n int, err error) {
 	return len(p), nil
 }
+
 func (o *mockConn) Close() error {
-	return nil
-}
-
-type mockEmitter struct {
-	Emitter       events.Emitter
-	emittedEvents []events.AuditEvent
-	mtx           sync.Mutex
-}
-
-func (m *mockEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
-	m.mtx.Lock()
-	defer m.mtx.Unlock()
-	m.emittedEvents = append(m.emittedEvents, event)
 	return nil
 }
 

--- a/lib/srv/exec_test.go
+++ b/lib/srv/exec_test.go
@@ -78,7 +78,7 @@ func TestEmitExecAuditEvent(t *testing.T) {
 		XXX_sizecache:        0,
 	}
 
-	var tests = []struct {
+	tests := []struct {
 		inCommand  string
 		inError    error
 		outCommand string

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -2052,9 +2052,9 @@ func (s *session) emitAuditEvent(ctx context.Context, event apievents.AuditEvent
 		}
 		s.setRecorder(newRecorder)
 
-		return trace.Wrap(newRecorder.EmitAuditEvent(ctx, event))
+		return trace.Wrap(newRecorder.EmitSessionRecordingEvent(ctx, event))
 	default:
-		return trace.Wrap(rec.EmitAuditEvent(ctx, event))
+		return trace.Wrap(rec.EmitSessionRecordingEvent(ctx, event))
 	}
 }
 

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -143,7 +143,6 @@ func TestIsApprovedFileTransfer(t *testing.T) {
 		reqID          string
 		location       string
 	}{
-
 		{
 			name:           "no file request found with supplied ID",
 			expectedResult: false,
@@ -743,6 +742,10 @@ func (m *mockRecorder) Done() <-chan struct{} {
 
 func (m *mockRecorder) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	return m.emitter.EmitAuditEvent(ctx, event)
+}
+
+func (m *mockRecorder) EmitSessionRecordingEvent(ctx context.Context, event apievents.AuditEvent) error {
+	return m.emitter.EmitSessionRecordingEvent(ctx, event)
 }
 
 type trackerService struct {


### PR DESCRIPTION
Introduce a new method of `AuditWriter` that is exclusively for emitting session recording events to make it clear whether audit or session recording events are being emitted.

Fixes [#16773](https://github.com/gravitational/teleport/issues/16773).
Fixes [#25115](https://github.com/gravitational/teleport/issues/25115).