### PR TITLE
Use file descriptors to get listeners for tests without collision

### DIFF
--- a/lib/tbot/testhelpers/srv.go
+++ b/lib/tbot/testhelpers/srv.go
@@ -18,7 +18,6 @@ package testhelpers
 
 import (
 	"context"
-	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -35,15 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	botconfig "github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/utils"
-)
-
-// from lib/service/listeners.go
-// TODO(espadolini): have the constants exported
-const (
-	listenerAuth        = "auth"
-	listenerProxySSH    = "proxy:ssh"
-	listenerProxyWeb    = "proxy:web"
-	listenerProxyTunnel = "proxy:tunnel"
+	"github.com/gravitational/teleport/tool/teleport/testenv"
 )
 
 // DefaultConfig returns a FileConfig to be used in tests, with random listen
@@ -61,56 +52,21 @@ func DefaultConfig(t *testing.T) (*config.FileConfig, []servicecfg.FileDescripto
 		Proxy: config.Proxy{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: newListener(t, listenerProxySSH, &fds),
+				ListenAddress: testenv.NewTCPListener(t, service.ListenerProxySSH, &fds),
 			},
-			WebAddr:    newListener(t, listenerProxyWeb, &fds),
-			TunAddr:    newListener(t, listenerProxyTunnel, &fds),
+			WebAddr:    testenv.NewTCPListener(t, service.ListenerProxyWeb, &fds),
+			TunAddr:    testenv.NewTCPListener(t, service.ListenerProxyTunnel, &fds),
 			PublicAddr: []string{"proxy.example.com"},
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: newListener(t, listenerAuth, &fds),
+				ListenAddress: testenv.NewTCPListener(t, service.ListenerAuth, &fds),
 			},
 		},
 	}
 
 	return fc, fds
-}
-
-// newListener creates a new TCP listener on 127.0.0.1:0, adds it to the
-// FileDescriptor slice (with the specified type) and returns its actual local
-// address as a string (for use in configuration). Takes a pointer to the slice
-// so that it's convenient to call in the middle of a FileConfig or Config
-// struct literal.
-// TODO(espadolini): move this to a more generic place so we can use the same
-// approach in other tests that spin up a TeleportProcess
-func newListener(t *testing.T, ty string, fds *[]servicecfg.FileDescriptor) string {
-	t.Helper()
-
-	l, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-	defer l.Close()
-	addr := l.Addr().String()
-
-	// File() returns a dup of the listener's file descriptor as an *os.File, so
-	// the original net.Listener still needs to be closed.
-	lf, err := l.(*net.TCPListener).File()
-	require.NoError(t, err)
-	// If the file descriptor slice ends up being passed to a TeleportProcess
-	// that successfully starts, listeners will either get "imported" and used
-	// or discarded and closed, this is just an extra safety measure that closes
-	// the listener at the end of the test anyway (the finalizer would do that
-	// anyway, in principle).
-	t.Cleanup(func() { lf.Close() })
-
-	*fds = append(*fds, servicecfg.FileDescriptor{
-		Type:    ty,
-		Address: addr,
-		File:    lf,
-	})
-
-	return addr
 }
 
 // MakeAndRunTestAuthServer creates an auth server useful for testing purposes.


### PR DESCRIPTION
Moves `NewTCPListener` to a more common location as a follow up to https://github.com/gravitational/teleport/pull/13346.

As a follow up to this PR, tbot, tsh, tctl, and integration tests would ideally be updated to use `tool/teleport/testenv.MakeTestServer` instead of having a custom test server implementation for each (volunteers welcome).