### PR TITLE
[v13] Move "Device Trust" to a top-level docs item

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -304,14 +304,6 @@
               ]
             },
             {
-              "title": "Device Trust (Preview)",
-              "slug": "/access-controls/guides/device-trust/",
-              "forScopes": [
-                "enterprise",
-                "cloud"
-              ]
-            },
-            {
               "title": "Headless WebAuthn (Preview)",
               "slug": "/access-controls/guides/headless/"
             },
@@ -473,6 +465,20 @@
               "forScopes": [
                 "enterprise"
               ]
+            }
+          ]
+        },
+        {
+          "title": "Device Trust",
+          "slug": "/access-controls/device-trust/",
+          "forScopes": [
+            "enterprise",
+            "cloud"
+          ],
+          "entries": [
+            {
+              "title": "Set Up Device Trust",
+              "slug": "/access-controls/device-trust/guide/"
             }
           ]
         },
@@ -2809,6 +2815,11 @@
     {
       "source": "/choose-an-edition/teleport-cloud/",
       "destination": "/choose-an-edition/teleport-cloud/introduction/",
+      "permanent": true
+    },
+    {
+      "source": "/access-controls/guides/device-trust/",
+      "destination": "/access-controls/device-trust/guide/",
       "permanent": true
     }
   ]

--- a/docs/pages/access-controls/device-trust.mdx
+++ b/docs/pages/access-controls/device-trust.mdx
@@ -1,0 +1,29 @@
+---
+title: Device Trust (Preview)
+description: Use and enforce trusted devices with Teleport
+layout: tocless-doc
+---
+
+<Admonition type="warning">
+Device Trust is currently in Preview mode.
+</Admonition>
+
+Device Trust allows Teleport admins to enforce the use of trusted devices.
+Resources protected by the device mode "required" will enforce the use of a
+trusted device, in addition to establishing the user's identity and enforcing
+the necessary roles. Furthermore, users using a trusted device leave audit
+trails that include the device's information.
+
+The device trust preview works on macOS and Windows devices and supports the
+following Teleport features:
+
+- SSH access enforcement
+- Database access enforcement
+- Kubernetes access enforcement
+
+Support for other operating systems and access features is planned for upcoming
+Teleport versions.
+
+## Guides
+
+- [Set Up Device Trust](./device-trust/guide.mdx)

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -1,30 +1,12 @@
 ---
-title: "Device Trust (Preview)"
+title: Set Up Device Trust (Preview)
 description: Learn how to use and enforce trusted devices with Teleport
 videoBanner: gBQyj_X1LVw
 ---
 
 <Admonition type="warning">
 Device Trust is currently in Preview mode.
-
-Device Trust requires Teleport Enterprise v12+.
 </Admonition>
-
-Device Trust allows Teleport admins to enforce the use of trusted devices.
-Resources protected by the device mode "required" will enforce the use of a
-trusted device, in addition to establishing the user's identity and enforcing
-the necessary roles. Furthermore, users using a trusted device leave audit
-trails that include the device's information.
-
-The device trust preview works on macOS and Windows devices and supports the
-following Teleport features:
-
-- SSH access enforcement
-- Database access enforcement
-- Kubernetes access enforcement
-
-Support for other operating systems and access features is planned for upcoming
-Teleport versions.
 
 ## Concepts
 
