### PR TITLE
Use Debian as base image for the operator build

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -19,27 +19,6 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-# Sync with devbox.json.
-GOLANG_VERSION ?= go1.21.0
-
-# Sync with devbox.json.
-NODE_VERSION ?= 16.18.1
-
-# Sync any version changes below with devbox.json.
-# run lint-rust check locally before merging code after you bump this
-RUST_VERSION ?= 1.71.0
-LIBBPF_VERSION ?= 1.0.1
-LIBPCSCLITE_VERSION ?= 1.9.9-teleport
-
-# Sync any version changes below with devbox.json.
-# Protogen related versions.
-BUF_VERSION ?= 1.25.1
-# Keep in sync with api/proto/buf.yaml (and buf.lock)
-GOGO_PROTO_TAG ?= v1.3.2
-NODE_GRPC_TOOLS_VERSION ?= 1.12.4
-NODE_PROTOC_TS_VERSION ?= 5.0.1
-PROTOC_VER ?= 3.20.3
-
 UID := $$(id -u)
 GID := $$(id -g)
 
@@ -53,6 +32,7 @@ RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
 # BUILDBOX_VERSION, BUILDBOX and BUILDBOX_variant variables are included
 include images.mk
 include grpcbox.mk
+include versions.mk
 
 # These variables are used to dynamically change the name of the buildbox Docker image used by the 'release'
 # target. The other solution was to remove the 'buildbox' dependency from the 'release' target, but this would

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -1,7 +1,6 @@
 # Keep all tool versions in one place.
 # This file can be included in other Makefiles to avoid duplication.
 
-
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.21.0
 

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -1,0 +1,24 @@
+# Keep all tool versions in one place.
+# This file can be included in other Makefiles to avoid duplication.
+
+
+# Sync with devbox.json.
+GOLANG_VERSION ?= go1.21.0
+
+# Sync with devbox.json.
+NODE_VERSION ?= 16.18.1
+
+# Sync any version changes below with devbox.json.
+# run lint-rust check locally before merging code after you bump this
+RUST_VERSION ?= 1.71.0
+LIBBPF_VERSION ?= 1.0.1
+LIBPCSCLITE_VERSION ?= 1.9.9-teleport
+
+# Sync any version changes below with devbox.json.
+# Protogen related versions.
+BUF_VERSION ?= 1.25.1
+# Keep in sync with api/proto/buf.yaml (and buf.lock)
+GOGO_PROTO_TAG ?= v1.3.2
+NODE_GRPC_TOOLS_VERSION ?= 1.12.4
+NODE_PROTOC_TS_VERSION ?= 5.0.1
+PROTOC_VER ?= 3.20.3

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -1,6 +1,30 @@
-ARG BUILDBOX
 # BUILDPLATFORM is provided by Docker/buildx
-FROM --platform=$BUILDPLATFORM $BUILDBOX as builder
+FROM --platform=$BUILDPLATFORM docker.io/debian:11 as builder
+ARG BUILDARCH
+
+## Install dependencies.
+
+RUN apt-get update && apt-get -y install curl unzip build-essential gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+
+# Install Go.
+ARG GOLANG_VERSION
+RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | tar xz && \
+    chmod a+w /var/lib && \
+    chmod a-w /
+ENV GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="$PATH:/opt/go/bin:/go/bin"
+
+# Install protoc.
+ARG PROTOC_VER # eg, "3.20.2"
+RUN VERSION="$PROTOC_VER" && \
+  PB_REL='https://github.com/protocolbuffers/protobuf/releases' && \
+  PB_FILE="$(mktemp protoc-XXXXXX.zip)" && \
+  curl -fsSL -o "$PB_FILE" "$PB_REL/download/v$VERSION/protoc-$VERSION-linux-$(if [ "$BUILDARCH" = "amd64" ]; then echo "x86_64"; else echo "aarch_64"; fi).zip"  && \
+  unzip "$PB_FILE" -d /usr/local && \
+  rm -f "$PB_FILE"
+
+## Build the operator
 
 WORKDIR /go/src/github.com/gravitational/teleport
 
