### PR TITLE
feat: add support for label expressions to k8s operator

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
@@ -41,6 +41,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -61,12 +65,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -87,6 +99,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -114,6 +130,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -196,6 +216,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -232,6 +256,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -439,6 +467,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -457,6 +489,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -477,12 +513,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -503,6 +547,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -530,6 +578,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -612,6 +664,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -648,6 +704,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -855,6 +915,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -1018,7 +1082,7 @@ spec:
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
-                      users what they aught to
+                      users what they aught to request.
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
@@ -1143,6 +1207,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -1163,12 +1231,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -1189,6 +1265,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -1216,6 +1296,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -1298,6 +1382,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -1334,6 +1422,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -1541,6 +1633,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -1559,6 +1655,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -1579,12 +1679,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -1605,6 +1713,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -1632,6 +1744,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -1714,6 +1830,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -1750,6 +1870,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -1957,6 +2081,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -2120,7 +2248,7 @@ spec:
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
-                      users what they aught to
+                      users what they aught to request.
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -41,6 +41,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -61,12 +65,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -87,6 +99,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -114,6 +130,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -196,6 +216,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -232,6 +256,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -439,6 +467,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -457,6 +489,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -477,12 +513,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -503,6 +547,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -530,6 +578,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -612,6 +664,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -648,6 +704,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -855,6 +915,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -1018,7 +1082,7 @@ spec:
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
-                      users what they aught to
+                      users what they aught to request.
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced
@@ -1143,6 +1207,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -1163,12 +1231,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -1189,6 +1265,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -1216,6 +1296,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -1298,6 +1382,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -1334,6 +1422,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -1541,6 +1633,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -1559,6 +1655,10 @@ spec:
                     description: AppLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  app_labels_expression:
+                    description: AppLabelsExpression is a predicate expression used
+                      to allow/deny access to Apps.
+                    type: string
                   aws_role_arns:
                     description: AWSRoleARNs is a list of AWS role ARNs this role
                       is allowed to assume.
@@ -1579,12 +1679,20 @@ spec:
                     description: ClusterLabels is a map of node labels (used to dynamically
                       grant access to clusters).
                     type: object
+                  cluster_labels_expression:
+                    description: ClusterLabelsExpression is a predicate expression
+                      used to allow/deny access to remote Teleport clusters.
+                    type: string
                   db_labels:
                     additionalProperties:
                       x-kubernetes-preserve-unknown-fields: true
                     description: DatabaseLabels are used in RBAC system to allow/deny
                       access to databases.
                     type: object
+                  db_labels_expression:
+                    description: DatabaseLabelsExpression is a predicate expression
+                      used to allow/deny access to Databases.
+                    type: string
                   db_names:
                     description: DatabaseNames is a list of database names this role
                       is allowed to connect to.
@@ -1605,6 +1713,10 @@ spec:
                     description: DatabaseServiceLabels are used in RBAC system to
                       allow/deny access to Database Services.
                     type: object
+                  db_service_labels_expression:
+                    description: DatabaseServiceLabelsExpression is a predicate expression
+                      used to allow/deny access to Database Services.
+                    type: string
                   db_users:
                     description: DatabaseUsers is a list of databases users this role
                       is allowed to connect as.
@@ -1632,6 +1744,10 @@ spec:
                     description: GroupLabels is a map of labels used as part of the
                       RBAC system.
                     type: object
+                  group_labels_expression:
+                    description: GroupLabelsExpression is a predicate expression used
+                      to allow/deny access to user groups.
+                    type: string
                   host_groups:
                     description: HostGroups is a list of groups for created users
                       to be added to
@@ -1714,6 +1830,10 @@ spec:
                     description: KubernetesLabels is a map of kubernetes cluster labels
                       used for RBAC.
                     type: object
+                  kubernetes_labels_expression:
+                    description: KubernetesLabelsExpression is a predicate expression
+                      used to allow/deny access to kubernetes clusters.
+                    type: string
                   kubernetes_resources:
                     description: KubernetesResources is the Kubernetes Resources this
                       Role grants access to.
@@ -1750,6 +1870,10 @@ spec:
                     description: NodeLabels is a map of node labels (used to dynamically
                       grant access to nodes).
                     type: object
+                  node_labels_expression:
+                    description: NodeLabelsExpression is a predicate expression used
+                      to allow/deny access to SSH nodes.
+                    type: string
                   request:
                     nullable: true
                     properties:
@@ -1957,6 +2081,10 @@ spec:
                     description: WindowsDesktopLabels are used in the RBAC system
                       to allow/deny access to Windows desktops.
                     type: object
+                  windows_desktop_labels_expression:
+                    description: WindowsDesktopLabelsExpression is a predicate expression
+                      used to allow/deny access to Windows desktops.
+                    type: string
                   windows_desktop_logins:
                     description: WindowsDesktopLogins is a list of desktop login names
                       allowed/denied for Windows desktops.
@@ -2120,7 +2248,7 @@ spec:
                     type: string
                   request_prompt:
                     description: RequestPrompt is an optional message which tells
-                      users what they aught to
+                      users what they aught to request.
                     type: string
                   require_session_mfa:
                     description: RequireMFAType is the type of MFA requirement enforced


### PR DESCRIPTION
This is the result of running `make manifests` in integrations/operator to update the CRDs with the latest role spec definition, which includes label expressions.