### PR TITLE
Restore resource requests guide with an admonition.

### DIFF
--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -42,9 +42,9 @@ upgraded to version 10.
 ## Step 1/8. Create the requester role
 
 <Admonition type="note">
-As of version 13.1.2, Teleport comes with built in `reviewer` and `requester` roles that
-are defined similarly to the way presented here. If you are looking to quickly try out
-Access Requests, you can skip to step 3 and use these built in roles. However, if you are
+As of version 13.1.2, Teleport comes with built-in `reviewer` and `requester` roles that
+are defined similarly to the ones presented here. If you are looking to quickly try out
+Access Requests, you can skip to step 3 and use these built-in roles. However, if you are
 using an earlier version of Teleport or you are looking to get general guidance for creating
 roles for Access Requests, steps 1 and 2 are still useful.
 </Admonition>

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -39,13 +39,65 @@ It is not recommended to enable Resource Access Requests by setting any
 upgraded to version 10.
 </Admonition>
 
-## Step 1/6. Grant the reviewer and requester roles to users
+## Step 1/8. Create the requester role
 
-Teleport comes with the built-in role `requester`, which allows users to request access
-to all resources within Teleport, and `reviewer`, which allows users to review all access
-requests within Teleport. To test this feature, grant the built-in `requester` and `reviewer`
-roles to existing users, or create new users.  Make sure the requester has a valid `login`
-so that they can view and access SSH nodes.
+<Admonition type="note">
+As of version 13.1.2, Teleport comes with built in `reviewer` and `requester` roles. That
+are defined similarly to the way presented here. If you are looking to quickly try out
+Access Requests, you can skip to step 3 and use these built in roles. However, if you are
+using an earlier version of Teleport or you are looking to get general guidance for creating
+roles for Access Requests, steps 1 and 2 are still useful.
+</Admonition>
+
+This role allows the requester to search for resources accessible by the
+`access` role (all resources by default) and request access to them.
+
+```yaml
+# requester.yaml
+kind: role
+version: v5
+metadata:
+  name: requester
+spec:
+  allow:
+    request:
+      search_as_roles:
+        - access
+```
+
+```code
+$ tctl create requester.yaml
+```
+
+## Step 2/8. Create the reviewer role
+
+This role allows the reviewer to approve all requests for the `access` role.
+
+```yaml
+# reviewer.yaml
+kind: role
+version: v5
+metadata:
+  name: reviewer
+spec:
+  allow:
+    review_requests:
+      roles:
+        - access
+      preview_as_roles:
+        - access
+```
+
+```code
+$ tctl create reviewer.yaml
+```
+
+## Step 3/8. Grant the roles to users
+
+Grant the `requester` and `reviewer` roles to existing users, or create new
+users to test this feature.
+Make sure the requester has a valid `login` so that they can view and access SSH
+nodes.
 
 ```code
 $ tctl users add alice --roles requester --logins alice
@@ -56,7 +108,7 @@ For the rest of the guide we will assume that the `requester` role has been
 granted to a user named `alice` and the `reviewer` role has been granted to a
 user named `bob`.
 
-## Step 2/6. Search for resources
+## Step 4/8. Search for resources
 
 First, log in as `alice`.
 
@@ -102,7 +154,7 @@ To request access to these resources, run
     --reason <request reason>
 ```
 
-## Step 3/6. Request access to a resource
+## Step 5/8. Request access to a resource
 
 Copy the command output by `tsh request search` in the previous step, optionally filling in a request reason.
 
@@ -126,7 +178,7 @@ Waiting for request approval...
 
 The command will automatically wait until the request is approved.
 
-## Step 4/6. Approve the Access Request
+## Step 6/8. Approve the Access Request
 
 First, log in as `bob`.
 
@@ -166,7 +218,7 @@ Check out our
 to notify the right people about new Access Requests.
 </Notice>
 
-## Step 5/6. Access the requested resource
+## Step 7/8. Access the requested resource
 
 `alice`'s `tsh request create` command should resolve now that the request has been approved.
 
@@ -212,7 +264,7 @@ $ tsh ssh alice@iot
 iot:~ alice$
 ```
 
-## Step 6/6. Resume regular access
+## Step 8/8. Resume regular access
 
 While logged in with a Resource Access Request, users will be blocked from access to any other resources.
 This is necessary because their certificate now contains an elevated role,

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -42,7 +42,7 @@ upgraded to version 10.
 ## Step 1/8. Create the requester role
 
 <Admonition type="note">
-As of version 13.1.2, Teleport comes with built in `reviewer` and `requester` roles. That
+As of version 13.1.2, Teleport comes with built in `reviewer` and `requester` roles that
 are defined similarly to the way presented here. If you are looking to quickly try out
 Access Requests, you can skip to step 3 and use these built in roles. However, if you are
 using an earlier version of Teleport or you are looking to get general guidance for creating


### PR DESCRIPTION
The resource request guide has been restored with an additional admonition about the new `reviewer` and `requester` roles that were just introduced. This is necessary to demonstrate how to configure roles for use in access requests.