### PR TITLE
Clarify the disablesse S3 backend setting

### DIFF
--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -225,12 +225,33 @@ Service reads these parameters to configure its interactions with S3:
 `s3://bucket/path?region=us-east-1&endpoint=mys3.example.com&insecure=false&disablesse=false&acl=private&use_fips_endpoint=true`
 
 - `region=us-east-1` - set the Amazon region to use.
+
 - `endpoint=mys3.example.com` - connect to a custom S3 endpoint. Optional.
-- `insecure=true` - set to `true` or `false`. If `true`, TLS will be disabled. Default value is `false`.
-- `disablesse=true` - set to `true` or `false`. If `true`, S3 server-side encryption will be disabled. If `false`, aws:kms (Key Management Service) will be used for server-side encryption. Other SSE types are not supported at this time. Setting `insecure=true` implicitly sets `disablesse=true`.
-- `sse_kms_key=kms_key_id` - If set to a valid AWS KMS CMK key ID all objects uploaded to S3 will be encrypted with this key. Details can be found below.
-- `acl=private` - set the [canned ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl) to use. Must be one of the predefined ACL values.
-- `use_fips_endpoint=true` -  [Configure S3 FIPS endpoints](#configuring-aws-fips-endpoints)
+
+- `insecure=true` - set to `true` or `false`. If `true`, TLS will be disabled.
+  Default value is `false`.
+
+- `disablesse=true` - set to `true` or `false`. The Auth Service checks this
+  value before uploading an object to an S3 bucket. 
+
+  If this is `false`, the Auth Service will set the server-side encryption
+  configuration of the upload to use AWS Key Management Service and, if
+  `sse_kms_key` is set, configure the upload to use this key.
+
+  If this value is `true`, the Auth Service will not set an explicit server-side
+  encryption configuration for the object upload, meaning that the upload will
+  use the bucket-level server-side encryption configuration.
+
+- `sse_kms_key=kms_key_id` - If set to a valid AWS KMS CMK key ID, all objects
+  uploaded to S3 will be encrypted with this key (as long as `disablesse` is
+  `false`). Details can be found below.
+
+- `acl=private` - set the [canned
+  ACL](https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html#canned-acl)
+  to use. Must be one of the predefined ACL values.
+
+- `use_fips_endpoint=true` -  [Configure S3 FIPS
+  endpoints](#configuring-aws-fips-endpoints)
 
 ### S3 IAM policy
 


### PR DESCRIPTION
Closes #14788

The description of the `disablesse` S3 backend setting implies that this setting disables server-side encryption, when it actually stops the Auth Service from enabling SSE on a per-operation basis.

Also clarify the relationship between `disablesse` and `sse_kms_key`.