### PR TITLE
Remove further unused fips infrastructure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6236,29 +6236,6 @@ steps:
     path: /var/run
   - name: dockerconfig
     path: /root/.docker
-- name: Build and push buildbox-fips
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make aws-cli
-  - chown -R $UID:$GID /go
-  - aws ecr get-login-password --profile staging --region=us-west-2 | docker login
-    -u="AWS" --password-stdin 146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - make -C build.assets buildbox-fips
-  - docker tag public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
-    146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  - docker push 146628656107.dkr.ecr.us-west-2.amazonaws.com/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION-$DRONE_COMMIT_SHA
-  - docker logout 146628656107.dkr.ecr.us-west-2.amazonaws.com
-  - aws ecr-public get-login-password --profile production --region=us-east-1 | docker
-    login -u="AWS" --password-stdin public.ecr.aws
-  - docker push public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
 - name: Build and push buildbox-arm
   image: docker
   pull: if-not-exists
@@ -17231,6 +17208,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 00665b79186e25b022b99fea2af4a2da0cd867f7b0b995ce4541af3d2d242b3d
+hmac: d3185434ba38b96a9cbf435a59a3ab0d7e4d3ef6ef39a198164e0e2198f1286d
 
 ...

--- a/build.assets/Dockerfile-arm-fips
+++ b/build.assets/Dockerfile-arm-fips
@@ -1,6 +1,0 @@
-ARG BUILDBOX_VERSION
-FROM public.ecr.aws/gravitational/teleport-buildbox-fips:$BUILDBOX_VERSION
-
-RUN apt-get -y update && \
-    apt-get -y install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu && \
-    apt-get -y autoclean && apt-get -y clean

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -58,7 +58,6 @@ include grpcbox.mk
 # target. The other solution was to remove the 'buildbox' dependency from the 'release' target, but this would
 # make it harder to run `make -C build.assets release` locally as the buildbox would not automatically be built.
 BUILDBOX_NAME=$(BUILDBOX)
-BUILDBOX_FIPS_NAME=$(BUILDBOX_FIPS)
 
 DOCSBOX=ghcr.io/gravitational/docs
 
@@ -435,9 +434,9 @@ release-arm64: buildbox-arm
 # CI should not use this target, it should use named Makefile targets like release-amd64-fips.
 #
 .PHONY:release-fips
-release-fips: buildbox-fips
+release-fips: buildbox-centos7-fips
 	@if [ -z ${VERSION} ]; then echo "VERSION is not set"; exit 1; fi
-	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_FIPS_NAME) \
+	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
 		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=yes
 
 #

--- a/dronegen/buildbox.go
+++ b/dronegen/buildbox.go
@@ -52,8 +52,8 @@ func buildboxPipelineSteps() []step {
 
 	for _, name := range []string{"buildbox", "buildbox-arm", "buildbox-centos7"} {
 		for _, fips := range []bool{false, true} {
-			// FIPS is unsupported on ARM/ARM64
-			if name == "buildbox-arm" && fips {
+			// FIPS is only supported on centos7
+			if fips && name != "buildbox-centos7" {
 				continue
 			}
 			steps = append(steps, buildboxPipelineStep(name, fips))


### PR DESCRIPTION
This patch remove the `buildbox-fips` publishing pipeline, and fixes an issue seen in teleport.e fips builds caused by using `buildbox-fips` instead of `buildbox-centos7-fips`.

Context: I missed a couple items in https://github.com/gravitational/teleport/pull/26859, as these were not caught by any pre-merge checks.  This resulted in some post-merge pipelines failing, as seen here:

* `build-buildboxes` https://drone.platform.teleport.sh/gravitational/teleport/25238/9/10
* `teleport.e` `push-build-linux-amd64-fips` https://drone.platform.teleport.sh/gravitational/teleport.e/1486/3/3 (note: we should probably use the same make targets as `teleport`'s `push-build-linux-amd64-fips`, which was ok after the first PR merged)

This supercedes https://github.com/gravitational/teleport/pull/27879

Contributes to https://github.com/gravitational/teleport/issues/26856

### Testing Done
I hacked up a branch to run the buildboxes pipeline on push:

https://drone.platform.teleport.sh/gravitational/teleport/25253

Its green!