### PR TITLE
Docs: Remove nobr in tables

### DIFF
--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -216,7 +216,7 @@ The program, which you can find in
 |---|---|
 |`context`|Includes the `context.Context` type. `context.Context` is an abstraction for controlling long-running routines, such as connections to external services, that might fail or time out. Programs can cancel contexts or assign them timeouts and metadata. |
 |`crypto/rand`|Includes cryptographic randomization functions, which we will use to generate join tokens for Application Services to use to establish trust with the Teleport Auth Service.|
-|<nobr>`encoding/hex`</nobr>|The number generator we use from `crypto/rand` returns data in bytes, so we will encode these as hexadecimal strings using this package.|
+|`encoding/hex`|The number generator we use from `crypto/rand` returns data in bytes, so we will encode these as hexadecimal strings using this package.|
 |`fmt`|Formats data for printing, strings, or errors.|
 |`net`|Deals with network I/O.|
 |`net/url`|Parses URLs.|
@@ -228,7 +228,7 @@ The client imports the following third-party code:
 |Package|Description|
 |---|---|
 |`github.com/docker/docker/api/types`|Types used in the Docker daemon API. Aliased as `dtypes` here. |
-|<nobr>`github.com/docker/docker/api/types/container`</nobr>|Container-specific types used in the Docker daemon API.|
+|`github.com/docker/docker/api/types/container`|Container-specific types used in the Docker daemon API.|
 |`github.com/docker/docker/api/types/filters`|Types used for filtering containers in the Docker daemon API.|
 |`github.com/docker/docker/api/types/strslice`|A utility package for working with slices of strings in Docker's API client library. (In Go, slices are similar to arrays, but with variable lengths and capacities. Arrays have a fixed size.)|
 |`github.com/docker/docker/client`|The Docker API client library, aliased as `docker` here.|
@@ -266,7 +266,7 @@ want to change later, including:
 |`proxyAddr`|The host and port of the Teleport Proxy Service, e.g., `mytenant.teleport.sh:443`, which we will use to connect the client to your cluster. **Assign this to your own Proxy Service's host and port.**|
 |`teleportImage`|The name of the Teleport container image, which the program will use to run instances of the Teleport Application Service.|
 |`initTimeout`|The timeout for connecting to the Teleport cluster (30 seconds).|
-|<nobr>`updateInterval`</nobr>|How often the program will wait between reconciling Application Service instances and application containers (5 seconds).|
+|`updateInterval`|How often the program will wait between reconciling Application Service instances and application containers (5 seconds).|
 |`tokenTTL`|How long of a TTL to set for join tokens that Application Service instances will use to establish trust with the Teleport cluster. This client application will use join tokens immediately after creating them, so we can set this TTL to a small value (5 minutes) to prevent this credential from leaking.|
 |`networkName`|The name of the Docker network to search for application containers. `bridge` is the default local network managed by the Docker daemon.|
 |`managementPort`|The management API port of our RabbitMQ containers.|
@@ -529,8 +529,9 @@ corresponding role permissions with the `create` verb:
 |Resource|Method|Within a Role|
 |---|---|---|
 |Database|`*client.Client.CreateDatabase`|`db`|
-|Kubernetes cluster|<nobr>`*client.Client.CreateKubernetesCluster`</nobr>|`kube_cluster`|
-|Windows Desktop|`*client.Client.CreateWindowsDesktop`|<nobr>`windows_desktop`</nobr>|
+|Kubernetes cluster|`*client.Client.CreateKubernetesCluster`|`kube_cluster`|
+|Windows Desktop|`*client.Client.CreateWindowsDesktop`|`windows_desktop`|
+
 Since a server must run an instance of the Teleport Service in order to join
 a Teleport cluster, API clients can only register servers by using tokens.
 

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -445,7 +445,7 @@ Here are the packages our client application imports from Go's standard library:
 
 |Package|Description|
 |---|---|
