### PR TITLE
AWS OIDC - DeployService: configure IAM

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,12 +40,14 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.100.1
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.27.1
 	github.com/aws/aws-sdk-go-v2/service/glue v1.51.0
+	github.com/aws/aws-sdk-go-v2/service/iam v1.20.3
 	github.com/aws/aws-sdk-go-v2/service/rds v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.35.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.20.13
 	github.com/aws/aws-sdk-go-v2/service/sqs v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/sts v1.19.2
 	github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin v0.0.0-20220331165046-e4d000c0d6a6
+	github.com/aws/smithy-go v1.13.5
 	github.com/beevik/etree v1.2.0
 	github.com/bufbuild/connect-go v1.7.0
 	github.com/buildkite/bintest/v3 v3.1.1
@@ -229,7 +231,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.14.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.14.12 // indirect
-	github.com/aws/smithy-go v1.13.5 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/boombuler/barcode v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -274,6 +274,8 @@ github.com/aws/aws-sdk-go-v2/service/ecs v1.27.1 h1:54QSuWR3Pot7HqBRXd+c1yF97h2b
 github.com/aws/aws-sdk-go-v2/service/ecs v1.27.1/go.mod h1:SB6YszwN1iKvyt/Qk+ICeKsfBxjd0CTEwwkmej9qoa0=
 github.com/aws/aws-sdk-go-v2/service/glue v1.51.0 h1:ezO4k5Nnowpedvk1LGtYQUWiXaWx+zq+CCmbcTcZBoI=
 github.com/aws/aws-sdk-go-v2/service/glue v1.51.0/go.mod h1:wMCE0B6l8eHb57l2DMYCGxt0rHIfcu3RvIY7SAfc+Fs=
+github.com/aws/aws-sdk-go-v2/service/iam v1.20.3 h1:oO895XrrD1khVUv0fUFTpbvCK+/IS9nnlhie5WYXPgw=
+github.com/aws/aws-sdk-go-v2/service/iam v1.20.3/go.mod h1:aQZ8BI+reeaY7RI/QQp7TKCSUHOesTdrzzylp3CW85c=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11 h1:y2+VQzC6Zh2ojtV2LoC0MNwHWc6qXv/j2vrQtlftkdA=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11/go.mod h1:iV4q2hsqtNECrfmlXyord9u4zyuFEJX9eLgLpSPzWA8=
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.28/go.mod h1:spfrICMD6wCAhjhzHuy6DOZZ+LAIY10UxhUmLzpJTTs=

--- a/lib/cloud/aws/errors.go
+++ b/lib/cloud/aws/errors.go
@@ -20,6 +20,8 @@ import (
 	"errors"
 	"net/http"
 
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gravitational/trace"
@@ -34,7 +36,11 @@ func ConvertRequestFailureError(err error) error {
 		return err
 	}
 
-	switch requestErr.StatusCode() {
+	return convertRequestFailureErrorFromStatusCode(requestErr.StatusCode(), requestErr)
+}
+
+func convertRequestFailureErrorFromStatusCode(statusCode int, requestErr error) error {
+	switch statusCode {
 	case http.StatusForbidden:
 		return trace.AccessDenied(requestErr.Error())
 	case http.StatusConflict:
@@ -43,7 +49,7 @@ func ConvertRequestFailureError(err error) error {
 		return trace.NotFound(requestErr.Error())
 	}
 
-	return err // Return unmodified.
+	return requestErr // Return unmodified.
 }
 
 // ConvertIAMError converts common errors from IAM clients to trace errors.
@@ -78,4 +84,33 @@ func parseMetadataClientError(err error) error {
 		return trace.ReadError(httpError.HTTPStatusCode(), nil)
 	}
 	return trace.Wrap(err)
+}
+
+// ConvertIAMv2Error converts common errors from IAM clients to trace errors.
+func ConvertIAMv2Error(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	var entityExistsError *iamTypes.EntityAlreadyExistsException
+	if errors.As(err, &entityExistsError) {
+		return trace.AlreadyExists(*entityExistsError.Message)
+	}
+
+	var entityNotFound *iamTypes.NoSuchEntityException
+	if errors.As(err, &entityNotFound) {
+		return trace.NotFound(*entityNotFound.Message)
+	}
+
+	var malformedPolicyDocument *iamTypes.MalformedPolicyDocumentException
+	if errors.As(err, &malformedPolicyDocument) {
+		return trace.BadParameter(*malformedPolicyDocument.Message)
+	}
+
+	var re *awshttp.ResponseError
+	if errors.As(err, &re) {
+		return convertRequestFailureErrorFromStatusCode(re.HTTPStatusCode(), re.Err)
+	}
+
+	return err
 }

--- a/lib/cloud/aws/errors_test.go
+++ b/lib/cloud/aws/errors_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+import (
+	"net/http"
+	"testing"
+
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestConvertIAMv2Error(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		inErr    error
+		errCheck require.ErrorAssertionFunc
+	}{
+		{
+			name:     "no error",
+			inErr:    nil,
+			errCheck: require.NoError,
+		},
+		{
+			name: "resource already exists",
+			inErr: &iamTypes.EntityAlreadyExistsException{
+				Message: strPtr("resource exists"),
+			},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(tt, trace.IsAlreadyExists(err), "expected trace.AlreadyExists error, got %v", err)
+			},
+		},
+		{
+			name: "resource already exists",
+			inErr: &iamTypes.NoSuchEntityException{
+				Message: strPtr("resource not found"),
+			},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(tt, trace.IsNotFound(err), "expected trace.NotFound error, got %v", err)
+			},
+		},
+		{
+			name: "invalid policy document",
+			inErr: &iamTypes.MalformedPolicyDocumentException{
+				Message: strPtr("malformed document"),
+			},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(tt, trace.IsBadParameter(err), "expected trace.BadParameter error, got %v", err)
+			},
+		},
+		{
+			name: "unauthorized",
+			inErr: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{Response: &http.Response{
+						StatusCode: http.StatusForbidden,
+					}},
+					Err: trace.Errorf(""),
+				},
+			},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(tt, trace.IsAccessDenied(err), "expected trace.AccessDenied error, got %v", err)
+			},
+		},
+		{
+			name: "not found",
+			inErr: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{Response: &http.Response{
+						StatusCode: http.StatusNotFound,
+					}},
+					Err: trace.Errorf(""),
+				},
+			},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(tt, trace.IsNotFound(err), "expected trace.NotFound error, got %v", err)
+			},
+		},
+		{
+			name: "resource already exists",
+			inErr: &awshttp.ResponseError{
+				ResponseError: &smithyhttp.ResponseError{
+					Response: &smithyhttp.Response{Response: &http.Response{
+						StatusCode: http.StatusConflict,
+					}},
+					Err: trace.Errorf(""),
+				},
+			},
+			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+				require.True(tt, trace.IsAlreadyExists(err), "expected trace.AlreadyExists error, got %v", err)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.errCheck(t, ConvertIAMv2Error(tt.inErr))
+		})
+	}
+}

