### PR TITLE
Pass `teleport-reversetunnelv2` for auth connections

### DIFF
--- a/lib/reversetunnelclient/transport.go
+++ b/lib/reversetunnelclient/transport.go
@@ -87,7 +87,10 @@ func (t *TunnelAuthDialer) DialContext(ctx context.Context, _, _ string) (net.Co
 	if mode == types.ProxyListenerMode_Multiplex {
 		opts = append(opts, proxy.WithALPNDialer(client.ALPNDialerConfig{
 			TLSConfig: &tls.Config{
-				NextProtos:         []string{string(alpncommon.ProtocolReverseTunnel)},
+				NextProtos: []string{
+					string(alpncommon.ProtocolReverseTunnelV2),
+					string(alpncommon.ProtocolReverseTunnel),
+				},
 				InsecureSkipVerify: t.InsecureSkipTLSVerify,
 			},
 			DialTimeout:             t.ClientConfig.Timeout,


### PR DESCRIPTION
As there's never any reason to require "full connectivity" (mesh mode) for auth connections going through the reverse tunnel protocol, we can just add `teleport-reversetunnelv2` to the list to signify that we're ok with being routed through the closest proxy, when possible.

Fixes gravitational/cloud#4630, although the real fix would be to use a standard api client that can take advantage of direct-ish connections via ALPN routing.