### PR TITLE
apiserver: Remove rate limiting on /webapi/find endpoint

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -560,7 +560,7 @@ func (h *Handler) bindMinimalEndpoints() {
 	// and does not fetch the data that servers don't need, e.g.
 	// OIDC connectors and auth preferences
 	// Note that find is a unique endpoint that requires high request rates
-	// sometimes through NAT's and thus should not be rate limited by IP.
+	// sometimes through NATs and thus should not be rate limited by IP.
 	h.GET("/webapi/find", httplib.MakeHandler(h.find))
 	// Issue host credentials.
 	h.POST("/webapi/host/credentials", h.WithUnauthenticatedHighLimiter(h.hostCredentials))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -1220,6 +1220,7 @@ func (h *Handler) ping(w http.ResponseWriter, r *http.Request, p httprouter.Para
 }
 
 func (h *Handler) find(w http.ResponseWriter, r *http.Request, p httprouter.Params) (interface{}, error) {
+	// TODO(jent,espadolini): add a time-based cache to further reduce load on this endpoint
 	proxyConfig, err := h.cfg.ProxySettings.GetProxySettings(r.Context())
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -559,7 +559,9 @@ func (h *Handler) bindMinimalEndpoints() {
 	// find is like ping, but is faster because it is optimized for servers
 	// and does not fetch the data that servers don't need, e.g.
 	// OIDC connectors and auth preferences
-	h.GET("/webapi/find", h.WithUnauthenticatedHighLimiter(h.find))
+	// Note that find is a unique endpoint that requires high request rates
+	// sometimes through NAT's and thus should not be rate limited by IP.
+	h.GET("/webapi/find", httplib.MakeHandler(h.find))
 	// Issue host credentials.
 	h.POST("/webapi/host/credentials", h.WithUnauthenticatedHighLimiter(h.hostCredentials))
 }


### PR DESCRIPTION
It was discovered in recent load testing that our high rate limit was still potentially impactful. After discussions with @espadolini we decided that because of the low load impacts from this endpoint it's probably safest to just avoid rate limiting for the `find` endpoint.

The addition of these rate limits is still only in `master`, originally implemented in this PR: https://github.com/gravitational/teleport/pull/24623