### PR TITLE
add name to docker run command

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -79,7 +79,7 @@ expose, skip over to **Step 3**.
 Grafana can be launched in a Docker container with a single command:
 
 ```code
-$ docker run -d -p 3000:3000 grafana/grafana
+$ docker run -d --name grafana -p 3000:3000 grafana/grafana
 ```
 
 Next, we need to edit `/etc/grafana/grafana.ini` in the container. Under


### PR DESCRIPTION
The docker exec command...

```docker exec -u 0 grafana sed -i 's/;domain = localhost/domain = teleport.example.com/g' /etc/grafana/grafana.ini```

on this page doesn't work because the docker container wasn't given a name (grafana). Either have to provide the name in the ```docker run``` command OR use the container id (instead of the name) in the ```docker exec``` command.  This PR is to update the former. 