### PR TITLE
add questionnaire to onboarding

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -807,8 +807,9 @@ func (h *Handler) bindDefaultEndpoints() {
 	// Fetches the user's preferences
 	h.GET("/webapi/user/preferences", h.WithAuth(h.getUserPreferences))
 
-	// Updates the user's preferences
-	h.PUT("/webapi/user/preferences", h.WithAuth(h.updateUserPreferences))
+	// Updates the user's preferences. This leverages WithAuthCookieAndCSRF rather than WithAuth because
+	// we update preferences during the onboarding flow, before a bearer token is set.
+	h.PUT("/webapi/user/preferences", h.WithAuthCookieAndCSRF(h.updateUserPreferences))
 }
 
 // GetProxyClient returns authenticated auth server client

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.story.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.story.tsx
@@ -17,8 +17,9 @@ limitations under the License.
 import React from 'react';
 import { Card } from 'design';
 
-import { Props, NewCredentials, SliderProps } from './NewCredentials';
+import { NewCredentials, SliderProps } from './NewCredentials';
 import { NewMfaDevice } from './NewMfaDevice';
+import { NewCredentialsProps } from './types';
 
 export default {
   title: 'Teleport/Welcome/Form',
@@ -184,7 +185,7 @@ const sliderProps: SliderProps & {
   password: '',
   updatePassword: () => null,
 };
-const props: Props = {
+const props: NewCredentialsProps = {
   auth2faType: 'off',
   primaryAuthType: 'local',
   isPasswordlessEnabled: true,
@@ -245,4 +246,6 @@ const props: Props = {
       'IYKEEEFCiCAh5KMwdgQ8OCEhRJAQ8v8AAAD//1QuL6EmJFBiAAAAAElFTkSuQmCC',
   },
   isDashboard: false,
+  displayOnboardingQuestionnaire: false,
+  setDisplayOnboardingQuestionnaire: () => {},
 };

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.test.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attempt } from 'shared/hooks/useAttemptNext';
+
+import { render, screen } from 'design/utils/testing';
+import React from 'react';
+
+import { RecoveryCodes, ResetToken } from 'teleport/services/auth';
+import { NewCredentialsProps } from 'teleport/Welcome/NewCredentials/types';
+import { NewCredentials } from 'teleport/Welcome/NewCredentials/NewCredentials';
+
+describe('newCredentials', () => {
+  let props: NewCredentialsProps;
+  const attempt: Attempt = { status: '' };
+  const failedAttempt: Attempt = { status: 'failed' };
+  const processingAttempt: Attempt = { status: 'processing' };
+  const successAttempt: Attempt = { status: 'success', statusText: 'hey' };
+
+  const resetToken: ResetToken = {
+    tokenId: 'tokenId',
+    qrCode: 'qrCode',
+    user: 'user',
+  };
+  const recoveryCodes: RecoveryCodes = {
+    createdDate: new Date(),
+  };
+
+  beforeEach(() => {
+    props = {
+      auth2faType: 'off',
+      primaryAuthType: 'sso',
+      isPasswordlessEnabled: false,
+      fetchAttempt: attempt,
+      submitAttempt: attempt,
+      clearSubmitAttempt: () => {},
+      onSubmit: () => {},
+      onSubmitWithWebauthn: () => {},
+      resetToken: resetToken,
+      recoveryCodes: recoveryCodes,
+      redirect: () => {},
+      success: false,
+      finishedRegister: () => {},
+      privateKeyPolicyEnabled: false,
+      displayOnboardingQuestionnaire: false,
+      setDisplayOnboardingQuestionnaire: () => {},
+      resetMode: false,
+      isDashboard: false,
+    };
+  });
+
+  test('renders expired for failed fetch attempt', () => {
+    props.fetchAttempt = failedAttempt;
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Invitation Code Expired/i)).toBeInTheDocument();
+  });
+
+  // eslint-disable-next-line jest/require-hook
+  [{ attempt: processingAttempt }, { attempt: attempt }].forEach(spec => {
+    test(`renders ${spec.attempt.status} as null`, () => {
+      props.fetchAttempt = spec.attempt;
+      const { container } = render(<NewCredentials {...props} />);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  });
+
+  test('renders Reset Complete for success and private key policy enabled during reset', () => {
+    props.fetchAttempt = successAttempt;
+    props.success = true;
+    props.privateKeyPolicyEnabled = true;
+    props.resetMode = true;
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Reset Complete/i)).toBeInTheDocument();
+  });
+
+  test('renders Registration Complete for success and private key policy enabled during registration', () => {
+    props.fetchAttempt = { status: 'success' };
+    props.success = true;
+    props.privateKeyPolicyEnabled = true;
+    props.resetMode = false;
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Registration Complete/i)).toBeInTheDocument();
+  });
+
+  test('renders Register Success on success', () => {
+    props.fetchAttempt = { status: 'success' };
+    props.privateKeyPolicyEnabled = false;
+    props.recoveryCodes = undefined;
+    props.success = true;
+    render(<NewCredentials {...props} />);
+
+    expect(
+      screen.getByText(/Proceed to access your account./i)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Go to Dashboard/i)).toBeInTheDocument();
+  });
+
+  test('renders recovery codes', () => {
+    props.fetchAttempt = { status: 'success' };
+    props.success = false;
+    props.recoveryCodes = {
+      codes: ['foo', 'bar'],
+      createdDate: new Date(),
+    };
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Backup & Recovery Codes/i)).toBeInTheDocument();
+  });
+
+  test('renders credential flow for passwordless', () => {
+    props.fetchAttempt = { status: 'success' };
+    props.success = false;
+    props.recoveryCodes = undefined;
+    props.primaryAuthType = 'passwordless';
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Set A Passwordless Device/i)).toBeInTheDocument();
+  });
+
+  test('renders credential flow for local', () => {
+    props.fetchAttempt = { status: 'success' };
+    props.success = false;
+    props.recoveryCodes = undefined;
+    props.primaryAuthType = 'local';
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Set A Password/i)).toBeInTheDocument();
+  });
+
+  test('renders credential flow for sso', () => {
+    props.fetchAttempt = { status: 'success' };
+    props.success = false;
+    props.recoveryCodes = undefined;
+    props.primaryAuthType = 'sso';
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Set A Password/i)).toBeInTheDocument();
+  });
+
+  test('renders questionnaire', () => {
+    props.fetchAttempt = { status: 'success' };
+    props.success = true;
+    props.recoveryCodes = undefined;
+    props.displayOnboardingQuestionnaire = true;
+    render(<NewCredentials {...props} />);
+
+    expect(screen.getByText(/Tell us about yourself/i)).toBeInTheDocument();
+  });
+});

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.test.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.test.tsx
@@ -22,145 +22,157 @@ import React from 'react';
 import { RecoveryCodes, ResetToken } from 'teleport/services/auth';
 import { NewCredentialsProps } from 'teleport/Welcome/NewCredentials/types';
 import { NewCredentials } from 'teleport/Welcome/NewCredentials/NewCredentials';
+import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
+import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
 
