### PR TITLE
fix: correct minSupportedLabelExpressionVersion to v13.1.1

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3771,8 +3771,8 @@ func minRequiredVersionForRole(role types.Role) (semver.Version, string, error) 
 // the zero version.
 //
 // Examples:
-// - (15.x.x, 13.1.0) -> true (anything older than 13.1.0 is >1 major behind v15)
-// - (14.x.x, 13.1.0) -> false (13.0.9 is within one major of v14)
+// - (15.x.x, 13.1.1) -> true (anything older than 13.1.1 is >1 major behind v15)
+// - (14.x.x, 13.1.1) -> false (13.0.9 is within one major of v14)
 // - (14.x.x, 13.0.0) -> true (anything older than 13.0.0 is >1 major behind v14)
 func safeToSkipInventoryCheck(authVersion, minRequiredVersion semver.Version) bool {
 	return authVersion.Major > roundToNextMajor(minRequiredVersion)
@@ -3781,7 +3781,7 @@ func safeToSkipInventoryCheck(authVersion, minRequiredVersion semver.Version) bo
 // roundToNextMajor returns the next major version that is *not less than* [v].
 //
 // Examples:
-// - 13.1.0 -> 14.0.0
+// - 13.1.1 -> 14.0.0
 // - 13.0.0 -> 13.0.0
 // - 13.0.0-alpha -> 13.0.0
 func roundToNextMajor(v semver.Version) int64 {

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -1959,7 +1959,7 @@ func maybeDowngradeRole(ctx context.Context, role *types.RoleV6) (*types.RoleV6,
 	return role, nil
 }
 
-var minSupportedLabelExpressionVersion = semver.Version{Major: 13, Minor: 2}
+var minSupportedLabelExpressionVersion = semver.Version{Major: 13, Minor: 1, Patch: 1}
 
 func maybeDowngradeRoleLabelExpressions(ctx context.Context, role *types.RoleV6, clientVersion *semver.Version) (*types.RoleV6, error) {
 	if !clientVersion.LessThan(minSupportedLabelExpressionVersion) {


### PR DESCRIPTION
Label expressions went out in v13.1.1, this commit corrects the `minSupportedLabelExpressionVersion` constant to match. This is necessary for label expressions to work when nodes on versions between 13.1.1 and 13.2.0 connect to auth servers on versions >=14.0.0-alpha. This doesn't affect any released versions, we just want this to be right before we ship v14.

Notably, branch/v13 already has this set to v13.1.1

This was expected, so testcases already use `minSupportedLabelExpressionVersion` and are automatically up to date.
