### PR TITLE
usagereporter: add context check in `RunSubmitter`

### DIFF
--- a/lib/usagereporter/teleport/aggregating/submitter.go
+++ b/lib/usagereporter/teleport/aggregating/submitter.go
@@ -106,7 +106,7 @@ func RunSubmitter(ctx context.Context, cfg SubmitterConfig) {
 	})
 	defer iv.Stop()
 
-	for {
+	for ctx.Err() == nil {
 		select {
 		case <-ctx.Done():
 			return


### PR DESCRIPTION
This avoids rare situations in which `submitOnce` can get called immediately after returning, if the context is closed (if enough time has passed, `iv.Next()` might have a value in its buffer, and `select` might pick that branch rather than the one from `ctx.Done()`).