### PR TITLE
include port for proxy in ssh_config for tbot

### DIFF
--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -51,7 +51,7 @@ Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
     {{- if eq $dot.AppName "tsh" }}
     ProxyCommand "{{ $dot.ExecutablePath }}" proxy ssh --cluster={{ $clusterName }} --proxy={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} %r@%h:%p
 {{- end }}{{- if eq $dot.AppName "tbot" }}
-    ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy={{ $dot.ProxyHost }} ssh --cluster={{ $clusterName }}  %r@%h:%p
+    ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} ssh --cluster={{ $clusterName }}  %r@%h:%p
 {{- end }}
 {{- end }}
 

--- a/lib/tbot/config/configtemplate_ssh_client.go
+++ b/lib/tbot/config/configtemplate_ssh_client.go
@@ -194,7 +194,7 @@ func (c *TemplateSSHClient) Render(
 		IdentityFilePath:    identityFilePath,
 		CertificateFilePath: certificateFilePath,
 		ProxyHost:           proxyHost,
-    ProxyPort:           proxyPort, 
+		ProxyPort:           proxyPort,
 		ExecutablePath:      executablePath,
 		DestinationDir:      destDir,
 	}); err != nil {

--- a/lib/tbot/config/configtemplate_ssh_client.go
+++ b/lib/tbot/config/configtemplate_ssh_client.go
@@ -123,7 +123,7 @@ func (c *TemplateSSHClient) Render(
 		return trace.Wrap(err)
 	}
 
-	proxyHost, _, err := utils.SplitHostPort(ping.ProxyPublicAddr)
+	proxyHost, proxyPort, err := utils.SplitHostPort(ping.ProxyPublicAddr)
 	if err != nil {
 		return trace.BadParameter("proxy %+v has no usable public address: %v", ping.ProxyPublicAddr, err)
 	}
@@ -194,6 +194,7 @@ func (c *TemplateSSHClient) Render(
 		IdentityFilePath:    identityFilePath,
 		CertificateFilePath: certificateFilePath,
 		ProxyHost:           proxyHost,
+    ProxyPort:           proxyPort, 
 		ExecutablePath:      executablePath,
 		DestinationDir:      destDir,
 	}); err != nil {

--- a/lib/tbot/config/testdata/TestTemplateSSHClient_Render/latest_OpenSSH/ssh_config.golden
+++ b/lib/tbot/config/testdata/TestTemplateSSHClient_Render/latest_OpenSSH/ssh_config.golden
@@ -10,7 +10,7 @@ Host *.tele.blackmesa.gov tele.blackmesa.gov
 # Flags for all tele.blackmesa.gov hosts except the proxy
 Host *.tele.blackmesa.gov !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.blackmesa.gov  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.blackmesa.gov  %r@%h:%p
 # Common flags for all tele.aperture.labs hosts
 Host *.tele.aperture.labs tele.blackmesa.gov
     UserKnownHostsFile "/test/dir/known_hosts"
@@ -21,6 +21,6 @@ Host *.tele.aperture.labs tele.blackmesa.gov
 # Flags for all tele.aperture.labs hosts except the proxy
 Host *.tele.aperture.labs !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.aperture.labs  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.aperture.labs  %r@%h:%p
 
 # End generated Teleport configuration

--- a/lib/tbot/config/testdata/TestTemplateSSHClient_Render/legacy_OpenSSH/ssh_config.golden
+++ b/lib/tbot/config/testdata/TestTemplateSSHClient_Render/legacy_OpenSSH/ssh_config.golden
@@ -10,7 +10,7 @@ Host *.tele.blackmesa.gov tele.blackmesa.gov
 # Flags for all tele.blackmesa.gov hosts except the proxy
 Host *.tele.blackmesa.gov !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.blackmesa.gov  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.blackmesa.gov  %r@%h:%p
 # Common flags for all tele.aperture.labs hosts
 Host *.tele.aperture.labs tele.blackmesa.gov
     UserKnownHostsFile "/test/dir/known_hosts"
@@ -21,6 +21,6 @@ Host *.tele.aperture.labs tele.blackmesa.gov
 # Flags for all tele.aperture.labs hosts except the proxy
 Host *.tele.aperture.labs !tele.blackmesa.gov
     Port 3022
-    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov ssh --cluster=tele.aperture.labs  %r@%h:%p
+    ProxyCommand "/path/to/tbot" proxy --destination-dir=/test/dir --proxy=tele.blackmesa.gov:443 ssh --cluster=tele.aperture.labs  %r@%h:%p
 
 # End generated Teleport configuration


### PR DESCRIPTION
Includes port for proxy in `ssh_config` file for `tbot` as done for `tsh` in #27536. Will include in backport for #27536 if still pending approval.