### PR TITLE
Firestore backend improvements 

### DIFF
--- a/lib/backend/etcdbk/etcd_test.go
+++ b/lib/backend/etcdbk/etcd_test.go
@@ -82,7 +82,7 @@ func TestEtcd(t *testing.T) {
 		// we can't fiddle with clocks inside the etcd client, so instead of creating
 		// and returning a fake clock, we wrap the real clock used by the etcd client
 		// in a FakeClock interface that sleeps instead of instantly advancing.
-		sleepingClock := blockingFakeClock{bk.clock}
+		sleepingClock := test.BlockingFakeClock{Clock: bk.clock}
 
 		return bk, sleepingClock, nil
 	}
@@ -254,22 +254,4 @@ func etcdTestEndpoint() string {
 		return host
 	}
 	return "https://127.0.0.1:2379"
-}
-
-func (r blockingFakeClock) Advance(d time.Duration) {
-	if d < 0 {
-		panic("Invalid argument, negative duration")
-	}
-
-	// We cannot rewind time for etcd since it will not have any effect on the server
-	// so we actually sleep in this case
-	time.Sleep(d)
-}
-
-func (r blockingFakeClock) BlockUntil(int) {
-	panic("Not implemented")
-}
-
-type blockingFakeClock struct {
-	clockwork.Clock
 }

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -198,6 +198,8 @@ const (
 	timestampDocProperty = "timestamp"
 	// idDocProperty references the record's internal ID
 	idDocProperty = "id"
+	// valueDocProperty references the value of the record
+	valueDocProperty = "value"
 	// timeInBetweenIndexCreationStatusChecks
 	timeInBetweenIndexCreationStatusChecks = time.Second * 10
 )
@@ -209,16 +211,38 @@ func GetName() string {
 }
 
 // keep this here to test interface conformance
-var _ backend.Backend = &Backend{}
+var _ backend.Backend = (*Backend)(nil)
+
+// ownerCredentials adds the needed authorization headers when
+// interacting with the emulator to allow access to the
+// batched write api. Without the header, the emulator returns
+// the following error:
+// rpc error: code = PermissionDenied desc = Batch writes require admin authentication
+//
+// See the following issues for more details:
+// https://github.com/firebase/firebase-tools/issues/1363
+// https://github.com/firebase/firebase-tools/issues/3833
+type ownerCredentials struct{}
+
+func (t ownerCredentials) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	return map[string]string{"Authorization": "Bearer owner"}, nil
+}
+
+func (t ownerCredentials) RequireTransportSecurity() bool { return false }
 
 // CreateFirestoreClients creates a firestore admin and normal client given the supplied parameters
 func CreateFirestoreClients(ctx context.Context, projectID string, endPoint string, credentialsFile string) (*apiv1.FirestoreAdminClient, *firestore.Client, error) {
-
 	var args []option.ClientOption
 
-	if len(endPoint) != 0 {
-		args = append(args, option.WithoutAuthentication(), option.WithEndpoint(endPoint), option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
-	} else if len(credentialsFile) != 0 {
+	if endPoint != "" {
+		args = append(args,
+			option.WithTelemetryDisabled(),
+			option.WithoutAuthentication(),
+			option.WithEndpoint(endPoint),
+			option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
+			option.WithGRPCDialOption(grpc.WithPerRPCCredentials(ownerCredentials{})),
+		)
+	} else if credentialsFile != "" {
 		args = append(args, option.WithCredentialsFile(credentialsFile))
 	}
 
@@ -337,14 +361,20 @@ func (b *Backend) Put(ctx context.Context, item backend.Item) (*backend.Lease, e
 // Update updates value in the backend
 func (b *Backend) Update(ctx context.Context, item backend.Item) (*backend.Lease, error) {
 	r := newRecord(item, b.clock)
-	_, err := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(item.Key)).Get(ctx)
+
+	updates := []firestore.Update{
+		{Path: keyDocProperty, Value: r.Key},
+		{Path: timestampDocProperty, Value: r.Timestamp},
+		{Path: expiresDocProperty, Value: r.Expires},
+		{Path: idDocProperty, Value: r.ID},
+		{Path: valueDocProperty, Value: r.Value},
+	}
+
+	_, err := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(item.Key)).Update(ctx, updates)
 	if err != nil {
 		return nil, ConvertGRPCError(err)
 	}
-	_, err = b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(item.Key)).Set(ctx, r)
-	if err != nil {
-		return nil, ConvertGRPCError(err)
-	}
+
 	return b.newLease(item), nil
 }
 
@@ -443,7 +473,6 @@ func (b *Backend) Get(ctx context.Context, key []byte) (*backend.Item, error) {
 	return &bi, nil
 }
 
-// CompareAndSwap compares and swap values in atomic operation
 // CompareAndSwap compares item with existing item
 // and replaces is with replaceWith item
 func (b *Backend) CompareAndSwap(ctx context.Context, expected backend.Item, replaceWith backend.Item) (*backend.Lease, error) {
@@ -457,25 +486,32 @@ func (b *Backend) CompareAndSwap(ctx context.Context, expected backend.Item, rep
 		return nil, trace.BadParameter("expected and replaceWith keys should match")
 	}
 
-	expectedDocSnap, err := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(expected.Key)).Get(ctx)
-	if err != nil {
-		return nil, trace.CompareFailed("error or object not found, error: %v", ConvertGRPCError(err))
-	}
+	ref := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(expected.Key))
+	err := b.svc.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
+		expectedDocSnap, err := tx.Get(ref)
+		if err != nil {
+			return trace.CompareFailed("error or object not found, error: %v", ConvertGRPCError(err))
+		}
 