-| <nobr>`context`</nobr> |Includes the `context.Context` type. `context.Context` is an abstraction for controlling long-running routines, such as connections to external services, that might fail or time out. Programs can cancel contexts or assign them timeouts and metadata.|
+| `context`|Includes the `context.Context` type. `context.Context` is an abstraction for controlling long-running routines, such as connections to external services, that might fail or time out. Programs can cancel contexts or assign them timeouts and metadata.|
 |`fmt`|Formatting data for printing, strings, or errors.|
 |`io`|Dealing with I/O operations, e.g., reading files or network sockets.|
 |`os`|Interacting with the operating system, e.g., to open files.|
@@ -455,12 +455,12 @@ The client imports the following third-party code:
 
 |Package|Description|
 |---|---|
-|`github.com/gravitational/`<nobr>`teleport/api/client`</nobr>|A library for authenticating to the Auth Service's gRPC API and making requests, aliased as `teleport`.|
-|`github.com/gravitational/`<nobr>`teleport/api/types`</nobr>|Types used in the Auth Service API, e.g., Application Service records.|
+|`github.com/gravitational/teleport/api/client`|A library for authenticating to the Auth Service's gRPC API and making requests, aliased as `teleport`.|
+|`github.com/gravitational/teleport/api/types`|Types used in the Auth Service API, e.g., Application Service records.|
 |`github.com/gravitational/trace`|Presenting errors with more useful detail than the standard library provides.|
 |`google.golang.org/grpc`|The gRPC client and server library.|
 |`k8s.io/api/rbac/v1`|The Kubernetes RBAC API client library.|
-|`k8s.io/apimachinery/`<nobr>`pkg/apis/meta/v1`</nobr>|Code common to Kubernetes' API client libraries.|
+|`k8s.io/apimachinery/pkg/apis/meta/v1`|Code common to Kubernetes' API client libraries.|
 |`k8s.io/client-go/kubernetes`|Setting up an general-purpose Kubernetes client.|
 |`k8s.io/client-go/kubernetes/typed/rbac/v1`|Types for the Kubernetes RBAC API.|
 |`k8s.io/client-go/tools/clientcmd`|Another general-purpose Kubernetes client library.|
@@ -490,7 +490,7 @@ want to change later, including:
 |`initTimeout`|The timeout for connecting to the Teleport cluster. We have defined this as 30 seconds.|
 |`identityFilePath`|The path to the Teleport identity file you created earlier.|
 |`clusterName`|The name of the Kubernetes cluster you will fetch RBAC resources from. In this guide, the cluster's name is `minikube`.|
-|<nobr>`roleAnnotationKey`</nobr>|In Kubernetes, annotations are arbitrary key/value pairs that you can add to resources. The role and cluster role bindings we created earlier have the annotation key we specify here so our client application can fetch them.|
+|`roleAnnotationKey`|In Kubernetes, annotations are arbitrary key/value pairs that you can add to resources. The role and cluster role bindings we created earlier have the annotation key we specify here so our client application can fetch them.|
 
 ### Initializing a Kubernetes RBAC client
 
@@ -615,7 +615,7 @@ client's role type, based on the cluster role binding:
 |---|---|---|
 |`allow.kubernetes_labels`|Labels for Teleport-registered Kubernetes clusters that a user with this role is allowed to access.|Based on the Teleport-registered Kubernetes cluster that the cluster role binding belongs to.|
 |`allow.kubernetes_resources`|Kubernetes pods in specific namespaces that that a user with this role is allowed to access.|Allow access to all namespaces, since cluster role bindings are not restricted by namespace.|
-|<nobr>`allow.kubernetes_users`</nobr> and `allow.kubernetes_groups`|The Kubernetes groups and users that a Teleport user with this role will assume when interacting with the Kubernetes cluster.|Supply the names of any users or groups connected to the cluster role binding.|
+|`allow.kubernetes_users` and `allow.kubernetes_groups`|The Kubernetes groups and users that a Teleport user with this role will assume when interacting with the Kubernetes cluster.|Supply the names of any users or groups connected to the cluster role binding.|
 
 ### Creating a Teleport role from a Kubernetes role binding
 

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -142,9 +142,9 @@ spec:
 
 | Flag                       | Description                                                                                                                              |
 |----------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| <nobr>`--db-users`</nobr>  | List of database usernames the user will be allowed to use when connecting to the databases. A wildcard allows any user.                 |
