### PR TITLE
Don't use WithError() when logging "Missing session cookie"

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -465,7 +465,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 			session, err := h.authenticateWebSession(w, r)
 			if err != nil {
-				h.log.WithError(err).Debug("Could not authenticate.")
+				h.log.Debugf("Could not authenticate: %v", err)
 			}
 			session.XCSRF = csrfToken
 


### PR DESCRIPTION
This is a normal circumstance when you log in from a browser for the first time or after your cookie expires. Omitting the WithError() logging will make it look less like a critical error in log output.