### PR TITLE
[v11] Remove absolute goteleport.com/docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -389,8 +389,9 @@ Visit the individual repositories to find out more and see usage examples:
 - https://github.com/teleport-actions/auth
 - https://github.com/teleport-actions/auth-k8s
 
-For a more in-depth guide, see our refreshed documentation for using Teleport with
-GitHub Actions at https://goteleport.com/docs/machine-id/guides/github-actions/
+For a more in-depth guide, see our
+[documentation](./docs/pages/machine-id/guides/github-actions.mdx) for using
+Teleport with GitHub Actions.
 
 ### Secure certificate mapping for Desktop Access
 
@@ -643,9 +644,8 @@ Teleport 11 clients (such as tsh or Connect) support storing their private key
 material on Yubikey devices instead of filesystem which helps prevent
 credentials exfiltration attacks.
 
-See how to enable it in this guide:
-
-https://goteleport.com/docs/access-controls/guides/hardware-key-support/
+See how to enable it in the
+[documentation](./docs/pages/access-controls/guides/hardware-key-support.mdx):
 
 Hardware-backed private keys is an enterprise only feature, and is currently
 supported for server access only.
@@ -659,8 +659,8 @@ editing files on remote systems.
 The following guides explain how to use IDEs to connect to a remote machine via
 Teleport:
 
-https://goteleport.com/docs/server-access/guides/vscode/
-https://goteleport.com/docs/server-access/guides/jetbrains-sftp/
+- [VS Code](./docs/pages/server-access/guides/vscode.mdx)
+- [JetBrains](./docs/pages/server-access/guides/jetbrains-sftp.mdx)
 
 In addition, Teleport 11 clients will use SFTP protocol for file transfer under
 the hood instead of the obsolete scp protocol. Server-side scp is still
@@ -689,8 +689,9 @@ Teleport agents running on Azure VMs will now automatically import Azure tags to
 label resources.
 
 Teleport database access now supports auto-discovery for Azure-hosted PostgreSQL
-and MySQL databases. See the updated Azure guide for more details:
-https://goteleport.com/docs/ver/11.0/database-access/guides/azure-postgres-mysql/.
+and MySQL databases. See the [Azure
+guide](docs/pages/database-access/guides/azure-postgres-mysql.mdx) for more
+details.
 
 In addition, Teleport database access will now use Azure AD managed identity
 authentication for Azure-hosted SQL Server databases.
@@ -750,8 +751,8 @@ redirect_url = [ "http://example.com" ]
 #### Deprecated Quay.io registry
 
 Starting with Teleport 11, Quay.io as a container registry has been deprecated.
