### PR TITLE
docs: correct docker installation table

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -171,8 +171,8 @@ considered deprecated, and they may be removed in future releases.
 </TabItem>
 <TabItem label="Enterprise" scope={["cloud", "enterprise"]}>
 
-| Image name | Teleport version | Includes troubleshooting tools | Image base |
-| - | - | - | - |
+| Image name | Includes troubleshooting tools | Image base |
+| - | - | - |
 | `(=teleport.latest_ent_docker_image=)` | No | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
 | `(=teleport.latest_ent_debug_docker_image=)` | Yes | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
 
@@ -180,8 +180,8 @@ We also provide the following images for FIPS builds of Teleport Enterprise:
 
 | Image name | Includes troubleshooting tools | Image base |
 | - | - | - |
-| `gravitational/teleport-ent-fips-distroless` | No | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
-| `gravitational/teleport-ent-fips-distroless-debug` | Yes | [Ubuntu 20.04](https://hub.docker.com/\_/ubuntu) |
+| `gravitational/teleport-ent-fips-distroless` | No | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
+| `gravitational/teleport-ent-fips-distroless-debug` | Yes | [Distroless Debian 11](https://github.com/GoogleContainerTools/distroless) |
 
 For testing, we always recommend that you use the latest release version of
 Teleport Enterprise, which is currently `(=teleport.latest_ent_docker_image=)`.


### PR DESCRIPTION
- mismatched column in enterprise
- fips distroless listed as ubuntu 20.04 based