### PR TITLE
[v13] Fix the default `teleport-kube-agent` upgrade server

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -162,9 +162,9 @@ You must not enable this if:
 
 ### `updater.versionServer`
 
-| Type     | Default value                         | Required?                       |
-|----------|---------------------------------------|---------------------------------|
-| `string` | "https://update.gravitational.io/v1/" | Yes if not using Teleport Cloud |
+| Type     | Default value                               | Required?                       |
+|----------|---------------------------------------------|---------------------------------|
+| `string` | "https://updates.releases.teleport.dev/v1/" | Yes if not using Teleport Cloud |
 
 `updater.versionServer` is the URL of the version server the agent fetches the
 target version from. The complete version endpoint is built by concatenating

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -146,7 +146,7 @@ updater:
   # `updater.versionServer` is the URL of the version server the agent fetches
   # the target version from. The complete version endpoint is built by
   # concatenating `versionServer` and `releaseChannel`.
-  versionServer: "https://update.gravitational.io/v1/"
+  versionServer: "https://updates.releases.teleport.dev/v1/"
   # Release channel the agent subscribes to.
   releaseChannel: "stable/cloud"
   image: public.ecr.aws/gravitational/teleport-kube-agent-updater

--- a/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
+++ b/integrations/kube-agent-updater/cmd/teleport-kube-agent-updater/main.go
@@ -71,7 +71,7 @@ func main() {
 	flag.DurationVar(&syncPeriod, "sync-period", 10*time.Hour, "Operator sync period (format: https://pkg.go.dev/time#ParseDuration)")
 	flag.BoolVar(&insecureNoVerify, "insecure-no-verify-image", false, "Disable image signature verification.")
 	flag.BoolVar(&disableLeaderElection, "disable-leader-election", false, "Disable leader election, used when running the kube-agent-updater outside of Kubernetes.")
-	flag.StringVar(&versionServer, "version-server", "https://update.gravitational.io/v1/", "URL of the HTTP server advertising target version and critical maintenances. Trailing slash is optional.")
+	flag.StringVar(&versionServer, "version-server", "https://updates.releases.teleport.dev/v1/", "URL of the HTTP server advertising target version and critical maintenances. Trailing slash is optional.")
 	flag.StringVar(&versionChannel, "version-channel", "cloud/stable", "Version channel to get updates from.")
 	flag.StringVar(&baseImageName, "base-image", "public.ecr.aws/gravitational/teleport", "Image reference containing registry and repository.")
 

--- a/rfd/0109-cloud-agent-upgrades.md
+++ b/rfd/0109-cloud-agent-upgrades.md
@@ -72,7 +72,7 @@ their control planes are always compatible with the current version targeted by 
 The current `cloud-stable` target version will be served via an `s3` bucket backed by CloudFront. Ex:
 
 ```
-$ VERSION="$(curl --proto '=https' --tlsv1.2 -sSf https://update.gravitational.io/v1/cloud-stable/version)"
+$ VERSION="$(curl --proto '=https' --tlsv1.2 -sSf https://updates.releases.teleport.dev/v1/cloud/stable/version)"
 ```
 
 Formally, this will be the only definition of what the current "cloud-stable" target is. An agent "downgrade" will
@@ -123,8 +123,8 @@ is treated as non-critical.
 Example usage:
 
 ```bash
-VERSION="$(curl --proto '=https' --tlsv1.2 -sSf https://update.gravitational.io/v1/cloud-stable/version)"
-CRITICAL="$(curl --proto '=https' --tlsv1.2 -sSf https://update.gravitational.io/v1/cloud-stable/critical)"
+VERSION="$(curl --proto '=https' --tlsv1.2 -sSf https://updates.releases.teleport.dev/v1/cloud/stable/version)"
+CRITICAL="$(curl --proto '=https' --tlsv1.2 -sSf https://updates.releases.teleport.dev/v1/cloud/stable/critical)"
 
 if [[ "$CRITICAL" == "yes" || "$UPGRADE_WINDOW" == "yes" ]]
 then


### PR DESCRIPTION
Backport #27504 to branch/v13

This is needed for auto upgrades to work when v13 goes live on teleport cloud.