-Customers should use the new AWS ECR registry to pull Teleport Docker images:
-https://goteleport.com/docs/installation/#docker.
+Customers should use the new AWS ECR registry to pull [Teleport Docker
+images](./docs/pages/installation.mdx#docker).
 
 Quay.io registry support will be removed in a future release.
 
@@ -760,7 +761,7 @@ Quay.io registry support will be removed in a future release.
 In Teleport 11, old deb/rpm repositories (deb.releases.teleport.dev and
 rpm.releases.teleport.dev) have been deprecated. Customers should use the new
 repositories (apt.releases.teleport.dev and yum.releases.teleport.dev) to
-install Teleport: https://goteleport.com/docs/installation/#linux.
+[install Teleport](docs/pages/installation.mdx#linux).
 
 Support for our old deb/rpm repositories will be removed in a future release.
 
@@ -824,7 +825,7 @@ Teleport 10 introduces passwordless support to your clusters. To use passwordles
 users may register a security key with resident credentials or use a built-in
 authenticator, like Touch ID.
 
-See https://goteleport.com/docs/access-controls/guides/passwordless/.
+See the [documentation](./docs/pages/access-controls/guides/passwordless.mdx).
 
 ### Resource Access Requests (Preview)
 
@@ -876,8 +877,8 @@ Teleport 10 can be configured to automatically create Linux host users upon
 login without having to use Teleport's PAM integration. Users can be added to specific
 Linux groups and assigned appropriate “sudoer” privileges.
 
-To learn more about configuring automatic user provisioning read the guide:
-https://goteleport.com/docs/server-access/guides/host-user-creation/.
+To learn more about configuring automatic user provisioning read the
+[documentation](docs/pages/server-access/guides/host-user-creation.mdx).
 
 ### Audit Logging for Microsoft SQL Server database access
 
@@ -889,8 +890,8 @@ to other supported database protocols.
 Teleport database access for SQL Server remains in Preview mode with more UX
 improvements coming in future releases.
 
-Refer to the guide to set up access to a SQL Server with Active Directory
-authentication: https://goteleport.com/docs/database-access/guides/sql-server-ad/.
+Refer to [the guide](docs/pages/database-access/guides/sql-server-ad.mdx) to set
+up access to a SQL Server with Active Directory authentication.
 
 ### Snowflake database access (Preview)
 
@@ -899,8 +900,8 @@ set up access to Snowflake databases through Teleport for their users with
 standard database access features like role-based access control and audit
 logging, including query activity.
 
-Connect your Snowflake database to Teleport following this guide:
-https://goteleport.com/docs/database-access/guides/snowflake/.
+Connect your Snowflake database to Teleport following the
+[documentation](docs/pages/database-access/guides/snowflake.mdx).
 
 ### Elasticache/MemoryDB database access (Preview)
 
@@ -909,8 +910,8 @@ this integration by adding native support for AWS-hosted Elasticache and
 MemoryDB, including auto-discovery and automatic credential management in some
 deployment configurations.
 
-Learn more about it in this guide:
-https://goteleport.com/docs/database-access/guides/redis-aws/.
+Learn more about it in the [documentation](
+docs/pages/database-access/guides/redis-aws.mdx).
 
 ### Teleport Connect for server and database access (Preview)
 
@@ -926,8 +927,8 @@ https://goteleport.com/download/.
 In Teleport 10 we’ve added database access support to Machine ID. Applications
 can use Machine ID to access databases protected by Teleport.
 
-You can find Machine ID guide for database access in the documentation:
-https://goteleport.com/docs/machine-id/guides/databases/.
+You can find Machine ID guide for database access in the
+[documentation](docs/pages/machine-id/guides/databases.mdx).
 
 ### Breaking changes
 
@@ -940,8 +941,8 @@ Teleport 10 agents will now refuse to start if they detect that the Auth Service
 is more than one major version behind them. You can use the `--skip-version-check` flag to
 bypass the version check.
 
-Take a look at component compatibility guarantees in the documentation:
-https://goteleport.com/docs/setup/operations/upgrading/#component-compatibility.
+Take a look at component compatibility guarantees in the
+[documentation](docs/pages/management/operations/upgrading.mdx).
 
 #### HTTP_PROXY for reverse tunnels
 
@@ -950,8 +951,9 @@ This may result in reverse tunnel agents not being able to re-establish
 connections if the HTTP proxy is set in their environment and does not allow
 connections to the Teleport Proxy Service.
 
-Refer to the following documentation section for more details:
-https://goteleport.com/docs/setup/reference/networking/#http-connect-proxies.
+Refer to the
+[documentation](docs/pages/reference/networking.mdx#http-connect-proxies)
+for more details.
 
 #### New APT repos
 
@@ -961,8 +963,8 @@ repositories have been backfilled with Teleport versions starting from 6.2.31
 and we recommend upgrading to them. The old repositories will be maintained for
 the foreseeable future.
 
-See updated installation instructions:
-https://goteleport.com/docs/server-access/getting-started/#step-14-install-teleport-on-your-linux-host.
+See the [installation
+instructions](docs/pages/server-access/getting-started.mdx#step-14-install-teleport-on-your-linux-host).
 
 #### Removed “tctl access ls”
 
@@ -977,8 +979,9 @@ pod in order to join a session. Teleport 10 relaxes this requirement. Joining
 sessions remains deny-by-default but now only `join_sessions` statements are
 checked for session join RBAC.
 
-See the Moderated Sessions guide for more details:
-https://goteleport.com/docs/access-controls/guides/moderated-sessions/.
+See the [Moderated Sessions
+guide](docs/pages/access-controls/guides/moderated-sessions.mdx) for more
+details.
 
 #### GitHub connectors
 
@@ -996,8 +999,8 @@ for example:
 s3://bucket/path?region=us-east-1&use_fips_endpoint=false
 ```
 
-See the S3/DynamoDB backends documentation for more information:
-https://goteleport.com/docs/setup/reference/backends/#s3.
+See the [S3/DynamoDB backend
+documentation](docs/pages/reference/backends.mdx) for more information.
 
 ## 9.3.9
 
@@ -1128,9 +1131,9 @@ Teleport 9.3.0 reduces the minimum GLIBC requirement to 2.18 and enforces more
 secure cipher suites for desktop access.
 
 As a result of these changes, desktop access users with desktops running Windows
-Server 2012R2 will need to perform
-[additional configuration](https://goteleport.com/docs/desktop-access/getting-started/#step-47-configure-a-certificate-for-rdp-connections)
-to force Windows to use compatible cipher suites.
+Server 2012R2 will need to perform [additional
+configuration](docs/pages/desktop-access/getting-started.mdx) to force Windows
+to use compatible cipher suites.
 
 Windows desktops running Windows Server 2016 and newer will continue to operate
 normally - no additional configuration is required.
@@ -1236,9 +1239,7 @@ Teleport build infrastructure was updated to use Go v1.17.9 to fix CVE-2022-2467
 
 Teleport users can now use PostgreSQL or CockroachDB for storing auth server data.
 
-See the documentation for more information:
-
-https://goteleport.com/docs/setup/reference/backends/#postgresqlcockroachdb-preview
+See the [documentation](docs/pages/reference/backends.mdx) for more information.
 
 ### Server-side filtering and pagination
 
@@ -1776,7 +1777,13 @@ Teleport 6.1 contains multiple new features, improvements, and bug fixes.
 
 Added support for U2F authentication on every SSH and Kubernetes "connection" (a single `tsh ssh` or `kubectl` call). This is an advanced security feature that protects users against compromises of their on-disk Teleport certificates. Per-session MFA can be enforced cluster-wide or only for some specific roles.
 
-For more details see [Per-Session MFA](https://goteleport.com/docs/access-controls/guides/per-session-mfa) documentation or [RFD 14](https://github.com/gravitational/teleport/blob/master/rfd/0014-session-2FA.md) and [RFD 15](https://github.com/gravitational/teleport/blob/master/rfd/0015-2fa-management.md) for technical details.
+For more details see [Per-Session
+MFA](docs/pages/access-controls/guides/per-session-mfa.mdx) documentation or
+[RFD
+14](https://github.com/gravitational/teleport/blob/master/rfd/0014-session-2FA.md)
+and [RFD
+15](https://github.com/gravitational/teleport/blob/master/rfd/0015-2fa-management.md)
+for technical details.
 
 #### Dual Authorization Workflows
 
@@ -1845,17 +1852,17 @@ Configure database access following the [Getting Started](./docs/pages/database-
 
 ##### Guides
 
-* [AWS RDS/Aurora PostgreSQL](https://goteleport.com/teleport/docs/database-access/guides/postgres-aws/)
-* [AWS RDS/Aurora MySQL](https://goteleport.com/teleport/docs/database-access/guides/mysql-aws/)
-* [Self-hosted PostgreSQL](https://goteleport.com/teleport/docs/database-access/guides/postgres-self-hosted/)
-* [Self-hosted MySQL](https://goteleport.com/teleport/docs/database-access/guides/mysql-self-hosted/)
-* [GUI clients](https://goteleport.com/docs/connect-your-client/gui-clients/)
+* [AWS RDS/Aurora
+  PostgreSQL](docs/pages/database-access/guides/rds.mdx)
+* [Self-hosted PostgreSQL](docs/pages/database-access/guides/postgres-self-hosted.mdx)
+* [Self-hosted MySQL](docs/pages/database-access/guides/mysql-self-hosted.mdx)
+* [GUI clients](docs/pages/connect-your-client/gui-clients.mdx)
 
 ##### Resources
 
-To learn more about configuring role-based access control for database access, check out the [RBAC](./docs/pages/database-access/introduction.mdx/) section.
+To learn more about configuring role-based access control for database access, check out the [RBAC](./docs/pages/database-access/introduction.mdx) section.
 
-[Architecture](./docs/pages/database-access/introduction.mdx/) provides a more in-depth look at database access internals such as networking and security.
+[Architecture](./docs/pages/database-access/introduction.mdx) provides a more in-depth look at database access internals such as networking and security.
 
 See [Reference](./docs/pages/database-access/reference.mdx) for an overview of database access related configuration and CLI commands.
 
@@ -2204,7 +2211,7 @@ Enterprise Only:
 
 #### Documentation
 
-We've added an [API Reference](https://goteleport.com/docs/api-reference/) to simply developing applications against Teleport.
+We've added an [API Guide](docs/pages/api/introduction.mdx) to simply developing applications against Teleport.
 
 #### Upgrade Notes
 

--- a/docs/pages/architecture/session-recording.mdx
+++ b/docs/pages/architecture/session-recording.mdx
@@ -41,7 +41,7 @@ Teleport cluster. It can be configured by setting `session_recording`
 in the `auth_service` section of your `teleport.yaml`, or dynamically via
 the the `session_recording_config` resource. If you need to apply different
 recording configuration to different sets of resources, we recommend setting up
-[Trusted Clusters](/docs/management/admin/trustedclusters/) with their own
+[Trusted Clusters](../management/admin/trustedclusters.mdx) with their own
 recording configurations.
 
 <Admonition type="note">

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -16,7 +16,7 @@ Ensure that your environment includes the following:
 <TabItem scope={["oss"]} label="Open Source">
 
 - A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](/docs/getting-started) guides.
+  [Getting Started](../try-out-teleport/introduction.mdx) guides.
 
 - The `tsh` client tool version >= (=teleport.version=).
 
@@ -25,14 +25,14 @@ Ensure that your environment includes the following:
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
 
-  See [Installation](/docs/installation.mdx) for details.
+  See [Installation](../installation.mdx) for details.
 
 </TabItem>
 <TabItem
   scope={["enterprise"]} label="Enterprise">
 
 - A running Teleport cluster. For details on how to set this up, see our Enterprise
-  [Getting Started](/docs/enterprise/getting-started) guide.
+  [Getting Started](../choose-an-edition/teleport-enterprise/getting-started.mdx) guide.
 
 - The `tsh` client tool version >= (=teleport.version=), which you can download
   by visiting your [Teleport account](https://teleport.sh).

--- a/docs/pages/desktop-access/directory-sharing.mdx
+++ b/docs/pages/desktop-access/directory-sharing.mdx
@@ -27,6 +27,7 @@ after the session ends.
   your cluster. If you have not yet configured Desktop Access, read [Getting
   Started with Desktop Access](./getting-started.mdx) before beginning this
   guide.
+
 - A browser on your local machine that supports the File System Access API,
   which Teleport uses for Directory Sharing. We support the latest versions of
   Chromium-based browsers like Google Chrome, Brave, and Microsoft Edge.

--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -4,7 +4,7 @@
 
 - A running Teleport Enterprise cluster, including the Auth Service and Proxy Service. For
   details on how to set this up, see our Enterprise [Getting
-  Started](/docs/enterprise/getting-started) guide.
+  Started](../choose-an-edition/teleport-enterprise/introduction.mdx) guide.
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
   which you can download by visiting your [Teleport account](https://teleport.sh).

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -1,13 +1,8 @@
-{/* 
-TODO: Since we can't control the directory level of the page that uses this
-partial, and it is currently not possible to include absolute paths to MDX 
-files in partials, this partial uses relative URL paths instead.
-*/}
 <Tabs>
 <TabItem scope={["oss"]} label="Open Source">
 
-- A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](/docs/getting-started) guides. 
+- A running Teleport cluster. For details on how to set this up, see our
+  [Getting Started](../try-out-teleport/linux-server.mdx) guide.
 
 - The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
 
@@ -19,14 +14,14 @@ files in partials, this partial uses relative URL paths instead.
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
 
-  See [Installation](/docs/installation.mdx) for details.
+  See [Installation](../installation.mdx) for details.
 
 </TabItem>
 <TabItem
   scope={["enterprise"]} label="Enterprise">
 
 - A running Teleport Enterprise cluster. For details on how to set this up, see our Enterprise
-  [Getting Started](/docs/enterprise/getting-started) guide.
+  [Getting Started](../choose-an-edition/teleport-enterprise/introduction.mdx) guide.
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
   which you can download by visiting your [Teleport account](https://teleport.sh).

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -6,7 +6,7 @@ Visit your [Teleport account](https://teleport.sh) and select the URL for your p
 
 <ScopedBlock scope={["cloud"]}>
 
-Visit the [Downloads Page](/docs/choose-an-edition/teleport-cloud/downloads.mdx)
+Visit the [Downloads Page](../choose-an-edition/teleport-cloud/downloads.mdx)
 and select the URL for your package of choice.
 
 </ScopedBlock>

--- a/docs/pages/machine-id/guides/host-certificate.mdx
+++ b/docs/pages/machine-id/guides/host-certificate.mdx
@@ -17,7 +17,7 @@ and reducing risk by ensuring that short-lived certificates adhering to the prin
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-(!/docs/pages/includes/tctl.mdx!)
+(!docs/pages/includes/tctl.mdx!)
 
 - A Linux based host that can support Machine ID. This "Machine ID Host" is the host that will be used to create Host Certificates using `tbot`.
   This host should additionally have OpenSSH server `sshd` version 6.9 or above running. The SSH port on this host must be open to traffic from the Teleport Proxy Service host.
@@ -28,7 +28,7 @@ and reducing risk by ensuring that short-lived certificates adhering to the prin
 
 ## Step 1/5. Download and install Teleport (=teleport.version=)
 
-(!/docs/pages/includes/install-linux.mdx!)
+(!docs/pages/includes/install-linux.mdx!)
 
 Next, log in to your cluster from your local machine using `tsh` to ensure that your device will be able to interact with the cluster:
 

--- a/docs/pages/management/admin/self-signed-certs.mdx
+++ b/docs/pages/management/admin/self-signed-certs.mdx
@@ -33,8 +33,8 @@ to the Proxy Service.
 <Tabs>
 <TabItem scope={["oss"]} label="Open Source">
 
-- A running Teleport cluster. For details on how to set this up, see one of our
-  [Getting Started](/docs/getting-started) guides (skip TLS certificate setup).
+- A running Teleport cluster. For details on how to set this up, see our
+  [Getting Started](../../try-out-teleport/linux-server.mdx) guide (skip TLS certificate setup).
 
 - A Teleport Proxy Service which does not have certificates or ACME automatic certificates configured.
 For example, this Teleport Proxy Service configuration would use self-signed certs:
@@ -50,14 +50,14 @@ For example, this Teleport Proxy Service configuration would use self-signed cer
 
 - (!docs/pages/includes/tctl-tsh-prerequisite.mdx!)
 
-  See [Installation](/docs/installation.mdx) for details.
+  See [Installation](../../installation.mdx) for details.
 
 </TabItem>
 <TabItem
   scope={["enterprise"]} label="Enterprise">
 
 - A running Teleport cluster. For details on how to set this up, see our Enterprise
-  [Getting Started](/docs/enterprise/getting-started) guide.
+  [Getting Started](../../choose-an-edition/teleport-enterprise/introduction.mdx) guide.
 
 - A Teleport Proxy Service which does not have certificates or ACME automatic certificates configured.
 For example, this Teleport Proxy Service configuration would use self-signed certs:

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -45,11 +45,11 @@ This guide will explain how to:
 <TabItem scope={["oss"]} label="Open Source">
 
 - Two running Teleport clusters. For details on how to set up your clusters, see
-  one of our [Getting Started](/docs/getting-started) guides.
+  our [Getting Started](../../try-out-teleport/linux-server.mdx) guide.
 
 - (!docs/pages/includes/tctl-tsh-prerequisite.mdx!)
 
-  See [Installation](/docs/installation.mdx) for details.
+  See [Installation](../../installation.mdx) for details.
 
 - A Teleport Node that is joined to one of your clusters. We will refer to this
   cluster as the **leaf cluster** throughout this guide.
@@ -62,7 +62,8 @@ This guide will explain how to:
   scope={["enterprise"]} label="Enterprise">
 
 - Two running Teleport clusters. For details on how to set up your clusters, see
-  our Enterprise [Getting Started](/docs/enterprise/getting-started) guide.
+  our Enterprise [Getting
+  Started](../../choose-an-edition/teleport-enterprise/introduction.mdx) guide.
 
 - (!docs/pages/includes/enterprise/tctl-tsh-prerequisite.mdx!)
 
@@ -80,8 +81,8 @@ This guide will explain how to:
   [sign up page](https://goteleport.com/signup/) to begin your free trial.
 
 - A second Teleport cluster, which will act as the leaf cluster. For details on
-how to set up this cluster, see one of our
-[Getting Started](/docs/getting-started) guides.
+how to set up this cluster, see our
+[Getting Started](../../try-out-teleport/linux-server.mdx) guide.
 
   As an alternative, you can set up a second Teleport Cloud account.
 

--- a/docs/pages/management/admin/upgrading-the-teleport-binary.mdx
+++ b/docs/pages/management/admin/upgrading-the-teleport-binary.mdx
@@ -38,7 +38,7 @@ $ sudo mv ${DIR}/teleport ${DIR}/teleport.bak
 
 Install the newest version of Teleport on the host:
 
-(!/docs/pages/includes/install-linux.mdx!)
+(!docs/pages/includes/install-linux.mdx!)
 
 ## Step 2/3. Fork the `teleport` process
 

--- a/docs/pages/server-access/guides/vscode.mdx
+++ b/docs/pages/server-access/guides/vscode.mdx
@@ -13,7 +13,7 @@ This guide explains how to use Teleport and Visual Studio Code's remote SSH exte
 - OpenSSH client.
 - Visual Studio Code with the [Remote - SSH extension](https://code.visualstudio.com/docs/remote/ssh#_system-requirements)
   for the Remote - SSH extension.
-- One or more Teleport Nodes with Server Access enabled. If you have not yet
+- One or more Teleport agents running the Teleport SSH Service. If you have not yet
   done this, read the
   [Server Access Getting Started Guide](../getting-started.mdx) to learn how.
 


### PR DESCRIPTION
Backports #28170

We'll be adding a linter that checks for absolute docs links in order to ensure that the docs engine's link-checking logic works as expected. This change sets up the docs to pass the linter.