### PR TITLE
Describe subject flags in Event Handler guides

### DIFF
--- a/docs/pages/includes/configure-event-handler.mdx
+++ b/docs/pages/includes/configure-event-handler.mdx
@@ -78,3 +78,30 @@ $ ls -l
 | `client.crt` and `client.key`      | Fluentd client certificate and key, all signed by the generated CA  |
 | `teleport-event-handler-role.yaml` | `user` and `role` resource definitions for Teleport's event handler |
 | `fluent.conf`                      | Fluentd plugin configuration                                        |
+
+<Details title="Running the Event Handler separately from the log forwarder">
+
+This guide assumes that you are running the Event Handler on the same host or
+Kubernetes pod as your log forwarder. If you are not, you will need to instruct
+the Event Handler to generate mTLS certificates for subjects besides
+`localhost`. To do this, use the `--cn` and `--dns-names` flags of the
+`teleport-event-handler` configure command.
+
+For example, if your log forwarder is addressable at `forwarder.example.com` and the
+Event Handler at `handler.example.com`, you would run the following `configure`
+command:
+
+```code
+$ teleport-event-handler configure --cn=handler.example.com --dns-names=forwarder.example.com
+```
+
+The command generates client and server certificates with the subjects set to
+the value of `--cn`.
+
+The `--dns-names` flag accepts a comma-separated list of DNS names. It will
+append subject alternative names (SANs) to the server certificate (the one you
+will provide to your log forwarder) for each DNS name in the list. The Event
+Handler looks up each DNS name before appending it as an SAN and exits with an
+error if the lookup fails.
+
+</Details>


### PR DESCRIPTION
Closes #15487

Document the `--cn` and `--dns-names` flags of the `teleport-event-handler configure` command and when you would use them.