### PR TITLE
docs: replace "Golang" with "Go"

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -35,8 +35,7 @@ related information on the [Teleport Trust Portal](https://trust.goteleport.com)
 
 ### How do you store passwords?
 
-Password hashes are generated using
-[Golang's bcrypt](https://pkg.go.dev/golang.org/x/crypto/bcrypt).
+Password hashes are generated using [bcrypt](https://pkg.go.dev/golang.org/x/crypto/bcrypt).
 
 ### Do you encrypt data at rest?
 
@@ -299,5 +298,3 @@ address traffic to any individual software instance within the cluster.
 ### How do I set up recovery codes for my account so I don't lose access?
 
 We have a [short step-by-step guide](https://github.com/gravitational/teleport/discussions/12379) on setting up recovery codes.
-
-

--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -123,45 +123,47 @@
 | `teleport_cache_stale_events` | counter | Teleport | Number of stale events received by a Teleport service cache. A high percentage of stale events can indicate a degraded backend. |
 | `tx` | counter | Teleport | Number of bytes transmitted during an SSH connection. |
 
-## Golang runtime metrics
+## Go runtime metrics
+
+These metrics are surfaced by the Go runtime and are not specific to Teleport.
 
 | Name | Type | Component | Description |
 | - | - | - | - |
-| `go_gc_duration_seconds` | summary | Internal Golang | A summary of GC invocation durations. |
-| `go_goroutines` | gauge | Internal Golang | Number of goroutines that currently exist. |
-| `go_info` | gauge | Internal Golang | Information about the Go environment. |
-| `go_memstats_alloc_bytes_total` | counter | Internal Golang | Total number of bytes allocated, even if freed. |
-| `go_memstats_alloc_bytes` | gauge | Internal Golang | Number of bytes allocated and still in use. |
-| `go_memstats_buck_hash_sys_bytes` | gauge | Internal Golang | Number of bytes used by the profiling bucket hash table. |
-| `go_memstats_frees_total` | counter | Internal Golang | Total number of frees. |
-| `go_memstats_gc_cpu_fraction` | gauge | Internal Golang | The fraction of this program's available CPU time used by the GC since the program started. |
-| `go_memstats_gc_sys_bytes` | gauge | Internal Golang | Number of bytes used for garbage collection system metadata. |
-| `go_memstats_heap_alloc_bytes` | gauge | Internal Golang | Number of heap bytes allocated and still in use. |
-| `go_memstats_heap_idle_bytes` | gauge | Internal Golang | Number of heap bytes waiting to be used. |
-| `go_memstats_heap_inuse_bytes` | gauge | Internal Golang | Number of heap bytes that are in use. |
-| `go_memstats_heap_objects` | gauge | Internal Golang | Number of allocated objects. |
-| `go_memstats_heap_released_bytes` | gauge | Internal Golang | Number of heap bytes released to the OS. |
-| `go_memstats_heap_sys_bytes` | gauge | Internal Golang | Number of heap bytes obtained from the system. |
-| `go_memstats_last_gc_time_seconds` | gauge | Internal Golang | Number of seconds since the Unix epoch of the last garbage collection. |
-| `go_memstats_lookups_total` | counter | Internal Golang | Total number of pointer lookups. |
-| `go_memstats_mallocs_total` | counter | Internal Golang | Total number of mallocs. |
-| `go_memstats_mcache_inuse_bytes` | gauge | Internal Golang | Number of bytes in use by mcache structures. |
-| `go_memstats_mcache_sys_bytes` | gauge | Internal Golang | Number of bytes used for mcache structures obtained from system. |
-| `go_memstats_mspan_inuse_bytes` | gauge | Internal Golang | Number of bytes in use by mspan structures. |
-| `go_memstats_mspan_sys_bytes` | gauge | Internal Golang | Number of bytes used for mspan structures obtained from system. |
-| `go_memstats_next_gc_bytes` | gauge | Internal Golang | Number of heap bytes when next the garbage collection will take place. |
-| `go_memstats_other_sys_bytes` | gauge | Internal Golang | Number of bytes used for other system allocations. |
-| `go_memstats_stack_inuse_bytes` | gauge | Internal Golang | Number of bytes in use by the stack allocator. |
-| `go_memstats_stack_sys_bytes` | gauge | Internal Golang | Number of bytes obtained from the system for stack allocator. |
-| `go_memstats_sys_bytes` | gauge | Internal Golang | Number of bytes obtained from the system. |
-| `go_threads` | gauge | Internal Golang | Number of OS threads created. |
-| `process_cpu_seconds_total` | counter | Internal Golang | Total user and system CPU time spent in seconds. |
-| `process_max_fds` | gauge | Internal Golang | Maximum number of open file descriptors. |
-| `process_open_fds` | gauge | Internal Golang | Number of open file descriptors. |
-| `process_resident_memory_bytes` | gauge | Internal Golang | Resident memory size in bytes. |
-| `process_start_time_seconds` | gauge | Internal Golang | Start time of the process since the Unix epoch in seconds. |
-| `process_virtual_memory_bytes` | gauge | Internal Golang | Virtual memory size in bytes. |
-| `process_virtual_memory_max_bytes` | gauge | Internal Golang | Maximum amount of virtual memory available in bytes. |
+| `go_gc_duration_seconds` | summary | Internal Go | A summary of GC invocation durations. |
+| `go_goroutines` | gauge | Internal Go | Number of goroutines that currently exist. |
+| `go_info` | gauge | Internal Go | Information about the Go environment. |
+| `go_memstats_alloc_bytes_total` | counter | Internal Go | Total number of bytes allocated, even if freed. |
+| `go_memstats_alloc_bytes` | gauge | Internal Go | Number of bytes allocated and still in use. |
+| `go_memstats_buck_hash_sys_bytes` | gauge | Internal Go | Number of bytes used by the profiling bucket hash table. |
+| `go_memstats_frees_total` | counter | Internal Go | Total number of frees. |
+| `go_memstats_gc_cpu_fraction` | gauge | Internal Go | The fraction of this program's available CPU time used by the GC since the program started. |
+| `go_memstats_gc_sys_bytes` | gauge | Internal Go | Number of bytes used for garbage collection system metadata. |
+| `go_memstats_heap_alloc_bytes` | gauge | Internal Go | Number of heap bytes allocated and still in use. |
+| `go_memstats_heap_idle_bytes` | gauge | Internal Go | Number of heap bytes waiting to be used. |
+| `go_memstats_heap_inuse_bytes` | gauge | Internal Go | Number of heap bytes that are in use. |
+| `go_memstats_heap_objects` | gauge | Internal Go | Number of allocated objects. |
+| `go_memstats_heap_released_bytes` | gauge | Internal Go | Number of heap bytes released to the OS. |
+| `go_memstats_heap_sys_bytes` | gauge | Internal Go | Number of heap bytes obtained from the system. |
+| `go_memstats_last_gc_time_seconds` | gauge | Internal Go | Number of seconds since the Unix epoch of the last garbage collection. |
+| `go_memstats_lookups_total` | counter | Internal Go | Total number of pointer lookups. |
+| `go_memstats_mallocs_total` | counter | Internal Go | Total number of mallocs. |
+| `go_memstats_mcache_inuse_bytes` | gauge | Internal Go | Number of bytes in use by mcache structures. |
+| `go_memstats_mcache_sys_bytes` | gauge | Internal Go | Number of bytes used for mcache structures obtained from system. |
+| `go_memstats_mspan_inuse_bytes` | gauge | Internal Go | Number of bytes in use by mspan structures. |
+| `go_memstats_mspan_sys_bytes` | gauge | Internal Go | Number of bytes used for mspan structures obtained from system. |
+| `go_memstats_next_gc_bytes` | gauge | Internal Go | Number of heap bytes when next the garbage collection will take place. |
+| `go_memstats_other_sys_bytes` | gauge | Internal Go | Number of bytes used for other system allocations. |
+| `go_memstats_stack_inuse_bytes` | gauge | Internal Go | Number of bytes in use by the stack allocator. |
+| `go_memstats_stack_sys_bytes` | gauge | Internal Go | Number of bytes obtained from the system for stack allocator. |
+| `go_memstats_sys_bytes` | gauge | Internal Go | Number of bytes obtained from the system. |
+| `go_threads` | gauge | Internal Go | Number of OS threads created. |
+| `process_cpu_seconds_total` | counter | Internal Go | Total user and system CPU time spent in seconds. |
+| `process_max_fds` | gauge | Internal Go | Maximum number of open file descriptors. |
+| `process_open_fds` | gauge | Internal Go | Number of open file descriptors. |
+| `process_resident_memory_bytes` | gauge | Internal Go | Resident memory size in bytes. |
+| `process_start_time_seconds` | gauge | Internal Go | Start time of the process since the Unix epoch in seconds. |
+| `process_virtual_memory_bytes` | gauge | Internal Go | Virtual memory size in bytes. |
+| `process_virtual_memory_max_bytes` | gauge | Internal Go | Maximum amount of virtual memory available in bytes. |
 
 ## Prometheus
 

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -48,7 +48,7 @@ spec:
       # a list of allowed values:
       'region': ['us-west-1', 'eu-central-1']
       # regular expressions start with ^ and end with $
-      # Teleport uses Golang's regexp syntax.
+      # Teleport uses Go's regexp syntax (https://github.com/google/re2/wiki/Syntax)
       # the list example above can be expressed as:
       'reg': '^us-west-1|eu-central-1$'
 
@@ -82,7 +82,7 @@ providers. For OIDC logins, `{{external.xyz}}` refers to the "xyz" claim; for
 SAML logins, `{{external.xyz}}` refers to the "xyz" assertion.
 
 For example, here is what a role may look like if you want to assign allowed
-server environment types and allowed logins from the user's Okta `environments` and 
+server environment types and allowed logins from the user's Okta `environments` and
 `allowedlogins` assertions:
 
 ```yaml
@@ -173,7 +173,7 @@ spec:
       # Optional: the default session recording mode to use when a
       # protocol-specific mode is not set.
       default: best_effort|strict
-      # Optional: Session recording mode for SSH sessions. 
+      # Optional: Session recording mode for SSH sessions.
       # If not set, the value set on default will be used.
       ssh: best_effort|strict
     # Enterprise-only: when enabled, the source IP that was used to log in is embedded in the user


### PR DESCRIPTION
The language is called Go, not Golang.