### PR TITLE
Machine ID: Default to `SymlinksTrySecure` rather than `SymlinksSecure`

### DIFF
--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -78,13 +78,11 @@ func (dd *DestinationDirectory) CheckAndSetDefaults() error {
 
 	switch dd.Symlinks {
 	case "":
-		if secureSupported {
-			// We expect Openat2 to be available, so try to use it by default.
-			dd.Symlinks = botfs.SymlinksSecure
-		} else {
-			// TrySecure will print a warning on fallback.
-			dd.Symlinks = botfs.SymlinksTrySecure
-		}
+		// We default to SymlinksTrySecure. It's become apparent that the
+		// kernel version alone is not usually enough information to know that
+		// secure symlinks is supported by the OS. In future, we should aim to
+		// perform a more definitive test.
+		dd.Symlinks = botfs.SymlinksTrySecure
 	case botfs.SymlinksInsecure, botfs.SymlinksTrySecure:
 		// valid
 	case botfs.SymlinksSecure:


### PR DESCRIPTION
A few users have reported issues where despite their kernel version exceeding the threshold for `openat2` syscall support, calls to this syscall still fail. This is down to a few factors:

- Container runtimes blocking access to the syscall
- Security tools such as `selinux` or `apparmor`
- Kernels being compiled with a different set of supported syscalls.

This is further complicated by the fact that using this syscall can succeed on certain paths, but fail on others when using more advanced tools like `selinux` or `apparmor`

Because of this, our current default of `secure` fails to run on their system. This increases the users time-to-value.

Closes https://github.com/gravitational/teleport/issues/24686

## Release note

Machine ID's `tbot` agent will now default to trying secure symlinks mode rather than enforcing it. If you wish to enforce the usage of secure symlink mode when `tbot` reads files, please explicitly set the `symlink` field on the destination or storage configuration to `secure`, e.g:

```yaml
destinations:
  - directory:
       path: /opt/machine-id
       symlinks: secure # set this field to `secure`
```