### PR TITLE
Updated v12 makefile RELEASE_RECIPE to use $(UID):$(GID)

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -456,7 +456,7 @@ define RELEASE_RECIPE
 			-v "/tmp:/tmp" \
 			-v "$(WORKSPACE):/go/teleport" \
 			-w /go/teleport \
-			-u 1000:1000 \
+			-u $(UID):$(GID) \
 			$(BUILDBOX) \
 		make $(1) ARCH=$(ARCH) ADDFLAGS="$(ADDFLAGS)" OS=$(OS) RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=no
 endef


### PR DESCRIPTION
UID/GID of 1000 is hard-coded rather than pulling from makefile variables, causing ARM64 builds to fail on v12 releases specifically.