### PR TITLE
docs: bump cloud to 13.1.5

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1735,7 +1735,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.1.2",
+      "version": "13.1.5",
       "major_version": "13",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Cloud will be upgrading to 13.1.5 on 2023/06/28

Helps gravitational/cloud#5038
