### PR TITLE
[v13] Trim yum release version in install-linux.mdx

### DIFF
--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -29,6 +29,9 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
+  # First, get the major version from $VERSION_ID so this fetches the correct
+  # package version.
+  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   $ sudo yum install teleport
   #
@@ -107,6 +110,9 @@ Use the appropriate commands for your environment to install your package.
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
+  # First, get the major version from $VERSION_ID so this fetches the correct
+  # package version.
+  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   $ sudo yum install teleport-ent
   #
@@ -207,6 +213,9 @@ Use the appropriate commands for your environment to install your package.
   # Source variables about OS version
   $ source /etc/os-release
   # Add the Teleport yum repository for cloud.
+  # First, get the major version from $VERSION_ID so this fetches the correct
+  # package version.
+  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   $ sudo yum-config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport.repo")"
   $ sudo yum install teleport-ent
   #


### PR DESCRIPTION
Backports #27367

* Trim yum release version in install-linux.mdx

Fixes #20978

The `$VERSION_ID` variable we tell users to use when adding our yum repo is incorrect, since it does not include a minor version. This quick-and-dirty fix instructs users to trim `$VERSION_ID` to include only the major version before adding the repo.

* lint fixes

---------