### PR TITLE
[Assist] Fix panic when writing to one WS from multiple threads

### DIFF
--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -185,10 +185,10 @@ func (h *Handler) executeCommand(
 		return nil, trace.Wrap(err)
 	}
 
-	// Wrap the raw websocket connection in a safeThreadWSConn so that we can
+	// Wrap the raw websocket connection in a syncRWWSConn so that we can
 	// safely read and write to the the single websocket connection from
-	// mutliple goroutines/nodes.
-	ws := &safeThreadWSConn{WSConn: rawWS}
+	// mutliple goroutines/execution nodes.
+	ws := &syncRWWSConn{WSConn: rawWS}
 
 	// Update the read deadline upon receiving a pong message.
 	ws.SetPongHandler(func(_ string) error {

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -187,13 +187,13 @@ func (h *Handler) executeCommand(
 	// Update the read deadline upon receiving a pong message.
 	rawWS.SetPongHandler(func(_ string) error {
 		// This is intentonally called without a lock as this callback is
-		// called from the same goroutine as the read loop which is aready locked.
+		// called from the same goroutine as the read loop which is already locked.
 		return trace.Wrap(rawWS.SetReadDeadline(deadlineForInterval(keepAliveInterval)))
 	})
 
 	// Wrap the raw websocket connection in a syncRWWSConn so that we can
 	// safely read and write to the the single websocket connection from
-	// mutliple goroutines/execution nodes.
+	// multiple goroutines/execution nodes.
 	ws := &syncRWWSConn{WSConn: rawWS}
 
 	hosts, err := findByQuery(ctx, clt, req.Query)

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -22,9 +22,9 @@ import (
 	"encoding/json"
 	"io"
 	"net"
+	"sync"
 	"time"
 
-	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
 )
 
@@ -39,13 +39,9 @@ type WSConn interface {
 
 	WriteControl(messageType int, data []byte, deadline time.Time) error
 	WriteMessage(messageType int, data []byte) error
-	NextReader() (messageType int, r io.Reader, err error)
 	ReadMessage() (messageType int, p []byte, err error)
 	SetReadLimit(limit int64)
 	SetReadDeadline(t time.Time) error
-	PingHandler() func(appData string) error
-	SetPingHandler(h func(appData string) error)
-	PongHandler() func(appData string) error
 	SetPongHandler(h func(appData string) error)
 }
 
@@ -98,10 +94,41 @@ func newPayloadWriter(nodeID, outputName string, stream io.Writer) *payloadWrite
 // by any underlying code as we want to keep the connection open until the command
 // is executed on all nodes and a single failure should not close the connection.
 type noopCloserWS struct {
-	*websocket.Conn
+	WSConn
 }
 
 // Close does nothing.
 func (ws *noopCloserWS) Close() error {
 	return nil
+}
+
+// safeThreadWSConn is a wrapper around websocket.Conn, which serializes
+// read and write to a web socket connection. This is needed to prevent
+// a race conditions and panics in gorilla/websocket.
+// Details https://pkg.go.dev/github.com/gorilla/websocket#hdr-Concurrency
+type safeThreadWSConn struct {
+	// WSConn the underlying websocket connection.
+	WSConn
+	// rmtx is a mutex used to serialize reads.
+	rmtx sync.Mutex
+	// wmtx is a mutex used to serialize writes.
+	wmtx sync.Mutex
+}
+
+func (s *safeThreadWSConn) WriteMessage(messageType int, data []byte) error {
+	s.wmtx.Lock()
+	defer s.wmtx.Unlock()
+	return s.WSConn.WriteMessage(messageType, data)
+}
+
+func (s *safeThreadWSConn) ReadMessage() (messageType int, p []byte, err error) {
+	s.rmtx.Lock()
+	defer s.rmtx.Unlock()
+	return s.WSConn.ReadMessage()
+}
+
+func (s *safeThreadWSConn) SetReadDeadline(t time.Time) error {
+	s.rmtx.Lock()
+	defer s.rmtx.Unlock()
+	return s.WSConn.SetReadDeadline(t)
 }


### PR DESCRIPTION
 Fixes https://github.com/gravitational/teleport.e/issues/1650

TODO:
- [x] Figure out the `ReadMessage()`/`SetReadDeadline()` deadlock issue.