### PR TITLE
[v11] use teleport.sh instead of dashboard.goteleport.com for license info

### DIFF
--- a/tool/teleport/common/usage.go
+++ b/tool/teleport/common/usage.go
@@ -119,7 +119,7 @@ const (
 # A Sample Teleport configuration file.
 #
 # Things to update:
-#  1. license.pem: You only need a license from https://dashboard.goteleport.com
+#  1. license.pem: Retrieve a license from your Teleport account https://teleport.sh
 #     if you are an Enterprise customer.
 #`
 )


### PR DESCRIPTION
Backport #28421 to branch/v11