### PR TITLE
Replace `graviational/oxy.Forwarder` with `httputil.ReverseProxy`

### DIFF
--- a/integration/appaccess/appaccess_test.go
+++ b/integration/appaccess/appaccess_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
-	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
@@ -39,6 +38,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/events"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -405,10 +405,10 @@ func testRewriteHeadersRoot(p *Pack, t *testing.T) {
 	require.NotEqual(t, req.Header.Get(teleport.AppJWTHeader), "rewritten-app-jwt-header")
 	require.NotEqual(t, req.Header.Get(teleport.AppCFHeader), "rewritten-app-cf-header")
 	require.NotEqual(t, req.Header.Get(common.TeleportAPIErrorHeader), "rewritten-x-teleport-api-error")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedFor), "rewritten-x-forwarded-for-header")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedHost), "rewritten-x-forwarded-host-header")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedProto), "rewritten-x-forwarded-proto-header")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedServer), "rewritten-x-forwarded-server-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedFor), "rewritten-x-forwarded-for-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedHost), "rewritten-x-forwarded-host-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedProto), "rewritten-x-forwarded-proto-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedServer), "rewritten-x-forwarded-server-header")
 	require.NotEqual(t, req.Header.Get(common.XForwardedSSL), "rewritten-x-forwarded-ssl")
 
 	// Verify JWT tokens.
@@ -444,10 +444,10 @@ func testRewriteHeadersLeaf(p *Pack, t *testing.T) {
 	require.NotEqual(t, req.Header.Get(teleport.AppCFHeader), "rewritten-app-cf-header")
 	require.NotEqual(t, req.Header.Get(common.TeleportAPIErrorHeader), "rewritten-x-teleport-api-error")
 	require.NotEqual(t, req.Header.Get(common.XForwardedSSL), "rewritten-x-forwarded-ssl")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedFor), "rewritten-x-forwarded-for-header")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedHost), "rewritten-x-forwarded-host-header")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedProto), "rewritten-x-forwarded-proto-header")
-	require.NotEqual(t, req.Header.Get(forward.XForwardedServer), "rewritten-x-forwarded-server-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedFor), "rewritten-x-forwarded-for-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedHost), "rewritten-x-forwarded-host-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedProto), "rewritten-x-forwarded-proto-header")
+	require.NotEqual(t, req.Header.Get(reverseproxy.XForwardedServer), "rewritten-x-forwarded-server-header")
 }
 
 // testLogout verifies the session is removed from the backend when the user logs out.

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
-	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -45,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/httplib/csrf"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -701,19 +701,19 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 							Value: "rewritten-x-teleport-api-error",
 						},
 						{
-							Name:  forward.XForwardedFor,
+							Name:  reverseproxy.XForwardedFor,
 							Value: "rewritten-x-forwarded-for-header",
 						},
 						{
-							Name:  forward.XForwardedHost,
+							Name:  reverseproxy.XForwardedHost,
 							Value: "rewritten-x-forwarded-host-header",
 						},
 						{
-							Name:  forward.XForwardedProto,
+							Name:  reverseproxy.XForwardedProto,
 							Value: "rewritten-x-forwarded-proto-header",
 						},
 						{
-							Name:  forward.XForwardedServer,
+							Name:  reverseproxy.XForwardedServer,
 							Value: "rewritten-x-forwarded-server-header",
 						},
 						{
@@ -721,7 +721,7 @@ func (p *Pack) startRootAppServers(t *testing.T, count int, opts AppTestOptions)
 							Value: "rewritten-x-forwarded-ssl-header",
 						},
 						{
-							Name:  forward.XForwardedPort,
+							Name:  reverseproxy.XForwardedPort,
 							Value: "rewritten-x-forwarded-port-header",
 						},
 						// Make sure we can insert JWT token in custom header.
