### PR TITLE
Always collect `deny` arm of `kubernetes_resources`

### DIFF
--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -2815,11 +2815,12 @@ func (set RoleSet) GetKubeResources(cluster types.KubeCluster, userTraits wrappe
 	}
 
 	for _, role := range set {
-		matchLabels, _, err := checkRoleLabelsMatch(types.Deny, role, userTraits, cluster, false)
-		if err != nil || !matchLabels {
-			continue
-		}
-
+		// deny rules are not checked for labels because they are greedy. It means that
+		// if there is a deny rule for a cluster, it will deny access to all resources
+		// in that cluster, regardless of kubernetes_resources (i.e. making them irrelevant).
+		// If the goal is to deny access to a specific resource, it should be done by collecting
+		// all kube resources in deny rules and ignoring if the role matches or not
+		// the cluster (i.e. no labels check).
 		denied = append(denied, role.GetKubeResources(types.Deny)...)
 	}
 

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -6662,6 +6662,7 @@ func TestGetKubeResources(t *testing.T) {
 			},
 			clusterLabels: map[string]string{"env": "staging"},
 			expectAllowed: []types.KubernetesResource{podA, podB},
+			expectDenied:  []types.KubernetesResource{podA},
 		},
 	} {
 		t.Run(tc.desc, func(t *testing.T) {


### PR DESCRIPTION
Denied `kubernetes_resources` weren't properly loaded when collecting resources for list filtering.

This PR collects all deny arms - if the `kubernetes_labels` match the cluster, the access is denied - of Kubernetes resources.

Fixes #28262