### PR TITLE
[v13] Remove most t.Log() from tests

### DIFF
--- a/integrations/kube-agent-updater/pkg/img/cosign_test.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign_test.go
@@ -51,7 +51,6 @@ func Test_cosignKeyValidator_ValidateAndResolveDigest(t *testing.T) {
 	// This is the worst case scenario and also reduces the amount of noise and failed calls in the logs.
 	testRegistry := httptest.NewServer(registry.New(registry.WithReferrersSupport(true)))
 	t.Cleanup(testRegistry.Close)
-	t.Log(testRegistry.URL)
 
 	// Put test layers and manifests into the registry
 	for digest, contents := range blobs {

--- a/integrations/lib/testing/integration/ssh_test.go
+++ b/integrations/lib/testing/integration/ssh_test.go
@@ -77,8 +77,6 @@ func (s *IntegrationSSHSuite) TestSSH() {
 	require.NoError(t, err)
 
 	err = cmd.Wait()
-	t.Log("STDOUT", cmdStdout.String())
-	t.Log("STDERR", cmdStderr.String())
 	require.NoError(t, err)
 
 	require.Contains(t, cmdStdout.String(), fmt.Sprintf("MYUSER=%s", user.GetName()))

--- a/lib/cloud/aws/tags_helpers_test.go
+++ b/lib/cloud/aws/tags_helpers_test.go
@@ -44,7 +44,6 @@ func TestTagsToLabels(t *testing.T) {
 				Value: aws.String("test"),
 			},
 		}
-		t.Log(inputTags)
 
 		expectLabels := map[string]string{
 			"Name":                        "test",
@@ -71,7 +70,6 @@ func TestTagsToLabels(t *testing.T) {
 				Value: aws.String("test"),
 			},
 		}
-		t.Log(inputTags)
 
 		expectLabels := map[string]string{
 			"Name":                        "test",

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -64,7 +64,6 @@ func TestCheckImpersonationPermissions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		t.Log(tt.desc)
 		mock := &mockSARClient{
 			err:              tt.sarErr,
 			allowedVerbs:     tt.allowedVerbs,

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -944,8 +944,6 @@ func TestSetupImpersonationHeaders(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Log(tt.desc)
-
 		err := setupImpersonationHeaders(
 			logrus.NewEntry(logrus.New()),
 			authContext{
@@ -955,7 +953,6 @@ func TestSetupImpersonationHeaders(t *testing.T) {
 			},
 			tt.inHeaders,
 		)
-		t.Log("got error:", err)
 		tt.errAssertion(t, err)
 
 		if err == nil {

--- a/lib/srv/db/elasticsearch/util_test.go
+++ b/lib/srv/db/elasticsearch/util_test.go
@@ -132,7 +132,6 @@ func TestEngineGetQueryFromRequestBody(t *testing.T) {
 			e.Log = logrus.StandardLogger()
 
 			result := GetQueryFromRequestBody(e.EngineConfig, tt.contentType, []byte(tt.body))
-			t.Log(result)
 			require.Equal(t, tt.want, result)
 		})
 	}

--- a/lib/utils/archive_test.go
+++ b/lib/utils/archive_test.go
@@ -114,7 +114,6 @@ func TestCompressAsTarGzArchive(t *testing.T) {
 
 			gotBytes, err := io.ReadAll(tarReader)
 			require.NoError(t, err)
-			t.Log(string(gotBytes))
 
 			require.Equal(t, tt.fsContents[header.Name].content, gotBytes)
 			require.Equal(t, tt.fsContents[header.Name].mode, fs.FileMode(header.Mode))

--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -759,7 +759,6 @@ db_service:
 			}
 
 			if test.extraAssertions != nil {
-				t.Log(script)
 				test.extraAssertions(script)
 			}
 		})


### PR DESCRIPTION
Backport #28453 to branch/v13