### PR TITLE
Refactor websocket termination and stream handling

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -2259,7 +2259,7 @@ func TestCloseConnectionsOnLogout(t *testing.T) {
 	_, err = io.WriteString(stream, "expr 137 + 39\r\n")
 	require.NoError(t, err)
 
-	// make sure server has replied
+	// make sure the server has replied
 	out := make([]byte, 100)
 	_, err = stream.Read(out)
 	require.NoError(t, err)
@@ -2267,7 +2267,7 @@ func TestCloseConnectionsOnLogout(t *testing.T) {
 	_, err = pack.clt.Delete(s.ctx, pack.clt.Endpoint("webapi", "sessions", "web"))
 	require.NoError(t, err)
 
-	// wait until we timeout or detect that connection has been closed
+	// wait until timeout or detect that the connection has been closed.
 	after := time.After(5 * time.Second)
 	errC := make(chan error)
 	go func() {
@@ -2275,6 +2275,7 @@ func TestCloseConnectionsOnLogout(t *testing.T) {
 			_, err := stream.Read(out)
 			if err != nil {
 				errC <- err
+				return
 			}
 		}
 	}()

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -674,7 +674,7 @@ func (t *commandHandler) streamOutput(ctx context.Context, tc *client.TeleportCl
 		return
 	}
 
-	if err := t.stream.Close(); err != nil {
+	if err := t.stream.SendCloseMessage(); err != nil {
 		t.log.WithError(err).Error("Unable to send close event to web client.")
 		return
 	}

--- a/lib/web/command_test.go
+++ b/lib/web/command_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sashabaranov/go-openai"
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -173,43 +174,28 @@ func TestExecuteCommandSummary(t *testing.T) {
 	ws, _, err := s.makeCommand(t, authPack, conversationID)
 	require.NoError(t, err)
 
-	// The current Assist execution relies on a hack that multiplexes multiple
-	// streams over a single one. This causes issues when a stream close as the
-	// single stream receiver will consider it should close. We work around by
-	// using a non-closing websocket and initiating a proper stream close.
-	// Then we reopen a new stream on the same websocket and continue reading
-	// the summary.
-	nonClosableWebsocket := &noopCloserWS{ws}
-	stream := NewWStream(ctx, nonClosableWebsocket, utils.NewLoggerForTests(), nil)
+	// For simplicity, use simple WS to io.Reader adapter
+	stream := &wsReader{conn: ws}
 
 	// Wait for command execution to complete
 	require.NoError(t, waitForCommandOutput(stream, "teleport"))
 
-	// Stop the stream consumption
-	err = stream.Close()
-	require.NoError(t, err)
-
-	// Start a new stream and process the summary event
 	var env Envelope
-	stream = NewWStream(ctx, ws, utils.NewLoggerForTests(), nil)
 	dec := json.NewDecoder(stream)
 	err = dec.Decode(&env)
 	require.NoError(t, err)
 	require.Equal(t, envelopeTypeSummary, env.GetType())
 	require.NotEmpty(t, env.GetPayload())
 
-	// Close the stream, and the underlying websocket
-	_ = stream.Close()
-
 	// Wait for the command execution history to be saved
 	var messages *assist.GetAssistantMessagesResponse
-	// Command execution history is saved in asynchronusly, so we need to wait for it.
+	// Command execution history is saved in asynchronously, so we need to wait for it.
 	require.Eventually(t, func() bool {
 		messages, err = clt.GetAssistantMessages(ctx, &assist.GetAssistantMessagesRequest{
 			ConversationId: conversationID.String(),
 			Username:       testUser,
 		})
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		return len(messagesByType(messages.GetMessages())[assistlib.MessageKindCommandResultSummary]) == 1
 	}, 5*time.Second, 100*time.Millisecond)
@@ -363,4 +349,29 @@ func messagesByType(messages []*assist.AssistantMessage) map[assistlib.MessageTy
 		byType[assistlib.MessageType(message.GetType())] = append(byType[assistlib.MessageType(message.GetType())], message)
 	}
 	return byType
+}
+
+// wsReader implements io.Reader interface over websocket connection
+type wsReader struct {
+	conn *websocket.Conn
+}
+
+// Read reads data from websocket connection.
+// It expects that the passed buffer is big enough to fit the whole message.
+func (r *wsReader) Read(p []byte) (int, error) {
+	_, data, err := r.conn.ReadMessage()
+	if err != nil {
+		return 0, trace.Wrap(err)
+	}
+
+	var envelope Envelope
+	if err := proto.Unmarshal(data, &envelope); err != nil {
+		return 0, trace.Errorf("Unable to parse message payload %v", err)
+	}
+
+	if len(envelope.Payload) > len(p) {
+		return 0, trace.BadParameter("buffer too small")
+	}
+
+	return copy(p, envelope.Payload), nil
 }

--- a/lib/web/command_test.go
+++ b/lib/web/command_test.go
@@ -357,6 +357,7 @@ type wsReader struct {
 }
 
 // Read reads data from websocket connection.
+// The message should be in web.Envelope format and only the payload will be returned.
 // It expects that the passed buffer is big enough to fit the whole message.
 func (r *wsReader) Read(p []byte) (int, error) {
 	_, data, err := r.conn.ReadMessage()

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -996,7 +996,6 @@ func (t *WSStream) writeError(msg string) {
 
 func (t *WSStream) processMessages(ctx context.Context) {
 	defer func() {
-		//close(t.completedC)
 		t.close()
 	}()
 	t.ws.SetReadLimit(teleport.MaxHTTPRequestSize)
@@ -1197,7 +1196,6 @@ func (t *WSStream) readChallengeResponse(codec mfaCodec) (*authproto.MFAAuthenti
 	}
 	resp, err := codec.decodeResponse([]byte(envelope.Payload), defaults.WebsocketWebauthnChallenge)
 	return resp, trace.Wrap(err)
-
 }
 
 // readChallenge reads and decodes the challenge from the

--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -1309,7 +1309,7 @@ func (t *WSStream) SendCloseMessage() error {
 
 	t.mu.Lock()
 	defer t.mu.Unlock()
-	return trace.NewAggregate(t.ws.WriteMessage(websocket.BinaryMessage, envelopeBytes))
+	return trace.Wrap(t.ws.WriteMessage(websocket.BinaryMessage, envelopeBytes))
 }
 
 func (t *WSStream) close() {


### PR DESCRIPTION
Refactored websocket stream shutdown and error handling. Replaced `Close()` with `SendCloseMessage()` for better control over the websocket connection termination process. Added checks for the validity of channels to prevent reading from closed channels. The commit also includes minor typo fixes.