### PR TITLE
Add t.Parallel() to several tsh tests

### DIFF
--- a/tool/tsh/common/app_azure_test.go
+++ b/tool/tsh/common/app_azure_test.go
@@ -213,6 +213,8 @@ func makeUserWithAzureRole(t *testing.T) (types.User, types.Role) {
 }
 
 func Test_getAzureIdentityFromFlags(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name              string
 		requestedIdentity string
@@ -441,6 +443,8 @@ func Test_getMSISecret(t *testing.T) {
 }
 
 func Test_formatAzureIdentities(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		identities []string

--- a/tool/tsh/common/app_cloud_test.go
+++ b/tool/tsh/common/app_cloud_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func Test_filterApps(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name            string
 		matchRouteToApp func(tlsca.RouteToApp) bool

--- a/tool/tsh/common/app_gcp_test.go
+++ b/tool/tsh/common/app_gcp_test.go
@@ -27,6 +27,8 @@ import (
 )
 
 func Test_getGCPServiceAccountFromFlags(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name                    string
 		requestedServiceAccount string
@@ -139,6 +141,8 @@ func Test_getGCPServiceAccountFromFlags(t *testing.T) {
 }
 
 func Test_formatGCPServiceAccounts(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name     string
 		accounts []string

--- a/tool/tsh/common/db_test.go
+++ b/tool/tsh/common/db_test.go
@@ -391,6 +391,8 @@ func TestListDatabase(t *testing.T) {
 }
 
 func TestFormatDatabaseListCommand(t *testing.T) {
+	t.Parallel()
+
 	t.Run("default", func(t *testing.T) {
 		require.Equal(t, "tsh db ls", formatDatabaseListCommand(""))
 	})
@@ -401,6 +403,8 @@ func TestFormatDatabaseListCommand(t *testing.T) {
 }
 
 func TestFormatConfigCommand(t *testing.T) {
+	t.Parallel()
+
 	db := tlsca.RouteToDatabase{
 		ServiceName: "example-db",
 	}
@@ -415,6 +419,8 @@ func TestFormatConfigCommand(t *testing.T) {
 }
 
 func TestDBInfoHasChanged(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name               string
 		databaseUserName   string

--- a/tool/tsh/common/recording_export_test.go
+++ b/tool/tsh/common/recording_export_test.go
@@ -45,6 +45,8 @@ func init() {
 }
 
 func TestWriteMovieCanBeCanceled(t *testing.T) {
+	t.Parallel()
+
 	events := []apievents.AuditEvent{
 		&apievents.WindowsDesktopSessionStart{},
 	}
@@ -53,18 +55,20 @@ func TestWriteMovieCanBeCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	frames, err := writeMovie(ctx, fs, session.ID("test"), "test.avi")
+	frames, err := writeMovie(ctx, fs, "test", "test.avi")
 	require.Equal(t, context.Canceled, err)
 	require.Equal(t, 0, frames)
 }
 
 func TestWriteMovieDoesNotSupportSSH(t *testing.T) {
+	t.Parallel()
+
 	events := []apievents.AuditEvent{
 		&apievents.SessionStart{},
 	}
 	fs := eventstest.NewFakeStreamer(events, 0)
 
-	frames, err := writeMovie(context.Background(), fs, session.ID("test"), "test.avi")
+	frames, err := writeMovie(context.Background(), fs, "test", "test.avi")
 	require.True(t, trace.IsBadParameter(err), "expected bad paramater error, got %v", err)
 	require.Equal(t, 0, frames)
 }
@@ -75,6 +79,8 @@ func TestWriteMovieDoesNotSupportSSH(t *testing.T) {
 // At the time of this implementation, desktop access does not support resizing during the
 // screen during a session. This test exists to prevent regressions should that behavior change.
 func TestWriteMovieMultipleScreenSpecs(t *testing.T) {
+	t.Parallel()
+
 	events := []apievents.AuditEvent{
 		tdpEvent(t, tdp.ClientScreenSpec{Width: 1920, Height: 1080}),
 		tdpEvent(t, tdp.ClientScreenSpec{Width: 1920, Height: 1080}),
@@ -88,6 +94,8 @@ func TestWriteMovieMultipleScreenSpecs(t *testing.T) {
 }
 
 func TestWriteMovieWritesOneFrame(t *testing.T) {
+	t.Parallel()
+
 	oneFrame := frameDelayMillis
 	// need a PNG that will actually decode
 	events := []apievents.AuditEvent{
@@ -103,6 +111,8 @@ func TestWriteMovieWritesOneFrame(t *testing.T) {
 }
 
 func TestWriteMovieWritesManyFrames(t *testing.T) {
+	t.Parallel()
+
 	events := []apievents.AuditEvent{
 		tdpEventMillis(t, tdp.ClientScreenSpec{Width: 128, Height: 128}, 0),
 		tdpEventMillis(t, tdp.PNG2Frame(pngFrame), 0),

--- a/tool/tsh/common/tshconfig_test.go
+++ b/tool/tsh/common/tshconfig_test.go
@@ -111,6 +111,8 @@ func TestLoadAllConfigs(t *testing.T) {
 }
 
 func TestTshConfigMerge(t *testing.T) {
+	t.Parallel()
+
 	sampleConfig := TshConfig{
 		ExtraHeaders: []ExtraProxyHeaders{{
 			Proxy: "foo",
@@ -254,6 +256,8 @@ func TestTshConfigMerge(t *testing.T) {
 
 // TestProxyTemplatesApply verifies proxy templates matching functionality.
 func TestProxyTemplatesApply(t *testing.T) {
+	t.Parallel()
+
 	tshConfig := TshConfig{
 		ProxyTemplates: ProxyTemplates{
 			{
@@ -331,6 +335,8 @@ func TestProxyTemplatesApply(t *testing.T) {
 
 // TestProxyTemplates verifies proxy templates apply properly to client config.
 func TestProxyTemplatesMakeClient(t *testing.T) {
+	t.Parallel()
+
 	tshConfig := TshConfig{
 		ProxyTemplates: ProxyTemplates{
 			{


### PR DESCRIPTION
Added the `t.Parallel()` function call in each test function to enable parallel test execution. This should reduce the overall time it takes to run all these tests by enabling them to run concurrently.