### PR TITLE
helm: add hostAliases support

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -1713,10 +1713,6 @@ A list of extra environment variables to be set on the main Teleport container.
 
 ## `extraVolumeMounts`
 
-| Type   | Default value | Can be used in `custom` mode? |
-|--------|---------------|-------------------------------|
-| `list` | `[]`          | ✅                             |
-
 [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/)
 
 A list of extra Kubernetes volume mounts which should be mounted into any `Pod` created by the chart. These volume
@@ -1730,11 +1726,28 @@ mounts will also be mounted into any `initContainers` configured by the chart.
     mountPath: /path/to/mount/volume
   ```
 
-## `imagePullPolicy`
+## `hostAliases`
 
-| Type     | Default value  | Can be used in `custom` mode? |
-|----------|----------------|-------------------------------|
-| `string` | `IfNotPresent` | ✅                             |
+Configure aliases in the pod's `/etc/hosts`.
+This can be used to have the agent join the Teleport cluster through a different
+non-public route, or to allow the agent to access applications or databases that
+are not resolvable. See [the Kubernetes documentation
+](https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/) for
+more details.
+
+```yaml
+hostAliases:
+  - ip: "127.0.0.1"
+    hostnames:
+      - "foo.local"
+      - "bar.local"
+  - ip: "10.1.2.3"
+    hostnames:
+      - "foo.remote"
+      - "bar.remote"
+```
+
+## `imagePullPolicy`
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
 

--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -972,9 +972,9 @@ connecting to a Teleport Cloud instance enrolled in automatic updates.
 
 ## `imagePullSecrets`
 
-| Type   | Default value | Can be used in `custom` mode? |
-|--------|---------------|-------------------------------|
-| `list` | `[]`          | ✅                             |
+| Type   | Default value |
+|--------|---------------|
+| `list` | `[]`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod)
 
@@ -1132,9 +1132,9 @@ Ensures that this number of replicas is available during voluntary disruptions, 
 
 ## `serviceAccount.create`
 
-| Type      | Default value | Required? | Can be used in `custom` mode? |
-|-----------|---------------|-----------|-------------------------------|
-| `boolean` | `true`        | No        | ✅                             |
+| Type      | Default value | Required? |
+|-----------|---------------|-----------|
+| `boolean` | `true`        | No        |
 
 [Kubernetes reference](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/)
 
@@ -1151,9 +1151,9 @@ When off, the `serviceAccount.name` parameter should be set to the existing `Ser
 
 ## `serviceAccount.name`
 
-| Type     | Default value | Required? | Can be used in `custom` mode? |
-|----------|---------------|-----------|-------------------------------|
-| `string` | `""`          | No        | ✅                             |
+| Type     | Default value | Required? |
+|----------|---------------|-----------|
+| `string` | `""`          | No        |
 
 `serviceAccount.name` provides a custom name for the `ServiceAccount` resource
 that the `teleport-kube-agent` chart creates for the Teleport pod. By default,
@@ -1246,9 +1246,9 @@ The default is `INFO`, which is recommended in production.
 
 ### `log.output`
 
-| Type     | Default value | Can be used in `custom` mode? | `teleport.yaml` equivalent |
-|----------|---------------|-------------------------------|----------------------------|
-| `string` | `stderr`      | ❌                             | `teleport.log.output`      |
+| Type     | Default value | `teleport.yaml` equivalent |
+|----------|---------------|----------------------------|
+| `string` | `stderr`      | `teleport.log.output`      |
 
 `log.output` sets the output destination for the Teleport process.
 
@@ -1265,9 +1265,9 @@ The value can also be set to a file path (such as `/var/log/teleport.log`) to wr
 
 ### `log.format`
 
-| Type     | Default value | Can be used in `custom` mode? | `teleport.yaml` equivalent   |
-|----------|---------------|-------------------------------|------------------------------|
-| `string` | `text`        | ❌                             | `teleport.log.format.output` |
+| Type     | Default value | `teleport.yaml` equivalent   |
+|----------|---------------|------------------------------|
+| `string` | `text`        | `teleport.log.format.output` |
 
 `log.format` sets the output type for the Teleport process.
 
