### PR TITLE
Set the default session ttl in generateCert

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -2071,6 +2071,10 @@ func generateCert(a *Server, req certRequest, caType types.CertAuthType) (*proto
 	var sessionTTL time.Duration
 	var allowedLogins []string
 
+	if req.ttl == 0 {
+		req.ttl = time.Duration(authPref.GetDefaultSessionTTL())
+	}
+
 	// If the role TTL is ignored, do not restrict session TTL and allowed logins.
 	// The only caller setting this parameter should be "tctl auth sign".
 	// Otherwise, set the session TTL to the smallest of all roles and


### PR DESCRIPTION
This fixes an issue that was introduced in https://github.com/gravitational/teleport/pull/26824 where the the default session ttl was not getting set by the auth server, and was only being setthe client as the check for setting the session ttl was aonly added to `GenerateOpenSSHCert`