-| <nobr>`--db-names`</nobr>  | List of logical databases (aka schemas) the user will be allowed to connect to within a database server. A wildcard allows any database. |
-| <nobr>`--db-labels`</nobr> | List of labels assigned to the database the user will be able to access. A wildcard entry allows any database.                           |
+| `--db-users` | List of database usernames the user will be allowed to use when connecting to the databases. A wildcard allows any user.                 |
+| `--db-names` | List of logical databases (aka schemas) the user will be allowed to connect to within a database server. A wildcard allows any database. |
+| `--db-labels` | List of labels assigned to the database the user will be able to access. A wildcard entry allows any database.                           |
 
 Save this file and apply it to your Teleport cluster:
 

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -195,16 +195,16 @@ returns the <nobr>`ERR Teleport: command not supported`</nobr> error.
 Teleport conducts additional processing on the following commands before 
 communicating with Redis Cluster:
 
-| Command                      | Description                                                                                                                                                                                                  |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `DBSIZE`                     | Sends the query to all nodes and returns the number of keys in the whole cluster.                                                                                                                            |
-| `KEYS`                       | Sends the query to all nodes and returns a list of all keys in the whole cluster.                                                                                                                            |
-| `MGET`                       | Translates the commands to multiple `GET`s and sends them to multiple nodes. Result is merged in Teleport and returned back to the client. If Teleport fails to fetch at least one key an error is returned. |
-| `FLUSHDB`                    | Sends the query to all nodes.                                                                                                                                                                                |
-| `FLUSHALL`                   | Works the same as `FLUSHDB`.                                                                                                                                                                                 |
-| <nobr>`SCRIPT EXISTS`</nobr> | Sends the query to all nodes. `1` is returned only if script exists on all nodes.                                                                                                                            |
-| <nobr>`SCRIPT LOAD`</nobr>   | Sends the script to all nodes.                                                                                                                                                                               |
-| <nobr>`SCRIPT FLUSH`</nobr>  | Sends the query to all nodes. `ASYNC` parameter is ignored.                                                                                                                                                  |
+| Command         | Description                                                                        |
+|-----------------|------------------------------------------------------------------------------------|
+| `DBSIZE`        | Sends the query to all nodes and returns the number of keys in the whole cluster.  |
+| `KEYS`          | Sends the query to all nodes and returns a list of all keys in the whole cluster.  |
+| `MGET`          | Translates the commands to multiple `GET`s and sends them to multiple nodes. Result is merged in Teleport and returned back to the client. If Teleport fails to fetch at least one key an error is returned. |
+| `FLUSHDB`       | Sends the query to all nodes.                                                      |
+| `FLUSHALL`      | Works the same as `FLUSHDB`.                                                       |
+| `SCRIPT EXISTS` | Sends the query to all nodes. `1` is returned only if script exists on all nodes.  |
+| `SCRIPT LOAD`   | Sends the script to all nodes.                                                     |
+| `SCRIPT FLUSH`  | Sends the query to all nodes. `ASYNC` parameter is ignored.                        |
 
 ## Next steps
 

--- a/docs/pages/deploy-a-cluster/high-availability.mdx
+++ b/docs/pages/deploy-a-cluster/high-availability.mdx
@@ -161,7 +161,7 @@ These ports are required:
 
 | Load Balancer Port | Proxy Service Port | Description |
 | - | - | - |
