### PR TITLE
ci: Remove -new suffix from helm directory

### DIFF
--- a/.github/workflows/unit-tests-helm.yaml
+++ b/.github/workflows/unit-tests-helm.yaml
@@ -22,8 +22,7 @@ jobs:
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport14
       env:
-        # TODO(hugoShaka) remove the '-new' prefix when updating to teleport13 buildbox
-        HELM_PLUGINS: /home/ci/.local/share/helm/plugins-new
+        HELM_PLUGINS: /home/ci/.local/share/helm/plugins
 
     steps:
       - name: Checkout Teleport

--- a/Makefile
+++ b/Makefile
@@ -675,13 +675,13 @@ helmunit/installed:
 # environment variable.
 .PHONY: test-helm
 test-helm: helmunit/installed
-	helm unittest -3 examples/chart/teleport-cluster
-	helm unittest -3 examples/chart/teleport-kube-agent
+	helm unittest examples/chart/teleport-cluster
+	helm unittest examples/chart/teleport-kube-agent
 
 .PHONY: test-helm-update-snapshots
 test-helm-update-snapshots: helmunit/installed
-	helm unittest -3 -u examples/chart/teleport-cluster
-	helm unittest -3 -u examples/chart/teleport-kube-agent
+	helm unittest -u examples/chart/teleport-cluster
+	helm unittest -u examples/chart/teleport-kube-agent
 
 #
 # Runs all Go tests except integration, called by CI/CD.


### PR DESCRIPTION
Remove the `-new` suffix from the helm plugins directory and the
associated TODO. That TODO was done in the buildbox in commit
5d53c91c7a8d41391422171749b3a3d7f23084ab.

`make test-helm` is now failing on CI due to that removal, so followup
with this removal.