### PR TITLE
Fix `Assist` import so it does not break storybook

### DIFF
--- a/web/packages/teleport/src/TopBar/TopBar.story.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.story.tsx
@@ -23,6 +23,7 @@ import { getOSSFeatures } from 'teleport/features';
 import TeleportContext from 'teleport/teleportContext';
 import { makeUserContext } from 'teleport/services/user';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
+import { LayoutContextProvider } from 'teleport/Main/LayoutContext';
 
 import { TopBar } from './TopBar';
 
@@ -34,6 +35,7 @@ export function Story() {
   const ctx = new TeleportContext();
 
   ctx.storeUser.state = makeUserContext({
+    userName: 'admin',
     cluster: {
       name: 'test-cluster',
       lastConnected: Date.now(),
@@ -42,11 +44,13 @@ export function Story() {
 
   return (
     <Router history={createMemoryHistory()}>
-      <TeleportContextProvider ctx={ctx}>
-        <FeaturesContextProvider value={getOSSFeatures()}>
-          <TopBar />
-        </FeaturesContextProvider>
-      </TeleportContextProvider>
+      <LayoutContextProvider>
+        <TeleportContextProvider ctx={ctx}>
+          <FeaturesContextProvider value={getOSSFeatures()}>
+            <TopBar />
+          </FeaturesContextProvider>
+        </TeleportContextProvider>
+      </LayoutContextProvider>
     </Router>
   );
 }

--- a/web/packages/teleport/src/TopBar/TopBar.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.tsx
@@ -47,7 +47,7 @@ import {
 
 import ClusterSelector from './ClusterSelector';
 
-const Assist = React.lazy(() => import('web/packages/teleport/src/Assist'));
+const Assist = React.lazy(() => import('teleport/Assist'));
 
 const AssistButton = styled.div`
   padding: 0 10px;


### PR DESCRIPTION
Currently, running storybook fails with an error:
```
ModuleNotFoundError: Module not found: Error: Can't resolve 'web/packages/teleport/src/Assist' in '/Users/grzegorz/code/teleport/web/packages/teleport/src/TopBar'
```

@ryanclark could you verify if that change doesn't break Assist? I tested that and it seems to be fine.
