### PR TITLE
ai: compute opportinistic summary of command execution

### DIFF
--- a/lib/ai/client.go
+++ b/lib/ai/client.go
@@ -81,7 +81,10 @@ func (client *Client) Summary(ctx context.Context, message string) (string, erro
 // CommandSummary creates a command summary based on the command output.
 // The message history is also passed to the model in order to keep context
 // and extract relevant information from the output.
-func (client *Client) CommandSummary(ctx context.Context, messages []openai.ChatCompletionMessage) (string, error) {
+func (client *Client) CommandSummary(ctx context.Context, messages []openai.ChatCompletionMessage, output map[string][]byte) (string, error) {
+	messages = append(messages, openai.ChatCompletionMessage{
+		Role: openai.ChatMessageRoleUser, Content: model.ConversationCommandResult(output)})
+
 	resp, err := client.svc.CreateChatCompletion(
 		ctx,
 		openai.ChatCompletionRequest{

--- a/lib/ai/client.go
+++ b/lib/ai/client.go
@@ -77,3 +77,22 @@ func (client *Client) Summary(ctx context.Context, message string) (string, erro
 
 	return resp.Choices[0].Message.Content, nil
 }
+
+// CommandSummary creates a command summary based on the command output.
+// The message history is also passed to the model in order to keep context
+// and extract relevant information from the output.
+func (client *Client) CommandSummary(ctx context.Context, messages []openai.ChatCompletionMessage) (string, error) {
+	resp, err := client.svc.CreateChatCompletion(
+		ctx,
+		openai.ChatCompletionRequest{
+			Model:    openai.GPT4,
+			Messages: messages,
+		},
+	)
+
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	return resp.Choices[0].Message.Content, nil
+}

--- a/lib/ai/model/agent.go
+++ b/lib/ai/model/agent.go
@@ -315,6 +315,7 @@ func parsePlanningOutput(text string) (*agentAction, *agentFinish, error) {
 	log.Tracef("received planning output: \"%v\"", text)
 	response, err := parseJSONFromModel[planOutput](text)
 	if err != nil {
+		log.WithError(err).Trace("failed to parse planning output")
 		return nil, nil, trace.Wrap(err)
 	}
 

--- a/lib/ai/model/prompt.go
+++ b/lib/ai/model/prompt.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package model
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 var observationPrefix = "Observation: "
 var thoughtPrefix = "Thought: "
@@ -105,12 +108,12 @@ Okay, so what is the response to my last comment? If using information obtained 
 }
 
 func ConversationCommandResult(result map[string][]byte) string {
-	var message string
+	var message strings.Builder
 	for node, output := range result {
-		message += fmt.Sprintf(`Command ran on node "%s" and produced the following output:\n`, node)
-		message += string(output)
-		message += "\n"
+		message.WriteString(fmt.Sprintf(`Command ran on node "%s" and produced the following output:\n`, node))
+		message.WriteString(string(output))
+		message.WriteString("\n")
 	}
-	message += "Based on the chat history, extract relevant information out of the command output and write a summary."
-	return message
+	message.WriteString("Based on the chat history, extract relevant information out of the command output and write a summary.")
+	return message.String()
 }

--- a/lib/ai/model/prompt.go
+++ b/lib/ai/model/prompt.go
@@ -24,6 +24,9 @@ var thoughtPrefix = "Thought: "
 const PromptSummarizeTitle = `You will be given a message. Create a short summary of that message.
 Respond only with summary, nothing else.`
 
+const PromptSummarizeCommand = `You will be given a chat history and a command output. Based on the history context, extract relevant information from the command output and write a short summary of the command output.
+Respond only with summary, nothing else.`
+
 const InitialAIResponse = `Hey, I'm Teleport - a powerful tool that can assist you in managing your Teleport cluster via OpenAI GPT-4.`
 
 func PromptCharacter(username string) string {
@@ -99,4 +102,15 @@ USER'S INPUT
 --------------------
 
 Okay, so what is the response to my last comment? If using information obtained from the tools you must mention it explicitly without mentioning the tool names - I have forgotten all TOOL RESPONSES! Remember to respond with a markdown code snippet of a json blob with a single action, and NOTHING else.`, toolResponse)
+}
+
+func ConversationCommandResult(result map[string][]byte) string {
+	var message string
+	for node, output := range result {
+		message += fmt.Sprintf(`Command ran on node "%s" and produced the following output:\n`, node)
+		message += string(output)
+		message += "\n"
+	}
+	message += "Based on the chat history, extract relevant information out of the command output and write a summary."
+	return message
 }

--- a/lib/assist/assist.go
+++ b/lib/assist/assist.go
@@ -162,10 +162,7 @@ func (a *Assist) GenerateCommandSummary(ctx context.Context, messages []*assist.
 			modelMessages = append(modelMessages, openai.ChatCompletionMessage{Role: role, Content: payload})
 		}
 	}
-	// Inject command output and final instructions
-	modelMessages = append(modelMessages, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: model.ConversationCommandResult(output)})
-
-	return a.client.CommandSummary(ctx, modelMessages)
+	return a.client.CommandSummary(ctx, modelMessages, output)
 }
 
 // loadMessages loads the messages from the database.

--- a/lib/assist/assist.go
+++ b/lib/assist/assist.go
@@ -44,6 +44,11 @@ const (
 	MessageKindCommand MessageType = "COMMAND"
 	// MessageKindCommandResult is the type of Assist message that contains the command execution result.
 	MessageKindCommandResult MessageType = "COMMAND_RESULT"
+	// MessageKindCommandResultSummary is the type of message that is optionally
+	// emitted after a command and contains a summary of the command output.
+	// This message is both sent after the command execution to the web UI,
+	// and persisted in the conversation history.
+	MessageKindCommandResultSummary MessageType = "COMMAND_RESULT_SUMMARY"
 	// MessageKindUserMessage is the type of Assist message that contains the user message.
 	MessageKindUserMessage MessageType = "CHAT_MESSAGE_USER"
 	// MessageKindAssistantMessage is the type of Assist message that contains the assistant message.
@@ -104,6 +109,10 @@ type Chat struct {
 	ConversationID string
 	// Username is the username of the user who started the chat.
 	Username string
+	// potentiallyStaleHistory indicates messages might have been inserted into
+	// the chat history and the messages should be re-fecthed before attempting
+	// the next completion.
+	potentiallyStaleHistory bool
 }
 
 // NewChat creates a new Assist chat.
@@ -113,11 +122,12 @@ func (a *Assist) NewChat(ctx context.Context, assistService MessageService,
 	aichat := a.client.NewChat(username)
 
 	chat := &Chat{
-		assist:         a,
-		chat:           aichat,
-		assistService:  assistService,
-		ConversationID: conversationID,
-		Username:       username,
+		assist:                  a,
+		chat:                    aichat,
+		assistService:           assistService,
+		ConversationID:          conversationID,
+		Username:                username,
+		potentiallyStaleHistory: false,
 	}
 
 	if err := chat.loadMessages(ctx); err != nil {
@@ -130,6 +140,32 @@ func (a *Assist) NewChat(ctx context.Context, assistService MessageService,
 // GenerateSummary generates a summary for the given message.
 func (a *Assist) GenerateSummary(ctx context.Context, message string) (string, error) {
 	return a.client.Summary(ctx, message)
+}
+
+// GenerateCommandSummary summarizes the output of a command executed on one or
+// many nodes. The conversation history is also sent into the prompt in order
+// to gather context and know what information is relevant in the command output.
+func (a *Assist) GenerateCommandSummary(ctx context.Context, messages []*assist.AssistantMessage, output map[string][]byte) (string, error) {
+	// Create system prompt
+	modelMessages := []openai.ChatCompletionMessage{
+		{Role: openai.ChatMessageRoleSystem, Content: model.PromptSummarizeCommand},
+	}
+
+	// Load context back into prompt
+	for _, message := range messages {
+		role := kindToRole(MessageType(message.Type))
+		if role != "" && role != openai.ChatMessageRoleSystem {
+			payload, err := formatMessagePayload(message)
+			if err != nil {
+				return "", trace.Wrap(err)
+			}
+			modelMessages = append(modelMessages, openai.ChatCompletionMessage{Role: role, Content: payload})
+		}
+	}
+	// Inject command output and final instructions
+	modelMessages = append(modelMessages, openai.ChatCompletionMessage{Role: openai.ChatMessageRoleUser, Content: model.ConversationCommandResult(output)})
+
+	return a.client.CommandSummary(ctx, modelMessages)
 }
 
 // loadMessages loads the messages from the database.
@@ -147,7 +183,11 @@ func (c *Chat) loadMessages(ctx context.Context) error {
 	for _, msg := range messages.GetMessages() {
 		role := kindToRole(MessageType(msg.Type))
 		if role != "" {
-			c.chat.Insert(role, msg.Payload)
+			payload, err := formatMessagePayload(msg)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			c.chat.Insert(role, payload)
 		}
 	}
 
@@ -201,6 +241,16 @@ type onMessageFunc func(kind MessageType, payload []byte, createdTime time.Time)
 func (c *Chat) ProcessComplete(ctx context.Context, onMessage onMessageFunc, userInput string,
 ) (*model.TokensUsed, error) {
 	var tokensUsed *model.TokensUsed
+
+	// If data might have been inserted into the chat history, we want to
+	// refresh and get the latest data before querying the model.
+	if c.potentiallyStaleHistory {
+		c.chat = c.assist.client.NewChat(c.Username)
+		err := c.loadMessages(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
 
 	// query the assistant and fetch an answer
 	message, err := c.chat.Complete(ctx, userInput)
@@ -279,6 +329,11 @@ func (c *Chat) ProcessComplete(ctx context.Context, onMessage onMessageFunc, use
 		if err := onMessage(MessageKindCommand, payloadJson, c.assist.clock.Now().UTC()); nil != err {
 			return nil, trace.Wrap(err)
 		}
+		// As we emitted a command suggestion, the user might have run it. If
+		// the command ran, a summary could have been inserted in the backend.
+		// To take this command summary into account we note the history might
+		// be stale.
+		c.potentiallyStaleHistory = true
 	default:
 		return nil, trace.Errorf("unknown message type")
 	}
@@ -313,7 +368,27 @@ func kindToRole(kind MessageType) string {
 		return openai.ChatMessageRoleAssistant
 	case MessageKindSystemMessage:
 		return openai.ChatMessageRoleSystem
+	case MessageKindCommandResultSummary:
+		return openai.ChatMessageRoleUser
 	default:
 		return ""
+	}
+}
+
+// formatMessagePayload generates the OpemAI message payload corresponding to
+// an Assist message. Most Assist message payloads can be converted directly,
+// but some payloads are JSON-formatted and must be processed before being
+// passed to the model.
+func formatMessagePayload(message *assist.AssistantMessage) (string, error) {
+	switch MessageType(message.GetType()) {
+	case MessageKindCommandResultSummary:
+		var summary CommandExecSummary
+		err := json.Unmarshal([]byte(message.GetPayload()), &summary)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+		return summary.String(), nil
+	default:
+		return message.GetPayload(), nil
 	}
 }

--- a/lib/assist/assist.go
+++ b/lib/assist/assist.go
@@ -110,7 +110,7 @@ type Chat struct {
 	// Username is the username of the user who started the chat.
 	Username string
 	// potentiallyStaleHistory indicates messages might have been inserted into
-	// the chat history and the messages should be re-fecthed before attempting
+	// the chat history and the messages should be re-fetched before attempting
 	// the next completion.
 	potentiallyStaleHistory bool
 }

--- a/lib/assist/messages.go
+++ b/lib/assist/messages.go
@@ -19,11 +19,28 @@
 
 package assist
 
-import "github.com/gravitational/teleport/lib/ai/model"
+import (
+	"fmt"
+
+	"github.com/gravitational/teleport/lib/ai/model"
+)
 
 // commandPayload is a payload for a command message.
 type commandPayload struct {
 	Command string        `json:"command,omitempty"`
 	Nodes   []string      `json:"nodes,omitempty"`
 	Labels  []model.Label `json:"labels,omitempty"`
+}
+
+// CommandExecSummary is a payload for the COMMAND_RESULT_SUMMARY message.
+type CommandExecSummary struct {
+	ExecutionID string `json:"execution_id"`
+	Summary     string `json:"summary"`
+	Command     string `json:"command"`
+}
+
+// String implements the Stringer interface and formats the message for AI
+// model consumption.
+func (s CommandExecSummary) String() string {
+	return fmt.Sprintf("Command: `%s` executed. The command output summary is: %s", s.Command, s.Summary)
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1795,7 +1795,7 @@ func TestTerminalRouting(t *testing.T) {
 
 			// here we intentionally run a command where the output we're looking
 			// for is not present in the command itself
-			_, err = io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
+			_, err = io.WriteString(stream, testCommand+"\r\n")
 			require.NoError(t, err)
 			require.NoError(t, waitForOutput(stream, tt.output))
 		})
@@ -1954,7 +1954,7 @@ func TestTerminalRequireSessionMfa(t *testing.T) {
 			require.Nil(t, err)
 
 			// Test we can write.
-			_, err = io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
+			_, err = io.WriteString(stream, testCommand+"\r\n")
 			require.Nil(t, err)
 			require.Nil(t, waitForOutput(stream, "teleport"))
 		})
@@ -7926,7 +7926,7 @@ func validateTerminalStream(t *testing.T, ws *websocket.Conn) {
 
 	// here we intentionally run a command where the output we're looking
 	// for is not present in the command itself
-	_, err := io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
+	_, err := io.WriteString(stream, testCommand+"\r\n")
 	require.NoError(t, err)
 	require.NoError(t, waitForOutput(stream, "teleport"))
 }

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1795,7 +1795,7 @@ func TestTerminalRouting(t *testing.T) {
 
 			// here we intentionally run a command where the output we're looking
 			// for is not present in the command itself
-			_, err = io.WriteString(stream, testCommand+"\r\n")
+			_, err = io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
 			require.NoError(t, err)
 			require.NoError(t, waitForOutput(stream, tt.output))
 		})
@@ -1954,7 +1954,7 @@ func TestTerminalRequireSessionMfa(t *testing.T) {
 			require.Nil(t, err)
 
 			// Test we can write.
-			_, err = io.WriteString(stream, testCommand+"\r\n")
+			_, err = io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
 			require.Nil(t, err)
 			require.Nil(t, waitForOutput(stream, "teleport"))
 		})
@@ -7926,7 +7926,7 @@ func validateTerminalStream(t *testing.T, ws *websocket.Conn) {
 
 	// here we intentionally run a command where the output we're looking
 	// for is not present in the command itself
-	_, err := io.WriteString(stream, testCommand+"\r\n")
+	_, err := io.WriteString(stream, "echo txlxport | sed 's/x/e/g'\r\n")
 	require.NoError(t, err)
 	require.NoError(t, waitForOutput(stream, "teleport"))
 }

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -287,6 +287,7 @@ func (h *Handler) executeCommand(
 	runCommands(hosts, runCmd, h.log)
 
 	// Optionally try to compute the command summary.
+	// TODO: find way to skip this in tests?
 	if output := buffer.Export(); output != nil {
 		summary, err := h.summarizeOutput(output, clt, identity, req, ctx)
 		if err != nil {

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -45,6 +45,13 @@ type WSConn interface {
 	SetPongHandler(h func(appData string) error)
 }
 
+const (
+	envelopeTypeStdout  = "stdout"
+	envelopeTypeStderr  = "stderr"
+	envelopeTypeError   = "teleport-error"
+	envelopeTypeSummary = "summary"
+)
+
 // outEnvelope is an envelope used to wrap messages send back to the client connected over WS.
 type outEnvelope struct {
 	NodeID  string `json:"node_id"`
@@ -56,7 +63,7 @@ type outEnvelope struct {
 // outEnvelope and writes it to the underlying stream.
 type payloadWriter struct {
 	nodeID string
-	// output name, can be stdout, stderr or teleport-error.
+	// output name, can be stdout, stderr, teleport-error or summary.
 	outputName string
 	// stream is the underlying stream.
 	stream io.Writer
@@ -129,4 +136,64 @@ func (s *syncRWWSConn) ReadMessage() (messageType int, p []byte, err error) {
 	s.rmtx.Lock()
 	defer s.rmtx.Unlock()
 	return s.WSConn.ReadMessage()
+}
+
+func newBufferedPayloadWriter(pw *payloadWriter, buffer *summaryBuffer) *bufferedPayloadWriter {
+	return &bufferedPayloadWriter{
+		payloadWriter: pw,
+		buffer:        buffer,
+	}
+}
+
+type bufferedPayloadWriter struct {
+	*payloadWriter
+	buffer *summaryBuffer
+}
+
+func (bp *bufferedPayloadWriter) Write(data []byte) (int, error) {
+	bp.buffer.Write(bp.nodeID, data)
+	return bp.payloadWriter.Write(data)
+}
+
+func newSummaryBuffer(capacity int) *summaryBuffer {
+	return &summaryBuffer{
+		buffer:            make(map[string][]byte),
+		remainingCapacity: capacity,
+		invalid:           false,
+		mutex:             sync.Mutex{},
+	}
+}
+
+type summaryBuffer struct {
+	buffer            map[string][]byte
+	remainingCapacity int
+	invalid           bool
+	mutex             sync.Mutex
+}
+
+func (b *summaryBuffer) Write(node string, data []byte) {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	if b.invalid {
+		return
+	}
+	if len(data) > b.remainingCapacity {
+		// We're out of capacity, not all content will be written to the buffer
+		// it should not be used anymore
+		b.invalid = true
+		return
+	}
+	b.buffer[node] = append(b.buffer[node], data...)
+	b.remainingCapacity -= len(data)
+}
+
+func (b *summaryBuffer) Export() map[string][]byte {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	if b.invalid || len(b.buffer) == 0 {
+		return nil
+	}
+	// By setting this, we guarantee no one can write to the buffer again.
+	b.invalid = true
+	return b.buffer
 }

--- a/lib/web/command_utils_test.go
+++ b/lib/web/command_utils_test.go
@@ -1,0 +1,118 @@
+package web
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSummaryBuffer(t *testing.T) {
+	tests := []struct {
+		name     string
+		outputs  map[string][][]byte
+		capacity int
+		expected map[string][]byte
+	}{
+		{
+			name: "Single node",
+			outputs: map[string][][]byte{
+				"node": {
+					[]byte("foo"),
+					[]byte("bar"),
+					[]byte("baz"),
+				},
+			},
+			capacity: 9,
+			expected: map[string][]byte{
+				"node": []byte("foobarbaz"),
+			},
+		},
+		{
+			name: "Single node overflow",
+			outputs: map[string][][]byte{
+				"node": {
+					[]byte("foo"),
+					[]byte("bar"),
+					[]byte("baz"),
+				},
+			},
+			capacity: 8,
+			expected: nil,
+		},
+		{
+			name: "Multiple nodes",
+			outputs: map[string][][]byte{
+				"node1": {
+					[]byte("foo"),
+					[]byte("bar"),
+					[]byte("baz"),
+				},
+				"node2": {
+					[]byte("baz"),
+					[]byte("bar"),
+					[]byte("foo"),
+				},
+				"node3": {
+					[]byte("baz"),
+					[]byte("baz"),
+					[]byte("baz"),
+				},
+			},
+			capacity: 30,
+			expected: map[string][]byte{
+				"node1": []byte("foobarbaz"),
+				"node2": []byte("bazbarfoo"),
+				"node3": []byte("bazbazbaz"),
+			},
+		},
+		{
+			name: "Multiple nodes overflow",
+			outputs: map[string][][]byte{
+				"node1": {
+					[]byte("foo"),
+					[]byte("bar"),
+					[]byte("baz"),
+				},
+				"node2": {
+					[]byte("baz"),
+					[]byte("bar"),
+					[]byte("foo"),
+				},
+				"node3": {
+					[]byte("baz"),
+					[]byte("baz"),
+					[]byte("baz"),
+				},
+			},
+			capacity: 25,
+			expected: nil,
+		},
+		/*
+			{name: "Multiple nodes"},
+			{name: "No node"},
+			{name: "Multiple nodes overflow"},
+		*/
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			buffer := newSummaryBuffer(tc.capacity)
+			var wg sync.WaitGroup
+			for node, output := range tc.outputs {
+				node := node
+				output := output
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for _, chunk := range output {
+						buffer.Write(node, chunk)
+					}
+				}()
+			}
+			wg.Wait()
+			require.Equal(t, tc.expected, buffer.Export())
+
+		})
+	}
+}

--- a/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
@@ -40,7 +40,7 @@ const Title = styled.div`
 
 const Summary = styled.div`
   padding: 10px 15px 0 17px;
-  
+
   ${markdownCSS}
 `;
 
@@ -50,14 +50,22 @@ const Header = styled.div`
   padding-right: 20px;
 `;
 
-export function CommandResultSummaryEntry(props: CommandResultSummaryEntryProps) {
+export function CommandResultSummaryEntry(
+  props: CommandResultSummaryEntryProps
+) {
   return (
     <Container>
       <Header>
-        <Title>Summary of command execution <pre>{props.command}"</pre></Title>
+        <Title>
+          Summary of command execution <pre>{props.command}</pre>
+        </Title>
       </Header>
 
-      <Summary><ReactMarkdown remarkPlugins={[remarkGfm]}>{props.summary}</ReactMarkdown></Summary>
+      <Summary>
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>
+          {props.summary}
+        </ReactMarkdown>
+      </Summary>
     </Container>
   );
 }

--- a/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import styled, { keyframes } from 'styled-components';
+import styled from 'styled-components';
 
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';

--- a/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
@@ -54,7 +54,7 @@ export function CommandResultSummaryEntry(props: CommandResultSummaryEntryProps)
   return (
     <Container>
       <Header>
-        <Title>Execution summary of command "{props.command}"</Title>
+        <Title>Summary of command execution <pre>{props.command}"</pre></Title>
       </Header>
 
       <Summary><ReactMarkdown remarkPlugins={[remarkGfm]}>{props.summary}</ReactMarkdown></Summary>

--- a/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import styled, { keyframes } from 'styled-components';
+
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+
+import { markdownCSS } from 'teleport/Assist/markdown';
+
+interface CommandResultSummaryEntryProps {
+  command: string;
+  summary: string;
+}
+
+const Container = styled.div`
+  border-radius: 10px;
+  position: relative;
+`;
+
+const Title = styled.div`
+  font-size: 15px;
+  font-weight: 600;
+  padding: 10px 15px;
+`;
+
+const Summary = styled.div`
+  padding: 10px 15px 0 17px;
+  
+  ${markdownCSS}
+`;
+
+const Header = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-right: 20px;
+`;
+
+export function CommandResultSummaryEntry(props: CommandResultSummaryEntryProps) {
+  return (
+    <Container>
+      <Header>
+        <Title>Execution summary of command "{props.command}"</Title>
+      </Header>
+
+      <Summary><ReactMarkdown remarkPlugins={[remarkGfm]}>{props.summary}</ReactMarkdown></Summary>
+    </Container>
+  );
+}

--- a/web/packages/teleport/src/Assist/Conversation/Message.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Message.tsx
@@ -17,20 +17,30 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import {CheckIcon} from 'design/SVGIcon';
+import { CheckIcon } from 'design/SVGIcon';
 
-import type {ConversationMessage} from 'teleport/Assist/types';
-import {Author, ResolvedServerMessage, ServerMessageType,} from 'teleport/Assist/types';
+import type { ConversationMessage } from 'teleport/Assist/types';
+import {
+  Author,
+  ResolvedServerMessage,
+  ServerMessageType,
+} from 'teleport/Assist/types';
 
-import {TeleportAvatar, UserAvatar,} from 'teleport/Assist/Conversation/Avatar';
-import {TypingContainer, TypingDot,} from 'teleport/Assist/Conversation/Typing';
-import {Timestamp} from 'teleport/Assist/Conversation/Timestamp';
-import {EntryContainer} from 'teleport/Assist/Conversation/EntryContainer';
-import {MessageEntry} from 'teleport/Assist/Conversation/MessageEntry';
-import {useAssist} from 'teleport/Assist/context/AssistContext';
-import {ExecuteRemoteCommandEntry} from 'teleport/Assist/Conversation/ExecuteRemoteCommandEntry';
-import {CommandResultEntry} from 'teleport/Assist/Conversation/CommandResultEntry';
-import {CommandResultSummaryEntry} from 'teleport/Assist/Conversation/CommandResultSummaryEntry';
+import {
+  TeleportAvatar,
+  UserAvatar,
+} from 'teleport/Assist/Conversation/Avatar';
+import {
+  TypingContainer,
+  TypingDot,
+} from 'teleport/Assist/Conversation/Typing';
+import { Timestamp } from 'teleport/Assist/Conversation/Timestamp';
+import { EntryContainer } from 'teleport/Assist/Conversation/EntryContainer';
+import { MessageEntry } from 'teleport/Assist/Conversation/MessageEntry';
+import { useAssist } from 'teleport/Assist/context/AssistContext';
+import { ExecuteRemoteCommandEntry } from 'teleport/Assist/Conversation/ExecuteRemoteCommandEntry';
+import { CommandResultEntry } from 'teleport/Assist/Conversation/CommandResultEntry';
+import { CommandResultSummaryEntry } from 'teleport/Assist/Conversation/CommandResultSummaryEntry';
 
 interface MessageProps {
   message: ConversationMessage;
@@ -131,10 +141,10 @@ function createComponentForEntry(
       );
     case ServerMessageType.CommandResultSummary:
       return (
-          <CommandResultSummaryEntry
-              command={entry.command}
-              summary={entry.summary}
-          />
+        <CommandResultSummaryEntry
+          command={entry.command}
+          summary={entry.summary}
+        />
       );
   }
 }

--- a/web/packages/teleport/src/Assist/Conversation/Message.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Message.tsx
@@ -19,9 +19,9 @@ import styled from 'styled-components';
 
 import { CheckIcon } from 'design/SVGIcon';
 
-import type { ConversationMessage } from 'teleport/Assist/types';
 import {
   Author,
+  ConversationMessage,
   ResolvedServerMessage,
   ServerMessageType,
 } from 'teleport/Assist/types';

--- a/web/packages/teleport/src/Assist/Conversation/Message.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Message.tsx
@@ -17,30 +17,20 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import { CheckIcon } from 'design/SVGIcon';
+import {CheckIcon} from 'design/SVGIcon';
 
-import {
-  Author,
-  ResolvedServerMessage,
-  ServerMessageType,
-} from 'teleport/Assist/types';
+import type {ConversationMessage} from 'teleport/Assist/types';
+import {Author, ResolvedServerMessage, ServerMessageType,} from 'teleport/Assist/types';
 
-import {
-  TeleportAvatar,
-  UserAvatar,
-} from 'teleport/Assist/Conversation/Avatar';
-import {
-  TypingContainer,
-  TypingDot,
-} from 'teleport/Assist/Conversation/Typing';
-import { Timestamp } from 'teleport/Assist/Conversation/Timestamp';
-import { EntryContainer } from 'teleport/Assist/Conversation/EntryContainer';
-import { MessageEntry } from 'teleport/Assist/Conversation/MessageEntry';
-import { useAssist } from 'teleport/Assist/context/AssistContext';
-import { ExecuteRemoteCommandEntry } from 'teleport/Assist/Conversation/ExecuteRemoteCommandEntry';
-import { CommandResultEntry } from 'teleport/Assist/Conversation/CommandResultEntry';
-
-import type { ConversationMessage } from 'teleport/Assist/types';
+import {TeleportAvatar, UserAvatar,} from 'teleport/Assist/Conversation/Avatar';
+import {TypingContainer, TypingDot,} from 'teleport/Assist/Conversation/Typing';
+import {Timestamp} from 'teleport/Assist/Conversation/Timestamp';
+import {EntryContainer} from 'teleport/Assist/Conversation/EntryContainer';
+import {MessageEntry} from 'teleport/Assist/Conversation/MessageEntry';
+import {useAssist} from 'teleport/Assist/context/AssistContext';
+import {ExecuteRemoteCommandEntry} from 'teleport/Assist/Conversation/ExecuteRemoteCommandEntry';
+import {CommandResultEntry} from 'teleport/Assist/Conversation/CommandResultEntry';
+import {CommandResultSummaryEntry} from 'teleport/Assist/Conversation/CommandResultSummaryEntry';
 
 interface MessageProps {
   message: ConversationMessage;
@@ -138,6 +128,13 @@ function createComponentForEntry(
           finished={true}
           errorMessage={entry.errorMessage}
         />
+      );
+    case ServerMessageType.CommandResultSummary:
+      return (
+          <CommandResultSummaryEntry
+              command={entry.command}
+              summary={entry.summary}
+          />
       );
   }
 }

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -413,8 +413,6 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
     executeCommandWebSocket.current = new WebSocket(url);
     executeCommandWebSocket.current.binaryType = 'arraybuffer';
 
-    let sessionsEnded = 0;
-
     executeCommandWebSocket.current.onmessage = event => {
       const uintArray = new Uint8Array(event.data);
 

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -462,25 +462,17 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
           break;
 
         case MessageTypeEnum.SESSION_END:
-          // we don't know the nodeId of the session that ended, so we have to
-          // count the finished sessions and then mark them all as done once
-          // they've all finished
-          sessionsEnded += 1;
-
-          if (sessionsEnded === nodeIdToResultId.size) {
-            for (const nodeId of nodeIdToResultId.keys()) {
-              dispatch({
-                type: AssistStateActionType.FinishCommandResult,
-                conversationId: state.conversations.selectedId,
-                commandResultId: nodeIdToResultId.get(nodeId),
-              });
-            }
-
-            nodeIdToResultId.clear();
-
-            // TODO(ryan): move this to after the summary is sent once it's implemented
-            executeCommandWebSocket.current.close();
+          for (const nodeId of nodeIdToResultId.keys()) {
+            dispatch({
+              type: AssistStateActionType.FinishCommandResult,
+              conversationId: state.conversations.selectedId,
+              commandResultId: nodeIdToResultId.get(nodeId),
+            });
           }
+
+          nodeIdToResultId.clear();
+
+          executeCommandWebSocket.current.close();
 
           break;
       }

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -421,13 +421,22 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
           const data = JSON.parse(msg.payload) as RawPayload;
           const payload = atob(data.payload);
 
-          dispatch({
-            type: AssistStateActionType.UpdateCommandResult,
-            conversationId: state.conversations.selectedId,
-            commandResultId: nodeIdToResultId.get(data.node_id),
-            output: payload,
-          });
-
+          if (data.type === "summary") {
+            dispatch({
+              type: AssistStateActionType.AddCommandResultSummary,
+              conversationId: state.conversations.selectedId,
+              summary: payload,
+              executionId: execParams.execution_id,
+              command: execParams.command,
+            })
+          } else {
+            dispatch({
+              type: AssistStateActionType.UpdateCommandResult,
+              conversationId: state.conversations.selectedId,
+              commandResultId: nodeIdToResultId.get(data.node_id),
+              output: payload,
+            });
+          }
           break;
 
         case MessageTypeEnum.WEBAUTHN_CHALLENGE:

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -31,7 +31,11 @@ import useStickyClusterId from 'teleport/useStickyClusterId';
 import cfg from 'teleport/config';
 import { getAccessToken, getHostName } from 'teleport/services/api';
 
-import { RawPayload, ServerMessageType } from 'teleport/Assist/types';
+import {
+  ExecutionEnvelopeType,
+  RawPayload,
+  ServerMessageType,
+} from 'teleport/Assist/types';
 
 import { MessageTypeEnum, Protobuf } from 'teleport/lib/term/protobuf';
 
@@ -421,7 +425,7 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
           const data = JSON.parse(msg.payload) as RawPayload;
           const payload = atob(data.payload);
 
-          if (data.type === 'summary') {
+          if (data.type === ExecutionEnvelopeType) {
             dispatch({
               type: AssistStateActionType.AddCommandResultSummary,
               conversationId: state.conversations.selectedId,

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -24,7 +24,6 @@ import React, {
   useRef,
 } from 'react';
 
-import type { AssistState } from 'teleport/Assist/context/state';
 import { AssistStateActionType, reducer } from 'teleport/Assist/context/state';
 
 import { convertServerMessages } from 'teleport/Assist/context/utils';
@@ -32,11 +31,6 @@ import useStickyClusterId from 'teleport/useStickyClusterId';
 import cfg from 'teleport/config';
 import { getAccessToken, getHostName } from 'teleport/services/api';
 
-import type {
-  ConversationMessage,
-  ResolvedServerMessage,
-  ServerMessage,
-} from 'teleport/Assist/types';
 import {
   ExecutionEnvelopeType,
   RawPayload,
@@ -51,7 +45,16 @@ import {
 } from 'teleport/services/auth';
 
 import * as service from '../service';
+
 import { resolveServerCommandMessage, resolveServerMessage } from '../service';
+
+import type {
+  ConversationMessage,
+  ResolvedServerMessage,
+  ServerMessage,
+} from 'teleport/Assist/types';
+
+import type { AssistState } from 'teleport/Assist/context/state';
 
 interface AssistContextValue {
   cancelMfaChallenge: () => void;

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -421,14 +421,14 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
           const data = JSON.parse(msg.payload) as RawPayload;
           const payload = atob(data.payload);
 
-          if (data.type === "summary") {
+          if (data.type === 'summary') {
             dispatch({
               type: AssistStateActionType.AddCommandResultSummary,
               conversationId: state.conversations.selectedId,
               summary: payload,
               executionId: execParams.execution_id,
               command: execParams.command,
-            })
+            });
           } else {
             dispatch({
               type: AssistStateActionType.UpdateCommandResult,

--- a/web/packages/teleport/src/Assist/context/state.ts
+++ b/web/packages/teleport/src/Assist/context/state.ts
@@ -60,6 +60,7 @@ export enum AssistStateActionType {
   PromptMfa,
   DeleteConversation,
   UpdateConversationTitle,
+  AddCommandResultSummary,
 }
 
 export interface ReplaceConversationsAction {
@@ -164,6 +165,14 @@ export interface UpdateConversationTitleAction {
   title: string;
 }
 
+export interface AddCommandResultSummaryAction {
+  type: AssistStateActionType.AddCommandResultSummary;
+  summary: string;
+  conversationId: string;
+  command: string;
+  executionId: string;
+}
+
 export type AssistContextAction =
   | SetConversationsLoadingAction
   | ReplaceConversationsAction
@@ -181,7 +190,8 @@ export type AssistContextAction =
   | FinishCommandResultAction
   | PromptMfaAction
   | DeleteConversationAction
-  | UpdateConversationTitleAction;
+  | UpdateConversationTitleAction
+  | AddCommandResultSummaryAction;
 
 export function reducer(
   state: AssistState,
@@ -238,6 +248,9 @@ export function reducer(
 
     case AssistStateActionType.UpdateConversationTitle:
       return updateConversationTitle(state, action);
+
+    case AssistStateActionType.AddCommandResultSummary:
+      return addCommandResultSummary(state, action);
 
     default:
       return state;
@@ -589,6 +602,35 @@ export function finishCommandResult(
   };
 }
 
+export function addCommandResultSummary(
+    state: AssistState,
+    action: AddCommandResultSummaryAction
+): AssistState {
+  const messages = new Map(state.messages.data);
+
+  let conversationMessages = messages.get(action.conversationId);
+
+  conversationMessages = [
+    ...conversationMessages,
+    {
+      type: ServerMessageType.CommandResultSummary,
+      created: new Date(),
+      executionId: action.executionId,
+      command: action.command,
+      summary: action.summary,
+    },
+  ];
+
+  messages.set(action.conversationId, conversationMessages);
+
+  return {
+    ...state,
+    messages: {
+      ...state.messages,
+      data: messages,
+    },
+  };
+}
 export function promptMfa(
   state: AssistState,
   action: PromptMfaAction

--- a/web/packages/teleport/src/Assist/context/state.ts
+++ b/web/packages/teleport/src/Assist/context/state.ts
@@ -603,8 +603,8 @@ export function finishCommandResult(
 }
 
 export function addCommandResultSummary(
-    state: AssistState,
-    action: AddCommandResultSummaryAction
+  state: AssistState,
+  action: AddCommandResultSummaryAction
 ): AssistState {
   const messages = new Map(state.messages.data);
 

--- a/web/packages/teleport/src/Assist/context/utils.ts
+++ b/web/packages/teleport/src/Assist/context/utils.ts
@@ -32,6 +32,7 @@ function getMessageTypeAuthor(type: string) {
     case ServerMessageType.Command:
     case ServerMessageType.CommandResult:
     case ServerMessageType.CommandResultStream:
+    case ServerMessageType.CommandResultSummary:
     case ServerMessageType.Error:
       return Author.Teleport;
   }

--- a/web/packages/teleport/src/Assist/service.ts
+++ b/web/packages/teleport/src/Assist/service.ts
@@ -27,6 +27,8 @@ import { EventType } from 'teleport/lib/term/enums';
 
 import NodeService from 'teleport/services/nodes';
 
+import { ServerMessageType } from './types';
+
 import type {
   CommandResultPayload,
   CommandResultSummaryPayload,
@@ -44,7 +46,6 @@ import type {
   ServerMessage,
   SessionEvent,
 } from './types';
-import { ServerMessageType } from './types';
 
 export async function loadConversations(): Promise<Conversation[]> {
   const res: GetConversationsResponse = await api.get(

--- a/web/packages/teleport/src/Assist/service.ts
+++ b/web/packages/teleport/src/Assist/service.ts
@@ -17,9 +17,13 @@
 import api from 'teleport/services/api';
 import cfg from 'teleport/config';
 
-import {convertPayloadToQuery, findIntersection, sortLoginsWithRootLoginsLast,} from 'teleport/Assist/context/utils';
+import {
+  convertPayloadToQuery,
+  findIntersection,
+  sortLoginsWithRootLoginsLast,
+} from 'teleport/Assist/context/utils';
 
-import {EventType} from 'teleport/lib/term/enums';
+import { EventType } from 'teleport/lib/term/enums';
 
 import NodeService from 'teleport/services/nodes';
 
@@ -40,7 +44,7 @@ import type {
   ServerMessage,
   SessionEvent,
 } from './types';
-import {ServerMessageType} from './types';
+import { ServerMessageType } from './types';
 
 export async function loadConversations(): Promise<Conversation[]> {
   const res: GetConversationsResponse = await api.get(
@@ -66,7 +70,7 @@ export async function resolveServerMessage(
       return resolveServerCommandResultMessage(message, clusterId);
 
     case ServerMessageType.CommandResultSummary:
-      return resolveServerCommandResultSummaryMessage(message)
+      return resolveServerCommandResultSummaryMessage(message);
 
     case ServerMessageType.Assist:
     case ServerMessageType.User:
@@ -174,17 +178,17 @@ export async function resolveServerCommandResultMessage(
 }
 
 export function resolveServerCommandResultSummaryMessage(
-    message: ServerMessage,
+  message: ServerMessage
 ): ResolvedCommandResultSummaryServerMessage {
   const payload = JSON.parse(message.payload) as CommandResultSummaryPayload;
 
-    return {
-      type: ServerMessageType.CommandResultSummary,
-      executionId: payload.execution_id,
-      command: payload.command,
-      summary: payload.summary,
-      created: new Date(message.created_time),
-    };
+  return {
+    type: ServerMessageType.CommandResultSummary,
+    executionId: payload.execution_id,
+    command: payload.command,
+    summary: payload.summary,
+    created: new Date(message.created_time),
+  };
 }
 
 export function resolveServerCommandMessage(

--- a/web/packages/teleport/src/Assist/types.ts
+++ b/web/packages/teleport/src/Assist/types.ts
@@ -21,6 +21,7 @@ export enum ServerMessageType {
   Error = 'CHAT_MESSAGE_ERROR',
   Command = 'COMMAND',
   CommandResult = 'COMMAND_RESULT',
+  CommandResultSummary = 'COMMAND_RESULT_SUMMARY',
   CommandResultStream = 'COMMAND_RESULT_STREAM',
   AssistPartialMessage = 'CHAT_PARTIAL_MESSAGE_ASSISTANT',
   AssistPartialMessageEnd = 'CHAT_PARTIAL_MESSAGE_ASSISTANT_FINALIZE',
@@ -68,6 +69,14 @@ export interface ResolvedCommandResultServerMessage {
   created: Date;
 }
 
+export interface ResolvedCommandResultSummaryServerMessage {
+  type: ServerMessageType.CommandResultSummary;
+  executionId: string;
+  summary: string;
+  command: string;
+  created: Date;
+}
+
 export interface ResolvedAssistThoughtServerMessage {
   type: ServerMessageType.AssistThought;
   message: string;
@@ -108,6 +117,7 @@ export type ResolvedServerMessage =
   | ResolvedUserServerMessage
   | ResolvedErrorServerMessage
   | ResolvedCommandResultServerMessage
+  | ResolvedCommandResultSummaryServerMessage
   | ResolvedAssistThoughtServerMessage
   | ResolvedCommandResultStreamServerMessage;
 
@@ -140,6 +150,12 @@ export interface CommandResultPayload {
   node_name: string;
   session_id: string;
   execution_id: string;
+}
+
+export interface CommandResultSummaryPayload {
+  execution_id: string;
+  command: string;
+  summary: string;
 }
 
 export interface ExecEvent {

--- a/web/packages/teleport/src/Assist/types.ts
+++ b/web/packages/teleport/src/Assist/types.ts
@@ -178,6 +178,7 @@ export interface NodeState {
 
 export interface RawPayload {
   node_id: string;
+  type: string;
   payload: string;
 }
 

--- a/web/packages/teleport/src/Assist/types.ts
+++ b/web/packages/teleport/src/Assist/types.ts
@@ -28,6 +28,8 @@ export enum ServerMessageType {
   AssistThought = 'CHAT_THOUGHT_ASSISTANT',
 }
 
+export const ExecutionEnvelopeType = 'summary';
+
 export interface Conversation {
   id: string;
   title?: string;

--- a/web/packages/teleport/src/lib/term/protobuf.js
+++ b/web/packages/teleport/src/lib/term/protobuf.js
@@ -95,7 +95,6 @@ export class Protobuf {
     return this.encode(messageFields.type.values.close, '');
   }
 
-
   encodePayload(buffer, text) {
     // set type
     buffer.push(messageFields.payload.code);

--- a/web/packages/teleport/src/lib/term/protobuf.js
+++ b/web/packages/teleport/src/lib/term/protobuf.js
@@ -90,6 +90,12 @@ export class Protobuf {
     return this.encode(messageFields.type.values.data, message);
   }
 
+  encodeCloseMessage() {
+    // Close message has no payload
+    return this.encode(messageFields.type.values.close, '');
+  }
+
+
   encodePayload(buffer, text) {
     // set type
     buffer.push(messageFields.payload.code);


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport.e/issues/1466

This is the MVP for the command execution summary. During the implementation, I encountered the following issues:
- the execution endpoint is different from the conversation one. The `Chat` from the conversation endpoint will not be notified that messages were inserted by the execution. I worked around by flagging the history as stale after a command suggestion and rebuilding the `Chat` object. This is not ideal but will work at our current scale. We might want to merge the discussion and execution endpoint later.
- When asking followup question the model makes mistakes when invoking the command suggestion tool. This is not related directly to the feature but harms the UX a bit. I think we'll want to prioritize fixing this.

I have not implemented posthog events reporting token consumption and command execution as part of the MVP.

The tests in `command_test.go` required mocking openAI to avoid summary generation warnings. I copied some code from https://github.com/gravitational/teleport/pull/28077 and we'll want to cleanup once the two branches are merged.