### PR TITLE
[v13] Don't use WithError() when logging "Missing session cookie"

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -449,7 +449,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 			session, err := h.authenticateWebSession(w, r)
 			if err != nil {
-				h.log.WithError(err).Debug("Could not authenticate.")
+				h.log.Debugf("Could not authenticate: %v", err)
 			}
 			session.XCSRF = csrfToken
 


### PR DESCRIPTION
Backport #27707 to branch/v13