### PR TITLE
Respect client idle timeout setting

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -128,6 +128,7 @@ func TestIntegrations(t *testing.T) {
 	t.Run("BPFExec", suite.bind(testBPFExec))
 	t.Run("BPFInteractive", suite.bind(testBPFInteractive))
 	t.Run("BPFSessionDifferentiation", suite.bind(testBPFSessionDifferentiation))
+	t.Run("ClientIdleConnection", suite.bind(testClientIdleConnection))
 	t.Run("CmdLabels", suite.bind(testCmdLabels))
 	t.Run("ControlMaster", suite.bind(testControlMaster))
 	t.Run("CustomReverseTunnel", suite.bind(testCustomReverseTunnel))
@@ -1807,6 +1808,114 @@ type disconnectTestCase struct {
 	// itself, as those assertions must run in the main test goroutine, but
 	// verifyError runs in a different goroutine.
 	verifyError errorVerifier
+}
+
+// repeatingReader is an [io.ReadCloser] that produces the
+// provided output at the configured interval until closed.
+// For example, all calls to Read on the following reader will
+// block for a minute and then return "hi" to the caller. Once
+// Closed an `io.EOF` will be returned from Read
+//
+// r := repeatingReader{output: hi, interval:time.Minute}
+// n, err := r.Read(out)
+type repeatingReader struct {
+	output   string
+	interval time.Duration
+	closed   chan struct{}
+}
+
+func newRepeatingReader(output string, interval time.Duration) repeatingReader {
+	return repeatingReader{
+		interval: interval,
+		output:   output,
+		closed:   make(chan struct{}),
+	}
+}
+
+func (r repeatingReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	select {
+	case <-time.After(r.interval):
+	case <-r.closed:
+		return 0, io.EOF
+	}
+
+	end := len(r.output)
+	if end > len(p) {
+		end = len(p)
+	}
+
+	n := copy(p, r.output[:end])
+	return n, nil
+}
+
+func (r repeatingReader) Close() error {
+	close(r.closed)
+	return nil
+}
+
+// testClientIdleConnection validates that if a user is active beyond
+// the client idle timeout that the session is not terminated.
+func testClientIdleConnection(t *testing.T, suite *integrationTestSuite) {
+	netConfig := types.DefaultClusterNetworkingConfig()
+	netConfig.SetClientIdleTimeout(time.Second)
+
+	tconf := servicecfg.MakeDefaultConfig()
+	tconf.SSH.Enabled = true
+	tconf.Log = utils.NewLoggerForTests()
+	tconf.Proxy.DisableWebService = true
+	tconf.Proxy.DisableWebInterface = true
+	tconf.Auth.NetworkingConfig = netConfig
+	tconf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+	tconf.InstanceMetadataClient = cloud.NewDisabledIMDSClient()
+
+	instance := suite.NewTeleportWithConfig(t, nil, nil, tconf)
+	t.Cleanup(func() { require.NoError(t, instance.StopAll()) })
+
+	var output bytes.Buffer
+
+	// SSH into the server, and stay active for longer than
+	// the client idle timeout.
+	sessionErr := make(chan error)
+	openSession := func() {
+		cl, err := instance.NewClient(helpers.ClientConfig{
+			Login:   suite.Me.Username,
+			Cluster: helpers.Site,
+			Host:    Host,
+		})
+		if err != nil {
+			sessionErr <- trace.Wrap(err)
+			return
+		}
+		cl.Stdout = &output
+		// Execute a command 10x faster than the idle timeout to stay active.
+		reader := newRepeatingReader("echo txlxport | sed 's/x/e/g'\n", netConfig.GetClientIdleTimeout()/10)
+		defer func() { reader.Close() }()
+		cl.Stdin = reader
+
+		// Terminate the session after 3x the idle timeout
+		ctx, cancel := context.WithTimeout(context.Background(), netConfig.GetClientIdleTimeout()*3)
+		defer cancel()
+		sessionErr <- cl.SSH(ctx, nil, false)
+	}
+
+	go openSession()
+
+	// Wait for the sessions to end - we expect an error
+	// since we are canceling the context.
+	err := waitForError(sessionErr, time.Second*10)
+	require.Error(t, err)
+
+	// Ensure that the session was alive beyond the idle timeout by
+	// counting the number of times "teleport" was output. If the session
+	// was alive past the idle timeout then there should be at least 11 occurrences
+	// since the command is run at 1/10 the idle timeout.
+	require.NotEmpty(t, output)
+	count := strings.Count(output.String(), "teleport")
+	require.Greater(t, count, 10)
 }
 
 // TestDisconnectScenarios tests multiple scenarios with client disconnects

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -61,10 +61,10 @@ const (
 	connContextKey appServerContextKey = "teleport-connContextKey"
 )
 
-// ConnMonitor monitors authorized connnections and terminates them when
+// ConnMonitor monitors authorized connections and terminates them when
 // session controls dictate so.
 type ConnMonitor interface {
-	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error)
+	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error)
 }
 
 // Config is the configuration for an application server.