@@ -1282,9 +1282,9 @@ Possible values are `text` (default) or `json`.
 
 ### `log.extraFields`
 
-| Type   | Default value                                   | Can be used in `custom` mode? | `teleport.yaml` equivalent         |
-|--------|-------------------------------------------------|-------------------------------|------------------------------------|
-| `list` | `["timestamp", "level", "component", "caller"]` | ❌                             | `teleport.log.format.extra_fields` |
+| Type   | Default value                                   | `teleport.yaml` equivalent         |
+|--------|-------------------------------------------------|------------------------------------|
+| `list` | `["timestamp", "level", "component", "caller"]` | `teleport.log.format.extra_fields` |
 
 `log.extraFields` sets the fields used in logging for the Teleport process.
 
@@ -1583,18 +1583,13 @@ chart for the Teleport pod.
 
 ## `annotations.config`
 
-| Type     | Default value | Can be used in `custom` mode? | `teleport.yaml` equivalent |
-|----------|---------------|-------------------------------|----------------------------|
-| `object` | `{}`          | ❌                             | None                       |
+| Type     | Default value | `teleport.yaml` equivalent |
+|----------|---------------|----------------------------|
+| `object` | `{}`          | None                       |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 
 Kubernetes annotations which should be applied to the `ConfigMap` created by the chart.
-
-<Admonition type="note">
-  These annotations will not be applied in `custom` mode, as the `ConfigMap` is not managed by the chart.
-  In this instance, you should apply annotations manually to your created `ConfigMap`.
-</Admonition>
 
 `values.yaml` example:
 
@@ -1606,9 +1601,9 @@ Kubernetes annotations which should be applied to the `ConfigMap` created by the
 
 ## `annotations.deployment`
 
-| Type     | Default value | Can be used in `custom` mode? |
-|----------|---------------|-------------------------------|
-| `object` | `{}`          | ✅                             |
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 
@@ -1624,9 +1619,9 @@ Kubernetes annotations which should be applied to the `Deployment` created by th
 
 ## `annotations.pod`
 
-| Type     | Default value | Can be used in `custom` mode? |
-|----------|---------------|-------------------------------|
-| `object` | `{}`          | ✅                             |
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 
@@ -1642,9 +1637,9 @@ Kubernetes annotations which should be applied to each `Pod` created by the char
 
 ## `annotations.serviceAccount`
 
-| Type     | Default value | Can be used in `custom` mode? |
-|----------|---------------|-------------------------------|
-| `object` | `{}`          | ✅                             |
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
 
@@ -1660,9 +1655,9 @@ Kubernetes annotations which should be applied to the `ServiceAccount` created b
 
 ## `extraVolumes`
 
-| Type   | Default value | Can be used in `custom` mode? |
-|--------|---------------|-------------------------------|
-| `list` | `[]`          | ✅                             |
+| Type   | Default value |
+|--------|---------------|
+| `list` | `[]`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/)
 
@@ -1713,6 +1708,10 @@ A list of extra environment variables to be set on the main Teleport container.
 
 ## `extraVolumeMounts`
 
