### PR TITLE
[v11] Docs: document labels for trusted clusters

### DIFF
--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -286,6 +286,12 @@ Use this token when defining a trusted cluster resource on a remote cluster.
 This command generates a Trusted Cluster join token. The token can be used
 multiple times and has an expiration time of 5 minutes.
 
+<Details title="Optional: Add labels">
+The `--labels` flag will add labels to the trusted cluster. This lets teams use
+the same RBAC controls used on individual resources to approve or deny access
+to clusters.
+</Details>
+
 Copy the join token for later use. If you need to display your join token again,
 run the following command against your root cluster:
 

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1557,10 +1557,10 @@ $ tctl tokens add --type=TYPE [<flags>]
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
+| `--format` | none | `text`, `json`, `yaml` | Output format |
+| `--ttl` | 1h | relative duration like 5s, 2m, or 3h | Set expiration time for token |
 | `--type` | none | `proxy`, `auth`, `trusted_cluster`, `node`,  `db`, `kube`, `app`, `windowsdesktop` | Type of token to add |
 | `--value` | none | **string** token value | Value of token to add |
-| `--ttl` | 1h | relative duration like 5s, 2m, or 3h | Set expiration time for token |
-| `--format` | none | `text`, `json`, `yaml` | Output format |
 
 #### Global flags
 

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1558,7 +1558,7 @@ $ tctl tokens add --type=TYPE [<flags>]
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
 | <nobr>`--format`</nobr> | none | `text`, `json`, `yaml` | Output format |
-| `--labels` | none | `text` | Sets token labels, e.g. `env=prod,region=us-west` |
+| `--labels` | none | `text` | Sets token labels |
 | `--ttl` | 1h | relative duration like 5s, 2m, or 3h | Set expiration time for token |
 | `--type` | none | `proxy`, `auth`, `trusted_cluster`, `node`,  `db`, `kube`, `app`, `windowsdesktop` | Type of token to add |
 | `--value` | none | **string** token value | Value of token to add |
@@ -1574,7 +1574,7 @@ These flags are available for all commands `--debug, --config` . Run
 # Generate an invite token for a trusted_cluster
 $ tctl tokens add --type=trusted_cluster --ttl=5m
 # Generate an invite token for a trusted_cluster with labels
-$ tctl tokens add --type=trusted_cluster --labels=env=prod
+$ tctl tokens add --type=trusted_cluster --labels=env=prod,region=us-west
 # Generate an invite token for a node
 # This is equivalent to `tctl nodes add`
 $ tctl tokens add --type=node

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1557,7 +1557,7 @@ $ tctl tokens add --type=TYPE [<flags>]
 
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
-| `--format` | none | `text`, `json`, `yaml` | Output format |
+| <nobr>`--format`</nobr> | none | `text`, `json`, `yaml` | Output format |
 | `--ttl` | 1h | relative duration like 5s, 2m, or 3h | Set expiration time for token |
 | `--type` | none | `proxy`, `auth`, `trusted_cluster`, `node`,  `db`, `kube`, `app`, `windowsdesktop` | Type of token to add |
 | `--value` | none | **string** token value | Value of token to add |

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1559,7 +1559,7 @@ $ tctl tokens add --type=TYPE [<flags>]
 | - | - | - | - |
 | <nobr>`--format`</nobr> | none | `text`, `json`, `yaml` | Output format |
 | `--labels` | none | `text` | Sets token labels |
-| `--ttl` | 1h | relative duration like 5s, 2m, or 3h | Set expiration time for token |
+| `--ttl` | 1h | Duration like 5s, 2m, or 3h | Sets how long the token is valid for. |
 | `--type` | none | `proxy`, `auth`, `trusted_cluster`, `node`,  `db`, `kube`, `app`, `windowsdesktop` | Type of token to add |
 | `--value` | none | **string** token value | Value of token to add |
 

--- a/docs/pages/reference/cli.mdx
+++ b/docs/pages/reference/cli.mdx
@@ -1558,6 +1558,7 @@ $ tctl tokens add --type=TYPE [<flags>]
 | Name | Default Value(s) | Allowed Value(s) | Description |
 | - | - | - | - |
 | <nobr>`--format`</nobr> | none | `text`, `json`, `yaml` | Output format |
+| `--labels` | none | `text` | Sets token labels, e.g. `env=prod,region=us-west` |
 | `--ttl` | 1h | relative duration like 5s, 2m, or 3h | Set expiration time for token |
 | `--type` | none | `proxy`, `auth`, `trusted_cluster`, `node`,  `db`, `kube`, `app`, `windowsdesktop` | Type of token to add |
 | `--value` | none | **string** token value | Value of token to add |


### PR DESCRIPTION
Backport #27032 to branch/v11