@@ -844,19 +844,19 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 							Value: "rewritten-x-teleport-api-error",
 						},
 						{
-							Name:  forward.XForwardedFor,
+							Name:  reverseproxy.XForwardedFor,
 							Value: "rewritten-x-forwarded-for-header",
 						},
 						{
-							Name:  forward.XForwardedHost,
+							Name:  reverseproxy.XForwardedHost,
 							Value: "rewritten-x-forwarded-host-header",
 						},
 						{
-							Name:  forward.XForwardedProto,
+							Name:  reverseproxy.XForwardedProto,
 							Value: "rewritten-x-forwarded-proto-header",
 						},
 						{
-							Name:  forward.XForwardedServer,
+							Name:  reverseproxy.XForwardedServer,
 							Value: "rewritten-x-forwarded-server-header",
 						},
 						{
@@ -864,7 +864,7 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 							Value: "rewritten-x-forwarded-ssl-header",
 						},
 						{
-							Name:  forward.XForwardedPort,
+							Name:  reverseproxy.XForwardedPort,
 							Value: "rewritten-x-forwarded-port-header",
 						},
 					},

--- a/lib/httplib/reverseproxy/handler.go
+++ b/lib/httplib/reverseproxy/handler.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reverseproxy
+
+import (
+	"io"
+	"net"
+	"net/http"
+)
+
+// ErrorHandler is an interface for handling errors.
+type ErrorHandler interface {
+	ServeHTTP(w http.ResponseWriter, req *http.Request, err error)
+}
+
+// DefaultHandler is the default error handler.
+var DefaultHandler ErrorHandler = &defaultHandler{}
+
+// defaultHandler is the default error handler.
+type defaultHandler struct{}
+
+// ServeHTTP writes the error message to the response.
+func (e *defaultHandler) ServeHTTP(w http.ResponseWriter, req *http.Request, err error) {
+	statusCode := http.StatusInternalServerError
+	switch {
+	case err == io.EOF:
+		statusCode = http.StatusBadGateway
+	default:
+		switch e, ok := err.(net.Error); {
+		case ok && e.Timeout():
+			statusCode = http.StatusGatewayTimeout
+		case ok:
+			statusCode = http.StatusBadGateway
+		}
+	}
+	w.WriteHeader(statusCode)
+	w.Write([]byte(http.StatusText(statusCode)))
+}
+
+// ErrorHandlerFunc is an adapter to allow the use of ordinary functions as
+// error handlers. If f is a function with the appropriate signature,
+// ErrorHandlerFunc(f) is a ErrorHandler that calls f.
+type ErrorHandlerFunc func(http.ResponseWriter, *http.Request, error)
+
+// ServeHTTP calls f(w, r).
+func (f ErrorHandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request, err error) {
+	f(w, r, err)
+}

