### PR TITLE
Refactor lib/teleterm gateway

### DIFF
--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -369,26 +369,7 @@ func (l *LocalProxy) CheckDBCerts(dbRoute tlsca.RouteToDatabase) error {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(CheckCertSubject(cert, dbRoute))
-}
-
-// CheckCertSubject checks if the route to the database from the cert matches the provided route in
-// terms of username and database (if present).
-func CheckCertSubject(cert *x509.Certificate, dbRoute tlsca.RouteToDatabase) error {
-	identity, err := tlsca.FromSubject(cert.Subject, cert.NotAfter)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if dbRoute.Username != "" && dbRoute.Username != identity.RouteToDatabase.Username {
-		return trace.Errorf("certificate subject is for user %s, but need %s",
-			identity.RouteToDatabase.Username, dbRoute.Username)
-	}
-	if dbRoute.Database != "" && dbRoute.Database != identity.RouteToDatabase.Database {
-		return trace.Errorf("certificate subject is for database name %s, but need %s",
-			identity.RouteToDatabase.Database, dbRoute.Database)
-	}
-
-	return nil
+	return trace.Wrap(dbRoute.CheckCertSubject(cert))
 }
 
 // SetCerts sets the local proxy's configured TLS certificates.

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -22,7 +22,6 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
-	"github.com/gravitational/teleport/lib/teleterm/gateway"
 )
 
 // Config is the cluster service config
