### PR TITLE
[devbox] Use devbox for grpc, fix-imports, protos-up-to-date if enabled.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -933,7 +933,11 @@ lint-go:
 
 .PHONY: fix-imports
 fix-imports:
-	make -C build.assets/ fix-imports
+ifndef TELEPORT_DEVBOX
+	$(MAKE) -C build.assets/ fix-imports
+else
+	$(MAKE) fix-imports/host
+endif
 
 .PHONY: fix-imports/host
 fix-imports/host:
@@ -1187,7 +1191,11 @@ buf/installed:
 # This target runs in the buildbox container.
 .PHONY: grpc
 grpc:
+ifndef TELEPORT_DEVBOX
 	$(MAKE) -C build.assets grpc
+else
+	$(MAKE) grpc/host
+endif
 
 # grpc/host generates GRPC stubs.
 # Unlike grpc, this target runs locally.
@@ -1199,7 +1207,11 @@ grpc/host: protos/all
 # This target runs in the buildbox container.
 .PHONY: protos-up-to-date
 protos-up-to-date:
+ifndef TELEPORT_DEVBOX
 	$(MAKE) -C build.assets protos-up-to-date
+else
+	$(MAKE) protos-up-to-date/host
+endif
 
 # protos-up-to-date/host checks if the generated GRPC stubs are up to date.
 # Unlike protos-up-to-date, this target runs locally.


### PR DESCRIPTION
The Makefile will now detect if TELEPORT_DEVBOX is set and, if it is, will not start up Docker for the grpc, fix-imports, and protos-up-to-date targets.