### PR TITLE
render-tests: Remove test output from flaky test reporter

### DIFF
--- a/build.assets/tooling/cmd/render-tests/main.go
+++ b/build.assets/tooling/cmd/render-tests/main.go
@@ -118,9 +118,9 @@ func main() {
 		rr.printFlakinessSummary(summaryOut)
 	} else {
 		rr.printSummary(summaryOut)
-		fmt.Fprintln(os.Stdout, separator)
-		rr.printFailedTestOutput(os.Stdout)
 	}
+	fmt.Fprintln(os.Stdout, separator)
+	rr.printFailedTestOutput(os.Stdout)
 
 	if rr.testCount.fail == 0 {
 		os.Exit(0)

--- a/build.assets/tooling/cmd/render-tests/result.go
+++ b/build.assets/tooling/cmd/render-tests/result.go
@@ -204,7 +204,7 @@ func (rr *runResult) printFlakinessSummary(out io.Writer) {
 		if rr.top != 0 && i >= rr.top {
 			break
 		}
-		fmt.Fprintf(out, "FAIL(%d from %d): %s\n", test.count.fail, test.count.total, test.name)
+		fmt.Fprintf(out, "FAIL(%d/%d): %s\n", test.count.fail, test.count.total, test.name)
 	}
 }
 

--- a/build.assets/tooling/cmd/render-tests/result.go
+++ b/build.assets/tooling/cmd/render-tests/result.go
@@ -186,6 +186,15 @@ func (rr *runResult) printFlakinessSummary(out io.Writer) {
 				alltests = append(alltests, test)
 			}
 		}
