### PR TITLE
Fix Teleport Connect assume roles

### DIFF
--- a/lib/teleterm/clusters/cluster_access_requests.go
+++ b/lib/teleterm/clusters/cluster_access_requests.go
@@ -252,8 +252,9 @@ func (c *Cluster) AssumeRole(ctx context.Context, req *api.AssumeRoleRequest) er
 				params.AccessRequests = append(params.AccessRequests, reqID)
 			}
 		}
-
-		return c.clusterClient.ReissueUserCerts(ctx, client.CertCacheKeep, params)
+		// When assuming a role, we want to drop all cached certs otherwise
+		// tsh will continue to use the old certs.
+		return c.clusterClient.ReissueUserCerts(ctx, client.CertCacheDrop, params)
 	})
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Teleport Connect didn't purge the cache on assume roles action which resulted in certificates being reused without the new role.

This PR drops locally cached certificates when a new assume role action is invoked.