### PR TITLE
[v13] fix: Use correct sync defaults and validation

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -5795,8 +5795,7 @@ message JamfInventoryEntry {
   // PARTIAL syncs are scheduled in the time window between FULL syncs, so
   // sync_period_partial must always be smaller than sync_period_full, otherwise
   // it would never trigger.
-  // Set to negative to disable PARTIAL syncs.
-  // Defaults to 6h.
+  // Set to zero or negative to disable PARTIAL syncs.
   int64 sync_period_partial = 2 [
     (gogoproto.jsontag) = "sync_period_partial,omitempty",
     (gogoproto.casttype) = "Duration"
@@ -5804,8 +5803,7 @@ message JamfInventoryEntry {
   // Sync period for FULL syncs.
   // Ideally sync_period_full is a multiple of sync_period_partial, so schedules
   // line up perfectly.
-  // Set to negative to disable FULL syncs.
-  // Defaults to 24h.
+  // Set to zero or negative to disable FULL syncs.
   int64 sync_period_full = 3 [
     (gogoproto.jsontag) = "sync_period_full,omitempty",
     (gogoproto.casttype) = "Duration"

--- a/api/types/jamf.go
+++ b/api/types/jamf.go
@@ -17,7 +17,6 @@ package types
 import (
 	"net/url"
 	"strings"
-	"time"
 
 	"github.com/gravitational/trace"
 	"golang.org/x/exp/slices"
@@ -38,15 +37,6 @@ var JamfOnMissingActions = []string{
 	JamfOnMissingNoop,
 	JamfOnMissingDelete,
 }
-
-const (
-	// JamfSyncPeriodPartialDefault is the default value for sync_period_partial
-	// in inventory entries.
-	JamfSyncPeriodPartialDefault = 6 * time.Hour
-	// JamfSyncPeriodFullDefault is the default value for sync_period_full in
-	// inventory entries.
-	JamfSyncPeriodFullDefault = 24 * time.Hour
-)
 
 // ValidateJamfSpecV1 validates a [JamfSpecV1] instance.
 func ValidateJamfSpecV1(s *JamfSpecV1) error {
@@ -77,15 +67,9 @@ func ValidateJamfSpecV1(s *JamfSpecV1) error {
 		}
 
 		syncPartial := e.SyncPeriodPartial
-		if syncPartial == 0 {
-			syncPartial = Duration(JamfSyncPeriodPartialDefault)
-		}
 		syncFull := e.SyncPeriodFull
-		if syncFull == 0 {
-			syncFull = Duration(JamfSyncPeriodFullDefault)
-		}
-		if syncPartial > syncFull {
-			return trace.BadParameter("inventory[%v]: sync_period_partial is greater than sync_period_full, partial syncs will never happen", i)
+		if syncFull > 0 && syncPartial >= syncFull {
+			return trace.BadParameter("inventory[%v]: sync_period_partial is greater or equal to sync_period_full, partial syncs will never happen", i)
 		}
 	}
 

--- a/api/types/jamf_test.go
+++ b/api/types/jamf_test.go
@@ -148,7 +148,7 @@ func TestValidateJamfSpecV1(t *testing.T) {
 					},
 				}
 			}),
-			wantErr: "greater than sync_period_full",
+			wantErr: "greater or equal to sync_period_full",
 		},
 		{
 			name: "inventory on_missing invalid",
@@ -161,6 +161,42 @@ func TestValidateJamfSpecV1(t *testing.T) {
 				}
 			}),
 			wantErr: "on_missing",
+		},
+		{
+			name: "inventory sync_partial disabled",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Inventory = []*types.JamfInventoryEntry{
+					validEntry,
+					{
+						SyncPeriodPartial: -1,
+						SyncPeriodFull:    types.Duration(8 * time.Hour),
+					},
+				}
+			}),
+		},
+		{
+			name: "inventory sync_full disabled",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Inventory = []*types.JamfInventoryEntry{
+					validEntry,
+					{
+						SyncPeriodPartial: types.Duration(12 * time.Hour),
+						SyncPeriodFull:    -1,
+					},
+				}
+			}),
+		},
+		{
+			name: "inventory all syncs disabled",
+			spec: modify(func(spec *types.JamfSpecV1) {
+				spec.Inventory = []*types.JamfInventoryEntry{
+					validEntry,
+					{
+						SyncPeriodPartial: 0,
+						SyncPeriodFull:    0,
+					},
+				}
+			}),
 		},
 	}
 	for _, test := range tests {

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -15566,14 +15566,12 @@ type JamfInventoryEntry struct {
 	// PARTIAL syncs are scheduled in the time window between FULL syncs, so
 	// sync_period_partial must always be smaller than sync_period_full, otherwise
 	// it would never trigger.
-	// Set to negative to disable PARTIAL syncs.
-	// Defaults to 6h.
+	// Set to zero or negative to disable PARTIAL syncs.
 	SyncPeriodPartial Duration `protobuf:"varint,2,opt,name=sync_period_partial,json=syncPeriodPartial,proto3,casttype=Duration" json:"sync_period_partial,omitempty"`
 	// Sync period for FULL syncs.
 	// Ideally sync_period_full is a multiple of sync_period_partial, so schedules
 	// line up perfectly.
-	// Set to negative to disable FULL syncs.
-	// Defaults to 24h.
+	// Set to zero or negative to disable FULL syncs.
 	SyncPeriodFull Duration `protobuf:"varint,3,opt,name=sync_period_full,json=syncPeriodFull,proto3,casttype=Duration" json:"sync_period_full,omitempty"`
 	// on_missing is the trigger used on devices missing from the MDM view in a
 	// FULL sync.


### PR DESCRIPTION
Backport #28540 to branch/v13

Apply the following fixes to our config validation, so it matches [docs][1] and [implementation][2]:

* Sync periods are disabled with zero or -1
* Sync periods have no default
* Disabling either or both periods is allowed

[1]: https://github.com/gravitational/teleport/blob/20559218ad693de5d3cfd432307063416da6acbd/docs/pages/includes/config-reference/jamf-service.yaml#L46-L56
[2]: https://github.com/gravitational/teleport.e/blob/f0b35b878a4223cc265dc24e034520dacbd9c733/lib/mdm/scheduler.go#L29-L38