### PR TITLE
[Buddy] Fix: time.Since should not be used directly after a defer statement

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3243,7 +3243,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 
 	// only observe latencies for non-throttled requests
 	start := a.clock.Now()
-	defer generateRequestsLatencies.Observe(time.Since(start).Seconds())
+	defer func() { generateRequestsLatencies.Observe(time.Since(start).Seconds()) }()
 
 	generateRequestsCount.Inc()
 	generateRequestsCurrent.Inc()


### PR DESCRIPTION
Buddies https://github.com/gravitational/teleport/pull/27072

---

This is a classic error-prone example in Go, the result of this code is not 1 second, but nanoseconds.
```
func main() {
	start := time.Now()
	defer fmt.Println(time.Since(start))
	time.Sleep(1 * time.Second)
}
```
The Go community is trying to circumvent this problem by adding vet detection items