### PR TITLE
[v13] Warn about clamshell-related touch ID unavailability

### DIFF
--- a/lib/auth/touchid/api.go
+++ b/lib/auth/touchid/api.go
@@ -108,6 +108,16 @@ type DiagResult struct {
 	// IsAvailable is true if Touch ID is considered functional.
 	// It means enough of the preceding tests to enable the feature.
 	IsAvailable bool
+
+	// isClamshellFailure is set when it's likely that clamshell mode is the sole
+	// culprit of Touch ID unavailability.
+	isClamshellFailure bool
+}
+
+// IsClamshellFailure returns true if the lack of touch ID availability could be
+// due to clamshell mode.
+func (d *DiagResult) IsClamshellFailure() bool {
+	return d.isClamshellFailure
 }
 
 // CredentialInfo holds information about a Secure Enclave credential.

--- a/lib/auth/touchid/diag.h
+++ b/lib/auth/touchid/diag.h
@@ -16,12 +16,16 @@
 #define DIAG_H_
 
 #include <stdbool.h>
+#include <stdint.h>
 
 typedef struct DiagResult {
   bool has_signature;
   bool has_entitlements;
   bool passed_la_policy_test;
   bool passed_secure_enclave_test;
+  int64_t la_error_code;
+  const char *la_error_domain;
+  const char *la_error_description;
 } DiagResult;
 
 // RunDiag runs self-diagnostics to verify if Touch ID is supported.

--- a/lib/auth/touchid/diag.m
+++ b/lib/auth/touchid/diag.m
@@ -66,9 +66,15 @@ void RunDiag(DiagResult *diagOut) {
   // This fails if Touch ID is not available or cannot be used for various
   // reasons (no password set, device locked, lid is closed, etc).
   LAContext *ctx = [[LAContext alloc] init];
+  NSError *laError = NULL;
   diagOut->passed_la_policy_test =
       [ctx canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics
-                       error:NULL];
+                       error:&laError];
+  if (laError) {
+    diagOut->la_error_code = [laError code];
+    diagOut->la_error_domain = CopyNSString([laError domain]);
+    diagOut->la_error_description = CopyNSString([laError description]);
+  }
 
   // Attempt to write a non-permanent key to the enclave.
   NSDictionary *attributes = @{

--- a/tool/tsh/mfa.go
+++ b/tool/tsh/mfa.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/prompt"
+	"golang.org/x/exp/slices"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/ghodss/yaml"
@@ -219,6 +220,14 @@ func (c *mfaAddCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 	ctx := cf.Context
+
+	// Attempt to diagnose clamshell failures.
+	if !slices.Contains(defaultDeviceTypes, touchIDDeviceType) {
+		diag, err := touchid.Diag()
+		if err == nil && diag.IsClamshellFailure() {
+			log.Warn("Touch ID support disabled, is your MacBook lid closed?")
+		}
+	}
 
 	if c.devType == "" {
 		// If we are prompting the user for the device type, then take a glimpse at

--- a/tool/tsh/touchid.go
+++ b/tool/tsh/touchid.go
@@ -70,6 +70,11 @@ func (c *touchIDDiagCommand) run(cf *CLIConf) error {
 	fmt.Printf("Passed LAPolicy test? %v\n", res.PassedLAPolicyTest)
 	fmt.Printf("Passed Secure Enclave test? %v\n", res.PassedSecureEnclaveTest)
 	fmt.Printf("Touch ID enabled? %v\n", res.IsAvailable)
+
+	if res.IsClamshellFailure() {
+		fmt.Printf("\nTouch ID diagnostics failed, is your MacBook lid closed?\n")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Backport #28175 to branch/v13

Warn users on select situations, namely `tsh touchid diag` and `tsh mfa add -d`,
about Touch ID failures that are likely due to clamshell mode (aka lid closed).

This takes a light-handed approach in order to 1) avoid false-positives and 2)
not be annoying in case of (1) or to frequent clamshell users.

I've hand-picked `diag` because it often comes up in debugging and `mfa add`
because I think it's more impactful - the assumption being that users expect to
use the sensor during login, but may not have a strong mental model of how
registration works.

Examples:

```shell
# lid closed, binary not signed.
$ tsh touchid diag
Has compile support? true
Has signature? false
Has entitlements? false
Passed LAPolicy test? false
Passed Secure Enclave test? true
Touch ID enabled? false

# lid closed, binary signed/entitled/etc.
$ tsh touchid diag
Has compile support? true
Has signature? true
Has entitlements? true
Passed LAPolicy test? false
Passed Secure Enclave test? true
Touch ID enabled? false

Touch ID diagnostics failed, is your MacBook lid closed?

# lid closed, registration.
$ tsh mfa add -d
(a bunch of lines)
2023-06-22T18:10:50-03:00 DEBU             Touch ID: LAError description: Error Domain=com.apple.LocalAuthentication Code=-4 "Touch ID is not available in closed clamshell mode." UserInfo={NSDebugDescription=Touch ID is not available in closed clamshell mode., NSLocalizedDescription=Authentication canceled.} touchid/api_darwin.go:109
2023-06-22T18:10:50-03:00 WARN [TSH]       Touch ID support disabled, is your MacBook lid closed? common/mfa.go:229
(^-C)
```

#27407