### PR TITLE
Don't add keys to agent during headless login

### DIFF
--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -699,7 +699,8 @@ func TestList(t *testing.T) {
 	}
 }
 
-func createAgent(t *testing.T) string {
+// create a new local agent key ring and serve it on $SSH_AUTH_SOCK for tests.
+func createAgent(t *testing.T) (agent.ExtendedAgent, string) {
 	t.Helper()
 
 	currentUser, err := user.Current()
@@ -725,7 +726,7 @@ func createAgent(t *testing.T) string {
 
 	t.Setenv(teleport.SSHAuthSock, teleAgent.Path)
 
-	return teleAgent.Path
+	return keyring, teleAgent.Path
 }
 
 func disableAgent(t *testing.T) {
@@ -811,10 +812,11 @@ func runOpenSSHCommand(t *testing.T, configFile string, sshConnString string, po
 	sshPath, err := exec.LookPath("ssh")
 	require.NoError(t, err)
 
+	_, agentPath := createAgent(t)
 	cmd := exec.Command(sshPath, ss...)
 	cmd.Env = []string{
 		fmt.Sprintf("%s=1", tshBinMainTestEnv),
-		fmt.Sprintf("SSH_AUTH_SOCK=%s", createAgent(t)),
+		fmt.Sprintf("SSH_AUTH_SOCK=%s", agentPath),
 		fmt.Sprintf("PATH=%s", filepath.Dir(sshPath)),
 		fmt.Sprintf("%s=%s", types.HomeEnvVar, os.Getenv(types.HomeEnvVar)),
 	}

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -3592,6 +3592,14 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 		c.AddKeysToAgent = client.AddKeysToAgentNo
 	}
 
+	// headless login produces short-lived MFA-verifed certs, which should never be added to the agent.
+	if cf.AuthConnector == constants.HeadlessConnector {
+		if cf.AddKeysToAgent == client.AddKeysToAgentYes || cf.AddKeysToAgent == client.AddKeysToAgentOnly {
+			log.Info("Skipping adding keys to agent for headless login")
+		}
+		c.AddKeysToAgent = client.AddKeysToAgentNo
+	}
+
 	c.EnableEscapeSequences = cf.EnableEscapeSequences
 
 	// pass along mock functions if provided (only used in tests)

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -2275,6 +2275,81 @@ func TestSSHHeadless(t *testing.T) {
 	}
 }
 
+func TestHeadlessDoesNotAddKeysToAgent(t *testing.T) {
+	modules.SetTestModules(t, &modules.TestModules{TestBuildType: modules.BuildEnterprise})
+	agentKeyring, _ := createAgent(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	user, err := user.Current()
+	require.NoError(t, err)
+
+	// Headless ssh should pass session mfa requirements
+	nodeAccess, err := types.NewRole("node-access", types.RoleSpecV6{
+		Options: types.RoleOptions{
+			RequireMFAType: types.RequireMFAType_SESSION,
+		},
+		Allow: types.RoleConditions{
+			Logins:     []string{user.Username},
+			NodeLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+		},
+	})
+	require.NoError(t, err)
+
+	alice, err := types.NewUser("alice@example.com")
+	require.NoError(t, err)
+	alice.SetRoles([]string{"node-access"})
+
+	sshHostname := "test-ssh-host"
+	rootAuth, rootProxy := makeTestServers(t, withBootstrap(nodeAccess, alice), withConfig(func(cfg *servicecfg.Config) {
+		cfg.Hostname = sshHostname
+		cfg.SSH.Enabled = true
+		cfg.SSH.Addr = utils.NetAddr{AddrNetwork: "tcp", Addr: net.JoinHostPort("127.0.0.1", ports.Pop())}
+	}))
+
+	proxyAddr, err := rootProxy.ProxyWebAddr()
+	require.NoError(t, err)
+
+	require.NoError(t, rootAuth.GetAuthServer().SetAuthPreference(ctx, &types.AuthPreferenceV2{
+		Spec: types.AuthPreferenceSpecV2{
+			Type:         constants.Local,
+			SecondFactor: constants.SecondFactorOptional,
+			Webauthn: &types.Webauthn{
+				RPID: "127.0.0.1",
+			},
+		},
+	}))
+
+	go func() {
+		if err := approveAllAccessRequests(ctx, rootAuth.GetAuthServer()); err != nil {
+			assert.ErrorIs(t, err, context.Canceled, "unexpected error from approveAllAccessRequests")
+		}
+		// Cancel the context, so Run calls don't block
+		cancel()
+	}()
+
+	err = Run(ctx, []string{
+		"ssh",
+		"-d",
+		"--insecure",
+		"--proxy", proxyAddr.String(),
+		"--headless",
+		"--user", "alice",
+		"--add-keys-to-agent=yes",
+		fmt.Sprintf("%s@%s", user.Username, sshHostname),
+		"echo", "test",
+	}, CliOption(func(cf *CLIConf) error {
+		cf.MockHeadlessLogin = mockHeadlessLogin(t, rootAuth.GetAuthServer(), alice)
+		return nil
+	}))
+	require.NoError(t, err)
+
+	keys, err := agentKeyring.List()
+	require.NoError(t, err)
+	require.Empty(t, keys)
+}
+
 func TestFormatConnectCommand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This PR sets `--add-keys-to-agent=no` for all headless requests.

Fixes https://github.com/gravitational/teleport-private/issues/721