### PR TITLE
Connect: Make tabs shadows look better

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/DocumentCluster.tsx
@@ -82,7 +82,7 @@ export function Cluster() {
   }
 
   return (
-    <Layout mx="auto" px={5} pt={3} height="100%">
+    <Layout mx="auto" px={5} pt={2} height="100%">
       <ClusterResources />
     </Layout>
   );

--- a/web/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
+++ b/web/packages/teleterm/src/ui/Documents/KeyboardShortcutsPanel.tsx
@@ -73,10 +73,17 @@ export function KeyboardShortcutsPanel() {
 function Entry(props: { title: string; accelerator: string }) {
   return (
     <>
-      <Text textAlign="right" color="light" typography="subtitle1" py="4px">
+      <Text textAlign="right" typography="subtitle1" py="4px">
         {props.title}
       </Text>
-      <MonoText bg="levels.surface" textAlign="left" px="12px" py="4px">
+      <MonoText
+        css={`
+          background: ${props => props.theme.colors.spotBackground[0]};
+        `}
+        textAlign="left"
+        px="12px"
+        py="4px"
+      >
         {props.accelerator}
       </MonoText>
     </>
@@ -84,9 +91,7 @@ function Entry(props: { title: string; accelerator: string }) {
 }
 
 const MonoText = styled(Text)`
-  font-family: ${props => props.theme.fonts.mono};
   width: fit-content;
-  opacity: 0.7;
   border-radius: 4px;
 `;
 

--- a/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
+++ b/web/packages/teleterm/src/ui/TabHost/TabHost.tsx
@@ -106,7 +106,6 @@ export function TabHost({ ctx }: { ctx: IAppContext }) {
           onContextMenu={handleTabContextMenu}
           activeTab={activeDocument?.uri}
           onMoved={handleTabMoved}
-          disableNew={false}
           onNew={openClusterTab}
           newTabTooltip={getLabelWithAccelerator('New Tab', 'newTab')}
           closeTabTooltip={getLabelWithAccelerator('Close', 'closeTab')}

--- a/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React, { useRef } from 'react';
 import styled from 'styled-components';
-import { Close as CloseIcon } from 'design/Icon';
+import * as Icons from 'design/Icon';
 import { ButtonIcon, Text } from 'design';
 
 import LinearProgress from 'teleterm/ui/components/LinearProgress';
@@ -68,6 +68,10 @@ export function TabItem(props: TabItemProps) {
       onClick={onClick}
       onContextMenu={onContextMenu}
       title={name}
+      css={`
+        flex-grow: 1;
+        min-width: 0;
+      `}
     >
       <TabContent
         ref={ref}
@@ -89,7 +93,7 @@ export function TabItem(props: TabItemProps) {
             `}
             onClick={handleClose}
           >
-            <CloseIcon fontSize="16px" />
+            <Icons.Close fontSize="16px" />
           </ButtonIcon>
         )}
       </TabContent>
@@ -99,13 +103,35 @@ export function TabItem(props: TabItemProps) {
   );
 }
 
+type NewTabItemProps = {
+  tooltip: string;
+  onClick(): void;
+};
+
+export function NewTabItem(props: NewTabItemProps) {
+  return (
+    <RelativeContainer>
+      <TabContent active={false}>
+        <ButtonIcon
+          ml="1"
+          mr="2"
+          size={0}
+          title={props.tooltip}
+          onClick={props.onClick}
+        >
+          <Icons.Add fontSize="16px" />
+        </ButtonIcon>
+      </TabContent>
+      <BottomShadow />
+    </RelativeContainer>
+  );
+}
+
 const RelativeContainer = styled.div`
   position: relative;
   display: flex;
   flex-basis: 0;
-  flex-grow: 1;
   align-items: center;
-  min-width: 0;
   height: 100%;
 `;
 

--- a/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -67,7 +67,6 @@ export function TabItem(props: TabItemProps) {
     <RelativeContainer
       onClick={onClick}
       onContextMenu={onContextMenu}
-      title={name}
       css={`
         flex-grow: 1;
         min-width: 0;
@@ -78,6 +77,7 @@ export function TabItem(props: TabItemProps) {
         active={active}
         dragging={isDragging}
         canDrag={canDrag}
+        title={name}
       >
         <Title color="inherit" fontWeight={700} fontSize="12px">
           {name}

--- a/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/TabItem.tsx
@@ -27,6 +27,7 @@ type TabItemProps = {
   index?: number;
   name?: string;
   active?: boolean;
+  nextActive?: boolean;
   closeTabTooltip?: string;
   isLoading?: boolean;
   onClick?(): void;
@@ -39,6 +40,7 @@ export function TabItem(props: TabItemProps) {
   const {
     name,
     active,
+    nextActive,
     onClick,
     onClose,
     index,
@@ -62,71 +64,78 @@ export function TabItem(props: TabItemProps) {
   };
 
   return (
-    <StyledTabItem
+    <RelativeContainer
       onClick={onClick}
       onContextMenu={onContextMenu}
-      ref={ref}
-      active={active}
-      dragging={isDragging}
       title={name}
-      canDrag={canDrag}
     >
-      <Title color="inherit" fontWeight={700} fontSize="12px">
-        {name}
-      </Title>
-      {isLoading && active && <LinearProgress transparentBackground={true} />}
-      {onClose && (
-        <ButtonIcon
-          size={0}
-          mr={1}
-          title={closeTabTooltip}
-          css={`
-            transition: none;
-          `}
-          onClick={handleClose}
-        >
-          <CloseIcon fontSize="16px" />
-        </ButtonIcon>
-      )}
-    </StyledTabItem>
+      <TabContent
+        ref={ref}
+        active={active}
+        dragging={isDragging}
+        canDrag={canDrag}
+      >
+        <Title color="inherit" fontWeight={700} fontSize="12px">
+          {name}
+        </Title>
+        {isLoading && active && <LinearProgress transparentBackground={true} />}
+        {onClose && (
+          <ButtonIcon
+            size={0}
+            mr={1}
+            title={closeTabTooltip}
+            css={`
+              transition: none;
+            `}
+            onClick={handleClose}
+          >
+            <CloseIcon fontSize="16px" />
+          </ButtonIcon>
+        )}
+      </TabContent>
+      {!active && !nextActive && <Separator />}
+      {(!active || isDragging) && <BottomShadow />}
+    </RelativeContainer>
   );
 }
 
-const StyledTabItem = styled.div(({ theme, active, dragging, canDrag }) => {
-  const styles: any = {
-    display: 'flex',
-    flexBasis: '0',
-    flexGrow: '1',
-    opacity: '1',
-    color: theme.colors.text.slightlyMuted,
-    alignItems: 'center',
-    minWidth: '0',
-    height: '100%',
-    border: 'none',
-    borderRadius: '8px 8px 0 0',
-    '&:hover, &:focus': {
-      color: theme.colors.text.main,
-      transition: 'color .3s',
-    },
-    position: 'relative',
-  };
+const RelativeContainer = styled.div`
+  position: relative;
+  display: flex;
+  flex-basis: 0;
+  flex-grow: 1;
+  align-items: center;
+  min-width: 0;
+  height: 100%;
+`;
 
-  if (active) {
-    styles['backgroundColor'] = theme.colors.levels.sunken;
-    styles['color'] = theme.colors.text.main;
-    styles['transition'] = 'none';
+const TabContent = styled.div`
+  display: flex;
+  z-index: 1; // covers shadow from the top
+  align-items: center;
+  min-width: 0;
+  width: 100%;
+  height: 100%;
+  border-radius: 8px 8px 0 0;
+  position: relative;
+  opacity: ${props => (props.dragging ? 0 : 1)};
+  color: ${props =>
+    props.active
+      ? props.theme.colors.text.main
+      : props.theme.colors.text.slightlyMuted};
+  background: ${props =>
+    props.active
+      ? props.theme.colors.levels.sunken
+      : props.theme.colors.levels.surface};
+  box-shadow: ${props =>
+    props.active ? 'inset 0px 2px 1.5px -1px rgba(0, 0, 0, 0.12)' : undefined};
+
+  &:hover,
+  &:focus {
+    color: ${props => props.theme.colors.text.main};
+    transition: color 0.3s;
   }
-
-  if (dragging) {
-    styles['opacity'] = 0;
-  }
-
-  if (canDrag) {
-    styles['cursor'] = 'pointer';
-  }
-
-  return styles;
-});
+`;
 
 const Title = styled(Text)`
   display: block;
@@ -141,4 +150,24 @@ const Title = styled(Text)`
   border: none;
   min-width: 0;
   width: 100%;
+`;
+
+const BottomShadow = styled.div`
+  box-shadow: 0 2px 1px -1px rgba(0, 0, 0, 0.2), 0 1px 1.5px rgba(0, 0, 0, 0.13),
+    0 1px 4px rgba(0, 0, 0, 0.12);
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: inherit;
+`;
+
+const Separator = styled.div`
+  height: 23px;
+  width: 1px;
+  position: absolute;
+  z-index: 1;
+  right: 0;
+  background: ${props => props.theme.colors.spotBackground[2]};
 `;

--- a/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React, { Fragment } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import { typography } from 'design/system';
 import { Box, ButtonIcon } from 'design';
@@ -39,34 +39,29 @@ export function Tabs(props: Props) {
     ...styledProps
   } = props;
 
-  const $emptyTab = (
-    <>
-      <TabItem active={true} />
-      <Separator />
-    </>
+  const $items = items.length ? (
+    items.map((item, index) => {
+      const active = item.uri === activeTab;
+      const nextActive = items[index + 1]?.uri === activeTab;
+      return (
+        <TabItem
+          key={item.uri}
+          index={index}
+          name={item.title}
+          active={active}
+          nextActive={nextActive}
+          onClick={() => onSelect(item)}
+          onClose={() => onClose(item)}
+          onContextMenu={() => onContextMenu(item)}
+          onMoved={onMoved}
+          isLoading={getIsLoading(item)}
+          closeTabTooltip={closeTabTooltip}
+        />
+      );
+    })
+  ) : (
+    <TabItem active={true} />
   );
-
-  const $items = items.length
-    ? items.map((item, index) => {
-        const active = item.uri === activeTab;
-        return (
-          <Fragment key={item.uri}>
-            <TabItem
-              index={index}
-              name={item.title}
-              active={active}
-              onClick={() => onSelect(item)}
-              onClose={() => onClose(item)}
-              onContextMenu={() => onContextMenu(item)}
-              onMoved={onMoved}
-              isLoading={getIsLoading(item)}
-              closeTabTooltip={closeTabTooltip}
-            />
-            <Separator />
-          </Fragment>
-        );
-      })
-    : $emptyTab;
 
   return (
     <StyledTabs as="nav" typography="h5" bold {...styledProps}>
@@ -102,13 +97,6 @@ type Props = {
   [index: string]: any;
 };
 
-const Separator = styled.div`
-  height: 23px;
-  width: 1px;
-  margin: 0 1px;
-  background: ${props => props.theme.colors.spotBackground[2]};
-`;
-
 const StyledTabs = styled(Box)`
   background-color: ${props => props.theme.colors.levels.surface};
   min-height: 32px;
@@ -116,10 +104,8 @@ const StyledTabs = styled(Box)`
   flex-wrap: nowrap;
   align-items: center;
   flex-shrink: 0;
-  overflow: hidden;
+  max-width: 100%;
   position: relative;
   z-index: 1;
-  box-shadow: 0px 1px 10px 0px rgba(0, 0, 0, 0.12),
-    0px 4px 5px 0px rgba(0, 0, 0, 0.14), 0px 2px 4px -1px rgba(0, 0, 0, 0.2);
   ${typography}
 `;

--- a/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
+++ b/web/packages/teleterm/src/ui/Tabs/Tabs.tsx
@@ -17,12 +17,11 @@ limitations under the License.
 import React from 'react';
 import styled from 'styled-components';
 import { typography } from 'design/system';
-import { Box, ButtonIcon } from 'design';
-import * as Icons from 'design/Icon';
+import { Box } from 'design';
 
 import { Document } from 'teleterm/ui/services/workspacesService';
 
-import { TabItem } from './TabItem';
+import { TabItem, NewTabItem } from './TabItem';
 
 export function Tabs(props: Props) {
   const {
@@ -31,7 +30,6 @@ export function Tabs(props: Props) {
     onSelect,
     onClose,
     onNew,
-    disableNew,
     onMoved,
     onContextMenu,
     newTabTooltip,
@@ -66,16 +64,7 @@ export function Tabs(props: Props) {
   return (
     <StyledTabs as="nav" typography="h5" bold {...styledProps}>
       {$items}
-      <ButtonIcon
-        ml="1"
-        mr="2"
-        size={0}
-        disabled={disableNew}
-        title={newTabTooltip}
-        onClick={onNew}
-      >
-        <Icons.Add fontSize="16px" />
-      </ButtonIcon>
+      <NewTabItem tooltip={newTabTooltip} onClick={onNew} />
     </StyledTabs>
   );
 }
@@ -87,7 +76,6 @@ function getIsLoading(doc: Document): boolean {
 type Props = {
   items: Document[];
   activeTab: string;
-  disableNew: boolean;
   newTabTooltip: string;
   closeTabTooltip: string;
   onNew: () => void;

--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -49,7 +49,6 @@ const Grid = styled(Flex).attrs({ gap: 3, py: 2, px: 3 })`
   height: 56px;
   align-items: center;
   justify-content: space-between;
-  z-index: 2; // minimally higher z-index than the one defined in StyledTabs, so that its drop-shadow doesn't cover the TopBar
 `;
 
 const CentralContainer = styled(Flex).attrs({ gap: 3 })`


### PR DESCRIPTION
The last part of https://github.com/gravitational/teleport/issues/27079

I tweaked the shadow, compared to the image I posted on Slack, it is now more concise (more like on the table).
<img width="1179" alt="image" src="https://github.com/gravitational/teleport/assets/20583051/396fcc67-80a0-4689-8df7-242c297c6e6d">

