### PR TITLE
[Docs] Assist built-in role access

### DIFF
--- a/docs/pages/ai-assist.mdx
+++ b/docs/pages/ai-assist.mdx
@@ -104,7 +104,7 @@ proxy_service:
 
 
 Make sure that your Teleport user has the `assistant` permission. By default, users
-with built-in `auditor` and `editor` roles have this permission. You can also
+with built-in `access` and `editor` roles have this permission. You can also
 add it to a custom role. Here is an example:
 
 ```yaml


### PR DESCRIPTION
Fix the incorrect built-in role name that gives access to the assist. Code change: https://github.com/gravitational/teleport/pull/27413