### PR TITLE
Parallelized OS compatibility test

### DIFF
--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -18,12 +18,7 @@ jobs:
   build:
     name: OS Compatibility Build
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on:
-      group: prod
-      labels:
-        - self-hosted
-        - x64
-        - linux
+    runs-on: ubuntu-22.04-16core
 
     permissions:
       contents: read
@@ -43,8 +38,6 @@ jobs:
 
       - name: Run make
         run: |
-          apt update
-          apt install -y make # Required on self-hosted runners
           make binaries
 
       - name: Upload binaries
@@ -56,12 +49,7 @@ jobs:
   test-compat:
     needs: build
     name: OS Compatibility Test
-    runs-on:
-      group: prod
-      labels:
-        - self-hosted
-        - x64
-        - linux
+    runs-on: ubuntu-latest
 
     permissions:
       contents: read

--- a/.github/workflows/os-compatibility-test.yaml
+++ b/.github/workflows/os-compatibility-test.yaml
@@ -18,7 +18,12 @@ jobs:
   build:
     name: OS Compatibility Build
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on: ubuntu-22.04-16core
+    runs-on:
+      group: prod
+      labels:
+        - self-hosted
+        - x64
+        - linux
 
     permissions:
       contents: read
@@ -38,6 +43,8 @@ jobs:
 
       - name: Run make
         run: |
+          apt update
+          apt install -y make # Required on self-hosted runners
           make binaries
 
       - name: Upload binaries
@@ -49,7 +56,12 @@ jobs:
   test-compat:
     needs: build
     name: OS Compatibility Test
-    runs-on: ubuntu-latest
+    runs-on:
+      group: prod
+      labels:
+        - self-hosted
+        - x64
+        - linux
 
     permissions:
       contents: read

--- a/build.assets/build-test-compat.sh
+++ b/build.assets/build-test-compat.sh
@@ -90,15 +90,41 @@ function run_docker {
   return $test_result
 }
 
+# Wrapper function for run_docker to assist with running tests in parallel.
+#
+# Arguments:
+# $1    - distro name
+function run_test {
+  DISTRO="$1"
+  echo "============ Checking ${DISTRO} ============"
+  if [ "$(docker pull "${DISTRO}")" ]; then
+    run_docker "$DISTRO" "$PWD/build/teleport" version
+    run_docker "$DISTRO" "$PWD/build/tsh" version
+    run_docker "$DISTRO" "$PWD/build/tctl" version
+    run_docker "$DISTRO" "$PWD/build/tbot" version
+  else
+    echo "Failed to pull ${DISTRO} image, aborting ${DISTRO} test" >&2
+  fi
+}
+
+# Setup
+LOG_DIR="/tmp/distro-logs"
+mkdir -p "$LOG_DIR"
+
+# Job
 for DISTRO in "${DISTROS[@]}";
 do
-  echo "============ Checking ${DISTRO} ============"
-  docker pull "${DISTRO}"
-
-  run_docker "$DISTRO" $PWD/build/teleport version
-  run_docker "$DISTRO" $PWD/build/tsh version
-  run_docker "$DISTRO" $PWD/build/tctl version
-  run_docker "$DISTRO" $PWD/build/tbot version
+  # Write to a log so that it's clear what log lines are associated with the distro
+  echo "Starting test for $DISTRO"
+  run_test "$DISTRO" &> "$LOG_DIR/${DISTRO//\//_}.log" &
 done
+wait
+
+# Results
+echo "Job results:"
+tail -n +1 "$LOG_DIR/"*
+
+# Cleanup
+rm -rf "$LOG_DIR"
 
 exit $EXIT_CODE

--- a/build.assets/build-test-compat.sh
+++ b/build.assets/build-test-compat.sh
@@ -71,12 +71,11 @@ function run_docker {
   distro=$1
   binary=$(basename $2)
 
-  container=$(docker create $distro /tmp/$binary "${@:3}")
+  container=$(docker create -v "$2:/tmp/$binary" $distro /tmp/$binary "${@:3}")
   # I *want* the variable below expanded now, so disabling lint
   # shellcheck disable=SC2064
   trap "docker rm $container > /dev/null" RETURN
 
-  docker cp $2 $container:/tmp/$binary
   docker start $container > /dev/null
   test_result=$(docker wait $container)
 


### PR DESCRIPTION
I took the script behind the `OS Compatibility Test` workflow and rewrote part of it to run the tests in parallel instead of series. In my local testing on M1 Mac, the end result of this is that the script runtime was reduced by a little more than half. I expect that we'll see even greater gains when ran on GHA runners with more CPU cores.