### PR TITLE
integrations/operator: Try to delete bot role

### DIFF
--- a/integrations/operator/sidecar/tbot.go
+++ b/integrations/operator/sidecar/tbot.go
@@ -236,27 +236,14 @@ func CreateAndBootstrapBot(ctx context.Context, opts Options) (*Bot, *proto.Feat
 // See https://github.com/gravitational/teleport/issues/13091
 func createOrReplaceBot(ctx context.Context, opts Options, authClient auth.ClientI) (string, error) {
 	var token string
-	botPresent, err := botExists(ctx, opts, authClient)
-	if err != nil {
+	// We remove the bot and its role. If this is the first operator to run,
+	// this throws a "NotFound" error.
+	botRoleName := fmt.Sprintf("bot-%s", opts.Name)
+	if err := authClient.DeleteBot(ctx, opts.Name); err != nil && !trace.IsNotFound(err) {
 		return "", trace.Wrap(err)
 	}
-
-	// If the bot already exists, we remove it and its role.
-	// Else, we still check if the role is here. We expect an error (Not Found).
-	// If there's no error, there's a leftover role and we need to remove it to
-	// recover, else the bot creation will fail and the operator be stuck.
-	botRoleName := fmt.Sprintf("bot-%s", opts.Name)
-	if botPresent {
-		if err := authClient.DeleteBot(ctx, opts.Name); err != nil {
-			return "", trace.Wrap(err)
-		}
-		if err := authClient.DeleteRole(ctx, botRoleName); err != nil {
-			return "", trace.Wrap(err)
-		}
-	} else if _, err := authClient.GetRole(ctx, botRoleName); err == nil {
-		if err := authClient.DeleteRole(ctx, botRoleName); err != nil {
-			return "", trace.Wrap(err)
-		}
+	if err := authClient.DeleteRole(ctx, botRoleName); err != nil && !trace.IsNotFound(err) {
+		return "", trace.Wrap(err)
 	}
 	response, err := authClient.CreateBot(ctx, &proto.CreateBotRequest{
 		Name:  opts.Name,
@@ -268,18 +255,4 @@ func createOrReplaceBot(ctx context.Context, opts Options, authClient auth.Clien
 	token = response.TokenID
 
 	return token, nil
-}
-
-func botExists(ctx context.Context, opts Options, authClient auth.ClientI) (bool, error) {
-	botUsers, err := authClient.GetBotUsers(ctx)
-	if err != nil {
-		return false, trace.Wrap(err)
-	}
-	for _, botUser := range botUsers {
-
-		if botUser.GetName() == fmt.Sprintf("bot-%s", opts.Name) {
-			return true, nil
-		}
-	}
-	return false, nil
 }


### PR DESCRIPTION
We're stuck if a user with the role `Editor` manually deletes the operator bot but leaves the bot role.

This PR makes the bootstrap behaviour more resilient: we always try to delete the bot and its role.

This fix is a followup on the support request: https://goteleport.slack.com/archives/C0582MBSMHN/p1687800479331509