### PR TITLE
[devbox] Add IOKit as a dependency to Darwin.

### DIFF
--- a/build.assets/flake/flake.nix
+++ b/build.assets/flake/flake.nix
@@ -208,15 +208,21 @@
             '';
           };
 
-          conditional = if pkgs.stdenv.isLinux then pkgs.stdenv.mkDerivation {
+          conditionalBuildInputs = if pkgs.stdenv.isLinux then [
+            bats
+            libbpf
+          ] else if pkgs.stdenv.isDarwin then [
+            pkgs.darwin.IOKit
+          ] else [
+            pkgs.hello # The derivation below will not work with an empty array, so this is a dummy package to fill it in.
+          ];
+
+          conditional = pkgs.stdenv.mkDerivation {
             name = "conditional";
             dontUnpack = true;
             dontBuild = true;
-            propagatedBuildInputs = [
-              bats
-              libbpf
-            ];
-          } else pkgs.hello;
+            propagatedBuildInputs = conditionalBuildInputs;
+          };
         in
         {
           packages = {

--- a/devbox.json
+++ b/devbox.json
@@ -31,6 +31,7 @@
   "shell": {
     "init_hook": [
       "export TELEPORT_DEVBOX=1",
+      "export PATH=\"$HOME/.cargo/bin:$PATH\"",
       "unset GOROOT"
     ]
   },


### PR DESCRIPTION
IOKit has been added as a dependency for Darwin based machines running devbox. This will ensure that IOKit is present for the Teleport build. Additionally, the cargo bin directory has been added to the PATH on shell startup, which helps when running the shell in pure mode.