### PR TITLE
Improve the upload completer logs

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -68,7 +68,7 @@ func (cfg *UploadCompleterConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("missing parameter ClusterName")
 	}
 	if cfg.Component == "" {
-		cfg.Component = teleport.ComponentAuth
+		cfg.Component = teleport.ComponentProcess
 	}
 	if cfg.CheckPeriod == 0 {
 		cfg.CheckPeriod = AbandonedUploadPollingRate
@@ -140,6 +140,7 @@ func (u *UploadCompleter) Serve(ctx context.Context) error {
 		Jitter:        retryutils.NewSeventhJitter(),
 	})
 	defer periodic.Stop()
+	u.log.Infof("upload completer will run every %v", u.cfg.CheckPeriod.String())
 
 	for {
 		select {

--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -67,7 +67,9 @@ func (h *Handler) CreateUpload(ctx context.Context, sessionID session.ID) (*even
 // UploadPart uploads part
 func (h *Handler) UploadPart(ctx context.Context, upload events.StreamUpload, partNumber int64, partBody io.ReadSeeker) (*events.StreamPart, error) {
 	start := time.Now()
-	defer func() { h.Infof("UploadPart(%v) part(%v) uploaded in %v.", upload.ID, partNumber, time.Since(start)) }()
+	defer func() {
+		h.Infof("UploadPart(upload %v) part(%v) session(%v) uploaded in %v.", upload.ID, partNumber, upload.SessionID, time.Since(start))
+	}()
 
 	// This upload exceeded maximum number of supported parts, error now.
 	if partNumber > s3manager.MaxUploadParts {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1155,7 +1155,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 	// run one upload completer per-process
 	// even in sync recording modes, since the recording mode can be changed
 	// at any time with dynamic configuration
-	process.RegisterFunc("common.upload", process.initUploaderService)
+	process.RegisterFunc("common.upload.init", process.initUploaderService)
 
 	if !serviceStarted {
 		return nil, trace.BadParameter("all services failed to start")


### PR DESCRIPTION
- use ComponentProcess by default (auth's upload completer overrides this)
- log when the completer starts
- include the session ID in logs for part uploads