### PR TITLE
add default join-method for tctl bots add

### DIFF
--- a/tool/tctl/common/bots_command.go
+++ b/tool/tctl/common/bots_command.go
@@ -167,8 +167,8 @@ certificates:
 > tbot start \
    --destination-dir=./tbot-user \
    --token={{.token}} \
-   --auth-server={{.addr}}{{if .join_method}} \
-   --join-method={{.join_method}}{{end}}
+   --auth-server={{.addr}} \
+   --join-method={{if .join_method}}{{.join_method}}{{else}}token{{end}}
 
 Please note:
 


### PR DESCRIPTION
the parameter `join-method` is required for `tbot start`.  Current output command example doesn't include it for the default.