### PR TITLE
Set UID/GID for ARC runner builds

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -96,10 +96,6 @@ else
 	DEVTOOLSET ?= devtoolset-11
 endif
 
-.PHONY:testthis
-testthis:
-	echo "$(UID):$(GID)"
-
 #
 # Build 'teleport' release inside a docker container
 #

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -9,7 +9,7 @@ SRCDIR=/go/src/github.com/gravitational/teleport
 GOMODCACHE ?= /tmp/gomodcache
 GOCACHE ?= /tmp/gocache
 # TODO(hugoShaka) remove HELM_PLUGINS with teleport13 buildbox
-DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e GOCACHE=$(GOCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new
+DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new
 
 ADDFLAGS ?=
 BATSFLAGS :=

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -7,7 +7,6 @@ endif
 HOSTNAME=buildbox
 SRCDIR=/go/src/github.com/gravitational/teleport
 GOMODCACHE ?= /tmp/gomodcache
-GOCACHE ?= /tmp/gocache
 # TODO(hugoShaka) remove HELM_PLUGINS with teleport13 buildbox
 DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -69,9 +69,17 @@ ifeq ("$(DRONE)","true")
 CI := true
 endif
 ifeq ("$(CI)","true")
+# The UID/GID of the runner user on ARC runners is 1001, not 1000
+# This var is currently only set for ARC runners via https://github.com/gravitational/cloud-terraform/pull/2473
+ifeq ("$(CI_SYSTEM)","ARC")
+UID := 1001
+GID := 1001
+NOROOT := -u 1001:1001
+else
 UID := 1000
 GID := 1000
 NOROOT := -u 1000:1000
+endif
 # if running in CI and the GOCACHE environment variable is not set, set it to a sensible default
 ifeq ("$(GOCACHE)",)
 GOCACHE := /go/cache

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -7,8 +7,9 @@ endif
 HOSTNAME=buildbox
 SRCDIR=/go/src/github.com/gravitational/teleport
 GOMODCACHE ?= /tmp/gomodcache
+GOCACHE ?= /tmp/gocache
 # TODO(hugoShaka) remove HELM_PLUGINS with teleport13 buildbox
-DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new
+DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e GOCACHE=$(GOCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new
 
 ADDFLAGS ?=
 BATSFLAGS :=
@@ -94,6 +95,10 @@ ifeq ("$(RUNTIME_ARCH)","arm64")
 else
 	DEVTOOLSET ?= devtoolset-11
 endif
+
+.PHONY:testthis
+testthis:
+	echo "$(UID):$(GID)"
 
 #
 # Build 'teleport' release inside a docker container


### PR DESCRIPTION
ARM64 builds are currently failing as the makefile incorrectly assumes that all CI systems we have use UID/GID 1000. This PR, along with https://github.com/gravitational/cloud-terraform/pull/2473, set the UID/GID to the value required by the new runners.

Confirmation that this value is set correctly: https://github.com/gravitational/dev-fred-gha-eks/actions/runs/5215479394/jobs/9413060326?pr=58#step:3:52