### PR TITLE
Allow dynamic role registration.

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -255,7 +255,9 @@ const (
 	// TeleportOKEvent is emitted whenever a service is operating normally.
 	TeleportOKEvent = "TeleportOKEvent"
 
-	// externalUpgraderEnv is the external upgrader environment variable.
+	// externalUpgraderEnv is the external upgrader environment variable. This specifies the
+	// external program that is responsible for updating Teleport. More details
+	// can be found at https://goteleport.com/docs/architecture/agent-update-management/?scope=enterprise
 	externalUpgraderEnv = "TELEPORT_EXT_UPGRADER"
 )
 


### PR DESCRIPTION
Roles can now be registered dynamically and these will be reflected in the inventory. This is used by the Okta plugin so that it's able to properly detect when Okta services are connected.