### PR TITLE
Connect: Add theme configuration

### DIFF
--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -44,7 +44,10 @@ const ThemeDecorator = (storyFn, meta) => {
 
   if (meta.title.startsWith('Teleterm/')) {
     ThemeProvider = TeletermThemeProvider;
-    theme = meta.globals.theme === 'Dark Theme' ? teletermDarkTheme : teletermLightTheme;
+    theme =
+      meta.globals.theme === 'Dark Theme'
+        ? teletermDarkTheme
+        : teletermLightTheme;
   } else {
     ThemeProvider = DefaultThemeProvider;
     theme = meta.globals.theme === 'Dark Theme' ? darkTheme : lightTheme;

--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -21,13 +21,12 @@ import { darkTheme, lightTheme } from './../packages/design/src/theme';
 import DefaultThemeProvider from '../packages/design/src/ThemeProvider';
 import Box from './../packages/design/src/Box';
 import '../packages/teleport/src/lib/polyfillRandomUuid';
-import { ThemeProvider as TeletermThemeProvider } from './../packages/teleterm/src/ui/ThemeProvider';
+import { StaticThemeProvider as TeletermThemeProvider } from './../packages/teleterm/src/ui/ThemeProvider';
 import {
   darkTheme as teletermDarkTheme,
   lightTheme as teletermLightTheme,
 } from './../packages/teleterm/src/ui/ThemeProvider/theme';
 import { handlersTeleport } from './../packages/teleport/src/mocks/handlers';
-import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 
 // Checks we are running non-node environment (browser)
 if (typeof global.process === 'undefined') {
@@ -40,26 +39,22 @@ if (typeof global.process === 'undefined') {
 
 // wrap each story with theme provider
 const ThemeDecorator = (storyFn, meta) => {
+  let ThemeProvider;
+  let theme;
+
   if (meta.title.startsWith('Teleterm/')) {
-    const theme =
-      meta.globals.theme === 'Dark Theme'
-        ? teletermDarkTheme
-        : teletermLightTheme;
-    return (
-      <MockAppContextProvider>
-        <TeletermThemeProvider theme={theme}>
-          <Box p={3}>{storyFn()}</Box>
-        </TeletermThemeProvider>
-      </MockAppContextProvider>
-    );
+    ThemeProvider = TeletermThemeProvider;
+    theme = meta.globals.theme === 'Dark Theme' ? teletermDarkTheme : teletermLightTheme;
   } else {
-    const theme = meta.globals.theme === 'Dark Theme' ? darkTheme : lightTheme;
-    return (
-      <DefaultThemeProvider theme={theme}>
-        <Box p={3}>{storyFn()}</Box>
-      </DefaultThemeProvider>
-    );
+    ThemeProvider = DefaultThemeProvider;
+    theme = meta.globals.theme === 'Dark Theme' ? darkTheme : lightTheme;
   }
+
+  return (
+    <ThemeProvider theme={theme}>
+      <Box p={3}>{storyFn()}</Box>
+    </ThemeProvider>
+  );
 };
 
 addDecorator(ThemeDecorator);

--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -22,8 +22,12 @@ import DefaultThemeProvider from '../packages/design/src/ThemeProvider';
 import Box from './../packages/design/src/Box';
 import '../packages/teleport/src/lib/polyfillRandomUuid';
 import { ThemeProvider as TeletermThemeProvider } from './../packages/teleterm/src/ui/ThemeProvider';
-import { theme as TeletermTheme } from './../packages/teleterm/src/ui/ThemeProvider/theme';
+import {
+  darkTheme as teletermDarkTheme,
+  lightTheme as teletermLightTheme,
+} from './../packages/teleterm/src/ui/ThemeProvider/theme';
 import { handlersTeleport } from './../packages/teleport/src/mocks/handlers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 
 // Checks we are running non-node environment (browser)
 if (typeof global.process === 'undefined') {
@@ -36,22 +40,26 @@ if (typeof global.process === 'undefined') {
 
 // wrap each story with theme provider
 const ThemeDecorator = (storyFn, meta) => {
-  let ThemeProvider;
-  let theme;
-
   if (meta.title.startsWith('Teleterm/')) {
-    ThemeProvider = TeletermThemeProvider;
-    theme = TeletermTheme;
+    const theme =
+      meta.globals.theme === 'Dark Theme'
+        ? teletermDarkTheme
+        : teletermLightTheme;
+    return (
+      <MockAppContextProvider>
+        <TeletermThemeProvider theme={theme}>
+          <Box p={3}>{storyFn()}</Box>
+        </TeletermThemeProvider>
+      </MockAppContextProvider>
+    );
   } else {
-    ThemeProvider = DefaultThemeProvider;
-    theme = meta.globals.theme === 'Dark Theme' ? darkTheme : lightTheme;
+    const theme = meta.globals.theme === 'Dark Theme' ? darkTheme : lightTheme;
+    return (
+      <DefaultThemeProvider theme={theme}>
+        <Box p={3}>{storyFn()}</Box>
+      </DefaultThemeProvider>
+    );
   }
-
-  return (
-    <ThemeProvider theme={theme}>
-      <Box p={3}>{storyFn()}</Box>
-    </ThemeProvider>
-  );
 };
 
 addDecorator(ThemeDecorator);

--- a/web/packages/teleterm/src/main.ts
+++ b/web/packages/teleterm/src/main.ts
@@ -18,7 +18,7 @@ import { spawn } from 'child_process';
 
 import path from 'path';
 
-import { app, globalShortcut, shell } from 'electron';
+import { app, globalShortcut, shell, nativeTheme } from 'electron';
 
 import MainProcess from 'teleterm/mainProcess';
 import { getRuntimeSettings } from 'teleterm/mainProcess/runtimeSettings';
@@ -59,6 +59,8 @@ async function initializeApp(): Promise<void> {
     jsonSchemaFile: configJsonSchemaFileStorage,
     platform: settings.platform,
   });
+
+  nativeTheme.themeSource = configService.get('theme').value;
   const windowsManager = new WindowsManager(appStateFileStorage, settings);
 
   process.on('uncaughtException', (error, origin) => {

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -69,8 +69,8 @@ export class MockMainProcessClient implements MainProcessClient {
     return '';
   }
 
-  getNativeTheme() {
-    return 'dark' as const;
+  shouldUseDarkColors() {
+    return true;
   }
 
   subscribeToNativeThemeUpdate() {

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -68,6 +68,14 @@ export class MockMainProcessClient implements MainProcessClient {
   async openConfigFile() {
     return '';
   }
+
+  getNativeTheme() {
+    return 'dark' as const;
+  }
+
+  subscribeToNativeThemeUpdate() {
+    return { cleanup: () => undefined };
+  }
 }
 
 export const makeRuntimeSettings = (

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -194,8 +194,8 @@ export default class MainProcess {
       event.returnValue = this.settings;
     });
 
-    ipcMain.on('main-process-get-native-theme', event => {
-      event.returnValue = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+    ipcMain.on('main-process-should-use-dark-colors', event => {
+      event.returnValue = nativeTheme.shouldUseDarkColors;
     });
 
     ipcMain.handle('main-process-get-resolved-child-process-addresses', () => {

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -26,6 +26,7 @@ import {
   ipcMain,
   Menu,
   MenuItemConstructorOptions,
+  nativeTheme,
   shell,
 } from 'electron';
 import { wait } from 'shared/utils/wait';
@@ -191,6 +192,10 @@ export default class MainProcess {
   private _initIpc() {
     ipcMain.on('main-process-get-runtime-settings', event => {
       event.returnValue = this.settings;
+    });
+
+    ipcMain.on('main-process-get-native-theme', event => {
+      event.returnValue = nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
     });
 
     ipcMain.handle('main-process-get-resolved-child-process-addresses', () => {

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -61,7 +61,7 @@ export default function createMainProcessClient(): MainProcessClient {
     },
     subscribeToNativeThemeUpdate: listener => {
       const onThemeChange = (_, value: 'dark' | 'light') => listener(value);
-      const channel = 'main-process-subscribe-to-native-theme-update';
+      const channel = 'main-process-native-theme-update';
       ipcRenderer.addListener(channel, onThemeChange);
       return {
         cleanup: () => ipcRenderer.removeListener(channel, onThemeChange),

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -56,11 +56,12 @@ export default function createMainProcessClient(): MainProcessClient {
     openConfigFile() {
       return ipcRenderer.invoke('main-process-open-config-file');
     },
-    getNativeTheme() {
-      return ipcRenderer.sendSync('main-process-get-native-theme');
+    shouldUseDarkColors() {
+      return ipcRenderer.sendSync('main-process-should-use-dark-colors');
     },
     subscribeToNativeThemeUpdate: listener => {
-      const onThemeChange = (_, value: 'dark' | 'light') => listener(value);
+      const onThemeChange = (_, value: { shouldUseDarkColors: boolean }) =>
+        listener(value);
       const channel = 'main-process-native-theme-update';
       ipcRenderer.addListener(channel, onThemeChange);
       return {

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -53,8 +53,19 @@ export default function createMainProcessClient(): MainProcessClient {
     removeTshSymlinkMacOs() {
       return ipcRenderer.invoke('main-process-remove-tsh-symlink-macos');
     },
-    openConfigFile(): Promise<string> {
+    openConfigFile() {
       return ipcRenderer.invoke('main-process-open-config-file');
+    },
+    getNativeTheme() {
+      return ipcRenderer.sendSync('main-process-get-native-theme');
+    },
+    subscribeToNativeThemeUpdate: listener => {
+      const onThemeChange = (_, value: 'dark' | 'light') => listener(value);
+      const channel = 'main-process-subscribe-to-native-theme-update';
+      ipcRenderer.addListener(channel, onThemeChange);
+      return {
+        cleanup: () => ipcRenderer.removeListener(channel, onThemeChange),
+      };
     },
   };
 }

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -75,10 +75,10 @@ export type MainProcessClient = {
 
   /** Opens config file and returns a path to it. */
   openConfigFile(): Promise<string>;
-  getNativeTheme(): 'dark' | 'light';
+  shouldUseDarkColors(): boolean;
   /** Subscribes to updates of the native theme. Returns a cleanup function. */
   subscribeToNativeThemeUpdate: (
-    listener: (theme: 'dark' | 'light') => void
+    listener: (value: { shouldUseDarkColors: boolean }) => void
   ) => {
     cleanup: () => void;
   };

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -75,6 +75,13 @@ export type MainProcessClient = {
 
   /** Opens config file and returns a path to it. */
   openConfigFile(): Promise<string>;
+  getNativeTheme(): 'dark' | 'light';
+  /** Subscribes to updates of the native theme. Returns a cleanup function. */
+  subscribeToNativeThemeUpdate: (
+    listener: (theme: 'dark' | 'light') => void
+  ) => {
+    cleanup: () => void;
+  };
 };
 
 export type ChildProcessAddresses = {

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -100,7 +100,7 @@ export class WindowsManager {
 
     nativeTheme.on('updated', () => {
       window.webContents.send(
-        'main-process-subscribe-to-native-theme-update',
+        'main-process-native-theme-update',
         nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
       );
     });

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -99,10 +99,9 @@ export class WindowsManager {
     });
 
     nativeTheme.on('updated', () => {
-      window.webContents.send(
-        'main-process-native-theme-update',
-        nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
-      );
+      window.webContents.send('main-process-native-theme-update', {
+        shouldUseDarkColors: nativeTheme.shouldUseDarkColors,
+      });
     });
 
     window.webContents.session.setPermissionRequestHandler(

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -16,11 +16,18 @@
 
 import path from 'path';
 
-import { app, BrowserWindow, Menu, Rectangle, screen } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  Rectangle,
+  screen,
+  nativeTheme,
+} from 'electron';
 
 import { FileStorage } from 'teleterm/services/fileStorage';
 import { RuntimeSettings } from 'teleterm/mainProcess/types';
-import theme from 'teleterm/ui/ThemeProvider/theme';
+import { darkTheme, lightTheme } from 'teleterm/ui/ThemeProvider/theme';
 
 type WindowState = Rectangle;
 
@@ -47,13 +54,16 @@ export class WindowsManager {
   }
 
   createWindow(): void {
+    const activeTheme = nativeTheme.shouldUseDarkColors
+      ? darkTheme
+      : lightTheme;
     const windowState = this.getWindowState();
     const window = new BrowserWindow({
       x: windowState.x,
       y: windowState.y,
       width: windowState.width,
       height: windowState.height,
-      backgroundColor: theme.colors.levels.sunken,
+      backgroundColor: activeTheme.colors.levels.sunken,
       minWidth: 400,
       minHeight: 300,
       show: false,
@@ -86,6 +96,13 @@ export class WindowsManager {
 
     window.webContents.on('context-menu', (_, props) => {
       this.popupUniversalContextMenu(window, props);
+    });
+
+    nativeTheme.on('updated', () => {
+      window.webContents.send(
+        'main-process-subscribe-to-native-theme-update',
+        nativeTheme.shouldUseDarkColors ? 'dark' : 'light'
+      );
     });
 
     window.webContents.session.setPermissionRequestHandler(

--- a/web/packages/teleterm/src/services/config/appConfigSchema.ts
+++ b/web/packages/teleterm/src/services/config/appConfigSchema.ts
@@ -106,6 +106,10 @@ export const createAppConfigSchema = (platform: Platform) => {
       .max(256)
       .default(15)
       .describe('Font size for the terminal.'),
+    theme: z
+      .enum(['light', 'dark', 'system'])
+      .default('system')
+      .describe('Color theme for the app.'),
   });
 };
 

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/Terminal.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React, { useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
+import styled, { useTheme } from 'styled-components';
 import { Box, Flex } from 'design';
 import { debounce } from 'shared/utils/highbar';
 import {
@@ -54,6 +54,7 @@ export function Terminal(props: TerminalProps) {
   const [startPtyProcessAttempt, setStartPtyProcessAttempt] = useState<
     Attempt<void>
   >(makeEmptyAttempt());
+  const theme = useTheme();
 
   useEffect(() => {
     const removeOnStartErrorListener = props.ptyProcess.onStartError(
@@ -69,6 +70,7 @@ export function Terminal(props: TerminalProps) {
     const ctrl = new XTermCtrl(props.ptyProcess, {
       el: refElement.current,
       fontSize: props.fontSize,
+      theme: theme.colors.terminal,
     });
 
     // Start the PTY process.
@@ -102,6 +104,12 @@ export function Terminal(props: TerminalProps) {
     refCtrl.current.focus();
     refCtrl.current.requestResize();
   }, [props.visible]);
+
+  useEffect(() => {
+    if (refCtrl.current) {
+      refCtrl.current.term.options.theme = theme.colors.terminal;
+    }
+  }, [theme]);
 
   return (
     <Flex

--- a/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
+++ b/web/packages/teleterm/src/ui/DocumentTerminal/Terminal/ctrl.ts
@@ -15,19 +15,19 @@ limitations under the License.
 */
 
 import 'xterm/css/xterm.css';
-import { IDisposable, Terminal } from 'xterm';
+import { IDisposable, ITheme, Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
 import { debounce } from 'shared/utils/highbar';
 
 import { IPtyProcess } from 'teleterm/sharedProcess/ptyHost';
 import Logger from 'teleterm/logger';
-import theme from 'teleterm/ui/ThemeProvider/theme';
 
 const WINDOW_RESIZE_DEBOUNCE_DELAY = 200;
 
 type Options = {
   el: HTMLElement;
   fontSize: number;
+  theme: ITheme;
 };
 
 export default class TtyTerminal {
@@ -62,29 +62,7 @@ export default class TtyTerminal {
       fontSize: this.options.fontSize,
       scrollback: 5000,
       minimumContrastRatio: 4.5, // minimum for WCAG AA compliance
-      theme: {
-        foreground: theme.colors.terminal.foreground,
-        background: theme.colors.terminal.background,
-        selectionBackground: theme.colors.terminal.selectionBackground,
-        cursor: theme.colors.terminal.cursor,
-        cursorAccent: theme.colors.terminal.cursorAccent,
-        red: theme.colors.terminal.red,
-        green: theme.colors.terminal.green,
-        yellow: theme.colors.terminal.yellow,
-        blue: theme.colors.terminal.blue,
-        magenta: theme.colors.terminal.magenta,
-        cyan: theme.colors.terminal.cyan,
-        brightWhite: theme.colors.terminal.brightWhite,
-        white: theme.colors.terminal.white,
-        brightBlack: theme.colors.terminal.brightBlack,
-        black: theme.colors.terminal.black,
-        brightRed: theme.colors.terminal.brightRed,
-        brightGreen: theme.colors.terminal.brightGreen,
-        brightYellow: theme.colors.terminal.brightYellow,
-        brightBlue: theme.colors.terminal.brightBlue,
-        brightMagenta: theme.colors.terminal.brightMagenta,
-        brightCyan: theme.colors.terminal.brightCyan,
-      },
+      theme: this.options.theme,
       windowOptions: {
         setWinSizeChars: true,
       },

--- a/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
+++ b/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
@@ -25,9 +25,7 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 import { GlobalStyle } from './globals';
 import { darkTheme, lightTheme } from './theme';
 
-export const ThemeProvider = (
-  props: React.PropsWithChildren<{ theme?: unknown }>
-) => {
+export const ThemeProvider = (props: React.PropsWithChildren<unknown>) => {
   // Listening to Electron's nativeTheme.on('updated') is a workaround.
   // The renderer should be able to get the current theme via "prefers-color-scheme" media query.
   // Unfortunately, it does not work correctly on Ubuntu where the query from above always returns the old value
@@ -54,7 +52,18 @@ export const ThemeProvider = (
   }, [ctx.mainProcessClient]);
 
   return (
-    <StyledThemeProvider theme={props.theme || activeTheme}>
+    <StaticThemeProvider theme={activeTheme}>
+      {props.children}
+    </StaticThemeProvider>
+  );
+};
+
+/** Uses a theme from a prop. Useful in storybbok. */
+export const StaticThemeProvider = (
+  props: React.PropsWithChildren<{ theme?: unknown }>
+) => {
+  return (
+    <StyledThemeProvider theme={props.theme}>
       <StyleSheetManager disableVendorPrefixes>
         <React.Fragment>
           <GlobalStyle />

--- a/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
+++ b/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
@@ -58,7 +58,7 @@ export const ThemeProvider = (props: React.PropsWithChildren<unknown>) => {
   );
 };
 
-/** Uses a theme from a prop. Useful in storybbok. */
+/** Uses a theme from a prop. Useful in storybook. */
 export const StaticThemeProvider = (
   props: React.PropsWithChildren<{ theme?: unknown }>
 ) => {

--- a/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
+++ b/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
@@ -39,14 +39,14 @@ export const ThemeProvider = (
   // Additional issue is that nativeTheme does not return correct values at all on Fedora:
   // https://github.com/electron/electron/issues/33635#issuecomment-1502215450
   const ctx = useAppContext();
-  const [activeTheme, setActiveTheme] = useState(
-    ctx.mainProcessClient.getNativeTheme() === 'dark' ? darkTheme : lightTheme
+  const [activeTheme, setActiveTheme] = useState(() =>
+    ctx.mainProcessClient.shouldUseDarkColors() ? darkTheme : lightTheme
   );
 
   useEffect(() => {
     const { cleanup } = ctx.mainProcessClient.subscribeToNativeThemeUpdate(
-      theme => {
-        setActiveTheme(theme === 'dark' ? darkTheme : lightTheme);
+      ({ shouldUseDarkColors }) => {
+        setActiveTheme(shouldUseDarkColors ? darkTheme : lightTheme);
       }
     );
 

--- a/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
+++ b/web/packages/teleterm/src/ui/ThemeProvider/ThemeProvider.tsx
@@ -14,22 +14,53 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   ThemeProvider as StyledThemeProvider,
   StyleSheetManager,
 } from 'styled-components';
 
-import { GlobalStyle } from './globals';
-import theme from './theme';
+import { useAppContext } from 'teleterm/ui/appContextProvider';
 
-export const ThemeProvider: React.FC = props => (
-  <StyledThemeProvider theme={theme}>
-    <StyleSheetManager disableVendorPrefixes>
-      <React.Fragment>
-        <GlobalStyle />
-        {props.children}
-      </React.Fragment>
-    </StyleSheetManager>
-  </StyledThemeProvider>
-);
+import { GlobalStyle } from './globals';
+import { darkTheme, lightTheme } from './theme';
+
+export const ThemeProvider = (
+  props: React.PropsWithChildren<{ theme?: unknown }>
+) => {
+  // Listening to Electron's nativeTheme.on('updated') is a workaround.
+  // The renderer should be able to get the current theme via "prefers-color-scheme" media query.
+  // Unfortunately, it does not work correctly on Ubuntu where the query from above always returns the old value
+  // (for example, when the app was launched in a dark mode, it always returns 'dark'
+  // ignoring that the system theme is now 'light').
+  // Related Electron issue: https://github.com/electron/electron/issues/21427#issuecomment-589796481,
+  // Related Chromium issue: https://bugs.chromium.org/p/chromium/issues/detail?id=998903
+  //
+  // Additional issue is that nativeTheme does not return correct values at all on Fedora:
+  // https://github.com/electron/electron/issues/33635#issuecomment-1502215450
+  const ctx = useAppContext();
+  const [activeTheme, setActiveTheme] = useState(
+    ctx.mainProcessClient.getNativeTheme() === 'dark' ? darkTheme : lightTheme
+  );
+
+  useEffect(() => {
+    const { cleanup } = ctx.mainProcessClient.subscribeToNativeThemeUpdate(
+      theme => {
+        setActiveTheme(theme === 'dark' ? darkTheme : lightTheme);
+      }
+    );
+
+    return cleanup;
+  }, [ctx.mainProcessClient]);
+
+  return (
+    <StyledThemeProvider theme={props.theme || activeTheme}>
+      <StyleSheetManager disableVendorPrefixes>
+        <React.Fragment>
+          <GlobalStyle />
+          {props.children}
+        </React.Fragment>
+      </StyleSheetManager>
+    </StyledThemeProvider>
+  );
+};

--- a/web/packages/teleterm/src/ui/ThemeProvider/index.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/index.ts
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-export { ThemeProvider } from './ThemeProvider';
+export * from './ThemeProvider';

--- a/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
+++ b/web/packages/teleterm/src/ui/ThemeProvider/theme.ts
@@ -23,7 +23,7 @@ import { lighten } from 'design/theme/utils/colorManipulator';
 
 const sansSerif = 'system-ui';
 
-const darkTheme = {
+export const darkTheme = {
   ...designDarkTheme,
   colors: {
     ...designDarkTheme.colors,
@@ -43,8 +43,7 @@ const darkTheme = {
   },
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const lightTheme = {
+export const lightTheme = {
   ...designLightTheme,
   font: sansSerif,
   fonts: {
@@ -52,5 +51,3 @@ const lightTheme = {
     mono: fonts.mono,
   },
 };
-
-export default darkTheme;


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/27079

Enables Connect theme configuration. The available options are: `light`, `dark`, `system` (sync with OS).
The default is `system`.

The implementation turned to be slightly more complex than I thought, because of two Linux-related issues:
- `prefers-color-scheme` [is not updated](https://github.com/electron/electron/issues/21427#issuecomment-589796481) when the system theme changes. There [is a bug in Chromium](https://bugs.chromium.org/p/chromium/issues/detail?id=998903) related to to this. Apparently it was fixed in Chromium 114, but people are still reporting issues with that (which is interesting, I tested Chromium 114 on my Ubuntu VM and webpages seemed to respect the system theme). Probably there have be some work done on the Electron side, because I tested Electron 25 (Chromium 114) and it was not better than Electron 24. 
The workaround that I added relies on `nativeTheme` updates that work correctly. These updates are then passed to the renderer via IPC and `webContents.send`.
- On Fedora, `nativeTheme` is not updated at all 😓. It is a [known issue](https://github.com/electron/electron/issues/33635#issuecomment-1502215450). Because of that, the app is always rendered in the light mode and the user will have to switch do dark in the app settings if they won't like the light one. Theoretically, we could detect Fedora and use `dark` as a default value there, but I don't know if this is worth it, probably not.
I also took a look at vscode, but they don't have any smart fix for that.

(BTW I still have to work on the appearance of the tabs)