+| Type   | Default value |
+|--------|---------------|
+| `list` | `[]`          |
+
 [Kubernetes reference](https://kubernetes.io/docs/concepts/storage/volumes/)
 
 A list of extra Kubernetes volume mounts which should be mounted into any `Pod` created by the chart. These volume
@@ -1727,6 +1726,10 @@ mounts will also be mounted into any `initContainers` configured by the chart.
   ```
 
 ## `hostAliases`
+
+| Type   | Default value |
+|--------|---------------|
+| `list` | `[]`          |
 
 Configure aliases in the pod's `/etc/hosts`.
 This can be used to have the agent join the Teleport cluster through a different
@@ -1749,6 +1752,10 @@ hostAliases:
 
 ## `imagePullPolicy`
 
+| Type     | Default value  |
+|----------|----------------|
+| `string` | `IfNotPresent` |
+
 [Kubernetes reference](https://kubernetes.io/docs/concepts/containers/images/#updating-images)
 
 Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
@@ -1761,9 +1768,9 @@ Allows the `imagePullPolicy` for any pods created by the chart to be overridden.
 
 ## `initContainers`
 
-| Type   | Default value | Can be used in `custom` mode? |
-|--------|---------------|-------------------------------|
-| `list` | `[]`          | ✅                             |
+| Type   | Default value |
+|--------|---------------|
+| `list` | `[]`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/)
 
@@ -1780,9 +1787,9 @@ A list of `initContainers` which will be run before the main Teleport container 
 
 ## `resources`
 
-| Type     | Default value | Can be used in `custom` mode? |
-|----------|---------------|-------------------------------|
-| `object` | `{}`          | ✅                             |
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
 
@@ -1838,9 +1845,9 @@ To unset the security context, set it to `null` or `~`.
 
 ## `tolerations`
 
-| Type   | Default value | Can be used in `custom` mode? |
-|--------|---------------|-------------------------------|
-| `list` | `[]`          | ✅                             |
+| Type   | Default value |
+|--------|---------------|
+| `list` | `[]`          |
 
 [Kubernetes reference](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)
 

--- a/examples/chart/teleport-kube-agent/.lint/host-aliases.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/host-aliases.yaml
@@ -1,0 +1,11 @@
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+hostAliases:
+  - ip: "127.0.0.1"
+    hostnames:
+      - "foo.local"
+      - "bar.local"
+  - ip: "10.1.2.3"
+    hostnames:
+      - "foo.remote"
+      - "bar.remote"

--- a/examples/chart/teleport-kube-agent/templates/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/deployment.yaml
@@ -43,6 +43,9 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | quote }}
       {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- toYaml .Values.hostAliases | nindent 8 }}
+      {{- end }}
       {{- if or .Values.affinity (gt (int $replicaCount) 1) }}
       affinity:
         {{- if .Values.affinity }}

--- a/examples/chart/teleport-kube-agent/templates/statefulset.yaml
+++ b/examples/chart/teleport-kube-agent/templates/statefulset.yaml
@@ -39,6 +39,9 @@ spec:
       {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy | quote }}
       {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases: {{- toYaml .Values.hostAliases | nindent 8 }}
+      {{- end }}
       securityContext:
         fsGroup: 9807
       {{- if or .Values.affinity (gt (int $replicaCount) 1) }}

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -701,3 +701,21 @@ tests:
           content:
             name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
             value: "true"
+
+  - it: should set the hostAliases when specified
+    template: statefulset.yaml
+    values:
+      - ../.lint/stateful.yaml
+      - ../.lint/host-aliases.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.hostAliases
+          value:
+            - ip: "127.0.0.1"
+              hostnames:
+                - "foo.local"
+                - "bar.local"
+            - ip: "10.1.2.3"
+              hostnames:
+                - "foo.remote"
+                - "bar.remote"

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -578,6 +578,11 @@
             "type": "array",
             "default": []
         },
+        "hostAliases": {
+            "$id": "#/properties/hostAliases",
+            "type": "array",
+            "default": []
+        },
         "imagePullPolicy": {
             "$id": "#/properties/imagePullPolicy",
             "type": "string",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -366,6 +366,17 @@ extraVolumeMounts: []
 # - name: myvolume
 #   mountPath: /path/on/host
 
+# Pod Host aliases (see https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/)
+hostAliases: []
+# - ip: "127.0.0.1"
+#   hostnames:
+#     - "foo.local"
+#     - "bar.local"
+# - ip: "10.1.2.3"
+#   hostnames:
+#     - "foo.remote"
+#     - "bar.remote"
+
 # Allow the imagePullPolicy to be overridden
 imagePullPolicy: IfNotPresent
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/27611

- Allows `hostAlias` to be configured in the agent chart.
- Removes `custom` mode from the `teleport-kube-agent` reference as there is no such thing and this is a copy/paste from the old `teleport-cluster` reference page