@@ -28,7 +52,9 @@ COPY integrations/operator/namespace.go integrations/operator/namespace.go
 # Compiler package should use host-triplet-agnostic name (i.e. "x86-64-linux-gnu-gcc" instead of "gcc")
 #  in most cases, to avoid issues on systems with multiple versions of gcc (i.e. buildboxes)
 # TARGETOS and TARGETARCH are provided by Docker/buildx, but must be explicitly listed here
-ARG COMPILER_NAME TARGETOS TARGETARCH
+ARG COMPILER_NAME
+ARG TARGETOS
+ARG TARGETARCH
 
 # Build the program
 # CGO is required for github.com/gravitational/teleport/lib/system

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM docker.io/debian:11 as builder
 ARG BUILDARCH
 
 ## Install dependencies.
-RUN apt-get update && apt-get -y install --no-install-recommends \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     ca-certificates \
     unzip \

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -6,6 +6,7 @@ ARG BUILDARCH
 
 RUN apt-get update && apt-get -y install --no-install-recommends \
     curl \
+    ca-certificates \
     unzip \
     build-essential \
     gcc-arm-linux-gnueabi \

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -3,7 +3,6 @@ FROM --platform=$BUILDPLATFORM docker.io/debian:11 as builder
 ARG BUILDARCH
 
 ## Install dependencies.
-
 RUN apt-get update && apt-get -y install --no-install-recommends \
     curl \
     ca-certificates \

--- a/integrations/operator/Dockerfile
+++ b/integrations/operator/Dockerfile
@@ -4,7 +4,14 @@ ARG BUILDARCH
 
 ## Install dependencies.
 
-RUN apt-get update && apt-get -y install curl unzip build-essential gcc-arm-linux-gnueabi binutils-arm-linux-gnueabi gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu
+RUN apt-get update && apt-get -y install --no-install-recommends \
+    curl \
+    unzip \
+    build-essential \
+    gcc-arm-linux-gnueabi \
+    binutils-arm-linux-gnueabi \
+    gcc-aarch64-linux-gnu \
+    binutils-aarch64-linux-gnu
 
 # Install Go.
 ARG GOLANG_VERSION

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -8,6 +8,13 @@ VERSION ?= 0.0.1
 # Image URL to use all building/pushing image targets
 IMG ?= teleport-operator:latest
 
+# TODO(jakule): Reuse the value from build.assets/Makefile
+GOLANG_VERSION ?= go1.20.5
+PROTOC_VER ?= 3.20.3
+
+GO_ENV_ARCH := $(shell go env GOARCH)
+ARCH ?= $(GO_ENV_ARCH)
+
 # Setting SHELL to bash allows bash commands to be executed by recipes.
 # This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
@@ -125,7 +132,10 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: docker-build
 docker-build: ## Build docker image with the manager.
-	docker buildx build --platform="$(OS)/$(ARCH)" --build-arg BUILDBOX=$(PLATFORM_BUILDBOX) \
+	docker buildx build --platform="$(OS)/$(ARCH)" \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg PROTOC_VER=$(PROTOC_VER) \
+		--build-arg BUILDARCH=$(ARCH) \
 		--build-arg COMPILER_NAME=$(COMPILER) -t ${IMG} --load ../.. -f ./Dockerfile
 
 .PHONY: docker-push

--- a/integrations/operator/Makefile
+++ b/integrations/operator/Makefile
@@ -8,9 +8,9 @@ VERSION ?= 0.0.1
 # Image URL to use all building/pushing image targets
 IMG ?= teleport-operator:latest
 
-# TODO(jakule): Reuse the value from build.assets/Makefile
-GOLANG_VERSION ?= go1.20.5
-PROTOC_VER ?= 3.20.3
+# Include build.assets/versions.mk to get the latest same versions of tooling
+# across all builds.
+include ../../build.assets/versions.mk
 
 GO_ENV_ARCH := $(shell go env GOARCH)
 ARCH ?= $(GO_ENV_ARCH)


### PR DESCRIPTION
Why
---

The operator is broken right now, as it's build using our CI image (Ubuntu 22.04) and we pack it in Docker with distroless (Debian-11). Glibc in Ubuntu is too newer.

What
---

This PR introduces a new image to stop using the buildbox for building the K8S operator to pin down Glibc version. This potentially prevents any modification to our CI image from breaking the operator.