### PR TITLE
Docs: Document that root cluster's can't populate OS users from leaves.

### DIFF
--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -812,8 +812,8 @@ these pieces of data from it. It then performs the following actions:
 Trusted Clusters work only in one direction. In the example above, users from
 the leaf cluster cannot see or connect to Nodes in the root cluster.
 
-The Teleport root cluster's web UI will not populate available OS users for
-leaf cluster nodes. When using the web UI, type in the host user when creating
+The Teleport root cluster's Web UI will not populate available OS users for
+leaf cluster Nodes. When using the web UI, type in the host user when creating
 SSH sessions.
 </Admonition>
 

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -809,10 +809,12 @@ these pieces of data from it. It then performs the following actions:
   type="tip"
   title="Note"
 >
+Trusted Clusters work only in one direction. In the example above, users from
+the leaf cluster cannot see or connect to Nodes in the root cluster.
 
-  Trusted Clusters work only in one direction. In the example above, users from
-  the leaf cluster cannot see or connect to Nodes in the root cluster.
-
+The Teleport root cluster's web UI will not populate available OS users for
+leaf cluster nodes. When using the web UI, type in the host user when creating
+SSH sessions.
 </Admonition>
 
 ## Step 5/5. Remove trust between your clusters


### PR DESCRIPTION
Closes #14949 

Document that root cluster web UIs cannot populate OS users for leaf cluster hosts.