### PR TITLE
Add associated applications and user groups to UI objects.

### DIFF
--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -48,7 +48,7 @@ type App struct {
 	// FriendlyName is a friendly name for the app.
 	FriendlyName string `json:"friendlyName,omitempty"`
 	// UserGroups is a list of associated user groups.
-	UserGroups []UserGroupAndDescription `json:"user_groups,omitempty"`
+	UserGroups []UserGroupAndDescription `json:"userGroups,omitempty"`
 }
 
 // UserGroupAndDescription is a user group name and its description.

--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -48,7 +48,15 @@ type App struct {
 	// FriendlyName is a friendly name for the app.
 	FriendlyName string `json:"friendlyName,omitempty"`
 	// UserGroups is a list of associated user groups.
-	UserGroups []string `json:"user_groups,omitempty"`
+	UserGroups []UserGroupAndDescription `json:"user_groups,omitempty"`
+}
+
+// UserGroupAndDescription is a user group name and its description.
+type UserGroupAndDescription struct {
+	// Name is the name of the user group.
+	Name string `json:"name"`
+	// Description is the description of the user group.
+	Description string `json:"description"`
 }
 
 // MakeAppsConfig contains parameters for converting apps to UI representation.
@@ -61,6 +69,8 @@ type MakeAppsConfig struct {
 	AppClusterName string
 	// Apps is a list of registered apps.
 	Apps types.Apps
+	// AppsToUserGroups is a mapping of application names to user groups.
+	AppsToUserGroups map[string]types.UserGroups
 	// Identity is identity of the logged in user.
 	Identity *tlsca.Identity
 }
