### PR TITLE
Upgrade mongodb to v1.11.7

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       - dependency-name: github.com/gravitational/ttlmap
       # Breaks backwards compatibility
       - dependency-name: github.com/go-webauthn/webauthn
-      # TODO(greedy52): Update mongo-driver and fix API changes.
-      - dependency-name: go.mongodb.org/mongo-driver
       # Must be kept in-sync with libbpf
       - dependency-name: github.com/aquasecurity/libbpfgo
       # Forked/replaced dependencies

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/xitongsys/parquet-go-source v0.0.0-20230312005205-fbbcdea5f512
 	go.etcd.io/etcd/api/v3 v3.5.9
 	go.etcd.io/etcd/client/v3 v3.5.9
-	go.mongodb.org/mongo-driver v1.10.6
+	go.mongodb.org/mongo-driver v1.11.6
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0

--- a/go.mod
+++ b/go.mod
@@ -137,7 +137,7 @@ require (
 	github.com/xitongsys/parquet-go-source v0.0.0-20230312005205-fbbcdea5f512
 	go.etcd.io/etcd/api/v3 v3.5.9
 	go.etcd.io/etcd/client/v3 v3.5.9
-	go.mongodb.org/mongo-driver v1.11.6
+	go.mongodb.org/mongo-driver v1.11.7
 	go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352
 	go.opentelemetry.io/contrib/instrumentation/github.com/aws/aws-sdk-go-v2/otelaws v0.42.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -1666,8 +1666,8 @@ go.etcd.io/etcd/tests/v3 v3.5.0-alpha.0/go.mod h1:HnrHxjyCuZ8YDt8PYVyQQ5d1ZQfzJV
 go.etcd.io/etcd/tests/v3 v3.5.0/go.mod h1:f+mtZ1bE1YPvgKdOJV2BKy4JQW0nAFnQehgOE7+WyJE=
 go.etcd.io/etcd/v3 v3.5.0-alpha.0/go.mod h1:JZ79d3LV6NUfPjUxXrpiFAYcjhT+06qqw+i28snx8To=
 go.etcd.io/etcd/v3 v3.5.0/go.mod h1:FldM0/VzcxYWLvWx1sdA7ghKw7C3L2DvUTzGrcEtsC4=
-go.mongodb.org/mongo-driver v1.10.6 h1:d/XGSUi/++VkvvU7+QpFqJZzuccp+rUSYMJ5Q3rjx8I=
-go.mongodb.org/mongo-driver v1.10.6/go.mod h1:z4XpeoU6w+9Vht+jAFyLgVrD+jGSQQe0+CBWFHNiHt8=
+go.mongodb.org/mongo-driver v1.11.6 h1:XM7G6PjiGAO5betLF13BIa5TlLUUE3uJ/2Ox3Lz1K+o=
+go.mongodb.org/mongo-driver v1.11.6/go.mod h1:G9TgswdsWjX4tmDA5zfs2+6AEPpYJwqblyjsfuh8oXY=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=

--- a/go.sum
+++ b/go.sum
@@ -1666,8 +1666,8 @@ go.etcd.io/etcd/tests/v3 v3.5.0-alpha.0/go.mod h1:HnrHxjyCuZ8YDt8PYVyQQ5d1ZQfzJV
 go.etcd.io/etcd/tests/v3 v3.5.0/go.mod h1:f+mtZ1bE1YPvgKdOJV2BKy4JQW0nAFnQehgOE7+WyJE=
 go.etcd.io/etcd/v3 v3.5.0-alpha.0/go.mod h1:JZ79d3LV6NUfPjUxXrpiFAYcjhT+06qqw+i28snx8To=
 go.etcd.io/etcd/v3 v3.5.0/go.mod h1:FldM0/VzcxYWLvWx1sdA7ghKw7C3L2DvUTzGrcEtsC4=
-go.mongodb.org/mongo-driver v1.11.6 h1:XM7G6PjiGAO5betLF13BIa5TlLUUE3uJ/2Ox3Lz1K+o=
-go.mongodb.org/mongo-driver v1.11.6/go.mod h1:G9TgswdsWjX4tmDA5zfs2+6AEPpYJwqblyjsfuh8oXY=
+go.mongodb.org/mongo-driver v1.11.7 h1:LIwYxASDLGUg/8wOhgOOZhX8tQa/9tgZPgzZoVqJvcs=
+go.mongodb.org/mongo-driver v1.11.7/go.mod h1:G9TgswdsWjX4tmDA5zfs2+6AEPpYJwqblyjsfuh8oXY=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352 h1:CCriYyAfq1Br1aIYettdHZTy8mBTIPo7We18TuO/bak=
 go.mozilla.org/pkcs7 v0.0.0-20210826202110-33d05740a352/go.mod h1:SNgMg+EgDFwmvSmLRTNKC5fegJjB7v23qTQ0XLGUNHk=
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -807,13 +807,15 @@ func TestAccessMongoDB(t *testing.T) {
 		opts []mongodb.TestServerOption
 	}{
 		{
-			name: "new server",
-			opts: []mongodb.TestServerOption{},
+			name: "current server",
+			opts: []mongodb.TestServerOption{
+				mongodb.TestServerWireVersion(wiremessage.OpmsgWireVersion),
+			},
 		},
 		{
-			name: "old server",
+			name: "mongodb 3.6 server",
 			opts: []mongodb.TestServerOption{
-				mongodb.TestServerWireVersion(wiremessage.OpmsgWireVersion - 1),
+				mongodb.TestServerWireVersion(6),
 			},
 		},
 	}

--- a/lib/srv/db/mongodb/connect.go
+++ b/lib/srv/db/mongodb/connect.go
@@ -109,7 +109,7 @@ func (e *Engine) getTopologyOptions(ctx context.Context, sessionCtx *common.Sess
 		return nil, nil, trace.Wrap(err)
 	}
 
-	serverOptions, err := e.getServerOptions(ctx, sessionCtx)
+	serverOptions, err := e.getServerOptions(ctx, sessionCtx, clientCfg)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -124,8 +124,8 @@ func (e *Engine) getTopologyOptions(ctx context.Context, sessionCtx *common.Sess
 }
 
 // getServerOptions constructs server options for connecting to a MongoDB server.
-func (e *Engine) getServerOptions(ctx context.Context, sessionCtx *common.Session) ([]topology.ServerOption, error) {
-	connectionOptions, err := e.getConnectionOptions(ctx, sessionCtx)
+func (e *Engine) getServerOptions(ctx context.Context, sessionCtx *common.Session, clientCfg *options.ClientOptions) ([]topology.ServerOption, error) {
+	connectionOptions, err := e.getConnectionOptions(ctx, sessionCtx, clientCfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -137,7 +137,7 @@ func (e *Engine) getServerOptions(ctx context.Context, sessionCtx *common.Sessio
 }
 
 // getConnectionOptions constructs connection options for connecting to a MongoDB server.
-func (e *Engine) getConnectionOptions(ctx context.Context, sessionCtx *common.Session) ([]topology.ConnectionOption, error) {
+func (e *Engine) getConnectionOptions(ctx context.Context, sessionCtx *common.Session, clientCfg *options.ClientOptions) ([]topology.ConnectionOption, error) {
 	tlsConfig, err := e.Auth.GetTLSConfig(ctx, sessionCtx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -163,7 +163,7 @@ func (e *Engine) getConnectionOptions(ctx context.Context, sessionCtx *common.Se
 				// client connecting to Teleport will get an error when they try
 				// to send its own metadata since client metadata is immutable.
 				&handshaker{},
-				&auth.HandshakeOptions{Authenticator: authenticator})
+				&auth.HandshakeOptions{Authenticator: authenticator, HTTPClient: clientCfg.HTTPClient})
 		}),
 	}, nil
 }

--- a/lib/srv/db/mongodb/connect.go
+++ b/lib/srv/db/mongodb/connect.go
@@ -19,12 +19,12 @@ package mongodb
 import (
 	"context"
 	"crypto/tls"
-	"net/url"
-	"time"
+	"strings"
 
 	"github.com/gravitational/trace"
 	"go.mongodb.org/mongo-driver/mongo/address"
 	"go.mongodb.org/mongo-driver/mongo/description"
+	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/x/mongo/driver"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/auth"
@@ -61,7 +61,7 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (drive
 	// over server connections (reading/writing wire messages) but at the
 	// same time get access to logic such as picking a server to connect to
 	// in a replica set.
-	top, err := topology.New(options...)
+	top, err := topology.New(options)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
@@ -91,30 +91,36 @@ func (e *Engine) connect(ctx context.Context, sessionCtx *common.Session) (drive
 }
 
 // getTopologyOptions constructs topology options for connecting to a MongoDB server.
-func (e *Engine) getTopologyOptions(ctx context.Context, sessionCtx *common.Session) ([]topology.Option, description.ServerSelector, error) {
-	connString, err := getConnectionString(sessionCtx)
+func (e *Engine) getTopologyOptions(ctx context.Context, sessionCtx *common.Session) (*topology.Config, description.ServerSelector, error) {
+	clientCfg := options.Client()
+	clientCfg.SetServerSelectionTimeout(common.DefaultMongoDBServerSelectionTimeout)
+	if strings.HasPrefix(sessionCtx.Database.GetURI(), connstring.SchemeMongoDB) ||
+		strings.HasPrefix(sessionCtx.Database.GetURI(), connstring.SchemeMongoDBSRV) {
+		clientCfg.ApplyURI(sessionCtx.Database.GetURI())
+	} else {
+		clientCfg.Hosts = []string{sessionCtx.Database.GetURI()}
+	}
+	err := clientCfg.Validate()
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	selector, err := getServerSelector(connString)
+	topoConfig, err := topology.NewConfig(clientCfg, nil)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
+
 	serverOptions, err := e.getServerOptions(ctx, sessionCtx)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	return []topology.Option{
-		topology.WithConnString(func(cs connstring.ConnString) connstring.ConnString {
-			return connString
-		}),
-		topology.WithServerSelectionTimeout(func(time.Duration) time.Duration {
-			return common.DefaultMongoDBServerSelectionTimeout
-		}),
-		topology.WithServerOptions(func(so ...topology.ServerOption) []topology.ServerOption {
-			return serverOptions
-		}),
-	}, selector, nil
+	topoConfig.ServerOpts = serverOptions
+
+	selector, err := getServerSelector(clientCfg)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	return topoConfig, selector, nil
 }
 
 // getServerOptions constructs server options for connecting to a MongoDB server.
@@ -213,32 +219,15 @@ func (e *Engine) getAWSAuthenticator(ctx context.Context, sessionCtx *common.Ses
 	return authenticator, nil
 }
 
-// getConnectionString returns connection string for the server.
-func getConnectionString(sessionCtx *common.Session) (connstring.ConnString, error) {
-	uri, err := url.Parse(sessionCtx.Database.GetURI())
-	if err != nil {
-		return connstring.ConnString{}, trace.Wrap(err)
-	}
-	switch uri.Scheme {
-	case connstring.SchemeMongoDB, connstring.SchemeMongoDBSRV:
-		return connstring.ParseAndValidate(sessionCtx.Database.GetURI())
-	}
-	return connstring.ConnString{Hosts: []string{sessionCtx.Database.GetURI()}}, nil
-}
-
 // getServerSelector returns selector for picking the server to connect to,
 // which is mostly useful when connecting to a MongoDB replica set.
 //
 // It uses readPreference connection flag. Defaults to "primary".
-func getServerSelector(connString connstring.ConnString) (description.ServerSelector, error) {
-	if connString.ReadPreference == "" {
+func getServerSelector(clientOptions *options.ClientOptions) (description.ServerSelector, error) {
+	if clientOptions.ReadPreference == nil {
 		return description.ReadPrefSelector(readpref.Primary()), nil
 	}
-	readPrefMode, err := readpref.ModeFromString(connString.ReadPreference)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	readPref, err := readpref.New(readPrefMode)
+	readPref, err := readpref.New(clientOptions.ReadPreference.Mode())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/srv/db/mongodb/protocol/message.go
+++ b/lib/srv/db/mongodb/protocol/message.go
@@ -78,8 +78,7 @@ func ReadMessage(reader io.Reader) (Message, error) {
 
 // ReadServerMessage reads wire protocol message from the MongoDB server connection.
 func ReadServerMessage(ctx context.Context, conn driver.Connection) (Message, error) {
-	var wm []byte
-	wm, err := conn.ReadWireMessage(ctx, wm)
+	wm, err := conn.ReadWireMessage(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
In order to update versions some minor code changes were needed with how the MongoDb topology is configured.  

Unit tests are also currently failing as we are validating support with wire version 5.  MongoDB v1.11.0 dropped support for "legacy" servers prior to version 3.6.  And thus wire version 5 is no longer supported in new versions of their library.  Long term we will either need to bring this support back into a fork, or also update the minimum supported server version for Teleport.

For that reason this PR is just being opened for discussion.  Do we need to continue to support these old server versions?

Motivation for the update was to investigate the current state of: https://github.com/gravitational/security-findings/issues/21