### PR TITLE
Fix build for new buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -254,6 +254,13 @@ RUN mkdir -p helm-tarball && \
     curl -fsSL https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \
     cp helm-tarball/$(go env GOOS)-$(go env GOARCH)/helm /bin/ && \
     rm -r helm-tarball*
+# TODO(hugoShaka): remove this backward compatible hack with teleportv13 buildbox
+RUN helm plugin install https://github.com/quintush/helm-unittest --version 0.2.11 && \
+    mkdir -p /home/ci/.local/share/helm && \
+    cp -r /root/.local/share/helm/plugins /home/ci/.local/share/helm/plugins-new && \
+    chown -R ci /home/ci/.local/share/helm && \
+    helm plugin uninstall unittest && \
+    HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new helm plugin list
 RUN helm plugin install https://github.com/vbehar/helm3-unittest && \
     mkdir -p /home/ci/.local/share/helm && \
     cp -r /root/.local/share/helm/plugins /home/ci/.local/share/helm && \

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -7,7 +7,8 @@ endif
 HOSTNAME=buildbox
 SRCDIR=/go/src/github.com/gravitational/teleport
 GOMODCACHE ?= /tmp/gomodcache
-DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE)
+# TODO(hugoShaka) remove HELM_PLUGINS with teleport13 buildbox
+DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new
 
 ADDFLAGS ?=
 BATSFLAGS :=

--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -125,7 +125,7 @@ func TestRootHostUsersBackend(t *testing.T) {
 		require.NoError(t, err)
 		invalidSudoersEntry := []byte("yipee i broke sudo!!!!")
 		err = backend.CheckSudoers(invalidSudoersEntry)
-		require.EqualError(t, err, "parse error in stdin near line 1\n\n\tvisudo: invalid sudoers file")
+		require.Contains(t, err.Error(), "visudo: invalid sudoers file")
 		// test sudoers entry containing . or ~
 		require.NoError(t, backend.WriteSudoersFile("user.name", validSudoersEntry))
 		_, err = os.Stat(filepath.Join(sudoersTestDir, "teleport-hostuuid-user_name"))


### PR DESCRIPTION
The teleport14 buildbox was updated to Ubuntu 22.04 and at the same
time, quintush/helm-unittest was removed. The former causes a sudoers
file test to fail, the latter is still needed. Fix these to try to
unbreak the build.