### PR TITLE
Proxy Templates overwrite CLI `cluster` value

### DIFF
--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1484,8 +1484,8 @@ ERROR: proxy jump contains {{proxy}} variable but did not match any of the templ
 
 If the proxy variable `-J {{proxy}}` is not explicitly provided, then `tsh` will 
 still attempt to match a template, but will not fail when there is no match.
-Additionally, it will not replace the `proxy` or `cluster` values when explicitly
-set by the client.
+Additionally, it will not replace the `proxy` value when explicitly set by the
+client.
 
 ```bash
 $ tsh ssh -J leaf2.us.example.com:443 node1.leaf2

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3423,8 +3423,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 			log.Debugf("Will connect to proxy %q according to proxy template.", tProxy)
 		}
 
-		// Don't overwrite cluster if explicitly provided
-		if cf.SiteName == "" && tCluster != "" {
+		if tCluster != "" {
 			cf.SiteName = tCluster
 			log.Debugf("Will connect to cluster %q according to proxy template.", tCluster)
 		}


### PR DESCRIPTION
Update Proxy Template behavior to prioritize `cluster` provided in a matching template over `--cluster`, `TELEPORT_CLUSTER_NAME`, or `SSH_TELEPORT_CLUSTER_NAME`. This is especially important for the Headless use case where `SSH_TELEPORT_CLUSTER_NAME` may be set in the remote session.

Note: the original decision to have Proxy Templates not overwrite `--cluster` was relatively arbitrary, so I don't think there is any wider impact to making this change now.