### PR TITLE
Devbox update - fix legacy warning

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,12 +1,10 @@
 {
   "packages": [
     "addlicense@1.0.0",
-    "bash",
     "bats@1.3.0",
     "github:nixos/nixpkgs/d7f28652048b3bed6a512542e62ea1a50691e349#buf",
     "clang@11.1.0",
     "gci@0.9.1",
-    "git",
     "github:nixos/nixpkgs/757a0d107c238d031652a8c09d1f6bf1b6f523a3#go",
     "github:nixos/nixpkgs/3a785fc61f9d2960970bdce4fa86eb634c86b9d6#golangci-lint",
     "libiconvReal@1.16",
@@ -26,7 +24,9 @@
     "path:build.assets/flake#node-protoc-ts",
     "path:build.assets/flake#protoc-gen-gogo",
     "path:build.assets/flake#rust",
-    "path:build.assets/flake#yarn"
+    "path:build.assets/flake#yarn",
+    "bash@latest",
+    "git@latest"
   ],
   "shell": {
     "init_hook": [

--- a/devbox.lock
+++ b/devbox.lock
@@ -6,7 +6,7 @@
       "resolved": "github:NixOS/nixpkgs/d3248619647234b5dc74a6921bcdf6dd8323eb22#addlicense",
       "version": "1.0.0"
     },
-    "bash": {
+    "bash@latest": {
       "resolved": "github:NixOS/nixpkgs/f91ee3065de91a3531329a674a45ddcb3467a650#bash"
     },
     "bats@1.3.0": {
@@ -24,7 +24,7 @@
       "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#gci",
       "version": "0.9.1"
     },
-    "git": {
+    "git@latest": {
       "resolved": "github:NixOS/nixpkgs/f91ee3065de91a3531329a674a45ddcb3467a650#git"
     },
     "libfido2@1.13.0": {
@@ -54,6 +54,7 @@
     },
     "python@3.11.2": {
       "last_modified": "2023-03-31T22:52:29Z",
+      "plugin_version": "0.0.1",
       "resolved": "github:NixOS/nixpkgs/242246ee1e58f54d2322227fc5eef53b4a616a31#python311",
       "version": "3.11.2"
     },


### PR DESCRIPTION
Looks like the latest version v0.5.5 of devbox started complaining about our `devbox.json`. I applied the recommended changes which seems to solve the issue.