### PR TITLE
Update tctl help output

### DIFF
--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -113,7 +113,7 @@ func (c *TokensCommand) Initialize(app *kingpin.Application, config *servicecfg.
 
 	// tctl tokens add ..."
 	c.tokenAdd = tokens.Command("add", "Create a invitation token.")
-	c.tokenAdd.Flag("type", "Type(s) of token to add, e.g. --type=node,app,db").Required().StringVar(&c.tokenType)
+	c.tokenAdd.Flag("type", "Type(s) of token to add, e.g. --type=node,app,db,proxy,etc").Required().StringVar(&c.tokenType)
 	c.tokenAdd.Flag("value", "Override the default random generated token with a specified value").StringVar(&c.value)
 	c.tokenAdd.Flag("labels", "Set token labels, e.g. env=prod,region=us-west").StringVar(&c.labels)
 	c.tokenAdd.Flag("ttl", fmt.Sprintf("Set expiration time for token, default is %v minutes",


### PR DESCRIPTION
`tctl tokens add` has `type`s of `proxy`, `desktop`, `discovery`, and others that are not currently listed in the help output. This PR (currently) adds one more, and `etc` to avoid the false assumption that the options listed are the only ones available.

This _could_ be expanded to link to `https://goteleport.com/docs/reference/cli/#tctl-tokens-add` for more info.