### PR TITLE
Adds AccessDenied reporting to PagerDuty

### DIFF
--- a/integrations/access/pagerduty/client.go
+++ b/integrations/access/pagerduty/client.go
@@ -136,11 +136,18 @@ func onAfterPagerDutyResponse(sink common.StatusSink) resty.ResponseMiddleware {
 		}
 
 		if resp.IsError() {
-			result := resp.Error()
-			if result, ok := result.(*ErrorResult); ok {
-				return trace.Errorf("http error code=%v, err_code=%v, message=%v, errors=[%v]", resp.StatusCode(), result.Code, result.Message, strings.Join(result.Errors, ", "))
+			var details string
+			switch result := resp.Error().(type) {
+			case *ErrorResult:
+				details = fmt.Sprintf("http error code=%v, err_code=%v, message=%v, errors=[%v]", resp.StatusCode(), result.Code, result.Message, strings.Join(result.Errors, ", "))
+			default:
+				details = fmt.Sprintf("unknown error result %#v", result)
 			}
-			return trace.Errorf("unknown error result %#v", result)
+
+			if status.GetCode() == types.PluginStatusCode_UNAUTHORIZED {
+				return trace.AccessDenied(details)
+			}
+			return trace.Errorf(details)
 		}
 		return nil
 	}

--- a/integrations/access/pagerduty/client.go
+++ b/integrations/access/pagerduty/client.go
@@ -139,6 +139,10 @@ func onAfterPagerDutyResponse(sink common.StatusSink) resty.ResponseMiddleware {
 			var details string
 			switch result := resp.Error().(type) {
 			case *ErrorResult:
+				// Do we have a formatted PagerDuty API error response? We set
+				// an empty `ErrorResult` in the pre-request hook, and if the
+				// HTTP server returns an error, the `resty` middleware will
+				// attempt to unmarshal the error response into it.
 				details = fmt.Sprintf("http error code=%v, err_code=%v, message=%v, errors=[%v]", resp.StatusCode(), result.Code, result.Message, strings.Join(result.Errors, ", "))
 			default:
 				details = fmt.Sprintf("unknown error result %#v", result)


### PR DESCRIPTION
The PagerDuty plugin now returns a `trace.AccessDeniedErorr` when a request fails due to an authentication error. This is to allow the integrations UI to display a useful error state when the plugin exits, rather than a generic "unknown error".