### PR TITLE
Update `AD` configuration validation requirement for SQL Server RDS proxy databases

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -188,7 +188,7 @@ func ValidateDatabase(db types.Database) error {
 	}
 
 	// Validate Active Directory specific configuration, when Kerberos auth is required.
-	if db.GetProtocol() == defaults.ProtocolSQLServer && (db.GetAD().Domain != "" || !strings.Contains(db.GetURI(), azureutils.MSSQLEndpointSuffix)) {
+	if needsADValidation(db) {
 		if db.GetAD().KeytabFile == "" && db.GetAD().KDCHostName == "" {
 			return trace.BadParameter("either keytab file path or kdc_host_name must be provided for database %q, both are missing", db.GetName())
 		}
@@ -226,6 +226,28 @@ func ValidateDatabase(db types.Database) error {
 	}
 
 	return nil
+}
+
+// needsADValidation returns whether a database AD configuration needs to
+// be validated.
+func needsADValidation(db types.Database) bool {
+	if db.GetProtocol() != defaults.ProtocolSQLServer {
+		return false
+	}
+
+	// Domain is always required when configuring the AD section, so we assume
+	// users intend to use Kerberos authentication if the configuration has it.
+	if db.GetAD().Domain != "" {
+		return true
+	}
+
+	// Azure-hosted databases and RDS Proxy support other authentication
+	// methods, and do not require this section to be validated.
+	if strings.Contains(db.GetURI(), azureutils.MSSQLEndpointSuffix) || db.GetAWS().RDSProxy.Name != "" {
+		return false
+	}
+
+	return true
 }
 
 // needsURIValidation returns whether a database URI needs to be validated.

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -284,6 +284,135 @@ func TestValidateDatabase(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			inputName: "invalid-mssql-without-ad",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.goteleport.com:1433",
+				AD:       types.AD{},
+			},
+			expectError: true,
+		},
+		{
+			inputName: "valid-mssql-kerberos-keytabfile",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.goteleport.com:1433",
+				AD: types.AD{
+					KeytabFile: "path-to.keytab",
+					Krb5File:   "path-to.krb5",
+					Domain:     "domain.goteleport.com",
+					SPN:        "MSSQLSvc/sqlserver.goteleport.com:1433",
+				},
+			},
+			expectError: false,
+		},
+		{
+			inputName: "valid-mssql-kerberos-kdchostname",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.goteleport.com:1433",
+				AD: types.AD{
+					KDCHostName: "DOMAIN-CONTROLLER.domain.goteleport.com",
+					Krb5File:    "path-to.krb5",
+					Domain:      "domain.goteleport.com",
+					SPN:         "MSSQLSvc/sqlserver.goteleport.com:1433",
+					LDAPCert:    "-----BEGIN CERTIFICATE-----",
+				},
+			},
+			expectError: false,
+		},
+		{
+			inputName: "invalid-mssql-kerberos-kdchostname-without-ldapcert",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.goteleport.com:1433",
+				AD: types.AD{
+					KDCHostName: "DOMAIN-CONTROLLER.domain.goteleport.com",
+					Krb5File:    "path-to.krb5",
+					Domain:      "domain.goteleport.com",
+					SPN:         "MSSQLSvc/sqlserver.goteleport.com:1433",
+				},
+			},
+			expectError: true,
+		},
+		{
+			inputName: "valid-mssql-azure-kerberos",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.database.windows.net:1433",
+				AD: types.AD{
+					KeytabFile: "path-to.keytab",
+					Krb5File:   "path-to.krb5",
+					Domain:     "domain.goteleport.com",
+					SPN:        "MSSQLSvc/sqlserver.database.windows.net:1433",
+				},
+			},
+			expectError: false,
+		},
+		{
+			inputName: "valid-mssql-azure-ad",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.database.windows.net:1433",
+				AD:       types.AD{},
+			},
+			expectError: false,
+		},
+		{
+			inputName: "valid-mssql-rds-kerberos-keytab",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.rds.amazonaws.com:1433",
+				AD: types.AD{
+					KeytabFile: "path-to.keytab",
+					Krb5File:   "path-to.krb5",
+					Domain:     "domain.goteleport.com",
+					SPN:        "MSSQLSvc/sqlserver.rds.amazonaws.com:1433",
+				},
+			},
+			expectError: false,
+		},
+		{
+			inputName: "valid-mssql-aws-rds-proxy",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.rds.amazonaws.com:1433",
+				AWS: types.AWS{
+					RDSProxy: types.RDSProxy{
+						Name: "sqlserver-proxy",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			inputName: "invalid-mssql-rds-kerberos-without-ad",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.rds.amazonaws.com:1433",
+				AD:       types.AD{},
+			},
+			expectError: true,
+		},
+		{
+			inputName: "invalid-mssql-aws-rds-proxy-kerberos-without-spn",
+			inputSpec: types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolSQLServer,
+				URI:      "sqlserver.rds.amazonaws.com:1433",
+				AWS: types.AWS{
+					RDSProxy: types.RDSProxy{
+						Name: "sqlserver-proxy",
+					},
+				},
+				AD: types.AD{
+					KeytabFile: "path-to.keytab",
+					Krb5File:   "path-to.krb5",
+					Domain:     "domain.goteleport.com",
+				},
+			},
+			expectError: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #28092.

For SQL Server RDS proxy databases, Teleport supports IAM token authentication, which makes the `AD` section unnecessary. This PR removes the `AD` validation when users provide the `RDSProxy` configuration for a SQL Server database—allowing it to be created without giving placeholder values.

However, if they provide, the `AD` configuration will still be validated, as this authentication method (Kerberos) will be used.

Here are some configuration examples now supported:

<details>
<summary>mssql-uri.yaml</summary>

```yaml
kind: db
version: v3
metadata:
  name: sql
  description: "MSSQL RDS PROXY"
  labels: {}
spec:
  protocol: "sqlserver"
  uri: "sql-instance.proxy-xxxxxxxxxxxx.us-east-1.rds.amazonaws.com:1433"
```
</details>

<details>
<summary>mssql-aws-config.yaml</summary>

```yaml
kind: db
version: v3
metadata:
  name: sql
  description: "MSSQL RDS PROXY"
  labels: {}
spec:
  protocol: "sqlserver"
  uri: "sql-instance.proxy-xxxxxxxxxxxx.us-east-1.rds.amazonaws.com:1433"
  aws:
    region: "us-east-1"
    account_id: "111111111111"
    rdsproxy:
      name: "sql-instance"
```
</details>