### PR TITLE
Fix `TestDiagnoseSSHConnection` flakiness

### DIFF
--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -60,6 +60,10 @@ var (
 		// TestProxySSH and TestList takes around 10-15s to run, largely due to the 7-10 seconds it takes to create a
 		// tsh test suite. This prevents it from ever completing the 100 runs successfully.
 		"TestProxySSH", "TestList", "TestForwardingTraces", "TestExportingTraces",
+
+		// TestDiagnoseSSHConnection takes around 15s to run.
+		// When running 100x it exceeds the 600s defined to run the tests.
+		"TestDiagnoseSSHConnection",
 	}
 )
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/pquerna/otp/totp"
 	"github.com/sashabaranov/go-openai"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonv1 "go.opentelemetry.io/proto/otlp/common/v1"
 	resourcev1 "go.opentelemetry.io/proto/otlp/resource/v1"
@@ -5840,8 +5841,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 		if trace.IsNotFound(err) {
 			return false
 		}
-		require.NoError(t, err)
-
+		assert.NoError(t, err, "GetNode returned an unexpected error")
 		return true
 	}, 5*time.Second, 250*time.Millisecond)
 


### PR DESCRIPTION
The following changes were applied:
- ensure node is ready before starting the test
- removes the timeout to use the default one, which is closer to a production setting
  - as a side effect, the test has more time to complete which allows for environments with less compute power
- skip `TestDiagnoseSSHConnection` during flaky test detector runs because the test exceeds the maximum allowed time (600s) for the `go test` command

I ran it locally using the same config as the flaky test detector but with a higher timeout and got 0 failures:
```shell
> SUBJECT='-run "^TestDiagnoseSSHConnection$$" ./lib/web' ADDFLAGS='-count 100 -timeout 1700s' make test-go-unit
CGO_ENABLED=1 go test -cover -json -tags "     "  -run "^TestDiagnoseSSHConnection$" ./lib/web -race -shuffle on -count 100 -timeout 1700s \
        | tee /home/dinis/src/teleport/test-logs/unit.json \
        | /home/dinis/src/teleport/build.assets/tooling/bin/render-tests
------ pass (in 1529.58s): github.com/gravitational/teleport/lib/web
===================================================
701 tests passed. 0 failed, 0 skipped
===================================================
All tests pass. Yay!
```
And another test (macos):
```shell
> SUBJECT='-run "^TestDiagnoseSSHConnection$$" ./lib/web' ADDFLAGS='-count 300 -timeout 9999s' make test-go-unit
CGO_ENABLED=1 go test -cover -json -tags "   desktop_access_rdp  "  -run "^TestDiagnoseSSHConnection$" ./lib/web -race -shuffle on -count 300 -timeout 9999s \
		| tee /Users/marcodinis/src/teleport/test-logs/unit.json \
		| /Users/marcodinis/src/teleport/build.assets/tooling/bin/render-tests
pass   8.2% (in 4599.94s): github.com/gravitational/teleport/lib/web
===================================================
Tests: 2100 passed, 0 failed, 0 skipped
Packages: 1 passed, 0 failed, 0 skipped
===================================================
All tests pass. Yay!
===================================================
```

Fixes https://github.com/gravitational/teleport/issues/17428