### PR TITLE
Try to Fix Flaky Test

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -7563,7 +7563,10 @@ func newWebPack(t *testing.T, numProxies int, opts ...proxyOption) *webPack {
 	require.NoError(t, err)
 
 	require.NoError(t, node.Start())
-	t.Cleanup(func() { require.NoError(t, node.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, node.Close())
+		node.Wait()
+	})
 
 	var proxies []*testProxy
 	for p := 0; p < numProxies; p++ {

--- a/tool/tctl/common/helpers_test.go
+++ b/tool/tctl/common/helpers_test.go
@@ -36,7 +36,6 @@ import (
 
 	"github.com/gravitational/teleport/api/breaker"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
-	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/cloud"
@@ -293,28 +292,4 @@ func waitForDatabases(t *testing.T, auth *service.TeleportProcess, dbs []service
 			t.Fatal("databases not registered after 10s")
 		}
 	}
-}
-
-func newDynamicServiceAddr(t *testing.T) *dynamicServiceAddr {
-	var fds []servicecfg.FileDescriptor
-	webAddr := helpers.NewListener(t, service.ListenerProxyWeb, &fds)
-	tunnelAddr := helpers.NewListener(t, service.ListenerProxyTunnel, &fds)
-	authAddr := helpers.NewListener(t, service.ListenerAuth, &fds)
-
-	return &dynamicServiceAddr{
-		descriptors: fds,
-		webAddr:     webAddr,
-		tunnelAddr:  tunnelAddr,
-		authAddr:    authAddr,
-	}
-}
-
-// dynamicServiceAddr collects listeners addresses and sockets descriptors allowing to create and network listeners
-// and pass the file descriptors to teleport service.
-// This is usefully when Teleport service is created from config file where a port is allocated by OS.
-type dynamicServiceAddr struct {
-	webAddr     string
-	tunnelAddr  string
-	authAddr    string
-	descriptors []servicecfg.FileDescriptor
 }

--- a/tool/tctl/common/lock_command_test.go
+++ b/tool/tctl/common/lock_command_test.go
@@ -26,11 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/config"
 )
 
 func TestLocks(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -39,20 +40,20 @@ func TestLocks(t *testing.T) {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
 	timeNow := time.Now().UTC()
 	fakeClock := clockwork.NewFakeClockAt(timeNow)
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors), withFakeClock(fakeClock))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withFakeClock(fakeClock))
 
 	t.Run("create", func(t *testing.T) {
 		err := runLockCommand(t, fileConfig, []string{"--user=bad@actor", "--message=Come see me"})

--- a/tool/tctl/common/resource_command_test.go
+++ b/tool/tctl/common/resource_command_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/constants"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
@@ -44,7 +45,7 @@ import (
 
 // TestDatabaseServerResource tests tctl db_server rm/get commands.
 func TestDatabaseServerResource(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	caCertFilePath := filepath.Join(t.TempDir(), "ca-cert.pem")
 	require.NoError(t, os.WriteFile(caCertFilePath, []byte(fixtures.TLSCACertPEM), 0644))
 
@@ -89,13 +90,13 @@ func TestDatabaseServerResource(t *testing.T) {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
@@ -157,7 +158,7 @@ func TestDatabaseServerResource(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_ = makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	_ = makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	var out []*types.DatabaseServerV3
 
@@ -217,7 +218,7 @@ func TestDatabaseServerResource(t *testing.T) {
 
 // TestDatabaseServiceResource tests tctl db_services get commands.
 func TestDatabaseServiceResource(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 
 	ctx := context.Background()
 	fileConfig := &config.FileConfig{
@@ -228,18 +229,18 @@ func TestDatabaseServiceResource(t *testing.T) {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
-	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	var out []*types.DatabaseServiceV1
 
@@ -299,7 +300,7 @@ func TestDatabaseServiceResource(t *testing.T) {
 
 // TestIntegrationResource tests tctl integration commands.
 func TestIntegrationResource(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 
 	ctx := context.Background()
 	fileConfig := &config.FileConfig{
@@ -310,18 +311,18 @@ func TestIntegrationResource(t *testing.T) {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
-	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	auth := makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	t.Run("get", func(t *testing.T) {
 
@@ -412,7 +413,7 @@ func TestIntegrationResource(t *testing.T) {
 }
 
 func TestCreateLock(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -421,20 +422,20 @@ func TestCreateLock(t *testing.T) {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
 	timeNow := time.Now().UTC()
 	fakeClock := clockwork.NewFakeClockAt(timeNow)
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors), withFakeClock(fakeClock))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors), withFakeClock(fakeClock))
 
 	_, err := types.NewLock("test-lock", types.LockSpecV2{
 		Target: types.LockTarget{
@@ -481,7 +482,7 @@ func TestCreateLock(t *testing.T) {
 
 // TestCreateDatabaseInInsecureMode connects to auth server with --insecure mode and creates a DB resource.
 func TestCreateDatabaseInInsecureMode(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
@@ -496,18 +497,18 @@ func TestCreateDatabaseInInsecureMode(t *testing.T) {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	// Create the databases yaml file.
 	dbYAMLPath := filepath.Join(t.TempDir(), "db.yaml")
@@ -612,7 +613,7 @@ spec:
 )
 
 func TestCreateClusterAuthPreference_WithSupportForSecondFactorWithoutQuotes(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -620,12 +621,12 @@ func TestCreateClusterAuthPreference_WithSupportForSecondFactorWithoutQuotes(t *
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	tests := []struct {
 		desc               string
@@ -697,7 +698,7 @@ version: v2`,
 }
 
 func TestCreateSAMLIdPServiceProvider(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -705,12 +706,12 @@ func TestCreateSAMLIdPServiceProvider(t *testing.T) {
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	tests := []struct {
 		desc           string
@@ -858,7 +859,7 @@ func (test *dynamicResourceTest[T]) setup(t *testing.T) *config.FileConfig {
 	requireResource(t, test.fooResource, "foo")
 	requireResource(t, test.fooBarResource, "foo-bar")
 	requireResource(t, test.fooBarBazResource, "foo-bar-baz")
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -867,17 +868,17 @@ func (test *dynamicResourceTest[T]) setup(t *testing.T) *config.FileConfig {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
-	_ = makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	_ = makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 	return fileConfig
 }
 

--- a/tool/tctl/common/tctl_test.go
+++ b/tool/tctl/common/tctl_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/auth/authclient"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
@@ -28,7 +29,7 @@ import (
 
 // TestConnect tests client config and connection logic.
 func TestConnect(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	ctx := context.Background()
 
 	fileConfig := &config.FileConfig{
@@ -38,11 +39,11 @@ func TestConnect(t *testing.T) {
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	username := "admin"
 	mustAddUser(t, fileConfig, "admin", "access")

--- a/tool/tctl/common/token_command_test.go
+++ b/tool/tctl/common/token_command_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/config"
 )
 
@@ -49,7 +50,7 @@ type listedToken struct {
 }
 
 func TestTokens(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -63,18 +64,18 @@ func TestTokens(t *testing.T) {
 			Service: config.Service{
 				EnabledFlag: "true",
 			},
-			WebAddr: dynAddr.webAddr,
-			TunAddr: dynAddr.tunnelAddr,
+			WebAddr: dynAddr.WebAddr,
+			TunAddr: dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
 
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 
 	// Test all output formats of "tokens add".
 	t.Run("add", func(t *testing.T) {

--- a/tool/tctl/common/user_command_test.go
+++ b/tool/tctl/common/user_command_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/config"
 )
 
@@ -65,7 +66,7 @@ func TestTrimDurationSuffix(t *testing.T) {
 }
 
 func TestUserAdd(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -73,11 +74,11 @@ func TestUserAdd(t *testing.T) {
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 	ctx := context.Background()
 	client := getAuthClient(ctx, t, fileConfig)
 
@@ -217,7 +218,7 @@ func TestUserAdd(t *testing.T) {
 }
 
 func TestUserUpdate(t *testing.T) {
-	dynAddr := newDynamicServiceAddr(t)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Global: config.Global{
 			DataDir: t.TempDir(),
@@ -225,11 +226,11 @@ func TestUserUpdate(t *testing.T) {
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: dynAddr.authAddr,
+				ListenAddress: dynAddr.AuthAddr,
 			},
 		},
 	}
-	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.descriptors))
+	makeAndRunTestAuthServer(t, withFileConfig(fileConfig), withFileDescriptors(dynAddr.Descriptors))
 	ctx := context.Background()
 	client := getAuthClient(ctx, t, fileConfig)
 

--- a/tool/tsh/common/tsh_helper_test.go
+++ b/tool/tsh/common/tsh_helper_test.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -34,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/api/breaker"
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/service"
@@ -49,9 +49,7 @@ type suite struct {
 }
 
 func (s *suite) setupRootCluster(t *testing.T, options testSuiteOptions) {
-	sshListenAddr := localListenerAddr()
-	_, sshListenPort, err := net.SplitHostPort(sshListenAddr)
-	require.NoError(t, err)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Version: "v2",
 		Global: config.Global{
@@ -61,32 +59,34 @@ func (s *suite) setupRootCluster(t *testing.T, options testSuiteOptions) {
 		SSH: config.SSH{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: localListenerAddr(),
+				ListenAddress: dynAddr.NodeSSHAddr,
 			},
 		},
 		Proxy: config.Proxy{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: sshListenAddr,
+				ListenAddress: dynAddr.ProxySSHAddr,
 			},
-			SSHPublicAddr: []string{net.JoinHostPort("localhost", sshListenPort)},
-			WebAddr:       localListenerAddr(),
-			TunAddr:       localListenerAddr(),
+			SSHPublicAddr: []string{dynAddr.ProxySSHAddr},
+			WebAddr:       dynAddr.WebAddr,
+			TunAddr:       dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: localListenerAddr(),
+				ListenAddress: dynAddr.AuthAddr,
 			},
-			ClusterName: "root",
+			ClusterName:      "root",
+			SessionRecording: "node-sync",
 		},
 	}
 
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.Log = utils.NewLoggerForTests()
-	err = config.ApplyFileConfig(fileConfig, cfg)
+	err := config.ApplyFileConfig(fileConfig, cfg)
 	require.NoError(t, err)
+	cfg.FileDescriptors = dynAddr.Descriptors
 
 	cfg.Proxy.DisableWebInterface = true
 	cfg.Auth.StaticTokens, err = types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -138,9 +138,7 @@ func (s *suite) setupRootCluster(t *testing.T, options testSuiteOptions) {
 }
 
 func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
-	sshListenAddr := localListenerAddr()
-	_, sshListenPort, err := net.SplitHostPort(sshListenAddr)
-	require.NoError(t, err)
+	dynAddr := helpers.NewDynamicServiceAddr(t)
 	fileConfig := &config.FileConfig{
 		Version: "v2",
 		Global: config.Global{
@@ -150,17 +148,17 @@ func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
 		SSH: config.SSH{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: localListenerAddr(),
+				ListenAddress: dynAddr.NodeSSHAddr,
 			},
 		},
 		Proxy: config.Proxy{
 			Service: config.Service{
 				EnabledFlag:   "true",
-				ListenAddress: sshListenAddr,
+				ListenAddress: dynAddr.ProxySSHAddr,
 			},
-			SSHPublicAddr: []string{net.JoinHostPort("localhost", sshListenPort)},
-			WebAddr:       localListenerAddr(),
-			TunAddr:       localListenerAddr(),
+			SSHPublicAddr: []string{dynAddr.ProxySSHAddr},
+			WebAddr:       dynAddr.WebAddr,
+			TunAddr:       dynAddr.TunnelAddr,
 		},
 		Auth: config.Auth{
 			Service: config.Service{
@@ -169,14 +167,16 @@ func (s *suite) setupLeafCluster(t *testing.T, options testSuiteOptions) {
 			},
 			ClusterName:       "leaf1",
 			ProxyListenerMode: types.ProxyListenerMode_Multiplex,
+			SessionRecording:  "node-sync",
 		},
 	}
 
 	cfg := servicecfg.MakeDefaultConfig()
 	cfg.CircuitBreakerConfig = breaker.NoopBreakerConfig()
 	cfg.Log = utils.NewLoggerForTests()
-	err = config.ApplyFileConfig(fileConfig, cfg)
+	err := config.ApplyFileConfig(fileConfig, cfg)
 	require.NoError(t, err)
+	cfg.FileDescriptors = dynAddr.Descriptors
 
 	user, err := user.Current()
 	require.NoError(t, err)


### PR DESCRIPTION
### What: 


Try to fix test flakiness issues:  https://github.com/gravitational/teleport/issues/13623 and https://github.com/gravitational/teleport/issues/13944 caused by racate between t.TmpDir cleanup and session recording handler: 
```
ERROR: access denied to invalidUser connecting to localhost:24915

    testing.go:1206: TempDir RemoveAll cleanup: unlinkat /tmp/TestTSHConfigConnectWithOpenSSHClientnode_recording_mode_with_TLS_routing_disabled2058613825/001/log/upload/streaming/default: directory not empty
--- FAIL: TestTSHConfigConnectWithOpenSSHClient/node_recording_mode_with_TLS_routing_disabled (3.93s)
```

- Force the `node-sync` and add missing `node.Wait()` call 
- Move `dynamicServiceAddr` to common package and reuse.  (TestTerminalRequireSessionMfa) 
- Fix flaky way of acquiring open local port by using `dynamicServiceAddr` 