### PR TITLE
Always use the real clock in pgbk

### DIFF
--- a/lib/backend/pgbk/background.go
+++ b/lib/backend/pgbk/background.go
@@ -38,8 +38,8 @@ func (b *Backend) backgroundExpiry(ctx context.Context) {
 			var n int64
 			if err := b.retry(ctx, func(p *pgxpool.Pool) error {
 				tag, err := p.Exec(ctx,
-					"DELETE FROM kv WHERE key = ANY(ARRAY(SELECT key FROM kv WHERE expires IS NOT NULL AND expires <= $1 LIMIT $2))",
-					b.clock.Now().UTC(), expiryBatchSize,
+					"DELETE FROM kv WHERE key = ANY(ARRAY(SELECT key FROM kv WHERE expires IS NOT NULL AND expires <= now() LIMIT $1))",
+					expiryBatchSize,
 				)
 				if err != nil {
 					return trace.Wrap(err)


### PR DESCRIPTION
This PR makes it so that pgbk will use the server time for expiry calculations, making the view of all auth servers consistent.