### PR TITLE
Skip databases with validation errors when adding them to Cache.

### DIFF
--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -1801,6 +1801,108 @@ func TestDatabases(t *testing.T) {
 	})
 }
 
+// TestInvalidDatabases tests that invalid database items won't cause the cache
+// to malfunction and be in a bad state.
+func TestInvalidDatabases(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	generateInvalidDB := func(t *testing.T, resourceID int64, name string) types.Database {
+		db := &types.DatabaseV3{Metadata: types.Metadata{
+			ID:   resourceID,
+			Name: name,
+		}, Spec: types.DatabaseSpecV3{
+			Protocol: "invalid-protocol",
+			URI:      "non-empty-uri",
+		}}
+		// Just ensures the database we're using on this test will trigger a
+		// validation failure.
+		require.Error(t, services.ValidateDatabase(db))
+		return db
+	}
+
+	for name, tc := range map[string]struct {
+		storeFunc func(*testing.T, *backend.Wrapper, *Cache)
+	}{
+		"CreateDatabase": {
+			storeFunc: func(t *testing.T, b *backend.Wrapper, _ *Cache) {
+				db := generateInvalidDB(t, 0, "invalid-db")
+				value, err := services.MarshalDatabase(db)
+				require.NoError(t, err)
+				_, err = b.Create(ctx, backend.Item{
+					Key:     backend.Key("db", db.GetName()),
+					Value:   value,
+					Expires: db.Expiry(),
+					ID:      db.GetResourceID(),
+				})
+				require.NoError(t, err)
+			},
+		},
+		// Although validation is not executed when updating databases, this
+		// test ensures bad database updates won't cause any issues to the
+		// cache.
+		"UpdateDatabase": {
+			storeFunc: func(t *testing.T, b *backend.Wrapper, c *Cache) {
+				dbName := "updated-db"
+				validDB, err := types.NewDatabaseV3(types.Metadata{
+					Name: dbName,
+				}, types.DatabaseSpecV3{
+					Protocol: defaults.ProtocolPostgres,
+					URI:      "postgres://localhost",
+				})
+				require.NoError(t, err)
+				require.NoError(t, services.ValidateDatabase(validDB))
+
+				marshalledDB, err := services.MarshalDatabase(validDB)
+				require.NoError(t, err)
+				_, err = b.Create(ctx, backend.Item{
+					Key:     backend.Key("db", validDB.GetName()),
+					Value:   marshalledDB,
+					Expires: validDB.Expiry(),
+					ID:      validDB.GetResourceID(),
+				})
+				require.NoError(t, err)
+
+				// Wait until the database appear on cache.
+				require.Eventually(t, func() bool {
+					if dbs, err := c.GetDatabases(ctx); err == nil {
+						return len(dbs) == 1
+					}
+
+					return false
+				}, time.Second, 100*time.Millisecond, "expected database to be on cache, but nothing found")
+
+				cacheDB, err := c.GetDatabase(ctx, dbName)
+				require.NoError(t, err)
+
+				invalidDB := generateInvalidDB(t, cacheDB.GetResourceID(), cacheDB.GetName())
+				value, err := services.MarshalDatabase(invalidDB)
+				require.NoError(t, err)
+				_, err = b.Update(ctx, backend.Item{
+					Key:     backend.Key("db", cacheDB.GetName()),
+					Value:   value,
+					Expires: invalidDB.Expiry(),
+					ID:      cacheDB.GetResourceID(),
+				})
+				require.NoError(t, err)
+			},
+		},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPack(t, ForAuth)
+			t.Cleanup(p.Close)
+
+			tc.storeFunc(t, p.backend, p.cache)
+
+			// Events processing should not restart due to an invalid database error.
+			unexpectedEvent(t, p.eventsC, Reloading)
+		})
+	}
+
+}
+
 // TestSAMLIdPServiceProviders tests that CRUD operations on SAML IdP service provider resources are
 // replicated from the backend to the cache.
 func TestSAMLIdPServiceProviders(t *testing.T) {

--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -1252,7 +1252,7 @@ func (databaseExecutor) upsert(ctx context.Context, cache *Cache, resource types
 		// where the database stored on the backend is no longer valid given the
 		// Teleport version.
 		if trace.IsBadParameter(err) {
-			cache.Logger.Infof("Skipping database %q addition to cache due to validation errors. Solve the errors and update your database spec to get it on cache: %s", resource.GetName(), err)
+			cache.Logger.Infof("Adding database %q to cache was skipped due to validation errors. Please update your database spec accordingly: %s", resource.GetName(), err)
 			return nil
 		}
 


### PR DESCRIPTION
Closes #27904.

Since we're [now validating database creation on cache](https://github.com/gravitational/teleport/blob/master/lib/services/local/databases.go#L77-L79), a Teleport version upgrade/downgrade can cause the database to be invalid due to validation rule changes. In those cases, the cache would [stop consuming backend events while retrying to create the invalid database](https://github.com/gravitational/teleport/blob/master/lib/cache/cache.go#L936-L963).

In this PR, we add a condition to skip and log databases that have validation failures. This way, the cache would keep running fine and won't affect other resources.

As it is, this only affects databases not present on the cache as [database updates don't call the `ValidateDatabase`](https://github.com/gravitational/teleport/blob/master/lib/services/local/databases.go#L98).