### PR TITLE
Report failures if Windows build fails

### DIFF
--- a/.github/workflows/build-windows.yaml
+++ b/.github/workflows/build-windows.yaml
@@ -39,7 +39,7 @@ jobs:
           go-version: ${{ steps.go-version.outputs.go-version }}
 
       - name: Build
+        shell: bash
         run: |
-          $Env:OS="windows"
-          make build/tsh
-          make build/tctl
+          export OS="windows"
+          make build/tsh build/tctl


### PR DESCRIPTION
Currently, "Build on Windows" build does not report failures even if they happen. This PR fixes this behavior.

Force triggered build as "Build on Windows" is skipped on PR push:
https://github.com/gravitational/teleport/actions/runs/5390670986/jobs/9786370966

Depends on https://github.com/gravitational/teleport/pull/28357