### PR TITLE
Make use of keepAliveInterval in terminal handler

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2697,7 +2697,7 @@ func (h *Handler) siteNodeConnect(
 	if keepAliveInterval < time.Second {
 		authAccessPoint, err := site.CachingAccessPoint()
 		if err != nil {
-			h.log.WithError(err).Debug("Unable to get auth access point.")
+			h.log.Debugf("Unable to get auth access point: %v", err)
 			return nil, trace.Wrap(err)
 		}
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2691,16 +2691,23 @@ func (h *Handler) siteNodeConnect(
 	h.log.Debugf("New terminal request for server=%s, login=%s, sid=%s, websid=%s.",
 		req.Server, req.Login, sessionData.ID, sessionCtx.GetSessionID())
 
-	authAccessPoint, err := site.CachingAccessPoint()
-	if err != nil {
-		h.log.WithError(err).Debug("Unable to get auth access point.")
-		return nil, trace.Wrap(err)
-	}
+	keepAliveInterval := req.KeepAliveInterval
+	// Try to use the keep alive interval from the request.
+	// When it is not set, use the cluster's keep alive interval.
+	if keepAliveInterval == 0 {
+		authAccessPoint, err := site.CachingAccessPoint()
+		if err != nil {
+			h.log.WithError(err).Debug("Unable to get auth access point.")
+			return nil, trace.Wrap(err)
+		}
 
-	netConfig, err := authAccessPoint.GetClusterNetworkingConfig(ctx)
-	if err != nil {
-		h.log.WithError(err).Debug("Unable to fetch cluster networking config.")
-		return nil, trace.Wrap(err)
+		netConfig, err := authAccessPoint.GetClusterNetworkingConfig(ctx)
+		if err != nil {
+			h.log.WithError(err).Debug("Unable to fetch cluster networking config.")
+			return nil, trace.Wrap(err)
+		}
+
+		keepAliveInterval = netConfig.GetKeepAliveInterval()
 	}
 
 	terminalConfig := TerminalHandlerConfig{
@@ -2710,7 +2717,7 @@ func (h *Handler) siteNodeConnect(
 		LocalAuthProvider:  h.auth.accessPoint,
 		DisplayLogin:       displayLogin,
 		SessionData:        sessionData,
-		KeepAliveInterval:  netConfig.GetKeepAliveInterval(),
+		KeepAliveInterval:  keepAliveInterval,
 		ProxyHostPort:      h.ProxyHostPort(),
 		ProxyPublicAddr:    h.PublicProxyAddr(),
 		InteractiveCommand: req.InteractiveCommand,

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2693,8 +2693,8 @@ func (h *Handler) siteNodeConnect(
 
 	keepAliveInterval := req.KeepAliveInterval
 	// Try to use the keep alive interval from the request.
-	// When it is not set, use the cluster's keep alive interval.
-	if keepAliveInterval == 0 {
+	// When it's not set or below a second, use the cluster's keep alive interval.
+	if keepAliveInterval < time.Second {
 		authAccessPoint, err := site.CachingAccessPoint()
 		if err != nil {
 			h.log.WithError(err).Debug("Unable to get auth access point.")

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1666,7 +1666,7 @@ func TestTerminalPing(t *testing.T) {
 
 	select {
 	case <-done:
-	case <-time.After(time.Minute):
+	case <-time.After(6 * time.Second):
 		t.Fatal("timeout waiting for ping")
 	}
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1632,7 +1632,7 @@ func isResizeEventEnvelope(e *Envelope) bool {
 func TestTerminalPing(t *testing.T) {
 	t.Parallel()
 	s := newWebSuite(t)
-	ws, _, err := s.makeTerminal(t, s.authPack(t, "foo"), withKeepaliveInterval(500*time.Millisecond))
+	ws, _, err := s.makeTerminal(t, s.authPack(t, "foo"), withKeepaliveInterval(time.Second))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, ws.Close()) })
 


### PR DESCRIPTION
Looks like keepAliveInternal is being ignored in the web terminal handler. This change sets the keep alive interval from the request if provided or uses the cluster value as a backup. As a side effect, TestTerminalPing runs ~ 1s instead of ~ 10s.