### PR TITLE
helm: Use local auth server address in auth pod to prevent extra connections

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.common.tpl
@@ -55,6 +55,7 @@ auth_service:
   proxy_listener_mode: {{ .Values.proxyListenerMode }}
 {{- end }}
 teleport:
+  auth_server: 127.0.0.1:3025
   log:
     severity: {{ $logLevel }}
     output: {{ .Values.log.output }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -35,6 +35,7 @@ matches snapshot for acme-off.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -69,6 +70,7 @@ matches snapshot for acme-on.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -103,6 +105,7 @@ matches snapshot for acme-uri-staging.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -138,6 +141,7 @@ matches snapshot for auth-connector-name.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -170,6 +174,7 @@ matches snapshot for auth-disable-local.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -205,6 +210,7 @@ matches snapshot for auth-locking-mode.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -240,6 +246,7 @@ matches snapshot for auth-passwordless.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -274,6 +281,7 @@ matches snapshot for auth-type-legacy.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -308,6 +316,7 @@ matches snapshot for auth-type.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -346,6 +355,7 @@ matches snapshot for auth-webauthn-legacy.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -384,6 +394,7 @@ matches snapshot for auth-webauthn.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -418,6 +429,7 @@ matches snapshot for aws-dynamodb-autoscaling.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -469,6 +481,7 @@ matches snapshot for aws-ha-acme.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -514,6 +527,7 @@ matches snapshot for aws-ha-antiaffinity.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -559,6 +573,7 @@ matches snapshot for aws-ha-log.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -605,6 +620,7 @@ matches snapshot for aws-ha.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -650,6 +666,7 @@ matches snapshot for aws.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -693,6 +710,7 @@ matches snapshot for existing-tls-secret-with-ca.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -727,6 +745,7 @@ matches snapshot for existing-tls-secret.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -763,6 +782,7 @@ matches snapshot for gcp-ha-acme.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -807,6 +827,7 @@ matches snapshot for gcp-ha-antiaffinity.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -851,6 +872,7 @@ matches snapshot for gcp-ha-log.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -896,6 +918,7 @@ matches snapshot for gcp.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -938,6 +961,7 @@ matches snapshot for initcontainers.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -972,6 +996,7 @@ matches snapshot for kube-cluster-name.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1006,6 +1031,7 @@ matches snapshot for log-basic.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1040,6 +1066,7 @@ matches snapshot for log-extra.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1074,6 +1101,7 @@ matches snapshot for log-legacy.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1108,6 +1136,7 @@ matches snapshot for priority-class-name.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1142,6 +1171,7 @@ matches snapshot for proxy-listener-mode-multiplex.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1176,6 +1206,7 @@ matches snapshot for proxy-listener-mode-separate.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1210,6 +1241,7 @@ matches snapshot for public-addresses.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1244,6 +1276,7 @@ matches snapshot for separate-mongo-listener.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1278,6 +1311,7 @@ matches snapshot for separate-postgres-listener.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1312,6 +1346,7 @@ matches snapshot for service.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1347,6 +1382,7 @@ matches snapshot for session-recording.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1383,6 +1419,7 @@ matches snapshot for standalone-customsize.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1419,6 +1456,7 @@ matches snapshot for standalone-existingpvc.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1453,6 +1491,7 @@ matches snapshot for tolerations.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1499,6 +1538,7 @@ matches snapshot for version-override.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:
@@ -1533,6 +1573,7 @@ matches snapshot for volumes.yaml:
       ssh_service:
         enabled: false
       teleport:
+        auth_server: 127.0.0.1:3025
         log:
           format:
             extra_fields:


### PR DESCRIPTION
Not specifying `auth_server` means that the `kubernetes_service` in the auth pod repeatedly attempts to dial `0.0.0.0:3025` (which is the default auth server address) before getting a successful connection back to `localhost`. In environments with HTTP proxies set, this results in connection attempts appearing from the pod roughly every minute:

```
1686772791.987      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686772874.886      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686772923.174      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686772989.237      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773074.707      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773160.701      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773223.395      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773312.850      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773372.639      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773437.719      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773520.251      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773589.440      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773647.131      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773715.917      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773785.210      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773843.085      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686773913.941      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774003.752      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774062.090      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774118.847      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774206.325      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774287.153      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774360.473      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774411.925      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774480.743      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774563.305      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
1686774648.561      0 192.168.24.162 TCP_DENIED/403 3926 CONNECT 0.0.0.0:3025 - HIER_NONE/- text/html
```

This is inefficient and unnecessary, so we can just tell the `kubernetes_service` to always connect locally to the auth service instead.

Tested by redeploying and noting that there were no further connection attempts to `0.0.0.0:3025`, and all functionality still worked correctly.