### PR TITLE
Extend Resource Access Requests to all Kubernetes kinds

### DIFF
--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -606,7 +606,8 @@ func (k *KubernetesResourceV1) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 
-	if len(k.Spec.Namespace) == 0 {
+	// Unless the resource is cluster-wide, it must have a namespace.
+	if len(k.Spec.Namespace) == 0 && !slices.Contains(KubernetesClusterWideResourceKinds, k.Kind) {
 		return trace.BadParameter("missing kubernetes namespace")
 	}
 

--- a/api/types/role.go
+++ b/api/types/role.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"path"
 	"time"
 
 	"github.com/gogo/protobuf/proto"
@@ -1648,7 +1649,7 @@ func validateKubeResources(roleVersion string, kubeResources []KubernetesResourc
 // ClusterResource returns the resource name in the following format
 // <namespace>/<name>.
 func (k *KubernetesResource) ClusterResource() string {
-	return k.Namespace + "/" + k.Name
+	return path.Join(k.Namespace, k.Name)
 }
 
 // IsEmpty will return true if the condition is empty.

--- a/lib/kube/grpc/grpc.go
+++ b/lib/kube/grpc/grpc.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/exp/slices"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiproto "github.com/gravitational/teleport/api/client/proto"
@@ -118,8 +119,8 @@ func (c *Config) CheckAndSetDefaults() error {
 	return nil
 }
 
-// ListKubernetesResources returns the list of pods available for the user for
-// the specified Kubernetes cluster and namespace.
+// ListKubernetesResources returns the list of resources available for the user for
+// the specified Resource kind, Kubernetes cluster and namespace.
 func (s *Server) ListKubernetesResources(ctx context.Context, req *proto.ListKubernetesResourcesRequest) (*proto.ListKubernetesResourcesResponse, error) {
 	userContext, err := s.authorize(ctx)
 	if err != nil {
@@ -157,8 +158,8 @@ func (s *Server) ListKubernetesResources(ctx context.Context, req *proto.ListKub
 	case requiresFakePagination(req):
 		rsp, err := s.listResourcesUsingFakePagination(ctx, identity, req)
 		return rsp, trail.ToGRPC(err)
-	case req.ResourceType == types.KindKubePod:
-		rsp, err := s.listKubernetesPods(ctx, identity, true, req)
+	case slices.Contains(types.KubernetesResourcesKinds, req.ResourceType):
+		rsp, err := s.listKubernetesResources(ctx, identity, true, req)
 		return rsp, trail.ToGRPC(err)
 	default:
 		return nil, trail.ToGRPC(trace.BadParameter("unsupported resource type %q", req.ResourceType))
@@ -195,12 +196,13 @@ func (s *Server) emitAuditEvent(ctx context.Context, userContext *authz.Context,
 	return trace.Wrap(err)
 }
 
-// listKubernetesPods returns the list of pods available for the user for
+// listKubernetesResources returns the list of resources available for the user for
 // the specified Kubernetes cluster and namespace. If respectLimit is true,
 // the limit will be respected, otherwise the limit will be ignored and we return
-// all pods available to the user. If any search parameters are specified, the
-// only pods returned will be those that match the search parameters.
-func (s *Server) listKubernetesPods(
+// all resources from type=req.ResourceType available to the user.
+// If any search parameters are specified, the only resources returned will be
+// those that match the search parameters.
+func (s *Server) listKubernetesResources(
 	ctx context.Context,
 	identity tlsca.Identity,
 	respectLimit bool,
@@ -222,7 +224,7 @@ func (s *Server) listKubernetesPods(
 	}
 
 	rsp := &proto.ListKubernetesResourcesResponse{}
-	err := s.iterateKubernetesPods(
+	err := s.iterateKubernetesResources(
 		ctx, identity, req, respectLimit,
 		func(r *types.KubernetesResourceV1, continueKey string) (int, error) {
 			switch match, err := services.MatchResourceByFilters(r, filter, nil /* ignore dup matches  */); {
@@ -242,9 +244,9 @@ func (s *Server) listKubernetesPods(
 	return rsp, trace.Wrap(err)
 }
 
-// iterateKubernetesPods creates a new Kubernetes Client with temporary user
-// certificates and iterates through the returned Kubernetes Pods.
-// For each Pod discovered, the fn function is called to decide the action.
+// iterateKubernetesResources creates a new Kubernetes Client with temporary user
+// certificates and iterates through the returned Kubernetes resources.
+// For each resources discovered, the fn function is called to decide the action.
 // Kubernetes continue key is a base64 encoded json payload with the resource
 // version of the request. In order to resume the operation when using the paginated
 // mode, Teleport respects the Kubernetes Continue Key and will return it to the client
@@ -252,7 +254,7 @@ func (s *Server) listKubernetesPods(
 // In order to have the expected behavior Teleport must respect the ContinueKey and
 // cannot manipulate it. It means that Teleport needs to manipulate the number of
 // requested items from the Kubernetes Cluster in order to have the expected behavior.
-func (s *Server) iterateKubernetesPods(
+func (s *Server) iterateKubernetesResources(
 	ctx context.Context,
 	identity tlsca.Identity,
 	req *proto.ListKubernetesResourcesRequest,
@@ -268,29 +270,174 @@ func (s *Server) iterateKubernetesPods(
 	continueKey := req.StartKey
 	itemsAppended := 0
 	for {
-		podList, err := kubeClient.CoreV1().Pods(req.KubernetesNamespace).List(ctx, metav1.ListOptions{
-			Limit:    decideLimit(int64(req.Limit), int64(itemsAppended), respectLimit),
-			Continue: continueKey,
-		})
-		if err != nil {
-			return trace.Wrap(err)
+		var (
+			items           []kObject
+			nextContinueKey string
+			listOpts        = metav1.ListOptions{
+				Limit:    decideLimit(int64(req.Limit), int64(itemsAppended), respectLimit),
+				Continue: continueKey,
+			}
+		)
+
+		switch req.ResourceType {
+		case types.KindKubePod:
+			lItems, err := kubeClient.CoreV1().Pods(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeSecret:
+			lItems, err := kubeClient.CoreV1().Secrets(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeConfigmap:
+			lItems, err := kubeClient.CoreV1().ConfigMaps(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeNamespace:
+			lItems, err := kubeClient.CoreV1().Namespaces().List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeService:
+			lItems, err := kubeClient.CoreV1().Services(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeServiceAccount:
+			lItems, err := kubeClient.CoreV1().ServiceAccounts(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeNode:
+			lItems, err := kubeClient.CoreV1().Nodes().List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubePersistentVolume:
+			lItems, err := kubeClient.CoreV1().PersistentVolumes().List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubePersistentVolumeClaim:
+			lItems, err := kubeClient.CoreV1().PersistentVolumeClaims(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeDeployment:
+			lItems, err := kubeClient.AppsV1().Deployments(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeReplicaSet:
+			lItems, err := kubeClient.AppsV1().ReplicaSets(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeStatefulset:
+			lItems, err := kubeClient.AppsV1().StatefulSets(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeDaemonSet:
+			lItems, err := kubeClient.AppsV1().DaemonSets(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeClusterRole:
+			lItems, err := kubeClient.RbacV1().ClusterRoles().List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeRole:
+			lItems, err := kubeClient.RbacV1().Roles(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeClusterRoleBinding:
+			lItems, err := kubeClient.RbacV1().ClusterRoleBindings().List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeRoleBinding:
+			lItems, err := kubeClient.RbacV1().RoleBindings(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeCronjob:
+			lItems, err := kubeClient.BatchV1().CronJobs(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeJob:
+			lItems, err := kubeClient.BatchV1().Jobs(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeCertificateSigningRequest:
+			lItems, err := kubeClient.CertificatesV1().CertificateSigningRequests().List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		case types.KindKubeIngress:
+			lItems, err := kubeClient.NetworkingV1().Ingresses(req.KubernetesNamespace).List(ctx, listOpts)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			items = itemListToKObjectList(itemListToItemListPtr(lItems.Items))
+			nextContinueKey = lItems.Continue
+		default:
+			return trace.BadParameter("unsupported resource type: %q", req.ResourceType)
 		}
 
-		for _, pod := range podList.Items {
-			resource, err := types.NewKubernetesPodV1(
-				types.Metadata{
-					Name:   pod.Name,
-					Labels: pod.Labels,
-				},
-				types.KubernetesResourceSpecV1{
-					Namespace: pod.Namespace,
-				},
-			)
+		for _, resource := range items {
+			resource, err := getKubernetesResourceFromKObject(resource, req.ResourceType)
 			if err != nil {
 				return trace.Wrap(err)
 			}
 
-			itemsAppended, err = fn(resource, podList.Continue)
+			itemsAppended, err = fn(resource, nextContinueKey)
 			if errors.Is(err, errDone) {
 				return nil
 			} else if err != nil {
@@ -298,11 +445,58 @@ func (s *Server) iterateKubernetesPods(
 			}
 		}
 
-		if len(podList.Continue) == 0 {
+		if len(nextContinueKey) == 0 {
 			return nil
 		}
-		continueKey = podList.Continue
+		continueKey = nextContinueKey
 	}
+}
+
+// kObject is an interface that all Kubernetes objects implement.
+type kObject interface {
+	GetName() string
+	GetNamespace() string
+	GetLabels() map[string]string
+}
+
+// getKubernetesResourceFromKObject converts a Kubernetes object to a
+// KubernetesResourceV1.
+func getKubernetesResourceFromKObject(
+	kObj kObject,
+	resourceType string,
+) (*types.KubernetesResourceV1, error) {
+	return types.NewKubernetesResourceV1(
+		resourceType,
+		types.Metadata{
+			Name:   kObj.GetName(),
+			Labels: kObj.GetLabels(),
+		},
+		types.KubernetesResourceSpecV1{
+			Namespace: kObj.GetNamespace(),
+		},
+	)
+}
+
+// itemListToItemListPtr is a helper function that converts a list of items
+// to a list of pointers to items.
+// This is needed because the Kubernetes API returns a list of items, but
+// only a list of pointers to items satisfies the kObject interface.
+func itemListToItemListPtr[T any](items []T) []*T {
+	kObjects := make([]*T, len(items))
+	for i := range items {
+		kObjects[i] = &(items[i])
+	}
+	return kObjects
+}
+
+// itemListToKObjectList is a helper function that converts a list of items
+// to a list of kObjects.
+func itemListToKObjectList[T kObject](items []T) []kObject {
+	kObjects := make([]kObject, len(items))
+	for i, item := range items {
+		kObjects[i] = item
+	}
+	return kObjects
 }
 
 // listResourcesUsingFakePagination is a helper function that lists Kubernetes
@@ -317,8 +511,8 @@ func (s *Server) listResourcesUsingFakePagination(
 		err error
 	)
 	switch {
-	case req.ResourceType == types.KindKubePod:
-		rsp, err = s.listKubernetesPods(ctx, identity, false /* do not respect the limit value */, req)
+	case slices.Contains(types.KubernetesResourcesKinds, req.ResourceType):
+		rsp, err = s.listKubernetesResources(ctx, identity, false /* do not respect the limit value */, req)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -131,19 +131,25 @@ func NewKubeAPIMock() (*KubeMockServer, error) {
 
 func (s *KubeMockServer) setup() {
 	s.router.UseRawPath = true
-	s.router.POST("/api/:ver/namespaces/:podNamespace/pods/:podName/exec", s.withWriter(s.exec))
-	s.router.GET("/api/:ver/namespaces/:podNamespace/pods/:podName/exec", s.withWriter(s.exec))
-	s.router.GET("/api/:ver/namespaces/:podNamespace/pods/:podName/portforward", s.withWriter(s.portforward))
-	s.router.POST("/api/:ver/namespaces/:podNamespace/pods/:podName/portforward", s.withWriter(s.portforward))
+	s.router.POST("/api/:ver/namespaces/:namespace/pods/:name/exec", s.withWriter(s.exec))
+	s.router.GET("/api/:ver/namespaces/:namespace/pods/:name/exec", s.withWriter(s.exec))
+	s.router.GET("/api/:ver/namespaces/:namespace/pods/:name/portforward", s.withWriter(s.portforward))
+	s.router.POST("/api/:ver/namespaces/:namespace/pods/:name/portforward", s.withWriter(s.portforward))
 
 	s.router.GET("/apis/rbac.authorization.k8s.io/:ver/clusterroles", s.withWriter(s.listClusterRoles))
 	s.router.GET("/apis/rbac.authorization.k8s.io/:ver/clusterroles/:name", s.withWriter(s.getClusterRole))
 	s.router.DELETE("/apis/rbac.authorization.k8s.io/:ver/clusterroles/:name", s.withWriter(s.deleteClusterRole))
 
-	s.router.GET("/api/:ver/namespaces/:podNamespace/pods", s.withWriter(s.listPods))
+	s.router.GET("/api/:ver/namespaces/:namespace/pods", s.withWriter(s.listPods))
 	s.router.GET("/api/:ver/pods", s.withWriter(s.listPods))
-	s.router.GET("/api/:ver/namespaces/:podNamespace/pods/:podName", s.withWriter(s.getPod))
-	s.router.DELETE("/api/:ver/namespaces/:podNamespace/pods/:podName", s.withWriter(s.deletePod))
+	s.router.GET("/api/:ver/namespaces/:namespace/pods/:name", s.withWriter(s.getPod))
+	s.router.DELETE("/api/:ver/namespaces/:namespace/pods/:name", s.withWriter(s.deletePod))
+
+	s.router.GET("/api/:ver/namespaces/:namespace/secrets", s.withWriter(s.listSecrets))
+	s.router.GET("/api/:ver/secrets", s.withWriter(s.listSecrets))
+	s.router.GET("/api/:ver/namespaces/:namespace/secrets/:name", s.withWriter(s.getSecret))
+	s.router.DELETE("/api/:ver/namespaces/:namespace/secrets/:name", s.withWriter(s.deleteSecret))
+
 	s.router.POST("/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", s.withWriter(s.selfSubjectAccessReviews))
 	s.server = httptest.NewUnstartedServer(s.router)
 	s.server.EnableHTTP2 = true
@@ -187,8 +193,8 @@ func (s *KubeMockServer) exec(w http.ResponseWriter, req *http.Request, p httpro
 	q := req.URL.Query()
 
 	request := remoteCommandRequest{
-		podNamespace:       p.ByName("podNamespace"),
-		podName:            p.ByName("podName"),
+		namespace:          p.ByName("namespace"),
+		name:               p.ByName("name"),
 		containerName:      q.Get("container"),
 		cmd:                q["command"],
 		stdin:              utils.AsBool(q.Get("stdin")),
@@ -265,8 +271,8 @@ func (s *KubeMockServer) exec(w http.ResponseWriter, req *http.Request, p httpro
 
 // remoteCommandRequest is a request to execute a remote command
 type remoteCommandRequest struct {
-	podNamespace       string
-	podName            string
+	namespace          string
+	name               string
 	containerName      string
 	cmd                []string
 	stdin              bool
@@ -596,7 +602,7 @@ func (s *KubeMockServer) portforward(w http.ResponseWriter, req *http.Request, p
 		errStream.Write([]byte(err.Error()))
 		return nil, nil
 	}
-	fmt.Fprint(data, PortForwardPayload, p.ByName("podName"), string(buf[:n]))
+	fmt.Fprint(data, PortForwardPayload, p.ByName("name"), string(buf[:n]))
 	return nil, nil
 }
 

--- a/lib/kube/proxy/testing/kube_server/pods.go
+++ b/lib/kube/proxy/testing/kube_server/pods.go
@@ -65,7 +65,7 @@ func newPod(name, namespace string) corev1.Pod {
 func (s *KubeMockServer) listPods(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
 	items := []corev1.Pod{}
 
-	namespace := p.ByName("podNamespace")
+	namespace := p.ByName("namespace")
 	filter := func(pod corev1.Pod) bool {
 		return len(namespace) == 0 || namespace == pod.Namespace
 	}
@@ -87,8 +87,8 @@ func (s *KubeMockServer) listPods(w http.ResponseWriter, req *http.Request, p ht
 }
 
 func (s *KubeMockServer) getPod(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
-	namespace := p.ByName("podNamespace")
-	name := p.ByName("podName")
+	namespace := p.ByName("namespace")
+	name := p.ByName("name")
 	filter := func(pod corev1.Pod) bool {
 		return pod.Name == name && namespace == pod.Namespace
 	}
@@ -101,8 +101,8 @@ func (s *KubeMockServer) getPod(w http.ResponseWriter, req *http.Request, p http
 }
 
 func (s *KubeMockServer) deletePod(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
-	namespace := p.ByName("podNamespace")
-	name := p.ByName("podName")
+	namespace := p.ByName("namespace")
+	name := p.ByName("name")
 	deleteOpts, err := parseDeleteCollectionBody(req.Body)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/kube/proxy/testing/kube_server/secrets.go
+++ b/lib/kube/proxy/testing/kube_server/secrets.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubeserver
+
+import (
+	"net/http"
+	"path/filepath"
+
+	"github.com/gravitational/trace"
+	"github.com/julienschmidt/httprouter"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+var secretList = corev1.SecretList{
+	TypeMeta: metav1.TypeMeta{
+		Kind:       "SecretList",
+		APIVersion: "v1",
+	},
+	ListMeta: metav1.ListMeta{
+		ResourceVersion: "1231415",
+	},
+	Items: []corev1.Secret{
+		newSecret("secret-1", "default"),
+		newSecret("secret-2", "default"),
+		newSecret("test", "default"),
+		newSecret("secret-1", "dev"),
+		newSecret("secret-2", "dev"),
+	},
+}
+
+func newSecret(name, namespace string) corev1.Secret {
+	return corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func (s *KubeMockServer) listSecrets(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
+	items := []corev1.Secret{}
+
+	namespace := p.ByName("namespace")
+	filter := func(secret corev1.Secret) bool {
+		return len(namespace) == 0 || namespace == secret.Namespace
+	}
+	for _, secret := range secretList.Items {
+		if filter(secret) {
+			items = append(items, secret)
+		}
+	}
+	return &corev1.SecretList{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SecretList",
+			APIVersion: "v1",
+		},
+		ListMeta: metav1.ListMeta{
+			ResourceVersion: "1231415",
+		},
+		Items: items,
+	}, nil
+}
+
+func (s *KubeMockServer) getSecret(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
+	namespace := p.ByName("namespace")
+	name := p.ByName("name")
+	filter := func(secret corev1.Secret) bool {
+		return secret.Name == name && namespace == secret.Namespace
+	}
+	for _, secret := range secretList.Items {
+		if filter(secret) {
+			return secret, nil
+		}
+	}
+	return nil, trace.NotFound("secret %q not found", filepath.Join(namespace, name))
+}
+
+func (s *KubeMockServer) deleteSecret(w http.ResponseWriter, req *http.Request, p httprouter.Params) (any, error) {
+	namespace := p.ByName("namespace")
+	name := p.ByName("name")
+	deleteOpts, err := parseDeleteCollectionBody(req.Body)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	reqID := ""
+	if deleteOpts.Preconditions != nil && deleteOpts.Preconditions.UID != nil {
+		reqID = string(*deleteOpts.Preconditions.UID)
+	}
+	filter := func(secret corev1.Secret) bool {
+		return secret.Name == name && namespace == secret.Namespace
+	}
+	for _, secret := range secretList.Items {
+		if filter(secret) {
+			s.mu.Lock()
+			s.deletedResources[deletedResource{kind: types.KindKubeSecret, requestID: reqID}] = append(s.deletedResources[deletedResource{kind: types.KindKubeSecret, requestID: reqID}], filepath.Join(namespace, name))
+			s.mu.Unlock()
+			return secret, nil
+		}
+	}
+	return nil, trace.NotFound("secret %q not found", filepath.Join(namespace, name))
+}

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -8097,7 +8097,7 @@ func TestKubeResourcesMatcher(t *testing.T) {
 			// because unmatchedResources is not empty.
 			wantMatch:          boolsToSlice(true),
 			assertErr:          require.NoError,
-			unmatchedResources: []string{"default/nginx*"},
+			unmatchedResources: []string{"pod/default/nginx*"},
 		},
 		{
 			name: "user requests a valid subset of pods but distributed across two roles",
@@ -8136,7 +8136,7 @@ func TestKubeResourcesMatcher(t *testing.T) {
 			},
 			wantMatch:          boolsToSlice(false, false),
 			assertErr:          require.NoError,
-			unmatchedResources: []string{"default/pod"},
+			unmatchedResources: []string{"pod/default/pod"},
 		},
 		{
 			name: "user requests a denied pod",
@@ -8170,7 +8170,7 @@ func TestKubeResourcesMatcher(t *testing.T) {
 			},
 			wantMatch:          boolsToSlice(false),
 			assertErr:          require.Error,
-			unmatchedResources: []string{"default/restricted"},
+			unmatchedResources: []string{"pod/default/restricted"},
 		},
 	}
 	for _, tt := range tests {

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -382,7 +383,7 @@ func onRequestSearch(cf *CLIConf) error {
 	if cf.KubernetesCluster == "" {
 		cf.KubernetesCluster = selectedKubeCluster(tc.SiteName)
 	}
-	if cf.ResourceKind == types.KindKubePod && cf.KubernetesCluster == "" {
+	if slices.Contains(types.KubernetesResourcesKinds, cf.ResourceKind) && cf.KubernetesCluster == "" {
 		return trace.BadParameter("when searching for Pods, --kube-cluster cannot be empty")
 	}
 	// if --all-namespaces flag was provided we search in every namespace.
@@ -459,7 +460,7 @@ func onRequestSearch(cf *CLIConf) error {
 				ClusterName:     tc.SiteName,
 				Kind:            resource.GetKind(),
 				Name:            cf.KubernetesCluster,
-				SubResourceName: fmt.Sprintf("%s/%s", r.Spec.Namespace, resource.GetName()),
+				SubResourceName: path.Join(r.Spec.Namespace, resource.GetName()),
 			})
 			if ignoreDuplicateResourceId(deduplicateResourceIDs, resourceID) {
 				continue


### PR DESCRIPTION
This PR adds support for resource access requests for the following Kubernetes kinds:

- KindKubeSecret
- KindKubeConfigmap
- KindKubeNamespace
- KindKubeService
- KindKubeServiceAccount
- KindKubeNode
- KindKubePersistentVolume
- KindKubePersistentVolumeClaim
- KindKubeDeployment
- KindKubeReplicaSet
- KindKubeStatefulset
- KindKubeDaemonSet
- KindKubeClusterRole
- KindKubeRole
- KindKubeClusterRoleBinding
- KindKubeRoleBinding
- KindKubeCronjob
- KindKubeJob
- KindKubeCertificateSigningRequest
- KindKubeIngress

It extends and generalizes existing support of KindKubePod.