--- a/lib/httplib/reverseproxy/reverse_proxy.go
+++ b/lib/httplib/reverseproxy/reverse_proxy.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reverseproxy
+
+import (
+	"io"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// X-* Header names.
+const (
+	XForwardedProto  = "X-Forwarded-Proto"
+	XForwardedFor    = "X-Forwarded-For"
+	XForwardedHost   = "X-Forwarded-Host"
+	XForwardedPort   = "X-Forwarded-Port"
+	XForwardedServer = "X-Forwarded-Server"
+	XRealIP          = "X-Real-Ip"
+)
+
+// XHeaders X-* headers.
+var XHeaders = []string{
+	XForwardedProto,
+	XForwardedFor,
+	XForwardedHost,
+	XForwardedPort,
+	XForwardedServer,
+	XRealIP,
+}
+
+const (
+	// ContentLength is the Content-Length header.
+	ContentLength = "Content-Length"
+)
+
+// Forwarder is a reverse proxy that forwards http requests to another server.
+type Forwarder struct {
+	passHostHeader bool
+	headerRewriter Rewriter
+	*httputil.ReverseProxy
+	log       utils.FieldLoggerWithWriter
+	transport http.RoundTripper
+}
+
+// New returns a new reverse proxy that forwards to the given url.
+// If passHostHeader is true, the Host header will be copied from the
+// request to the forwarded request. Otherwise, the Host header will be
+// set to the host portion of the url.
+func New(opts ...Option) (*Forwarder, error) {
+	fwd := &Forwarder{
+		headerRewriter: NewHeaderRewriter(),
+		ReverseProxy: &httputil.ReverseProxy{
+			ErrorHandler: DefaultHandler.ServeHTTP,
+		},
+		log: utils.NewLogger(),
+	}
+	// Apply options.
+	for _, opt := range opts {
+		opt(fwd)
+	}
+
+	// Director is called by the ReverseProxy to modify the request.
+	fwd.Director = func(request *http.Request) {
+		modifyRequest(request)
+		if fwd.headerRewriter != nil {
+			fwd.headerRewriter.Rewrite(request)
+		}
+		if !fwd.passHostHeader {
+			request.Host = request.URL.Host
+		}
+	}
+
+	if fwd.transport == nil {
+		tr, err := defaults.Transport()
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		fwd.transport = tr
+	}
+	// Set the transport for the reverse proxy to use a round tripper
+	// that logs the request and response.
+	fwd.ReverseProxy.Transport = &roundTripperWithLogger{transport: fwd.transport, log: fwd.log}
+
+	return fwd, nil
+}
+
+// Option is a functional option for the forwarder.
+type Option func(*Forwarder)
+
+// WithFlushInterval sets the flush interval for the forwarder.
+func WithFlushInterval(interval time.Duration) Option {
+	return func(rp *Forwarder) {
+		rp.FlushInterval = interval
+	}
+}
+
+// WithLogger sets the logger for the forwarder. It uses the logger.Writer()
+// method to get the io.Writer to use for the stdlib logger.
+func WithLogger(logger utils.FieldLoggerWithWriter) Option {
+	return func(rp *Forwarder) {
+		rp.log = logger
+		// TODO: this is a hack to get the stdlib logger to work with the
+		// logrus logger.
+		if rp.ReverseProxy.ErrorLog == nil {
+			rp.ReverseProxy.ErrorLog = log.New(logger.WriterLevel(logrus.DebugLevel), "", log.LstdFlags)
+		}
+	}
+}
+
+// WithLogWriter sets the writer for the stdlib logger to use a different
+// io.Writer than the default one created when using WithLogger.
+func WithLogWriter(w *io.PipeWriter) Option {
+	return func(rp *Forwarder) {
+		rp.ReverseProxy.ErrorLog = log.New(w, "", log.LstdFlags)
+	}
+}
+
+// WithRoundTripper sets the round tripper for the forwarder.
+func WithRoundTripper(transport http.RoundTripper) Option {
+	return func(rp *Forwarder) {
+		rp.transport = transport
+	}
+}
+
+// WithErrorHandler sets the error handler for the forwarder.
+func WithErrorHandler(e ErrorHandlerFunc) Option {
+	return func(rp *Forwarder) {
+		rp.ErrorHandler = e
+	}
+}
+
+// WithRewriter sets the header rewriter for the forwarder.
+func WithRewriter(h Rewriter) Option {
+	return func(rp *Forwarder) {
+		rp.headerRewriter = h
+	}
+}
+
+// WithPassHostHeader sets whether the Host header should be passed to the
+// forwarded request.
+func WithPassHostHeader() Option {
+	return func(rp *Forwarder) {
+		rp.passHostHeader = true
+	}
+}
+
+// Modify the request to handle the target URL.
+func modifyRequest(outReq *http.Request) {
+	u := getURLFromRequest(outReq)
+
+	outReq.URL.Path = u.Path
+	outReq.URL.RawPath = u.RawPath
+	outReq.URL.RawQuery = u.RawQuery
+	outReq.RequestURI = "" // Outgoing request should not have RequestURI
+
+	outReq.Proto = "HTTP/1.1"
+	outReq.ProtoMajor = 1
+	outReq.ProtoMinor = 1
+}
+
+// getURLFromRequest returns the URL from the request object. If the request
+// RequestURI is non-empty and parsable, it will be used. Otherwise, the URL
+// will be used.
+func getURLFromRequest(req *http.Request) *url.URL {
+	// If the Request was created by Go via a real HTTP request,
+	// RequestURI will contain the original query string.
+	// If the Request was created in code,
+	// RequestURI will be empty, and we will use the URL object instead
+	u := req.URL
+	if req.RequestURI != "" {
+		parsedURL, err := url.ParseRequestURI(req.RequestURI)
+		if err == nil {
+			return parsedURL
+		}
+	}
+	return u
+}
+
+type roundTripperWithLogger struct {
+	log       logrus.FieldLogger
+	transport http.RoundTripper
+}
+
+// CloseIdleConnections ensures idle connections of the wrapped
+// [http.RoundTripper] are closed.
+func (r *roundTripperWithLogger) CloseIdleConnections() {
+	type closeIdler interface {
+		CloseIdleConnections()
+	}
+	if tr, ok := r.transport.(closeIdler); ok {
+		tr.CloseIdleConnections()
+	}
+}
+
+// RoundTrip forwards the request on to the provided http.RoundTripper and logs
+// the request and response.
+func (r *roundTripperWithLogger) RoundTrip(req *http.Request) (*http.Response, error) {
+	start := time.Now()
+	rsp, err := r.transport.RoundTrip(req)
+	if err != nil {
+		r.log.Errorf("Error forwarding to %v, err: %v", req.URL, err)
+		return rsp, err
+	}
+
+	if req.TLS != nil {
+		r.log.Infof("Round trip: %v %v, code: %v, duration: %v tls:version: %x, tls:resume:%t, tls:csuite:%x, tls:server:%v",
+			req.Method, req.URL, rsp.StatusCode, time.Now().UTC().Sub(start),
+			req.TLS.Version,
+			req.TLS.DidResume,
+			req.TLS.CipherSuite,
+			req.TLS.ServerName)
+	} else {
+		r.log.Infof("Round trip: %v %v, code: %v, duration: %v",
+			req.Method, req.URL, rsp.StatusCode, time.Now().UTC().Sub(start))
+	}
+
+	return rsp, nil
+}

--- a/lib/httplib/reverseproxy/rewriter.go
+++ b/lib/httplib/reverseproxy/rewriter.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reverseproxy
+
+import (
+	"net"
+	"net/http"
+	"os"
+	"strings"
+)
+
+// Rewriter is an interface for rewriting http requests.
+type Rewriter interface {
+	Rewrite(*http.Request)
+}
+
+// NewHeaderRewriter creates a new HeaderRewriter.
+func NewHeaderRewriter() *HeaderRewriter {
+	h, err := os.Hostname()
+	if err != nil {
+		h = "localhost"
+	}
+	return &HeaderRewriter{TrustForwardHeader: true, Hostname: h}
+}
+
+// HeaderRewriter re-sets the X-Forwarded-* headers and sets X-Real-IP header.
+type HeaderRewriter struct {
+	TrustForwardHeader bool
+	Hostname           string
+}
+
+// Rewrite request headers.
+func (rw *HeaderRewriter) Rewrite(req *http.Request) {
+	if !rw.TrustForwardHeader {
+		for _, h := range XHeaders {
+			req.Header.Del(h)
+		}
+	}
+
+	// Set X-Real-IP header if it is not set to the IP address of the client making the request.
+	maybeSetXRealIP(req)
+
+	// Set X-Forwarded-Proto header if it is not set to the scheme of the request.
+	maybeSetForwardedProto(req)
+
+	if xfPort := req.Header.Get(XForwardedPort); xfPort == "" {
+		req.Header.Set(XForwardedPort, forwardedPort(req))
+	}
+
+	if xfHost := req.Header.Get(XForwardedHost); xfHost == "" && req.Host != "" {
+		req.Header.Set(XForwardedHost, req.Host)
+	}
+
+	if rw.Hostname != "" {
+		req.Header.Set(XForwardedServer, rw.Hostname)
+	}
+}
+
+// forwardedPort returns the port part of the Host header if present, otherwise,
+// returns "80" if the scheme is http or "443" if the scheme is https or wss.
+func forwardedPort(req *http.Request) string {
+	if req == nil {
+		return ""
+	}
+
+	if _, port, err := net.SplitHostPort(req.Host); err == nil && port != "" {
+		return port
+	}
+
+	if req.Header.Get(XForwardedProto) == "https" || req.Header.Get(XForwardedProto) == "wss" {
+		return "443"
+	}
+
+	if req.TLS != nil {
+		return "443"
+	}
+
+	return "80"
+}
+
+// maybeSetXRealIP sets X-Real-IP header if it is not set to the IP address of
+// the client making the request.
+func maybeSetXRealIP(req *http.Request) {
+	if req.Header.Get(XRealIP) != "" {
+		return
+	}
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		clientIP = ipv6fix(clientIP)
+		req.Header.Set(XRealIP, clientIP)
+	}
+}
+
+// maybeSetForwardedProto sets X-Forwarded-Proto header if it is not set to the
+// scheme of the request.
+func maybeSetForwardedProto(req *http.Request) {
+	if req.Header.Get(XForwardedProto) != "" {
+		return
+	}
+
+	if req.TLS != nil {
+		req.Header.Set(XForwardedProto, "https")
+	} else {
+		req.Header.Set(XForwardedProto, "http")
+	}
+}
+
+// clean up IP in case if it is ipv6 address and it has {zone} information in
+// it, like "[fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)]:64692".
+func ipv6fix(clientIP string) string {
+	return strings.Split(clientIP, "%")[0]
+}

