### PR TITLE
Add `omitempty` to new ResourceMatcherAWS block for best backwards compat

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1714,7 +1714,7 @@ type ResourceMatcher struct {
 	// Labels match resource labels.
 	Labels map[string]apiutils.Strings `yaml:"labels,omitempty"`
 	// AWS contains AWS specific settings.
-	AWS ResourceMatcherAWS `yaml:"aws"`
+	AWS ResourceMatcherAWS `yaml:"aws,omitempty"`
 }
 
 // ResourceMatcherAWS contains AWS specific settings for resource matcher.


### PR DESCRIPTION
Related pr:
- #28039

thanks @kimlisa for finding this. 

For example, https://github.com/gravitational/teleport/blob/master/lib/integrations/awsoidc/deployservice_config.go#L30 generates an empty `aws: {}` block, which will not be backwards compatible.