### PR TITLE
[v13] fix: Ignore staticcheck false positive on darwin

### DIFF
--- a/lib/devicetrust/native/api.go
+++ b/lib/devicetrust/native/api.go
@@ -57,7 +57,9 @@ func SolveTPMAuthnDeviceChallenge(challenge *devicepb.TPMAuthenticateDeviceChall
 // HandleTPMActivateCredential completes the credential activation part of an
 // enrollment challenge. This is usually called in an elevated process that's
 // created by SolveTPMEnrollChallenge.
-func HandleTPMActivateCredential(encryptedCredential string, encryptedCredentialSecret string) error {
+//
+//nolint:staticcheck // HandleTPMActivateCredential works depending on the platform.
+func HandleTPMActivateCredential(encryptedCredential, encryptedCredentialSecret string) error {
 	return handleTPMActivateCredential(encryptedCredential, encryptedCredentialSecret)
 }
 

--- a/tool/tsh/device.go
+++ b/tool/tsh/device.go
@@ -166,9 +166,11 @@ type deviceActivateCredentialCommand struct {
 }
 
 func (c *deviceActivateCredentialCommand) run(cf *CLIConf) error {
+	//nolint:staticcheck // HandleTPMActivateCredential works depending on the platform.
 	err := dtnative.HandleTPMActivateCredential(
 		c.encryptedCredential, c.encryptedCredentialSecret,
 	)
+	//nolint:staticcheck // `err` can indeed be nil.
 	if cf.Debug && err != nil {
 		// On error, wait for user input before executing. This is because this
 		// opens in a second window. If we return the error immediately, then


### PR DESCRIPTION
Backport #28038 to branch/v13

`staticcheck` is too clever for its own good and thinks that
`HandleTPMActivateCredential` only ever returns non-nil. While this is true for
darwin, it ain't true in other platforms.

Before the fix (on darwin):

```sh
$ golangci-lint run --fast ./tool/tsh/common ./lib/devicetrust/native
tool/tsh/common/device.go:172:17: SA4023: this comparison is always true (staticcheck)
	if cf.Debug && err != nil {
	               ^
tool/tsh/common/device.go:169:2: SA4023(related information): the lhs of the comparison is the 1st return value of this function call (staticcheck)
	err := dtnative.HandleTPMActivateCredential(
	^
lib/devicetrust/native/api.go:60:1: SA4023(related information): github.com/gravitational/teleport/lib/devicetrust/native.HandleTPMActivateCredential never returns a nil interface value (staticcheck)
func HandleTPMActivateCredential(encryptedCredential string, encryptedCredentialSecret string) error {
^
```