### PR TITLE
athena audit logs - use sqs attribute as oldest metric

### DIFF
--- a/lib/events/athena/consumer_test.go
+++ b/lib/events/athena/consumer_test.go
@@ -846,3 +846,44 @@ func TestCollectedEventsMetadataMerge(t *testing.T) {
 		})
 	}
 }
+
+func Test_getMessageSentTimestamp(t *testing.T) {
+	tests := []struct {
+		name    string
+		msg     sqsTypes.Message
+		want    time.Time
+		wantErr string
+	}{
+		{
+			name: "valid value sentTimestamp",
+			msg:  sqsTypes.Message{Attributes: map[string]string{"SentTimestamp": "1687183084420"}},
+			want: time.Date(2023, time.June, 19, 13, 58, 4, 420000000, time.UTC),
+		},
+		{
+			name: "empty map",
+			msg:  sqsTypes.Message{},
+			want: time.Time{},
+		},
+		{
+			name: "missing attribute",
+			msg:  sqsTypes.Message{Attributes: map[string]string{"abc": "def"}},
+			want: time.Time{},
+		},
+		{
+			name:    "wrong format of sentTimestamp",
+			msg:     sqsTypes.Message{Attributes: map[string]string{"SentTimestamp": "def"}},
+			wantErr: "invalid syntax",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getMessageSentTimestamp(tt.msg)
+			if tt.wantErr == "" {
+				require.NoError(t, err, "getMessageSentTimestamp return unexpected err")
+				require.Equal(t, tt.want, got)
+			} else {
+				require.ErrorContains(t, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR changes two thing:
1. It set value of `teleport_audit_parquetlog_age_oldest_processed_message` to 0 when there are no items to process, so gauge metric don't expose stale value
2. It is using `sentTimestamp` from sqs attribute as `teleport_audit_parquetlog_age_oldest_processed_message`. Previously we were using timestamp from event, but it will provide inaccurate results during both migration and if node is sending events with some delay. In this metric we are just interested how much collect is behind publish