### PR TITLE
Test `tool/tsh/common` in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -730,7 +730,7 @@ endif
 # Runs ci tsh tests
 .PHONY: test-go-tsh
 test-go-tsh: FLAGS ?= -race -shuffle on
-test-go-tsh: SUBJECT ?= github.com/gravitational/teleport/tool/tsh
+test-go-tsh: SUBJECT ?= github.com/gravitational/teleport/tool/tsh/...
 test-go-tsh:
 	$(CGOFLAG_TSH) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(LIBFIDO2_TEST_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \

--- a/tool/tsh/common/config_test.go
+++ b/tool/tsh/common/config_test.go
@@ -42,7 +42,7 @@ Host *.test-cluster localhost
 # Flags for all test-cluster hosts except the proxy
 Host *.test-cluster !localhost
     Port 3022
-    ProxyCommand "/bin/tsh" proxy ssh --cluster=test-cluster --proxy=localhost %r@%h:%p
+    ProxyCommand "/bin/tsh" proxy ssh --cluster=test-cluster --proxy=localhost:3080 %r@%h:%p
 
 # End generated Teleport configuration
 `
@@ -55,6 +55,7 @@ Host *.test-cluster !localhost
 		IdentityFilePath:    "/tmp/alice",
 		CertificateFilePath: "/tmp/localhost-cert.pub",
 		ProxyHost:           "localhost",
+		ProxyPort:           "3080",
 		ExecutablePath:      "/bin/tsh",
 	}, func() (*semver.Version, error) {
 		return semver.New("9.0.0"), nil

--- a/tool/tsh/common/tshconfig_test.go
+++ b/tool/tsh/common/tshconfig_test.go
@@ -439,7 +439,7 @@ func TestProxyTemplatesMakeClient(t *testing.T) {
 			}},
 		},
 		{
-			name: "match does not overwrite user specified cluster or proxy jump",
+			name: "match does not overwrite user specified proxy jump",
 			InConf: newCLIConf(func(conf *CLIConf) {
 				conf.UserHost = "node-1.us.example.com:3022"
 				conf.SiteName = "specified.cluster"
@@ -447,7 +447,7 @@ func TestProxyTemplatesMakeClient(t *testing.T) {
 			}),
 			outHost:    "node-1",
 			outPort:    4022,
-			outCluster: "specified.cluster",
+			outCluster: "us.example.com",
 			outJumpHosts: []utils.JumpHost{{
 				Addr: utils.NetAddr{
 					Addr:        "specified.proxy.com:443",


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/26862 moved `tool/tsh` to `tool/tsh/common`, but did not update `make test-go-tsh` to look at the new path. As a result, CI stopped testing tsh tests on master.

Caught when backporting https://github.com/gravitational/teleport/pull/27505, so I included the fix for that test here.