### PR TITLE
[v12] [Buddy] Fix: time.Since should not be used directly after a defer statement

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3055,7 +3055,7 @@ func (a *Server) GenerateHostCerts(ctx context.Context, req *proto.HostCertsRequ
 
 	// only observe latencies for non-throttled requests
 	start := a.clock.Now()
-	defer generateRequestsLatencies.Observe(time.Since(start).Seconds())
+	defer func() { generateRequestsLatencies.Observe(time.Since(start).Seconds()) }()
 
 	generateRequestsCount.Inc()
 	generateRequestsCurrent.Inc()


### PR DESCRIPTION
Backport #27792 to branch/v12