### PR TITLE
apply Stripe CSP for team/usage users only

### DIFF
--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/observability/tracing"
 )
 
@@ -274,6 +275,30 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 		"form-action":     "'self'",
 		"frame-ancestors": "'none'",
 		"object-src":      "'none'",
+		"style-src":       "'self' 'unsafe-inline'",
+		"img-src":         "'self' data: blob:",
+		"font-src":        "'self' data:",
+		"connect-src":     "'self' wss:",
+	}
+
+	h := make(http.Header)
+	SetIndexContentSecurityPolicy(h, proto.Features{})
+	actualCsp := h.Get("Content-Security-Policy")
+	for k, v := range expectedCspVals {
+		expectedCspSubString := fmt.Sprintf("%s %s;", k, v)
+		require.Contains(t, actualCsp, expectedCspSubString)
+	}
+}
+
+func TestSetIndexContentSecurityPolicyForCloudUsageBased(t *testing.T) {
+	t.Parallel()
+
+	expectedCspVals := map[string]string{
+		"default-src":     "'self'",
+		"base-uri":        "'self'",
+		"form-action":     "'self'",
+		"frame-ancestors": "'none'",
+		"object-src":      "'none'",
 		"script-src":      "'self' https://js.stripe.com",
 		"frame-src":       "https://js.stripe.com",
 		"style-src":       "'self' 'unsafe-inline'",
@@ -283,7 +308,7 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 	}
 
 	h := make(http.Header)
-	SetIndexContentSecurityPolicy(h)
+	SetIndexContentSecurityPolicy(h, proto.Features{Cloud: true, IsUsageBased: true})
 	actualCsp := h.Get("Content-Security-Policy")
 	for k, v := range expectedCspVals {
 		expectedCspSubString := fmt.Sprintf("%s %s;", k, v)
@@ -302,8 +327,6 @@ func TestSetAppLaunchContentSecurityPolicy(t *testing.T) {
 		"form-action":     "'self'",
 		"frame-ancestors": "'none'",
 		"object-src":      "'none'",
-		"script-src":      "'self' https://js.stripe.com",
-		"frame-src":       "https://js.stripe.com",
 		"style-src":       "'self' 'unsafe-inline'",
 		"img-src":         "'self' data: blob:",
 		"font-src":        "'self' data:",
@@ -330,7 +353,6 @@ func TestSetRedirectPageContentSecurityPolicy(t *testing.T) {
 		"form-action":     "'self'",
 		"frame-ancestors": "'none'",
 		"object-src":      "'none'",
-		"frame-src":       "https://js.stripe.com",
 		"style-src":       "'self' 'unsafe-inline'",
 		"img-src":         "'self' data: blob:",
 		"script-src":      fmt.Sprintf("'%s'", scriptSrc),

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -480,7 +480,7 @@ func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 
 				httplib.SetAppLaunchContentSecurityPolicy(w.Header(), applicationURL)
 			} else {
-				httplib.SetIndexContentSecurityPolicy(w.Header())
+				httplib.SetIndexContentSecurityPolicy(w.Header(), cfg.ClusterFeatures)
 			}
 			if err := indexPage.Execute(w, session); err != nil {
 				h.log.WithError(err).Error("Failed to execute index page template.")


### PR DESCRIPTION
This will remove the Stripe CSP from the default policy and only add it to the CSP header for the main index.html page if the user is both cloud and usage based (i.e. user is on the Team plan).

supports: gravitational/cloud#5017