### PR TITLE
Pass context through `UpsertAuthServer`

### DIFF
--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -41,7 +41,7 @@ type Announcer interface {
 
 	// UpsertAuthServer registers auth server presence, permanently if ttl is 0 or
 	// for the specified duration with second resolution if it's >= 1 second
-	UpsertAuthServer(s types.Server) error
+	UpsertAuthServer(ctx context.Context, s types.Server) error
 
 	// UpsertKubernetesServer registers a kubernetes server
 	UpsertKubernetesServer(context.Context, types.KubeServer) (*types.KeepAlive, error)

--- a/lib/auth/apiserver.go
+++ b/lib/auth/apiserver.go
@@ -250,7 +250,7 @@ func (s *APIServer) upsertServer(auth services.Presence, role types.SystemRole, 
 		}
 		return handle, nil
 	case types.RoleAuth:
-		if err := auth.UpsertAuthServer(server); err != nil {
+		if err := auth.UpsertAuthServer(r.Context(), server); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	case types.RoleProxy:

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1883,11 +1883,11 @@ func (a *ServerWithRoles) ListWindowsDesktopServices(ctx context.Context, req ty
 	return nil, trace.NotImplemented(notImplementedMessage)
 }
 
-func (a *ServerWithRoles) UpsertAuthServer(s types.Server) error {
+func (a *ServerWithRoles) UpsertAuthServer(ctx context.Context, s types.Server) error {
 	if err := a.action(apidefaults.Namespace, types.KindAuthServer, types.VerbCreate, types.VerbUpdate); err != nil {
 		return trace.Wrap(err)
 	}
-	return a.authServer.UpsertAuthServer(s)
+	return a.authServer.UpsertAuthServer(ctx, s)
 }
 
 func (a *ServerWithRoles) GetAuthServers() ([]types.Server, error) {

--- a/lib/auth/http_client.go
+++ b/lib/auth/http_client.go
@@ -632,7 +632,7 @@ func (c *HTTPClient) CreateRemoteCluster(rc types.RemoteCluster) error {
 
 // UpsertAuthServer is used by auth servers to report their presence
 // to other auth servers in form of hearbeat expiring after ttl period.
-func (c *HTTPClient) UpsertAuthServer(s types.Server) error {
+func (c *HTTPClient) UpsertAuthServer(ctx context.Context, s types.Server) error {
 	data, err := services.MarshalServer(s)
 	if err != nil {
 		return trace.Wrap(err)
@@ -640,7 +640,7 @@ func (c *HTTPClient) UpsertAuthServer(s types.Server) error {
 	args := &upsertServerRawReq{
 		Server: data,
 	}
-	_, err = c.PostJSON(context.TODO(), c.Endpoint("authservers"), args)
+	_, err = c.PostJSON(ctx, c.Endpoint("authservers"), args)
 	return trace.Wrap(err)
 }
 

--- a/lib/auth/state.go
+++ b/lib/auth/state.go
@@ -85,8 +85,8 @@ const (
 )
 
 // GetState reads rotation state from disk.
-func (p *ProcessStorage) GetState(role types.SystemRole) (*StateV2, error) {
-	item, err := p.stateStorage.Get(context.TODO(), backend.Key(statesPrefix, strings.ToLower(role.String()), stateName))
+func (p *ProcessStorage) GetState(ctx context.Context, role types.SystemRole) (*StateV2, error) {
+	item, err := p.stateStorage.Get(ctx, backend.Key(statesPrefix, strings.ToLower(role.String()), stateName))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1555,14 +1555,14 @@ func TestAuthServers(t *testing.T) {
 		newResource: func(name string) (types.Server, error) {
 			return suite.NewServer(types.KindAuthServer, name, "127.0.0.1:2022", apidefaults.Namespace), nil
 		},
-		create: modifyNoContext(p.presenceS.UpsertAuthServer),
+		create: p.presenceS.UpsertAuthServer,
 		list: func(_ context.Context) ([]types.Server, error) {
 			return p.presenceS.GetAuthServers()
 		},
 		cacheList: func(_ context.Context) ([]types.Server, error) {
 			return p.cache.GetAuthServers()
 		},
-		update: modifyNoContext(p.presenceS.UpsertAuthServer),
+		update: p.presenceS.UpsertAuthServer,
 		deleteAll: func(_ context.Context) error {
 			return p.presenceS.DeleteAllAuthServers()
 		},

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -809,7 +809,7 @@ func (authServerExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets 
 }
 
 func (authServerExecutor) upsert(ctx context.Context, cache *Cache, resource types.Server) error {
-	return cache.presenceCache.UpsertAuthServer(resource)
+	return cache.presenceCache.UpsertAuthServer(ctx, resource)
 }
 
 func (authServerExecutor) deleteAll(ctx context.Context, cache *Cache) error {

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -228,7 +228,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 	for _, opt := range opts {
 		opt(&options)
 	}
-	state, err := process.storage.GetState(role)
+	state, err := process.storage.GetState(context.TODO(), role)
 	if err != nil {
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
@@ -737,7 +737,7 @@ func (process *TeleportProcess) syncOpenSSHRotationState() error {
 		return trace.Wrap(err)
 	}
 
-	state, err := process.storage.GetState(types.RoleNode)
+	state, err := process.storage.GetState(ctx, types.RoleNode)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -975,7 +975,7 @@ func (process *TeleportProcess) syncRotationState(conn *Connector) (*rotationSta
 // syncServiceRotationState syncs up rotation state for internal services (Auth, Proxy, Node) and
 // if necessary, updates credentials. Returns true if the service will need to reload.
 func (process *TeleportProcess) syncServiceRotationState(ca types.CertAuthority, conn *Connector) (*rotationStatus, error) {
-	state, err := process.storage.GetState(conn.ClientIdentity.ID.Role)
+	state, err := process.storage.GetState(context.TODO(), conn.ClientIdentity.ID.Role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1886,7 +1886,7 @@ func (process *TeleportProcess) initAuthService() error {
 					Version:  teleport.Version,
 				},
 			}
-			state, err := process.storage.GetState(types.RoleAdmin)
+			state, err := process.storage.GetState(process.GracefulExitContext(), types.RoleAdmin)
 			if err != nil {
 				if !trace.IsNotFound(err) {
 					log.Warningf("Failed to get rotation state: %v.", err)
@@ -2199,7 +2199,7 @@ func (process *TeleportProcess) NewLocalCache(clt auth.ClientI, setupConfig cach
 
 // GetRotation returns the process rotation.
 func (process *TeleportProcess) GetRotation(role types.SystemRole) (*types.Rotation, error) {
-	state, err := process.storage.GetState(role)
+	state, err := process.storage.GetState(context.TODO(), role)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -357,8 +357,8 @@ func (s *PresenceService) GetAuthServers() ([]types.Server, error) {
 
 // UpsertAuthServer registers auth server presence, permanently if ttl is 0 or
 // for the specified duration with second resolution if it's >= 1 second
-func (s *PresenceService) UpsertAuthServer(server types.Server) error {
-	return s.upsertServer(context.TODO(), authServersPrefix, server)
+func (s *PresenceService) UpsertAuthServer(ctx context.Context, server types.Server) error {
+	return s.upsertServer(ctx, authServersPrefix, server)
 }
 
 // DeleteAllAuthServers deletes all auth servers

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -67,7 +67,7 @@ type Presence interface {
 
 	// UpsertAuthServer registers auth server presence, permanently if ttl is 0 or
 	// for the specified duration with second resolution if it's >= 1 second
-	UpsertAuthServer(server types.Server) error
+	UpsertAuthServer(ctx context.Context, server types.Server) error
 
 	// DeleteAuthServer deletes auth server by name
 	DeleteAuthServer(name string) error

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -425,7 +425,7 @@ func (s *ServicesTestSuite) ServerCRUD(t *testing.T) {
 	require.Equal(t, len(out), 0)
 
 	auth := NewServer(types.KindAuthServer, "auth1", "127.0.0.1:2025", apidefaults.Namespace)
-	require.NoError(t, s.PresenceS.UpsertAuthServer(auth))
+	require.NoError(t, s.PresenceS.UpsertAuthServer(ctx, auth))
 
 	out, err = s.PresenceS.GetAuthServers()
 	require.NoError(t, err)

--- a/lib/srv/heartbeat.go
+++ b/lib/srv/heartbeat.go
@@ -416,7 +416,7 @@ func (h *Heartbeat) announce() error {
 			if !ok {
 				return trace.BadParameter("expected services.Server, got %#v", h.current)
 			}
-			err := h.Announcer.UpsertAuthServer(auth)
+			err := h.Announcer.UpsertAuthServer(h.cancelCtx, auth)
 			if err != nil {
 				h.nextAnnounce = h.Clock.Now().UTC().Add(h.KeepAlivePeriod)
 				h.setState(HeartbeatStateAnnounceWait)

--- a/lib/srv/heartbeat_test.go
+++ b/lib/srv/heartbeat_test.go
@@ -358,7 +358,7 @@ func (f *fakeAnnouncer) UpsertProxy(ctx context.Context, s types.Server) error {
 	return f.err
 }
 
-func (f *fakeAnnouncer) UpsertAuthServer(s types.Server) error {
+func (f *fakeAnnouncer) UpsertAuthServer(ctx context.Context, s types.Server) error {
 	f.upsertCalls[HeartbeatModeAuth]++
 	return f.err
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -235,7 +235,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 
 	// Register the auth server, since test auth server doesn't start its own
 	// heartbeat.
-	err = s.server.Auth().UpsertAuthServer(&types.ServerV2{
+	err = s.server.Auth().UpsertAuthServer(ctx, &types.ServerV2{
 		Kind:    types.KindAuthServer,
 		Version: types.V2,
 		Metadata: types.Metadata{
@@ -7337,7 +7337,7 @@ func newWebPack(t *testing.T, numProxies int, opts ...proxyOption) *webPack {
 
 	// Register the auth server, since test auth server doesn't start its own
 	// heartbeat.
-	err = server.Auth().UpsertAuthServer(&types.ServerV2{
+	err = server.Auth().UpsertAuthServer(ctx, &types.ServerV2{
 		Kind:    types.KindAuthServer,
 		Version: types.V2,
 		Metadata: types.Metadata{

--- a/lib/web/ui/perf_test.go
+++ b/lib/web/ui/perf_test.go
@@ -135,7 +135,7 @@ func insertServers(ctx context.Context, b *testing.B, svc services.Presence, kin
 		case types.KindProxy:
 			err = svc.UpsertProxy(ctx, server)
 		case types.KindAuthServer:
-			err = svc.UpsertAuthServer(server)
+			err = svc.UpsertAuthServer(ctx, server)
 		default:
 			b.Errorf("Unexpected server kind: %s", kind)
 		}


### PR DESCRIPTION
As a bonus, also pass the context through `(*ProcessStorage).GetState`, seeing as those two are called from within the `auth.heartbeat` local service which had been reported as hanging during shutdown in certain rare cases.