### PR TITLE
Docs: Specify enterprise in commercial prereq cloud tab.

### DIFF
--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -19,9 +19,9 @@
 
 </TabItem>
 <TabItem scope={["cloud"]}
-  label="Teleport Cloud">
+  label="Teleport Enterprise Cloud">
 
-- A Teleport Cloud account, which includes a running Auth Service and Proxy
+- A Teleport Enterprise Cloud account, which includes a running Auth Service and Proxy
   Service. If you do not have a Teleport Cloud account, visit the [sign up
   page](https://goteleport.com/signup/) to begin your free trial.
 


### PR DESCRIPTION
Now that we have a non-enterprise cloud offering (Team).

Not backporting past 13 since Team wasn't offered previously.