### PR TITLE
[Assist] Do not parse event data is there is none

### DIFF
--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -263,7 +263,7 @@ async function convertServerMessage(
       const eventsData = (await eventsResp.json()) as {
         events: SessionEvent[];
       };
-      const execEvent = eventsData.events.find(isExecEvent);
+      const execEvent = eventsData.events?.find(isExecEvent);
       // The offset here is set base on A/B test that was run between me, myself and I.
       const stream = await api.fetch(
         sessionUrl + '/stream?offset=0&bytes=4096',

--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -88,6 +88,7 @@ interface ExecEvent {
   event: EventType.EXEC;
   exitError?: string;
 }
+
 type SessionEvent = ExecEvent | { event: string };
 
 const convertToQuery = (cmd: ExecuteRemoteCommandPayload): string => {
@@ -253,14 +254,15 @@ async function convertServerMessage(
 
     const eventsResp = await api.fetch(sessionUrl + '/events');
     const sessionExists = eventsResp.status === 200;
-    const eventsData = (await eventsResp.json()) as {
-      events: SessionEvent[];
-    };
 
     let msg;
     let errorMsg;
     if (sessionExists) {
-      // eventsData.events can be empty if the command execution failed.
+      // Get events only if the session exists. Otherwise, eventsData.events can be empty
+      // if the command execution failed.
+      const eventsData = (await eventsResp.json()) as {
+        events: SessionEvent[];
+      };
       const execEvent = eventsData.events.find(isExecEvent);
       // The offset here is set base on A/B test that was run between me, myself and I.
       const stream = await api.fetch(

--- a/web/packages/teleport/src/Assist/contexts/messages.tsx
+++ b/web/packages/teleport/src/Assist/contexts/messages.tsx
@@ -256,11 +256,12 @@ async function convertServerMessage(
     const eventsData = (await eventsResp.json()) as {
       events: SessionEvent[];
     };
-    const execEvent = eventsData.events.find(isExecEvent);
 
     let msg;
     let errorMsg;
     if (sessionExists) {
+      // eventsData.events can be empty if the command execution failed.
+      const execEvent = eventsData.events.find(isExecEvent);
       // The offset here is set base on A/B test that was run between me, myself and I.
       const stream = await api.fetch(
         sessionUrl + '/stream?offset=0&bytes=4096',


### PR DESCRIPTION
If there is no session data UI should not try to parse them. Otherwise, it will crash as this happens currently.

Example:
<img width="1719" alt="Screenshot 2023-06-05 at 6 46 44 PM" src="https://github.com/gravitational/teleport/assets/13811785/52678cee-d26a-43db-bf54-296dbd8a5094">
