### PR TITLE
Fix invalid command example.

### DIFF
--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -352,7 +352,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 				flags: DatabaseSampleFlags{
 					StaticDatabaseName:     "",
 					StaticDatabaseProtocol: "postgres",
-					StaticDatabaseURI:      "postgres://localhost:5432",
+					StaticDatabaseURI:      "localhost:5432",
 				},
 				requireFn: require.Error,
 			},
@@ -360,7 +360,7 @@ func TestMakeDatabaseConfig(t *testing.T) {
 				flags: DatabaseSampleFlags{
 					StaticDatabaseName:     "sample",
 					StaticDatabaseProtocol: "",
-					StaticDatabaseURI:      "postgres://localhost:5432",
+					StaticDatabaseURI:      "localhost:5432",
 				},
 				requireFn: require.Error,
 			},
@@ -372,11 +372,19 @@ func TestMakeDatabaseConfig(t *testing.T) {
 				},
 				requireFn: require.Error,
 			},
+			"BadURI": {
+				flags: DatabaseSampleFlags{
+					StaticDatabaseName:     "sample",
+					StaticDatabaseProtocol: "postgres",
+					StaticDatabaseURI:      "postgres://localhost:5432",
+				},
+				requireFn: require.Error,
+			},
 			"InvalidLabels": {
 				flags: DatabaseSampleFlags{
 					StaticDatabaseName:      "sample",
 					StaticDatabaseProtocol:  "postgres",
-					StaticDatabaseURI:       "postgres://localhost:5432",
+					StaticDatabaseURI:       "localhost:5432",
 					StaticDatabaseRawLabels: "abc",
 				},
 				requireFn: require.Error,

--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -87,7 +87,7 @@ the "us-west-1" and "us-west-2" regions.
    --proxy=localhost:3080 \
    --name=sample-db \
    --protocol=postgres \
-   --uri=postgres://localhost:5432 \
+   --uri=localhost:5432 \
    --labels=env=prod
 Generates a configuration with a Postgres database.
 


### PR DESCRIPTION
Using example uri yields error:
```
ERROR: invalid database "sample-db" address "postgres://localhost:5432": address postgres://localhost:5432: too many colons in address
```