### PR TITLE
Fix storybook after the addition of the user context

### DIFF
--- a/web/packages/teleport/src/TopBar/TopBar.story.tsx
+++ b/web/packages/teleport/src/TopBar/TopBar.story.tsx
@@ -25,7 +25,12 @@ import { makeUserContext } from 'teleport/services/user';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 import { LayoutContextProvider } from 'teleport/Main/LayoutContext';
 
+import { mockUserPreferencesResponse } from 'teleport/User/mock';
+import { UserContextProvider } from 'teleport/User';
+
 import { TopBar } from './TopBar';
+
+const { worker } = window.msw;
 
 export default {
   title: 'Teleport/TopBar',
@@ -42,13 +47,17 @@ export function Story() {
     },
   });
 
+  worker.use(mockUserPreferencesResponse());
+
   return (
     <Router history={createMemoryHistory()}>
       <LayoutContextProvider>
         <TeleportContextProvider ctx={ctx}>
-          <FeaturesContextProvider value={getOSSFeatures()}>
-            <TopBar />
-          </FeaturesContextProvider>
+          <UserContextProvider>
+            <FeaturesContextProvider value={getOSSFeatures()}>
+              <TopBar />
+            </FeaturesContextProvider>
+          </UserContextProvider>
         </TeleportContextProvider>
       </LayoutContextProvider>
     </Router>

--- a/web/packages/teleport/src/User/Loading.tsx
+++ b/web/packages/teleport/src/User/Loading.tsx
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from 'styled-components';
+
+export const LoadingContainer = styled.div`
+  flex-direction: column;
+  flex: 1;
+  overflow-x: auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;

--- a/web/packages/teleport/src/User/UserContext.test.tsx
+++ b/web/packages/teleport/src/User/UserContext.test.tsx
@@ -30,6 +30,10 @@ import { UserContextProvider } from 'teleport/User';
 import { ThemePreference } from 'teleport/services/userPreferences/types';
 import { useUser } from 'teleport/User/UserContext';
 import { KeysEnum } from 'teleport/services/localStorage';
+import {
+  mockUserPreferencesFailedResponse,
+  mockUserPreferencesResponse,
+} from 'teleport/User/mock';
 
 function ThemeName() {
   const { preferences } = useUser();
@@ -42,16 +46,7 @@ function ThemeName() {
 }
 
 describe('user context - success state', () => {
-  const server = setupServer(
-    rest.get(cfg.api.userPreferencesPath, (req, res, ctx) => {
-      return res(
-        ctx.json({
-          theme: ThemePreference.Light,
-          assist: {},
-        })
-      );
-    })
-  );
+  const server = setupServer(mockUserPreferencesResponse());
 
   beforeAll(() => server.listen());
   beforeEach(() => localStorage.clear());
@@ -102,11 +97,7 @@ describe('user context - success state', () => {
 });
 
 describe('user context - error state', () => {
-  const server = setupServer(
-    rest.get(cfg.api.userPreferencesPath, (req, res, ctx) => {
-      return res(ctx.status(500));
-    })
-  );
+  const server = setupServer(mockUserPreferencesFailedResponse());
 
   beforeAll(() => server.listen());
   beforeEach(() => localStorage.clear());

--- a/web/packages/teleport/src/User/UserContext.tsx
+++ b/web/packages/teleport/src/User/UserContext.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, {
   createContext,
   PropsWithChildren,
@@ -25,8 +26,6 @@ import useAttempt from 'shared/hooks/useAttemptNext';
 
 import { Indicator } from 'design';
 
-import { StyledIndicator } from 'teleport/Main';
-
 import * as service from 'teleport/services/userPreferences';
 
 import storage, { KeysEnum } from 'teleport/services/localStorage';
@@ -34,6 +33,8 @@ import storage, { KeysEnum } from 'teleport/services/localStorage';
 import { ThemePreference } from 'teleport/services/userPreferences/types';
 
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
+
+import { LoadingContainer } from 'teleport/User/Loading';
 
 import type {
   UserPreferences,
@@ -129,9 +130,9 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
 
   if (attempt.status === 'processing') {
     return (
-      <StyledIndicator>
+      <LoadingContainer>
         <Indicator />
-      </StyledIndicator>
+      </LoadingContainer>
     );
   }
 

--- a/web/packages/teleport/src/User/mock.ts
+++ b/web/packages/teleport/src/User/mock.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { rest } from 'msw';
+
+import cfg from 'teleport/config';
+import { ThemePreference } from 'teleport/services/userPreferences/types';
+
+export function mockUserPreferencesResponse() {
+  return rest.get(cfg.api.userPreferencesPath, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        theme: ThemePreference.Light,
+        assist: {},
+      })
+    );
+  });
+}
+
+export function mockUserPreferencesFailedResponse() {
+  return rest.get(cfg.api.userPreferencesPath, (req, res, ctx) => {
+    return res(ctx.status(500));
+  });
+}

--- a/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
+++ b/web/packages/teleport/src/components/UserMenuNav/UserMenuNav.story.tsx
@@ -1,50 +1,54 @@
-/**
- * Copyright 2022 Gravitational, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+/*
+Copyright 2019 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 
 import React from 'react';
-import { MemoryRouter } from 'react-router';
-import * as Icons from 'design/Icon';
 
-import { UserMenuNav } from './UserMenuNav';
+import { MemoryRouter } from 'react-router';
+
+import { UserMenuNav } from 'teleport/components/UserMenuNav/UserMenuNav';
+import { UserContextProvider } from 'teleport/User';
+import TeleportContextProvider from 'teleport/TeleportContextProvider';
+import TeleportContext from 'teleport/teleportContext';
+import { userContext } from 'teleport/Main/fixtures';
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
+import { getOSSFeatures } from 'teleport/features';
+import { mockUserPreferencesResponse } from 'teleport/User/mock';
+
+const { worker } = window.msw;
 
 export default {
   title: 'Teleport/UserMenuNav',
 };
 
 export function Loaded() {
+  const ctx = new TeleportContext();
+
+  ctx.storeUser.state = userContext;
+
+  worker.use(mockUserPreferencesResponse());
+
   return (
     <MemoryRouter>
-      <UserMenuNav {...props} />
+      <TeleportContextProvider ctx={ctx}>
+        <UserContextProvider>
+          <FeaturesContextProvider value={getOSSFeatures()}>
+            <UserMenuNav username="george" />
+          </FeaturesContextProvider>
+        </UserContextProvider>
+      </TeleportContextProvider>
     </MemoryRouter>
   );
 }
-
-const props = {
-  navItems: [
-    {
-      title: 'Nav Item 1',
-      Icon: Icons.Apple,
-      getLink: () => 'test',
-    },
-    {
-      title: 'Nav Item 2',
-      Icon: Icons.Cloud,
-      getLink: () => 'test2',
-    },
-  ],
-  username: 'george',
-  logout: () => null,
-};


### PR DESCRIPTION
The import from `UserContext.tsx` to `Main.tsx` was breaking storybook as `ContentMinWidth` couldn't be used before instantiation (for some reason), so I moved the styling for the component that was imported to `LoadingContainer.tsx` in the user context, removing its reliance on `Main`.

To fix the stories, I wrapped them in `UserContextProvider` and mocked the API response with msw. I added shareable mocks to the `User/` directory, so tests and stories can both use them.