### PR TITLE
Docs: Update recommended role

### DIFF
--- a/docs/pages/management/guides/terraform-provider.mdx
+++ b/docs/pages/management/guides/terraform-provider.mdx
@@ -65,15 +65,17 @@ spec:
         - cluster_auth_preference
         - cluster_networking_config
         - db
+        - device
         - github
+        - login_rule
         - oidc
+        - okta_import_rule
         - role
         - saml
         - session_recording_config
         - token
         - trusted_cluster
         - user
-        - login_rule
         verbs: ['list','create','read','update','delete']
 version: v6
 ---


### PR DESCRIPTION
The recommended role didn't include two resources that were recently added: devices and okta_import_rule.
This PR adds them and sorts the list.