@@ -700,14 +700,25 @@ func (s *Server) HandleConnection(conn net.Conn) {
 }
 
 func (s *Server) handleConnection(conn net.Conn) (func(), error) {
-	// Proxy sends a X.509 client certificate to pass identity information,
-	// extract it and run authorization checks on it.
-	tlsConn, user, app, err := s.getConnectionInfo(s.closeContext, conn)
+	ctx, cancel := context.WithCancel(s.closeContext)
+	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
+		Conn:    conn,
+		Clock:   s.c.Clock,
+		Context: ctx,
+		Cancel:  cancel,
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	ctx := authz.ContextWithUser(s.closeContext, user)
+	// Proxy sends a X.509 client certificate to pass identity information,
+	// extract it and run authorization checks on it.
+	tlsConn, user, app, err := s.getConnectionInfo(s.closeContext, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx = authz.ContextWithUser(s.closeContext, user)
 	ctx = authz.ContextWithClientAddr(ctx, conn.RemoteAddr())
 	authCtx, _, err := s.authorizeContext(ctx)
 
@@ -725,7 +736,7 @@ func (s *Server) handleConnection(conn net.Conn) (func(), error) {
 		}
 	} else {
 		// Monitor the connection an update the context.
-		ctx, err = s.c.ConnectionMonitor.MonitorConn(ctx, authCtx, conn)
+		ctx, _, err = s.c.ConnectionMonitor.MonitorConn(ctx, authCtx, tc)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -132,8 +132,8 @@ type suiteConfig struct {
 
 type fakeConnMonitor struct{}
 
-func (f fakeConnMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error) {
-	return ctx, nil
+func (f fakeConnMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error) {
+	return ctx, conn, nil
 }
 
 func SetUpSuite(t *testing.T) *Suite {

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -68,10 +68,10 @@ type ProxyServer struct {
 	log logrus.FieldLogger
 }
 
-// ConnMonitor monitors authorized connnections and terminates them when
+// ConnMonitor monitors authorized connections and terminates them when
 // session controls dictate so.
 type ConnMonitor interface {
-	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error)
+	MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error)
 }
 
 // ProxyServerConfig is the proxy configuration.
@@ -485,7 +485,8 @@ func isReverseTunnelDownError(err error) bool {
 func (s *ProxyServer) Proxy(ctx context.Context, proxyCtx *common.ProxyContext, clientConn, serviceConn net.Conn) error {
 	// Wrap a client connection with a monitor that auto-terminates
 	// idle connection and connection with expired cert.
-	ctx, err := s.cfg.ConnectionMonitor.MonitorConn(ctx, proxyCtx.AuthContext, clientConn)
+	var err error
+	ctx, clientConn, err = s.cfg.ConnectionMonitor.MonitorConn(ctx, proxyCtx.AuthContext, clientConn)
 	if err != nil {
 		clientConn.Close()
 		serviceConn.Close()

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -909,7 +909,7 @@ func (s *Server) handleConnection(ctx context.Context, clientConn net.Conn) erro
 
 	// Wrap a client connection into monitor that auto-terminates
 	// idle connection and connection with expired cert.
-	ctx, err = s.cfg.ConnectionMonitor.MonitorConn(ctx, sessionCtx.AuthContext, clientConn)
+	ctx, clientConn, err = s.cfg.ConnectionMonitor.MonitorConn(ctx, sessionCtx.AuthContext, clientConn)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -118,18 +118,36 @@ func NewConnectionMonitor(cfg ConnectionMonitorConfig) (*ConnectionMonitor, erro
 	return &ConnectionMonitor{cfg: cfg}, nil
 }
 
+func getTrackingReadConn(conn net.Conn) (*TrackingReadConn, bool) {
+	type netConn interface {
+		NetConn() net.Conn
+	}
+
+	for {
+		if tconn, ok := conn.(*TrackingReadConn); ok {
+			return tconn, true
+		}
+
+		connGetter, ok := conn.(netConn)
+		if !ok {
+			return nil, false
+		}
+		conn = connGetter.NetConn()
+	}
+}
+
 // MonitorConn ensures that the provided [net.Conn] is allowed per cluster configuration
 // and security controls. If at any point during the lifetime of the connection the
 // cluster controls dictate that the connection is not permitted it will be closed and the
 // returned [context.Context] will be canceled.
-func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, error) {
+func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error) {
 	authPref, err := c.cfg.AccessPoint.GetAuthPreference(ctx)
 	if err != nil {
-		return ctx, trace.Wrap(err)
+		return ctx, conn, trace.Wrap(err)
 	}
 	netConfig, err := c.cfg.AccessPoint.GetClusterNetworkingConfig(ctx)
 	if err != nil {
-		return ctx, trace.Wrap(err)
+		return ctx, conn, trace.Wrap(err)
 	}
 
 	identity := authzCtx.Identity.GetIdentity()
@@ -137,15 +155,18 @@ func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Con
 
 	idleTimeout := checker.AdjustClientIdleTimeout(netConfig.GetClientIdleTimeout())
 
-	monitorCtx, cancel := context.WithCancel(ctx)
-	tconn, err := NewTrackingReadConn(TrackingReadConnConfig{
-		Conn:    conn,
-		Clock:   c.cfg.Clock,
-		Context: monitorCtx,
-		Cancel:  cancel,
-	})
-	if err != nil {
-		return ctx, trace.Wrap(err)
+	tconn, ok := getTrackingReadConn(conn)
+	if !ok {
+		tctx, cancel := context.WithCancel(ctx)
+		tconn, err = NewTrackingReadConn(TrackingReadConnConfig{
+			Conn:    conn,
+			Clock:   c.cfg.Clock,
+			Context: tctx,
+			Cancel:  cancel,
+		})
+		if err != nil {
+			return ctx, conn, trace.Wrap(err)
+		}
 	}
 
 	// Start monitoring client connection. When client connection is closed the monitor goroutine exits.
@@ -166,10 +187,10 @@ func (c *ConnectionMonitor) MonitorConn(ctx context.Context, authzCtx *authz.Con
 		IdleTimeoutMessage:    netConfig.GetClientIdleTimeoutMessage(),
 		MonitorCloseChannel:   c.cfg.MonitorCloseChannel,
 	}); err != nil {
-		return ctx, trace.Wrap(err)
+		return ctx, conn, trace.Wrap(err)
 	}
 
-	return monitorCtx, nil
+	return tconn.cfg.Context, tconn, nil
 }
 
 // MonitorConfig is a wiretap configuration

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -101,8 +101,8 @@ func TestConnectionMonitorLockInForce(t *testing.T) {
 
 	t.Run("lock created after connection has been established", func(t *testing.T) {
 		// Create a fake connection and monitor it.
-		conn := &mockTrackingConn{closedC: make(chan struct{})}
-		monitorCtx, err := monitor.MonitorConn(ctx, authzCtx, conn)
+		tconn := &mockTrackingConn{closedC: make(chan struct{})}
+		monitorCtx, _, err := monitor.MonitorConn(ctx, authzCtx, tconn)
 		require.NoError(t, err)
 		require.Nil(t, monitorCtx.Err())
 
@@ -111,7 +111,7 @@ func TestConnectionMonitorLockInForce(t *testing.T) {
 
 		// Assert that the connection was terminated.
 		select {
-		case <-conn.closedC:
+		case <-tconn.closedC:
 		case <-time.After(2 * time.Second):
 			t.Fatal("Timeout waiting for connection close.")
 		}
@@ -126,14 +126,14 @@ func TestConnectionMonitorLockInForce(t *testing.T) {
 	t.Run("connection terminated if lock already exists", func(t *testing.T) {
 		// Create another connection for the locked user and validate
 		// that it is terminated right away.
-		conn := &mockTrackingConn{closedC: make(chan struct{})}
-		monitorCtx, err := monitor.MonitorConn(ctx, authzCtx, conn)
+		tconn := &mockTrackingConn{closedC: make(chan struct{})}
+		monitorCtx, _, err := monitor.MonitorConn(ctx, authzCtx, tconn)
 		require.NoError(t, err)
 
 		// Assert that the context was canceled and that the connection was terminated.
 		require.Error(t, monitorCtx.Err())
 		select {
-		case <-conn.closedC:
+		case <-tconn.closedC:
 		case <-time.After(2 * time.Second):
 			t.Fatal("Timeout waiting for connection close.")
 		}

--- a/lib/srv/transport/transportv1/transport_test.go
+++ b/lib/srv/transport/transportv1/transport_test.go
@@ -227,8 +227,8 @@ func fakeSigner(authzCtx *authz.Context, clusterName string) agentless.SignerCre
 
 type fakeMonitor struct{}
 
-func (f fakeMonitor) MonitorConn(ctx context.Context, authCtx *authz.Context, conn net.Conn) (context.Context, error) {
-	return ctx, nil
+func (f fakeMonitor) MonitorConn(ctx context.Context, authCtx *authz.Context, conn net.Conn) (context.Context, net.Conn, error) {
+	return ctx, conn, nil
 }
 
 // TestService_GetClusterDetails validates that a [Service] returns


### PR DESCRIPTION
Client connections were never using the `srv.TrackingReadConn` created by the `srv.ConnectionMonitor` which caused all connections to appear idle and be disconnected whenever the client idle timeout was reached.

`(srv.ConnectionMonitor) MonitorConn` now returns the provided connection which is wrapped in the tracking connection. Callers must ensure that the returned connection is used instead of the connection passed in to `MonitorConn`.

Fixes #27392