### PR TITLE
permission-warning.mdx: Advise NOT TO give access,editor to users

### DIFF
--- a/docs/pages/includes/permission-warning.mdx
+++ b/docs/pages/includes/permission-warning.mdx
@@ -12,8 +12,10 @@
     numbered < `1024` (e.g. `443`).
   - Follow the "Principle of Least Privilege" (PoLP). Don't give users
     permissive roles when giving them more restrictive roles will do instead.
-    For example, don't assign users the built-in `access,editor` roles which give
-    them permissions to access and edit all cluster resources.
+    For example, don't assign users the built-in `access,editor` roles, which give
+    them permissions to access and edit all cluster resources. Instead, define 
+    RBAC roles with the minimum required permissions for each user and configure
+    Access Requests for elevated permissions.
   - When joining a Teleport resource service (e.g., the Database Service or
     Application Service) to a cluster, save the invitation token to a file.
     Otherwise, the token will be visible when examining the `teleport` command

--- a/docs/pages/includes/permission-warning.mdx
+++ b/docs/pages/includes/permission-warning.mdx
@@ -12,7 +12,8 @@
     numbered < `1024` (e.g. `443`).
   - Follow the "Principle of Least Privilege" (PoLP). Don't give users
     permissive roles when giving them more restrictive roles will do instead.
-    For example, assign users the built-in `access,editor` roles.
+    For example, don't assign users the built-in `access,editor` roles which give
+    them permissions to access and edit all cluster resources.
   - When joining a Teleport resource service (e.g., the Database Service or
     Application Service) to a cluster, save the invitation token to a file.
     Otherwise, the token will be visible when examining the `teleport` command


### PR DESCRIPTION
It seems that the previous version lacks the "do not" part. If you want to follow the principle of least privilege, you _don't_ want to give users those roles.