### PR TITLE
[v13] Add UI `node` lock to use `server_id` instead

### DIFF
--- a/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Nodes.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/ResourceList/ServerSideSupportedList/Nodes.tsx
@@ -54,12 +54,14 @@ export function Nodes(props: ServerSideListProps & { nodes: Node[] }) {
         {
           altKey: 'action-btn',
           render: agent =>
-            renderActionCell(Boolean(selectedResources.node[agent.id]), () =>
-              toggleSelectResource({
-                kind: 'node',
-                targetValue: agent.id,
-                friendlyName: agent.hostname,
-              })
+            renderActionCell(
+              Boolean(selectedResources.server_id[agent.id]),
+              () =>
+                toggleSelectResource({
+                  kind: 'server_id',
+                  targetValue: agent.id,
+                  friendlyName: agent.hostname,
+                })
             ),
         },
       ]}

--- a/web/packages/teleport/src/LocksV2/NewLock/common.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/common.tsx
@@ -45,6 +45,7 @@ export type LockResourceKind =
   | 'role'
   | 'login'
   | 'node'
+  | 'server_id'
   | 'mfa_device'
   | 'windows_desktop'
   | 'access_request'
@@ -69,6 +70,7 @@ export function getEmptyResourceMap(): LockResourceMap {
     login: {},
     access_request: {},
     device: {},
+    server_id: {},
   };
 }
 
@@ -116,7 +118,7 @@ export const baseResourceKindOpts: LockResourceOption[] = [
     listKind: 'logins',
   },
   {
-    value: 'node',
+    value: 'server_id',
     label: 'Servers',
     listKind: 'server-side',
   },


### PR DESCRIPTION
Backport #27395 to branch/v13