### PR TITLE
Use more restrictive S3 object permissions

### DIFF
--- a/docs/pages/includes/s3-iam-policy.mdx
+++ b/docs/pages/includes/s3-iam-policy.mdx
@@ -41,7 +41,8 @@ You'll need to replace these values in the policy example below:
             "Action": [
                 "s3:GetObjectVersion",
                 "s3:GetObjectRetention",
-                "s3:*Object",
+                "s3:GetObject",
+                "s3:PutObject",
                 "s3:ListMultipartUploadParts",
                 "s3:AbortMultipartUpload"
             ],


### PR DESCRIPTION
Fixes #28449

Change the `docs/pages/includes/s3-iam-policy.mdx` partial to define a more restrictive list of S3 permissions.

Currently, the partial includes the `s3:*Object` action. This change expands the wildcard for only the permissions that the Auth Service needs.

All the possible `s3:*Object` permissions are:

`DeleteObject`
`GetObject`
`PutObject`
`ReplicateObject`
`RestoreObject`

The Auth Service needs `GetObject` for `*Handler.Download` and `PutObject` for `*Handler.Upload` (lib/events/s3sessions/s3handler.go), but only uses `DeleteObject` for tests in `*Handler.deleteBucket`. It doesn't seem to need `ReplicateObject` or `RestoreObject`.