### PR TITLE
[v13] athena audit logs - add migration script

### DIFF
--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -405,7 +405,7 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 	}
 
 	l := &Log{
-		publisher:      newPublisher(cfg),
+		publisher:      newPublisherFromAthenaConfig(cfg),
 		querier:        querier,
 		consumerCloser: consumer,
 	}

--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -293,8 +293,10 @@ func TestPublisherConsumer(t *testing.T) {
 	fS3 := newFakeS3manager()
 	fq := newFakeQueue()
 	p := &publisher{
-		snsPublisher: fq,
-		uploader:     fS3,
+		PublisherConfig: PublisherConfig{
+			SNSPublisher: fq,
+			Uploader:     fS3,
+		},
 	}
 
 	smallEvent := &apievents.AppCreate{

--- a/lib/events/athena/publisher_test.go
+++ b/lib/events/athena/publisher_test.go
@@ -88,8 +88,10 @@ func Test_EmitAuditEvent(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fq := newFakeQueue()
 			p := &publisher{
-				snsPublisher: fq,
-				uploader:     tt.uploader,
+				PublisherConfig: PublisherConfig{
+					SNSPublisher: fq,
+					Uploader:     tt.uploader,
+				},
 			}
 			err := p.EmitAuditEvent(context.Background(), tt.in)
 			require.NoError(t, err)


### PR DESCRIPTION
Backports https://github.com/gravitational/teleport/pull/27099/ to v13.

It only backports code change in lib/events/athena. We don't need to migrate teleport script so it was reverted from backport.