### PR TITLE
[Web] Add SAML Applications list

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -316,6 +316,12 @@ function sortResourcesByKind(
         ...resources.filter(r => r.kind !== ResourceKind.Kubernetes),
       ];
       break;
+    case 'saml application':
+      sorted = [
+        ...resources.filter(r => r.kind === ResourceKind.SamlApplication),
+        ...resources.filter(r => r.kind !== ResourceKind.SamlApplication),
+      ];
+      break;
   }
   return sorted;
 }

--- a/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
+++ b/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
@@ -63,7 +63,8 @@ export type AddButtonResourceKind =
   | 'application'
   | 'desktop'
   | 'kubernetes'
-  | 'database';
+  | 'database'
+  | 'saml application';
 
 export type Props = {
   isLeafCluster: boolean;

--- a/web/packages/teleport/src/services/resources/types.ts
+++ b/web/packages/teleport/src/services/resources/types.ts
@@ -25,4 +25,9 @@ export type Resource<T extends Kind> = {
 export type KindRole = 'role';
 export type KindTrustedCluster = 'trusted_cluster';
 export type KindAuthConnectors = 'github' | 'saml' | 'oidc';
-export type Kind = KindRole | KindTrustedCluster | KindAuthConnectors;
+export type KindSamlIdpServiceProvider = 'saml_idp_service_provider';
+export type Kind =
+  | KindRole
+  | KindTrustedCluster
+  | KindAuthConnectors
+  | KindSamlIdpServiceProvider;

--- a/web/packages/teleport/src/stores/storeUserContext.ts
+++ b/web/packages/teleport/src/stores/storeUserContext.ts
@@ -136,6 +136,10 @@ export default class StoreUserContext extends Store<UserContext> {
     return this.state.acl.accessRequests;
   }
 
+  getSamlIdpServiceProviderAccess() {
+    return this.state.acl.samlIdpServiceProvider;
+  }
+
   // hasPrereqAccessToAddAgents checks if user meets the prerequisite
   // access to add an agent:
   //  - user should be able to create provisioning tokens

--- a/web/packages/teleport/src/teleportContext.tsx
+++ b/web/packages/teleport/src/teleportContext.tsx
@@ -122,6 +122,7 @@ class TeleportContext implements types.Context {
         locks: false,
         newLocks: false,
         assist: false,
+        samlIdpServiceProviders: false,
       };
     }
 
@@ -154,6 +155,8 @@ class TeleportContext implements types.Context {
       newLocks:
         userContext.getLockAccess().create && userContext.getLockAccess().edit,
       assist: userContext.getAssistantAccess().list && this.assistEnabled,
+      samlIdpServiceProviders:
+        userContext.getSamlIdpServiceProviderAccess().list,
     };
   }
 }

--- a/web/packages/teleport/src/types.ts
+++ b/web/packages/teleport/src/types.ts
@@ -108,6 +108,7 @@ export interface FeatureFlags {
   locks: boolean;
   newLocks: boolean;
   assist: boolean;
+  samlIdpServiceProviders: boolean;
 }
 
 // LockedFeatures are used for determining which features are disabled in the user's cluster.


### PR DESCRIPTION
## Purpose

This PR adds a section to the Web UI where you can manage (edit/delete) SAML Applications. 

`e` counterpart: https://github.com/gravitational/teleport.e/pull/1684

## TODO

- [ ] Add unit tests
- [ ] Add storybook stories
