### PR TITLE
[v13] Add `omitempty` to new ResourceMatcherAWS block for best backwards compat

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1711,7 +1711,7 @@ type ResourceMatcher struct {
 	// Labels match resource labels.
 	Labels map[string]apiutils.Strings `yaml:"labels,omitempty"`
 	// AWS contains AWS specific settings.
-	AWS ResourceMatcherAWS `yaml:"aws"`
+	AWS ResourceMatcherAWS `yaml:"aws,omitempty"`
 }
 
 // ResourceMatcherAWS contains AWS specific settings for resource matcher.


### PR DESCRIPTION
Backport #28371 to branch/v13