### PR TITLE
improve startup with empty db or discovery config

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -225,7 +225,7 @@ const (
 	// been set up.
 	InstanceReady = "InstanceReady"
 
-	// DiscoveryReady is generated when the Teleport database proxy service
+	// DiscoveryReady is generated when the Teleport discovery service
 	// is ready to start accepting connections.
 	DiscoveryReady = "DiscoveryReady"
 
@@ -1072,7 +1072,7 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 	if cfg.Tracing.Enabled {
 		eventMapping.In = append(eventMapping.In, TracingReady)
 	}
-	if cfg.Discovery.Enabled {
+	if process.shouldInitDiscovery() {
 		eventMapping.In = append(eventMapping.In, DiscoveryReady)
 	}
 
@@ -1124,6 +1124,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		process.initDatabases()
 		serviceStarted = true
 	} else {
+		if process.Config.Databases.Enabled {
+			process.log.Warn("Database service is enabled with empty configuration, skipping initialization")
+		}
 		warnOnErr(process.closeImportedDescriptors(teleport.ComponentDatabase), process.log)
 	}
 
@@ -1145,6 +1148,9 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 		process.initDiscovery()
 		serviceStarted = true
 	} else {
+		if process.Config.Discovery.Enabled {
+			process.log.Warn("Discovery service is enabled with empty configuration, skipping initialization")
+		}
 		warnOnErr(process.closeImportedDescriptors(teleport.ComponentDiscovery), process.log)
 	}
 


### PR DESCRIPTION
This is tiny PR to fix log spamming when `teleport` is started with a discovery service `enabled: true` but which has an empty config. Prior to this PR, we added DiscoveryReady to the event mapping, but skipped initializing it, so the logs would just spam this message constantly:
```
2023-06-30T13:20:16-07:00 [PROC:1]    DEBU Teleport not yet ready: still waiting for DiscoveryReady pid:55142.1 service/supervisor.go:415
2023-06-30T13:20:16-07:00 [PROC:1]    DEBU Teleport not yet ready: still waiting for DiscoveryReady pid:55142.1 service/supervisor.go:415
2023-06-30T13:20:16-07:00 [PROC:1]    DEBU Teleport not yet ready: still waiting for DiscoveryReady pid:55142.1 service/supervisor.go:415
2023-06-30T13:20:19-07:00 [PROC:1]    DEBU Teleport not yet ready: still waiting for DiscoveryReady pid:55142.1 service/supervisor.go:415
```

Instead, it will now print a warning that the enabled service was not initialized due to empty config, and skip adding it to the event mapping.