@@ -30,9 +29,8 @@ type Config struct {
 	// Storage is a storage service that reads/writes to tsh profiles
 	Storage *clusters.Storage
 	// Log is a component logger
-	Log              *logrus.Entry
-	GatewayCreator   GatewayCreator
-	TCPPortAllocator gateway.TCPPortAllocator
+	Log            *logrus.Entry
+	GatewayCreator GatewayCreator
 	// CreateTshdEventsClientCredsFunc lazily creates creds for the tshd events server ran by the
 	// Electron app. This is to ensure that the server public key is written to the disk under the
 	// expected location by the time we get around to creating the client.
@@ -52,10 +50,6 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.GatewayCreator == nil {
 		c.GatewayCreator = clusters.NewGatewayCreator(c.Storage)
-	}
-
-	if c.TCPPortAllocator == nil {
-		c.TCPPortAllocator = gateway.NetTCPPortAllocator{}
 	}
 
 	if c.Log == nil {

--- a/lib/teleterm/daemon/gateway_cert_reissuer.go
+++ b/lib/teleterm/daemon/gateway_cert_reissuer.go
@@ -28,8 +28,8 @@ import (
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
+	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
-	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 // GatewayCertReissuer is responsible for managing the process of reissuing a db cert for a gateway
@@ -41,14 +41,6 @@ type GatewayCertReissuer struct {
 	// app can show only one login modal at a time, we need to submit only one request at a time.
 	reloginMu sync.Mutex
 	Log       *logrus.Entry
-}
-
-// DBCertReissuer lets us pass a mock in tests and clusters.Cluster (which makes calls to the
-// cluster) in production code.
-type DBCertReissuer interface {
-	// ReissueDBCerts reaches out to the cluster to get a cert for the specific tlsca.RouteToDatabase
-	// and saves it to disk.
-	ReissueDBCerts(context.Context, tlsca.RouteToDatabase) error
 }
 
 // TSHDEventsClient takes only those methods from api.TshdEventsServiceClient that
@@ -78,8 +70,8 @@ type TSHDEventsClient interface {
 // Any error ReissueCert returns is also forwarded to the Electron app so that it can show an error
 // notification. GatewayCertReissuer is typically called from within a goroutine that handles the
 // gateway, so without forwarding the error to the app, it would be visible only in the logs.
-func (r *GatewayCertReissuer) ReissueCert(ctx context.Context, gateway *gateway.Gateway, dbCertReissuer DBCertReissuer) error {
-	if err := r.reissueCert(ctx, gateway, dbCertReissuer); err != nil {
+func (r *GatewayCertReissuer) ReissueCert(ctx context.Context, gateway *gateway.Gateway, doReissueCert clusters.ReissueCertFunc) error {
+	if err := r.reissueCert(ctx, gateway, doReissueCert); err != nil {
 		r.notifyAppAboutError(ctx, err, gateway)
 
 		// Return the error to the alpn.LocalProxy's middleware.
@@ -89,7 +81,7 @@ func (r *GatewayCertReissuer) ReissueCert(ctx context.Context, gateway *gateway.
 	return nil
 }
 
-func (r *GatewayCertReissuer) reissueCert(ctx context.Context, gateway *gateway.Gateway, dbCertReissuer DBCertReissuer) error {
+func (r *GatewayCertReissuer) reissueCert(ctx context.Context, gateway *gateway.Gateway, doReissueCert clusters.ReissueCertFunc) error {
 	// Make the first attempt at reissuing the db cert.
 	//
 	// It might happen that the db cert has expired but the user cert is still active, allowing us to
@@ -98,7 +90,7 @@ func (r *GatewayCertReissuer) reissueCert(ctx context.Context, gateway *gateway.
 	// This can happen if the user cert was refreshed by anything other than the gateway itself. For
 	// example, if you execute `tsh ssh` within Connect after your user cert expires or there are two
 	// gateways that subsequently go through this flow.
-	err := r.reissueAndReloadGatewayCert(ctx, gateway, dbCertReissuer)
+	err := doReissueCert(ctx)
 
 	if err == nil {
 		return nil
@@ -129,21 +121,12 @@ func (r *GatewayCertReissuer) reissueCert(ctx context.Context, gateway *gateway.
 		return trace.Wrap(err)
 	}
 
-	err = r.reissueAndReloadGatewayCert(ctx, gateway, dbCertReissuer)
+	err = doReissueCert(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
 	return nil
-}
-
-func (r *GatewayCertReissuer) reissueAndReloadGatewayCert(ctx context.Context, gateway *gateway.Gateway, dbCertReissuer DBCertReissuer) error {
-	err := dbCertReissuer.ReissueDBCerts(ctx, gateway.RouteToDatabase())
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	return trace.Wrap(gateway.ReloadCert())
 }
 
 func (r *GatewayCertReissuer) requestReloginFromElectronApp(ctx context.Context, req *api.ReloginRequest) error {

--- a/lib/teleterm/daemon/gateway_cert_reissuer_test.go
+++ b/lib/teleterm/daemon/gateway_cert_reissuer_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
-	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 var log = logrus.WithField(trace.Component, "reissuer")
@@ -138,7 +137,7 @@ func TestReissueCert(t *testing.T) {
 			if tt.reissuerOpt != nil {
 				tt.reissuerOpt(t, reissuer)
 			}
-			err := reissuer.ReissueCert(ctx, gateway, dbCertReissuer)
+			err := reissuer.ReissueCert(ctx, gateway, dbCertReissuer.ReissueDBCerts)
 			if tt.wantErr != nil {
 				require.ErrorIs(t, err, tt.wantErr)
 				require.ErrorContains(t, err, tt.wantAddedMessage)
@@ -173,7 +172,7 @@ type mockDBCertReissuer struct {
 	returnValuesForSubsequentCalls []error
 }
 
-func (r *mockDBCertReissuer) ReissueDBCerts(context.Context, tlsca.RouteToDatabase) error {
+func (r *mockDBCertReissuer) ReissueDBCerts(context.Context) error {
 	var err error
 	if r.callCount < len(r.returnValuesForSubsequentCalls) {
 		err = r.returnValuesForSubsequentCalls[r.callCount]

--- a/lib/teleterm/gateway/db_middleware.go
+++ b/lib/teleterm/gateway/db_middleware.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 )
 
-type localProxyMiddleware struct {
+type dbMiddleware struct {
 	onExpiredCert func(context.Context) error
 	log           *logrus.Entry
 	dbRoute       tlsca.RouteToDatabase
@@ -39,7 +39,7 @@ type localProxyMiddleware struct {
 //
 // In the future, DBCertChecker is going to be extended so that it's used by both tsh and Connect
 // and this middleware will be removed.
-func (m *localProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy, conn net.Conn) error {
+func (m *dbMiddleware) OnNewConnection(ctx context.Context, lp *alpn.LocalProxy, conn net.Conn) error {
 	err := lp.CheckDBCerts(m.dbRoute)
 	if err == nil {
 		return nil
@@ -58,6 +58,6 @@ func (m *localProxyMiddleware) OnNewConnection(ctx context.Context, lp *alpn.Loc
 // OnStart is a noop. client.DBCertChecker.OnStart checks cert validity too. However in Connect
 // there's no flow which would allow the user to create a local proxy without valid
 // certs.
-func (m *localProxyMiddleware) OnStart(context.Context, *alpn.LocalProxy) error {
+func (m *dbMiddleware) OnStart(context.Context, *alpn.LocalProxy) error {
 	return nil
 }

--- a/lib/teleterm/gateway/db_middleware_test.go
+++ b/lib/teleterm/gateway/db_middleware_test.go
@@ -34,7 +34,7 @@ import (
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
 
-func TestLocalProxyMiddleware_OnNewConnection(t *testing.T) {
+func Test_dbMiddleware_OnNewConnection(t *testing.T) {
 	testCert, err := cert.GenerateSelfSignedCert([]string{"localhost"})
 	require.NoError(t, err)
 	tlsCert, err := keys.X509KeyPair(testCert.Cert, testCert.PrivateKey)
@@ -103,7 +103,7 @@ func TestLocalProxyMiddleware_OnNewConnection(t *testing.T) {
 
 			hasCalledOnExpiredCert := false
 
-			middleware := &localProxyMiddleware{
+			middleware := &dbMiddleware{
 				onExpiredCert: func(context.Context) error {
 					hasCalledOnExpiredCert = true
 					return nil

--- a/lib/teleterm/gateway/gateway_test.go
+++ b/lib/teleterm/gateway/gateway_test.go
@@ -60,7 +60,7 @@ func TestGatewayStart(t *testing.T) {
 		hs.Close()
 	})
 
-	keyPairPaths := gatewaytest.MustGenAndSaveCert(t, tlsca.Identity{
+	tlsCert := gatewaytest.MustGenDBCert(t, tlsca.Identity{
 		Username: "alice",
 		Groups:   []string{"test-group"},
 		RouteToDatabase: tlsca.RouteToDatabase{
@@ -76,8 +76,7 @@ func TestGatewayStart(t *testing.T) {
 			TargetURI:          uri.NewClusterURI("bar").AppendDB("foo").String(),
 			TargetUser:         "alice",
 			Protocol:           defaults.ProtocolPostgres,
-			CertPath:           keyPairPaths.CertPath,
-			KeyPath:            keyPairPaths.KeyPath,
+			Cert:               tlsCert,
 			Insecure:           true,
 			WebProxyAddr:       hs.Listener.Addr().String(),
 			CLICommandProvider: mockCLICommandProvider{},
@@ -180,7 +179,7 @@ func createGateway(t *testing.T, tcpPortAllocator TCPPortAllocator) *Gateway {
 		hs.Close()
 	})
 
-	keyPairPaths := gatewaytest.MustGenAndSaveCert(t, tlsca.Identity{
+	tlsCert := gatewaytest.MustGenDBCert(t, tlsca.Identity{
 		Username: "alice",
 		Groups:   []string{"test-group"},
 		RouteToDatabase: tlsca.RouteToDatabase{
@@ -196,8 +195,7 @@ func createGateway(t *testing.T, tcpPortAllocator TCPPortAllocator) *Gateway {
 			TargetURI:          uri.NewClusterURI("bar").AppendDB("foo").String(),
 			TargetUser:         "alice",
 			Protocol:           defaults.ProtocolPostgres,
-			CertPath:           keyPairPaths.CertPath,
-			KeyPath:            keyPairPaths.KeyPath,
+			Cert:               tlsCert,
 			Insecure:           true,
 			WebProxyAddr:       hs.Listener.Addr().String(),
 			CLICommandProvider: mockCLICommandProvider{},

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -249,6 +249,24 @@ func (r RouteToDatabase) String() string {
 		r.ServiceName, r.Protocol, r.Username, r.Database)
 }
 
+// CheckCertSubject checks if the route to the database from the cert matches
+// the provided route in terms of username and database (if present).
+func (r RouteToDatabase) CheckCertSubject(cert *x509.Certificate) error {
+	identity, err := FromSubject(cert.Subject, cert.NotAfter)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if r.Username != "" && r.Username != identity.RouteToDatabase.Username {
+		return trace.Errorf("certificate subject is for user %s, but need %s",
+			identity.RouteToDatabase.Username, r.Username)
+	}
+	if r.Database != "" && r.Database != identity.RouteToDatabase.Database {
+		return trace.Errorf("certificate subject is for database name %s, but need %s",
+			identity.RouteToDatabase.Database, r.Database)
+	}
+	return nil
+}
+
 // DeviceExtensions holds device-aware extensions for the identity.
 type DeviceExtensions struct {
 	// DeviceID is the trusted device identifier.


### PR DESCRIPTION
Prep for:
- #26836

Changes:
- Move construction of `DbcmdCLICommandProvider` from `lib/teleterm/daemon` to `lib/teleterm/clusters`
- Refactor cert reissue logic
  - `clusters.Cluster` hides gateway types from `daemon.GatewayCertReissuer`
  - `gateway.Gateway` takes `tls.Certficate` instead of cert paths, and gets a `tls.Certificate` directly on reissue callback