+		// Create a pseudo-test result for the package level output
+		// as it can contain relevant output not included in individual
+		// tests such as crash or data race output.
+		tr := &testResult{
+			name:   pkg.name,
+			count:  pkg.count,
+			output: pkg.output,
+		}
+		alltests = append(alltests, tr)
 	}
 	// reverse sort by failure rate
 	sort.Slice(alltests, func(i, j int) bool {

--- a/build.assets/tooling/cmd/render-tests/result.go
+++ b/build.assets/tooling/cmd/render-tests/result.go
@@ -195,7 +195,7 @@ func (rr *runResult) printFlakinessSummary(out io.Writer) {
 		if rr.top != 0 && i >= rr.top {
 			break
 		}
-		fmt.Fprintf(out, "FAIL(%3.1f%%): %s\n", test.count.failureRate()*100, test.name)
+		fmt.Fprintf(out, "FAIL(%d from %d): %s\n", test.count.fail, test.count.total, test.name)
 	}
 }
 

--- a/build.assets/tooling/cmd/render-tests/result.go
+++ b/build.assets/tooling/cmd/render-tests/result.go
@@ -170,7 +170,6 @@ func (rr *runResult) printSummary(out io.Writer) {
 }
 
 func (rr *runResult) printFlakinessSummary(out io.Writer) {
-	fmt.Fprintln(out, separator)
 	if rr.testCount.fail == 0 {
 		fmt.Fprintln(out, "No flaky tests!")
 		return
@@ -198,16 +197,6 @@ func (rr *runResult) printFlakinessSummary(out io.Writer) {
 		}
 		fmt.Fprintf(out, "FAIL(%3.1f%%): %s\n", test.count.failureRate()*100, test.name)
 	}
-
-	fmt.Fprintln(out, separator)
-
-	for i, test := range alltests {
-		if rr.top != 0 && i >= rr.top {
-			break
-		}
-		printOutput(out, test.name, test.output)
-	}
-
 }
 
 // printFailedTests prints a summary list of the failed tests and packages in

--- a/build.assets/tooling/cmd/render-tests/result_test.go
+++ b/build.assets/tooling/cmd/render-tests/result_test.go
@@ -235,9 +235,9 @@ func TestPrintFlakinessSummaryFail(t *testing.T) {
 	rr.printFlakinessSummary(output)
 
 	expected := `
-FAIL(4 from 10): example.com/package3
-FAIL(3 from 10): example.com/package3.Test5
-FAIL(2 from 10): example.com/package1.Test1
+FAIL(4/10): example.com/package3
+FAIL(3/10): example.com/package3.Test5
+FAIL(2/10): example.com/package1.Test1
 `[1:]
 	require.Equal(t, expected, output.String())
 }

--- a/build.assets/tooling/cmd/render-tests/result_test.go
+++ b/build.assets/tooling/cmd/render-tests/result_test.go
@@ -64,16 +64,16 @@ func TestStatus(t *testing.T) {
 	rr := newRunResult(byPackage, 0)
 	feedEvents(t, rr, passFailSkip)
 
-	require.Equal(t, rr.testCount.pass, 1)
-	require.Equal(t, rr.testCount.fail, 1)
-	require.Equal(t, rr.testCount.skip, 1)
-	require.Equal(t, rr.pkgCount.fail, 1)
+	require.Equal(t, 1, rr.testCount.pass)
+	require.Equal(t, 1, rr.testCount.fail)
+	require.Equal(t, 1, rr.testCount.skip)
+	require.Equal(t, 1, rr.pkgCount.fail)
 	pkgname := "example.com/package"
 	pkg := rr.packages[pkgname]
-	require.Equal(t, pkg.count.fail, 1)
-	require.Equal(t, pkg.tests[pkgname+".TestEmpty"].count.pass, 1)
-	require.Equal(t, pkg.tests[pkgname+".TestParse"].count.fail, 1)
-	require.Equal(t, pkg.tests[pkgname+".TestParseHostPort"].count.skip, 1)
+	require.Equal(t, 1, pkg.count.fail)
+	require.Equal(t, 1, pkg.tests[pkgname+".TestEmpty"].count.pass)
+	require.Equal(t, 1, pkg.tests[pkgname+".TestParse"].count.fail)
+	require.Equal(t, 1, pkg.tests[pkgname+".TestParseHostPort"].count.skip)
 }
 
 func TestSuccessOutput(t *testing.T) {
@@ -122,8 +122,8 @@ func TestFailureOutput(t *testing.T) {
 		"\texample.com/package\tcoverage: 2.4% of statements\n",
 		"FAIL\texample.com/package\t0.007s\n",
 	}
-	require.Equal(t, pkg.tests[pkgname+".TestParse"].output, expectedTestOutput)
-	require.Equal(t, pkg.output, expectedPkgOutput)
+	require.Equal(t, expectedTestOutput, pkg.tests[pkgname+".TestParse"].output)
+	require.Equal(t, expectedPkgOutput, pkg.output)
 }
 
 func TestPrintTestResultByPackage(t *testing.T) {

--- a/build.assets/tooling/cmd/render-tests/result_test.go
+++ b/build.assets/tooling/cmd/render-tests/result_test.go
@@ -219,7 +219,7 @@ func TestPrintFlakinessSummaryNoFail(t *testing.T) {
 }
 
 func TestPrintFlakinessSummaryFail(t *testing.T) {
-	rr := newRunResult(byFlakiness, 2) // top 2 failures only
+	rr := newRunResult(byFlakiness, 3) // top 3 failures only (including packages)
 	feedEvents(t, rr, flakyPass)
 	feedEvents(t, rr, flakyFail1)
 	feedEvents(t, rr, flakyPass)
@@ -235,6 +235,7 @@ func TestPrintFlakinessSummaryFail(t *testing.T) {
 	rr.printFlakinessSummary(output)
 
 	expected := `
+FAIL(4 from 10): example.com/package3
 FAIL(3 from 10): example.com/package3.Test5
 FAIL(2 from 10): example.com/package1.Test1
 `[1:]

--- a/build.assets/tooling/cmd/render-tests/result_test.go
+++ b/build.assets/tooling/cmd/render-tests/result_test.go
@@ -104,20 +104,6 @@ func TestFailureOutput(t *testing.T) {
 		"--- FAIL: TestParse (0.00s)\n",
 	}
 	expectedPkgOutput := []string{
-		"=== RUN   TestParseHostPort\n",
-		"=== PAUSE TestParseHostPort\n",
-		"=== RUN   TestEmpty\n",
-		"=== PAUSE TestEmpty\n",
-		"=== RUN   TestParse\n",
-		"=== PAUSE TestParse\n",
-		"=== CONT  TestParseHostPort\n",
-		"    addr_test.go:32: \n",
-		"=== CONT  TestParse\n",
-		"--- SKIP: TestParseHostPort (0.00s)\n",
-		"=== CONT  TestEmpty\n",
-		"    addr_test.go:71: failed\n",
-		"--- PASS: TestEmpty (0.00s)\n",
-		"--- FAIL: TestParse (0.00s)\n",
 		"FAIL\n",
 		"\texample.com/package\tcoverage: 2.4% of statements\n",
 		"FAIL\texample.com/package\t0.007s\n",
@@ -200,6 +186,12 @@ func TestPrintFailedTestOutput(t *testing.T) {
 	rr.printFailedTestOutput(output)
 
 	expected := `
+OUTPUT example.com/package
+===================================================
+FAIL
+	example.com/package	coverage: 2.4% of statements
+FAIL	example.com/package	0.007s
+===================================================
 OUTPUT example.com/package.TestParse
 ===================================================
 === RUN   TestParse

--- a/build.assets/tooling/cmd/render-tests/result_test.go
+++ b/build.assets/tooling/cmd/render-tests/result_test.go
@@ -243,8 +243,8 @@ func TestPrintFlakinessSummaryFail(t *testing.T) {
 	rr.printFlakinessSummary(output)
 
 	expected := `
-FAIL(30.0%): example.com/package3.Test5
-FAIL(20.0%): example.com/package1.Test1
+FAIL(3 from 10): example.com/package3.Test5
+FAIL(2 from 10): example.com/package1.Test1
 `[1:]
 	require.Equal(t, expected, output.String())
 }

--- a/build.assets/tooling/cmd/render-tests/result_test.go
+++ b/build.assets/tooling/cmd/render-tests/result_test.go
@@ -222,10 +222,7 @@ func TestPrintFlakinessSummaryNoFail(t *testing.T) {
 	output := &bytes.Buffer{}
 	rr.printFlakinessSummary(output)
 
-	expected := `
-===================================================
-No flaky tests!
-`[1:]
+	expected := "No flaky tests!\n"
 	require.Equal(t, expected, output.String())
 }
 
@@ -246,24 +243,8 @@ func TestPrintFlakinessSummaryFail(t *testing.T) {
 	rr.printFlakinessSummary(output)
 
 	expected := `
-===================================================
 FAIL(30.0%): example.com/package3.Test5
 FAIL(20.0%): example.com/package1.Test1
-===================================================
-OUTPUT example.com/package3.Test5
-===================================================
-=== RUN   Test5
-    baz_test.go:10: nevermind
---- FAIL: Test5 (0.00s)
-===================================================
-OUTPUT example.com/package1.Test1
-===================================================
-=== RUN   Test1
-    foo_test.go:6: doing stuff
-x =  1
-    foo_test.go:8: fail
---- FAIL: Test1 (0.00s)
-===================================================
 `[1:]
 	require.Equal(t, expected, output.String())
 }


### PR DESCRIPTION
Remove the output from the summary output by render-tests in the
flakiness reporting mode. Sometimes this output is very large depending
on the test that failed, and we fail to post it to Slack due to the
length. This only changes what is written to the summary file. Stdout
still contains the failed test output.

When posted to Slack, the message will have a link to the run logs which
will contain the failed test output. This output will be sorted
alphabetically by package/test name and not by failure rate, as it was
before.

Ensure package-level failures are reported in the summary as sometimes
you get a package failure without individual test failures such as with
data races or crashes. Package-level output no longer include the output
of the individual tests (that never made much sense anyway).