### PR TITLE
Preserve applications original URL's query

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -567,7 +567,7 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, hostname string) strin
 	// as a query part. Append query that was originally part of the URL.
 	query := fmt.Sprintf("path=%s", url.QueryEscape(r.URL.Path))
 	if len(r.URL.RawQuery) > 0 {
-		query = fmt.Sprintf("%s&%s", query, r.URL.RawQuery)
+		query = fmt.Sprintf("%s&query=%s", query, url.QueryEscape(r.URL.RawQuery))
 	}
 
 	u := url.URL{

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -750,44 +750,39 @@ func TestMakeAppRedirectURL(t *testing.T) {
 			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=",
 		},
 		{
-			name:        "OK - with path",
-			reqURL:      "https://grafana.localhost/foo",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Ffoo",
-		},
-		{
-			name:        "OK - with multi path",
-			reqURL:      "https://grafana.localhost/foo/bar",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Ffoo%2Fbar",
-		},
-		{
-			name:        "OK - adds paths with ampersands",
-			reqURL:      "https://grafana.localhost/foo/this&/that",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Ffoo%2Fthis%26%2Fthat",
-		},
-		{
-			name:        "OK - adds root path",
+			name:        "OK - add root path",
 			reqURL:      "https://grafana.localhost/",
 			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2F",
 		},
 		{
-			name:        "OK - adds query",
+			name:        "OK - add multi path",
+			reqURL:      "https://grafana.localhost/foo/bar",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Ffoo%2Fbar",
+		},
+		{
+			name:        "OK - add paths with ampersands",
+			reqURL:      "https://grafana.localhost/foo/this&/that",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Ffoo%2Fthis%26%2Fthat",
+		},
+		{
+			name:        "OK - add only query",
 			reqURL:      "https://grafana.localhost?foo=bar",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=&foo=bar",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=&query=foo%3Dbar",
+		},
+		{
+			name:        "OK - add duplicate query key path",
+			reqURL:      "https://grafana.localhost?foo=bar&path=test1&path=test",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=&query=foo%3Dbar%26path%3Dtest1%26path%3Dtest",
 		},
 		{
 			name:        "OK - adds query with root path",
-			reqURL:      "https://grafana.localhost/?foo=bar",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2F&foo=bar",
-		},
-		{
-			name:        "OK - adds multi query with path",
-			reqURL:      "https://grafana.localhost/foo/bar?fruit=apple&os=mac",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Ffoo%2Fbar&fruit=apple&os=mac",
+			reqURL:      "https://grafana.localhost/?foo=bar&baz=qux&fruit=apple",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2F&query=foo%3Dbar%26baz%3Dqux%26fruit%3Dapple",
 		},
 		{
 			name:        "OK - real grafana query example",
 			reqURL:      "https://grafana.localhost/alerting/list?search=state:inactive%20type:alerting%20health:nodata",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Falerting%2Flist&search=state:inactive%20type:alerting%20health:nodata",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Falerting%2Flist&query=search%3Dstate%3Ainactive%2520type%3Aalerting%2520health%3Anodata",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -770,9 +770,9 @@ func TestMakeAppRedirectURL(t *testing.T) {
 			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=&query=foo%3Dbar",
 		},
 		{
-			name:        "OK - add duplicate query key path",
-			reqURL:      "https://grafana.localhost?foo=bar&path=test1&path=test",
-			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=&query=foo%3Dbar%26path%3Dtest1%26path%3Dtest",
+			name:        "OK - add query with same keys used to store the original path and query",
+			reqURL:      "https://grafana.localhost?foo=bar&query=test1&path=test",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=&query=foo%3Dbar%26query%3Dtest1%26path%3Dtest",
 		},
 		{
 			name:        "OK - adds query with root path",
@@ -780,9 +780,14 @@ func TestMakeAppRedirectURL(t *testing.T) {
 			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2F&query=foo%3Dbar%26baz%3Dqux%26fruit%3Dapple",
 		},
 		{
-			name:        "OK - real grafana query example",
+			name:        "OK - real grafana query example (encoded spaces)",
 			reqURL:      "https://grafana.localhost/alerting/list?search=state:inactive%20type:alerting%20health:nodata",
 			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Falerting%2Flist&query=search%3Dstate%3Ainactive%2520type%3Aalerting%2520health%3Anodata",
+		},
+		{
+			name:        "OK - query with non-encoded spaces",
+			reqURL:      "https://grafana.localhost/alerting /list?search=state:inactive type:alerting health:nodata",
+			expectedURL: "https://proxy.com/web/launch/grafana.localhost?path=%2Falerting+%2Flist&query=search%3Dstate%3Ainactive+type%3Aalerting+health%3Anodata",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -76,7 +76,7 @@ const testCases = [
     queryParams:
       '?path=%2Falerting%2Flist&search=state:pending%20type:recording%20health:error',
     expectedPath:
-      '/alerting/list?search=state:pending+type:recording+health:error',
+      '/alerting/list?search=state:pending type:recording health:error',
   },
 ];
 

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -48,9 +48,9 @@ const testCases: { name: string; query: string; expectedPath: string }[] = [
     expectedPath: '?foo=bar',
   },
   {
-    name: 'with duplicate query key path',
-    query: '?path=foo&query=foo%3Dbar%26path%3Dtest1%26path%3Dtest',
-    expectedPath: '/foo?foo=bar&path=test1&path=test',
+    name: 'with query with same keys used to store the original path and query',
+    query: '?path=foo&query=foo%3Dbar%26query%3Dtest1%26path%3Dtest',
+    expectedPath: '/foo?foo=bar&query=test1&path=test',
   },
   {
     name: 'with query and root path',
@@ -58,11 +58,18 @@ const testCases: { name: string; query: string; expectedPath: string }[] = [
     expectedPath: '/?foo=bar&baz=qux&fruit=apple',
   },
   {
-    name: 'queries with spaces',
+    name: 'queries with encoded spaces',
     query:
       '?path=%2Falerting%2Flist&query=search%3Dstate%3Ainactive%2520type%3Aalerting%2520health%3Anodata',
     expectedPath:
       '/alerting/list?search=state:inactive%20type:alerting%20health:nodata',
+  },
+  {
+    name: 'queries with non-encoded spaces',
+    query:
+      '?path=%2Falerting+%2Flist&query=search%3Dstate%3Ainactive+type%3Aalerting+health%3Anodata',
+    expectedPath:
+      '/alerting /list?search=state:inactive type:alerting health:nodata',
   },
 ];
 

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.test.tsx
@@ -26,31 +26,6 @@ import service from 'teleport/services/apps';
 
 import { AppLauncher } from './AppLauncher';
 
-test('arn is url decoded', () => {
-  jest.spyOn(service, 'createAppSession');
-
-  const launcherPath =
-    '/web/launch/test-app.test.teleport/test.teleport/test-app.test.teleport/arn:aws:iam::joe123:role%2FEC2FullAccess';
-  const mockHistory = createMemoryHistory({
-    initialEntries: [launcherPath],
-  });
-
-  render(
-    <Router history={mockHistory}>
-      <Route path={cfg.routes.appLauncher}>
-        <AppLauncher />
-      </Route>
-    </Router>
-  );
-
-  expect(service.createAppSession).toHaveBeenCalledWith({
-    fqdn: 'test-app.test.teleport',
-    clusterId: 'test.teleport',
-    publicAddr: 'test-app.test.teleport',
-    arn: 'arn:aws:iam::joe123:role/EC2FullAccess',
-  });
-});
-
 const testCases = [
   {
     queryParams: '?path=%2F',
@@ -121,4 +96,29 @@ describe('app launcher path is properly formed', () => {
       );
     }
   );
+
+  test('arn is url decoded', () => {
+    jest.spyOn(service, 'createAppSession');
+
+    const launcherPath =
+      '/web/launch/test-app.test.teleport/test.teleport/test-app.test.teleport/arn:aws:iam::joe123:role%2FEC2FullAccess';
+    const mockHistory = createMemoryHistory({
+      initialEntries: [launcherPath],
+    });
+
+    render(
+      <Router history={mockHistory}>
+        <Route path={cfg.routes.appLauncher}>
+          <AppLauncher />
+        </Route>
+      </Router>
+    );
+
+    expect(service.createAppSession).toHaveBeenCalledWith({
+      fqdn: 'test-app.test.teleport',
+      clusterId: 'test.teleport',
+      publicAddr: 'test-app.test.teleport',
+      arn: 'arn:aws:iam::joe123:role/EC2FullAccess',
+    });
+  });
 });

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -51,6 +51,7 @@ export function AppLauncher() {
 
       const session = await service.createAppSession(params);
 
+      // Setting cookie
       await fetch(`https://${fqdn}${port}/x-teleport-auth`, {
         method: 'POST',
         credentials: 'include',
@@ -66,6 +67,12 @@ export function AppLauncher() {
 
         if (!path.startsWith('/')) {
           path = `/${path}`;
+        }
+
+        queryParams.delete('path');
+        const originalQuery = queryParams.toString();
+        if (originalQuery) {
+          path += '?' + decodeURIComponent(originalQuery);
         }
       }
 

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -72,7 +72,13 @@ export function AppLauncher() {
         queryParams.delete('path');
         const originalQuery = queryParams.toString();
         if (originalQuery) {
-          path += '?' + decodeURIComponent(originalQuery);
+          // Manually build the query since `searchParams.toString()`
+          // converts %20 to +
+          const queries = [];
+          for (const key of queryParams.keys()) {
+            queries.push(`${key}=${queryParams.get(key)}`);
+          }
+          path = `${path}?${queries.join('&')}`;
         }
       }
 

--- a/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
+++ b/web/packages/teleport/src/AppLauncher/AppLauncher.tsx
@@ -63,22 +63,14 @@ export function AppLauncher() {
 
       let path = '';
       if (queryParams.has('path')) {
-        path = decodeURIComponent(queryParams.get('path'));
+        path = queryParams.get('path');
 
-        if (!path.startsWith('/')) {
+        if (path && !path.startsWith('/')) {
           path = `/${path}`;
         }
 
-        queryParams.delete('path');
-        const originalQuery = queryParams.toString();
-        if (originalQuery) {
-          // Manually build the query since `searchParams.toString()`
-          // converts %20 to +
-          const queries = [];
-          for (const key of queryParams.keys()) {
-            queries.push(`${key}=${queryParams.get(key)}`);
-          }
-          path = `${path}?${queries.join('&')}`;
+        if (queryParams.has('query')) {
+          path += '?' + queryParams.get('query');
         }
       }
 


### PR DESCRIPTION
part of https://github.com/gravitational/teleport/issues/15998
fixes https://github.com/gravitational/cloud/issues/3598

We now append the original app URL's query along with the path.
The issue requested to preserve both the query and the `fragment` but the fragment might involve more work as mentioned [here](https://github.com/gravitational/teleport/issues/15998#issuecomment-1537231822) and [here](https://stackoverflow.com/questions/940905/can-i-read-the-hash-portion-of-the-url-on-my-server-side-application-php-ruby) (specific for php, but i think same diff).

I tried to test it out as well and no fragments were passed when parsing the URL

#### Manual Testing
Tested redirecting with github login and local login with this URL: `https://grafana.localhost:3080/alerting/list?search=state:inactive%20type:alerting%20health:nodata`