### PR TITLE
Fixed trailing whitespace on makefile vars

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -19,9 +19,11 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.20.4 # Sync with devbox.json.
+# Sync with devbox.json.
+GOLANG_VERSION ?= go1.20.4
 
-NODE_VERSION ?= 16.18.1 # Sync with devbox.json.
+# Sync with devbox.json.
+NODE_VERSION ?= 16.18.1
 
 # Sync any version changes below with devbox.json.
 # run lint-rust check locally before merging code after you bump this


### PR DESCRIPTION
A previous change added a space after the makefile vars and before a comment. As a result, the `GO_VERSION` and `NODE_VERSION` values propagated through the makefile with the trailing space, causing problems with builds. This PR fixes the issue by moving the comment above the vars, instead of inline with them.