-| <nobr>`3023`</nobr> | <nobr>`3023`</nobr> | SSH port for clients connect to. |
+| `3023` | `3023` | SSH port for clients connect to. |
 | `3024` | `3024` | SSH port used to create reverse SSH tunnels from behind-firewall environments. |
 | `443` | `3080` | HTTPS connections to authenticate `tsh` users into the cluster. The same connection is used to serve a Web UI. |
 
@@ -183,7 +183,7 @@ services:
 The Auth Service load balancer must forward traffic to the Auth Service's gRPC
 port. In this guide, we are assuming that you have configured the Auth Service
 load balancer to forward traffic from port `3025` to port `3025` on an available
-Auth Service instance. 
+Auth Service instance.
 
 ## Cluster state backend
 
@@ -497,7 +497,7 @@ Ensure that, on each Auth Service instance, the following ports are open:
 
 | Port | Description |
 | - | - |
-| <nobr>`3025`</nobr> | gRPC port to open to Proxy Service instances.|
+| `3025` | gRPC port to open to Proxy Service instances.|
 
 #### License file
 
@@ -507,7 +507,7 @@ and make it available to your Teleport Auth Service instances.
 (!docs/pages/includes//enterprise/obtainlicense.mdx!)
 
 The license file must be available to each Teleport Auth Service instance at
-`/var/lib/teleport/license.pem`. 
+`/var/lib/teleport/license.pem`.
 
 #### Configuration
 
@@ -516,9 +516,9 @@ instances at `/etc/teleport.yaml`. We will explain the required configuration
 fields for a high-availability Teleport deployment below. These are the minimum
 requirements, and when planning your high-availability deployment, you will want
 to follow a more specific [deployment guide](introduction.mdx) for your
-environment. 
+environment.
 
-#### `storage` 
+#### `storage`
 
 The first configuration section to write is the `storage` section, which
 configures the cluster state backend and session recording backend for the Auth

--- a/docs/pages/includes/database-access/create-user.mdx
+++ b/docs/pages/includes/database-access/create-user.mdx
@@ -14,11 +14,11 @@ $ tctl users add \
   alice
 ```
 
-| Flag                      | Description                                                                                                                              |
-|---------------------------|------------------------------------------------------------------------------------------------------------------------------------------|
-| <nobr>`--roles`</nobr>    | List of roles to assign to the user. The builtin `access` role allows them to connect to any database server registered with Teleport.   |
-| <nobr>`--db-users`</nobr> | List of database usernames the user will be allowed to use when connecting to the databases. A wildcard allows any user.                 |
-| <nobr>`--db-names`</nobr> | List of logical databases (aka schemas) the user will be allowed to connect to within a database server. A wildcard allows any database. |
+| Flag         | Description                                                                                                                              |
+|--------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `--roles`    | List of roles to assign to the user. The builtin `access` role allows them to connect to any database server registered with Teleport.   |
+| `--db-users` | List of database usernames the user will be allowed to use when connecting to the databases. A wildcard allows any user.                 |
+| `--db-names` | List of logical databases (aka schemas) the user will be allowed to connect to within a database server. A wildcard allows any database. |
 
 <Admonition type="warning">
   Database names are only enforced for PostgreSQL and MongoDB databases.

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -331,7 +331,7 @@ $ tsh gcloud [--app] [<command>]
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| <nobr>`--app`</nobr> | Currently logged in Google Cloud application | The name of a Google Cloud application as listed via `tsh apps ls`. | The Google Cloud application to run the command against, if logged in to multiple Google Cloud applications. |
+| `--app` | Currently logged in Google Cloud application | The name of a Google Cloud application as listed via `tsh apps ls`. | The Google Cloud application to run the command against, if logged in to multiple Google Cloud applications. |
 
 #### Global flags
 
@@ -363,7 +363,7 @@ $ tsh gsutil [--app] [<command>]
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| <nobr>`--app`</nobr> | Currently logged in Google Cloud application | The name of a Google Cloud application as listed via `tsh apps ls`. | The Google Cloud application to run the command against, if logged in to multiple Google Cloud applications. |
+| `--app` | Currently logged in Google Cloud application | The name of a Google Cloud application as listed via `tsh apps ls`. | The Google Cloud application to run the command against, if logged in to multiple Google Cloud applications. |
 
 #### Global flags
 
@@ -741,6 +741,7 @@ Access](../application-access/cloud-apis/azure.mdx).
 This command does not accept any arguments.
 
 #### Flags
+
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
 | `--app` | none | string | Name of the Teleport application representing Azure (i.e., based on `tsh apps ls`). Use this flag if your Teleport user has access to multiple Azure applications. |
@@ -766,9 +767,9 @@ $ tsh proxy aws [<flags>]
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
 | `--app` | Currently logged in AWS app | string | Optional name of the AWS application (as shown in `tsh apps ls`) to use if logged in to multiple |
-| `-p, --port` | none | port number | Specify the source port for the local proxy |
-| ` -e, --endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as an AWS endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
-| `-f, --format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the AWS proxy |
+| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
+| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as an AWS endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
+| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the AWS proxy |
 
 #### [Global Flags](#tsh-global-flags)
 
@@ -806,9 +807,9 @@ $ tsh proxy gcloud [<flags>]
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
 | `--app` | Currently logged in Google Cloud app | string | Optional name of the Google Cloud application (as shown in `tsh apps ls`) to use if logged in to multiple |
-| `-p, --port` | none | port number | Specify the source port for the local proxy |
-| <nobr>`-e, --endpoint-url`</nobr> | HTTP Proxy | Endpoint URL | Run the local proxy to serve as a Google Cloud endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
-| `-f, --format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the Google Cloud proxy |
+| `-p`, `--port` | none | port number | Specify the source port for the local proxy |
+| `-e`, `--endpoint-url` | HTTP Proxy | Endpoint URL | Run the local proxy to serve as a Google Cloud endpoint URL. If not specified, the local proxy serves as an HTTPS proxy. |
+| `-f`, `--format` | unix | `text`, `unix`, `command-prompt`, or `powershell` | Optional format for printing environment variables for the Google Cloud proxy |
 
 #### [Global Flags](#tsh-global-flags)
 
@@ -859,6 +860,7 @@ Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags)
 ```code
 $ tsh --proxy=proxy.example.com scp example.txt user@host:/destination/dir
 ```
