### PR TITLE
Connect: Update Electron to 25.1 and TypeScript to 5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "x-default-browser": "^0.5.2"
   },
   "devDependencies": {
-    "typescript": "^5.0.4"
+    "typescript": "^5.1.3"
   },
   "workspaces": {
     "packages": [

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -40,7 +40,7 @@
     "@types/node-forge": "^1.0.4",
     "clean-webpack-plugin": "4.0.0",
     "cross-env": "5.0.5",
-    "electron": "24.3.0",
+    "electron": "25.1.0",
     "electron-notarize": "^1.2.1",
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-loader": "3.0.3",

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -40,7 +40,7 @@
     "@types/node-forge": "^1.0.4",
     "clean-webpack-plugin": "4.0.0",
     "cross-env": "5.0.5",
-    "electron": "25.1.0",
+    "electron": "25.1.1",
     "electron-notarize": "^1.2.1",
     "eslint-import-resolver-webpack": "0.13.2",
     "eslint-loader": "3.0.3",

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -332,10 +332,7 @@ export default class MainProcess {
         role: 'help',
         submenu: [
           { label: 'Learn More', click: openDocsUrl },
-          {
-            label: 'About Teleport Connect',
-            click: app.showAboutPanel,
-          },
+          { role: 'about' },
         ],
       },
     ];
@@ -345,8 +342,7 @@ export default class MainProcess {
   }
 
   private updateAboutPanelIfNeeded(): void {
-    // There is no about menu for Linux. See https://github.com/electron/electron/issues/18918
-    // On Windows default menu does not show copyrights.
+    // On Windows and Linux default menu does not show copyrights.
     if (
       this.settings.platform === 'linux' ||
       this.settings.platform === 'win32'

--- a/web/packages/teleterm/src/mainProcess/windowsManager.ts
+++ b/web/packages/teleterm/src/mainProcess/windowsManager.ts
@@ -131,12 +131,12 @@ export class WindowsManager {
       return;
     }
 
-    // What follows is a special focus handler for windows.
-    //
-    // On Windows, app.focus() doesn't work as expected so instead we call win.focus().
-    // If the window is minimized, win.focus() will bring it to the front and give it focus.
-    // If the window is not minimized but simply covered by other another window, win.focus() will
+    // On Windows, app.focus() doesn't work the same as on the other platforms.
+    // If the window is minimized, app.focus() will bring it to the front and give it focus.
+    // If the window is not minimized but simply covered by other another window, app.focus() will
     // flash the icon of Connect in the task bar.
+    // To make things even more complicated, the app behaves like that only when it is packaged.
+    // When it is in dev mode, it seems to work correctly (it is brought to the front every time).
     //
     // Ideally, we'd like the not minimized window to receive focus too. We considered two
     // workarounds to bring focus to a window that's not minimized:
@@ -155,21 +155,20 @@ export class WindowsManager {
     //
     // https://github.com/electron/electron/issues/2867#issuecomment-1080573240
     //
-    // I don't understand why calling win.focus() on a minimized window gives it focus in the
+    // I don't understand why calling app.focus() on a minimized window gives it focus in the
     // first place. In theory it shouldn't work, see the links below:
     //
     // https://stackoverflow.com/a/72620653/742872
     // https://devblogs.microsoft.com/oldnewthing/20090220-00/?p=19083
     // https://github.com/electron/electron/issues/2867#issuecomment-142480964
     // https://github.com/electron/electron/issues/2867#issuecomment-142511956
-    if (this.settings.platform === 'win32') {
-      this.window.focus();
-      return;
-    }
 
     app.dock?.bounce('informational');
+
     // app.focus() alone doesn't un-minimize the window if the window is minimized.
-    this.window.show();
+    if (this.window.isMinimized()) {
+      this.window.restore();
+    }
     app.focus({ steal: true });
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6835,10 +6835,10 @@ electron-to-chromium@^1.4.284:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.304.tgz#d6eb7fea4073aacc471cf117df08b4b4978dc6ad"
   integrity sha512-6c8M+ojPgDIXN2NyfGn8oHASXYnayj+gSEnGeLMKb9zjsySeVB/j7KkNAAG9yDcv8gNlhvFg5REa1N/kQU6pgA==
 
-electron@25.1.0:
-  version "25.1.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-25.1.0.tgz#78c79aba4bef941217c337dca46745b5551b5735"
-  integrity sha512-VKk4G/0euO7ysMKQKHXmI4d3/qR4uHsAtVFXK2WfQUVxBmc160OAm2R6PN9/EXmgXEioKQBtbc2/lvWyYpDbuA==
+electron@25.1.1:
+  version "25.1.1"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.1.1.tgz#b7aaf0d66a56fbbbad987c13cee108642f63bd50"
+  integrity sha512-WvFUfVsJn6YiP35UxdibYVjU2LceastyMm4SVp2bmb4XvKEvItAIiwxgm7tPC5Syl1243aRCvQLqr84sZ71pyQ==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6835,10 +6835,10 @@ electron-to-chromium@^1.4.284:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.304.tgz#d6eb7fea4073aacc471cf117df08b4b4978dc6ad"
   integrity sha512-6c8M+ojPgDIXN2NyfGn8oHASXYnayj+gSEnGeLMKb9zjsySeVB/j7KkNAAG9yDcv8gNlhvFg5REa1N/kQU6pgA==
 
-electron@24.3.0:
-  version "24.3.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-24.3.0.tgz#d1ef519b0d6d86cc4992519b49821372cb957fe6"
-  integrity sha512-M7PpfpOzGdLeZPr2xhxXuvJeoXPEHMH40Rtv8BCGleRPolwna9BepAGc0H0F+Uz5kGKOv3xcm99fTurvXUH0nw==
+electron@25.1.0:
+  version "25.1.0"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-25.1.0.tgz#78c79aba4bef941217c337dca46745b5551b5735"
+  integrity sha512-VKk4G/0euO7ysMKQKHXmI4d3/qR4uHsAtVFXK2WfQUVxBmc160OAm2R6PN9/EXmgXEioKQBtbc2/lvWyYpDbuA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^18.11.18"
@@ -14301,10 +14301,10 @@ typescript@^4.0.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
-typescript@^5.0.4:
-  version "5.0.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
-  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
+typescript@^5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
+  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
 
 uglify-js@^3.1.4:
   version "3.14.3"


### PR DESCRIPTION
Updates Electron and TS to the latest versions.

While testing, I noticed that force focusing a minimized window no longer works on Windows. That is, the window did not unminimize or even blink on the taskbar. I made an attempt to fix this, and the solution I found is to restore the window if it is minimized, and then just call `app.focus`. 
I hoped that I fixed an issue that we had on Windows, when the window was not moved to the foreground when `forceFocus` was called, and the window was in the background. It worked fine when I tested it in dev mode, but today I tested the packaged app and it worked like before, that is, the window didn't go to the foreground if it was in the background 😵‍💫.

I also tried to replace [deprecated](https://www.electronjs.org/blog/electron-25-0#breaking-changes) `protocol.interceptFileProtocol`, but I failed. I used `protocol.handle('file', (request) => {}))`, but the callback was not invoked and I don't know why. Isn't `file` a valid protocol? I think we can leave it for now, and see how others implement it? It's hard to find any examples of that.

Tag build https://drone.platform.teleport.sh/gravitational/teleport/25192/2/8.