### PR TITLE
Provide client login IP when SSO initiated in a browser.

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3727,6 +3727,10 @@ func (a *Server) NewWebSession(ctx context.Context, req types.NewWebSessionReque
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	if req.LoginIP == "" {
+		// TODO(antonam): consider turning this into error after all use cases are covered (before v14.0 testplan)
+		log.Debug("Creating new web session without login IP specified.")
+	}
 	clusterName, err := a.GetClusterName()
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -646,6 +646,7 @@ func (a *Server) validateGithubAuthCallback(ctx context.Context, diagCtx *SSODia
 			Traits:     user.GetTraits(),
 			SessionTTL: params.SessionTTL,
 			LoginTime:  a.clock.Now().UTC(),
+			LoginIP:    req.ClientLoginIP,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err, "Failed to create web session.")


### PR DESCRIPTION
When SSO was initiated in the browser we were missing providing client login IP for the web session creation.
OSS part of fixing https://github.com/gravitational/teleport/issues/27636