### PR TITLE
Add billing_mode option to the DynamoDB backend so `pay_per_request` or `provisioned` billing can be configured

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -94,7 +94,7 @@ type Config struct {
 	WriteTargetValue float64 `json:"write_target_value,omitempty"`
 
 	// OnDemand sets on-demand capacity to the DynamoDB tables
-	OnDemand bool `json:"on_demand,omitempty"`
+	OnDemand *bool `json:"on_demand,omitempty"`
 }
 
 // CheckAndSetDefaults is a helper returns an error if the supplied configuration
@@ -105,18 +105,23 @@ func (cfg *Config) CheckAndSetDefaults() error {
 		return trace.BadParameter("DynamoDB: table_name is not specified")
 	}
 
-	if cfg.OnDemand && cfg.EnableAutoScaling {
+	if cfg.OnDemand == nil {
+		t := true
+		cfg.OnDemand = &t
+	}
+
+	if *cfg.OnDemand && cfg.EnableAutoScaling {
 		return trace.BadParameter("DynamoDB: both auto_scaling and on_demand can not both be enabled")
 	}
 
-	if cfg.OnDemand && (cfg.ReadCapacityUnits != 0 || cfg.WriteCapacityUnits != 0) {
+	if *cfg.OnDemand && (cfg.ReadCapacityUnits != 0 || cfg.WriteCapacityUnits != 0) {
 		return trace.BadParameter("DynamoDB: read_capacity_units and write_capacity_units must both be 0 when on_demand=true")
 	}
 
-	if cfg.ReadCapacityUnits == 0 && !cfg.OnDemand {
+	if cfg.ReadCapacityUnits == 0 && !*cfg.OnDemand {
 		cfg.ReadCapacityUnits = DefaultReadCapacityUnits
 	}
-	if cfg.WriteCapacityUnits == 0 && !cfg.OnDemand {
+	if cfg.WriteCapacityUnits == 0 && !*cfg.OnDemand {
 		cfg.WriteCapacityUnits = DefaultWriteCapacityUnits
 	}
 	if cfg.BufferSize == 0 {
@@ -668,7 +673,7 @@ func (b *Backend) getTableStatus(ctx context.Context, tableName string) (tableSt
 func (b *Backend) createTable(ctx context.Context, tableName string, rangeKey string) error {
 	var pThroughput *dynamodb.ProvisionedThroughput
 	var billingMode *string
-	if b.OnDemand {
+	if *b.OnDemand {
 		billingMode = aws.String(dynamodb.BillingModePayPerRequest)
 	} else {
 		pThroughput = &dynamodb.ProvisionedThroughput{

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -284,12 +284,12 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 	case tableStatusOK:
 		if tableBillingMode == dynamodb.BillingModePayPerRequest {
 			cfg.EnableAutoScaling = false
-			l.Debug("ignoring auto_scaling setting as table is in on-demand mode")
+			l.Info("Ignoring auto_scaling setting as table is in on-demand mode.")
 		}
 	case tableStatusMissing:
-		if tableBillingMode == dynamodb.BillingModePayPerRequest {
+		if cfg.BillingMode == billingModePayPerRequest {
 			cfg.EnableAutoScaling = false
-			l.Debug("ignoring auto_scaling setting as table is being created in on-demand mode")
+			l.Info("Ignoring auto_scaling setting as table is being created in on-demand mode.")
 		}
 		err = b.createTable(ctx, b.TableName, fullPathKey)
 	case tableStatusNeedsMigration:

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -106,22 +106,13 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	}
 
 	if cfg.OnDemand == nil {
-		t := true
-		cfg.OnDemand = &t
+		cfg.OnDemand = aws.Bool(true)
 	}
 
-	if *cfg.OnDemand && cfg.EnableAutoScaling {
-		return trace.BadParameter("DynamoDB: both auto_scaling and on_demand can not both be enabled")
-	}
-
-	if *cfg.OnDemand && (cfg.ReadCapacityUnits != 0 || cfg.WriteCapacityUnits != 0) {
-		return trace.BadParameter("DynamoDB: read_capacity_units and write_capacity_units must both be 0 when on_demand=true")
-	}
-
-	if cfg.ReadCapacityUnits == 0 && !*cfg.OnDemand {
+	if cfg.ReadCapacityUnits == 0 {
 		cfg.ReadCapacityUnits = DefaultReadCapacityUnits
 	}
-	if cfg.WriteCapacityUnits == 0 && !*cfg.OnDemand {
+	if cfg.WriteCapacityUnits == 0 {
 		cfg.WriteCapacityUnits = DefaultWriteCapacityUnits
 	}
 	if cfg.BufferSize == 0 {
@@ -132,6 +123,12 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	}
 	if cfg.RetryPeriod == 0 {
 		cfg.RetryPeriod = defaults.HighResPollingPeriod
+	}
+
+	if *cfg.OnDemand {
+		cfg.WriteCapacityUnits = 0
+		cfg.ReadCapacityUnits = 0
+		cfg.EnableAutoScaling = false
 	}
 
 	return nil

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -100,8 +100,8 @@ type Config struct {
 type billingMode string
 
 const (
-	billingModeProvisioned billingMode = "provisioned"
-	billingModeOnDemand    billingMode = "on_demand"
+	billingModeProvisioned   billingMode = "provisioned"
+	billingModePayPerRequest billingMode = "pay_per_request"
 )
 
 // CheckAndSetDefaults is a helper returns an error if the supplied configuration
@@ -113,7 +113,7 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	}
 
 	if cfg.BillingMode == "" {
-		cfg.BillingMode = billingModeOnDemand
+		cfg.BillingMode = billingModePayPerRequest
 	}
 
 	if cfg.ReadCapacityUnits == 0 {
@@ -681,7 +681,7 @@ func (b *Backend) createTable(ctx context.Context, tableName string, rangeKey st
 		ReadCapacityUnits:  aws.Int64(b.ReadCapacityUnits),
 		WriteCapacityUnits: aws.Int64(b.WriteCapacityUnits),
 	}
-	if b.BillingMode == billingModeOnDemand {
+	if b.BillingMode == billingModePayPerRequest {
 		billingMode = aws.String(dynamodb.BillingModePayPerRequest)
 		pThroughput = nil
 	}

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -178,7 +178,7 @@ func TestCreateTable(t *testing.T) {
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
-			name:               "create table suceeds",
+			name:               "create table succeeds",
 			readCapacityUnits:  10,
 			writeCapacityUnits: 10,
 			errorIsFn:          errIsNil,

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -142,7 +142,7 @@ func TestCreateTable(t *testing.T) {
 		{
 			name:                "table creation succeeds",
 			errorIsFn:           errIsNil,
-			billingMode:         billingModeOnDemand,
+			billingMode:         billingModePayPerRequest,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
@@ -150,7 +150,7 @@ func TestCreateTable(t *testing.T) {
 			readCapacityUnits:   10,
 			writeCapacityUnits:  10,
 			errorIsFn:           errIsNil,
-			billingMode:         billingModeOnDemand,
+			billingMode:         billingModePayPerRequest,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
@@ -162,7 +162,7 @@ func TestCreateTable(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(10),
 				WriteCapacityUnits: aws.Int64(10),
 			},
-			billingMode:         billingModeOnDemand,
+			billingMode:         billingModePayPerRequest,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
@@ -174,7 +174,7 @@ func TestCreateTable(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(10),
 				WriteCapacityUnits: aws.Int64(10),
 			},
-			billingMode:         billingModeOnDemand,
+			billingMode:         billingModePayPerRequest,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{

--- a/lib/backend/dynamo/dynamodbbk_test.go
+++ b/lib/backend/dynamo/dynamodbbk_test.go
@@ -137,12 +137,12 @@ func TestCreateTable(t *testing.T) {
 		writeCapacityUnits            int
 		expectedProvisionedThroughput *dynamodb.ProvisionedThroughput
 		expectedBillingMode           string
-		onDemand                      bool
+		billingMode                   billingMode
 	}{
 		{
 			name:                "table creation succeeds",
 			errorIsFn:           errIsNil,
-			onDemand:            true,
+			billingMode:         billingModeOnDemand,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
@@ -150,7 +150,7 @@ func TestCreateTable(t *testing.T) {
 			readCapacityUnits:   10,
 			writeCapacityUnits:  10,
 			errorIsFn:           errIsNil,
-			onDemand:            true,
+			billingMode:         billingModeOnDemand,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
@@ -162,7 +162,7 @@ func TestCreateTable(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(10),
 				WriteCapacityUnits: aws.Int64(10),
 			},
-			onDemand:            true,
+			billingMode:         billingModeOnDemand,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
@@ -174,7 +174,7 @@ func TestCreateTable(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(10),
 				WriteCapacityUnits: aws.Int64(10),
 			},
-			onDemand:            false,
+			billingMode:         billingModeOnDemand,
 			expectedBillingMode: dynamodb.BillingModePayPerRequest,
 		},
 		{
@@ -186,7 +186,7 @@ func TestCreateTable(t *testing.T) {
 				ReadCapacityUnits:  aws.Int64(10),
 				WriteCapacityUnits: aws.Int64(10),
 			},
-			onDemand:            false,
+			billingMode:         billingModeProvisioned,
 			expectedBillingMode: dynamodb.BillingModeProvisioned,
 		},
 	} {
@@ -201,7 +201,7 @@ func TestCreateTable(t *testing.T) {
 			backend := &Backend{
 				Entry: log.NewEntry(log.New()),
 				Config: Config{
-					OnDemand:           &tc.onDemand,
+					BillingMode:        tc.billingMode,
 					ReadCapacityUnits:  int64(tc.readCapacityUnits),
 					WriteCapacityUnits: int64(tc.writeCapacityUnits),
 				},


### PR DESCRIPTION
This adds a new `on_demand` option when configuring  the dynamodb backend.

AWS Docs [for on demand and provisioned mode](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadWriteCapacityMode.html#HowItWorks.OnDemand)

Resolves: https://github.com/gravitational/teleport/issues/23201

A future PR will resolve this getting applied to existing backends on config change: https://github.com/gravitational/teleport/issues/25829 