### PR TITLE
[v11] app access: fix broken docs link in error message

### DIFF
--- a/docs/pages/application-access/guides/connecting-apps.mdx
+++ b/docs/pages/application-access/guides/connecting-apps.mdx
@@ -96,6 +96,12 @@ a reverse tunnel.
 
 ### Application name
 
+{/*
+Note: this section of the docs is linked to from error messages in the product.
+Please make sure to update lib/service/cfg.go if you change this section
+header or move this page.
+*/}
+
 An application name should make a valid sub-domain (\<=63 characters, no spaces, only `a-z 0-9 -` allowed).
 
 After Teleport is running, users can access the app at `app-name.proxy_public_addr.com`

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -1122,7 +1122,7 @@ func (a *App) CheckAndSetDefaults() error {
 	// are invalid subdomains because for trusted clusters the name is used to
 	// construct the domain that the application will be available at.
 	if errs := validation.IsDNS1035Label(a.Name); len(errs) > 0 {
-		return trace.BadParameter("application name %q must be a valid DNS subdomain: https://goteleport.com/teleport/docs/application-access/#application-name", a.Name)
+		return trace.BadParameter("application name %q must be a valid DNS subdomain: https://goteleport.com/docs/application-access/guides/connecting-apps/#application-name", a.Name)
 	}
 	// Parse and validate URL.
 	if _, err := url.Parse(a.URI); err != nil {


### PR DESCRIPTION
Backports #27684 