### PR TITLE
Reorder resource filters in the search bar

### DIFF
--- a/web/packages/teleterm/src/ui/Search/useSearch.ts
+++ b/web/packages/teleterm/src/ui/Search/useSearch.ts
@@ -181,9 +181,9 @@ export function useFilterSearch() {
       };
       const getResourceType = () => {
         let resourceTypes = [
-          'kubes' as const,
           'servers' as const,
           'databases' as const,
+          'kubes' as const,
         ];
         if (search) {
           resourceTypes = resourceTypes.filter(resourceType =>


### PR DESCRIPTION
It took me until today to realize that the order of resource filters in the search bar seems a bit arbitrary. Instead of listing kubes as the first filter, let's make it follow the order of the sections in the DocumentCluster. This way it also follows the popularity of particular features in Connect.

| Before | After |
| --- | --- |
| ![before](https://github.com/gravitational/teleport/assets/27113/37357352-f8ab-4ec7-a658-3be414cc77a8) | ![after](https://github.com/gravitational/teleport/assets/27113/8804c2b0-32ac-40eb-b920-5c4fe8e2a146) |

