### PR TITLE
Docs: clarify the value of 'host' key where needed

### DIFF
--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -41,8 +41,8 @@ From your local workstation, create the secrets:
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```
 
-In this example, `db.example.com` is the hostname that the MySQL server is
-accessible from to the Teleport Proxy service.
+In this example, `db.example.com` is the hostname where the Teleport Database
+Service can reach the MySQL server.
 
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -41,6 +41,9 @@ From your local workstation, create the secrets:
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```
 
+In this example, `db.example.com` is the hostname that the MySQL server is
+accessible from to the Teleport Proxy service.
+
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 
 The command will create 3 files: `server.cas`, `server.crt` and `server.key`

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -45,6 +45,9 @@ Follow the instructions below to generate TLS credentials for your database.
 $ tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h
 ```
 
+In this example, `db.example.com` is the hostname that the Oracle server is
+accessible from to the Teleport Proxy service.
+
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 
 If `tctl` finds the Orapki tool in your local environment, the `tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h` command will produce an Oracle Wallet and

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -45,8 +45,8 @@ Follow the instructions below to generate TLS credentials for your database.
 $ tctl auth sign --format=oracle --host=db.example.com --out=server --ttl=2190h
 ```
 
-In this example, `db.example.com` is the hostname that the Oracle server is
-accessible from to the Teleport Proxy service.
+In this example, `db.example.com` is the hostname where the Teleport Database
+Service can reach the Oracle server.
 
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -46,6 +46,9 @@ Create the secrets:
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```
 
+In this example, `db.example.com` is the hostname that the PostgreSQL server is
+accessible from to the Teleport Proxy service.
+
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 
 The command will create 3 files: `server.cas`, `server.crt` and `server.key`

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -46,8 +46,8 @@ Create the secrets:
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```
 
-In this example, `db.example.com` is the hostname that the PostgreSQL server is
-accessible from to the Teleport Proxy service.
+In this example, `db.example.com` is the hostname where the Teleport Database
+Service can reach the PostgreSQL server.
 
 (!docs/pages/includes/database-access/ttl-note.mdx!)
 

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -152,7 +152,8 @@ configuring the Database Service with self-hosted database instances.
 
 <Admonition type="note" title="Note">
   For database formats, `tctl` must be run on an Auth Service host or the remote
-  user must be be able to impersonate the built-in `Db` role and user. See the [impersonation guide](../../access-controls/guides/impersonation.mdx)
+  user must be be able to impersonate the built-in `Db` role and user. See the
+  [impersonation guide](../../access-controls/guides/impersonation.mdx)
   for details on how to allow impersonation.
 </Admonition>
 
@@ -160,6 +161,10 @@ configuring the Database Service with self-hosted database instances.
 $ tctl auth sign --format=db --host=db.example.com --out=db --ttl=2190h
 $ tctl auth sign --format=db --host=host1,localhost,127.0.0.1 --out=db --ttl=2190h
 ```
+
+In this example, `db.example.com` is the hostname that the database server is
+accessible from to the Teleport Proxy service. The second example assumes a
+database running on the same host as Teleport.
 
 | Flag | Description |
 | - | - |

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -162,8 +162,8 @@ $ tctl auth sign --format=db --host=db.example.com --out=db --ttl=2190h
 $ tctl auth sign --format=db --host=host1,localhost,127.0.0.1 --out=db --ttl=2190h
 ```
 
-In this example, `db.example.com` is the hostname that the database server is
-accessible from to the Teleport Proxy service. The second example assumes a
+In this example, `db.example.com` is the hostname where the Teleport Database
+Service can reach the database server. The second example assumes a
 database running on the same host as Teleport.
 
 | Flag | Description |

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -21,12 +21,16 @@ due to expired certificates.
 
 The command used to generate a new certificate is `tctl auth sign`. For example,
 to create a certificate for PostgreSQL, the command looks like this:
+
 ```bash
 # Export Teleport's certificate authority and a generate certificate/key pair
 # for host db.example.com with a 1-year validity period.
 
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```
+
+In this example, `db.example.com` is the hostname that the PostgreSQL server is
+accessible from to the Teleport Proxy service.
 
 Each database uses a different format. You can check your database guide for more
 details and examples:

--- a/docs/pages/database-access/troubleshooting.mdx
+++ b/docs/pages/database-access/troubleshooting.mdx
@@ -29,8 +29,8 @@ to create a certificate for PostgreSQL, the command looks like this:
 $ tctl auth sign --format=db --host=db.example.com --out=server --ttl=2190h
 ```
 
-In this example, `db.example.com` is the hostname that the PostgreSQL server is
-accessible from to the Teleport Proxy service.
+In this example, `db.example.com` is the hostname where the Teleport Database
+Service can reach the PostgreSQL server.
 
 Each database uses a different format. You can check your database guide for more
 details and examples:


### PR DESCRIPTION
Closes #11113 by adding, where it wasn't already explained, info on what value to supply to the `host` key when running `tctl auth sign` to generate credentials for DB services.