### PR TITLE
Abort reverse tunnel connections early if the proxy is already claimed

### DIFF
--- a/api/utils/sshutils/callback.go
+++ b/api/utils/sshutils/callback.go
@@ -35,7 +35,7 @@ type HostKeyCallbackConfig struct {
 	// FIPS allows to set FIPS mode which will validate algorithms.
 	FIPS bool
 	// OnCheckCert is called on SSH certificate validation.
-	OnCheckCert func(*ssh.Certificate)
+	OnCheckCert func(*ssh.Certificate) error
 	// Clock is used to set the Checker Time
 	Clock clockwork.Clock
 }

--- a/api/utils/sshutils/checker.go
+++ b/api/utils/sshutils/checker.go
@@ -36,7 +36,7 @@ type CertChecker struct {
 	FIPS bool
 
 	// OnCheckCert is called when validating host certificate.
-	OnCheckCert func(*ssh.Certificate)
+	OnCheckCert func(*ssh.Certificate) error
 }
 
 // Authenticate checks the validity of a user certificate.
@@ -67,7 +67,9 @@ func (c *CertChecker) CheckCert(principal string, cert *ssh.Certificate) error {
 	}
 
 	if c.OnCheckCert != nil {
-		c.OnCheckCert(cert)
+		if err := c.OnCheckCert(cert); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	return nil
@@ -86,7 +88,9 @@ func (c *CertChecker) CheckHostKey(addr string, remote net.Addr, key ssh.PublicK
 	}
 
 	if cert, ok := key.(*ssh.Certificate); ok && c.OnCheckCert != nil {
-		c.OnCheckCert(cert)
+		if err := c.OnCheckCert(cert); err != nil {
+			return trace.Wrap(err)
+		}
 	}
 
 	return nil

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -87,6 +87,9 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 		return nil, trace.Wrap(err)
 	}
 
