### PR TITLE
Fix `tsh kube credentials` lock when no-login is required

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -542,7 +542,7 @@ func VirtualPathEnvNames(kind VirtualPathKind, params VirtualPathParams) []strin
 
 // RetryWithRelogin is a helper error handling method, attempts to relogin and
 // retry the function once.
-func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) error {
+func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, opts ...RetryWithReloginOption) error {
 	fnErr := fn()
 	switch {
 	case fnErr == nil:
@@ -554,7 +554,10 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 	case !IsErrorResolvableWithRelogin(fnErr):
 		return trace.Wrap(fnErr)
 	}
-
+	opt := retryWithReloginOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
 	log.Debugf("Activating relogin on %v.", fnErr)
 
 	// check if the error is a private key policy error.
@@ -568,6 +571,11 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 		tc.PrivateKeyPolicy = privateKeyPolicy
 	}
 
+	if opt.beforeLoginHook != nil {
+		if err := opt.beforeLoginHook(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	key, err := tc.Login(ctx)
 	if err != nil {
 		if errors.Is(err, prompt.ErrNotTerminal) {
@@ -595,6 +603,24 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 	}
 
 	return fn()
+}
+
+// RetryWithReloginOption is a functional option for configuring the
+// RetryWithRelogin helper.
+type RetryWithReloginOption func(*retryWithReloginOptions)
+
+// retryWithReloginOptions is a struct for configuring the RetryWithRelogin
+type retryWithReloginOptions struct {
+	// beforeLoginHook is a function that will be called before the login attempt.
+	beforeLoginHook func() error
+}
+
+// WithBeforeLogin is a functional option for configuring a function that will
+// be called before the login attempt.
+func WithBeforeLoginHook(fn func() error) RetryWithReloginOption {
+	return func(o *retryWithReloginOptions) {
+		o.beforeLoginHook = fn
+	}
 }
 
 func IsErrorResolvableWithRelogin(err error) bool {

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -36,6 +36,11 @@ import (
 // (most probably it was already locked by someone else), another try might succeed.
 var ErrUnsuccessfulLockTry = errors.New("could not acquire lock on the file at this time")
 
+const (
+	// FSLockRetryDelay is a delay between attempts to acquire lock.
+	FSLockRetryDelay = 10 * time.Millisecond
+)
+
 // OpenFileWithFlagsFunc defines a function used to open files providing options.
 type OpenFileWithFlagsFunc func(name string, flag int, perm os.FileMode) (*os.File, error)
 
@@ -160,7 +165,7 @@ func FSTryWriteLockTimeout(ctx context.Context, filePath string, timeout time.Du
 	fileLock := flock.New(getPlatformLockFilePath(filePath))
 	timedCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if _, err := fileLock.TryLockContext(timedCtx, 10*time.Millisecond); err != nil {
+	if _, err := fileLock.TryLockContext(timedCtx, FSLockRetryDelay); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
 
@@ -188,7 +193,7 @@ func FSTryReadLockTimeout(ctx context.Context, filePath string, timeout time.Dur
 	fileLock := flock.New(getPlatformLockFilePath(filePath))
 	timedCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if _, err := fileLock.TryRLockContext(timedCtx, 10*time.Millisecond); err != nil {
+	if _, err := fileLock.TryRLockContext(timedCtx, FSLockRetryDelay); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
 

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -610,7 +610,7 @@ func getKubeCredLockfilePath(homePath, proxy string) (string, error) {
 // errKubeCredLockfileFound is returned when kube credentials lockfile is found and user should resolve login problems manually.
 var errKubeCredLockfileFound = trace.AlreadyExists("Having problems with relogin, please use 'tsh login/tsh kube login' manually")
 
-func takeKubeCredLock(ctx context.Context, homePath, proxy string) (func(bool), error) {
+func takeKubeCredLock(ctx context.Context, homePath, proxy string, lockTimeout time.Duration) (func(bool), error) {
 	kubeCredLockfilePath, err := getKubeCredLockfilePath(homePath, proxy)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -627,17 +627,25 @@ func takeKubeCredLock(ctx context.Context, homePath, proxy string) (func(bool), 
 		return nil, trace.Wrap(err)
 	}
 	// Take a lock while we're trying to issue certificate and possibly relogin
-	unlock, err := utils.FSTryWriteLockTimeout(ctx, kubeCredLockfilePath, 5*time.Second)
+	unlock, err := utils.FSTryWriteLockTimeout(ctx, kubeCredLockfilePath, lockTimeout)
 	if err != nil {
 		log.Debugf("could not take kube credentials lock: %v", err.Error())
 		return nil, trace.Wrap(errKubeCredLockfileFound)
 	}
 
 	return func(removeFile bool) {
-		if removeFile {
-			os.Remove(kubeCredLockfilePath)
+		// We must unlock the lockfile before removing it, otherwise unlock operation will fail
+		// on Windows.
+		if err := unlock(); err != nil {
+			log.WithError(err).Warnf("could not unlock kube credentials lock")
 		}
-		unlock()
+		if !removeFile {
+			return
+		}
+		// Remove kube credentials lockfile.
+		if err = os.Remove(kubeCredLockfilePath); err != nil && !os.IsNotExist(err) {
+			log.WithError(err).Warnf("could not remove kube credentials lockfile %q", kubeCredLockfilePath)
+		}
 	}, nil
 }
 
@@ -715,31 +723,52 @@ func (c *kubeCredentialsCommand) issueCert(cf *CLIConf) error {
 	}
 
 	log.Debugf("Requesting TLS cert for Kubernetes cluster %q", c.kubeCluster)
-
-	unlockKubeCred, err := takeKubeCredLock(cf.Context, cf.HomePath, cf.Proxy)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	var unlockKubeCred func(bool)
 	deleteKubeCredsLock := false
 	defer func() {
-		unlockKubeCred(deleteKubeCredsLock) // by default (in case of an error) we don't delete lockfile.
+		if unlockKubeCred != nil {
+			unlockKubeCred(deleteKubeCredsLock) // by default (in case of an error) we don't delete lockfile.
+		}
 	}()
 
 	ctx, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/RetryWithRelogin")
-	err = client.RetryWithRelogin(ctx, tc, func() error {
-		// The requirement may change after a new login so check again just in
-		// case.
-		if err := c.checkLocalProxyRequirement(tc.Profile()); err != nil {
-			return trace.Wrap(err)
-		}
+	err = client.RetryWithRelogin(
+		ctx,
+		tc,
+		func() error {
+			// The requirement may change after a new login so check again just in
+			// case.
+			if err := c.checkLocalProxyRequirement(tc.Profile()); err != nil {
+				return trace.Wrap(err)
+			}
 
-		var err error
-		k, err = tc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
-			RouteToCluster:    c.teleportCluster,
-			KubernetesCluster: c.kubeCluster,
-		}, nil /*applyOpts*/)
-		return err
-	})
+			var err error
+			k, err = tc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
+				RouteToCluster:    c.teleportCluster,
+				KubernetesCluster: c.kubeCluster,
+			}, nil /*applyOpts*/)
+			return err
+		},
+		client.WithBeforeLoginHook(
+			// Before login we take a lock on the kube credentials file. This is
+			// done to prevent multiple tsh processes from requesting login and
+			// opening multiple browser tabs.
+			func() error {
+				var err error
+				lockTimeout := 5 * time.Second
+				// If we are under tests, MockSSOLogin is set and we want to allow just one try
+				// to take the lock and fail if the lock is already taken. This is done to prevent
+				// tests from hanging and continue to run once the lock is released.
+				// FSLockRetryDelay is 10ms and we want to fail as fast as possible if the lock is
+				// already taken by another process to validate that the lock is working as expected.
+				if cf.MockSSOLogin != nil {
+					lockTimeout = utils.FSLockRetryDelay
+				}
+				unlockKubeCred, err = takeKubeCredLock(cf.Context, cf.HomePath, cf.Proxy, lockTimeout)
+				return trace.Wrap(err)
+			},
+		),
+	)
 	span.End()
 	if err != nil {
 		// If we've got network error we remove the lockfile, so we could restore from temporary connection


### PR DESCRIPTION
This PR moves the creation of the `lock` file right before the login call is attempted instead of creating it for any call.

This fixes a problem where we create the lock file even if no login is required which limits the number of parallel kubectl invocations.

This PR also forces the unlock to run before deleting the file to prevent issues with Windows syscall failures