@@ -76,7 +58,6 @@ layer of protection.
   - A signed and notarized `tsh` binary for enrollment.
     [Download the macOS tsh installer](../../installation.mdx#macos).
   - A Teleport version newer than v12.0.0.
-  
 - To enroll a Windows device, you need:
   - A device that includes a TPM with 2.0 support.
   - `tsh` installed on the device. [Download the Windows tsh installer](../../installation.mdx#windows-tsh-client-only).
@@ -430,7 +411,7 @@ leaf clusters.
 Role-based configuration enforces trusted device access at the role level. It
 can be configured with the `spec.options.device_trust_mode` (`required`,
 `optional`, `off`) option and applies to the resources in its `allow` rules. It
-works similar to [`require_session_mfa`](./per-session-mfa.mdx).
+works similar to [`require_session_mfa`](../guides/per-session-mfa.mdx).
 
 To enforce authenticated device checks for a specific role, update the role with the following:
 
@@ -463,8 +444,8 @@ trusted device.
 
 ## Optional: Locking a device
 
-Similar to [session and identity locking](./locking.mdx), a device can be locked
-using `tctl lock`.
+Similar to [session and identity locking](../guides/locking.mdx), a device can
+be locked using `tctl lock`.
 
 Locking blocks certificate issuance and ongoing or future accesses originating
 from a locked device. Locking a device only works if device trust is enabled and

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -27,7 +27,8 @@ A lock can target the following objects or attributes:
 
 - a Teleport user by the user's name
 - a Teleport [RBAC](../reference.mdx) role by the role's name
-- a Teleport [trusted device](device-trust.mdx#optional-locking-a-device) by the device ID
+- a Teleport [trusted device](
+  ../device-trust/guide.mdx#optional-locking-a-device) by the device ID
 - an MFA device by the device's UUID
 - an OS/UNIX login
 - a Teleport agent by the agent's server UUID (effectively unregistering it from the

--- a/docs/pages/access-controls/introduction.mdx
+++ b/docs/pages/access-controls/introduction.mdx
@@ -6,7 +6,7 @@ layout: tocless-doc
 
 After [deploying a Teleport cluster](../deploy-a-cluster/introduction.mdx), the
 next step is to manage the access that Teleport users have to resources in your
-infrastructure. 
+infrastructure.
 
 Teleport's role-based access control (RBAC) enables you to set fine-grained
 policies for who can perform certain actions against specific resources. For
@@ -16,7 +16,7 @@ example:
   database.
 - Interns can't access production databases.
 - SREs can access a production server only when using a [trusted hardware
-  device](./guides/device-trust.mdx).
+  device](./device-trust/guide.mdx).
 - Members of a team can access the production Kubernetes cluster if approved by
   someone else from the same team.
 
@@ -30,7 +30,7 @@ Started](./getting-started.mdx) guide.
 The heart of Teleport's RBAC system is the **role**, a configuration document
 that specifies access policies for resources in your Teleport cluster.
 Assigning a role to a Teleport user applies the policies listed in the role to
-the user. 
+the user.
 
 See the [Cluster Access and RBAC](./guides.mdx) section for instructions on
 setting up Teleport roles.
@@ -39,7 +39,7 @@ setting up Teleport roles.
 
 While you can create Teleport users directly on the Auth Service, the more
 scalable approach is to integrate Teleport with a Single Sign-On identity
-provider (IdP), such as Okta or GitHub. 
+provider (IdP), such as Okta or GitHub.
 
 When a user authenticates to your Teleport cluster via your IdP, Teleport
 automatically assigns roles to the user based on data provided by the IdP. This

--- a/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/faq.mdx
@@ -61,9 +61,9 @@ Enterprise Cloud.
 
 We do not have plans to offer support for inbound connection IP allowlists.
 
-We believe mTLS with strong user and [device
-identity](../../access-controls/guides/device-trust.mdx) provides the best
-available security for client authentication.
+We believe mTLS with strong user and [device identity](
+../../access-controls/device-trust/guide.mdx) provides the best available
+security for client authentication.
 
 For customers that require IP-based control for compliance purposes, we do
 support IP Pinning. For more information see `pin_source_ip` in our [Teleport

--- a/docs/pages/includes/access-control-guides.mdx
+++ b/docs/pages/includes/access-control-guides.mdx
@@ -7,6 +7,6 @@
 - [Locking](../access-controls/guides/locking.mdx): Lock access to active user sessions or hosts.
 - [Moderated Sessions](../access-controls/guides/moderated-sessions.mdx): Require session auditors and allow fine-grained live session access.
 - [Hardware Key Support (Preview)](../access-controls/guides/hardware-key-support.mdx): Enforce the use of hardware-based private keys.
-- [Device Trust (Preview)](../access-controls/guides/device-trust.mdx): Register and enforce trusted devices.
+- [Device Trust (Preview)](../access-controls/device-trust/guide.mdx): Register and enforce trusted devices.
 - [Headless WebAuthn (Preview)](../access-controls/guides/headless.mdx): Login with Webauthn from a remote device.
 - [IP Pinning (Preview)](../access-controls/guides/ip-pinning.mdx): Pin a user's certificates to a login IP address.

--- a/docs/pages/includes/edition-comparison.mdx
+++ b/docs/pages/includes/edition-comparison.mdx
@@ -6,7 +6,7 @@
 |[Single Sign-On](../access-controls/sso.mdx)|GitHub|GitHub, Google Workspace, OIDC, SAML, Teleport|GitHub, Google Workspace, OIDC, SAML, Teleport|GitHub, Teleport|
 |[Role-Based Access Control](../access-controls/guides/role-templates.mdx)|✔|✔|✔|✔|
 |[Moderated Sessions](../access-controls/guides/moderated-sessions.mdx)|✖|✔|✔|✖|
-|[Device Trust](../access-controls/guides/device-trust.mdx)|✖|✔|✔|✖|
+|[Device Trust](../access-controls/device-trust/guide.mdx)|✖|✔|✔|✖|
 |[Dual Authorization](../access-controls/guides/dual-authz.mdx)|✖|✔|✔|✖|
 |[Hardware Key Support](../access-controls/guides/hardware-key-support.mdx)|✖|✔|✔|✖|
 

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -120,7 +120,7 @@ Here's the list of resources currently exposed via [`tctl`](./cli.mdx#tctl):
 | node | A registered SSH node. The same record is displayed via `tctl nodes ls` |
 | cluster | A trusted cluster. See [here](../management/admin/trustedclusters.mdx) for more details on connecting clusters together. |
 | login_rule | A Login Rule, see the [Login Rules guide](../access-controls/login-rules.mdx) for more info. |
-| device | A Teleport Trusted Device, see the [Device Trust guide](../access-controls/guides/device-trust.mdx) for more info. |
+| device | A Teleport Trusted Device, see the [Device Trust guide](../access-controls/device-trust/guide.mdx) for more info. |
 | [ui_config](#ui-config) | Configuration for the Web UI served by the Proxy Service |
 
 **Examples:**


### PR DESCRIPTION
Backport #28108 to branch/v13.

Move "Device Trust" from "Manage Access"->"Guides" to directly below "Manage
Access".