### PR TITLE
docs: Fix config file formatting error

### DIFF
--- a/docs/pages/desktop-access/reference/sessions.mdx
+++ b/docs/pages/desktop-access/reference/sessions.mdx
@@ -15,9 +15,8 @@ To disable session recording at the cluster level, edit your `teleport.yaml`
 configuration file.
 
 ```yaml
-teleport:
-  auth_service:
-    session_recording: off
+auth_service:
+  session_recording: off
 ```
 
 <Admonition type="warning">


### PR DESCRIPTION
`auth_service` is a top level key in the config file, not under `teleport`.