### PR TITLE
[v11] chore: Bump Buf to v1.22.0

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -28,7 +28,7 @@ LIBBPF_VERSION ?= 0.7.0-teleport
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Protogen related versions.
-BUF_VERSION ?= 1.21.0
+BUF_VERSION ?= 1.22.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Backport #28300 to branch/v11

* https://github.com/bufbuild/buf/releases/tag/v1.22.0