### PR TITLE
Remove console.log in AssistContext

### DIFF
--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -148,7 +148,6 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
 
     activeWebSocket.current.onmessage = async event => {
       const data = JSON.parse(event.data) as ServerMessage;
-      console.log('onmessage', data);
 
       switch (data.type) {
         case ServerMessageType.Assist:


### PR DESCRIPTION
Removes a `console.log` that was missed