### PR TITLE
[v11] Migrate to OpenSSL 3.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -36,8 +36,17 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     make install && \
     make clean
 
+# Install openssl.
+# install_sw install only binaries, skips docs.
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 && \
+    cd openssl && \
+    [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
+    ./config --release --libdir=/usr/local/lib && \
+    make && \
+    make install_sw
+
 # Install libfido2.
-# Depends on libcbor, libssl-dev, zlib1g-dev and libudev.
+# Depends on libcbor, libcrypto (OpenSSL 3.x), libudev and zlib1g-dev.
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
     [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
@@ -46,6 +55,7 @@ RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
         -DBUILD_MANPAGES=OFF \
         -DBUILD_TOOLS=OFF \
         -DCMAKE_BUILD_TYPE=Release . && \
+    grep 'CRYPTO_VERSION:INTERNAL=3\.0\.' CMakeCache.txt && \
     make && \
     make install && \
     make clean
@@ -288,16 +298,24 @@ RUN cd /usr/local/lib && ldconfig
 # Copy libfido2 libraries.
 # Do this near the end to take better advantage of the multi-stage build.
 COPY --from=libfido2 /usr/local/include/ /usr/local/include/
+COPY --from=libfido2 /usr/local/lib/engines-3/ /usr/local/lib/engines-3/
+COPY --from=libfido2 /usr/local/lib/ossl-modules/ /usr/local/lib/ossl-modules/
 COPY --from=libfido2 /usr/local/lib/pkgconfig/ /usr/local/lib/pkgconfig/
 COPY --from=libfido2 \
     /usr/local/lib/libcbor.a \
+    /usr/local/lib/libcrypto.a \
+    /usr/local/lib/libcrypto.so.3 \
     /usr/local/lib/libfido2.a \
     /usr/local/lib/libfido2.so.1.12.0 \
+    /usr/local/lib/libssl.a \
+    /usr/local/lib/libssl.so.3 \
     /usr/local/lib/libudev.a \
     /usr/local/lib/
 RUN cd /usr/local/lib && \
+    ln -s libcrypto.so.3 libcrypto.so && \
     ln -s libfido2.so.1.12.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
+    ln -s libssl.so.3 libssl.so && \
     ldconfig
 COPY pkgconfig/buildbox/ /
 

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -38,9 +38,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.9 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
+    [ "$(git rev-parse HEAD)" = 'de90e54bbe82e5be4fb9608b6f5c308bb837d355' ] && \
     ./config --release --libdir=/usr/local/lib && \
     make && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -42,9 +42,9 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
 
 # Install openssl.
 # install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 && \
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.9 && \
     cd openssl && \
-    [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
+    [ "$(git rev-parse HEAD)" = 'de90e54bbe82e5be4fb9608b6f5c308bb837d355' ] && \
     ./config --release --libdir=/usr/local/lib64 && \
     make && \
     make install_sw

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -18,6 +18,7 @@ RUN yum groupinstall -y 'Development Tools' && \
         devtoolset-11-gcc* \
         git \
         libudev-devel \
+        perl-IPC-Cmd \
         zlib-devel && \
     yum clean all
 
@@ -27,16 +28,6 @@ RUN git clone --depth=1 https://github.com/illiliti/libudev-zero.git -b 1.0.1 &&
     cd libudev-zero && \
     [ "$(git rev-parse HEAD)" = '4154cf252c17297f98a8ca33693ead003b4509da' ] && \
     make install-static LIBDIR='$(PREFIX)/lib64'
-
-# Instal openssl.
-# Pulled from source because repository versions are too old.
-# install_sw install only binaries, skips docs.
-RUN git clone --depth=1 https://github.com/openssl/openssl.git -b OpenSSL_1_1_1u && \
-    cd openssl && \
-    [ "$(git rev-parse HEAD)" = '70c2912f635aac8ab28629a2b5ea0c09740d2bda' ] && \
-    ./config --release --libdir=/usr/local/lib64 && \
-    make && \
-    make install_sw
 
 # Install libcbor.
 RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
@@ -49,18 +40,30 @@ RUN git clone --depth=1 https://github.com/PJK/libcbor.git -b v0.10.2 && \
     make && \
     make install
 
+# Install openssl.
+# install_sw install only binaries, skips docs.
+RUN git clone --depth=1 https://github.com/openssl/openssl.git -b openssl-3.0.8 && \
+    cd openssl && \
+    [ "$(git rev-parse HEAD)" = '31157bc0b46e04227b8468d3e6915e4d0332777c' ] && \
+    ./config --release --libdir=/usr/local/lib64 && \
+    make && \
+    make install_sw
+# Necessary for libfido2 to find the correct libcrypto.
+ENV PKG_CONFIG_PATH="/usr/local/lib64/pkgconfig"
+
 # Install libfido2.
-# Depends on libcbor, openssl, zlib-devel and libudev.
+# Depends on libcbor, libcrypto (OpenSSL 3.x), libudev and zlib-devel.
 # Linked so `make build/tsh` finds the library where it expects it.
 RUN git clone --depth=1 https://github.com/Yubico/libfido2.git -b 1.12.0 && \
     cd libfido2 && \
     [ "$(git rev-parse HEAD)" = '659a02679f99fd34a44e06e35dce90794f6ecc86' ] && \
     scl enable devtoolset-11 "\
-      cmake3 \
+      CFLAGS=-pthread cmake3 \
           -DBUILD_EXAMPLES=OFF \
           -DBUILD_MANPAGES=OFF \
           -DBUILD_TOOLS=OFF \
           -DCMAKE_BUILD_TYPE=Release . && \
+      grep 'CRYPTO_VERSION:INTERNAL=3\.0\.' CMakeCache.txt && \
       make" && \
     make install && \
     make clean
@@ -220,23 +223,25 @@ RUN curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | sh -s -- -y --p
 # Do this last to take better advantage of the multi-stage build.
 USER root
 COPY --from=libfido2 /usr/local/include/ /usr/local/include/
+COPY --from=libfido2 /usr/local/lib64/engines-3/ /usr/local/lib64/engines-3/
+COPY --from=libfido2 /usr/local/lib64/ossl-modules/ /usr/local/lib64/ossl-modules/
 COPY --from=libfido2 /usr/local/lib64/pkgconfig/ /usr/local/lib64/pkgconfig/
 COPY --from=libfido2 \
     /usr/local/lib64/libcbor.a \
     /usr/local/lib64/libcrypto.a \
-    /usr/local/lib64/libcrypto.so.1.1 \
+    /usr/local/lib64/libcrypto.so.3 \
     /usr/local/lib64/libfido2.a \
     /usr/local/lib64/libfido2.so.1.12.0 \
     /usr/local/lib64/libssl.a \
-    /usr/local/lib64/libssl.so.1.1 \
+    /usr/local/lib64/libssl.so.3 \
     /usr/local/lib64/libudev.a \
     /usr/local/lib64/
 # Re-create usual lib64 links.
 RUN cd /usr/local/lib64 && \
-    ln -s libcrypto.so.1.1 libcrypto.so && \
+    ln -s libcrypto.so.3 libcrypto.so && \
     ln -s libfido2.so.1.12.0 libfido2.so.1 && \
     ln -s libfido2.so.1 libfido2.so && \
-    ln -s libssl.so.1.1 libssl.so && \
+    ln -s libssl.so.3 libssl.so && \
 # Update ld.
     echo /usr/local/lib64 > /etc/ld.so.conf.d/libfido2.conf && \
     ldconfig

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -16,8 +16,8 @@ readonly MACOS_VERSION_MIN=10.13
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
-readonly CRYPTO_VERSION=OpenSSL_1_1_1u
-readonly CRYPTO_COMMIT=70c2912f635aac8ab28629a2b5ea0c09740d2bda
+readonly CRYPTO_VERSION=openssl-3.0.8
+readonly CRYPTO_COMMIT=31157bc0b46e04227b8468d3e6915e4d0332777c
 readonly FIDO2_VERSION=1.12.0
 readonly FIDO2_COMMIT=659a02679f99fd34a44e06e35dce90794f6ecc86
 
@@ -108,7 +108,6 @@ crypto_build() {
   ./config \
     -mmacosx-version-min="$MACOS_VERSION_MIN" \
     --prefix="$dest" \
-    --openssldir="$dest/openssl@1.1" \
     no-shared \
     no-zlib
   # Build and copy only what we need instead of 'make && make install'.
@@ -143,6 +142,7 @@ fido2_build() {
     -DCMAKE_OSX_DEPLOYMENT_TARGET="$MACOS_VERSION_MIN" \
     -G "Unix Makefiles" \
     .
+  grep 'CRYPTO_VERSION:INTERNAL=3\.0\.' CMakeCache.txt # double-check OpenSSL
   make
   make install
 }

--- a/build.assets/build-fido2-macos.sh
+++ b/build.assets/build-fido2-macos.sh
@@ -16,8 +16,8 @@ readonly MACOS_VERSION_MIN=10.13
 # Note: versions are the same as the corresponding git tags for each repo.
 readonly CBOR_VERSION=v0.10.2
 readonly CBOR_COMMIT=efa6c0886bae46bdaef9b679f61f4b9d8bc296ae
-readonly CRYPTO_VERSION=openssl-3.0.8
-readonly CRYPTO_COMMIT=31157bc0b46e04227b8468d3e6915e4d0332777c
+readonly CRYPTO_VERSION=openssl-3.0.9
+readonly CRYPTO_COMMIT=de90e54bbe82e5be4fb9608b6f5c308bb837d355
 readonly FIDO2_VERSION=1.12.0
 readonly FIDO2_COMMIT=659a02679f99fd34a44e06e35dce90794f6ecc86
 

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
@@ -1,11 +1,12 @@
-prefix=/usr
+prefix=/usr/local
 exec_prefix=${prefix}
-libdir=${exec_prefix}/lib/x86_64-linux-gnu
+libdir=${exec_prefix}/lib
 includedir=${prefix}/include
-enginesdir=${libdir}/engines-1.1
+enginesdir=${libdir}/engines-3
+modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 1.1.1
+Version: 3.0.8
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/buildbox/usr/local/lib/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.8
+Version: 3.0.9
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -2,10 +2,11 @@ prefix=/usr/local
 exec_prefix=${prefix}
 libdir=${exec_prefix}/lib64
 includedir=${prefix}/include
-enginesdir=${libdir}/engines-1.1
+enginesdir=${libdir}/engines-3
+modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 1.1.1
+Version: 3.0.8
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}

--- a/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
+++ b/build.assets/pkgconfig/centos7/usr/local/lib64/pkgconfig/libcrypto-static.pc
@@ -7,6 +7,6 @@ modulesdir=${libdir}/ossl-modules
 
 Name: OpenSSL-libcrypto
 Description: OpenSSL cryptography library
-Version: 3.0.8
+Version: 3.0.9
 Libs: ${libdir}/libcrypto.a -ldl -pthread
 Cflags: -I${includedir}


### PR DESCRIPTION
Backport #23810 and #27109 to branch/v11.

OpenSSL 1.1.1 is reaching EOL later this year, so we are moving to 3.0.x as a
result.

OpenSSL 3.0 is the latest LTS release, supported until September 2026, so I've
chosen it in favor of 3.1

* https://www.openssl.org/blog/blog/2023/03/28/1.1.1-EOL/
* https://github.com/openssl/openssl/releases/tag/openssl-3.0.9

#23689