--- a/lib/cloud/aws/errors_test.go
+++ b/lib/cloud/aws/errors_test.go
@@ -22,14 +22,11 @@ import (
 
 	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go/aws"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 )
-
-func strPtr(s string) *string {
-	return &s
-}
 
 func TestConvertIAMv2Error(t *testing.T) {
 	for _, tt := range []struct {
@@ -45,7 +42,7 @@ func TestConvertIAMv2Error(t *testing.T) {
 		{
 			name: "resource already exists",
 			inErr: &iamTypes.EntityAlreadyExistsException{
-				Message: strPtr("resource exists"),
+				Message: aws.String("resource exists"),
 			},
 			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
 				require.True(tt, trace.IsAlreadyExists(err), "expected trace.AlreadyExists error, got %v", err)
@@ -54,7 +51,7 @@ func TestConvertIAMv2Error(t *testing.T) {
 		{
 			name: "resource already exists",
 			inErr: &iamTypes.NoSuchEntityException{
-				Message: strPtr("resource not found"),
+				Message: aws.String("resource not found"),
 			},
 			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
 				require.True(tt, trace.IsNotFound(err), "expected trace.NotFound error, got %v", err)
@@ -63,7 +60,7 @@ func TestConvertIAMv2Error(t *testing.T) {
 		{
 			name: "invalid policy document",
 			inErr: &iamTypes.MalformedPolicyDocumentException{
-				Message: strPtr("malformed document"),
+				Message: aws.String("malformed document"),
 			},
 			errCheck: func(tt require.TestingT, err error, i ...interface{}) {
 				require.True(tt, trace.IsBadParameter(err), "expected trace.BadParameter error, got %v", err)

--- a/lib/cloud/aws/policy.go
+++ b/lib/cloud/aws/policy.go
@@ -19,7 +19,6 @@ package aws
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/url"
 	"sort"
 
@@ -29,6 +28,8 @@ import (
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
+
+	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
 // Policy represents an AWS IAM policy.
@@ -320,7 +321,7 @@ func NewPolicies(partitionID string, accountID string, iamClient iamiface.IAMAPI
 // * `iam:DeletePolicyVersion`: wildcard ("*") or policy that will be created;
 // * `iam:CreatePolicyVersion`: wildcard ("*") or policy that will be created;
 func (p *policies) Upsert(ctx context.Context, policy *Policy) (string, error) {
-	policyARN := PolicyARN(p.partitionID, p.accountID, policy.Name)
+	policyARN := awsutils.PolicyARN(p.partitionID, p.accountID, policy.Name)
 	encodedPolicyDocument, err := json.Marshal(policy.Document)
 	if err != nil {
 		return "", trace.Wrap(err)
@@ -496,20 +497,6 @@ func matchTag(policyTags []*iam.Tag, name, value string) bool {
 	}
 
 	return false
-}
-
-// PolicyARN returns the ARN representation of an AWS IAM Policy.
-func PolicyARN(partition, accountID, policy string) string {
-	return resourceARN(partition, accountID, "policy", policy)
-}
-
-// RoleARN returns the ARN representation of an AWS IAM Role.
-func RoleARN(partition, accountID, role string) string {
-	return resourceARN(partition, accountID, "role", role)
-}
-
-func resourceARN(partition, accountID, resourceType, resourceName string) string {
-	return fmt.Sprintf("arn:%s:iam::%s:%s/%s", partition, accountID, resourceType, resourceName)
 }
 
 const (

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+var (
+	allResources = []string{"*"}
+)
+
+// StatementForIAMEditRolePolicy returns a IAM Policy Statement which allows editting Role Policy
+// of the resources.
+func StatementForIAMEditRolePolicy(resources ...string) *Statement {
+	return &Statement{
+		Effect:    EffectAllow,
+		Actions:   []string{"iam:GetRolePolicy", "iam:PutRolePolicy", "iam:DeleteRolePolicy"},
+		Resources: resources,
+	}
+}
+
+// StatementForIAMEditUserPolicy returns a IAM Policy Statement which allows editting User Policy
+// of the resources.
+func StatementForIAMEditUserPolicy(resources ...string) *Statement {
+	return &Statement{
+		Effect:    EffectAllow,
+		Actions:   []string{"iam:GetUserPolicy", "iam:PutUserPolicy", "iam:DeleteUserPolicy"},
+		Resources: resources,
+	}
+}
+
+// StatementForECSDeployServicePolicy returns the statement that allows managing the ECS Service deployed
+// by DeployService (AWS OIDC Integration).
+func StatementForECSManageService() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"ecs:DescribeClusters", "ecs:CreateCluster", "ecs:PutClusterCapacityProviders",
+			"ecs:DescribeServices", "ecs:CreateService", "ecs:UpdateService",
+			"ecs:RegisterTaskDefinition",
+		},
+		Resources: allResources,
+	}
+}
+
+// StatementForLogsDeployServicePolicy returns the statement that allows the writing logs to CloudWatch.
+// This is used by the DeployService (ECS Service) to write teleport logs.
+// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
+func StatementForWritingLogs() *Statement {
+	return &Statement{
+		Effect:    EffectAllow,
+		Actions:   []string{"logs:CreateLogStream", "logs:PutLogEvents", "logs:CreateLogGroup"},
+		Resources: allResources,
+	}
+}
+
+// StatementForIAMPassRole returns a statement that allows to iam:PassRole the target role.
+// Usage example: when setting up the TaskRole for the ECS Task.
+// https://docs.aws.amazon.com/AmazonECS/latest/userguide/task-iam-roles.html#specify-task-iam-roles
+func StatementForIAMPassRole(targetRole string) *Statement {
+	return &Statement{
+		Effect:  EffectAllow,
+		Actions: SliceOrString{"iam:PassRole"},
+		Resources: SliceOrString{
+			targetRole,
+		},
+	}
+}
+
+// StatementForECSTasksAssumeRole returns the Trust Relationship to allow the ECS Tasks service to.
+// It allows the usage of this Role by the ECS Tasks service.
+func StatementForECSTasksAssumeRole() *Statement {
+	return &Statement{
+		Effect:  EffectAllow,
+		Actions: SliceOrString{"sts:AssumeRole"},
+		Principals: map[string]SliceOrString{
+			"Service": {"ecs-tasks.amazonaws.com"},
+		},
+	}
+}
+
+// StatementForRDSDBConnect returns a statement that allows the `rds-db:connect` for all RDS DBs.
+func StatementForRDSDBConnect() *Statement {
+	return &Statement{
+		Effect:    EffectAllow,
+		Actions:   SliceOrString{"rds-db:connect"},
+		Resources: allResources,
+	}
+}

--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -40,7 +40,7 @@ func StatementForIAMEditUserPolicy(resources ...string) *Statement {
 	}
 }
 
-// StatementForECSDeployServicePolicy returns the statement that allows managing the ECS Service deployed
+// StatementForECSManageService returns the statement that allows managing the ECS Service deployed
 // by DeployService (AWS OIDC Integration).
 func StatementForECSManageService() *Statement {
 	return &Statement{
@@ -54,7 +54,7 @@ func StatementForECSManageService() *Statement {
 	}
 }
 
-// StatementForLogsDeployServicePolicy returns the statement that allows the writing logs to CloudWatch.
+// StatementForWritingLogs returns the statement that allows the writing logs to CloudWatch.
 // This is used by the DeployService (ECS Service) to write teleport logs.
 // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/using_awslogs.html
 func StatementForWritingLogs() *Statement {
@@ -78,9 +78,9 @@ func StatementForIAMPassRole(targetRole string) *Statement {
 	}
 }
 
-// StatementForECSTasksAssumeRole returns the Trust Relationship to allow the ECS Tasks service to.
+// StatementForECSTaskRoleTrustRelationships returns the Trust Relationship to allow the ECS Tasks service to.
 // It allows the usage of this Role by the ECS Tasks service.
-func StatementForECSTasksAssumeRole() *Statement {
+func StatementForECSTaskRoleTrustRelationships() *Statement {
 	return &Statement{
 		Effect:  EffectAllow,
 		Actions: SliceOrString{"sts:AssumeRole"},

--- a/lib/cloud/aws/policy_test.go
+++ b/lib/cloud/aws/policy_test.go
@@ -661,43 +661,6 @@ func TestAttachPolicyBoundary(t *testing.T) {
 	}
 }
 
-func TestResourceARN(t *testing.T) {
-	for _, tt := range []struct {
-		name         string
-		resourceType string
-		partition    string
-		accountID    string
-		resourceName string
-		expected     string
-	}{
-		{
-			name:         "role",
-			resourceType: "role",
-			partition:    "aws",
-			accountID:    "123456789012",
-			resourceName: "MyRole",
-			expected:     "arn:aws:iam::123456789012:role/MyRole",
-		},
-		{
-			name:         "policy",
-			resourceType: "policy",
-			partition:    "aws",
-			accountID:    "123456789012",
-			resourceName: "MyPolicy",
-			expected:     "arn:aws:iam::123456789012:policy/MyPolicy",
-		},
-	} {
-		t.Run(tt.name, func(t *testing.T) {
-			switch tt.resourceType {
-			case "role":
-				require.Equal(t, tt.expected, RoleARN(tt.partition, tt.accountID, tt.resourceName))
-			case "policy":
-				require.Equal(t, tt.expected, PolicyARN(tt.partition, tt.accountID, tt.resourceName))
-			}
-		})
-	}
-}
-
 // userIdentity helper function to generate an user `Identity` .
 func userIdentity() Identity {
 	return &User{

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -194,17 +194,24 @@ type CommandLineFlags struct {
 	// Directory to store
 	DataDir string
 
-	// `teleport integration configure deployservice-iam` arguments
-	// IntegrationConfDeployServiceIAMCluster is the teleport cluster name.
-	IntegrationConfDeployServiceIAMCluster string
-	// IntegrationConfDeployServiceIAMIntegrationName is the integration name.
-	IntegrationConfDeployServiceIAMIntegrationName string
-	// IntegrationConfDeployServiceIAMRegion is the AWS Region used to set up the client.
-	IntegrationConfDeployServiceIAMRegion string
-	// IntegrationConfDeployServiceIAMIntegrationRole is the AWS Role associated with the Integration
-	IntegrationConfDeployServiceIAMIntegrationRole string
-	// IntegrationConfDeployServiceIAMTaskRole is the AWS Role to be used by the deployed service.
-	IntegrationConfDeployServiceIAMTaskRole string
+	// IntegrationConfDeployServiceIAMArguments contains the arguments of
+	// `teleport integration configure deployservice-iam` command
+	IntegrationConfDeployServiceIAMArguments IntegrationConfDeployServiceIAM
+}
+
+// IntegrationConfDeployServiceIAM contains the arguments of
+// `teleport integration configure deployservice-iam` command
+type IntegrationConfDeployServiceIAM struct {
+	// Cluster is the teleport cluster name.
+	Cluster string
+	// Name is the integration name.
+	Name string
+	// Region is the AWS Region used to set up the client.
+	Region string
+	// Role is the AWS Role associated with the Integration
+	Role string
+	// TaskRole is the AWS Role to be used by the deployed service.
+	TaskRole string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -193,6 +193,18 @@ type CommandLineFlags struct {
 	AdditionalPrincipals string
 	// Directory to store
 	DataDir string
+
+	// `teleport integration configure deployservice-iam` arguments
+	// IntegrationConfDeployServiceIAMCluster is the teleport cluster name.
+	IntegrationConfDeployServiceIAMCluster string
+	// IntegrationConfDeployServiceIAMIntegrationName is the integration name.
+	IntegrationConfDeployServiceIAMIntegrationName string
+	// IntegrationConfDeployServiceIAMRegion is the AWS Region used to set up the client.
+	IntegrationConfDeployServiceIAMRegion string
+	// IntegrationConfDeployServiceIAMIntegrationRole is the AWS Role associated with the Integration
+	IntegrationConfDeployServiceIAMIntegrationRole string
+	// IntegrationConfDeployServiceIAMTaskRole is the AWS Role to be used by the deployed service.
+	IntegrationConfDeployServiceIAMTaskRole string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -377,7 +377,7 @@ func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceR
 				},
 			},
 		}},
-		Tags: req.ResourceCreationTags.ForECS(),
+		Tags: req.ResourceCreationTags.ToECSTags(),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -405,7 +405,7 @@ func upsertCluster(ctx context.Context, clt DeployServiceClient, req DeployServi
 		createClusterResp, err := clt.CreateCluster(ctx, &ecs.CreateClusterInput{
 			ClusterName:       req.ClusterName,
 			CapacityProviders: requiredCapacityProviders,
-			Tags:              req.ResourceCreationTags.ForECS(),
+			Tags:              req.ResourceCreationTags.ToECSTags(),
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -579,7 +579,7 @@ func upsertService(ctx context.Context, clt DeployServiceClient, req DeployServi
 				Subnets:        req.SubnetIDs,
 			},
 		},
-		Tags:          req.ResourceCreationTags.ForECS(),
+		Tags:          req.ResourceCreationTags.ToECSTags(),
 		PropagateTags: ecsTypes.PropagateTagsService,
 	})
 	if err != nil {

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -296,84 +296,9 @@ func NewDeployServiceClient(ctx context.Context, clientReq *AWSClientRequest) (D
 // You can also use the role received as parameter (req.TaskRoleARN) to have an even stricter matching.
 // Eg of the identity ARN: "arn:aws:sts::0123456789012:assumed-role/<req.TaskRoleARN>/<abcd>"
 //
-// # Pre-requirement: TaskRole creation
-//
-// The req.TaskRoleARN Role must have permissions according to the Teleport Services being deployed.
-// Example for a DatabaseService:
-//
-//	{
-//	    "Version": "2012-10-17",
-//	    "Statement": [
-//	        {
-//	            "Effect": "Allow",
-//	            "Action": [
-//	                "iam:DeleteRolePolicy",
-//	                "iam:PutRolePolicy",
-//	                "iam:GetRolePolicy"
-//	            ],
-//	            "Resource": "arn:aws:iam::123456789012:role/<req.TaskRoleARN>"
-//	        },
-//	        {
-//	            "Effect": "Allow",
-//	            "Action": [
-//	                "rds:DescribeDBInstances",
-//	                "rds:ModifyDBInstance"
-//	            ],
-//	            "Resource": "*"
-//	        },
-//	        {
-//	            "Effect": "Allow",
-//	            "Action": "logs:*",
-//	            "Resource": "*"
-//	        }
-//	    ]
-//	}
-//
-// And the following Trust Policy
-//
-//	{
-//	    "Version": "2012-10-17",
-//	    "Statement": [
-//	        {
-//	            "Effect": "Allow",
-//	            "Principal": {
-//	                "Service": "ecs-tasks.amazonaws.com"
-//	            },
-//	            "Action": "sts:AssumeRole"
-//	        }
-//	    ]
-//	}
-//
-// # Pre-requirement: AWS OIDC Integration Role
-//
-// To deploy those services the AWS OIDC Integration Role requires the following policy:
-//
-//	{
-//	    "Version": "2012-10-17",
-//	    "Statement": [
-//	        {
-//	            "Effect": "Allow",
-//	            "Action": [
-//	                "ecs:CreateCluster",
-//	                "ecs:PutClusterCapacityProviders",
-//	                "ecs:DescribeClusters",
-//	                "ecs:RegisterTaskDefinition",
-//	                "ecs:CreateService",
-//	                "ecs:DescribeServices",
-//	                "ecs:UpdateService"
-//	            ],
-//	            "Resource": "*"
-//	        },
-//	        {
-//	            "Effect": "Allow",
-//	            "Action": [
-//	                "iam:PassRole"
-//	            ],
-//	            "Resource": "arn:aws:iam::123456789012:role/<req.TaskRoleARN>"
-//	        }
-//	    ]
-//	}
-//
+// # Pre-requirement: TaskRole and Integration Role
+// The required IAM Roles and Policies are described in [awsoidc.ConfigureDeployServiceIAM].
+
 // # Resource tagging
 //
 // Created resources have the following set of tags:

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -1,0 +1,327 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/utils/aws"
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+)
+
+const (
+	boundarySuffix = "Boundary"
+)
+
+// DeployServiceIAMConfigureRequest is a request to configure the DeployService action required Roles.
+type DeployServiceIAMConfigureRequest struct {
+	// Cluster is the Teleport Cluster.
+	// Used for tagging the created Roles/Policies.
+	Cluster string
+
+	// IntegrationName is the Integration Name.
+	// Used for tagging the created Roles/Policies.
+	IntegrationName string
+
+	// Region is the AWS Region.
+	// Used to set up the AWS SDK Client.
+	Region string
+
+	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
+	IntegrationRole string
+
+	// IntegrationRoleDeployServicePolicy is the Policy Name that is created to allow the DeployService to call AWS APIs (ecs, logs).
+	// Defaults to DeployService.
+	IntegrationRoleDeployServicePolicy string
+
+	// TaskRole is the AWS Role used by the deployed service.
+	TaskRole string
+
+	// TaskRoleBoundaryPolicyName is the name to be used to create a Policy to be used as boundary for the TaskRole.
+	// Defaults to <TaskRole>Boundary
+	TaskRoleBoundaryPolicyName string
+
+	// AccountID is the AWS Account ID.
+	// Optional. sts.GetCallerIdentity is used if not provided.
+	AccountID string
+
+	// ResourceCreationTags is used to add tags when creating resources in AWS.
+	// Defaults to:
+	// - teleport.dev/cluster: <cluster>
+	// - teleport.dev/origin: aws-oidc-integration
+	// - teleport.dev/integration: <integrationName>
+	ResourceCreationTags awsTags
+
+	// partitionID is the AWS Partition ID.
+	// Eg, aws, aws-cn, aws-us-gov
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/reference-arns.html
+	partitionID string
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *DeployServiceIAMConfigureRequest) CheckAndSetDefaults() error {
+	if r.Cluster == "" {
+		return trace.BadParameter("cluster is required")
+	}
+
+	if r.IntegrationName == "" {
+		return trace.BadParameter("integration name is required")
+	}
+
+	if r.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	if r.IntegrationRole == "" {
+		return trace.BadParameter("integration role is required")
+	}
+
+	if r.IntegrationRoleDeployServicePolicy == "" {
+		r.IntegrationRoleDeployServicePolicy = "DeployService"
+	}
+
+	if r.TaskRole == "" {
+		return trace.BadParameter("task role is required")
+	}
+
+	if r.TaskRoleBoundaryPolicyName == "" {
+		r.TaskRoleBoundaryPolicyName = r.TaskRole + boundarySuffix
+	}
+
+	if len(r.ResourceCreationTags) == 0 {
+		r.ResourceCreationTags = DefaultResourceCreationTags(r.Cluster, r.IntegrationName)
+	}
+
+	r.partitionID = aws.GetPartitionFromRegion(r.Region)
+
+	return nil
+}
+
+// DeployServiceIAMConfigureClient describes the required methods to create the IAM Roles/Policies required for the DeployService action.
+type DeployServiceIAMConfigureClient interface {
+	// GetCallerIdentity returns information about the caller identity.
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+
+	// CreatePolicy creates a new IAM Policy.
+	CreatePolicy(ctx context.Context, params *iam.CreatePolicyInput, optFns ...func(*iam.Options)) (*iam.CreatePolicyOutput, error)
+
+	// CreateRole creates a new IAM Role.
+	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
+
+	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type defaultDeployServiceIAMConfigureClient struct {
+	*iam.Client
+	stsClient *sts.Client
+}
+
+// NewDeployServiceIAMConfigureClient creates a new DeployServiceIAMConfigureClient.
+func NewDeployServiceIAMConfigureClient(ctx context.Context, region string) (DeployServiceIAMConfigureClient, error) {
+	if region == "" {
+		return nil, trace.BadParameter("region is required")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultDeployServiceIAMConfigureClient{
+		Client:    iam.NewFromConfig(cfg),
+		stsClient: sts.NewFromConfig(cfg),
+	}, nil
+}
+
+// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
+func (d defaultDeployServiceIAMConfigureClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return d.stsClient.GetCallerIdentity(ctx, params, optFns...)
+}
+
+// ConfigureDeployServiceIAM set ups the roles required for calling the DeployService action.
+// It creates the following:
+//
+// A) Role to be used by the deployed service, also known as _TaskRole_.
+// The Role is able to manage policies and create logs.
+// To ensure there's no priv escalation, we also set up a boundary policy.
+// The boundary policy only allows the above permissions and the `rds-db:connect`.
+//
+// B) Create a Policy in the Integration Role - the role used when setting up the integration.
+// This policy allows for the required API Calls to set up the Amazon ECS TaskDefinition, Cluster and Service.
+// It also allows to 'iam:PassRole' only for the _TaskRole_.
+//
+// The following actions must be allowed by the IAM Role assigned in the Client.
+// - iam:CreatePolicy
+// - iam:CreateRole
+// - iam:PutRolePolicy
+// - iam:TagPolicy
+// - iam:TagRole
+func ConfigureDeployServiceIAM(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if req.AccountID == "" {
+		callerIdentity, err := clt.GetCallerIdentity(ctx, nil)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.AccountID = *callerIdentity.Account
+	}
+
+	if err := createBoundaryPolicyForTaskRole(ctx, clt, req); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := createTaskRole(ctx, clt, req); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := addPolicyToTaskRole(ctx, clt, req); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if err := addPolicyToIntegrationRole(ctx, clt, req); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// createBoundaryPolicyForTaskRole creates a Policy to be used as TaskRole's Role Boundary.
+// It allows for the TaskRole to:
+// - connect to any RDS DB
+// - Get, Put and Delete Role Policies to manage the Policy Statements when adding other rds-db:connect entries
+// - write application logs to CloudWatch
+func createBoundaryPolicyForTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
+	taskRoleARN := awslib.RoleARN(req.partitionID, req.AccountID, req.TaskRole)
+
+	taskRoleBoundaryPolicyDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForRDSDBConnect(),
+		awslib.StatementForIAMEditRolePolicy(taskRoleARN),
+		awslib.StatementForWritingLogs(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.CreatePolicy(ctx, &iam.CreatePolicyInput{
+		PolicyName:     &req.TaskRoleBoundaryPolicyName,
+		PolicyDocument: &taskRoleBoundaryPolicyDocument,
+		Tags:           req.ResourceCreationTags.ForIAM(),
+	})
+	if err != nil {
+		if trace.IsAlreadyExists(awslib.ConvertIAMv2Error(err)) {
+			return trace.AlreadyExists("Policy %q already exists, please remove it and try again.", req.TaskRoleBoundaryPolicyName)
+		}
+		return trace.Wrap(err)
+	}
+
+	log.Printf("TaskRole: Boundary Policy %q created.\n", req.TaskRoleBoundaryPolicyName)
+	return nil
+}
+
+// createTaskRolecreates the TaskRole and sets up the Role Boundary and its Trust Relationship.
+func createTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
+	taskRoleAssumeRoleDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForECSTasksAssumeRole(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	policyARNForRoleBoundary := awslib.PolicyARN(req.partitionID, req.AccountID, req.TaskRoleBoundaryPolicyName)
+
+	_, err = clt.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 &req.TaskRole,
+		AssumeRolePolicyDocument: &taskRoleAssumeRoleDocument,
+		PermissionsBoundary:      &policyARNForRoleBoundary,
+		Tags:                     req.ResourceCreationTags.ForIAM(),
+	})
+	if err != nil {
+		if trace.IsAlreadyExists(awslib.ConvertIAMv2Error(err)) {
+			return trace.AlreadyExists("Role %q already exists, please remove it and try again.", req.TaskRole)
+		}
+		return trace.Wrap(err)
+	}
+
+	log.Printf("TaskRole: Role %q created with Boundary %q.\n", req.TaskRole, policyARNForRoleBoundary)
+	return nil
+}
+
+// addPolicyToTaskRole updates the TaskRole to allow the service to:
+// - manage Policies of the TaskRole
+// - write logs to CloudWatch
+func addPolicyToTaskRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
+	taskRoleARN := awslib.RoleARN(req.partitionID, req.AccountID, req.TaskRole)
+
+	taskRolePolicyDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForIAMEditRolePolicy(taskRoleARN),
+		awslib.StatementForWritingLogs(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		PolicyName:     &req.TaskRole,
+		RoleName:       &req.TaskRole,
+		PolicyDocument: &taskRolePolicyDocument,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	log.Printf("TaskRole: IAM Policy %q added to Role %q.\n", req.TaskRole, req.TaskRole)
+	return nil
+}
+
+// addPolicyToIntegrationRole creates or updates the DeployService Policy in IntegrationRole.
+// It allows the Proxy to call ECS APIs and to pass the TaskRole when deploying a service.
+func addPolicyToIntegrationRole(ctx context.Context, clt DeployServiceIAMConfigureClient, req DeployServiceIAMConfigureRequest) error {
+	taskRoleARN := awslib.RoleARN(req.partitionID, req.AccountID, req.TaskRole)
+
+	taskRolePolicyDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForIAMPassRole(taskRoleARN),
+		awslib.StatementForECSManageService(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		PolicyName:     &req.IntegrationRoleDeployServicePolicy,
+		RoleName:       &req.IntegrationRole,
+		PolicyDocument: &taskRolePolicyDocument,
+	})
+	if err != nil {
+		if trace.IsNotFound(awslib.ConvertIAMv2Error(err)) {
+			return trace.NotFound("Role %q not found.", req.IntegrationRole)
+		}
+		return trace.Wrap(err)
+	}
+
+	log.Printf("IntegrationRole: IAM Policy %q added to Role %q\n", req.IntegrationRoleDeployServicePolicy, req.IntegrationRole)
+	return nil
+}

--- a/lib/integrations/awsoidc/deployservice_iam_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+var badParameterCheck = func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+	require.True(t, trace.IsBadParameter(err), `expected "bad parameter", but got %v`, err)
+}
+
+var alreadyExistsCheck = func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+	require.True(t, trace.IsAlreadyExists(err), `expected "already exists", but got %v`, err)
+}
+
+var notFounCheck = func(t require.TestingT, err error, msgAndArgs ...interface{}) {
+	require.True(t, trace.IsNotFound(err), `expected "not found", but got %v`, err)
+}
+
+var baseReq = func() DeployServiceIAMConfigureRequest {
+	return DeployServiceIAMConfigureRequest{
+		Cluster:         "mycluster",
+		IntegrationName: "myintegration",
+		Region:          "us-east-1",
+		IntegrationRole: "integrationrole",
+		TaskRole:        "taskrole",
+	}
+}
+
+func TestDeployServiceIAMConfigReqDefaults(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		req      func() DeployServiceIAMConfigureRequest
+		errCheck require.ErrorAssertionFunc
+		expected DeployServiceIAMConfigureRequest
+	}{
+		{
+			name:     "set defaults",
+			req:      baseReq,
+			errCheck: require.NoError,
+			expected: DeployServiceIAMConfigureRequest{
+				Cluster:                            "mycluster",
+				IntegrationName:                    "myintegration",
+				Region:                             "us-east-1",
+				IntegrationRole:                    "integrationrole",
+				TaskRole:                           "taskrole",
+				partitionID:                        "aws",
+				IntegrationRoleDeployServicePolicy: "DeployService",
+				TaskRoleBoundaryPolicyName:         "taskroleBoundary",
+				ResourceCreationTags: awsTags{
+					"teleport.dev/cluster":     "mycluster",
+					"teleport.dev/integration": "myintegration",
+					"teleport.dev/origin":      "integration_awsoidc",
+				},
+			},
+		},
+		{
+			name: "missing cluster",
+			req: func() DeployServiceIAMConfigureRequest {
+				req := baseReq()
+				req.Cluster = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing integration name",
+			req: func() DeployServiceIAMConfigureRequest {
+				req := baseReq()
+				req.IntegrationName = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing region",
+			req: func() DeployServiceIAMConfigureRequest {
+				req := baseReq()
+				req.Region = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing integration role",
+			req: func() DeployServiceIAMConfigureRequest {
+				req := baseReq()
+				req.IntegrationRole = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing task role",
+			req: func() DeployServiceIAMConfigureRequest {
+				req := baseReq()
+				req.TaskRole = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.req()
+			err := req.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tt.expected, req)
+		})
+	}
+}
+
+func TestDeployServiceIAMConfig(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name                 string
+		mockAccountID        string
+		mockExistingPolicies []string
+		mockExistingRoles    []string
+		req                  func() DeployServiceIAMConfigureRequest
+		errCheck             require.ErrorAssertionFunc
+	}{
+		{
+			name:                 "valid",
+			mockAccountID:        "123456789012",
+			mockExistingPolicies: []string{},
+			mockExistingRoles:    []string{"integrationrole"},
+			req:                  baseReq,
+			errCheck:             require.NoError,
+		},
+		{
+			name:                 "boundary policy already exists",
+			mockAccountID:        "123456789012",
+			mockExistingPolicies: []string{"taskroleBoundary"},
+			mockExistingRoles:    []string{"integrationrole"},
+			req:                  baseReq,
+			errCheck:             alreadyExistsCheck,
+		},
+		{
+			name:                 "task role already exists",
+			mockAccountID:        "123456789012",
+			mockExistingPolicies: []string{},
+			mockExistingRoles:    []string{"integrationrole", "taskrole"},
+			req:                  baseReq,
+			errCheck:             alreadyExistsCheck,
+		},
+		{
+			name:                 "integration role does not exist",
+			mockAccountID:        "123456789012",
+			mockExistingPolicies: []string{},
+			mockExistingRoles:    []string{},
+			req:                  baseReq,
+			errCheck:             notFounCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := mockDeployServiceIAMConfigClient{
+				accountID:        tt.mockAccountID,
+				existingPolicies: tt.mockExistingPolicies,
+				existingRoles:    tt.mockExistingRoles,
+			}
+
+			err := ConfigureDeployServiceIAM(ctx, &clt, tt.req())
+			tt.errCheck(t, err)
+		})
+	}
+}
+
+type mockDeployServiceIAMConfigClient struct {
+	accountID        string
+	existingPolicies []string
+	existingRoles    []string
+}
+
+// GetCallerIdentity returns information about the caller identity.
+func (m *mockDeployServiceIAMConfigClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: &m.accountID,
+	}, nil
+}
+
+// CreatePolicy creates a new IAM Policy.
+func (m *mockDeployServiceIAMConfigClient) CreatePolicy(ctx context.Context, params *iam.CreatePolicyInput, optFns ...func(*iam.Options)) (*iam.CreatePolicyOutput, error) {
+	alreadyExistsMessage := fmt.Sprintf("Policy %q already exists.", *params.PolicyName)
+	if slices.Contains(m.existingPolicies, *params.PolicyName) {
+		return nil, &iamTypes.EntityAlreadyExistsException{
+			Message: &alreadyExistsMessage,
+		}
+	}
+
+	m.existingPolicies = append(m.existingPolicies, *params.PolicyName)
+	return nil, nil
+}
+
+// CreateRole creates a new IAM Role.
+func (m *mockDeployServiceIAMConfigClient) CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+	alreadyExistsMessage := fmt.Sprintf("Role %q already exists.", *params.RoleName)
+	if slices.Contains(m.existingRoles, *params.RoleName) {
+		return nil, &iamTypes.EntityAlreadyExistsException{
+			Message: &alreadyExistsMessage,
+		}
+	}
+	m.existingRoles = append(m.existingRoles, *params.RoleName)
+
+	return nil, nil
+}
+
+// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+func (m *mockDeployServiceIAMConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	noSuchEntityMessage := fmt.Sprintf("Role %q does not exist.", *params.RoleName)
+	if !slices.Contains(m.existingRoles, *params.RoleName) {
+		return nil, &iamTypes.NoSuchEntityException{
+			Message: &noSuchEntityMessage,
+		}
+	}
+	return nil, nil
+}

--- a/lib/integrations/awsoidc/tags.go
+++ b/lib/integrations/awsoidc/tags.go
@@ -51,8 +51,8 @@ func DefaultResourceCreationTags(clusterName, integrationName string) awsTags {
 	}
 }
 
-// ForECS returns the default tags using the expected type for ECS resources: [ecsTypes.Tag]
-func (d awsTags) ForECS() []ecsTypes.Tag {
+// ToECSTags returns the default tags using the expected type for ECS resources: [ecsTypes.Tag]
+func (d awsTags) ToECSTags() []ecsTypes.Tag {
 	ecsTags := make([]ecsTypes.Tag, 0, len(d))
 	for k, v := range d {
 		k, v := k, v
@@ -81,8 +81,8 @@ func (d awsTags) MatchesECSTags(resourceTags []ecsTypes.Tag) bool {
 	return true
 }
 
-// ForIAM returns the default tags using the expected type for IAM resources: [iamTypes.Tag]
-func (d awsTags) ForIAM() []iamTypes.Tag {
+// ToIAMTags returns the default tags using the expected type for IAM resources: [iamTypes.Tag]
+func (d awsTags) ToIAMTags() []iamTypes.Tag {
 	iamTags := make([]iamTypes.Tag, 0, len(d))
 	for k, v := range d {
 		k, v := k, v

--- a/lib/integrations/awsoidc/tags.go
+++ b/lib/integrations/awsoidc/tags.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
 	"github.com/gravitational/teleport/api/types"
 )
@@ -78,4 +79,17 @@ func (d awsTags) MatchesECSTags(resourceTags []ecsTypes.Tag) bool {
 	}
 
 	return true
+}
+
+// ForIAM returns the default tags using the expected type for IAM resources: [iamTypes.Tag]
+func (d awsTags) ForIAM() []iamTypes.Tag {
+	iamTags := make([]iamTypes.Tag, 0, len(d))
+	for k, v := range d {
+		k, v := k, v
+		iamTags = append(iamTags, iamTypes.Tag{
+			Key:   &k,
+			Value: &v,
+		})
+	}
+	return iamTags
 }

--- a/lib/integrations/awsoidc/tags_test.go
+++ b/lib/integrations/awsoidc/tags_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,6 +35,15 @@ func TestDefaultTags(t *testing.T) {
 		"teleport.dev/origin":      "integration_awsoidc",
 	}
 	require.Equal(t, expectedTags, d)
+
+	t.Run("iam tags", func(t *testing.T) {
+		expectedIAMTags := []iamTypes.Tag{
+			{Key: stringPointer("teleport.dev/cluster"), Value: stringPointer("mycluster")},
+			{Key: stringPointer("teleport.dev/integration"), Value: stringPointer("myawsaccount")},
+			{Key: stringPointer("teleport.dev/origin"), Value: stringPointer("integration_awsoidc")},
+		}
+		require.ElementsMatch(t, expectedIAMTags, d.ForIAM())
+	})
 
 	t.Run("ecs tags", func(t *testing.T) {
 		expectedECSTags := []ecsTypes.Tag{

--- a/lib/integrations/awsoidc/tags_test.go
+++ b/lib/integrations/awsoidc/tags_test.go
@@ -19,9 +19,9 @@ package awsoidc
 import (
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
 )
 

--- a/lib/integrations/awsoidc/tags_test.go
+++ b/lib/integrations/awsoidc/tags_test.go
@@ -21,6 +21,7 @@ import (
 
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,52 +39,52 @@ func TestDefaultTags(t *testing.T) {
 
 	t.Run("iam tags", func(t *testing.T) {
 		expectedIAMTags := []iamTypes.Tag{
-			{Key: stringPointer("teleport.dev/cluster"), Value: stringPointer("mycluster")},
-			{Key: stringPointer("teleport.dev/integration"), Value: stringPointer("myawsaccount")},
-			{Key: stringPointer("teleport.dev/origin"), Value: stringPointer("integration_awsoidc")},
+			{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+			{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
 		}
-		require.ElementsMatch(t, expectedIAMTags, d.ForIAM())
+		require.ElementsMatch(t, expectedIAMTags, d.ToIAMTags())
 	})
 
 	t.Run("ecs tags", func(t *testing.T) {
 		expectedECSTags := []ecsTypes.Tag{
-			{Key: stringPointer("teleport.dev/cluster"), Value: stringPointer("mycluster")},
-			{Key: stringPointer("teleport.dev/integration"), Value: stringPointer("myawsaccount")},
-			{Key: stringPointer("teleport.dev/origin"), Value: stringPointer("integration_awsoidc")},
+			{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+			{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
 		}
-		require.ElementsMatch(t, expectedECSTags, d.ForECS())
+		require.ElementsMatch(t, expectedECSTags, d.ToECSTags())
 	})
 
 	t.Run("resource is teleport managed", func(t *testing.T) {
 		t.Run("all tags match", func(t *testing.T) {
 			awsResourceTags := []ecsTypes.Tag{
-				{Key: stringPointer("teleport.dev/cluster"), Value: stringPointer("mycluster")},
-				{Key: stringPointer("teleport.dev/integration"), Value: stringPointer("myawsaccount")},
-				{Key: stringPointer("teleport.dev/origin"), Value: stringPointer("integration_awsoidc")},
+				{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+				{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+				{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
 			}
 			require.True(t, d.MatchesECSTags(awsResourceTags), "resource was wrongly detected as not Teleport managed")
 		})
 		t.Run("extra tags in aws resource", func(t *testing.T) {
 			awsResourceTags := []ecsTypes.Tag{
-				{Key: stringPointer("teleport.dev/cluster"), Value: stringPointer("mycluster")},
-				{Key: stringPointer("teleport.dev/integration"), Value: stringPointer("myawsaccount")},
-				{Key: stringPointer("teleport.dev/origin"), Value: stringPointer("integration_awsoidc")},
-				{Key: stringPointer("unrelated"), Value: stringPointer("true")},
+				{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+				{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+				{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
+				{Key: aws.String("unrelated"), Value: aws.String("true")},
 			}
 			require.True(t, d.MatchesECSTags(awsResourceTags), "resource was wrongly detected as not Teleport managed")
 		})
 		t.Run("missing one of the labels should return false", func(t *testing.T) {
 			awsResourceTags := []ecsTypes.Tag{
-				{Key: stringPointer("teleport.dev/cluster"), Value: stringPointer("mycluster")},
-				{Key: stringPointer("teleport.dev/integration"), Value: stringPointer("myawsaccount")},
+				{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+				{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
 			}
 			require.False(t, d.MatchesECSTags(awsResourceTags), "resource was wrongly detected as Teleport managed")
 		})
 		t.Run("one of the labels has a different value, should return false", func(t *testing.T) {
 			awsResourceTags := []ecsTypes.Tag{
-				{Key: stringPointer("teleport.dev/cluster"), Value: stringPointer("another-cluster")},
-				{Key: stringPointer("teleport.dev/integration"), Value: stringPointer("myawsaccount")},
-				{Key: stringPointer("teleport.dev/origin"), Value: stringPointer("integration_awsoidc")},
+				{Key: aws.String("teleport.dev/cluster"), Value: aws.String("another-cluster")},
+				{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+				{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
 			}
 			require.False(t, d.MatchesECSTags(awsResourceTags), "resource was wrongly detected as Teleport managed")
 		})

--- a/lib/utils/aws/aws.go
+++ b/lib/utils/aws/aws.go
@@ -460,3 +460,22 @@ func IsUserARN(userARN string) bool {
 
 	return strings.HasPrefix(resourceName, "user/")
 }
+
+// PolicyARN returns the ARN representation of an AWS IAM Policy.
+func PolicyARN(partition, accountID, policy string) string {
+	return iamResourceARN(partition, accountID, "policy", policy)
+}
+
+// RoleARN returns the ARN representation of an AWS IAM Role.
+func RoleARN(partition, accountID, role string) string {
+	return iamResourceARN(partition, accountID, "role", role)
+}
+
+func iamResourceARN(partition, accountID, resourceType, resourceName string) string {
+	return arn.ARN{
+		Partition: partition,
+		Service:   "iam",
+		AccountID: accountID,
+		Resource:  fmt.Sprintf("%s/%s", resourceType, resourceName),
+	}.String()
+}

--- a/lib/utils/aws/aws_test.go
+++ b/lib/utils/aws/aws_test.go
@@ -450,3 +450,40 @@ func FuzzParseSigV4(f *testing.F) {
 		})
 	})
 }
+
+func TestResourceARN(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		resourceType string
+		partition    string
+		accountID    string
+		resourceName string
+		expected     string
+	}{
+		{
+			name:         "role",
+			resourceType: "role",
+			partition:    "aws",
+			accountID:    "123456789012",
+			resourceName: "MyRole",
+			expected:     "arn:aws:iam::123456789012:role/MyRole",
+		},
+		{
+			name:         "policy",
+			resourceType: "policy",
+			partition:    "aws",
+			accountID:    "123456789012",
+			resourceName: "MyPolicy",
+			expected:     "arn:aws:iam::123456789012:policy/MyPolicy",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			switch tt.resourceType {
+			case "role":
+				require.Equal(t, tt.expected, RoleARN(tt.partition, tt.accountID, tt.resourceName))
+			case "policy":
+				require.Equal(t, tt.expected, PolicyARN(tt.partition, tt.accountID, tt.resourceName))
+			}
+		})
+	}
+}


### PR DESCRIPTION
DeployService allows the user to deploy a Database Service (other services will be available later on) in a single click.
You can read more about it here:
https://github.com/gravitational/teleport/pull/27035
https://github.com/gravitational/teleport/issues/25521#issuecomment-1548175324

The IAM set up consists of:
- creating a new Role with specific Policies and set a Boundary Policy
- allowing the Integration role to pass that Role when starting the ECS Service
It's quite tedious and error prone.

Instead of giving users a detailed guide on how to set this up, we will ask users to run this command on their machine or Amazon CloudShell.
They must have the following permission to be able to run the configuration command:
```
- iam:CreatePolicy
- iam:CreateRole
- iam:PutRolePolicy
- iam:TagPolicy
- iam:TagRole
```

The script does not try to be smart:
- only creates the resources if they don't exist previously
- does not attempt to rollback any created resources if some action fails

We can add more checks to ensure a better UX, but we decided to keep things simple and safe for now.
If you think otherwise, please let me know.

Demo:
```shell
ubuntu@ip-172-31-39-120 ~/pg [1]> teleport integration configure deployservice-iam --cluster lenix --name teleportdev --aws-region eu-west-1 --role MarcoTestRoleOIDCProvider --task-role MarcoRoleForDS
2023/06/26 16:21:51 TaskRole: Boundary Policy "MarcoRoleForDSBoundary" created.
2023/06/26 16:21:51 TaskRole: Role "MarcoRoleForDS" created with Boundary "arn:aws:iam::278576220453:policy/MarcoRoleForDSBoundary".
2023/06/26 16:21:51 TaskRole: IAM Policy "MarcoRoleForDS" added to Role "MarcoRoleForDS".
2023/06/26 16:21:51 IntegrationRole: IAM Policy "DeployService" added to Role "MarcoTestRoleOIDCProvider"
```

Running the script again, returns an error indicating that the policy (used as Task Role Boundary) already exists
```shell
ubuntu@ip-172-31-39-120 ~/pg> teleport integration configure deployservice-iam --cluster lenix --name teleportdev --aws-region eu-west-1 --role MarcoTestRoleOIDCProvider --task-role MarcoRoleForDS
ERROR: Policy "MarcoRoleForDSBoundary" already exists, please remove it and try again.
```

If the IntegrationRole does not exist:
```shell
ubuntu@ip-172-31-39-120 ~/pg [1]> teleport integration configure deployservice-iam --cluster lenix --name teleportdev --aws-region eu-west-1 --role RoleThatDoesNotExist --task-role MarcoRoleForDS
2023/06/26 16:23:55 TaskRole: Boundary Policy "MarcoRoleForDSBoundary" created.
2023/06/26 16:23:55 TaskRole: Role "MarcoRoleForDS" created with Boundary "arn:aws:iam::278576220453:policy/MarcoRoleForDSBoundary".
2023/06/26 16:23:55 TaskRole: IAM Policy "MarcoRoleForDS" added to Role "MarcoRoleForDS".
ERROR: Role "RoleThatDoesNotExist" not found.
```
