### PR TITLE
Ensure SSH_SESSION_WEBPROXY_ADDR is set for all sessions

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -38,8 +38,8 @@ const (
 	// SSHTeleportUser is the current Teleport user that is logged in.
 	SSHTeleportUser = "SSH_TELEPORT_USER"
 
-	// SSHSessionWebproxyAddr is the address the web proxy.
-	SSHSessionWebproxyAddr = "SSH_SESSION_WEBPROXY_ADDR"
+	// SSHSessionWebProxyAddr is the address the web proxy.
+	SSHSessionWebProxyAddr = "SSH_SESSION_WEBPROXY_ADDR"
 
 	// SSHTeleportClusterName is the name of the cluster this node belongs to.
 	SSHTeleportClusterName = "SSH_TELEPORT_CLUSTER_NAME"

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -2672,7 +2672,7 @@ func (tc *TeleportClient) runCommandOnNodes(ctx context.Context, clt *ClusterCli
 
 func (tc *TeleportClient) newSessionEnv() map[string]string {
 	env := map[string]string{
-		teleport.SSHSessionWebproxyAddr: tc.WebProxyAddr,
+		teleport.SSHSessionWebProxyAddr: tc.WebProxyAddr,
 	}
 	if tc.SessionID != "" {
 		env[sshutils.SessionEnvVar] = tc.SessionID

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -547,7 +547,7 @@ func onStatus() error {
 	sshClient := os.Getenv("SSH_CLIENT")
 	systemUser := os.Getenv("USER")
 	teleportUser := os.Getenv(teleport.SSHTeleportUser)
-	proxyAddr := os.Getenv(teleport.SSHSessionWebproxyAddr)
+	proxyAddr := os.Getenv(teleport.SSHSessionWebProxyAddr)
 	clusterName := os.Getenv(teleport.SSHTeleportClusterName)
 	hostUUID := os.Getenv(teleport.SSHTeleportHostUUID)
 	sid := os.Getenv(teleport.SSHSessionID)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -4634,7 +4634,7 @@ func setEnvFlags(cf *CLIConf, getEnv envGetter) {
 	// When using Headless, check for missing proxy/user/cluster values from the teleport session env variables.
 	if cf.Headless || cf.AuthConnector == constants.HeadlessConnector {
 		if cf.Proxy == "" {
-			cf.Proxy = getEnv(teleport.SSHSessionWebproxyAddr)
+			cf.Proxy = getEnv(teleport.SSHSessionWebProxyAddr)
 		}
 		if cf.Username == "" {
 			cf.Username = getEnv(teleport.SSHTeleportUser)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2495,7 +2495,7 @@ func TestEnvFlags(t *testing.T) {
 				Headless: false,
 			},
 			envMap: map[string]string{
-				teleport.SSHSessionWebproxyAddr: "proxy.example.com",
+				teleport.SSHSessionWebProxyAddr: "proxy.example.com",
 				teleport.SSHTeleportUser:        "alice",
 				teleport.SSHTeleportClusterName: "root-cluster",
 			},
@@ -2508,7 +2508,7 @@ func TestEnvFlags(t *testing.T) {
 				Headless: true,
 			},
 			envMap: map[string]string{
-				teleport.SSHSessionWebproxyAddr: "proxy.example.com",
+				teleport.SSHSessionWebProxyAddr: "proxy.example.com",
 				teleport.SSHTeleportUser:        "alice",
 				teleport.SSHTeleportClusterName: "root-cluster",
 			},
@@ -2524,7 +2524,7 @@ func TestEnvFlags(t *testing.T) {
 				AuthConnector: constants.HeadlessConnector,
 			},
 			envMap: map[string]string{
-				teleport.SSHSessionWebproxyAddr: "proxy.example.com",
+				teleport.SSHSessionWebProxyAddr: "proxy.example.com",
 				teleport.SSHTeleportUser:        "alice",
 				teleport.SSHTeleportClusterName: "root-cluster",
 			},
@@ -2543,7 +2543,7 @@ func TestEnvFlags(t *testing.T) {
 				SiteName: "root-cluster",
 			},
 			envMap: map[string]string{
-				teleport.SSHSessionWebproxyAddr: "other.example.com",
+				teleport.SSHSessionWebProxyAddr: "other.example.com",
 				teleport.SSHTeleportUser:        "bob",
 				teleport.SSHTeleportClusterName: "leaf-cluster",
 			},


### PR DESCRIPTION
Fixes a discrepancy in overwriting the environment value with the address observed for the Web UI for sessions not originating from the Web UI. All sessions will now use `tc.WebProxyAddr` as the default value and *only* update if an override is provided.

`TestIntegrations/EnvironmentVars` was updated to ensure that the expected environment variables are present in both interactive and non-interactive sessions.