### PR TITLE
chore: Bump Buf and Go versions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport14
   GID: "1000"
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
   UID: "1000"
 trigger:
   event:
@@ -155,7 +155,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport14
   GID: "1000"
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
   UID: "1000"
 trigger:
   event:
@@ -269,7 +269,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport14
   GID: "1000"
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
   UID: "1000"
 trigger:
   event:
@@ -387,7 +387,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport14
   GID: "1000"
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
   UID: "1000"
 trigger:
   event:
@@ -1042,7 +1042,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport14
   GID: "1000"
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
   UID: "1000"
 trigger:
   event:
@@ -1479,7 +1479,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
 trigger:
   event:
     include:
@@ -1688,7 +1688,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
 trigger:
   event:
     include:
@@ -1896,7 +1896,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
 trigger:
   event:
     include:
@@ -2111,7 +2111,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
 trigger:
   event:
     include:
@@ -3411,7 +3411,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
 trigger:
   event:
     include:
@@ -4237,7 +4237,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
 trigger:
   event:
     include:
@@ -5566,7 +5566,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.4
+  RUNTIME: go1.20.5
 trigger:
   event:
     include:
@@ -17230,6 +17230,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: a07eb27d94c8fe53e608a6876668464b470cbd061c5ea7cb18e83a7e3a673cbd
+hmac: 91a2ca37bd7d648e1bebd19817df269bf4498c881d8e02c64105b78fb3121c68
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -33,7 +33,7 @@ LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Sync any version changes below with devbox.json.
 # Protogen related versions.
-BUF_VERSION ?= 1.20.0
+BUF_VERSION ?= 1.21.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -20,7 +20,7 @@ OS ?= linux
 ARCH ?= amd64
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.20.4
+GOLANG_VERSION ?= go1.20.5
 
 # Sync with devbox.json.
 NODE_VERSION ?= 16.18.1

--- a/devbox.json
+++ b/devbox.json
@@ -3,7 +3,7 @@
     "addlicense@1.0.0",
     "bash",
     "bats@1.3.0",
-    "github:nixos/nixpkgs/757a0d107c238d031652a8c09d1f6bf1b6f523a3#buf",
+    "github:nixos/nixpkgs/d7f28652048b3bed6a512542e62ea1a50691e349#buf",
     "clang@11.1.0",
     "gci@0.9.1",
     "git",


### PR DESCRIPTION
Update Buf and Go to the latest releases.

* https://github.com/bufbuild/buf/releases/tag/v1.21.0
* https://go.dev/doc/devel/release#go1.20.minor

Devbox:

* https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/tools/buf/default.nix#L13
* https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/compilers/go/1.20.nix#L49 (still on 1.20.4)