### PR TITLE
[Docs] Add IdP-initiated SSO instructions to Grafana SAML guide 

### DIFF
--- a/docs/pages/access-controls/idps/saml-grafana.mdx
+++ b/docs/pages/access-controls/idps/saml-grafana.mdx
@@ -66,6 +66,8 @@ From the Grafana host, edit `grafana.ini` by adding a `[auth.saml]` section:
 [auth.saml]
 enabled = true
 auto_login = false
+allow_idp_initiated = true
+relay_state = ""
 private_key_path = '/path/to/certs/grafana-host-key.pem'
 certificate_path = '/path/to/certs/grafana-host.pem'
 idp_metadata = 'PEVudGl0eURl.....'
@@ -75,14 +77,16 @@ assertion_attribute_email = uid
 assertion_attribute_groups = eduPersonAffiliation
 ```
 
-| Key                | Value                                                          |
-|--------------------|----------------------------------------------------------------|
-| `enabled`          | Set to `true` to enable SAML authentication.                   |
-| `auto_login`       | When set to `true`, enables auto-login using SAML.             |
-| `private_key_path` | Path to the TLS key used to identify Grafana.                  |
-| `certificate_path` | Path to the TLS certificate used to identify Grafana.          |
-| `idp_metadata`     | The base64-encoded contents of the Teleport metadata XML file. |
-| `assertion_*`      | Various Grafana user fields to be mapped to SAML assertions.   |
+| Key                   | Value                                                                                 |
+|-----------------------|---------------------------------------------------------------------------------------|
+| `enabled`             | Set to `true` to enable SAML authentication.                                          |
+| `auto_login`          | When set to `true`, enables auto-login using SAML.                                    |
+| `allow_idp_initiated` | Set to `true` to allow IdP-initiated login.                                           |
+| `relay_state`         | Relay state for IdP-initiated login. Must be set to `""` to work with Teleport's IdP. |
+| `private_key_path`    | Path to the TLS key used to identify Grafana.                                         |
+| `certificate_path`    | Path to the TLS certificate used to identify Grafana.                                 |
+| `idp_metadata`        | The base64-encoded contents of the Teleport metadata XML file.                        |
+| `assertion_*`         | Various Grafana user fields to be mapped to SAML assertions.                          |
 
 For more information on editing `grafana.ini` for SAML, you can review their [Configure
 SAML authentication in Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/)


### PR DESCRIPTION
## Purpose

Adds documentation for getting SAML IdP-intiated SSO working with Grafana.

Our current guide for setting up Teleport as SAML IdP for Grafana is missing instructions for how to get IdP-initiated SSO working. Particularly, the fact that the `relay_state` in `grafana.ini` has to be set to `""` for it to work (since it's currently hardcoded to be blank on the Teleport side). This currently isn't documented anywhere in our docs and attempting to log into Grafana via IdP-initiated SSO without it will fail with the following error:

<img width="355" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/0b157d1c-1e5c-4ba3-9e4b-fb1aeb823f5c">


## Demo

<img width="500" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/0c689856-b936-4447-8ac6-616ac52425a8">

