### PR TITLE
Update teleport-operator.mdx with RFC 1123 requirement

### DIFF
--- a/docs/pages/management/guides/teleport-operator.mdx
+++ b/docs/pages/management/guides/teleport-operator.mdx
@@ -271,7 +271,7 @@ has been locked due to a certificate generation mismatch, possibly indicating a 
 In order to resolve this issue, remove any Teleport Kubernetes Operator sidecars connecting to the shared backend that are not in the same
 Kubernetes cluster or namespace.  Then redeploy the Auth Server pods.  When the operator starts, it deletes the cached information and recreates all required resources.
 
-### Teleport Resource Name is Invalid with the Operator
+### Teleport resource name is invalid with the Operator
 
 Kubernetes enforces all custom resource names to follow RFC 1123.  If attempting to create a resource using the operator with a name that is invalid, you will
 observe an error message similar to:

--- a/docs/pages/management/guides/teleport-operator.mdx
+++ b/docs/pages/management/guides/teleport-operator.mdx
@@ -28,6 +28,12 @@ Currently supported Teleport resources are:
 - GitHub connectors
 - Login Rules
 
+<Admonition type="note">
+   Kubernetes enforces all custom resource names to follow RFC 1123.  This requires the names of 
+   Teleport resources controlled by the operator to consist of lower case alphanumeric characters,
+   '-' or '.', and must start and end with an alphanumeric character.
+</Admonition>
+
 This guide covers how to:
 - Install Teleport Operator on Kubernetes.
 - Manage Teleport users and roles using Kubernetes.
@@ -264,6 +270,19 @@ has been locked due to a certificate generation mismatch, possibly indicating a 
 ```
 In order to resolve this issue, remove any Teleport Kubernetes Operator sidecars connecting to the shared backend that are not in the same
 Kubernetes cluster or namespace.  Then redeploy the Auth Server pods.  When the operator starts, it deletes the cached information and recreates all required resources.
+
+### Teleport Resource Name is Invalid with the Operator
+
+Kubernetes enforces all custom resource names to follow RFC 1123.  If attempting to create a resource using the operator with a name that is invalid, you will
+observe an error message similar to:
+
+```text
+The TeleportRole "my_role" is invalid: metadata.name: Invalid value: "my_role": a lowercase RFC 1123 subdomain
+must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character
+(e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
+```
+
+You will have to update the Teleport resource name to match the RFC 1123 requirements to resolve this issue.
 
 ## Next steps
 

--- a/docs/pages/management/guides/teleport-operator.mdx
+++ b/docs/pages/management/guides/teleport-operator.mdx
@@ -273,8 +273,8 @@ Kubernetes cluster or namespace.  Then redeploy the Auth Server pods.  When the 
 
 ### Teleport resource name is invalid with the Operator
 
-Kubernetes enforces all custom resource names to follow RFC 1123.  If attempting to create a resource using the operator with a name that is invalid, you will
-observe an error message similar to:
+Kubernetes enforces all custom resource names to follow RFC 1123 which includes specifications for hostnames.  If attempting to create a resource using the 
+operator with a name that is invalid, you will observe an error message similar to:
 
 ```text
 The TeleportRole "my_role" is invalid: metadata.name: Invalid value: "my_role": a lowercase RFC 1123 subdomain

--- a/docs/pages/management/guides/teleport-operator.mdx
+++ b/docs/pages/management/guides/teleport-operator.mdx
@@ -28,12 +28,6 @@ Currently supported Teleport resources are:
 - GitHub connectors
 - Login Rules
 
-<Admonition type="note">
-   Kubernetes enforces all custom resource names to follow RFC 1123.  This requires the names of 
-   Teleport resources controlled by the operator to consist of lower case alphanumeric characters,
-   '-' or '.', and must start and end with an alphanumeric character.
-</Admonition>
-
 This guide covers how to:
 - Install Teleport Operator on Kubernetes.
 - Manage Teleport users and roles using Kubernetes.
@@ -140,6 +134,12 @@ metadata:
 spec:
   roles: ['myrole']
 ```
+
+<Admonition type="note">
+   Kubernetes enforces all custom resource names to follow RFC 1123 which includes specifications for hostnames.
+   This requires the metadata.name of Teleport resources controlled by the operator consist of lowercase alphanumeric
+   characters, '-' or '.', and must start and end with an alphanumeric character.
+</Admonition>
 
 Apply the manifests to the Kubernetes cluster:
 
@@ -283,6 +283,8 @@ must consist of lower case alphanumeric characters, '-' or '.', and must start a
 ```
 
 You will have to update the Teleport resource name to match the RFC 1123 requirements to resolve this issue.
+The metadata.name of Teleport resources controlled by the operator must consist of lowercase alphanumeric
+characters, '-' or '.', and must start and end with an alphanumeric character.
 
 ## Next steps
 


### PR DESCRIPTION
based on interaction with a customer, updating the Kube operator docs to include the Kubernetes naming restrictions