### PR TITLE
Make RFD number one-liner more resistant to typos

### DIFF
--- a/rfd/0000-rfds.md
+++ b/rfd/0000-rfds.md
@@ -61,7 +61,7 @@ in the main Teleport branch.
    Use this one-liner to get the highest-numbered RFD branch that's been pushed:
 
    ```bash
-   git fetch --quiet && git branch -r -v | grep origin/rfd/ | awk '{print $1}' | sort | tail -n 1
+   git fetch --quiet && git branch -r -v | grep origin/rfd/ | awk -F'[/,-]' '{ n=$3+0; print n }' | sort -n | tail -n 1
    ```
 
 1. make a branch off of `master` called `rfd/$number-your-title`


### PR DESCRIPTION
At the moment, the one-liner doesn't return the correct result because someone created an rfd branch without a leading zero, so `sort` doesn't behave as expected.

This PR fixes the script by splitting the output of `git branch -r -v | grep origin/rfd/` by `/` and `-`, then stripping the leading zeroes by [casting the third element to a number by adding a zero to it](https://stackoverflow.com/a/15516151/742872) and then using a numeric sort.

If someone forgets to add a separator after the number, the script should work as well:

```bash
$ echo origin/rfd/0133aws | awk -F'[/,-]' '{ n=$3+0; print n }'
133
```