+	// ssh.NewClient will loop over the global requests channel in a goroutine,
+	// rejecting all requests; we want to handle the global requests ourselves,
+	// so we feed it a closed channel to have the goroutine exit immediately.
 	emptyRequests := make(chan *ssh.Request)
 	close(emptyRequests)
 

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -57,8 +57,9 @@ func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHC
 	callback, err := apisshutils.NewHostKeyCallback(
 		apisshutils.HostKeyCallbackConfig{
 			GetHostCheckers: d.hostCheckerFunc(ctx),
-			OnCheckCert: func(c *ssh.Certificate) {
+			OnCheckCert: func(c *ssh.Certificate) error {
 				principals = c.ValidPrincipals
+				return nil
 			},
 			FIPS: d.fips,
 		})

--- a/lib/reversetunnel/agent_dialer.go
+++ b/lib/reversetunnel/agent_dialer.go
@@ -45,57 +45,52 @@ type agentDialer struct {
 
 // DialContext creates an ssh connection to the given address.
 func (d *agentDialer) DialContext(ctx context.Context, addr utils.NetAddr) (SSHClient, error) {
-
-	for _, authMethod := range d.authMethods {
-		// Create a dialer (that respects HTTP proxies) and connect to remote host.
-		dialer := proxy.DialerFromEnvironment(addr.Addr, d.options...)
-		pconn, err := dialer.DialTimeout(ctx, addr.AddrNetwork, addr.Addr, apidefaults.DefaultIOTimeout)
-		if err != nil {
-			d.log.WithError(err).Debugf("Failed to dial %s.", addr.Addr)
-			continue
-		}
-
-		principals := make([]string, 0)
-		callback, err := apisshutils.NewHostKeyCallback(
-			apisshutils.HostKeyCallbackConfig{
-				GetHostCheckers: d.hostCheckerFunc(ctx),
-				OnCheckCert: func(c *ssh.Certificate) {
-					principals = c.ValidPrincipals
-				},
-				FIPS: d.fips,
-			})
-		if err != nil {
-			d.log.Debugf("Failed to create host key callback for %v: %v.", addr.Addr, err)
-			continue
-		}
-
-		// Build a new client connection. This is done to get access to incoming
-		// global requests which dialer.Dial would not provide.
-		conn, chans, reqs, err := tracessh.NewClientConn(ctx, pconn, addr.Addr, &ssh.ClientConfig{
-			User:            d.username,
-			Auth:            []ssh.AuthMethod{authMethod},
-			HostKeyCallback: callback,
-			Timeout:         apidefaults.DefaultIOTimeout,
-		})
-		if err != nil {
-			d.log.WithError(err).Debugf("Failed to create client to %v.", addr.Addr)
-			continue
-		}
-
-		emptyRequests := make(chan *ssh.Request)
-		close(emptyRequests)
-
-		client := tracessh.NewClient(conn, chans, emptyRequests)
-
-		return &sshClient{
-			Client:      client,
-			requests:    reqs,
-			newChannels: chans,
-			principals:  principals,
-		}, nil
+	// Create a dialer (that respects HTTP proxies) and connect to remote host.
+	dialer := proxy.DialerFromEnvironment(addr.Addr, d.options...)
+	pconn, err := dialer.DialTimeout(ctx, addr.AddrNetwork, addr.Addr, apidefaults.DefaultIOTimeout)
+	if err != nil {
+		d.log.WithError(err).Debugf("Failed to dial %s.", addr.Addr)
+		return nil, trace.Wrap(err)
 	}
 
-	return nil, trace.BadParameter("failed to dial: all auth methods failed")
+	var principals []string
+	callback, err := apisshutils.NewHostKeyCallback(
+		apisshutils.HostKeyCallbackConfig{
+			GetHostCheckers: d.hostCheckerFunc(ctx),
+			OnCheckCert: func(c *ssh.Certificate) {
+				principals = c.ValidPrincipals
+			},
+			FIPS: d.fips,
+		})
+	if err != nil {
+		d.log.Debugf("Failed to create host key callback for %v: %v.", addr.Addr, err)
+		return nil, trace.Wrap(err)
+	}
+
+	// Build a new client connection. This is done to get access to incoming
+	// global requests which dialer.Dial would not provide.
+	conn, chans, reqs, err := tracessh.NewClientConn(ctx, pconn, addr.Addr, &ssh.ClientConfig{
+		User:            d.username,
+		Auth:            d.authMethods,
+		HostKeyCallback: callback,
+		Timeout:         apidefaults.DefaultIOTimeout,
+	})
+	if err != nil {
+		d.log.WithError(err).Debugf("Failed to create client to %v.", addr.Addr)
+		return nil, trace.Wrap(err)
+	}
+
+	emptyRequests := make(chan *ssh.Request)
+	close(emptyRequests)
+
+	client := tracessh.NewClient(conn, chans, emptyRequests)
+
+	return &sshClient{
+		Client:      client,
+		requests:    reqs,
+		newChannels: chans,
+		principals:  principals,
+	}, nil
 }
 
 // hostCheckerFunc wraps a apisshutils.CheckersGetter function with a context.

--- a/lib/reversetunnel/agentpool.go
+++ b/lib/reversetunnel/agentpool.go
@@ -493,6 +493,7 @@ func (p *AgentPool) newAgent(ctx context.Context, tracker *track.Tracker, lease 
 		options:     options,
 		username:    p.HostUUID,
 		log:         p.log,
+		isClaimed:   p.tracker.IsClaimed,
 	}
 
 	agent, err := newAgent(agentConfig{


### PR DESCRIPTION
We don't need to complete the SSH handshake if we can tell from the principals of the server (that we read in the host key callback) that the proxy is already claimed.

We still only attempt to claim the proxy after the handshake has completed, which can still fail (two connections at the same time onto the same proxy might both pass the early check), but that's fine as this is only an optimization which saves some time and some CPU.