### PR TITLE
Add security notes to the session recording guide

### DIFF
--- a/docs/pages/architecture/session-recording.mdx
+++ b/docs/pages/architecture/session-recording.mdx
@@ -16,16 +16,19 @@ Teleport captures the entire pseudo-terminal (PTY) output of the session. The
 intention is for session recording to document what a user saw when they ran a
 session.
 
-Note that the design of session recording carries some security risks if you
-have not adequately hardened your servers. Namely, users can conceal terminal
-commands by encoding them (e.g., using `base64`), running scripts from disk or
-the internet, or changing the terminal settings. If this presents an issue for
-your environment, consider using the BPF-based [Enhanced Session
-Recording](../server-access/guides/bpf-session-recording.mdx) instead.
+Note that the design of session recording carries some security risks. Namely,
+users can conceal terminal commands by encoding them (e.g., using `base64`),
+running scripts from disk or the internet, or changing the terminal settings. If
+this presents an issue for your environment, consider using the BPF-based
+[Enhanced Session Recording](../server-access/guides/bpf-session-recording.mdx)
+instead.
 
 ### Kubernetes sessions
 
 Teleport captures the entire PTY output for `kubectl exec` invocations.
+
+Kubernetes session recording carries the same security risks as SSH session
+recording.
 
 ### Desktop sessions
 

--- a/docs/pages/architecture/session-recording.mdx
+++ b/docs/pages/architecture/session-recording.mdx
@@ -10,18 +10,38 @@ configuration options that apply to session recordings.
 
 The content that is captured depends on the type of the session.
 
-- SSH sessions: Teleport captures the entire pseudo-terminal (PTY) output
-  of the session.
-- Kubernetes sessions: Teleport captures the entire PTY output for
-  `kubectl exec` invocations.
-- Desktop sessions: Teleport captures the contents of the desktop screen
-  and any mouse input. Teleport does not capture keystrokes in the remote
-  desktop.
-- App sessions: Teleport captures a stream of `app.session.request`
-  audit events related to application access. The audit events are
-  bucketed into 5-minute time intervals informally referred to as "chunks."
-- Database sessions: Teleport captures a stream of audit events
-  related to the database being accessed.
+### SSH sessions
+
+Teleport captures the entire pseudo-terminal (PTY) output of the session. The
+intention is for session recording to document what a user saw when they ran a
+session.
+
+Note that the design of session recording carries some security risks if you
+have not adequately hardened your servers. Namely, users can conceal terminal
+commands by encoding them (e.g., using `base64`), running scripts from disk or
+the internet, or changing the terminal settings. If this presents an issue for
+your environment, consider using the BPF-based [Enhanced Session
+Recording](../server-access/guides/bpf-session-recording.mdx) instead.
+
+### Kubernetes sessions
+
+Teleport captures the entire PTY output for `kubectl exec` invocations.
+
+### Desktop sessions
+
+Teleport captures the contents of the desktop screen and any mouse input.
+Teleport does not capture keystrokes in the remote desktop.
+
+### App sessions
+
+Teleport captures a stream of `app.session.request` audit events related to
+application access. The audit events are bucketed into 5-minute time intervals
+informally referred to as "chunks."
+
+### Database sessions
+
+Teleport captures a stream of audit events related to the database being
+accessed.
 
 ## Session recording configurations
 


### PR DESCRIPTION
While there are several security risks for using session recording for SSH, these are only documented in the guide for Enhanced Session Recording, making them easy to miss if you are only reading the session recording guide in the "Architecture" section of the docs.

The session recording architecture guide and the Enhanced Session Recording guide get roughly equivalent traffic, so this change adds a variation on the security warning in the Enhanced Session Recording guide to the session recording architecture guide, ensuring that the security guidance is visible in both locations.