-describe('newCredentials', () => {
-  let props: NewCredentialsProps;
-  const attempt: Attempt = { status: '' };
-  const failedAttempt: Attempt = { status: 'failed' };
-  const processingAttempt: Attempt = { status: 'processing' };
-  const successAttempt: Attempt = { status: 'success', statusText: 'hey' };
+const attempt: Attempt = { status: '' };
+const failedAttempt: Attempt = { status: 'failed' };
+const processingAttempt: Attempt = { status: 'processing' };
+const successAttempt: Attempt = { status: 'success', statusText: 'hey' };
 
-  const resetToken: ResetToken = {
-    tokenId: 'tokenId',
-    qrCode: 'qrCode',
-    user: 'user',
+const resetToken: ResetToken = {
+  tokenId: 'tokenId',
+  qrCode: 'qrCode',
+  user: 'user',
+};
+const recoveryCodes: RecoveryCodes = {
+  createdDate: new Date(),
+};
+
+const makeProps = (): NewCredentialsProps => {
+  return {
+    auth2faType: 'off',
+    primaryAuthType: 'sso',
+    isPasswordlessEnabled: false,
+    fetchAttempt: attempt,
+    submitAttempt: attempt,
+    clearSubmitAttempt: () => {},
+    onSubmit: () => {},
+    onSubmitWithWebauthn: () => {},
+    resetToken: resetToken,
+    recoveryCodes: recoveryCodes,
+    redirect: () => {},
+    success: false,
+    finishedRegister: () => {},
+    privateKeyPolicyEnabled: false,
+    displayOnboardingQuestionnaire: false,
+    setDisplayOnboardingQuestionnaire: () => {},
+    resetMode: false,
+    isDashboard: false,
   };
-  const recoveryCodes: RecoveryCodes = {
+};
+
+test('renders expired for failed fetch attempt', () => {
+  const props = makeProps();
+  props.fetchAttempt = failedAttempt;
+  render(<NewCredentials {...props} />);
+
+  expect(screen.getByText(/Invitation Code Expired/i)).toBeInTheDocument();
+});
+
+const nullCases: {
+  attempt: Attempt;
+}[] = [{ attempt: processingAttempt }, { attempt: attempt }];
+
+test.each(nullCases)('renders $attempt as null', testCase => {
+  const props = makeProps();
+  props.fetchAttempt = testCase.attempt;
+  const { container } = render(<NewCredentials {...props} />);
+
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('renders Reset Complete for success and private key policy enabled during reset', () => {
+  const props = makeProps();
+  props.fetchAttempt = successAttempt;
+  props.success = true;
+  props.privateKeyPolicyEnabled = true;
+  props.resetMode = true;
+  render(<NewCredentials {...props} />);
+
+  expect(screen.getByText(/Reset Complete/i)).toBeInTheDocument();
+});
+
+test('renders Registration Complete for success and private key policy enabled during registration', () => {
+  const props = makeProps();
+  props.fetchAttempt = { status: 'success' };
+  props.success = true;
+  props.privateKeyPolicyEnabled = true;
+  props.resetMode = false;
+  render(<NewCredentials {...props} />);
+
+  expect(screen.getByText(/Registration Complete/i)).toBeInTheDocument();
+});
+
+test('renders Register Success on success', () => {
+  const props = makeProps();
+  props.fetchAttempt = { status: 'success' };
+  props.privateKeyPolicyEnabled = false;
+  props.recoveryCodes = undefined;
+  props.success = true;
+  render(<NewCredentials {...props} />);
+
+  expect(
+    screen.getByText(/Proceed to access your account./i)
+  ).toBeInTheDocument();
+  expect(screen.getByText(/Go to Cluster/i)).toBeInTheDocument();
+});
+
+test('renders recovery codes', () => {
+  const props = makeProps();
+  props.fetchAttempt = { status: 'success' };
+  props.success = false;
+  props.recoveryCodes = {
+    codes: ['foo', 'bar'],
     createdDate: new Date(),
   };
+  render(<NewCredentials {...props} />);
 
-  beforeEach(() => {
-    props = {
-      auth2faType: 'off',
-      primaryAuthType: 'sso',
-      isPasswordlessEnabled: false,
-      fetchAttempt: attempt,
-      submitAttempt: attempt,
-      clearSubmitAttempt: () => {},
-      onSubmit: () => {},
-      onSubmitWithWebauthn: () => {},
-      resetToken: resetToken,
-      recoveryCodes: recoveryCodes,
-      redirect: () => {},
-      success: false,
-      finishedRegister: () => {},
-      privateKeyPolicyEnabled: false,
-      displayOnboardingQuestionnaire: false,
-      setDisplayOnboardingQuestionnaire: () => {},
-      resetMode: false,
-      isDashboard: false,
-    };
-  });
+  expect(screen.getByText(/Backup & Recovery Codes/i)).toBeInTheDocument();
+});
 
-  test('renders expired for failed fetch attempt', () => {
-    props.fetchAttempt = failedAttempt;
-    render(<NewCredentials {...props} />);
+test('renders credential flow for passwordless', () => {
+  const props = makeProps();
+  props.fetchAttempt = { status: 'success' };
+  props.success = false;
+  props.recoveryCodes = undefined;
+  props.primaryAuthType = 'passwordless';
+  render(<NewCredentials {...props} />);
 
-    expect(screen.getByText(/Invitation Code Expired/i)).toBeInTheDocument();
-  });
+  expect(screen.getByText(/Set A Passwordless Device/i)).toBeInTheDocument();
+});
 
-  // eslint-disable-next-line jest/require-hook
-  [{ attempt: processingAttempt }, { attempt: attempt }].forEach(spec => {
-    test(`renders ${spec.attempt.status} as null`, () => {
-      props.fetchAttempt = spec.attempt;
-      const { container } = render(<NewCredentials {...props} />);
+test('renders credential flow for local', () => {
+  const props = makeProps();
+  props.fetchAttempt = { status: 'success' };
+  props.success = false;
+  props.recoveryCodes = undefined;
+  props.primaryAuthType = 'local';
+  render(<NewCredentials {...props} />);
 
-      expect(container).toBeEmptyDOMElement();
-    });
-  });
+  expect(screen.getByText(/Set A Password/i)).toBeInTheDocument();
+});
 
-  test('renders Reset Complete for success and private key policy enabled during reset', () => {
-    props.fetchAttempt = successAttempt;
-    props.success = true;
-    props.privateKeyPolicyEnabled = true;
-    props.resetMode = true;
-    render(<NewCredentials {...props} />);
+test('renders credential flow for sso', () => {
+  const props = makeProps();
+  props.fetchAttempt = { status: 'success' };
+  props.success = false;
+  props.recoveryCodes = undefined;
+  props.primaryAuthType = 'sso';
+  render(<NewCredentials {...props} />);
 
-    expect(screen.getByText(/Reset Complete/i)).toBeInTheDocument();
-  });
+  expect(screen.getByText(/Set A Password/i)).toBeInTheDocument();
+});
 
-  test('renders Registration Complete for success and private key policy enabled during registration', () => {
-    props.fetchAttempt = { status: 'success' };
-    props.success = true;
-    props.privateKeyPolicyEnabled = true;
-    props.resetMode = false;
-    render(<NewCredentials {...props} />);
+test('renders questionnaire', () => {
+  mockUserContextProviderWith(makeTestUserContext());
 
-    expect(screen.getByText(/Registration Complete/i)).toBeInTheDocument();
-  });
+  const props = makeProps();
+  props.fetchAttempt = { status: 'success' };
+  props.success = true;
+  props.recoveryCodes = undefined;
+  props.displayOnboardingQuestionnaire = true;
+  render(<NewCredentials {...props} />);
 
-  test('renders Register Success on success', () => {
-    props.fetchAttempt = { status: 'success' };
-    props.privateKeyPolicyEnabled = false;
-    props.recoveryCodes = undefined;
-    props.success = true;
-    render(<NewCredentials {...props} />);
-
-    expect(
-      screen.getByText(/Proceed to access your account./i)
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Go to Dashboard/i)).toBeInTheDocument();
-  });
-
-  test('renders recovery codes', () => {
-    props.fetchAttempt = { status: 'success' };
-    props.success = false;
-    props.recoveryCodes = {
-      codes: ['foo', 'bar'],
-      createdDate: new Date(),
-    };
-    render(<NewCredentials {...props} />);
-
-    expect(screen.getByText(/Backup & Recovery Codes/i)).toBeInTheDocument();
-  });
-
-  test('renders credential flow for passwordless', () => {
-    props.fetchAttempt = { status: 'success' };
-    props.success = false;
-    props.recoveryCodes = undefined;
-    props.primaryAuthType = 'passwordless';
-    render(<NewCredentials {...props} />);
-
-    expect(screen.getByText(/Set A Passwordless Device/i)).toBeInTheDocument();
-  });
-
-  test('renders credential flow for local', () => {
-    props.fetchAttempt = { status: 'success' };
-    props.success = false;
-    props.recoveryCodes = undefined;
-    props.primaryAuthType = 'local';
-    render(<NewCredentials {...props} />);
-
-    expect(screen.getByText(/Set A Password/i)).toBeInTheDocument();
-  });
-
-  test('renders credential flow for sso', () => {
-    props.fetchAttempt = { status: 'success' };
-    props.success = false;
-    props.recoveryCodes = undefined;
-    props.primaryAuthType = 'sso';
-    render(<NewCredentials {...props} />);
-
-    expect(screen.getByText(/Set A Password/i)).toBeInTheDocument();
-  });
-
-  test('renders questionnaire', () => {
-    props.fetchAttempt = { status: 'success' };
-    props.success = true;
-    props.recoveryCodes = undefined;
-    props.displayOnboardingQuestionnaire = true;
-    render(<NewCredentials {...props} />);
-
-    expect(screen.getByText(/Tell us about yourself/i)).toBeInTheDocument();
-  });
+  expect(screen.getByText(/Tell us about yourself/i)).toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
@@ -17,20 +17,17 @@ limitations under the License.
 import React, { useState } from 'react';
 import { Card } from 'design';
 import { PrimaryAuthType } from 'shared/services';
-
 import { NewFlow, StepComponentProps, StepSlider } from 'design/StepSlider';
 
 import RecoveryCodes from 'teleport/components/RecoveryCodes';
 import { PrivateKeyLoginDisabledCard } from 'teleport/components/PrivateKeyPolicy';
-
-import cfg from 'teleport/config';
-
-import { NewCredentialsProps } from 'teleport/Welcome/NewCredentials/types';
 import { Questionnaire } from 'teleport/Welcome/Questionnaire/Questionnaire';
+import cfg from 'teleport/config';
 
 import useToken from '../useToken';
 
 import { Expired } from './Expired';
+import { NewCredentialsProps } from './types';
 import { RegisterSuccess } from './Success';
 import { NewMfaDevice } from './NewMfaDevice';
 import { NewPasswordlessDevice } from './NewPasswordlessDevice';

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewMfaDevice.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewMfaDevice.tsx
@@ -30,7 +30,9 @@ import createMfaOptions from 'shared/utils/createMfaOptions';
 import { useRefAutoFocus } from 'shared/hooks';
 import { Auth2faType } from 'shared/services';
 
-import { Props as CredentialsProps, SliderProps } from './NewCredentials';
+import { UseTokenState } from 'teleport/Welcome/NewCredentials/types';
+
+import { SliderProps } from './NewCredentials';
 import secKeyGraphic from './sec-key-with-bg.png';
 
 export function NewMfaDevice(props: Props) {
@@ -48,7 +50,7 @@ export function NewMfaDevice(props: Props) {
   } = props;
   const [otp, setOtp] = useState('');
   const mfaOptions = createMfaOptions({
-    auth2faType: auth2faType,
+    auth2faType: auth2faType as Auth2faType,
   });
   const [mfaType, setMfaType] = useState(mfaOptions[0]);
   const [deviceName, setDeviceName] = useState(() =>
@@ -241,7 +243,7 @@ function getDefaultDeviceName(mfaType: Auth2faType) {
   return '';
 }
 
-type Props = CredentialsProps &
+type Props = UseTokenState &
   SliderProps & {
     password: string;
     updatePassword(pwd: string): void;

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewPassword.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewPassword.tsx
@@ -25,8 +25,7 @@ import {
 } from 'shared/components/Validation/rules';
 import { useRefAutoFocus } from 'shared/hooks';
 
-import { UseTokenState } from 'teleport/Welcome/NewCredentials/types';
-
+import { UseTokenState } from './types';
 import { SliderProps } from './NewCredentials';
 
 export function NewPassword(props: Props) {

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewPassword.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewPassword.tsx
@@ -25,7 +25,9 @@ import {
 } from 'shared/components/Validation/rules';
 import { useRefAutoFocus } from 'shared/hooks';
 
-import { Props as CredentialsProps, SliderProps } from './NewCredentials';
+import { UseTokenState } from 'teleport/Welcome/NewCredentials/types';
+
+import { SliderProps } from './NewCredentials';
 
 export function NewPassword(props: Props) {
   const {
@@ -143,7 +145,7 @@ export function NewPassword(props: Props) {
   );
 }
 
-type Props = CredentialsProps &
+type Props = UseTokenState &
   SliderProps & {
     password: string;
     updatePassword(pwd: string): void;

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
@@ -22,8 +22,7 @@ import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import { useRefAutoFocus } from 'shared/hooks';
 
-import { UseTokenState } from 'teleport/Welcome/NewCredentials/types';
-
+import { UseTokenState } from './types';
 import { SliderProps } from './NewCredentials';
 
 export function NewPasswordlessDevice(props: UseTokenState & SliderProps) {

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewPasswordlessDevice.tsx
@@ -22,9 +22,11 @@ import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import { useRefAutoFocus } from 'shared/hooks';
 
-import { Props, SliderProps } from './NewCredentials';
+import { UseTokenState } from 'teleport/Welcome/NewCredentials/types';
 
-export function NewPasswordlessDevice(props: Props & SliderProps) {
+import { SliderProps } from './NewCredentials';
+
+export function NewPasswordlessDevice(props: UseTokenState & SliderProps) {
   const {
     submitAttempt,
     onSubmitWithWebauthn,

--- a/web/packages/teleport/src/Welcome/NewCredentials/Success.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/Success.tsx
@@ -19,8 +19,7 @@ import { ButtonPrimary, Card, Flex, Image, Text } from 'design';
 
 import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
 
-import { RegisterSuccessProps } from 'teleport/Welcome/NewCredentials/types';
-
+import { RegisterSuccessProps } from './types';
 import shieldCheck from './shield-check.png';
 
 export function RegisterSuccess({

--- a/web/packages/teleport/src/Welcome/NewCredentials/Success.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/Success.tsx
@@ -19,6 +19,8 @@ import { ButtonPrimary, Card, Flex, Image, Text } from 'design';
 
 import { CaptureEvent, userEventService } from 'teleport/services/userEvent';
 
+import { RegisterSuccessProps } from 'teleport/Welcome/NewCredentials/types';
+
 import shieldCheck from './shield-check.png';
 
 export function RegisterSuccess({
@@ -26,12 +28,7 @@ export function RegisterSuccess({
   resetMode = false,
   username = '',
   isDashboard,
-}: {
-  redirect(): void;
-  resetMode: boolean;
-  username?: string;
-  isDashboard: boolean;
-}) {
+}: RegisterSuccessProps) {
   const actionTxt = resetMode ? 'reset' : 'registration';
 
   const handleRedirect = () => {

--- a/web/packages/teleport/src/Welcome/NewCredentials/types.ts
+++ b/web/packages/teleport/src/Welcome/NewCredentials/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Attempt } from 'shared/hooks/useAttemptNext';
+
+import { Auth2faType, PrimaryAuthType } from 'shared/services';
+
+import { RecoveryCodes, ResetToken } from 'teleport/services/auth';
+
+export type UseTokenState = {
+  auth2faType: Auth2faType;
+  primaryAuthType: PrimaryAuthType;
+  isPasswordlessEnabled: boolean;
+  fetchAttempt: Attempt;
+  submitAttempt: Attempt;
+  clearSubmitAttempt: () => void;
+  onSubmit: (password: string, otpCode?: string, deviceName?: string) => void;
+  onSubmitWithWebauthn: (password?: string, deviceName?: string) => void;
+  resetToken: ResetToken;
+  recoveryCodes: RecoveryCodes;
+  redirect: () => void;
+  success: boolean;
+  finishedRegister: () => void;
+  privateKeyPolicyEnabled: boolean;
+  displayOnboardingQuestionnaire: boolean;
+  setDisplayOnboardingQuestionnaire: (bool: boolean) => void;
+};
+
+export type NewCredentialsProps = UseTokenState & {
+  resetMode?: boolean;
+  isDashboard: boolean;
+};
+
+export type RegisterSuccessProps = {
+  redirect(): void;
+  resetMode: boolean;
+  username?: string;
+  isDashboard: boolean;
+};

--- a/web/packages/teleport/src/Welcome/Questionnaire/Company.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Company.tsx
@@ -21,7 +21,7 @@ import FieldSelect from 'shared/components/FieldSelect';
 import { requiredField } from 'shared/components/Validation/rules';
 
 import { EmployeeSelectOptions } from './constants';
-import { CompanyProps, EmployeeOptionsStrings } from './types';
+import { CompanyProps, EmployeeOption } from './types';
 
 export const Company = ({
   updateFields,
@@ -44,7 +44,7 @@ export const Company = ({
       label="Number of Employees"
       rule={requiredField('Number of Employees is required')}
       placeholder="Select Team Size"
-      onChange={(e: Option<EmployeeOptionsStrings, string>) =>
+      onChange={(e: Option<EmployeeOption>) =>
         updateFields({ employeeCount: e.value })
       }
       value={

--- a/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.test.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.test.tsx
@@ -21,18 +21,45 @@ import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserC
 import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
 
 import { Questionnaire } from './Questionnaire';
+import { QuestionnaireProps } from './types';
 
 describe('questionnaire', () => {
+  let props: QuestionnaireProps;
+
   beforeEach(() => {
     mockUserContextProviderWith(makeTestUserContext());
+    props = {
+      full: false,
+      username: '',
+    };
   });
 
   test('loads each question', () => {
-    render(<Questionnaire username="" />);
+    props.full = true;
+    render(<Questionnaire {...props} />);
 
-    expect(screen.getByText('Tell us about yourself')).toBeInTheDocument();
+    expect(screen.getByText('Tell us about yourself')).toBeVisible();
     expect(screen.getByLabelText('Company Name')).toBeInTheDocument();
     expect(screen.getByLabelText('Number of Employees')).toBeInTheDocument();
+    expect(screen.getByLabelText('Which Team are you on?')).toBeInTheDocument();
+    expect(screen.getByLabelText('Job Title')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Which infrastructure resources do you need to access frequently?'
+      )
+    ).toBeInTheDocument();
+  });
+
+  test('skips questions if not full', () => {
+    props.full = false;
+    render(<Questionnaire {...props} />);
+
+    expect(screen.getByText('Tell us about yourself')).toBeInTheDocument();
+
+    expect(screen.queryByLabelText('Company Name')).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText('Number of Employees')
+    ).not.toBeInTheDocument();
     expect(screen.getByLabelText('Which Team are you on?')).toBeInTheDocument();
     expect(screen.getByLabelText('Job Title')).toBeInTheDocument();
     expect(

--- a/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Questionnaire.tsx
@@ -27,11 +27,12 @@ import {
   ProtoResource,
   QuestionnaireFormFields,
   QuestionnaireProps,
+  ResourceOption,
 } from './types';
 import { Company } from './Company';
 import { Role } from './Role';
 import { Resources } from './Resources';
-import { resourceMapping, supportedResources } from './constants';
+import { resourceMapping } from './constants';
 
 export const Questionnaire = ({
   full,
@@ -44,6 +45,7 @@ export const Questionnaire = ({
     companyName: '',
     employeeCount: undefined,
     team: undefined,
+    teamName: '',
     role: undefined,
     resources: [],
   });
@@ -66,7 +68,7 @@ export const Questionnaire = ({
 
     // maps the string enum used for UI display & Sales Center object with proto int
     const protoResources: ProtoResource[] = formFields.resources.map(
-      r => resourceMapping[r]
+      r => resourceMapping[ResourceOption[r]]
     );
 
     void updatePreferences({
@@ -77,7 +79,7 @@ export const Questionnaire = ({
 
     const request: SurveyRequest = {
       companyName: formFields.companyName,
-      employeeCount: formFields.employeeCount,
+      employeeCount: String(formFields.employeeCount),
       resources: formFields.resources,
       role: formFields.role,
       team: formFields.team,
@@ -122,7 +124,6 @@ export const Questionnaire = ({
               updateFields={updateForm}
             />
             <Resources
-              resources={supportedResources}
               checked={formFields.resources}
               updateFields={updateForm}
             />

--- a/web/packages/teleport/src/Welcome/Questionnaire/Resources.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Resources.tsx
@@ -20,41 +20,44 @@ import Image from 'design/Image';
 import { CheckboxInput } from 'design/Checkbox';
 import { useRule } from 'shared/components/Validation';
 
-import { requiredResourceField } from 'teleport/Welcome/Questionnaire/constants';
+import { Option } from 'shared/components/Select';
 
-import { ResourcesProps, ResourceType, Resource } from './types';
+import {
+  GetResourceIcon,
+  requiredResourceField,
+  ResourceOptions,
+} from 'teleport/Welcome/Questionnaire/constants';
+
+import { ResourcesProps, ResourceOption } from './types';
 import { ResourceWrapper } from './ResourceWrapper';
 
-export const Resources = ({
-  resources,
-  checked,
-  updateFields,
-}: ResourcesProps) => {
+export const Resources = ({ checked, updateFields }: ResourcesProps) => {
   const { valid, message } = useRule(requiredResourceField(checked));
 
-  const updateResources = (label: Resource) => {
+  const updateResources = (r: Option<string, ResourceOption>) => {
+    const selected = r.value as ResourceOption;
     let updated = checked;
-    if (updated.includes(label)) {
-      updated = updated.filter(r => r !== label);
+    if (updated.includes(selected)) {
+      updated = updated.filter(r => r !== (r as ResourceOption));
     } else {
-      updated.push(label);
+      updated.push(selected);
     }
 
     updateFields({ resources: updated });
   };
 
-  const renderCheck = (resource: ResourceType) => {
-    const isSelected = checked.includes(resource.label);
+  const renderCheck = (resource: Option<string, ResourceOption>) => {
+    const isSelected = checked.includes(resource.value as ResourceOption);
     return (
       <label
-        htmlFor={`box-${resource.label}`}
-        data-testid={`box-${resource.label}`}
-        key={resource.label}
+        htmlFor={`box-${resource.value}`}
+        data-testid={`box-${resource.value}`}
+        key={resource.value}
         style={{
           width: '100%',
           height: '100%',
         }}
-        onClick={() => updateResources(resource.label)}
+        onClick={() => updateResources(resource)}
       >
         <ResourceWrapper isSelected={isSelected} invalid={!valid}>
           <CheckboxInput
@@ -63,7 +66,7 @@ export const Resources = ({
             type="checkbox"
             name={resource.label}
             readOnly
-            checked={checked.includes(resource.label)}
+            checked={checked.includes(resource.value as ResourceOption)}
             rule={requiredResourceField(checked)}
             style={{
               alignSelf: 'flex-end',
@@ -74,7 +77,11 @@ export const Resources = ({
             alignItems="center"
             justifyContent="center"
           >
-            <Image src={resource.image} height="64px" width="64px" />
+            <Image
+              src={GetResourceIcon(resource.label)}
+              height="64px"
+              width="64px"
+            />
             <Text textAlign="center" typography="body3">
               {resource.label}
             </Text>
@@ -95,7 +102,9 @@ export const Resources = ({
         </LabelInput>
       </Flex>
       <Flex gap={2} alignItems="flex-start" height="170px">
-        {resources.map((r: ResourceType) => renderCheck(r))}
+        {ResourceOptions.map((r: Option<string, ResourceOption>) =>
+          renderCheck(r)
+        )}
       </Flex>
     </>
   );

--- a/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
@@ -20,41 +20,38 @@ import React from 'react';
 
 import Validation from 'shared/components/Validation';
 
-import { RoleProps } from 'teleport/Welcome/Questionnaire/types';
-
+import { RoleProps } from './types';
 import { Role } from './Role';
 
-describe('role', () => {
-  let props: RoleProps;
+const makeProps = (): RoleProps => {
+  return {
+    role: 'C-Suite/Owner',
+    team: 'DevOps Engineering',
+    teamName: '',
+    updateFields: () => {},
+  };
+};
 
-  beforeEach(() => {
-    props = {
-      role: 'C-Suite/Owner',
-      team: 'DevOps Engineering',
-      teamName: '',
-      updateFields: () => {},
-    };
-  });
+test('hides custom team input for explicit fields', () => {
+  const props = makeProps();
+  props.team = 'DevOps Engineering';
+  render(
+    <Validation>
+      <Role {...props} />
+    </Validation>
+  );
 
-  test('hides custom team input for explicit fields', () => {
-    props.team = 'DevOps Engineering';
-    render(
-      <Validation>
-        <Role {...props} />
-      </Validation>
-    );
+  expect(screen.queryByLabelText('Team Name')).not.toBeInTheDocument();
+});
 
-    expect(screen.queryByLabelText('Team Name')).not.toBeInTheDocument();
-  });
+test('shows custom team input', () => {
+  const props = makeProps();
+  props.team = 'Other (free-form field)';
+  render(
+    <Validation>
+      <Role {...props} />
+    </Validation>
+  );
 
-  test('shows custom team input', () => {
-    props.team = 'Other (free-form field)';
-    render(
-      <Validation>
-        <Role {...props} />
-      </Validation>
-    );
-
-    expect(screen.getByLabelText('Team Name')).toBeInTheDocument();
-  });
+  expect(screen.getByLabelText('Team Name')).toBeInTheDocument();
 });

--- a/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
@@ -20,13 +20,13 @@ import React from 'react';
 
 import Validation from 'shared/components/Validation';
 
-import { RoleProps } from './types';
+import { RoleProps, TeamOption } from './types';
 import { Role } from './Role';
 
 const makeProps = (): RoleProps => {
   return {
-    role: 'C-Suite/Owner',
-    team: 'DevOps Engineering',
+    role: undefined,
+    team: undefined,
     teamName: '',
     updateFields: () => {},
   };
@@ -34,7 +34,6 @@ const makeProps = (): RoleProps => {
 
 test('hides custom team input for explicit fields', () => {
   const props = makeProps();
-  props.team = 'DevOps Engineering';
   render(
     <Validation>
       <Role {...props} />
@@ -46,7 +45,7 @@ test('hides custom team input for explicit fields', () => {
 
 test('shows custom team input', () => {
   const props = makeProps();
-  props.team = 'Other (free-form field)';
+  props.team = 'OTHER' as TeamOption;
   render(
     <Validation>
       <Role {...props} />

--- a/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Role.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { render, screen } from 'design/utils/testing';
+
+import React from 'react';
+
+import Validation from 'shared/components/Validation';
+
+import { RoleProps } from 'teleport/Welcome/Questionnaire/types';
+
+import { Role } from './Role';
+
+describe('role', () => {
+  let props: RoleProps;
+
+  beforeEach(() => {
+    props = {
+      role: 'C-Suite/Owner',
+      team: 'DevOps Engineering',
+      teamName: '',
+      updateFields: () => {},
+    };
+  });
+
+  test('hides custom team input for explicit fields', () => {
+    props.team = 'DevOps Engineering';
+    render(
+      <Validation>
+        <Role {...props} />
+      </Validation>
+    );
+
+    expect(screen.queryByLabelText('Team Name')).not.toBeInTheDocument();
+  });
+
+  test('shows custom team input', () => {
+    props.team = 'Other (free-form field)';
+    render(
+      <Validation>
+        <Role {...props} />
+      </Validation>
+    );
+
+    expect(screen.getByLabelText('Team Name')).toBeInTheDocument();
+  });
+});

--- a/web/packages/teleport/src/Welcome/Questionnaire/Role.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Role.tsx
@@ -18,11 +18,12 @@ import React from 'react';
 import { Option } from 'shared/components/Select';
 import FieldSelect from 'shared/components/FieldSelect';
 import { requiredField } from 'shared/components/Validation/rules';
+import FieldInput from 'shared/components/FieldInput';
 
 import { RoleProps, TeamOptionsStrings, TitleOptionsStrings } from './types';
 import { teamSelectOptions, titleSelectOptions } from './constants';
 
-export const Role = ({ team, role, updateFields }: RoleProps) => (
+export const Role = ({ team, teamName, role, updateFields }: RoleProps) => (
   <>
     <FieldSelect
       label="Which Team are you on?"
@@ -34,6 +35,18 @@ export const Role = ({ team, role, updateFields }: RoleProps) => (
       options={teamSelectOptions}
       value={team ? { label: team, value: team } : null}
     />
+    {team === 'Other (free-form field)' && (
+      <FieldInput
+        id="team-name"
+        type="text"
+        label="Team Name"
+        rule={requiredField('Team Name is required')}
+        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+          updateFields({ teamName: e.target.value })
+        }
+        value={teamName}
+      />
+    )}
     <FieldSelect
       label="Job Title"
       rule={requiredField('Job Title is required')}

--- a/web/packages/teleport/src/Welcome/Questionnaire/Role.tsx
+++ b/web/packages/teleport/src/Welcome/Questionnaire/Role.tsx
@@ -20,7 +20,7 @@ import FieldSelect from 'shared/components/FieldSelect';
 import { requiredField } from 'shared/components/Validation/rules';
 import FieldInput from 'shared/components/FieldInput';
 
-import { RoleProps, TeamOptionsStrings, TitleOptionsStrings } from './types';
+import { RoleProps, TeamOption, TitleOption } from './types';
 import { teamSelectOptions, titleSelectOptions } from './constants';
 
 export const Role = ({ team, teamName, role, updateFields }: RoleProps) => (
@@ -29,13 +29,18 @@ export const Role = ({ team, teamName, role, updateFields }: RoleProps) => (
       label="Which Team are you on?"
       rule={requiredField('Team is required')}
       placeholder="Select Team"
-      onChange={(e: Option<TeamOptionsStrings, string>) =>
-        updateFields({ team: e.value })
-      }
+      onChange={(e: Option<TeamOption>) => updateFields({ team: e.value })}
       options={teamSelectOptions}
-      value={team ? { label: team, value: team } : null}
+      value={
+        team
+          ? {
+              value: team,
+              label: TeamOption[team],
+            }
+          : null
+      }
     />
-    {team === 'Other (free-form field)' && (
+    {TeamOption[team] === TeamOption.OTHER && (
       <FieldInput
         id="team-name"
         type="text"
@@ -51,11 +56,16 @@ export const Role = ({ team, teamName, role, updateFields }: RoleProps) => (
       label="Job Title"
       rule={requiredField('Job Title is required')}
       placeholder="Select Job Title"
-      onChange={(e: Option<TitleOptionsStrings, string>) =>
-        updateFields({ role: e.value })
-      }
+      onChange={(e: Option<TitleOption>) => updateFields({ role: e.value })}
       options={titleSelectOptions}
-      value={role ? { label: role, value: role } : null}
+      value={
+        role
+          ? {
+              value: role,
+              label: TitleOption[role],
+            }
+          : null
+      }
     />
   </>
 );

--- a/web/packages/teleport/src/Welcome/Questionnaire/constants.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/constants.ts
@@ -21,79 +21,58 @@ import stack from 'design/assets/resources/stack.png';
 import { Option } from 'shared/components/Select';
 
 import {
-  EmployeeOptionsStrings,
+  EmployeeOption,
   ProtoResource,
-  Resource,
-  TeamOptionsStrings,
-  TitleOptionsStrings,
+  ResourceOption,
+  TeamOption,
+  TitleOption,
 } from './types';
 
-export enum EmployeeOptions {
-  '0-19',
-  '20-199',
-  '200-499',
-  '500-999',
-  '1000-4999',
-  '5000+',
-}
-
-export const EmployeeSelectOptions: Option<
-  EmployeeOptionsStrings,
-  EmployeeOptionsStrings
->[] = Object.values(EmployeeOptions)
-  .filter(v => !isNaN(Number(v)))
-  .map(key => ({
-    value: EmployeeOptions[key],
-    label: EmployeeOptions[key],
+export const EmployeeSelectOptions: Option<string, EmployeeOption>[] =
+  Object.keys(EmployeeOption).map(key => ({
+    value: key,
+    label: EmployeeOption[key],
   }));
 
-export enum TeamOptions {
-  'Software Engineering',
-  'DevOps Engineering',
-  'IT',
-  'Support',
-  'Finance',
-  'Legal',
-  'Other (free-form field)',
-}
+export const teamSelectOptions: Option<string, TeamOption>[] = (
+  Object.keys(TeamOption) as Array<keyof typeof TeamOption>
+).map(key => ({
+  value: key,
+  label: TeamOption[key],
+}));
 
-export const teamSelectOptions: Option<
-  TeamOptionsStrings,
-  TeamOptionsStrings
->[] = Object.values(TeamOptions)
-  .filter(v => !isNaN(Number(v)))
-  .map(key => ({
-    value: TeamOptions[key],
-    label: TeamOptions[key],
-  }));
+export const titleSelectOptions: Option<string, TitleOption>[] = (
+  Object.keys(TitleOption) as Array<keyof typeof TitleOption>
+).map(key => ({
+  value: key,
+  label: TitleOption[key],
+}));
 
-export enum TitleOptions {
-  'Individual contributor',
-  'Manager',
-  'Director',
-  'VP',
-  'C-Suite/Owner',
-}
+export const ResourceOptions: Option<string, ResourceOption>[] = Object.keys(
+  ResourceOption
+).map(key => ({
+  value: key,
+  label: ResourceOption[key],
+}));
 
-export const titleSelectOptions: Option<
-  TitleOptionsStrings,
-  TitleOptionsStrings
->[] = Object.values(TitleOptions)
-  .filter(v => !isNaN(Number(v)))
-  .map(key => ({
-    value: TitleOptions[key],
-    label: TitleOptions[key],
-  }));
+export const GetResourceIcon = key => {
+  switch (ResourceOption[key]) {
+    case ResourceOption.RESOURCE_WEB_APPLICATIONS:
+      return application;
+    case ResourceOption.RESOURCE_WINDOWS_DESKTOPS:
+      return desktop;
+    case ResourceOption.RESOURCE_SERVER_SSH:
+      return stack;
+    case ResourceOption.RESOURCE_DATABASES:
+      return database;
+    case ResourceOption.RESOURCE_KUBERNETES:
+      return stack;
+    default:
+      return stack;
+  }
+};
 
-export const supportedResources = [
-  { label: Resource.RESOURCE_WEB_APPLICATIONS, image: application },
-  { label: Resource.RESOURCE_WINDOWS_DESKTOPS, image: desktop },
-  { label: Resource.RESOURCE_SERVER_SSH, image: stack },
-  { label: Resource.RESOURCE_DATABASES, image: database },
-  { label: Resource.RESOURCE_KUBERNETES, image: stack },
-];
-
-export const requiredResourceField = (value: Resource[]) => () => {
+export const requiredResourceField = (value: ResourceOption[]) => () => {
   const valid = !!value.length;
   return {
     valid,
@@ -101,10 +80,12 @@ export const requiredResourceField = (value: Resource[]) => () => {
   };
 };
 
-export const resourceMapping: { [key in Resource]: ProtoResource } = {
-  [Resource.RESOURCE_WINDOWS_DESKTOPS]: ProtoResource.RESOURCE_WINDOWS_DESKTOPS,
-  [Resource.RESOURCE_SERVER_SSH]: ProtoResource.RESOURCE_SERVER_SSH,
-  [Resource.RESOURCE_DATABASES]: ProtoResource.RESOURCE_DATABASES,
-  [Resource.RESOURCE_KUBERNETES]: ProtoResource.RESOURCE_KUBERNETES,
-  [Resource.RESOURCE_WEB_APPLICATIONS]: ProtoResource.RESOURCE_WEB_APPLICATIONS,
+export const resourceMapping: { [key in ResourceOption]: ProtoResource } = {
+  [ResourceOption.RESOURCE_WINDOWS_DESKTOPS]:
+    ProtoResource.RESOURCE_WINDOWS_DESKTOPS,
+  [ResourceOption.RESOURCE_SERVER_SSH]: ProtoResource.RESOURCE_SERVER_SSH,
+  [ResourceOption.RESOURCE_DATABASES]: ProtoResource.RESOURCE_DATABASES,
+  [ResourceOption.RESOURCE_KUBERNETES]: ProtoResource.RESOURCE_KUBERNETES,
+  [ResourceOption.RESOURCE_WEB_APPLICATIONS]:
+    ProtoResource.RESOURCE_WEB_APPLICATIONS,
 };

--- a/web/packages/teleport/src/Welcome/Questionnaire/constants.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/constants.ts
@@ -22,6 +22,7 @@ import { Option } from 'shared/components/Select';
 
 import {
   EmployeeOptionsStrings,
+  ProtoResource,
   Resource,
   TeamOptionsStrings,
   TitleOptionsStrings,
@@ -98,4 +99,12 @@ export const requiredResourceField = (value: Resource[]) => () => {
     valid,
     message: 'Resource is required',
   };
+};
+
+export const resourceMapping: { [key in Resource]: ProtoResource } = {
+  [Resource.RESOURCE_WINDOWS_DESKTOPS]: ProtoResource.RESOURCE_WINDOWS_DESKTOPS,
+  [Resource.RESOURCE_SERVER_SSH]: ProtoResource.RESOURCE_SERVER_SSH,
+  [Resource.RESOURCE_DATABASES]: ProtoResource.RESOURCE_DATABASES,
+  [Resource.RESOURCE_KUBERNETES]: ProtoResource.RESOURCE_KUBERNETES,
+  [Resource.RESOURCE_WEB_APPLICATIONS]: ProtoResource.RESOURCE_WEB_APPLICATIONS,
 };

--- a/web/packages/teleport/src/Welcome/Questionnaire/types.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/types.ts
@@ -17,7 +17,12 @@
 import { EmployeeOptions, TeamOptions, TitleOptions } from './constants';
 
 export type QuestionnaireProps = {
+  // full indicates if a full survey should be presented
+  // false indicates that a partial survey is shown (some questions are skipped)
+  full: boolean;
   username: string;
+  // optional callback to handle parent interaction
+  onSubmit?: () => void;
 };
 
 export type QuestionProps = {
@@ -32,6 +37,7 @@ export type CompanyProps = QuestionProps & {
 export type RoleProps = QuestionProps & {
   role: TitleOptionsStrings;
   team: TeamOptionsStrings;
+  teamName: string;
 };
 
 export type ResourceType = {
@@ -43,6 +49,15 @@ export type ResourcesProps = QuestionProps & {
   resources: ResourceType[];
   checked: Resource[];
 };
+
+export enum ProtoResource {
+  RESOURCE_UNSPECIFIED = 0,
+  RESOURCE_WINDOWS_DESKTOPS = 1,
+  RESOURCE_SERVER_SSH = 2,
+  RESOURCE_DATABASES = 3,
+  RESOURCE_KUBERNETES = 4,
+  RESOURCE_WEB_APPLICATIONS = 5,
+}
 
 export enum Resource {
   RESOURCE_WINDOWS_DESKTOPS = 'Windows Desktops',
@@ -58,6 +73,7 @@ export type QuestionnaireFormFields = {
   role: TitleOptionsStrings;
   team: TeamOptionsStrings;
   resources: Resource[];
+  teamName?: string; // only set if "Other" is selected from team options
 };
 
 export type EmployeeOptionsStrings = keyof typeof EmployeeOptions;

--- a/web/packages/teleport/src/Welcome/Questionnaire/types.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/types.ts
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-import { EmployeeOptions, TeamOptions, TitleOptions } from './constants';
-
 export type QuestionnaireProps = {
   // full indicates if a full survey should be presented,
   // false indicates that a partial survey is shown (some questions are skipped)
@@ -31,24 +29,50 @@ export type QuestionProps = {
 
 export type CompanyProps = QuestionProps & {
   companyName: string;
-  numberOfEmployees: EmployeeOptionsStrings;
+  numberOfEmployees: EmployeeOption;
 };
 
 export type RoleProps = QuestionProps & {
-  role: TitleOptionsStrings;
-  team: TeamOptionsStrings;
+  role: TitleOption;
+  team: TeamOption;
   teamName: string;
 };
 
 export type ResourceType = {
-  label: Resource;
+  label: ResourceOption;
   image: string;
 };
 
 export type ResourcesProps = QuestionProps & {
-  resources: ResourceType[];
-  checked: Resource[];
+  checked: ResourceOption[];
 };
+
+export enum EmployeeOption {
+  '0-19',
+  '20-199',
+  '200-499',
+  '500-999',
+  '1000-4999',
+  '5000+',
+}
+
+export enum TeamOption {
+  SOFTWARE_ENGINEERING = 'Software Engineering',
+  DEVOPS_ENGINEERING = 'DevOps Engineering',
+  IT = 'IT',
+  SUPPORT = 'Support',
+  FINANCE = 'Finance',
+  LEGAL = 'Legal',
+  OTHER = 'Other (free-form field)',
+}
+
+export enum TitleOption {
+  INDIVIDUAL_CONTRIBUTOR = 'Individual contributor',
+  MANAGER = 'Manager',
+  DIRECTOR = 'Director',
+  VP = 'VP',
+  C_SUITE_OWNER = 'C-Suite/Owner',
+}
 
 export enum ProtoResource {
   RESOURCE_UNSPECIFIED = 0,
@@ -59,7 +83,7 @@ export enum ProtoResource {
   RESOURCE_WEB_APPLICATIONS = 5,
 }
 
-export enum Resource {
+export enum ResourceOption {
   RESOURCE_WINDOWS_DESKTOPS = 'Windows Desktops',
   RESOURCE_SERVER_SSH = 'Server/SSH',
   RESOURCE_DATABASES = 'Databases',
@@ -69,13 +93,9 @@ export enum Resource {
 
 export type QuestionnaireFormFields = {
   companyName: string;
-  employeeCount: EmployeeOptionsStrings;
-  role: TitleOptionsStrings;
-  team: TeamOptionsStrings;
-  resources: Resource[];
-  teamName?: string; // only set if "Other" is selected from team options
+  employeeCount: EmployeeOption;
+  role: TitleOption;
+  team: TeamOption;
+  resources: ResourceOption[];
+  teamName: string;
 };
-
-export type EmployeeOptionsStrings = keyof typeof EmployeeOptions;
-export type TeamOptionsStrings = keyof typeof TeamOptions;
-export type TitleOptionsStrings = keyof typeof TitleOptions;

--- a/web/packages/teleport/src/Welcome/Questionnaire/types.ts
+++ b/web/packages/teleport/src/Welcome/Questionnaire/types.ts
@@ -17,7 +17,7 @@
 import { EmployeeOptions, TeamOptions, TitleOptions } from './constants';
 
 export type QuestionnaireProps = {
-  // full indicates if a full survey should be presented
+  // full indicates if a full survey should be presented,
   // false indicates that a partial survey is shown (some questions are skipped)
   full: boolean;
   username: string;

--- a/web/packages/teleport/src/Welcome/Welcome.test.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.test.tsx
@@ -23,8 +23,9 @@ import { Logger } from 'shared/libs/logger';
 import cfg from 'teleport/config';
 import history from 'teleport/services/history';
 import auth from 'teleport/services/auth';
-
 import { userEventService } from 'teleport/services/userEvent';
+import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
+import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
 
 import Welcome from './Welcome';
 
@@ -44,6 +45,8 @@ describe('teleport/components/Welcome', () => {
     jest
       .spyOn(userEventService, 'capturePreUserEvent')
       .mockImplementation(() => new Promise(() => null));
+
+    mockUserContextProviderWith(makeTestUserContext());
   });
 
   afterEach(() => {
@@ -65,10 +68,9 @@ describe('teleport/components/Welcome', () => {
       </Router>
     );
 
-    expect(
-      screen.getByText(/Please click the button below to create an account/i)
-    ).toBeInTheDocument();
-
+    await screen.findByText(
+      /Please click the button below to create an account/i
+    );
     expect(auth.fetchPasswordToken).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText(/get started/i));
@@ -97,12 +99,9 @@ describe('teleport/components/Welcome', () => {
       </Router>
     );
 
-    expect(
-      screen.getByText(
-        /Please click the button below to begin recovery of your account/i
-      )
-    ).toBeInTheDocument();
-
+    await screen.findByText(
+      /Please click the button below to begin recovery of your account/i
+    );
     expect(auth.fetchPasswordToken).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByText(/Continue/i));

--- a/web/packages/teleport/src/Welcome/Welcome.tsx
+++ b/web/packages/teleport/src/Welcome/Welcome.tsx
@@ -20,6 +20,7 @@ import { Route, Switch, useParams } from 'teleport/components/Router';
 import history from 'teleport/services/history';
 import LogoHero from 'teleport/components/LogoHero';
 import cfg from 'teleport/config';
+import { UserContextProvider } from 'teleport/User';
 
 import { NewCredentials } from './NewCredentials';
 import { CardWelcome } from './CardWelcome';
@@ -38,30 +39,32 @@ export default function Welcome() {
   return (
     <>
       <LogoHero />
-      <Switch>
-        <Route exact path={cfg.routes.userInvite}>
-          <CardWelcome
-            title="Welcome to Teleport"
-            subTitle="Please click the button below to create an account"
-            btnText="Get started"
-            onClick={handleOnInviteContinue}
-          />
-        </Route>
-        <Route exact path={cfg.routes.userReset}>
-          <CardWelcome
-            title="Reset Authentication"
-            subTitle="Please click the button below to begin recovery of your account"
-            btnText="Continue"
-            onClick={handleOnResetContinue}
-          />
-        </Route>
-        <Route path={cfg.routes.userInviteContinue}>
-          <NewCredentials tokenId={tokenId} />
-        </Route>
-        <Route path={cfg.routes.userResetContinue}>
-          <NewCredentials resetMode={true} tokenId={tokenId} />
-        </Route>
-      </Switch>
+      <UserContextProvider>
+        <Switch>
+          <Route exact path={cfg.routes.userInvite}>
+            <CardWelcome
+              title="Welcome to Teleport"
+              subTitle="Please click the button below to create an account"
+              btnText="Get started"
+              onClick={handleOnInviteContinue}
+            />
+          </Route>
+          <Route exact path={cfg.routes.userReset}>
+            <CardWelcome
+              title="Reset Authentication"
+              subTitle="Please click the button below to begin recovery of your account"
+              btnText="Continue"
+              onClick={handleOnResetContinue}
+            />
+          </Route>
+          <Route path={cfg.routes.userInviteContinue}>
+            <NewCredentials tokenId={tokenId} />
+          </Route>
+          <Route path={cfg.routes.userResetContinue}>
+            <NewCredentials resetMode={true} tokenId={tokenId} />
+          </Route>
+        </Switch>
+      </UserContextProvider>
     </>
   );
 }

--- a/web/packages/teleport/src/Welcome/useToken.ts
+++ b/web/packages/teleport/src/Welcome/useToken.ts
@@ -26,12 +26,15 @@ import auth, {
   ResetPasswordWithWebauthnReqWithEvent,
   ResetToken,
 } from 'teleport/services/auth';
+import { UseTokenState } from 'teleport/Welcome/NewCredentials/types';
 
-export default function useToken(tokenId: string) {
+export default function useToken(tokenId: string): UseTokenState {
   const [resetToken, setResetToken] = useState<ResetToken>();
   const [recoveryCodes, setRecoveryCodes] = useState<RecoveryCodes>();
   const [success, setSuccess] = useState(false); // TODO rename
   const [privateKeyPolicyEnabled, setPrivateKeyPolicyEnabled] = useState(false);
+  const [displayOnboardingQuestionnaire, setDisplayOnboardingQuestionnaire] =
+    useState(cfg.isUsageBasedBilling && cfg.isCloud);
 
   const fetchAttempt = useAttempt('');
   const submitAttempt = useAttempt('');
@@ -109,7 +112,7 @@ export default function useToken(tokenId: string) {
     success,
     finishedRegister,
     privateKeyPolicyEnabled,
+    displayOnboardingQuestionnaire,
+    setDisplayOnboardingQuestionnaire,
   };
 }
-
-export type State = ReturnType<typeof useToken>;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -244,6 +244,8 @@ const cfg = {
     assistExecuteCommandWebSocketPath:
       'wss://:hostname/v1/webapi/command/:clusterId/execute',
     userPreferencesPath: '/v1/webapi/user/preferences',
+
+    surveyPath: '/v1/enterprise/cloud/survey',
   },
 
   getAppFqdnUrl(params: UrlAppParams) {

--- a/web/packages/teleport/src/services/survey/index.ts
+++ b/web/packages/teleport/src/services/survey/index.ts
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-export { surveyService as surveyService } from './survey';
+export { surveyService } from './survey';
 export * from './types';

--- a/web/packages/teleport/src/services/survey/index.ts
+++ b/web/packages/teleport/src/services/survey/index.ts
@@ -1,11 +1,11 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2023 Gravitational, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,19 +14,5 @@
  * limitations under the License.
  */
 
-import React from 'react';
-
-import { Questionnaire } from './Questionnaire';
-
-export default {
-  title: 'Teleport/Welcome/Questionnaire',
-  args: { userContext: true },
-};
-
-export const Full = () => {
-  return <Questionnaire full={true} username={''} />;
-};
-
-export const Partial = () => {
-  return <Questionnaire full={false} username={''} />;
-};
+export { surveyService as surveyService } from './survey';
+export * from './types';

--- a/web/packages/teleport/src/services/survey/survey.ts
+++ b/web/packages/teleport/src/services/survey/survey.ts
@@ -1,11 +1,11 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2023 Gravitational, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import React from 'react';
+import api from 'teleport/services/api';
+import cfg from 'teleport/config';
 
-import { Questionnaire } from './Questionnaire';
+import { SurveyRequest } from './types';
 
-export default {
-  title: 'Teleport/Welcome/Questionnaire',
-  args: { userContext: true },
-};
-
-export const Full = () => {
-  return <Questionnaire full={true} username={''} />;
-};
-
-export const Partial = () => {
-  return <Questionnaire full={false} username={''} />;
+export const surveyService = {
+  submitSurvey(survey: SurveyRequest) {
+    // using api.fetch instead of api.fetchJSON
+    // because we are not expecting a JSON response
+    void api.fetch(cfg.api.surveyPath, {
+      method: 'POST',
+      body: JSON.stringify(survey),
+    });
+  },
 };

--- a/web/packages/teleport/src/services/survey/types.ts
+++ b/web/packages/teleport/src/services/survey/types.ts
@@ -1,11 +1,11 @@
 /**
- * Copyright 2020 Gravitational, Inc.
+ * Copyright 2023 Gravitational, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,19 +14,11 @@
  * limitations under the License.
  */
 
-import React from 'react';
-
-import { Questionnaire } from './Questionnaire';
-
-export default {
-  title: 'Teleport/Welcome/Questionnaire',
-  args: { userContext: true },
-};
-
-export const Full = () => {
-  return <Questionnaire full={true} username={''} />;
-};
-
-export const Partial = () => {
-  return <Questionnaire full={false} username={''} />;
+export type SurveyRequest = {
+  companyName: string;
+  employeeCount: string;
+  resources: Array<string>;
+  role: string;
+  team: string;
+  username: string;
 };

--- a/web/packages/teleport/src/services/userPreferences/types.ts
+++ b/web/packages/teleport/src/services/userPreferences/types.ts
@@ -16,8 +16,8 @@
 
 import { DeprecatedThemeOption } from 'design/theme';
 
+import { ProtoResource } from 'teleport/Welcome/Questionnaire/types';
 import type { AssistUserPreferences } from 'teleport/Assist/types';
-import type { Resource } from 'teleport/Welcome/Questionnaire/types';
 
 export enum ThemePreference {
   Light = 1,
@@ -25,7 +25,7 @@ export enum ThemePreference {
 }
 
 export type OnboardUserPreferences = {
-  preferredResources: Resource[];
+  preferredResources: ProtoResource[];
 };
 
 export interface UserPreferences {


### PR DESCRIPTION
This PR adds the questionnaire survey to the onboarding flow. On save, the full survey results are sent to Sales Center, Resources are saved to cluster state (user preferences) and a Posthog event is triggered.

This does not include:
- final design
- showing partial surveys (full is hardcoded as true)
- showing the survey after login if registered before the release of this feature

blocked by: https://github.com/gravitational/teleport.e/pull/1713
supports: https://github.com/gravitational/cloud/issues/4802