### PR TITLE
Connect My Computer: Add a setup document and an icon in the top bar

### DIFF
--- a/web/packages/teleterm/src/ui/DocumentConnectMyComputer/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentConnectMyComputer/DocumentConnectMyComputerSetup.story.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { DocumentConnectMyComputerSetup } from './DocumentConnectMyComputerSetup';
 
 export default {
-  title: 'Teleterm/DocumentConnectMyComputerSetup',
+  title: 'Teleterm/ConnectMyComputer/DocumentConnectMyComputerSetup',
 };
 
 export function Default() {

--- a/web/packages/teleterm/src/ui/DocumentConnectMyComputer/DocumentConnectMyComputerSetup.story.tsx
+++ b/web/packages/teleterm/src/ui/DocumentConnectMyComputer/DocumentConnectMyComputerSetup.story.tsx
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+
+import { DocumentConnectMyComputerSetup } from './DocumentConnectMyComputerSetup';
+
+export default {
+  title: 'Teleterm/DocumentConnectMyComputerSetup',
+};
+
+export function Default() {
+  return <DocumentConnectMyComputerSetup visible={true} doc={undefined} />;
+}

--- a/web/packages/teleterm/src/ui/DocumentConnectMyComputer/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/DocumentConnectMyComputer/DocumentConnectMyComputerSetup.tsx
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import React, { useState } from 'react';
+import { Box, ButtonPrimary, Text } from 'design';
+
+import * as types from 'teleterm/ui/services/workspacesService';
+import Document from 'teleterm/ui/Document';
+
+interface DocumentConnectMyComputerSetupProps {
+  visible: boolean;
+  doc: types.DocumentConnectMyComputerSetup;
+}
+
+export function DocumentConnectMyComputerSetup(
+  props: DocumentConnectMyComputerSetupProps
+) {
+  const [step, setStep] =
+    useState<'information' | 'agent-setup'>('information');
+
+  return (
+    <Document visible={props.visible}>
+      <Box maxWidth="590px" mx="auto" mt="4" px="5" width="100%">
+        <Text typography="h3" mb="4">
+          Connect My Computer
+        </Text>
+        {step === 'information' && (
+          <Information onSetUpAgentClick={() => setStep('agent-setup')} />
+        )}
+        {step === 'agent-setup' && <AgentSetup />}
+      </Box>
+    </Document>
+  );
+}
+
+function Information(props: { onSetUpAgentClick(): void }) {
+  return (
+    <>
+      {/* TODO(gzdunek): change the temporary copy */}
+      <Text>
+        The setup process will download the teleport agent and configure it to
+        make your computer available in the <strong>acme.teleport.sh</strong>{' '}
+        cluster.
+        <br />
+        All cluster users with the role{' '}
+        <strong>connect-my-computer-robert@acme.com</strong> will be able to
+        access your computer as <strong>bob</strong>.
+        <br />
+        You can stop computer sharing at any time from Connect My Computer menu.
+      </Text>
+      <ButtonPrimary
+        mt={4}
+        mx="auto"
+        css={`
+          display: block;
+        `}
+        onClick={props.onSetUpAgentClick}
+      >
+        Set up agent
+      </ButtonPrimary>
+    </>
+  );
+}
+
+function AgentSetup() {
+  const steps = [
+    'Setting up roles',
+    'Downloading the agent',
+    'Generating the config file',
+    'Joining the cluster',
+  ];
+
+  return (
+    <ol
+      css={`
+        padding-left: 0;
+        list-style: inside decimal;
+      `}
+    >
+      {steps.map(step => (
+        <li key={step}>{step}</li>
+      ))}
+    </ol>
+  );
+}

--- a/web/packages/teleterm/src/ui/DocumentConnectMyComputer/index.ts
+++ b/web/packages/teleterm/src/ui/DocumentConnectMyComputer/index.ts
@@ -1,0 +1,17 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export * from './DocumentConnectMyComputerSetup';

--- a/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
+++ b/web/packages/teleterm/src/ui/Documents/DocumentsRenderer.tsx
@@ -32,6 +32,7 @@ import {
 import DocumentCluster from 'teleterm/ui/DocumentCluster';
 import DocumentGateway from 'teleterm/ui/DocumentGateway';
 import { DocumentTerminal } from 'teleterm/ui/DocumentTerminal';
+import { DocumentConnectMyComputerSetup } from 'teleterm/ui/DocumentConnectMyComputer';
 
 import Document from 'teleterm/ui/Document';
 import { RootClusterUri } from 'teleterm/ui/uri';
@@ -106,6 +107,8 @@ function MemoizedDocument(props: { doc: types.Document; visible: boolean }) {
         return <DocumentTerminal doc={doc} visible={visible} />;
       case 'doc.access_requests':
         return <DocumentAccessRequests doc={doc} visible={visible} />;
+      case 'doc.connect_my_computer_setup':
+        return <DocumentConnectMyComputerSetup doc={doc} visible={visible} />;
       default:
         return (
           <Document visible={visible}>

--- a/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputer.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputer.tsx
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useCallback, useRef, useState } from 'react';
+import Popover from 'design/Popover';
+import styled from 'styled-components';
+import { Box } from 'design';
+
+import { useAppContext } from 'teleterm/ui/appContextProvider';
+import { ListItem } from 'teleterm/ui/components/ListItem';
+
+import { ConnectMyComputerIcon } from './ConnectMyComputerIcon';
+
+export function ConnectMyComputer() {
+  const iconRef = useRef();
+  const [isPopoverOpened, setIsPopoverOpened] = useState(false);
+  const appCtx = useAppContext();
+
+  const togglePopover = useCallback(() => {
+    setIsPopoverOpened(wasOpened => !wasOpened);
+  }, []);
+
+  function openSetupDocument(): void {
+    const documentService =
+      appCtx.workspacesService.getActiveWorkspaceDocumentService();
+    const clusterUri = appCtx.workspacesService.getRootClusterUri();
+    const document = documentService.createConnectMyComputerSetupDocument({
+      clusterUri,
+    });
+    documentService.add(document);
+    documentService.open(document.uri);
+    setIsPopoverOpened(false);
+  }
+
+  return (
+    <>
+      <ConnectMyComputerIcon onClick={togglePopover} ref={iconRef} />
+      <Popover
+        open={isPopoverOpened}
+        anchorEl={iconRef.current}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'left',
+        }}
+        onClose={() => setIsPopoverOpened(false)}
+      >
+        <Container width="200px">
+          <ListItem onClick={openSetupDocument}>Set up agent</ListItem>
+        </Container>
+      </Popover>
+    </>
+  );
+}
+
+const Container = styled(Box)`
+  background: ${props => props.theme.colors.levels.elevated};
+`;

--- a/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputer.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputer.tsx
@@ -36,9 +36,9 @@ export function ConnectMyComputer() {
   function openSetupDocument(): void {
     const documentService =
       appCtx.workspacesService.getActiveWorkspaceDocumentService();
-    const clusterUri = appCtx.workspacesService.getRootClusterUri();
+    const rootClusterUri = appCtx.workspacesService.getRootClusterUri();
     const document = documentService.createConnectMyComputerSetupDocument({
-      clusterUri,
+      rootClusterUri,
     });
     documentService.add(document);
     documentService.open(document.uri);

--- a/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputerIcon.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputerIcon.tsx
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { forwardRef } from 'react';
+import styled from 'styled-components';
+import { Wand } from 'design/Icon';
+import { Button } from 'design';
+
+interface ConnectMyComputerIconProps {
+  onClick(): void;
+}
+
+export const ConnectMyComputerIcon = forwardRef<
+  HTMLDivElement,
+  ConnectMyComputerIconProps
+>((props, ref) => {
+  return (
+    <Container ref={ref}>
+      <StyledButton
+        onClick={props.onClick}
+        kind="secondary"
+        size="small"
+        m="auto"
+        title="Open Connect My Computer"
+      >
+        <Wand fontSize={16} />
+      </StyledButton>
+    </Container>
+  );
+});
+
+const Container = styled.div`
+  position: relative;
+  display: inline-block;
+`;
+
+const StyledButton = styled(Button)`
+  background: ${props => props.theme.colors.spotBackground[0]};
+  padding: 9px;
+  width: 30px;
+  height: 30px;
+`;

--- a/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputerIcon.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/ConnectMyComputerIcon.tsx
@@ -28,28 +28,22 @@ export const ConnectMyComputerIcon = forwardRef<
   ConnectMyComputerIconProps
 >((props, ref) => {
   return (
-    <Container ref={ref}>
-      <StyledButton
-        onClick={props.onClick}
-        kind="secondary"
-        size="small"
-        m="auto"
-        title="Open Connect My Computer"
-      >
-        <Wand fontSize={16} />
-      </StyledButton>
-    </Container>
+    <StyledButton
+      setRef={ref}
+      onClick={props.onClick}
+      kind="secondary"
+      size="small"
+      m="auto"
+      title="Open Connect My Computer"
+    >
+      <Wand fontSize={16} />
+    </StyledButton>
   );
 });
 
-const Container = styled.div`
-  position: relative;
-  display: inline-block;
-`;
-
 const StyledButton = styled(Button)`
   background: ${props => props.theme.colors.spotBackground[0]};
-  padding: 9px;
-  width: 30px;
-  height: 30px;
+  padding: 0;
+  width: ${props => props.theme.space[5]}px;
+  height: ${props => props.theme.space[5]}px;
 `;

--- a/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/index.ts
+++ b/web/packages/teleterm/src/ui/TopBar/ConnectMyComputer/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { ConnectMyComputer } from './ConnectMyComputer';

--- a/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/Connections/ConnectionsIcon/ConnectionsIcon.tsx
@@ -58,7 +58,7 @@ const Container = styled.div`
 
 const StyledButton = styled(Button)`
   background: ${props => props.theme.colors.spotBackground[0]};
-  padding: 9px;
-  width: 30px;
-  height: 30px;
+  padding: 0;
+  width: ${props => props.theme.space[5]}px;
+  height: ${props => props.theme.space[5]}px;
 `;

--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -24,12 +24,14 @@ import { Connections } from './Connections';
 import { Clusters } from './Clusters';
 import { Identity } from './Identity';
 import { AdditionalActions } from './AdditionalActions';
+import { ConnectMyComputer } from './ConnectMyComputer';
 
 export function TopBar() {
   return (
     <Grid>
       <JustifyLeft>
         <Connections />
+        <ConnectMyComputer />
       </JustifyLeft>
       <CentralContainer>
         <Clusters />
@@ -64,6 +66,7 @@ const JustifyLeft = styled.div`
   justify-self: start;
   align-items: center;
   height: 100%;
+  gap: 16px;
 `;
 
 const JustifyRight = styled.div`

--- a/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
+++ b/web/packages/teleterm/src/ui/TopBar/TopBar.tsx
@@ -61,12 +61,9 @@ const CentralContainer = styled(Flex).attrs({ gap: 3 })`
   max-width: calc(${props => props.theme.space[10]}px * 9);
 `;
 
-const JustifyLeft = styled.div`
-  display: flex;
-  justify-self: start;
+const JustifyLeft = styled(Flex).attrs({ gap: 3 })`
   align-items: center;
   height: 100%;
-  gap: 16px;
 `;
 
 const JustifyRight = styled.div`

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -42,10 +42,7 @@ import {
 
 export class DocumentsService {
   constructor(
-    private getState: () => {
-      documents: Document[];
-      location: string;
-    },
+    private getState: () => { documents: Document[]; location: string },
     private setState: (
       draftState: (draft: { documents: Document[]; location: string }) => void
     ) => void
@@ -114,9 +111,7 @@ export class DocumentsService {
 
   createTshNodeDocument(
     serverUri: ServerUri,
-    params: {
-      origin: DocumentOrigin;
-    }
+    params: { origin: DocumentOrigin }
   ): DocumentTshNodeWithServerId {
     const { params: routingParams } = routing.parseServerUri(serverUri);
     const uri = routing.getDocUri({ docId: unique() });

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -20,11 +20,13 @@ import { DocumentUri, ServerUri, paths, routing } from 'teleterm/ui/uri';
 import {
   CreateAccessRequestDocumentOpts,
   CreateClusterDocumentOpts,
+  CreateConnectMyComputerSetupDocumentOpts,
   CreateGatewayDocumentOpts,
   CreateTshKubeDocumentOptions,
   Document,
   DocumentAccessRequests,
   DocumentCluster,
+  DocumentConnectMyComputerSetup,
   DocumentGateway,
   DocumentGatewayCliClient,
   DocumentOrigin,
@@ -178,6 +180,18 @@ export class DocumentsService {
       targetUser,
       targetName,
       targetProtocol,
+    };
+  }
+
+  createConnectMyComputerSetupDocument(
+    opts: CreateConnectMyComputerSetupDocumentOpts
+  ): DocumentConnectMyComputerSetup {
+    const uri = routing.getDocUri({ docId: unique() });
+    return {
+      uri,
+      kind: 'doc.connect_my_computer_setup',
+      title: 'Connect My Computer',
+      clusterUri: opts.clusterUri,
     };
   }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsService.ts
@@ -15,12 +15,17 @@ limitations under the License.
 */
 
 import { unique } from 'teleterm/ui/utils/uid';
-import { DocumentUri, ServerUri, paths, routing } from 'teleterm/ui/uri';
+import {
+  DocumentUri,
+  ServerUri,
+  paths,
+  routing,
+  RootClusterUri,
+} from 'teleterm/ui/uri';
 
 import {
   CreateAccessRequestDocumentOpts,
   CreateClusterDocumentOpts,
-  CreateConnectMyComputerSetupDocumentOpts,
   CreateGatewayDocumentOpts,
   CreateTshKubeDocumentOptions,
   Document,
@@ -37,7 +42,10 @@ import {
 
 export class DocumentsService {
   constructor(
-    private getState: () => { documents: Document[]; location: string },
+    private getState: () => {
+      documents: Document[];
+      location: string;
+    },
     private setState: (
       draftState: (draft: { documents: Document[]; location: string }) => void
     ) => void
@@ -106,7 +114,9 @@ export class DocumentsService {
 
   createTshNodeDocument(
     serverUri: ServerUri,
-    params: { origin: DocumentOrigin }
+    params: {
+      origin: DocumentOrigin;
+    }
   ): DocumentTshNodeWithServerId {
     const { params: routingParams } = routing.parseServerUri(serverUri);
     const uri = routing.getDocUri({ docId: unique() });
@@ -183,15 +193,18 @@ export class DocumentsService {
     };
   }
 
-  createConnectMyComputerSetupDocument(
-    opts: CreateConnectMyComputerSetupDocumentOpts
-  ): DocumentConnectMyComputerSetup {
+  createConnectMyComputerSetupDocument(opts: {
+    // URI of the root cluster could be passed to the `DocumentsService`
+    // constructor and then to the document, instead of being taken from the parameter.
+    // However, we decided not to do so because other documents are based only on the provided parameters.
+    rootClusterUri: RootClusterUri;
+  }): DocumentConnectMyComputerSetup {
     const uri = routing.getDocUri({ docId: unique() });
     return {
       uri,
       kind: 'doc.connect_my_computer_setup',
       title: 'Connect My Computer',
-      clusterUri: opts.clusterUri,
+      rootClusterUri: opts.rootClusterUri,
     };
   }
 
@@ -277,7 +290,10 @@ export class DocumentsService {
 
   isActive(uri: string) {
     const location = this.getLocation();
-    return !!routing.parseUri(location, { exact: true, path: uri });
+    return !!routing.parseUri(location, {
+      exact: true,
+      path: uri,
+    });
   }
 
   add(doc: Document, position?: number) {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -50,7 +50,7 @@ export function getResourceUri(
         leafClusterId: document.leafClusterId,
       });
     case 'doc.connect_my_computer_setup':
-      return document.clusterUri;
+      return document.rootClusterUri;
     case 'doc.blank':
       return undefined;
     default:

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/documentsUtils.ts
@@ -49,6 +49,8 @@ export function getResourceUri(
         rootClusterId: document.rootClusterId,
         leafClusterId: document.leafClusterId,
       });
+    case 'doc.connect_my_computer_setup':
+      return document.clusterUri;
     case 'doc.blank':
       return undefined;
     default:

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -154,7 +154,10 @@ export interface DocumentPtySession extends DocumentBase {
 
 export interface DocumentConnectMyComputerSetup extends DocumentBase {
   kind: 'doc.connect_my_computer_setup';
-  clusterUri: uri.ClusterUri;
+  // `DocumentConnectMyComputerSetup` always operates on the root cluster, so in theory `rootClusterUri` is not needed.
+  // However, there are a few components in the system, such as `getResourceUri`, which need to determine the relation
+  // between a document and a cluster just by looking at the document fields.
+  rootClusterUri: uri.RootClusterUri;
 }
 
 export type DocumentTerminal =
@@ -200,10 +203,6 @@ export type CreateGatewayDocumentOpts = {
 
 export type CreateClusterDocumentOpts = {
   clusterUri: uri.ClusterUri;
-};
-
-export type CreateConnectMyComputerSetupDocumentOpts = {
-  clusterUri: uri.RootClusterUri;
 };
 
 export type CreateTshKubeDocumentOptions = {

--- a/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/documentsService/types.ts
@@ -152,6 +152,11 @@ export interface DocumentPtySession extends DocumentBase {
   leafClusterId?: string;
 }
 
+export interface DocumentConnectMyComputerSetup extends DocumentBase {
+  kind: 'doc.connect_my_computer_setup';
+  clusterUri: uri.ClusterUri;
+}
+
 export type DocumentTerminal =
   | DocumentPtySession
   | DocumentGatewayCliClient
@@ -163,7 +168,8 @@ export type Document =
   | DocumentBlank
   | DocumentGateway
   | DocumentCluster
-  | DocumentTerminal;
+  | DocumentTerminal
+  | DocumentConnectMyComputerSetup;
 
 export function isDocumentTshNodeWithLoginHost(
   doc: Document
@@ -194,6 +200,10 @@ export type CreateGatewayDocumentOpts = {
 
 export type CreateClusterDocumentOpts = {
   clusterUri: uri.ClusterUri;
+};
+
+export type CreateConnectMyComputerSetupDocumentOpts = {
+  clusterUri: uri.RootClusterUri;
 };
 
 export type CreateTshKubeDocumentOptions = {


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/27881 

Changelog: Add Connect My Computer to Teleport Connect for Team plan users

Foundation (WIP CTA + new document)

The PR adds a new icon to the top bar (CTA) that opens the Connect My Computer setup document. In the document, users can read a general copy explaining what will happen when they click "Set up agent". Clicking it starts the process. For now, I just added a view that shows the steps that the setup process will perform. The actual implementation for them will be added in the upcoming PRs.