### PR TITLE
[v13] chore: Bump golangci-lint to v1.53.3

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -294,7 +294,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.9.1
 
 # Install golangci-lint.
-RUN TAG='v1.53.2' && \
+RUN TAG='v1.53.3' && \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
 


### PR DESCRIPTION
Backport #27898 to branch/v13.

Update to the latest patch.

* https://github.com/golangci/golangci-lint/releases/tag/v1.53.3