### PR TITLE
Add wasm-pack to docker images

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -209,6 +209,8 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
     rustc --version && \
     rustup component add rustfmt clippy && \
     if [ "$BUILDARCH" = "amd64" ]; then rustup target add aarch64-unknown-linux-gnu; fi
+# Install wasm-pack for targeting WebAssembly from Rust.
+RUN cargo install wasm-pack
 # Switch back to root for the remaining instructions and keep it as the default
 # user.
 USER root

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -167,6 +167,7 @@ RUN apt-get -y update && \
     tee /etc/apt/sources.list.d/docker.list > /dev/null && \
     apt-get update && \
     apt-get install -y docker-ce-cli && \
+    if [ "$BUILDARCH" = "arm64" ]; then apt-get install -y binaryen; fi && \
     pip3 --no-cache-dir install yamllint && \
     dpkg-reconfigure locales && \
     apt-get -y clean && \

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -253,6 +253,8 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
     rustup --version && \
     cargo --version && \
     rustc --version
+# Install wasm-pack for targeting WebAssembly from Rust.
+RUN cargo install wasm-pack
 
 # Do a quick switch back to root and copy/setup libfido2 and libpcsclite binaries.
 # Do this last to take better advantage of the multi-stage build.

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -166,6 +166,8 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
     rustc --version && \
     rustup component add rustfmt clippy && \
     rustup target add aarch64-unknown-linux-gnu
+# Install wasm-pack for targeting WebAssembly from Rust.
+RUN cargo install wasm-pack
 
 
 # Copy BoringSSL into the final image

--- a/build.assets/Dockerfile-multiarch
+++ b/build.assets/Dockerfile-multiarch
@@ -130,6 +130,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --pr
     cargo --version && \
     rustc --version && \
     rustup target add ${RUST_ARCH}
+# Install wasm-pack for targeting WebAssembly from Rust.
+RUN cargo install wasm-pack
 
 USER root
 

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -33,7 +33,7 @@ Then you can upload the result to an S3 bucket for release.
 docker run -it -e AWS_ACL=public-read -e S3_BUCKET=my-teleport-releases -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY teleportbuilder
 ```
 
-Or simply copy the binary out of the image using a volume (it will be copied to current directory/build/teleport.
+Or simply copy the binary out of the image using a volume (it will be copied to current directory/build/teleport).
 ```
 docker run -v $(pwd)/build:/builds -it teleportbuilder cp /gopath/src/github.com/gravitational/teleport/teleport.tgz /builds
 ```

--- a/build.assets/README.md
+++ b/build.assets/README.md
@@ -20,20 +20,23 @@ should be split into two stages:
    ECR.
 3. Then you can open another PR which starts using the new build box image.
 
-# DynamoDB static binary docker build 
+# DynamoDB static binary docker build
 
 The static binary will be built along with all nodejs assets inside the container.
 From the root directory of the source checkout run:
+
 ```
 docker build -f build.assets/Dockerfile.dynamodb -t teleportbuilder .
 ```
 
 Then you can upload the result to an S3 bucket for release.
+
 ```
 docker run -it -e AWS_ACL=public-read -e S3_BUCKET=my-teleport-releases -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY teleportbuilder
 ```
 
 Or simply copy the binary out of the image using a volume (it will be copied to current directory/build/teleport).
+
 ```
 docker run -v $(pwd)/build:/builds -it teleportbuilder cp /gopath/src/github.com/gravitational/teleport/teleport.tgz /builds
 ```
@@ -41,11 +44,13 @@ docker run -v $(pwd)/build:/builds -it teleportbuilder cp /gopath/src/github.com
 # OS package repo migrations
 
 An OS package repo migration is semi-manually publishing specific releases to the new APT and YUM repos. This is required in several situations:
-* A customer requests that we add an older version to the repos
-* We add another OS package repo (for example APK)
-* A OS package promotion fails (for example https://drone.platform.teleport.sh/gravitational/teleport/14666/1/3), requires a PR to fix, and we don't want to cut another minor version
+
+- A customer requests that we add an older version to the repos
+- We add another OS package repo (for example APK)
+- A OS package promotion fails (for example https://drone.platform.teleport.sh/gravitational/teleport/14666/1/3), requires a PR to fix, and we don't want to cut another minor version
 
 Multiple migrations can be performed at once. To run a migration do the following:
+
 1. Clone https://github.com/gravitational/teleport.git.
 2. Change to the directory the repo was cloned to.
 3. Create a new branch from master.


### PR DESCRIPTION
We're in the process of swapping out RDP clients in order to improve desktop access performance, which includes adding wasm module compiled from rust via [wasm-pack](https://rustwasm.github.io/wasm-pack/) (https://github.com/gravitational/teleport/pull/26874).

This means that wasm-pack will be needed for the Docker images that run UI unit tests and UI linting, as well as any image that builds the UI in our release pipelines. I'm unsure of precisely how all of these various Docker images are used, so simply added `cargo install wasm-pack` in any image where `yarn` and `cargo` are installed (the two of which are always found together).