### PR TITLE
docs: include token generation for app access getting started

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -50,29 +50,11 @@ Teleport Cloud will automatically provide a subdomain and signed TLS certificate
 for your application under your tenant address.
 </Admonition>
 
-<Tabs>
-<TabItem label="Docker">
-
-## Step 1/3. Start Grafana
-
-We've picked Grafana for this tutorial since it's very easy to run with zero
-configuration required. If you have another web application you'd like to
-expose, skip over to **Step 2**.
-
-Grafana can be launched in a Docker container with a single command:
-
-```code
-$ docker run -d -p 3000:3000 grafana/grafana
-```
-
-## Step 2/3. Install and configure Teleport
-(!docs/pages/includes/permission-warning.mdx!)
-
-### Generate a token
+## 1/4 Generate a token
 
 A join token is required to authorize a Teleport Application Service instance to
 join the cluster. Generate a short-lived join token and save it, for example,
-in `/tmp/token` on your Teleport Application Service host:
+in `/tmp/token`:
 
 ```code
 $ tctl tokens add \
@@ -80,6 +62,25 @@ $ tctl tokens add \
     --app-name=grafana \
     --app-uri=http://localhost:3000
 ```
+
+<Tabs>
+<TabItem label="Docker">
+
+## Step 2/4. Start Grafana
+
+We've picked Grafana for this tutorial since it's very easy to run with zero
+configuration required. If you have another web application you'd like to
+expose, skip over to **Step 3**.
+
+Grafana can be launched in a Docker container with a single command:
+
+```code
+$ docker run -d -p 3000:3000 grafana/grafana
+```
+
+## Step 3/4. Install and configure Teleport
+(!docs/pages/includes/permission-warning.mdx!)
+
 
 ### Configure and Start Teleport
 
@@ -109,11 +110,11 @@ The `--token` flag points to the file on the Application Service host where we s
 </TabItem>
 <TabItem label="Kubernetes cluster">
 
-## Step 1/3. Start Grafana
+## Step 2/4. Start Grafana
 
 We've picked Grafana for this tutorial since it's very easy to run with zero
 configuration required. If you have another web application you'd like to
-expose, skip over to **Step 2**. Install Grafana with these helm instructions
+expose, skip over to **Step 3**. Install Grafana with these helm instructions
 and it will be available at `http://example-grafana.example-grafana.svc.cluster.local`
 within the Kubernetes cluster.
 
@@ -125,7 +126,7 @@ $ helm install example-grafana grafana/grafana \
     --namespace example-grafana
 ```
 
-## Step 2/3. Install and configure Teleport
+## Step 3/4. Install and configure Teleport
 
   (!docs/pages/kubernetes-access/helm/includes/helm-repo-add.mdx!)
 
@@ -185,7 +186,7 @@ $ tctl users add --roles=access alice
 
 The command will output a signup link. Use it to choose a password and set up a second factor. After that, it will take you to the Teleport Web UI.
 
-## Step 3/3. Access the application
+## Step 4/4. Access the application
 
 There are a couple of ways to access the proxied application.
 


### PR DESCRIPTION
The token wasn't available for the Kubernetes option.  Corrected. Will then backport to 13, 12, 11 branches.