### PR TITLE
Assist: fix summary logic

### DIFF
--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -287,8 +287,7 @@ func (h *Handler) executeCommand(
 	runCommands(hosts, runCmd, h.log)
 
 	// Optionally, try to compute the command summary.
-	if buffer.CanBeExported() {
-		output, _ := buffer.Export()
+	if output, valid := buffer.Export(); valid {
 		summaryReq := summaryRequest{
 			hosts:          hosts,
 			output:         output,

--- a/lib/web/command.go
+++ b/lib/web/command.go
@@ -287,7 +287,8 @@ func (h *Handler) executeCommand(
 	runCommands(hosts, runCmd, h.log)
 
 	// Optionally, try to compute the command summary.
-	if output, overflow := buffer.Export(); !overflow || len(output) != 0 {
+	if buffer.CanBeExported() {
+		output, _ := buffer.Export()
 		summaryReq := summaryRequest{
 			hosts:          hosts,
 			output:         output,

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -199,3 +199,9 @@ func (b *summaryBuffer) Export() (map[string][]byte, bool) {
 	b.invalid = true
 	return b.buffer, false
 }
+
+func (b *summaryBuffer) CanBeExported() bool {
+	b.mutex.Lock()
+	defer b.mutex.Unlock()
+	return !b.invalid && len(b.buffer) != 0
+}

--- a/lib/web/command_utils.go
+++ b/lib/web/command_utils.go
@@ -189,19 +189,14 @@ func (b *summaryBuffer) Write(node string, data []byte) {
 	b.remainingCapacity -= len(data)
 }
 
-// Export returns the buffer content and a whether the buffer overflowed.
+// Export returns the buffer content and a whether the Export is valid.
+// Exporting the buffer can only happen once.
 func (b *summaryBuffer) Export() (map[string][]byte, bool) {
 	b.mutex.Lock()
 	defer b.mutex.Unlock()
 	if b.invalid {
-		return nil, true
+		return nil, false
 	}
 	b.invalid = true
-	return b.buffer, false
-}
-
-func (b *summaryBuffer) CanBeExported() bool {
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-	return !b.invalid && len(b.buffer) != 0
+	return b.buffer, len(b.buffer) != 0
 }

--- a/lib/web/command_utils_test.go
+++ b/lib/web/command_utils_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func TestSummaryBuffer(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name             string
 		outputs          map[string][][]byte
@@ -137,6 +138,60 @@ func TestSummaryBuffer(t *testing.T) {
 			require.Equal(t, tc.expectedOutput, output)
 			require.Equal(t, tc.expectedOverflow, overflow)
 
+		})
+	}
+}
+
+func TestSummaryBuffer_CanBeExported(t *testing.T) {
+	type fields struct {
+		buffer  map[string][]byte
+		invalid bool
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		assert require.BoolAssertionFunc
+	}{
+		{
+			name: "overflowed and not empty",
+			fields: fields{
+				buffer:  map[string][]byte{"foo": {0x00}},
+				invalid: true,
+			},
+			assert: require.False,
+		},
+		{
+			name: "overflowed and empty",
+			fields: fields{
+				buffer:  map[string][]byte{},
+				invalid: true,
+			},
+			assert: require.False,
+		},
+		{
+			name: "not overflowed and not empty",
+			fields: fields{
+				buffer:  map[string][]byte{"foo": {0x00}},
+				invalid: false,
+			},
+			assert: require.True,
+		},
+		{
+			name: "not overflowed and empty",
+			fields: fields{
+				buffer:  map[string][]byte{},
+				invalid: false,
+			},
+			assert: require.False,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &summaryBuffer{
+				buffer:  tt.fields.buffer,
+				invalid: tt.fields.invalid,
+			}
+			tt.assert(t, b.CanBeExported())
 		})
 	}
 }


### PR DESCRIPTION
Fixes a logic issue: we want to generate a summary if the buffer is not empty AND has not overflowed.