### PR TITLE
docs: Fix curl commands on Windows

### DIFF
--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -204,7 +204,7 @@ machine where you can manage your group policy, assigning <Var name="proxy" />
 to the address of your Teleport Proxy Service:
 
 ```code
-$ curl 'https://<Var name="proxy"/>/webapi/auth/export?type=windows' > user-ca.cer
+$ curl -o user-ca.cer https://<Var name="proxy"/>/webapi/auth/export?type=windows
 ```
 
 <Admonition type="note" title="Take note of the location">

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -50,21 +50,8 @@ Export the Teleport user certificate authority by running the following from
 `cmd.exe` on your Windows system:
 
 ```code
-$ curl -o teleport.cer 'https://teleport-proxy.example.com:443/webapi/auth/export?type=windows'
+$ curl -o teleport.cer https://teleport-proxy.example.com/webapi/auth/export?type=windows
 ```
-
-<Admonition type="warning" title="PowerShell">
-Be sure to run the above command in `cmd.exe`. In PowerShell, `curl` is an alias for
-[`Invoke-WebRequest`](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.utility/invoke-webrequest?view=powershell-7.3)
-which has different semantics.
-
-If you must use PowerShell, remove the alias before running curl with the
-following command:
-
-```
-> Remove-Item alias:curl
-```
-</Admonition>
 
 ### Install the Teleport service for Windows
 

--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -59,7 +59,7 @@ Teleport CA was rotated since the last import, you will have to fetch the
 new CA using the following command, assigning <Var name="proxy" /> to the address of your Teleport Proxy Service:
 
 ```code
-$ curl 'https://<Var name="proxy"/>/webapi/auth/export?type=windows' > user-ca.cer
+$ curl -o user-ca.cer https://<Var name="proxy"/>/webapi/auth/export?type=windows
 ```
 
 If that doesn't help, log into the target host directly, open PowerShell and


### PR DESCRIPTION
As per https://github.com/gravitational/teleport/discussions/27656, the `curl` command on Windows (especially when run via the Powershell alias to `Invoke-WebRequest`) outputs a lot of extra guff, so redirecting this straight to a file causes the `.cer` file not to validate:

![image](https://github.com/gravitational/teleport/assets/897821/03c62ab4-3284-4c7c-8f9d-174a558d3691)

I rewrote the instructions and tested them using both `cmd.exe` and Powershell - they have exactly the same behaviour in both, because `Invoke-WebRequest` also treats `-o` as `-OutFile`. The removal of the quotes is mandatory to avoid an error from native `curl`.

The outputted `.cer` file is now the correct length:

![image](https://github.com/gravitational/teleport/assets/897821/50ecacc9-673a-418a-9082-1a2c8fb58355)

Specifying port `:443` is also redundant when using HTTPS.