### PR TITLE
Compile binaries for access plugin tests 

### DIFF
--- a/.github/workflows/unit-tests-integrations-bypass.yaml
+++ b/.github/workflows/unit-tests-integrations-bypass.yaml
@@ -1,5 +1,5 @@
 # This workflow is required to ensure that required Github check passes even if
-# the actual "Unit Tests (Operator)" workflow skipped due to path filtering. Otherwise
+# the actual "Unit Tests (Integrations)" workflow skipped due to path filtering. Otherwise
 # it will stay forever pending.
 #
 # See "Handling skipped but required checks" for more info:

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -43,8 +43,6 @@ jobs:
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport14
       options: --cap-add=SYS_ADMIN --privileged
-      env: 
-        TELEPORT_ENTERPRISE_LICENSE: ${{ secrets.TELEPORT_ENTERPRISE_LICENSE }}
 
     steps:
       - name: Checkout Teleport

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -52,7 +52,7 @@ jobs:
         uses: ./.github/actions/prepare-workspace
 
       - name: Build teleport binaries
-        run: make && echo "$PWD/build" >> "$GITHUB_PATH"
+        run: make build/tctl build/teleport build/tsh && echo "$PWD/build" >> "$GITHUB_PATH"
 
       - name: Run access plugin tests
         run: make test-access-integrations

--- a/.github/workflows/unit-tests-integrations.yaml
+++ b/.github/workflows/unit-tests-integrations.yaml
@@ -44,7 +44,6 @@ jobs:
       image: ghcr.io/gravitational/teleport-buildbox:teleport14
       options: --cap-add=SYS_ADMIN --privileged
       env: 
-        TELEPORT_GET_VERSION: v12.1.0
         TELEPORT_ENTERPRISE_LICENSE: ${{ secrets.TELEPORT_ENTERPRISE_LICENSE }}
 
     steps:
@@ -53,6 +52,9 @@ jobs:
 
       - name: Prepare workspace
         uses: ./.github/actions/prepare-workspace
+
+      - name: Build teleport binaries
+        run: make && echo "$PWD/build" >> "$GITHUB_PATH"
 
       - name: Run access plugin tests
         run: make test-access-integrations

--- a/integrations/access/pagerduty/pagerduty_test.go
+++ b/integrations/access/pagerduty/pagerduty_test.go
@@ -596,7 +596,12 @@ func (s *PagerdutySuite) assertNewEvent(watcher types.Watcher, opType types.OpTy
 			assert.Equal(t, resourceKind, ev.Resource.GetKind())
 			assert.Equal(t, resourceName, ev.Resource.GetName())
 		} else {
-			assert.Nil(t, ev.Resource)
+			switch r := ev.Resource.(type) {
+			case nil:
+			case *types.WatchStatusV1:
+			default:
+				t.Errorf("expected nil or *WatchStatusV1, got %T instead", r)
+			}
 		}
 	case <-s.Context().Done():
 		t.Error(t, "No events received", s.Context().Err())

--- a/integrations/lib/testing/integration/bootstrap.go
+++ b/integrations/lib/testing/integration/bootstrap.go
@@ -45,10 +45,7 @@ func (bootstrap *Bootstrap) AddUserWithRoles(name string, roles ...string) (type
 }
 
 func (bootstrap *Bootstrap) AddRole(name string, spec types.RoleSpecV6) (types.Role, error) {
-	// TODO(justinas|marcoandredinis): Remove this once Test Integration is updated to build tctl
-	// instead of using the binary from the release tarball.
-	// https://github.com/gravitational/teleport/issues/27528
-	role, err := types.NewRoleWithVersion(name, types.V6, spec)
+	role, err := types.NewRole(name, spec)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integrations/lib/testing/integration/integration.go
+++ b/integrations/lib/testing/integration/integration.go
@@ -195,12 +195,6 @@ func NewFromEnv(ctx context.Context) (*Integration, error) {
 
 	var paths BinPaths
 
-	if os.Getenv("CI") != "" {
-		if licenseStr == "" {
-			return nil, trace.AccessDenied("tests on CI should run with enterprise license")
-		}
-	}
-
 	if version := os.Getenv("TELEPORT_GET_VERSION"); version == "" {
 		paths = BinPaths{
 			Teleport: os.Getenv("TELEPORT_BINARY"),

--- a/integrations/lib/testing/integration/integration_test.go
+++ b/integrations/lib/testing/integration/integration_test.go
@@ -40,7 +40,7 @@ func (s *IntegrationSuite) TestVersion() {
 
 	versionMin, err := version.NewVersion("v11.0.0")
 	require.NoError(t, err)
-	versionMax, err := version.NewVersion("v13")
+	versionMax, err := version.NewVersion("v14")
 	require.NoError(t, err)
 
 	assert.True(t, s.Integration.Version().GreaterThanOrEqual(versionMin))


### PR DESCRIPTION
Modifies the "Unit tests (Integrations)" workflow to use teleport / tctl compiled from the current commit, rather than downloading the specified version.

Some of the tests require the Enterprise binaries and as such are skipped in the OSS test runs. This is covered by running access plugin tests in `teleport.e` as well, see Enterprise counterpart https://github.com/gravitational/teleport.e/pull/1661

Fixes https://github.com/gravitational/teleport/issues/27528 .