### PR TITLE
[Assist] Use the reasoning in the UI if available

### DIFF
--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -51,7 +51,7 @@ func TestChat_PromptTokens(t *testing.T) {
 					Content: "Hello",
 				},
 			},
-			want: 697,
+			want: 703,
 		},
 		{
 			name: "system and user messages",
@@ -65,7 +65,7 @@ func TestChat_PromptTokens(t *testing.T) {
 					Content: "Hi LLM.",
 				},
 			},
-			want: 705,
+			want: 711,
 		},
 		{
 			name: "tokenize our prompt",
@@ -79,7 +79,7 @@ func TestChat_PromptTokens(t *testing.T) {
 					Content: "Show me free disk space on localhost node.",
 				},
 			},
-			want: 908,
+			want: 914,
 		},
 	}
 

--- a/lib/ai/model/prompt.go
+++ b/lib/ai/model/prompt.go
@@ -61,7 +61,7 @@ Markdown code snippet formatted in the following schema:
 {
 	"action": string \\ The action to take. Must be one of %v
 	"action_input": string \\ The input to the action
-	"reasoning": string \\ Your reasoning for taking this action
+	"reasoning": string \\ A short consice thought with the reasoning for taking this action
 }
 %v
 

--- a/web/packages/teleport/src/Assist/service.ts
+++ b/web/packages/teleport/src/Assist/service.ts
@@ -204,7 +204,7 @@ export function resolveServerAssistThoughtMessage(
 
   return {
     type: ServerMessageType.AssistThought,
-    message: payload.action,
+    message: payload.reasoning || payload.action,
     created: new Date(message.created_time),
   };
 }

--- a/web/packages/teleport/src/Assist/types.ts
+++ b/web/packages/teleport/src/Assist/types.ts
@@ -162,6 +162,7 @@ export interface CommandResultSummaryPayload {
 
 export interface ThoughtMessagePayload {
   action: string;
+  reasoning: string;
 }
 
 export interface ExecEvent {


### PR DESCRIPTION
This changes the UI to use the `reasoning` value from the JSON payload from Assist, if it is provided by GPT-4. This gives a better message in the chat:

Before:
<img width="516" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/e6d88314-3537-41b5-ac41-43881db86053">

After:
<img width="510" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/7d4660ea-aee2-4ed9-8f18-56016146d146">

(note: these are still pretty long but I can't seem to get them shorter)

I modified the comment for the reasoning to guide GPT-4 to get it to return more of a thought than a strict reasoning, otherwise it would babble on in the wrong tone of voice:

<img width="513" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/00dc287c-600d-4600-a62f-abff8b6a4337">