@@ -72,6 +82,16 @@ func MakeApps(c MakeAppsConfig) []App {
 		fqdn := AssembleAppFQDN(c.LocalClusterName, c.LocalProxyDNSName, c.AppClusterName, teleApp)
 		labels := makeLabels(teleApp.GetAllLabels())
 
+		userGroups := c.AppsToUserGroups[teleApp.GetName()]
+
+		userGroupAndDescriptions := make([]UserGroupAndDescription, len(userGroups))
+		for i, userGroup := range userGroups {
+			userGroupAndDescriptions[i] = UserGroupAndDescription{
+				Name:        userGroup.GetName(),
+				Description: userGroup.GetMetadata().Description,
+			}
+		}
+
 		app := App{
 			Name:         teleApp.GetName(),
 			Description:  teleApp.GetDescription(),
@@ -82,7 +102,7 @@ func MakeApps(c MakeAppsConfig) []App {
 			FQDN:         fqdn,
 			AWSConsole:   teleApp.IsAWSConsole(),
 			FriendlyName: services.FriendlyName(teleApp),
-			UserGroups:   teleApp.GetUserGroups(),
+			UserGroups:   userGroupAndDescriptions,
 		}
 
 		if teleApp.IsAWSConsole() {

--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -47,6 +47,8 @@ type App struct {
 	AWSRoles []aws.Role `json:"awsRoles,omitempty"`
 	// FriendlyName is a friendly name for the app.
 	FriendlyName string `json:"friendlyName,omitempty"`
+	// UserGroups is a list of associated user groups.
+	UserGroups []string `json:"user_groups,omitempty"`
 }
 
 // MakeAppsConfig contains parameters for converting apps to UI representation.
@@ -80,6 +82,7 @@ func MakeApps(c MakeAppsConfig) []App {
 			FQDN:         fqdn,
 			AWSConsole:   teleApp.IsAWSConsole(),
 			FriendlyName: services.FriendlyName(teleApp),
+			UserGroups:   teleApp.GetUserGroups(),
 		}
 
 		if teleApp.IsAWSConsole() {

--- a/lib/web/ui/user_groups.go
+++ b/lib/web/ui/user_groups.go
@@ -31,6 +31,8 @@ type UserGroup struct {
 	Labels []Label `json:"labels"`
 	// FriendlyName is a friendly name for the user group.
 	FriendlyName string `json:"friendlyName,omitempty"`
+	// Applications is a list of associated applications.
+	Applications []string `json:"applications,omitempty"`
 }
 
 // MakeUserGroups creates user group objects for the UI.
@@ -44,6 +46,7 @@ func MakeUserGroups(clusterName string, userGroups []types.UserGroup, userRoles 
 			Description:  userGroup.GetMetadata().Description,
 			Labels:       uiLabels,
 			FriendlyName: services.FriendlyName(userGroup),
+			Applications: userGroup.GetApplications(),
 		})
 	}
 

--- a/lib/web/ui/user_groups_test.go
+++ b/lib/web/ui/user_groups_test.go
@@ -20,8 +20,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func TestMakeUserGroups(t *testing.T) {

--- a/lib/web/ui/user_groups_test.go
+++ b/lib/web/ui/user_groups_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ui
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeUserGroups(t *testing.T) {
+	tests := []struct {
+		name             string
+		userGroups       types.UserGroups
+		userGroupsToApps map[string]types.Apps
+		expected         []UserGroup
+	}{
+		{
+			name:     "empty",
+			expected: []UserGroup{},
+		},
+		{
+			name: "user groups with no apps",
+			userGroups: types.UserGroups{
+				newGroup(t, "group1", "group1 desc", map[string]string{"label1": "value1"}),
+				newGroup(t, "group2", "group2 desc", map[string]string{"label2": "value2", types.OriginLabel: types.OriginOkta}),
+			},
+			expected: []UserGroup{
+				{
+					Name:         "group1",
+					Description:  "group1 desc",
+					Labels:       []Label{{Name: "label1", Value: "value1"}},
+					Applications: []ApplicationAndFriendlyName{},
+				},
+				{
+					Name:         "group2",
+					Description:  "group2 desc",
+					FriendlyName: "group2 desc",
+					Labels: []Label{
+						{Name: "label2", Value: "value2"},
+						{Name: types.OriginLabel, Value: types.OriginOkta},
+					},
+					Applications: []ApplicationAndFriendlyName{},
+				},
+			},
+		},
+		{
+			name: "user groups with apps",
+			userGroups: types.UserGroups{
+				newGroup(t, "group1", "group1 desc", map[string]string{"label1": "value1"}),
+				newGroup(t, "group2", "group2 desc", map[string]string{"label2": "value2", types.OriginLabel: types.OriginOkta}),
+			},
+			userGroupsToApps: map[string]types.Apps{
+				"group1": {
+					newApp(t, "1", "1.com", "1 desc", nil),
+					newApp(t, "2", "2.com", "2 desc", map[string]string{types.OriginLabel: types.OriginOkta}),
+				},
+				"group2": {
+					newApp(t, "2", "2.com", "2 desc", map[string]string{types.OriginLabel: types.OriginOkta}),
+					newApp(t, "3", "3.com", "3 desc", nil),
+				},
+				// This should be ignored
+				"group3": {
+					newApp(t, "3", "3.com", "3 desc", nil),
+				},
+			},
+			expected: []UserGroup{
+				{
+					Name:        "group1",
+					Description: "group1 desc",
+					Labels:      []Label{{Name: "label1", Value: "value1"}},
+					Applications: []ApplicationAndFriendlyName{
+						{Name: "1"},
+						{Name: "2", FriendlyName: "2 desc"},
+					},
+				},
+				{
+					Name:         "group2",
+					Description:  "group2 desc",
+					FriendlyName: "group2 desc",
+					Labels: []Label{
+						{Name: "label2", Value: "value2"},
+						{Name: types.OriginLabel, Value: types.OriginOkta},
+					},
+					Applications: []ApplicationAndFriendlyName{
+						{Name: "2", FriendlyName: "2 desc"},
+						{Name: "3"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			userGroups, err := MakeUserGroups(test.userGroups, test.userGroupsToApps)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(test.expected, userGroups))
+		})
+	}
+}
+
+func newGroup(t *testing.T, name, description string, labels map[string]string) types.UserGroup {
+	userGroup, err := types.NewUserGroup(types.Metadata{
+		Name:        name,
+		Description: description,
+		Labels:      labels,
+	}, types.UserGroupSpecV1{})
+	require.NoError(t, err)
+	return userGroup
+}

--- a/lib/web/user_groups.go
+++ b/lib/web/user_groups.go
@@ -27,6 +27,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 
 	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnel"
@@ -51,9 +52,13 @@ func (h *Handler) getUserGroups(_ http.ResponseWriter, r *http.Request, params h
 		return nil, trace.Wrap(err)
 	}
 
-	appServers, err := clt.GetApplicationServers(r.Context(), apidefaults.Namespace)
+	appServers, err := apiclient.GetAllResources[types.AppServer](r.Context(), clt, &proto.ListResourcesRequest{
+		ResourceType:     types.KindAppServer,
+		Namespace:        apidefaults.Namespace,
+		UseSearchAsRoles: true,
+	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		h.log.Debugf("Unable to fetch applications while listing user groups, unable to display associated applications: %v", err)
 	}
 
 	appServerLookup := make(map[string]types.AppServer, len(appServers))
@@ -63,14 +68,14 @@ func (h *Handler) getUserGroups(_ http.ResponseWriter, r *http.Request, params h
 
 	userGroupsToApps := map[string]types.Apps{}
 	for _, userGroup := range page.Resources {
-		apps := make(types.Apps, len(userGroup.GetApplications()))
-		for i, appName := range userGroup.GetApplications() {
+		apps := make(types.Apps, 0, len(userGroup.GetApplications()))
+		for _, appName := range userGroup.GetApplications() {
 			app := appServerLookup[appName]
 			if app == nil {
 				h.log.Debugf("Unable to find application %s when creating user groups, skipping", appName)
 				continue
 			}
-			apps[i] = app.GetApp()
+			apps = append(apps, app.GetApp())
 		}
 		sort.Sort(apps)
 		userGroupsToApps[userGroup.GetName()] = apps

--- a/web/packages/teleport/src/services/apps/apps.test.ts
+++ b/web/packages/teleport/src/services/apps/apps.test.ts
@@ -41,6 +41,7 @@ test('correct formatting of apps fetch response', async () => {
         awsConsole: false,
         isCloudOrTcpEndpoint: false,
         addrWithProtocol: 'https://app-name.example.com',
+        userGroups: [],
       },
       {
         id: 'cluster-id-cloud-app-cloud://some-addr',
@@ -57,6 +58,7 @@ test('correct formatting of apps fetch response', async () => {
         awsConsole: false,
         isCloudOrTcpEndpoint: true,
         addrWithProtocol: 'cloud://some-addr',
+        userGroups: [],
       },
       {
         id: 'cluster-id-tcp-app-tcp://some-addr',
@@ -73,6 +75,7 @@ test('correct formatting of apps fetch response', async () => {
         awsConsole: false,
         isCloudOrTcpEndpoint: true,
         addrWithProtocol: 'tcp://some-addr',
+        userGroups: [],
       },
     ],
     startKey: mockResponse.startKey,

--- a/web/packages/teleport/src/services/apps/makeApps.ts
+++ b/web/packages/teleport/src/services/apps/makeApps.ts
@@ -38,6 +38,7 @@ export default function makeApp(json: any): App {
   const id = `${clusterId}-${name}-${publicAddr || uri}`;
   const labels = json.labels || [];
   const awsRoles = json.awsRoles || [];
+  const userGroups = json.userGroups || [];
 
   const isTcp = uri && uri.startsWith('tcp://');
   const isCloud = uri && uri.startsWith('cloud://');
@@ -68,5 +69,6 @@ export default function makeApp(json: any): App {
     isCloudOrTcpEndpoint: isTcp || isCloud,
     addrWithProtocol,
     friendlyName,
+    userGroups
   };
 }

--- a/web/packages/teleport/src/services/apps/makeApps.ts
+++ b/web/packages/teleport/src/services/apps/makeApps.ts
@@ -69,6 +69,6 @@ export default function makeApp(json: any): App {
     isCloudOrTcpEndpoint: isTcp || isCloud,
     addrWithProtocol,
     friendlyName,
-    userGroups
+    userGroups,
   };
 }

--- a/web/packages/teleport/src/services/apps/types.ts
+++ b/web/packages/teleport/src/services/apps/types.ts
@@ -33,10 +33,15 @@ export interface App {
   // if public address wasn't defined, fallback to uri
   addrWithProtocol?: string;
   friendlyName?: string;
-  userGroups?: string[];
+  userGroups?: UserGroupAndDescription[];
 }
 
 export type AwsRole = {
   arn: string;
   display: string;
+};
+
+export type UserGroupAndDescription = {
+  name: string;
+  description: string;
 };

--- a/web/packages/teleport/src/services/apps/types.ts
+++ b/web/packages/teleport/src/services/apps/types.ts
@@ -33,6 +33,7 @@ export interface App {
   // if public address wasn't defined, fallback to uri
   addrWithProtocol?: string;
   friendlyName?: string;
+  userGroups: string;
 }
 
 export type AwsRole = {

--- a/web/packages/teleport/src/services/apps/types.ts
+++ b/web/packages/teleport/src/services/apps/types.ts
@@ -33,7 +33,7 @@ export interface App {
   // if public address wasn't defined, fallback to uri
   addrWithProtocol?: string;
   friendlyName?: string;
-  userGroups: string;
+  userGroups?: string[];
 }
 
 export type AwsRole = {

--- a/web/packages/teleport/src/services/userGroups/makeUserGroup.ts
+++ b/web/packages/teleport/src/services/userGroups/makeUserGroup.ts
@@ -20,11 +20,13 @@ export function makeUserGroup(json): UserGroup {
   const { name, description, friendlyName } = json;
 
   const labels = json.labels || [];
+  const applications = json.applications || [];
 
   return {
     name,
     description,
     labels,
     friendlyName,
+    applications,
   };
 }

--- a/web/packages/teleport/src/services/userGroups/types.ts
+++ b/web/packages/teleport/src/services/userGroups/types.ts
@@ -27,7 +27,12 @@ export type UserGroup = {
   // FriendlyName for the user group.
   friendlyName?: string;
   // Applications is a list of associated applications.
-  applications?: string[];
+  applications?: ApplicationAndFriendlyName[];
+};
+
+export type ApplicationAndFriendlyName = {
+  name: string;
+  friendlyName: string;
 };
 
 export type UserGroupsResponse = {

--- a/web/packages/teleport/src/services/userGroups/types.ts
+++ b/web/packages/teleport/src/services/userGroups/types.ts
@@ -27,7 +27,7 @@ export type UserGroup = {
   // FriendlyName for the user group.
   friendlyName?: string;
   // Applications is a list of associated applications.
-  applications: string[];
+  applications?: string[];
 };
 
 export type UserGroupsResponse = {

--- a/web/packages/teleport/src/services/userGroups/types.ts
+++ b/web/packages/teleport/src/services/userGroups/types.ts
@@ -26,6 +26,8 @@ export type UserGroup = {
   labels: AgentLabel[];
   // FriendlyName for the user group.
   friendlyName?: string;
+  // Applications is a list of associated applications.
+  applications: string[];
 };
 
 export type UserGroupsResponse = {


### PR DESCRIPTION
The user groups UI object will now contain the list of associated applications and the applications UI object will contain the list of associated user groups. This will be used to improve the access request experience for Okta applications and user groups.