### PR TITLE
Add username to headless authentication backend key

### DIFF
--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -64,6 +64,10 @@ var (
 		// TestDiagnoseSSHConnection takes around 15s to run.
 		// When running 100x it exceeds the 600s defined to run the tests.
 		"TestDiagnoseSSHConnection",
+
+		// TestServer_Authenticate_headless takes about 4-5 seconds to run, so if other tests are changed
+		// in the same PR that take >1 second total, it may cause the flaky test detector to time out.
+		"TestServer_Authenticate_headless",
 	}
 )
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5262,31 +5262,35 @@ func (a *Server) GetLicense(ctx context.Context) (string, error) {
 	return fmt.Sprintf("%s%s", a.license.CertPEM, a.license.KeyPEM), nil
 }
 
-// GetHeadlessAuthentication returns a headless authentication from the backend by name.
-// If it does not yet exist, a stub will be created to signal the login process to upsert
-// login details. This method will wait for the updated headless authentication and return it.
-func (a *Server) GetHeadlessAuthentication(ctx context.Context, name string) (*types.HeadlessAuthentication, error) {
-	// Try to create a stub if it doesn't already exist, then wait for full login details.
-	if _, err := a.Services.CreateHeadlessAuthenticationStub(ctx, name); err != nil && !trace.IsAlreadyExists(err) {
-		return nil, trace.Wrap(err)
-	}
-
-	sub, err := a.headlessAuthenticationWatcher.Subscribe(ctx, name)
+// GetHeadlessAuthenticationFromWatcher gets a headless authentication from the headless
+// authentication watcher.
+func (a *Server) GetHeadlessAuthenticationFromWatcher(ctx context.Context, username, name string) (*types.HeadlessAuthentication, error) {
+	sub, err := a.headlessAuthenticationWatcher.Subscribe(ctx, username, name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	defer sub.Close()
 
-	waitCtx, cancel := context.WithTimeout(ctx, defaults.HTTPRequestTimeout)
-	defer cancel()
-
-	// wait for the headless authentication to be updated with valid login details
-	// by the login process. If the headless authentication is already updated,
-	// Wait will return it immediately.
-	headlessAuthn, err := a.headlessAuthenticationWatcher.WaitForUpdate(waitCtx, sub, func(ha *types.HeadlessAuthentication) (bool, error) {
+	// Wait for the login process to insert the headless authentication resource into the backend.
+	// If it already exists and passes the condition, WaitForUpdate will return it immediately.
+	headlessAuthn, err := sub.WaitForUpdate(ctx, func(ha *types.HeadlessAuthentication) (bool, error) {
 		return services.ValidateHeadlessAuthentication(ha) == nil, nil
 	})
 	return headlessAuthn, trace.Wrap(err)
+}
+
+// CreateHeadlessAuthenticationStub creates a headless authentication stub for the user
+// that will expire after the standard callback timeout.
+func (a *Server) CreateHeadlessAuthenticationStub(ctx context.Context, username string) error {
+	// Create the stub. If it already exists, update its expiration.
+	expires := a.clock.Now().Add(defaults.CallbackTimeout)
+	stub, err := types.NewHeadlessAuthentication(username, services.HeadlessAuthenticationUserStubID, expires)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = a.Services.UpsertHeadlessAuthentication(ctx, stub)
+	return trace.Wrap(err)
 }
 
 // GetAssistantMessages returns all messages with given conversation ID.

--- a/lib/auth/auth_login_test.go
+++ b/lib/auth/auth_login_test.go
@@ -780,14 +780,6 @@ func TestServer_Authenticate_headless(t *testing.T) {
 			},
 			expectErr: true,
 		}, {
-			name: "NOK user mismatch",
-			update: func(ha *types.HeadlessAuthentication, mfa *types.MFADevice) {
-				ha.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED
-				ha.MfaDevice = mfa
-				ha.User = "other-user"
-			},
-			expectErr: true,
-		}, {
 			name: "NOK denied",
 			update: func(ha *types.HeadlessAuthentication, mfa *types.MFADevice) {
 				ha.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED
@@ -834,7 +826,13 @@ func TestServer_Authenticate_headless(t *testing.T) {
 			go func() {
 				defer close(errC)
 
-				headlessAuthn, err := srv.Auth().GetHeadlessAuthentication(ctx, headlessID)
+				err := srv.Auth().CreateHeadlessAuthenticationStub(ctx, username)
+				if err != nil {
+					errC <- err
+					return
+				}
+
+				headlessAuthn, err := srv.Auth().GetHeadlessAuthenticationFromWatcher(ctx, username, headlessID)
 				if err != nil {
 					errC <- err
 					return

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -6183,50 +6183,61 @@ func (a *ServerWithRoles) DeleteAllUserGroups(ctx context.Context) error {
 	return a.authServer.DeleteAllUserGroups(ctx)
 }
 
-// GetHeadlessAuthentication retrieves a headless authentication by id.
-func (a *ServerWithRoles) GetHeadlessAuthentication(ctx context.Context, id string) (*types.HeadlessAuthentication, error) {
-	// GetHeadlessAuthentication will wait for the headless details
-	// if they don't yet exist in the backend.
-	ctx, cancel := context.WithTimeout(ctx, defaults.HTTPRequestTimeout)
-	defer cancel()
+// GetHeadlessAuthentication gets a headless authentication from the backend.
+func (a *ServerWithRoles) GetHeadlessAuthentication(ctx context.Context, name string) (*types.HeadlessAuthentication, error) {
+	// Only users can get their own headless authentication requests.
+	if !hasLocalUserRole(a.context) {
+		return nil, trace.AccessDenied("non-local user roles cannot get headless authentication resources")
+	}
+	username := a.context.User.GetName()
 
-	headlessAuthn, err := a.authServer.GetHeadlessAuthentication(ctx, id)
+	headlessAuthn, err := a.authServer.GetHeadlessAuthentication(ctx, username, name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	return headlessAuthn, nil
+}
 
+// GetHeadlessAuthenticationFromWatcher gets a headless authentication from the headless
+// authentication watcher.
+func (a *ServerWithRoles) GetHeadlessAuthenticationFromWatcher(ctx context.Context, name string) (*types.HeadlessAuthentication, error) {
 	// Only users can get their own headless authentication requests.
-	if !hasLocalUserRole(a.context) || headlessAuthn.User != a.context.User.GetName() {
-		// This method would usually time out above if the headless authentication
-		// does not exist, so we mimick this behavior here for users without access.
-		<-ctx.Done()
-		return nil, trace.Wrap(ctx.Err())
+	if !hasLocalUserRole(a.context) {
+		return nil, trace.AccessDenied("non-local user roles cannot get headless authentication resources")
+	}
+	username := a.context.User.GetName()
+
+	headlessAuthn, err := a.authServer.GetHeadlessAuthenticationFromWatcher(ctx, username, name)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return headlessAuthn, nil
 }
 
-// UpdateHeadlessAuthenticationState updates a headless authentication state.
-func (a *ServerWithRoles) UpdateHeadlessAuthenticationState(ctx context.Context, id string, state types.HeadlessAuthenticationState, mfaResp *proto.MFAAuthenticateResponse) error {
-	// GetHeadlessAuthentication will wait for the headless details
-	// if they don't yet exist in the backend.
-	ctx, cancel := context.WithTimeout(ctx, defaults.HTTPRequestTimeout)
-	defer cancel()
+// CreateHeadlessAuthenticationStub creates a headless authentication stub for the user
+// that will expire after the standard callback timeout. Headless login processes will
+// look for this stub before inserting the headless authentication resource into the
+// backend as a form of indirect authorization.
+func (a *ServerWithRoles) CreateHeadlessAuthenticationStub(ctx context.Context) error {
+	// Only users can create headless authentication stubs.
+	if !hasLocalUserRole(a.context) {
+		return trace.AccessDenied("non-local user roles cannot create headless authentication stubs")
+	}
+	username := a.context.User.GetName()
 
-	headlessAuthn, err := a.authServer.GetHeadlessAuthentication(ctx, id)
+	err := a.authServer.CreateHeadlessAuthenticationStub(ctx, username)
+	return trace.Wrap(err)
+}
+
+// UpdateHeadlessAuthenticationState updates a headless authentication state.
+func (a *ServerWithRoles) UpdateHeadlessAuthenticationState(ctx context.Context, name string, state types.HeadlessAuthenticationState, mfaResp *proto.MFAAuthenticateResponse) error {
+	headlessAuthn, err := a.GetHeadlessAuthentication(ctx, name)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	// Only users can update their own headless authentication requests.
-	if !hasLocalUserRole(a.context) || headlessAuthn.User != a.context.User.GetName() {
-		// This method would usually time out above if the headless authentication
-		// does not exist, so we mimick this behavior here for users without access.
-		<-ctx.Done()
-		return trace.Wrap(ctx.Err())
-	}
-
-	if headlessAuthn.State != types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING {
+	if !headlessAuthn.State.IsPending() {
 		return trace.AccessDenied("cannot update a headless authentication state from a non-pending state")
 	}
 

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4669,6 +4669,11 @@ func TestGetHeadlessAuthentication(t *testing.T) {
 		require.ErrorContains(t, err, context.DeadlineExceeded.Error(), "expected context deadline error but got: %v", err)
 	}
 
+	assertAccessDenied := func(t require.TestingT, err error, i ...interface{}) {
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied error but got: %v", err)
+	}
+
 	for _, tc := range []struct {
 		name                  string
 		headlessID            string
@@ -4692,20 +4697,17 @@ func TestGetHeadlessAuthentication(t *testing.T) {
 		}, {
 			name:        "NOK admin",
 			identity:    TestAdmin(),
-			assertError: assertTimeout,
+			assertError: assertAccessDenied,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
 			t.Parallel()
 
 			// create headless authn
 			headlessAuthn := newTestHeadlessAuthn(t, username, srv.Auth().clock)
-			stub, err := srv.Auth().CreateHeadlessAuthenticationStub(ctx, headlessAuthn.GetName())
+			err := srv.Auth().UpsertHeadlessAuthentication(ctx, headlessAuthn)
 			require.NoError(t, err)
-			_, err = srv.Auth().CompareAndSwapHeadlessAuthentication(ctx, stub, headlessAuthn)
-			require.NoError(t, err)
-
 			client, err := srv.NewClient(tc.identity)
 			require.NoError(t, err)
 
@@ -4736,9 +4738,14 @@ func TestUpdateHeadlessAuthenticationState(t *testing.T) {
 	_, _, err := CreateUserAndRole(srv.Auth(), otherUsername, nil, nil)
 	require.NoError(t, err)
 
-	assertTimeout := func(t require.TestingT, err error, i ...interface{}) {
+	assertNotFound := func(t require.TestingT, err error, i ...interface{}) {
 		require.Error(t, err)
-		require.ErrorContains(t, err, context.DeadlineExceeded.Error(), "expected context deadline error but got: %v", err)
+		require.True(t, trace.IsNotFound(err), "expected not found error but got: %v", err)
+	}
+
+	assertAccessDenied := func(t require.TestingT, err error, i ...interface{}) {
+		require.Error(t, err)
+		require.True(t, trace.IsAccessDenied(err), "expected access denied error but got: %v", err)
 	}
 
 	for _, tc := range []struct {
@@ -4761,49 +4768,45 @@ func TestUpdateHeadlessAuthenticationState(t *testing.T) {
 			withMFA:     true,
 			assertError: require.NoError,
 		}, {
-			name:    "NOK same user approved without mfa",
-			state:   types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED,
-			withMFA: false,
-			assertError: func(t require.TestingT, err error, i ...interface{}) {
-				require.Error(t, err)
-				require.True(t, trace.IsAccessDenied(err), "expected access denied error but got: %v", err)
-			},
+			name:        "NOK same user approved without mfa",
+			state:       types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED,
+			withMFA:     false,
+			assertError: assertAccessDenied,
 		}, {
 			name:        "NOK not found",
 			headlessID:  uuid.NewString(),
 			state:       types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED,
-			assertError: assertTimeout,
+			assertError: assertNotFound,
 		}, {
-			name:        "NOK different user denied",
+			name:        "NOK different user not found",
 			state:       types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED,
 			identity:    TestUser(otherUsername),
-			assertError: assertTimeout,
+			assertError: assertNotFound,
 		}, {
 			name:        "NOK different user approved",
 			state:       types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED,
 			identity:    TestUser(otherUsername),
-			assertError: assertTimeout,
+			assertError: assertNotFound,
 		}, {
 			name:        "NOK admin denied",
 			state:       types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED,
 			identity:    TestAdmin(),
-			assertError: assertTimeout,
+			assertError: assertAccessDenied,
 		}, {
 			name:        "NOK admin approved",
 			state:       types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED,
 			identity:    TestAdmin(),
-			assertError: assertTimeout,
+			assertError: assertAccessDenied,
 		},
 	} {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			tc := tc
 			t.Parallel()
 
 			// create headless authn
 			headlessAuthn := newTestHeadlessAuthn(t, mfa.User, srv.Auth().clock)
-			stub, err := srv.Auth().CreateHeadlessAuthenticationStub(ctx, headlessAuthn.GetName())
-			require.NoError(t, err)
-			_, err = srv.Auth().CompareAndSwapHeadlessAuthentication(ctx, stub, headlessAuthn)
+			headlessAuthn.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING
+			err := srv.Auth().UpsertHeadlessAuthentication(ctx, headlessAuthn)
 			require.NoError(t, err)
 
 			// default to mfa user

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -5171,14 +5171,36 @@ func (g *GRPCServer) UpdateHeadlessAuthenticationState(ctx context.Context, req 
 	return &emptypb.Empty{}, trace.Wrap(err)
 }
 
-// GetHeadlessAuthentication retrieves a headless authentication by id.
+// GetHeadlessAuthentication retrieves a headless authentication.
 func (g *GRPCServer) GetHeadlessAuthentication(ctx context.Context, req *proto.GetHeadlessAuthenticationRequest) (*types.HeadlessAuthentication, error) {
 	auth, err := g.authenticate(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	authReq, err := auth.GetHeadlessAuthentication(ctx, req.Id)
+	// First, try to retrieve the headless authentication directly if it already exists.
+	if ha, err := auth.GetHeadlessAuthentication(ctx, req.Id); err == nil {
+		return ha, nil
+	} else if !trace.IsNotFound(err) {
+		return nil, trace.Wrap(err)
+	}
+
+	// If the headless authentication doesn't exist yet, the headless login process may be waiting
+	// for the user to create a stub to authorize the insert.
+	if err := auth.CreateHeadlessAuthenticationStub(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Force a short request timeout to prevent GetHeadlessAuthenticationFromWatcher
+	// from waiting indefinitely for a nonexistent headless authentication. This is
+	// useful for cases when the headless link/command is copied incorrectly or is
+	// run with the wrong user.
+	timeout := 5 * time.Second
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// Wait for the login process to insert the actual headless authentication details.
+	authReq, err := auth.GetHeadlessAuthenticationFromWatcher(ctx, req.Id)
 	return authReq, trace.Wrap(err)
 }
 

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -4983,7 +4983,7 @@ func (tc *TeleportClient) HeadlessApprove(ctx context.Context, headlessAuthentic
 		return trace.Wrap(err)
 	}
 
-	if headlessAuthn.State != types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING {
+	if !headlessAuthn.State.IsPending() {
 		return trace.Errorf("cannot approve a headless authentication from a non-pending state: %v", headlessAuthn.State.Stringify())
 	}
 

--- a/lib/services/headlessauthn.go
+++ b/lib/services/headlessauthn.go
@@ -25,19 +25,22 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
+// HeadlessAuthenticationUserStubID is the ID of a headless authentication stub.
+const HeadlessAuthenticationUserStubID = "stub"
+
 // ValidateHeadlessAuthentication verifies that the headless authentication has
-// all of the required fields set. headless authentication stubs created with
-// CreateHeadlessAuthenticationStub will not pass this validation.
+// all of the required fields set. Headless authentication stubs will not pass
+// this validation.
 func ValidateHeadlessAuthentication(h *types.HeadlessAuthentication) error {
 	if err := h.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 
 	switch {
+	case h.State.IsUnspecified():
+		return trace.BadParameter("headless authentication resource state must be specified")
 	case h.Version != types.V1:
 		return trace.BadParameter("unsupported headless authentication resource version %q, current supported version is %s", h.Version, types.V1)
-	case h.User == "":
-		return trace.BadParameter("headless authentication resource must have non-empty user")
 	case h.PublicKey == nil:
 		return trace.BadParameter("headless authentication resource must have non-empty publicKey")
 	case h.Metadata.Name != NewHeadlessAuthenticationID(h.PublicKey):

--- a/lib/services/headlessauthn_test.go
+++ b/lib/services/headlessauthn_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+// TestValidateHeadlessAuthentication tests headless authentication validation logic.
+func TestValidateHeadlessAuthentication(t *testing.T) {
+	t.Parallel()
+
+	pubUUID := services.NewHeadlessAuthenticationID([]byte(sshPubKey))
+	expires := time.Now().Add(time.Minute)
+
+	newHA := func(modify func(*types.HeadlessAuthentication)) *types.HeadlessAuthentication {
+		ha := &types.HeadlessAuthentication{
+			ResourceHeader: types.ResourceHeader{
+				Metadata: types.Metadata{
+					Name:    pubUUID,
+					Expires: &expires,
+				},
+			},
+			State:     types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING,
+			User:      "user",
+			PublicKey: []byte(sshPubKey),
+		}
+		if modify != nil {
+			modify(ha)
+		}
+		return ha
+	}
+
+	tests := []struct {
+		name      string
+		ha        *types.HeadlessAuthentication
+		wantErr   string
+		assertErr require.ErrorAssertionFunc
+	}{
+		{
+			name: "OK valid headless authentication",
+			ha:   newHA(nil),
+		}, {
+			name: "NOK name missing",
+			ha: newHA(func(ha *types.HeadlessAuthentication) {
+				ha.SetName("")
+			}),
+			wantErr: "missing parameter Name",
+		}, {
+			name: "NOK name not derived from public key",
+			ha: newHA(func(ha *types.HeadlessAuthentication) {
+				// use a random UUID instead of the uuid.NewHash of the public key used above.
+				ha.SetName(uuid.NewString())
+			}),
+			wantErr: "headless authentication authentication resource name must be derived from public key",
+		}, {
+			name: "NOK expires missing",
+			ha: newHA(func(ha *types.HeadlessAuthentication) {
+				ha.SetExpiry(time.Time{})
+			}),
+			wantErr: "headless authentication resource must have non-zero header.metadata.expires",
+		}, {
+			name: "NOK username missing",
+			ha: newHA(func(ha *types.HeadlessAuthentication) {
+				ha.User = ""
+			}),
+			wantErr: "headless authentication resource must have non-empty user",
+		}, {
+			name: "NOK state not specified",
+			ha: newHA(func(ha *types.HeadlessAuthentication) {
+				ha.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_UNSPECIFIED
+			}),
+			wantErr: "headless authentication resource state must be specified",
+		}, {
+			name: "NOK public key missing",
+			ha: newHA(func(ha *types.HeadlessAuthentication) {
+				ha.PublicKey = nil
+			}),
+			wantErr: "headless authentication resource must have non-empty publicKey",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := services.ValidateHeadlessAuthentication(test.ha)
+			if test.wantErr == "" {
+				require.NoError(t, err, "ValidateHeadlessAuthentication errored unexpectedly")
+				return
+			}
+			require.True(t, trace.IsBadParameter(err), "ValidateHeadlessAuthentication returned non-BadParameter error: %v", err)
+			require.ErrorContains(t, err, test.wantErr, "ValidateHeadlessAuthentication error mismatch")
+		})
+	}
+}
+
+// sshPubKey is a randomly-generated public key used for login tests.
+const sshPubKey = `ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBGv+gN2C23P08ieJRA9gU/Ik4bsOh3Kw193UYscJDw41mATj+Kqyf45Rmj8F8rs3i7mYKRXXu1IjNRBzNgpXxqc=`

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -257,15 +257,7 @@ type Identity interface {
 	// GetKeyAttestationData gets a verified public key attestation response.
 	GetKeyAttestationData(ctx context.Context, publicKey crypto.PublicKey) (*keys.AttestationData, error)
 
-	// CreateHeadlessAuthenticationStub creates a headless authentication stub.
-	CreateHeadlessAuthenticationStub(ctx context.Context, name string) (*types.HeadlessAuthentication, error)
-
-	// CompareAndSwapHeadlessAuthentication performs a compare
-	// and swap replacement on a headless authentication resource.
-	CompareAndSwapHeadlessAuthentication(ctx context.Context, old, new *types.HeadlessAuthentication) (*types.HeadlessAuthentication, error)
-
-	// DeleteHeadlessAuthentication deletes a headless authentication from the backend by name.
-	DeleteHeadlessAuthentication(ctx context.Context, name string) error
+	HeadlessAuthenticationService
 
 	types.WebSessionsGetter
 	types.WebTokensGetter
@@ -324,6 +316,22 @@ type SAMLIdPSession interface {
 	DeleteAllSAMLIdPSessions(context.Context) error
 	// DeleteUserSAMLIdPSessions deletes all of a user's SAML IdP sessions.
 	DeleteUserSAMLIdPSessions(ctx context.Context, user string) error
+}
+
+// HeadlessAuthenticationService is responsible for headless authentication resource management
+type HeadlessAuthenticationService interface {
+	// GetHeadlessAuthentication gets a headless authentication.
+	GetHeadlessAuthentication(ctx context.Context, username, name string) (*types.HeadlessAuthentication, error)
+
+	// UpsertHeadlessAuthentication upserts a headless authentication.
+	UpsertHeadlessAuthentication(ctx context.Context, ha *types.HeadlessAuthentication) error
+
+	// CompareAndSwapHeadlessAuthentication performs a compare
+	// and swap replacement on a headless authentication resource.
+	CompareAndSwapHeadlessAuthentication(ctx context.Context, old, new *types.HeadlessAuthentication) (*types.HeadlessAuthentication, error)
+
+	// DeleteHeadlessAuthentication deletes a headless authentication from the backend.
+	DeleteHeadlessAuthentication(ctx context.Context, username, name string) error
 }
 
 // VerifyPassword makes sure password satisfies our requirements (relaxed),

--- a/lib/services/local/headlessauthn.go
+++ b/lib/services/local/headlessauthn.go
@@ -23,29 +23,19 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-// CreateHeadlessAuthenticationStub creates a headless authentication stub in the backend.
-func (s *IdentityService) CreateHeadlessAuthenticationStub(ctx context.Context, name string) (*types.HeadlessAuthentication, error) {
-	expires := s.Clock().Now().Add(defaults.CallbackTimeout)
-	headlessAuthn, err := types.NewHeadlessAuthenticationStub(name, expires)
+// UpsertHeadlessAuthentication upserts a headless authentication in the backend.
+func (s *IdentityService) UpsertHeadlessAuthentication(ctx context.Context, ha *types.HeadlessAuthentication) error {
+	item, err := MarshalHeadlessAuthenticationToItem(ha)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return trace.Wrap(err)
 	}
 
-	item, err := MarshalHeadlessAuthenticationToItem(headlessAuthn)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	if _, err = s.Create(ctx, *item); err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return headlessAuthn, nil
+	_, err = s.Put(ctx, *item)
+	return trace.Wrap(err)
 }
 
 // CompareAndSwapHeadlessAuthentication validates the new headless authentication and
@@ -73,9 +63,9 @@ func (s *IdentityService) CompareAndSwapHeadlessAuthentication(ctx context.Conte
 	return new, nil
 }
 
-// GetHeadlessAuthentication returns a headless authentication from the backend by name.
-func (s *IdentityService) GetHeadlessAuthentication(ctx context.Context, name string) (*types.HeadlessAuthentication, error) {
-	item, err := s.Get(ctx, headlessAuthenticationKey(name))
+// GetHeadlessAuthentication returns a headless authentication from the backend.
+func (s *IdentityService) GetHeadlessAuthentication(ctx context.Context, username, name string) (*types.HeadlessAuthentication, error) {
+	item, err := s.Get(ctx, headlessAuthenticationKey(username, name))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -90,8 +80,9 @@ func (s *IdentityService) GetHeadlessAuthentication(ctx context.Context, name st
 
 // GetHeadlessAuthentications returns all headless authentications from the backend.
 func (s *IdentityService) GetHeadlessAuthentications(ctx context.Context) ([]*types.HeadlessAuthentication, error) {
-	rangeStart := headlessAuthenticationKey("")
+	rangeStart := backend.Key(headlessAuthenticationPrefix)
 	rangeEnd := backend.RangeEnd(rangeStart)
+
 	items, err := s.GetRange(ctx, rangeStart, rangeEnd, 0)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -109,10 +100,9 @@ func (s *IdentityService) GetHeadlessAuthentications(ctx context.Context) ([]*ty
 	return headlessAuthns, nil
 }
 
-// DeleteHeadlessAuthentication deletes a headless authentication from the backend by name.
-func (s *IdentityService) DeleteHeadlessAuthentication(ctx context.Context, name string) error {
-	err := s.Delete(ctx, headlessAuthenticationKey(name))
-	return trace.Wrap(err)
+// DeleteHeadlessAuthentication deletes a headless authentication from the backend.
+func (s *IdentityService) DeleteHeadlessAuthentication(ctx context.Context, username, name string) error {
+	return trace.Wrap(s.Delete(ctx, headlessAuthenticationKey(username, name)))
 }
 
 // MarshalHeadlessAuthenticationToItem marshals a headless authentication to a backend.Item.
@@ -127,7 +117,7 @@ func MarshalHeadlessAuthenticationToItem(headlessAuthn *types.HeadlessAuthentica
 	}
 
 	return &backend.Item{
-		Key:     headlessAuthenticationKey(headlessAuthn.Metadata.Name),
+		Key:     headlessAuthenticationKey(headlessAuthn.User, headlessAuthn.Metadata.Name),
 		Value:   value,
 		Expires: *headlessAuthn.Metadata.Expires,
 	}, nil
@@ -147,6 +137,8 @@ func unmarshalHeadlessAuthenticationFromItem(item *backend.Item) (*types.Headles
 	return &headlessAuthn, nil
 }
 
-func headlessAuthenticationKey(name string) []byte {
-	return backend.Key("headless_authentication", name)
+const headlessAuthenticationPrefix = "headless_authentication"
+
+func headlessAuthenticationKey(username, name string) []byte {
+	return backend.Key(headlessAuthenticationPrefix, usersPrefix, username, name)
 }

--- a/lib/services/local/headlessauthn_watcher.go
+++ b/lib/services/local/headlessauthn_watcher.go
@@ -137,6 +137,12 @@ func (h *HeadlessAuthenticationWatcher) close() {
 	h.Lock()
 	defer h.Unlock()
 	close(h.closed)
+
+	for _, s := range h.subscribers {
+		if s != nil {
+			s.Close()
+		}
+	}
 }
 
 func (h *HeadlessAuthenticationWatcher) runWatchLoop(ctx context.Context) {
@@ -198,7 +204,7 @@ func (h *HeadlessAuthenticationWatcher) newWatcher(ctx context.Context) (backend
 	watcher, err := h.identityService.NewWatcher(ctx, backend.Watch{
 		Name:            types.KindHeadlessAuthentication,
 		MetricComponent: types.KindHeadlessAuthentication,
-		Prefixes:        [][]byte{headlessAuthenticationKey("")},
+		Prefixes:        [][]byte{backend.Key(headlessAuthenticationPrefix)},
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -225,45 +231,49 @@ func (h *HeadlessAuthenticationWatcher) notify(headlessAuthns ...*types.Headless
 
 	for _, ha := range headlessAuthns {
 		for _, s := range h.subscribers {
-			if s != nil && s.name == ha.Metadata.Name {
+			if s != nil && s.name == ha.Metadata.Name && s.username == ha.User {
 				s.update(ha)
 			}
 		}
 	}
 }
 
-// HeadlessAuthenticationSubscriber is a subscriber of updates
-// for a specific headless authentication resource.
+// HeadlessAuthenticationSubscriber is a subscriber for a specific headless authentication.
 type HeadlessAuthenticationSubscriber interface {
-	Name() string
 	// Updates is a channel used by the watcher to send headless authentication updates.
 	Updates() <-chan *types.HeadlessAuthentication
+	// WaitForUpdate returns the first update which passes the given condition, or returns
+	// early if the condition results in an error or if the subscriber or given context is closed.
+	WaitForUpdate(ctx context.Context, cond func(*types.HeadlessAuthentication) (bool, error)) (*types.HeadlessAuthentication, error)
+	// Done returns a channel that's closed when the subscriber is closed.
+	Done() <-chan struct{}
 	// Close closes the subscriber and its channels. This frees up resources for the watcher
 	// and should always be called on completion.
 	Close()
 }
 
-// Subscribe creates a new headless authentication subscriber for the given headless authentication name.
-func (h *HeadlessAuthenticationWatcher) Subscribe(ctx context.Context, name string) (HeadlessAuthenticationSubscriber, error) {
-	i, err := h.assignSubscriber(name)
+// Subscribe creates a subscriber for a specific headless authentication.
+func (h *HeadlessAuthenticationWatcher) Subscribe(ctx context.Context, username, name string) (HeadlessAuthenticationSubscriber, error) {
+	if name == "" {
+		return nil, trace.BadParameter("name must be provided")
+	}
+	if username == "" {
+		return nil, trace.BadParameter("username must be provided")
+	}
+
+	i, err := h.assignSubscriber(username, name)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	subscriber := h.subscribers[i]
 
 	go func() {
-		select {
-		case <-ctx.Done():
-		case <-subscriber.closed:
-		}
-
-		// reclaim the subscriber and close remaining open channels.
+		<-subscriber.Done()
 		h.unassignSubscriber(i)
-		close(subscriber.updates)
 	}()
 
 	// Check for an existing backend entry and send it as the first update.
-	if ha, err := h.identityService.GetHeadlessAuthentication(ctx, subscriber.Name()); err == nil {
+	if ha, err := h.identityService.GetHeadlessAuthentication(ctx, username, name); err == nil {
 		subscriber.update(ha)
 	} else if !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
@@ -272,7 +282,7 @@ func (h *HeadlessAuthenticationWatcher) Subscribe(ctx context.Context, name stri
 	return subscriber, nil
 }
 
-func (h *HeadlessAuthenticationWatcher) assignSubscriber(name string) (int, error) {
+func (h *HeadlessAuthenticationWatcher) assignSubscriber(username, name string) (int, error) {
 	h.Lock()
 	defer h.Unlock()
 
@@ -285,7 +295,8 @@ func (h *HeadlessAuthenticationWatcher) assignSubscriber(name string) (int, erro
 	for i := range h.subscribers {
 		if h.subscribers[i] == nil {
 			h.subscribers[i] = &headlessAuthenticationSubscriber{
-				name: name,
+				name:     name,
+				username: username,
 				// small buffer for updates so we can replace stale updates.
 				updates: make(chan *types.HeadlessAuthentication, 1),
 				closed:  make(chan struct{}),
@@ -305,8 +316,10 @@ func (h *HeadlessAuthenticationWatcher) unassignSubscriber(i int) {
 
 // headlessAuthenticationSubscriber is a subscriber for a specific headless authentication.
 type headlessAuthenticationSubscriber struct {
-	// name is the name of the headless authentication resource being subscribed to.
+	// name is a headless authentication name.
 	name string
+	// username is a teleport username.
+	username string
 	// updates is a channel used by the watcher to send resource updates. This channel
 	// will either be empty or have the latest update in its buffer.
 	updates   chan *types.HeadlessAuthentication
@@ -315,12 +328,50 @@ type headlessAuthenticationSubscriber struct {
 	closed chan struct{}
 }
 
-func (s *headlessAuthenticationSubscriber) Name() string {
-	return s.name
-}
-
+// Updates is a channel used by the watcher to send headless authentication updates.
 func (s *headlessAuthenticationSubscriber) Updates() <-chan *types.HeadlessAuthentication {
 	return s.updates
+}
+
+// WaitForUpdate returns the first update which passes the given condition, or returns
+// early if the condition results in an error or if the subscriber or given context is closed.
+func (s *headlessAuthenticationSubscriber) WaitForUpdate(ctx context.Context, cond func(*types.HeadlessAuthentication) (bool, error)) (*types.HeadlessAuthentication, error) {
+	for {
+		select {
+		case ha, ok := <-s.Updates():
+			if !ok {
+				return nil, ErrHeadlessAuthenticationWatcherClosed
+			}
+			if ok, err := cond(ha); err != nil {
+				return nil, trace.Wrap(err)
+			} else if ok {
+				return ha, nil
+			}
+		case <-ctx.Done():
+			return nil, trace.Wrap(ctx.Err())
+		case <-s.Done():
+			return nil, ErrHeadlessAuthenticationWatcherClosed
+		}
+	}
+}
+
+// Done returns a channel that's closed when the subscriber is closed.
+func (s *headlessAuthenticationSubscriber) Done() <-chan struct{} {
+	return s.closed
+}
+
+// Close closes the subscriber and its channels. This frees up resources for the watcher
+// and should always be called on completion.
+func (s *headlessAuthenticationSubscriber) Close() {
+	s.updatesMu.Lock()
+	defer s.updatesMu.Unlock()
+
+	select {
+	case <-s.closed:
+	default:
+		close(s.closed)
+		close(s.updates)
+	}
 }
 
 func (s *headlessAuthenticationSubscriber) update(ha *types.HeadlessAuthentication) {
@@ -329,36 +380,13 @@ func (s *headlessAuthenticationSubscriber) update(ha *types.HeadlessAuthenticati
 
 	// Drain stale update if there is one.
 	select {
-	case <-s.updates:
+	case _, ok := <-s.updates:
+		if !ok {
+			// updates channel is closed, subscriber is closing.
+			return
+		}
 	default:
 	}
 
 	s.updates <- apiutils.CloneProtoMsg(ha)
-}
-
-func (s *headlessAuthenticationSubscriber) Close() {
-	close(s.closed)
-}
-
-// WaitForUpdate waits until the headless authentication with the given name is updated in the
-// backend to meet the given condition or returns early if the condition results in an
-// error or if the watcher or given context is closed.
-func (h *HeadlessAuthenticationWatcher) WaitForUpdate(ctx context.Context, subscriber HeadlessAuthenticationSubscriber, cond func(*types.HeadlessAuthentication) (bool, error)) (*types.HeadlessAuthentication, error) {
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
-	for {
-		select {
-		case ha := <-subscriber.Updates():
-			if ok, err := cond(ha); err != nil {
-				return nil, trace.Wrap(err)
-			} else if ok {
-				return ha, nil
-			}
-		case <-ctx.Done():
-			return nil, trace.Wrap(ctx.Err())
-		case <-h.Done():
-			return nil, ErrHeadlessAuthenticationWatcherClosed
-		}
-	}
 }

--- a/lib/services/local/headlessauthn_watcher_test.go
+++ b/lib/services/local/headlessauthn_watcher_test.go
@@ -63,24 +63,34 @@ func newHeadlessAuthenticationWatcherTestEnv(t *testing.T, clock clockwork.Clock
 func TestHeadlessAuthenticationWatcher_Subscribe(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+
 	pubUUID := services.NewHeadlessAuthenticationID([]byte(sshPubKey))
+	username := "username"
+
+	newHeadlessAuthn := func(t *testing.T, s *headlessAuthenticationWatcherTestEnv) *types.HeadlessAuthentication {
+		headlessAuthn, err := types.NewHeadlessAuthentication(username, pubUUID, s.watcher.Clock.Now().Add(time.Minute))
+		require.NoError(t, err)
+		headlessAuthn.User = username
+		return headlessAuthn
+	}
 
 	t.Run("Updates", func(t *testing.T) {
 		t.Parallel()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clockwork.NewFakeClock())
+		headlessAuthn := newHeadlessAuthn(t, s)
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
-		stub, err := s.identity.CreateHeadlessAuthenticationStub(ctx, pubUUID)
+		err = s.identity.UpsertHeadlessAuthentication(ctx, headlessAuthn)
 		assert.NoError(t, err)
 
 		for {
 			select {
 			case update := <-sub.Updates():
 				// We should receive the update.
-				require.Equal(t, stub, update)
+				require.Equal(t, headlessAuthn, update)
 				return
 			case <-time.After(time.Second):
 				t.Fatal("Expected subscriber to receive an update")
@@ -91,26 +101,27 @@ func TestHeadlessAuthenticationWatcher_Subscribe(t *testing.T) {
 	t.Run("Stale", func(t *testing.T) {
 		t.Parallel()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clockwork.NewFakeClock())
+		headlessAuthn := newHeadlessAuthn(t, s)
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
 		// Create a second subscriber to wait for the update below. Since this
 		// subscriber was created second, it should receive the update second.
-		drain, err := s.watcher.Subscribe(ctx, pubUUID)
+		drain, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(drain.Close)
 
 		// Create 2 updates without servicing the subscriber's Updates channel.
 		// The backend update should be dropped in favor of the second update.
-		stub, err := s.identity.CreateHeadlessAuthenticationStub(ctx, pubUUID)
+		err = s.identity.UpsertHeadlessAuthentication(ctx, headlessAuthn)
 		require.NoError(t, err)
 
-		replace := *stub
-		replace.User = "user"
+		replace := *headlessAuthn
 		replace.PublicKey = []byte(sshPubKey)
-		swapped, err := s.identity.CompareAndSwapHeadlessAuthentication(ctx, stub, &replace)
+		replace.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED
+		swapped, err := s.identity.CompareAndSwapHeadlessAuthentication(ctx, headlessAuthn, &replace)
 		require.NoError(t, err)
 
 		// Drain updates and wait for the second update. Depending on the speed
@@ -141,8 +152,9 @@ func TestHeadlessAuthenticationWatcher_Subscribe(t *testing.T) {
 		t.Parallel()
 		clock := clockwork.NewFakeClock()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clock)
+		headlessAuthn := newHeadlessAuthn(t, s)
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
@@ -150,8 +162,8 @@ func TestHeadlessAuthenticationWatcher_Subscribe(t *testing.T) {
 		s.identity.Backend.CloseWatchers()
 		clock.BlockUntil(1)
 
-		stub, err := s.identity.CreateHeadlessAuthenticationStub(ctx, pubUUID)
-		assert.NoError(t, err)
+		err = s.identity.UpsertHeadlessAuthentication(ctx, headlessAuthn)
+		require.NoError(t, err)
 
 		// Reset the watcher. Make sure we are servicing the updates channel first.
 		readyForUpdate := make(chan struct{})
@@ -164,7 +176,7 @@ func TestHeadlessAuthenticationWatcher_Subscribe(t *testing.T) {
 		select {
 		case update := <-sub.Updates():
 			// We should receive an update of the current backend state on watcher reset.
-			require.Equal(t, stub, update)
+			require.Equal(t, headlessAuthn, update)
 			return
 		case <-time.After(time.Second):
 			t.Fatal("Expected subscriber to receive an update")
@@ -175,13 +187,36 @@ func TestHeadlessAuthenticationWatcher_Subscribe(t *testing.T) {
 func TestHeadlessAuthenticationWatcher_WaitForUpdate(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+
 	pubUUID := services.NewHeadlessAuthenticationID([]byte(sshPubKey))
+	username := "username"
+
+	newHeadlessAuthn := func(t *testing.T, s *headlessAuthenticationWatcherTestEnv) *types.HeadlessAuthentication {
+		headlessAuthn, err := types.NewHeadlessAuthentication(username, pubUUID, s.watcher.Clock.Now().Add(time.Minute))
+		require.NoError(t, err)
+		headlessAuthn.User = username
+		return headlessAuthn
+	}
+
+	deniedErr := errors.New("headless authentication denied")
+	conditionFunc := func(ha *types.HeadlessAuthentication) (bool, error) {
+		switch ha.State {
+		case types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING:
+			return false, nil
+		case types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED:
+			return true, nil
+		case types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED:
+			return false, deniedErr
+		}
+		return false, nil
+	}
 
 	t.Run("ConditionMet", func(t *testing.T) {
 		t.Parallel()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clockwork.NewFakeClock())
+		headlessAuthn := newHeadlessAuthn(t, s)
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
@@ -191,108 +226,91 @@ func TestHeadlessAuthenticationWatcher_WaitForUpdate(t *testing.T) {
 		headlessAuthnCh := make(chan *types.HeadlessAuthentication, 1)
 		errC := make(chan error, 1)
 		go func() {
-			ha, err := s.watcher.WaitForUpdate(ctx, sub, func(ha *types.HeadlessAuthentication) (bool, error) {
-				return ha.User != "", nil
-			})
+			ha, err := sub.WaitForUpdate(ctx, conditionFunc)
 			headlessAuthnCh <- ha
 			errC <- err
 		}()
 
 		// Make an update that passes the condition.
-		stub, err := s.identity.CreateHeadlessAuthenticationStub(ctx, pubUUID)
-		require.NoError(t, err)
-
-		replace := *stub
-		replace.User = "user"
-		replace.PublicKey = []byte(sshPubKey)
-		_, err = s.identity.CompareAndSwapHeadlessAuthentication(ctx, stub, &replace)
+		headlessAuthn.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED
+		err = s.identity.UpsertHeadlessAuthentication(ctx, headlessAuthn)
 		require.NoError(t, err)
 
 		require.NoError(t, <-errC)
-		require.Equal(t, &replace, <-headlessAuthnCh)
+		require.Equal(t, headlessAuthn, <-headlessAuthnCh)
 	})
 
 	t.Run("ConditionUnmet", func(t *testing.T) {
 		t.Parallel()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clockwork.NewFakeClock())
+		headlessAuthn := newHeadlessAuthn(t, s)
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
-		unknownUserErr := errors.New("Unknown user")
-		conditionFunc := func(ha *types.HeadlessAuthentication) (bool, error) {
-			if ha.User == "" {
-				return false, nil
-			} else if ha.User == "unknown" {
-				return false, unknownUserErr
-			}
-			return true, nil
-		}
-
-		// Make an update that doesn't pass the condition (user not set).
+		// Make an update that doesn't pass the condition (pending).
 		// The waiter should ignore this update and timeout.
-		stub, err := s.identity.CreateHeadlessAuthenticationStub(ctx, pubUUID)
+		err = s.identity.UpsertHeadlessAuthentication(ctx, headlessAuthn)
 		require.NoError(t, err)
 
 		timeoutCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 		t.Cleanup(cancel)
 
-		_, err = s.watcher.WaitForUpdate(timeoutCtx, sub, conditionFunc)
+		_, err = sub.WaitForUpdate(timeoutCtx, conditionFunc)
 		require.Error(t, err)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 
-		// Make an update that causes the condition to error (user "unknown").
-		// The waiter should return the condition error.
-		replace := *stub
-		replace.User = "unknown"
-		replace.PublicKey = []byte(sshPubKey)
-		_, err = s.identity.CompareAndSwapHeadlessAuthentication(ctx, stub, &replace)
+		// Make an update that causes the condition to error (denied).
+		// The waiter should return the condition error during the initial backend check.
+		headlessAuthn.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_DENIED
+		err = s.identity.UpsertHeadlessAuthentication(ctx, headlessAuthn)
 		require.NoError(t, err)
 
 		waitCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		t.Cleanup(cancel)
 
-		_, err = s.watcher.WaitForUpdate(waitCtx, sub, conditionFunc)
+		_, err = sub.WaitForUpdate(waitCtx, conditionFunc)
 		require.Error(t, err)
-		require.ErrorIs(t, err, unknownUserErr)
+		require.ErrorIs(t, err, deniedErr)
 	})
 
 	t.Run("InitialBackendCheck", func(t *testing.T) {
 		t.Parallel()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clockwork.NewFakeClock())
+		headlessAuthn := newHeadlessAuthn(t, s)
 
-		stub, err := s.identity.CreateHeadlessAuthenticationStub(ctx, pubUUID)
+		// Create a headless authentication that passes the condition before starting WaitForUpdate.
+		headlessAuthn.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_APPROVED
+		err := s.identity.UpsertHeadlessAuthentication(ctx, headlessAuthn)
 		require.NoError(t, err)
 
 		waitCtx, waitCancel := context.WithTimeout(ctx, 5*time.Second)
 		t.Cleanup(waitCancel)
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
-		// WaitForUpdate should immediately check the backend and return the existing headless authentication stub.
-		headlessAuthn, err := s.watcher.WaitForUpdate(waitCtx, sub, func(ha *types.HeadlessAuthentication) (bool, error) {
-			return true, nil
-		})
+		// WaitForUpdate should immediately check the backend and return the existing headless authentication.
+		headlessAuthnUpdate, err := sub.WaitForUpdate(waitCtx, conditionFunc)
 
 		require.NoError(t, err)
-		require.Equal(t, stub, headlessAuthn)
+		require.Equal(t, headlessAuthn, headlessAuthnUpdate)
 	})
 
 	t.Run("Timeout", func(t *testing.T) {
 		t.Parallel()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clockwork.NewFakeClock())
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
 		waitCtx, waitCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 		t.Cleanup(waitCancel)
 
-		_, err = s.watcher.WaitForUpdate(waitCtx, sub, func(ha *types.HeadlessAuthentication) (bool, error) { return true, nil })
+		_, err = sub.WaitForUpdate(waitCtx, func(ha *types.HeadlessAuthentication) (bool, error) { return true, nil })
 		require.Error(t, err)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
@@ -301,13 +319,13 @@ func TestHeadlessAuthenticationWatcher_WaitForUpdate(t *testing.T) {
 		t.Parallel()
 		s := newHeadlessAuthenticationWatcherTestEnv(t, clockwork.NewFakeClock())
 
-		sub, err := s.watcher.Subscribe(ctx, pubUUID)
+		sub, err := s.watcher.Subscribe(ctx, username, pubUUID)
 		require.NoError(t, err)
 		t.Cleanup(sub.Close)
 
 		errC := make(chan error)
 		go func() {
-			_, err := s.watcher.WaitForUpdate(ctx, sub, func(ha *types.HeadlessAuthentication) (bool, error) {
+			_, err := sub.WaitForUpdate(ctx, func(ha *types.HeadlessAuthentication) (bool, error) {
 				return true, nil
 			})
 			errC <- err
@@ -321,7 +339,7 @@ func TestHeadlessAuthenticationWatcher_WaitForUpdate(t *testing.T) {
 		require.ErrorIs(t, waitErr, local.ErrHeadlessAuthenticationWatcherClosed)
 
 		// New subscribers should be prevented.
-		_, err = s.watcher.Subscribe(ctx, pubUUID)
+		_, err = s.watcher.Subscribe(ctx, username, pubUUID)
 		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
This PR adds username to the headless authentication backend key, and makes related changes:
 - Require username to be set in `CheckAndSetDefaults` instead of `ValidateHeadlessAuthenticaiton`
 - Use key `headless_authentication/user/username/stub` for stubs instead of previously used `headless_authentications/request_id`. This makes the stub logic more generally usable for features like [Headless Polling](https://github.com/gravitational/teleport/issues/27137).
 - Update `GetHeadlessAuthentication` to time out after 5 seconds on the server side if no headless authentication matching the username and request ID is found. Fixes https://github.com/gravitational/teleport/issues/23436