+
 <Admonition type="note">
   `tsh scp` will not work from the CLI if the user requires session moderation. You can transfer files in a moderated session by joining the SSH session from the Web UI and requesting the file transfer there. Both the session initiator and moderators must be present in the Web UI in order to approve the file transfer request.
 </Admonition>

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -851,7 +851,7 @@ $ tsh scp [<flags>] <source>... <dest>
 
 #### Global flags
 
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost`.
+These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
 Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
 
 #### Examples
@@ -890,7 +890,7 @@ $ tsh ls [<flags>] [<label>]
 
 #### Global flags
 
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost`.
+These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
 Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
 
 #### Examples
@@ -953,7 +953,7 @@ $ tsh clusters [<flags>]
 
 #### Global flags
 
-These flags are available for all commands `--login, --proxy, --user, --ttl, --identity, --cert-format, --insecure, --auth, --skip-version, --debug, --jumphost`.
+These flags are available for all commands `--login`, `--proxy`, `--user`, `--ttl`, `--identity`, `--cert-format`, `--insecure`, `--auth`, `--skip-version-check`, `--debug`, `--jumphost`.
 Run `tsh help <subcommand>` or see the [Global Flags section](#tsh-global-flags).
 
 #### Examples


### PR DESCRIPTION
Do not merge until https://github.com/gravitational/docs/issues/126 is closed.

- Remove `<nobr>` tags from tables, which we used to avoid issues with badly formatted tables. I tested these changes using https://github.com/gravitational/docs/pull/306 and they all render nicely.

- While I was in there, I updated instances of `--skip-version` to `--skip-version-check`.

- Several cases where we had multiple `code` formatted terms in a single code block I separated into individual code blocks.