### PR TITLE
Set Renovate PR limit to 10 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
   ],
   "enabledManagers": ["gomod", "cargo"],
   "reviewers": ["codingllama", "jentfoo", "rosstimothy", "zmb3"],
+  "branchConcurrentLimit": 10,
+  "prConcurrentLimit": 10,
+  "prHourlyLimit": 0,
   "packageRules": [
     {
       "matchManagers": ["gomod"],


### PR DESCRIPTION
The default PR limit of 3 would prevent getting a PR per grouping
when the workflow is run weekly. Since there are only 8 groupings
we can ensure that any updates in any of them will result in a PR
when the workflow is run. The hourly PR limit is now also set to
unlimited(default was 2) to allow all PRs to be created.