### PR TITLE
Clarify permissions for Okta API tokens.

### DIFF
--- a/docs/pages/application-access/okta/guide.mdx
+++ b/docs/pages/application-access/okta/guide.mdx
@@ -19,10 +19,45 @@ configurations to enable it.
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
 - (!docs/pages/includes/tctl.mdx!)
-- An Okta organization with an [Okta API token](https://developer.okta.com/docs/guides/create-an-api-token) created.
 - A running Teleport cluster with Okta login configured.
 - An instance where you will run the Okta Service. This can live anywhere
   with outbound access to Okta and must be running Linux.
+- An Okta organization with an [Okta API token](https://developer.okta.com/docs/guides/create-an-api-token) created.
+
+<Details title="Okta API token permissions">
+
+Okta API tokens inherit the permissions of the user who created them. These can
+be controlled by using [custom admin roles](https://help.okta.com/en-us/Content/Topics/Security/custom-admin-role/about-creating-custom-admin-roles.htm)
+and assigning them to a user who will then create the API token. We recommend
+creating a user dedicated to the Teleport Okta API service to manage this token.
+
+The permissions required are:
+
+#### User permissions
+
+- View users and their details
+- Edit users' group membership
+- Edit users' application assignments
+
+#### Group permissions
+
+- View groups and their details
+- Manage group membership
+
+#### Application permissions
+
+- View applications and their details
+- Edit application's user assignments
+
+Additionally, the resource set associated with the must have unconstrained access to
+Users, Applications, and Groups.
+
+One caveat here is that it's impossible to assign API token creation permissions to a
+custom role. However, the Okta built in role "Group Membership Admin" has permissions
+to create an API token. See more information about built in roles
+[here](https://help.okta.com/en-us/Content/Topics/Security/administrators-admin-comparison.htm).
+
+</Details>
 
 ## Step 1/3. Create Okta import rules
 

--- a/docs/pages/application-access/okta/guide.mdx
+++ b/docs/pages/application-access/okta/guide.mdx
@@ -33,18 +33,18 @@ creating a user dedicated to the Teleport Okta API service to manage this token.
 
 The permissions required are:
 
-#### User permissions
+### User permissions
 
 - View users and their details
 - Edit users' group membership
 - Edit users' application assignments
 
-#### Group permissions
+### Group permissions
 
 - View groups and their details
 - Manage group membership
 
-#### Application permissions
+### Application permissions
 
 - View applications and their details
 - Edit application's user assignments

--- a/docs/pages/application-access/okta/guide.mdx
+++ b/docs/pages/application-access/okta/guide.mdx
@@ -49,8 +49,8 @@ The permissions required are:
 - View applications and their details
 - Edit application's user assignments
 
-Additionally, the resource set associated with the must have unconstrained access to
-Users, Applications, and Groups.
+Additionally, the resource set associated with the target user must have unconstrained
+access to Users, Applications, and Groups.
 
 One caveat here is that it's impossible to assign API token creation permissions to a
 custom role. However, the Okta built in role "Group Membership Admin" has permissions


### PR DESCRIPTION
In the Okta service guide, details about the permissions required for the Okta API token have been added. This will allow users to create less privileged API tokens to minimize the blast radius of a compromised API token.