### PR TITLE
Remove outdated comment from ClustersService

### DIFF
--- a/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
+++ b/web/packages/teleterm/src/ui/services/clusters/clustersService.ts
@@ -151,8 +151,6 @@ export class ClustersService extends ImmutableStore<types.ClustersServiceState> 
    */
   private async syncRootCluster(clusterUri: uri.RootClusterUri) {
     await Promise.all([
-      // syncClusterInfo never fails with a retryable error since it reads data from disk.
-      // syncLeafClusters reaches out to the proxy so it might return a retryable error.
       this.syncClusterInfo(clusterUri),
       this.syncLeafClustersList(clusterUri),
     ]);


### PR DESCRIPTION
syncClusterInfo has been making network requests ever since we made it return details needed for access requests.