--- a/lib/httplib/reverseproxy/rewriter_test.go
+++ b/lib/httplib/reverseproxy/rewriter_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reverseproxy
+
+import (
+	"crypto/tls"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIPv6Fix(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		clientIP string
+		expected string
+	}{
+		{
+			desc:     "empty",
+			clientIP: "",
+			expected: "",
+		},
+		{
+			desc:     "ipv4 localhost",
+			clientIP: "127.0.0.1",
+			expected: "127.0.0.1",
+		},
+		{
+			desc:     "ipv4",
+			clientIP: "10.13.14.15",
+			expected: "10.13.14.15",
+		},
+		{
+			desc:     "ipv6 zone",
+			clientIP: `fe80::d806:a55d:eb1b:49cc%vEthernet (vmxnet3 Ethernet Adapter - Virtual Switch)`,
+			expected: "fe80::d806:a55d:eb1b:49cc",
+		},
+		{
+			desc:     "ipv6 medium",
+			clientIP: `fe80::1`,
+			expected: "fe80::1",
+		},
+		{
+			desc:     "ipv6 small",
+			clientIP: `2000::`,
+			expected: "2000::",
+		},
+		{
+			desc:     "ipv6",
+			clientIP: `2001:3452:4952:2837::`,
+			expected: "2001:3452:4952:2837::",
+		},
+	}
+
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			actual := ipv6fix(test.clientIP)
+			require.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestRewriter(t *testing.T) {
+	const hostname = "teleport-dev"
+	testCases := []struct {
+		desc       string
+		reqHeaders http.Header
+		tlsReq     bool
+		hostReq    string
+		remoteAddr string
+		expected   http.Header
+	}{
+		{
+			desc:       "set x-real-ip",
+			reqHeaders: http.Header{},
+			tlsReq:     true,
+			hostReq:    "teleport.dev:3543",
+			remoteAddr: "1.2.3.4:1234",
+			expected: http.Header{
+				XForwardedHost:   []string{"teleport.dev:3543"},
+				XForwardedPort:   []string{"3543"},
+				XForwardedProto:  []string{"https"},
+				XForwardedServer: []string{hostname},
+				XRealIP:          []string{"1.2.3.4"},
+			},
+		},
+		{
+			desc: "trust x-real-ip",
+			reqHeaders: http.Header{
+				XRealIP: []string{"5.6.7.8"},
+			},
+			tlsReq:     false,
+			hostReq:    "teleport.dev:3543",
+			remoteAddr: "1.2.3.4:1234",
+			expected: http.Header{
+				XForwardedHost:   []string{"teleport.dev:3543"},
+				XForwardedPort:   []string{"3543"},
+				XForwardedProto:  []string{"http"},
+				XForwardedServer: []string{hostname},
+				XRealIP:          []string{"5.6.7.8"},
+			},
+		},
+		{
+			desc: "trust x-real-ip and guess port from schema",
+			reqHeaders: http.Header{
+				XRealIP: []string{"5.6.7.8"},
+			},
+			tlsReq:     false,
+			hostReq:    "teleport.dev",
+			remoteAddr: "1.2.3.4:1234",
+			expected: http.Header{
+				XForwardedHost:   []string{"teleport.dev"},
+				XForwardedPort:   []string{"80"},
+				XForwardedProto:  []string{"http"},
+				XForwardedServer: []string{hostname},
+				XRealIP:          []string{"5.6.7.8"},
+			},
+		},
+	}
+	rewriter := NewHeaderRewriter()
+	// set hostname to make sure it's the same in all tests.
+	rewriter.Hostname = hostname
+	for _, test := range testCases {
+		test := test
+		t.Run(test.desc, func(t *testing.T) {
+			t.Parallel()
+
+			req := &http.Request{
+				Host:       test.hostReq,
+				Header:     test.reqHeaders,
+				RemoteAddr: test.remoteAddr,
+			}
+			if test.tlsReq {
+				req.TLS = &tls.ConnectionState{}
+			}
+			rewriter.Rewrite(req)
+			require.Equal(t, test.expected, req.Header)
+		})
+	}
+}

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -38,8 +38,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
-	"github.com/gravitational/oxy/forward"
-	fwdutils "github.com/gravitational/oxy/utils"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/ttlmap"
 	"github.com/jonboulle/clockwork"
@@ -78,6 +76,7 @@ import (
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/filesessions"
 	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
 	"github.com/gravitational/teleport/lib/kube/proxy/streamproto"
 	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
@@ -161,7 +160,7 @@ type ForwarderConfig struct {
 	// PROXYSigner is used to sign PROXY headers for securely propagating client IP address
 	PROXYSigner multiplexer.PROXYHeaderSigner
 	// log is the logger function
-	log logrus.FieldLogger
+	log utils.FieldLoggerWithWriter
 	// TracerProvider is used to create tracers capable
 	// of starting spans.
 	TracerProvider oteltrace.TracerProvider
@@ -358,7 +357,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 // however some requests like exec sessions it intercepts and records.
 type Forwarder struct {
 	mu     sync.Mutex
-	log    logrus.FieldLogger
+	log    utils.FieldLoggerWithWriter
 	router http.Handler
 	cfg    ForwarderConfig
 	// clientCredentials is an expiring cache of ephemeral client credentials.
@@ -2120,7 +2119,7 @@ type clusterSession struct {
 	// It is non-nil if the kubernetes cluster is served by this teleport service,
 	// nil otherwise.
 	kubeAPICreds kubeCreds
-	forwarder    *forward.Forwarder
+	forwarder    *reverseproxy.Forwarder
 	// noAuditEvents is true if this teleport service should leave audit event
 	// logging to another service.
 	noAuditEvents bool
@@ -2288,24 +2287,20 @@ func (f *Forwarder) newClusterSessionDirect(ctx context.Context, authCtx authCon
 // - for HTTP2 in all other cases.
 // The reason being is that streaming requests are going to be upgraded to SPDY, which is only
 // supported coming from an HTTP1 request.
-func (f *Forwarder) makeSessionForwarder(sess *clusterSession) (*forward.Forwarder, error) {
+func (f *Forwarder) makeSessionForwarder(sess *clusterSession) (*reverseproxy.Forwarder, error) {
 	transport, err := f.transportForRequest(sess)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	forwarder, err := forward.New(
-		forward.FlushInterval(100*time.Millisecond),
-		forward.RoundTripper(transport),
-		forward.WebsocketDial(sess.Dial),
-		forward.Logger(f.log),
-		forward.ErrorHandler(fwdutils.ErrorHandlerFunc(f.formatForwardResponseError)),
+	forwarder, err := reverseproxy.New(
+		reverseproxy.WithFlushInterval(100*time.Millisecond),
+		reverseproxy.WithRoundTripper(transport),
+		reverseproxy.WithLogger(f.log),
+		reverseproxy.WithErrorHandler(f.formatForwardResponseError),
 	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
 
-	return forwarder, nil
+	return forwarder, trace.Wrap(err)
 }
 
 // getOrCreateRequestContext creates a new certificate request for a given context,

--- a/lib/kube/proxy/responsewriters/memory_response.go
+++ b/lib/kube/proxy/responsewriters/memory_response.go
@@ -19,9 +19,10 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/maps"
+
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 )
 
 // NewMemoryResponseWriter creates a MemoryResponseWriter that satisfies
@@ -92,6 +93,6 @@ func (f *MemoryResponseWriter) CopyInto(dst http.ResponseWriter) error {
 // includes the size of the response with the excluded resources.
 // For the "Content-Length" header, we replace the value with the new body size.
 func copyHeader(dst, src http.Header, contentLength int) {
-	src.Set(forward.ContentLength, strconv.Itoa(contentLength))
+	src.Set(reverseproxy.ContentLength, strconv.Itoa(contentLength))
 	maps.Copy(dst, src)
 }

--- a/lib/srv/app/aws/handler.go
+++ b/lib/srv/app/aws/handler.go
@@ -26,8 +26,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/gravitational/oxy/forward"
-	oxyutils "github.com/gravitational/oxy/utils"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
@@ -35,6 +33,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
@@ -43,7 +42,7 @@ import (
 // signerHandler is an http.Handler for signing and forwarding requests to AWS API.
 type signerHandler struct {
 	// fwd is a Forwarder used to forward signed requests to AWS API.
-	fwd *forward.Forwarder
+	fwd *reverseproxy.Forwarder
 	// SignerHandlerConfig is the configuration for the handler.
 	SignerHandlerConfig
 	// closeContext is the app server close context.
@@ -53,7 +52,7 @@ type signerHandler struct {
 // SignerHandlerConfig is the awsSignerHandler configuration.
 type SignerHandlerConfig struct {
 	// Log is a logger for the handler.
-	Log logrus.FieldLogger
+	Log utils.FieldLoggerWithWriter
 	// RoundTripper is an http.RoundTripper instance used for requests.
 	RoundTripper http.RoundTripper
 	// SigningService is used to sign requests before forwarding them.
@@ -93,18 +92,15 @@ func NewAWSSignerHandler(ctx context.Context, config SignerHandlerConfig) (http.
 		SignerHandlerConfig: config,
 		closeContext:        ctx,
 	}
-	fwd, err := forward.New(
-		forward.RoundTripper(config.RoundTripper),
-		forward.ErrorHandler(oxyutils.ErrorHandlerFunc(handler.formatForwardResponseError)),
-		// Explicitly passing false here to be clear that we always want the host
-		// header to be the same as the outbound request's URL host.
-		forward.PassHostHeader(false),
+
+	var err error
+	handler.fwd, err = reverseproxy.New(
+		reverseproxy.WithRoundTripper(config.RoundTripper),
+		reverseproxy.WithLogger(config.Log),
+		reverseproxy.WithErrorHandler(reverseproxy.ErrorHandlerFunc(handler.formatForwardResponseError)),
 	)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	handler.fwd = fwd
-	return handler, nil
+
+	return handler, trace.Wrap(err)
 }
 
 // formatForwardResponseError converts an error to a status code and writes the code to a response.

--- a/lib/srv/app/common/header.go
+++ b/lib/srv/app/common/header.go
@@ -19,10 +19,10 @@ package common
 import (
 	"net/http"
 
-	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 )
 
 // SetTeleportAPIErrorHeader saves the provided error in X-Teleport-API-Error header of response.
@@ -64,7 +64,7 @@ var ReservedHeaders = append([]string{
 	TeleportAWSAssumedRole,
 	TeleportAWSAssumedRoleAuthorization,
 },
-	forward.XHeaders...,
+	reverseproxy.XHeaders...,
 )
 
 // IsReservedHeader returns true if the provided header is one of headers

--- a/lib/srv/app/common/header_rewriter.go
+++ b/lib/srv/app/common/header_rewriter.go
@@ -19,7 +19,7 @@ package common
 import (
 	"net/http"
 
-	"github.com/gravitational/oxy/forward"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 )
 
 const (
@@ -27,14 +27,14 @@ const (
 	sslOff = "off"
 )
 
-// HeaderRewriter delegates to oxy's rewriter and then appends its own headers.
+// HeaderRewriter delegates to rewriters and then appends its own headers.
 type HeaderRewriter struct {
-	delegates []forward.ReqRewriter
+	delegates []reverseproxy.Rewriter
 }
 
 // NewHeaderRewriter will create a new header rewriter with a number of delegates.
 // The delegates will be executed in the order supplied
-func NewHeaderRewriter(delegates ...forward.ReqRewriter) *HeaderRewriter {
+func NewHeaderRewriter(delegates ...reverseproxy.Rewriter) *HeaderRewriter {
 	return &HeaderRewriter{
 		delegates: delegates,
 	}

--- a/lib/srv/app/session.go
+++ b/lib/srv/app/session.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/gravitational/oxy/forward"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/ttlmap"
 	"github.com/sirupsen/logrus"
@@ -37,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/filesessions"
+	"github.com/gravitational/teleport/lib/httplib/reverseproxy"
 	"github.com/gravitational/teleport/lib/services"
 	rsession "github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv"
@@ -183,19 +183,17 @@ func (s *Server) withJWTTokenForwarder(ctx context.Context, sess *sessionChunk, 
 		return trace.Wrap(err)
 	}
 
-	delegate := forward.NewHeaderRewriter()
-	fwd, err := forward.New(
-		forward.FlushInterval(100*time.Millisecond),
-		forward.RoundTripper(transport),
-		forward.Logger(logrus.StandardLogger()),
-		forward.WebsocketRewriter(common.NewHeaderRewriter(transport.ws, delegate)),
-		forward.WebsocketDial(transport.ws.dialer),
-		forward.Rewriter(common.NewHeaderRewriter(delegate)),
+	delegate := reverseproxy.NewHeaderRewriter()
+	sess.handler, err = reverseproxy.New(
+		reverseproxy.WithFlushInterval(100*time.Millisecond),
+		reverseproxy.WithRoundTripper(transport),
+		reverseproxy.WithLogger(sess.log),
+		reverseproxy.WithRewriter(common.NewHeaderRewriter(delegate)),
 	)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	sess.handler = fwd
+
 	return nil
 }
 

--- a/lib/utils/cli.go
+++ b/lib/utils/cli.go
@@ -119,6 +119,14 @@ type Logger interface {
 	SetLevel(level logrus.Level)
 }
 
+// FieldLoggerWithWriter describes a logger that can expose a writer
+// to be used by stdlib loggers.
+type FieldLoggerWithWriter interface {
+	logrus.FieldLogger
+	Writer() *io.PipeWriter
+	WriterLevel(logrus.Level) *io.PipeWriter
+}
+
 // FatalError is for CLI front-ends: it detects gravitational/trace debugging
 // information, sends it to the logger, strips it off and prints a clean message to stderr
 func FatalError(err error) {

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -135,6 +135,12 @@ func newTransport(c *transportConfig) (*transport, error) {
 // RoundTrip will rewrite the request, forward the request to the target
 // application, emit an event to the audit log, then rewrite the response.
 func (t *transport) RoundTrip(r *http.Request) (*http.Response, error) {
+	// Clone the request so we can modify it without affecting the original.
+	// This is necessary because the request cookies are deleted when the web
+	// handler forward the request to the app proxy. When this happens, the
+	// cookies are lost and the error handler will not be able to find the
+	// session based on cookies.
+	r = r.Clone(r.Context())
 	// Perform any request rewriting needed before forwarding the request.
 	if err := t.rewriteRequest(r); err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
This PR replaces the usage of `gravitational/oxy.Forwarder` in our codebase with `httputil.ReverseProxy`.

`httputil.ReverseProxy` is part of Go's standard library and thus it is
 maintained by the Go team. Converting everything to use the std lib
 allows us to drop our `oxy` fork.

 There are some operational changes between the two versions:

 1. `httputil.ReverseProxy` handles WebSockets upgrades internally and
    reuses the `Transport` provided for the initial request. Thus, it does
    not require any special dialer or rewriter mechanisms for WebSockets only.

 2. `httputil.ReverseProxy` calls the `ErrorHandler` with the request
       after it was rewritten and after roundtrip was called. This was a
       problem because our `web.transport` deletes Teleport-associated
       cookies and when the request failed, the request received by the
       `ErrorHandler` missed the cookies to generate a new session. This was
       fixed by cloning the request at `web.transport` round tripper.

 3. `httputil.ReverseProxy` uses std's `log.Logger`. `logrus` exposes a
       method `Writer` that allows it to be used with standard lib logger.

The API is similar to what our `oxy` fork has available.

Fixes https://github.com/gravitational/teleport/issues/27412