### PR TITLE
[Assist] Clear the refresh websocket timeout when closing Assist

### DIFF
--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -78,6 +78,7 @@ const TEN_MINUTES = 10 * 60 * 1000;
 
 export function AssistContextProvider(props: PropsWithChildren<unknown>) {
   const activeWebSocket = useRef<WebSocket>(null);
+  // TODO(ryan): this should be removed once https://github.com/gravitational/teleport.e/pull/1609 is implemented
   const executeCommandWebSocket = useRef<WebSocket>(null);
   const refreshWebSocketTimeout = useRef<number | null>(null);
 

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -550,6 +550,10 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
 
   useEffect(() => {
     loadConversations();
+
+    return () => {
+      window.clearTimeout(refreshWebSocketTimeout.current);
+    }
   }, []);
 
   const selectedConversationMessages = useMemo(

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -553,7 +553,7 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
 
     return () => {
       window.clearTimeout(refreshWebSocketTimeout.current);
-    }
+    };
   }, []);
 
   const selectedConversationMessages = useMemo(


### PR DESCRIPTION
Previously, after opening Assist & selecting a conversation/creating a conversation, the websocket would still refresh after 8 minutes even if Assist has been closed. This PR clears the timeout when the `AssistContext` is unmounted.