### PR TITLE
Update Locking docs to refer `server-id`

### DIFF
--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -30,7 +30,7 @@ A lock can target the following objects or attributes:
 - a Teleport [trusted device](device-trust.mdx#optional-locking-a-device) by the device ID
 - an MFA device by the device's UUID
 - an OS/UNIX login
-- a Teleport agent by the Agent's Server UUID (effectively unregistering it from the
+- a Teleport agent by the agent's server UUID (effectively unregistering it from the
   cluster)
 - a Windows desktop by the desktop's name
 - an [Access Request](../access-requests.mdx) by UUID
@@ -77,7 +77,7 @@ with one of the following options:
   <TabItem label="Agent">
   All connections to the specified agent will be locked and the agent will be excluded from the Teleport cluster.
   ```code
-  $ tctl lock --server-id=363256df-f78a-4d99-803c-bae19da9ede4 --message="The server running Kubernetes Service and Database service is under investigation." --ttl=10h
+  $ tctl lock --server-id=363256df-f78a-4d99-803c-bae19da9ede4 --message="The server running the Kubernetes Service and Database Service is under investigation." --ttl=10h
   # Created a lock with name "dc7cee9d-fe5e-4534-a90d-db770f0234a1".
   ```
   </TabItem>

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -1,6 +1,6 @@
 ---
 title: Session and Identity Locking
-description: How to lock compromised users or nodes
+description: How to lock compromised users or agents
 ---
 
 <Details
@@ -15,7 +15,7 @@ description: How to lock compromised users or nodes
   deployment.
 </Details>
 
-System administrators can disable a compromised user or node—or
+System administrators can disable a compromised user or Teleport agent—or
 prevent access during cluster maintenance—by placing a lock
 on a session, user or host identity.
 
@@ -30,7 +30,7 @@ A lock can target the following objects or attributes:
 - a Teleport [trusted device](device-trust.mdx#optional-locking-a-device) by the device ID
 - an MFA device by the device's UUID
 - an OS/UNIX login
-- a Teleport Node by the Node's UUID (effectively unregistering it from the
+- a Teleport agent by the Agent's Server UUID (effectively unregistering it from the
   cluster)
 - a Windows desktop by the desktop's name
 - an [Access Request](../access-requests.mdx) by UUID
@@ -74,10 +74,10 @@ with one of the following options:
   # Created a lock with name "d6c06a18-e147-4232-9dfe-6f83a28d5850".
   ```
   </TabItem>
-  <TabItem label="Node">
-  All connections to the specified node will be locked.
+  <TabItem label="Agent">
+  All connections to the specified agent will be locked and the agent will be excluded from the Teleport cluster.
   ```code
-  $ tctl lock --node=363256df-f78a-4d99-803c-bae19da9ede4 --message="The node is under investigation." --ttl=10h
+  $ tctl lock --server-id=363256df-f78a-4d99-803c-bae19da9ede4 --message="The server running Kubernetes Service and Database service is under investigation." --ttl=10h
   # Created a lock with name "dc7cee9d-fe5e-4534-a90d-db770f0234a1".
   ```
   </TabItem>


### PR DESCRIPTION
PR #27018 extended support for locking any type of Teleport instances besides `nodes`. 

This PR updates the documentation to be aligned with the new `--server-id` flag.