### PR TITLE
fix: Decode JSON directly from stream in `waitForCommandOutput`

### DIFF
--- a/lib/web/command_test.go
+++ b/lib/web/command_test.go
@@ -200,28 +200,20 @@ func waitForCommandOutput(stream io.Reader, substr string) error {
 		default:
 		}
 
-		out := make([]byte, 100)
-		n, err := stream.Read(out)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
 		var env Envelope
-		err = json.Unmarshal(out[:n], &env)
-		if err != nil {
-			return trace.Wrap(err)
+		dec := json.NewDecoder(stream)
+		if err := dec.Decode(&env); err != nil {
+			return trace.Wrap(err, "decoding envelope JSON from stream")
 		}
 
 		d, err := base64.StdEncoding.DecodeString(env.Payload)
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "decoding b64 payload")
 		}
+
 		data := removeSpace(string(d))
-		if n > 0 && strings.Contains(data, substr) {
+		if strings.Contains(data, substr) {
 			return nil
-		}
-		if err != nil {
-			return trace.Wrap(err)
 		}
 	}
 }


### PR DESCRIPTION
Fixes local breakage of `TestExecuteCommandHistory`.

Without the fix I consistently get this failure:

```sh
$ go test ./lib/web -run=TestExecuteCommandHistory
> ...
> === FAIL: lib/web TestExecuteCommandHistory (2.66s)
>     command_test.go:92:
>         	Error Trace:	/Users/alan/workspace/teleport/lib/web/command_test.go:92
>         	Error:      	Received unexpected error:
>         	            	unexpected end of JSON input
>         	Test:       	TestExecuteCommandHistory
```

While debugging I noticed that the 100 bytes buffer in `waitForCommandOutput` is too small, so instead of increasing the buffer I removed it altogether.