### PR TITLE
Correct the backend_requests metric help text

### DIFF
--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -15,7 +15,7 @@
 | `backend_batch_write_seconds`                            | histogram | cache               | Latency for backend batch write operations.                                                        |
 | `backend_read_requests_total`                            | counter   | cache               | Number of read requests to the backend.                                                            |
 | `backend_read_seconds`                                   | histogram | cache               | Latency for read operations.                                                                       |
-| `backend_requests`                                       | counter   | cache               | Number of write requests to the backend.                                                           |
+| `backend_requests`                                       | counter   | cache               | Number of requests to the backend (reads, writes, and keepalives).                                                           |
 | `backend_write_seconds`                                  | histogram | cache               | Latency for backend write operations.                                                              |
 | `cluster_name_not_found_total`                           | counter   | Teleport Auth       | Number of times a cluster was not found.                                                           |
 | `dynamo_requests_total`                                  | counter   | DynamoDB            | Total number of requests to the DynamoDB API.                                                      |

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -442,7 +442,7 @@ var (
 	requests = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: teleport.MetricBackendRequests,
-			Help: "Number of write requests to the backend",
+			Help: "Number of requests to the backend (reads, writes, and keepalives)",
 		},
 		[]string{teleport.ComponentLabel, teleport.TagReq, teleport.TagRange},
 	)


### PR DESCRIPTION
Closes #9865

Teleport increments this metric whenever there is a request to the backend, not just when there is a write request (see lib/backend/report.go for all the times we call `trackRequest()` to increment this metric). This change updates the metric help text and documentation.