### PR TITLE
[v13] docs: remove note about supporting any platform supporting Go

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -35,8 +35,8 @@ running Teleport on UNIX variants other than Linux \[1].
 | macOS v10.13+  (High Sierra)| yes | yes | yes | yes | yes |
 | Windows 10+ (rev. 1607) \[4] | no | no | yes | yes | no |
 
-\[1] *Teleport is written in Go and it's possible to build it on
-any OS supported by the [Golang toolchain](https://github.com/golang/go/wiki/MinimumRequirements)*.
+\[1] *Teleport is written in Go and many of these system requirements are due to the requirements
+of the [Go toolchain](https://github.com/golang/go/wiki/MinimumRequirements)*.
 
 \[2] *`tsh` is a Command Line Client (CLI) and Teleport Connect is a Graphical User Interface (GUI) desktop client. See
   [Using Teleport Connect](connect-your-client/teleport-connect.mdx) for usage and installation*.


### PR DESCRIPTION
Backport #28112 to branch/v13