### PR TITLE
Support for benchmarking concurrent web sessions

### DIFF
--- a/lib/benchmark/web.go
+++ b/lib/benchmark/web.go
@@ -27,6 +27,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -39,6 +40,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/session"
+	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/web"
 )
 
@@ -56,11 +58,20 @@ type WebSSHBenchmark struct {
 
 // BenchBuilder returns a WorkloadFunc for the given benchmark suite.
 func (s WebSSHBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (WorkloadFunc, error) {
+	// The benchmark runner may override stderr to be [io.Discard] which
+	// results in the login prompt being sent into the void and the user
+	// staring at a blank terminal. Temporarily override stderr to allow
+	// the prompt to be written to the terminal.
+	stderr := tc.Stderr
+	tc.Stderr = os.Stderr
+
 	clt, sess, err := tc.LoginWeb(ctx)
 	if err != nil {
+		tc.Stderr = stderr
 		return nil, trace.Wrap(err)
 	}
 
+	tc.Stderr = stderr
 	webSess := &webSession{
 		webSession: sess,
 		clt:        clt,
@@ -144,6 +155,27 @@ func (s WebSSHBenchmark) runCommand(ctx context.Context, tc *client.TeleportClie
 	return nil
 }
 
+// getServers returns all [types.Server] that the authenticated user has
+// access to.
+func getServers(ctx context.Context, tc *client.TeleportClient) ([]types.Server, error) {
+	clt, err := tc.ConnectToCluster(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer clt.Close()
+
+	resources, err := apiclient.GetAllResources[types.Server](ctx, clt.AuthClient, tc.ResourceFilter(types.KindNode))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(resources) == 0 {
+		return nil, trace.BadParameter("no target hosts available")
+	}
+
+	return resources, nil
+}
+
 // connectToHost opens an SSH session to the target host via the Proxy web api.
 func connectToHost(ctx context.Context, tc *client.TeleportClient, webSession *webSession, host string) (io.ReadWriteCloser, error) {
 	req := web.TerminalRequest{
@@ -196,27 +228,6 @@ func connectToHost(ctx context.Context, tc *client.TeleportClient, webSession *w
 	return stream, trace.Wrap(err)
 }
 
-// getServers returns all [types.Server] that the authenticated user has
-// access to.
-func getServers(ctx context.Context, tc *client.TeleportClient) ([]types.Server, error) {
-	clt, err := tc.ConnectToCluster(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	defer clt.Close()
-
-	resources, err := apiclient.GetAllResources[types.Server](ctx, clt.AuthClient, tc.ResourceFilter(types.KindNode))
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if len(resources) == 0 {
-		return nil, trace.BadParameter("no target hosts available")
-	}
-
-	return resources, nil
-}
-
 func (s *webSession) expires() time.Time {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -236,4 +247,184 @@ func (s *webSession) getToken() string {
 	defer s.mu.Unlock()
 
 	return s.webSession.GetBearerToken()
+}
+
+// WebSessionBenchmark is a benchmark suite that connects to the configured
+// target hosts via the web api and executes the provided command.
+type WebSessionBenchmark struct {
+	// Command to execute on the host.
+	Command []string
+	// Max number of sessions to have open at once.
+	Max int
+	// Duration of the test used to determine if renewing web sessions
+	// is necessary.
+	Duration time.Duration
+
+	servers []types.Server
+}
+
+func (s *WebSessionBenchmark) Config(ctx context.Context, tc *client.TeleportClient, cfg *Config) error {
+	servers, err := getServers(ctx, tc)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.servers = servers
+
+	if s.Max == 0 {
+		s.Max = len(servers)
+	}
+
+	// alter the minimum window such that the test will run
+	// for as long as is required to spawn all the sessions plus
+	// an additional minute.
+	interval := time.Duration(1 / float64(cfg.Rate) * float64(time.Second))
+	window := interval*time.Duration(s.Max) + (time.Minute)
+	if cfg.MinimumWindow < window {
+		cfg.MinimumWindow = window
+	}
+
+	return nil
+}
+
+// BenchBuilder returns a WorkloadFunc for the given benchmark suite.
+func (s *WebSessionBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (WorkloadFunc, error) {
+	// The benchmark runner may override stderr to be [io.Discard] which
+	// results in the login prompt being sent into the void and the user
+	// staring at a blank terminal. Temporarily override stderr to allow
+	// the prompt to be written to the terminal.
+	stderr := tc.Stderr
+	tc.Stderr = os.Stderr
+
+	clt, sess, err := tc.LoginWeb(ctx)
+	if err != nil {
+		tc.Stderr = stderr
+		return nil, trace.Wrap(err)
+	}
+
+	tc.Stderr = stderr
+
+	webSess := &webSession{
+		webSession: sess,
+		clt:        clt,
+	}
+
+	// The web session will expire before the duration of the test
+	// so launch the renewal loop.
+	if !time.Now().Add(s.Duration).Before(webSess.expires()) {
+		go webSess.renew(ctx)
+	}
+
+	var (
+		mu     sync.Mutex
+		active int
+		next   int
+	)
+
+	// Open a ssh session to the next host if the maximum
+	// number of connections has not already been reached.
+	return func(ctx context.Context) error {
+		mu.Lock()
+		if active >= s.Max {
+			mu.Unlock()
+			return nil
+		}
+		active++
+
+		current := next
+		next = (next + 1) % len(s.servers)
+		mu.Unlock()
+
+		defer func() {
+			mu.Lock()
+			active--
+			mu.Unlock()
+		}()
+
+		stream, err := connectToHost(ctx, tc, webSess, s.servers[current].GetName()+":0")
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		return trace.Wrap(utils.ProxyConn(ctx,
+			&streamCloser{
+				ReadWriteCloser: stream,
+			},
+			rwc{
+				r: repeatingReader{
+					ctx:      ctx,
+					s:        strings.Join(append(s.Command, "\r\n"), " "),
+					interval: time.Second,
+				},
+				w: tc.Stdout,
+				c: io.NopCloser(stream),
+			}))
+	}, nil
+}
+
+// streamCloser allows the client to end the
+// session by sending "exit" to the server. This
+// allows all sessions initiated by the benchmark to
+// disappear immediately instead of having them linger
+// until the session tracker is expired.
+type streamCloser struct {
+	io.ReadWriteCloser
+	once sync.Once
+}
+
+func (s *streamCloser) Close() error {
+	var err error
+	s.once.Do(func() {
+		_, exitErr := s.ReadWriteCloser.Write([]byte("\r\nexit\r\n"))
+		err = trace.NewAggregate(exitErr, s.ReadWriteCloser.Close())
+	})
+
+	return trace.Wrap(err)
+}
+
+type rwc struct {
+	r io.Reader
+	w io.Writer
+	c io.Closer
+}
+
+func (r rwc) Read(p []byte) (int, error) {
+	return r.r.Read(p)
+}
+
+func (r rwc) Write(p []byte) (int, error) {
+	return r.w.Write(p)
+}
+
+func (r rwc) Close() error {
+	return r.c.Close()
+}
+
+// repeatingReader is an [io.Reader] that periodically
+// returns the same value until the context is
+// terminated.
+type repeatingReader struct {
+	ctx      context.Context
+	s        string
+	interval time.Duration
+}
+
+func (r repeatingReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+
+	select {
+	case <-r.ctx.Done():
+		return 0, io.EOF
+	case <-time.After(r.interval):
+	}
+
+	end := len(r.s)
+	if end > len(p) {
+		end = len(p)
+	}
+
+	n := copy(p, r.s[:end])
+	return n, nil
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -230,6 +230,8 @@ type CLIConf struct {
 	BenchExport bool
 	// BenchExportPath saves the latency profile in provided path
 	BenchExportPath string
+	// BenchMaxSessions is the maximum number of sessions to open
+	BenchMaxSessions int
 	// BenchTicks ticks per half distance
 	BenchTicks int32
 	// BenchValueScale value at which to scale the values recorded
@@ -985,6 +987,11 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	benchWebSSH.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
 	benchWebSSH.Flag("random", "Connect to random hosts for each SSH session. The provided hostname must be all: tsh bench ssh --random <user>@all <command>").BoolVar(&cf.BenchRandom)
 
+	benchWebSessions := benchWeb.Command("sessions", "Run session benchmark tests").Hidden()
+	benchWebSessions.Arg("[user@]host", "Remote hostname and the login to use").Required().StringVar(&cf.UserHost)
+	benchWebSessions.Arg("command", "Command to execute on a remote host").Required().StringsVar(&cf.RemoteCommand)
+	benchWebSessions.Flag("max", "The maximum number of sessions to open. If not specified a single session per node will be opened.").IntVar(&cf.BenchMaxSessions)
+
 	var benchKubeOpts benchKubeOptions
 	benchKube := bench.Command("kube", "Run Kube benchmark tests").Hidden()
 	benchKube.Flag("kube-namespace", "Selects the ").Default("default").StringVar(&benchKubeOpts.namespace)
@@ -1269,6 +1276,15 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 			&benchmark.WebSSHBenchmark{
 				Command:  cf.RemoteCommand,
 				Random:   cf.BenchRandom,
+				Duration: cf.BenchDuration,
+			},
+		)
+	case benchWebSessions.FullCommand():
+		err = onBenchmark(
+			&cf,
+			&benchmark.WebSessionBenchmark{
+				Command:  cf.RemoteCommand,
+				Max:      cf.BenchMaxSessions,
 				Duration: cf.BenchDuration,
 			},
 		)
@@ -3274,7 +3290,7 @@ func onSSH(cf *CLIConf) error {
 }
 
 // onBenchmark executes benchmark
-func onBenchmark(cf *CLIConf, suite benchmark.BenchmarkSuite) error {
+func onBenchmark(cf *CLIConf, suite benchmark.Suite) error {
 	tc, err := makeClient(cf)
 	if err != nil {
 		return trace.Wrap(err)
@@ -3283,6 +3299,7 @@ func onBenchmark(cf *CLIConf, suite benchmark.BenchmarkSuite) error {
 		MinimumWindow: cf.BenchDuration,
 		Rate:          cf.BenchRate,
 	}
+
 	result, err := cnf.Benchmark(cf.Context, tc, suite)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, utils.UserMessageFromError(err))


### PR DESCRIPTION
Adds `tsh bench web session` to allow benchmarking concurrent web ssh sessions. 