-	existingRecord, err := newRecordFromDoc(expectedDocSnap)
+		existingRecord, err := newRecordFromDoc(expectedDocSnap)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		if !bytes.Equal(existingRecord.Value, expected.Value) {
+			return trace.CompareFailed("expected item value %v does not match actual item value %v", string(expected.Value), existingRecord.Value)
+		}
+
+		if err := tx.Set(ref, newRecord(replaceWith, b.clock)); err != nil {
+			return ConvertGRPCError(err)
+		}
+
+		return nil
+	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	if !bytes.Equal(existingRecord.Value, expected.Value) {
-		return nil, trace.CompareFailed("expected item value %v does not match actual item value %v", string(expected.Value), existingRecord.Value)
-	}
-
-	r := newRecord(replaceWith, b.clock)
-	_, err = expectedDocSnap.Ref.Set(ctx, r)
-	if err != nil {
-		return nil, ConvertGRPCError(err)
-	}
 	return b.newLease(replaceWith), nil
 }
 
@@ -637,14 +673,15 @@ const driftTolerance = time.Millisecond * 2500
 
 // watchCollection watches a firestore collection for changes and pushes those changes, events into the buffer for watchers
 func (b *Backend) watchCollection() error {
-	var snaps *firestore.QuerySnapshotIterator
-
+	// Filter any documents that don't have a key. If the collection is shared between
+	// the cluster state and audit events, this filters out the event documents since they
+	// have a different schema, and it's a requirement for all resources to have a key.
+	query := b.svc.Collection(b.CollectionName).Where(keyDocProperty, "!=", "")
 	if b.LimitWatchQuery {
-		snaps = b.svc.Collection(b.CollectionName).Query.Where(timestampDocProperty, ">=", b.clock.Now().UTC().Add(-driftTolerance).Unix()).Snapshots(b.clientContext)
-	} else {
-		snaps = b.svc.Collection(b.CollectionName).Snapshots(b.clientContext)
+		query = query.Where(timestampDocProperty, ">=", b.clock.Now().UTC().Add(-driftTolerance).Unix())
 	}
 
+	snaps := query.Snapshots(b.clientContext)
 	b.buf.SetInit()
 	defer b.buf.Reset()
 	defer snaps.Stop()

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -426,8 +426,21 @@ func (b *Backend) GetRange(ctx context.Context, startKey []byte, endKey []byte, 
 		}
 
 		if r.isExpired(b.clock.Now()) {
-			if _, err := docSnap.Ref.Delete(ctx); err != nil {
-				return nil, ConvertGRPCError(err)
+			if _, err := docSnap.Ref.Delete(ctx, firestore.LastUpdateTime(docSnap.UpdateTime)); err != nil && status.Code(err) == codes.FailedPrecondition {
+				// If the document has been updated, then attempt one additional get to see if the
+				// resource was updated and is no longer expired.
+				docSnap, err := b.svc.Collection(b.CollectionName).Doc(docSnap.Ref.ID).Get(ctx)
+				if err != nil {
+					return nil, ConvertGRPCError(err)
+				}
+				r, err := newRecordFromDoc(docSnap)
+				if err != nil {
+					return nil, trace.Wrap(err)
+				}
+
+				if !r.isExpired(b.clock.Now()) {
+					values = append(values, r.backendItem())
+				}
 			}
 			// Do not include this document in result.
 			continue
@@ -453,7 +466,10 @@ func (b *Backend) Get(ctx context.Context, key []byte) (*backend.Item, error) {
 	if len(key) == 0 {
 		return nil, trace.BadParameter("missing parameter key")
 	}
-	docSnap, err := b.svc.Collection(b.CollectionName).Doc(b.keyToDocumentID(key)).Get(ctx)
+
+	documentID := b.keyToDocumentID(key)
+
+	docSnap, err := b.svc.Collection(b.CollectionName).Doc(documentID).Get(ctx)
 	if err != nil {
 		return nil, ConvertGRPCError(err)
 	}
@@ -463,8 +479,22 @@ func (b *Backend) Get(ctx context.Context, key []byte) (*backend.Item, error) {
 	}
 
 	if r.isExpired(b.clock.Now()) {
-		if _, err := docSnap.Ref.Delete(ctx); err != nil {
-			return nil, trace.Wrap(err)
+		if _, err := docSnap.Ref.Delete(ctx, firestore.LastUpdateTime(docSnap.UpdateTime)); err != nil && status.Code(err) == codes.FailedPrecondition {
+			// If the document has been updated, then attempt one additional get to see if the
+			// resource was updated and is no longer expired.
+			docSnap, err := b.svc.Collection(b.CollectionName).Doc(documentID).Get(ctx)
+			if err != nil {
+				return nil, ConvertGRPCError(err)
+			}
+			r, err := newRecordFromDoc(docSnap)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			if !r.isExpired(b.clock.Now()) {
+				bi := r.backendItem()
+				return &bi, nil
+			}
 		}
 		return nil, trace.NotFound("the supplied key: %q does not exist", string(key))
 	}

--- a/lib/backend/firestore/firestorebk_test.go
+++ b/lib/backend/firestore/firestorebk_test.go
@@ -102,13 +102,8 @@ func ensureTestsEnabled(t *testing.T) {
 }
 
 func ensureEmulatorRunning(t *testing.T, cfg map[string]interface{}) {
-	v, ok := cfg["endpoint"]
-	if !ok {
-		return
-	}
-
-	endpoint, ok := v.(string)
-	if !ok || endpoint == "" {
+	endpoint, _ := cfg["endpoint"].(string)
+	if endpoint == "" {
 		return
 	}
 

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -131,58 +131,73 @@ type Constructor func(options ...ConstructionOption) (backend.Backend, clockwork
 // `newBackend` function, which callers will use inject instances of the
 // backend under test.
 func RunBackendComplianceSuite(t *testing.T, newBackend Constructor) {
+	t.Parallel()
 	t.Run("CRUD", func(t *testing.T) {
+		t.Parallel()
 		testCRUD(t, newBackend)
 	})
 
 	t.Run("QueryRange", func(t *testing.T) {
+		t.Parallel()
 		testQueryRange(t, newBackend)
 	})
 
 	t.Run("DeleteRange", func(t *testing.T) {
+		t.Parallel()
 		testDeleteRange(t, newBackend)
 	})
 
 	t.Run("PutRange", func(t *testing.T) {
+		t.Parallel()
 		testPutRange(t, newBackend)
 	})
 
 	t.Run("CompareAndSwap", func(t *testing.T) {
+		t.Parallel()
 		testCompareAndSwap(t, newBackend)
 	})
 
 	t.Run("Expiration", func(t *testing.T) {
+		t.Parallel()
 		testExpiration(t, newBackend)
 	})
 
 	t.Run("KeepAlive", func(t *testing.T) {
+		t.Parallel()
 		testKeepAlive(t, newBackend)
 	})
 
 	t.Run("Events", func(t *testing.T) {
+		t.Parallel()
 		testEvents(t, newBackend)
 	})
 	t.Run("WatchersClose", func(t *testing.T) {
+		t.Parallel()
 		testWatchersClose(t, newBackend)
 	})
 
 	t.Run("Locking", func(t *testing.T) {
+		t.Parallel()
 		testLocking(t, newBackend)
 	})
 
 	t.Run("ConcurrentOperations", func(t *testing.T) {
+		t.Parallel()
 		testConcurrentOperations(t, newBackend)
 	})
 
 	t.Run("Mirror", func(t *testing.T) {
+		t.Parallel()
 		testMirror(t, newBackend)
 	})
 
 	t.Run("FetchLimit", func(t *testing.T) {
+		t.Parallel()
 		testFetchLimit(t, newBackend)
 	})
 
 	t.Run("Limit", func(t *testing.T) {
+		t.Parallel()
 		testLimit(t, newBackend)
 	})
 }
@@ -680,7 +695,7 @@ func testLimit(t *testing.T, newBackend Constructor) {
 	item := &backend.Item{
 		Key:     prefix("/db/database_tail_item"),
 		Value:   []byte("data"),
-		Expires: clock.Now().Add(time.Minute),
+		Expires: clock.Now().Add(10 * time.Minute),
 	}
 	_, err = uut.Put(ctx, *item)
 	require.NoError(t, err)
@@ -688,7 +703,7 @@ func testLimit(t *testing.T, newBackend Constructor) {
 		item := &backend.Item{
 			Key:     prefix(fmt.Sprintf("/db/database%d", i)),
 			Value:   []byte("data"),
-			Expires: clock.Now().Add(time.Second * 10),
+			Expires: clock.Now().Add(time.Second * 3),
 		}
 		_, err = uut.Put(ctx, *item)
 		require.NoError(t, err)
@@ -698,7 +713,7 @@ func testLimit(t *testing.T, newBackend Constructor) {
 	item = &backend.Item{
 		Key:     prefix("/db/database_head_item"),
 		Value:   []byte("data"),
-		Expires: clock.Now().Add(time.Minute),
+		Expires: clock.Now().Add(10 * time.Minute),
 	}
 	_, err = uut.Put(ctx, *item)
 	require.NoError(t, err)

--- a/lib/backend/test/suite.go
+++ b/lib/backend/test/suite.go
@@ -109,8 +109,6 @@ func (r BlockingFakeClock) Advance(d time.Duration) {
 		panic("Invalid argument, negative duration")
 	}
 
-	// We cannot rewind time for etcd since it will not have any effect on the server
-	// so we actually sleep in this case
 	time.Sleep(d)
 }
 
@@ -131,7 +129,6 @@ type Constructor func(options ...ConstructionOption) (backend.Backend, clockwork
 // `newBackend` function, which callers will use inject instances of the
 // backend under test.
 func RunBackendComplianceSuite(t *testing.T, newBackend Constructor) {
-	t.Parallel()
 	t.Run("CRUD", func(t *testing.T) {
 		t.Parallel()
 		testCRUD(t, newBackend)

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -383,6 +383,7 @@ func (l *Log) searchEventsWithFilter(fromUTC, toUTC time.Time, namespace string,
 	}
 
 	query := l.svc.Collection(l.CollectionName).
+		Where(sessionIDDocProperty, "!=", ""). // exclude any non audit event documents in the collection
 		Where(eventNamespaceDocProperty, "==", apidefaults.Namespace).
 		Where(createdAtDocProperty, ">=", fromUTC.Unix()).
 		Where(createdAtDocProperty, "<=", toUTC.Unix())


### PR DESCRIPTION
1) CAS now utilizes a transaction to ensure the operation is atomic

The original implementation did not use transactions which violated
the atomic guarantees of the CAS operation. The backend compliance
test was able to catch this when it was updated to run concurrent
CAS operations.

2) Update is limited to updating a value

The original implementation of Update was actually doing a get and
then upsert. However, there are no guarantees that prevent a delete
from occurring between get and upsert, which means Update would
upsert the value instead of failing. Instead of get and then upsert
we now update the document using the `(firestore.DocumentRef) Update`
method.

3) Watching items from the collection filters out any audit events

If Teleport is configured to use the same collection for backend state
and audit events the collection watcher ends up consuming all audit
events as empty backend items. To avoid this the watcher is now filtering
out any collections which have an empty key since it is not possible
for backend resources to be written without a key this will only
exclude audit events which have a different schema.

4) SearchEvents now filters out backend resources

Similar to above, the Firestore events implementation now excludes
any documents which have an empty session id to prevent backend
resources from getting included in queries for audit events if the
collection is being shared.


Partially addresses #28118