### PR TITLE
Add HasPluginType to plugins interface.

### DIFF
--- a/lib/services/local/plugins.go
+++ b/lib/services/local/plugins.go
@@ -158,6 +158,22 @@ func (s *PluginsService) ListPlugins(ctx context.Context, limit int, startKey st
 	return plugins, nextKey, nil
 }
 
+// HasPluginType will return true if a plugin of the given type is registered.
+func (s *PluginsService) HasPluginType(ctx context.Context, pluginType types.PluginType) (bool, error) {
+	plugins, err := s.GetPlugins(ctx, false)
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	for _, plugin := range plugins {
+		if plugin.GetType() == pluginType {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
 // SetPluginCredentials implements services.Plugins
 func (s *PluginsService) SetPluginCredentials(ctx context.Context, name string, creds types.PluginCredentials) error {
 	return s.updateAndSwap(ctx, name, func(p types.Plugin) error {

--- a/lib/services/local/plugins_test.go
+++ b/lib/services/local/plugins_test.go
@@ -109,6 +109,15 @@ func TestPluginsCRUD(t *testing.T) {
 	))
 	require.Empty(t, cmp.Diff(status, cluster.GetStatus()))
 
+	// Test if plugin types exist.
+	exists, err := service.HasPluginType(ctx, types.PluginTypeOkta)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	exists, err = service.HasPluginType(ctx, types.PluginTypeSlack)
+	require.NoError(t, err)
+	require.True(t, exists)
+
 	// Delete a plugin.
 	err = service.DeletePlugin(ctx, plugin1.GetName())
 	require.NoError(t, err)

--- a/lib/services/plugins.go
+++ b/lib/services/plugins.go
@@ -35,6 +35,7 @@ type Plugins interface {
 	GetPlugin(ctx context.Context, name string, withSecrets bool) (types.Plugin, error)
 	GetPlugins(ctx context.Context, withSecrets bool) ([]types.Plugin, error)
 	ListPlugins(ctx context.Context, limit int, startKey string, withSecrets bool) ([]types.Plugin, string, error)
+	HasPluginType(ctx context.Context, pluginType types.PluginType) (bool, error)
 	SetPluginCredentials(ctx context.Context, name string, creds types.PluginCredentials) error
 	SetPluginStatus(ctx context.Context, name string, creds types.PluginStatus) error
 }


### PR DESCRIPTION
The plugins interface now supports HasPluginType, which returns true if a plugin of the given type has been detected within the backend.