### PR TITLE
Move database validation to gRPC methods

### DIFF
--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3957,6 +3957,9 @@ func (g *GRPCServer) CreateDatabase(ctx context.Context, database *types.Databas
 	if database.Origin() == "" {
 		database.SetOrigin(types.OriginDynamic)
 	}
+	if err := services.ValidateDatabase(database); err != nil {
+		return nil, trace.Wrap(err)
+	}
 	if err := auth.CreateDatabase(ctx, database); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3971,6 +3974,9 @@ func (g *GRPCServer) UpdateDatabase(ctx context.Context, database *types.Databas
 	}
 	if database.Origin() == "" {
 		database.SetOrigin(types.OriginDynamic)
+	}
+	if err := services.ValidateDatabase(database); err != nil {
+		return nil, trace.Wrap(err)
 	}
 	if err := auth.UpdateDatabase(ctx, database); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -2617,6 +2617,106 @@ func TestPartialHealth(t *testing.T) {
 	}
 }
 
+// TestInvalidDatbases given a database that returns an error on validation, the
+// cache should not be impacted, and the database must be on it. This scenario
+// is most common on Teleport upgrades/downgrades where the database validation
+// can have new rules, causing the existing database to fail on validation.
+func TestInvalidDatabases(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	generateInvalidDB := func(t *testing.T, resourceID int64, name string) types.Database {
+		db := &types.DatabaseV3{Metadata: types.Metadata{
+			ID:   resourceID,
+			Name: name,
+		}, Spec: types.DatabaseSpecV3{
+			Protocol: "invalid-protocol",
+			URI:      "non-empty-uri",
+		}}
+		// Just ensures the database we're using on this test will trigger a
+		// validation failure.
+		require.Error(t, services.ValidateDatabase(db))
+		return db
+	}
+
+	for name, tc := range map[string]struct {
+		storeFunc func(*testing.T, *backend.Wrapper, *Cache)
+	}{
+		"CreateDatabase": {
+			storeFunc: func(t *testing.T, b *backend.Wrapper, _ *Cache) {
+				db := generateInvalidDB(t, 0, "invalid-db")
+				value, err := services.MarshalDatabase(db)
+				require.NoError(t, err)
+				_, err = b.Create(ctx, backend.Item{
+					Key:     backend.Key("db", db.GetName()),
+					Value:   value,
+					Expires: db.Expiry(),
+					ID:      db.GetResourceID(),
+				})
+				require.NoError(t, err)
+			},
+		},
+		"UpdateDatabase": {
+			storeFunc: func(t *testing.T, b *backend.Wrapper, c *Cache) {
+				dbName := "updated-db"
+				validDB, err := types.NewDatabaseV3(types.Metadata{
+					Name: dbName,
+				}, types.DatabaseSpecV3{
+					Protocol: defaults.ProtocolPostgres,
+					URI:      "postgres://localhost",
+				})
+				require.NoError(t, err)
+				require.NoError(t, services.ValidateDatabase(validDB))
+
+				marshalledDB, err := services.MarshalDatabase(validDB)
+				require.NoError(t, err)
+				_, err = b.Create(ctx, backend.Item{
+					Key:     backend.Key("db", validDB.GetName()),
+					Value:   marshalledDB,
+					Expires: validDB.Expiry(),
+					ID:      validDB.GetResourceID(),
+				})
+				require.NoError(t, err)
+
+				// Wait until the database appear on cache.
+				require.Eventually(t, func() bool {
+					if dbs, err := c.GetDatabases(ctx); err == nil {
+						return len(dbs) == 1
+					}
+
+					return false
+				}, time.Second, 100*time.Millisecond, "expected database to be on cache, but nothing found")
+
+				cacheDB, err := c.GetDatabase(ctx, dbName)
+				require.NoError(t, err)
+
+				invalidDB := generateInvalidDB(t, cacheDB.GetResourceID(), cacheDB.GetName())
+				value, err := services.MarshalDatabase(invalidDB)
+				require.NoError(t, err)
+				_, err = b.Update(ctx, backend.Item{
+					Key:     backend.Key("db", cacheDB.GetName()),
+					Value:   value,
+					Expires: invalidDB.Expiry(),
+					ID:      cacheDB.GetResourceID(),
+				})
+				require.NoError(t, err)
+			},
+		},
+	} {
+		tc := tc
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			p := newTestPack(t, ForAuth)
+			t.Cleanup(p.Close)
+
+			tc.storeFunc(t, p.backend, p.cache)
+
+			// Events processing should not restart due to an invalid database error.
+			unexpectedEvent(t, p.eventsC, Reloading)
+		})
+	}
+}
+
 func withKeepalive[T any](fn func(context.Context, T) (*types.KeepAlive, error)) func(context.Context, T) error {
 	return func(ctx context.Context, resource T) error {
 		_, err := fn(ctx, resource)

--- a/lib/services/local/databases.go
+++ b/lib/services/local/databases.go
@@ -74,7 +74,7 @@ func (s *DatabaseService) GetDatabase(ctx context.Context, name string) (types.D
 
 // CreateDatabase creates a new database resource.
 func (s *DatabaseService) CreateDatabase(ctx context.Context, database types.Database) error {
-	if err := services.ValidateDatabase(database); err != nil {
+	if err := database.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
 	value, err := services.MarshalDatabase(database)

--- a/lib/services/local/databases_test.go
+++ b/lib/services/local/databases_test.go
@@ -78,13 +78,12 @@ func TestDatabasesCRUD(t *testing.T) {
 		URI:      "localhost",
 	})
 	require.NoError(t, err)
-	err = service.CreateDatabase(ctx, dbBadURI)
-	require.True(t, trace.IsBadParameter(err))
+	require.NoError(t, service.CreateDatabase(ctx, dbBadURI))
 
 	// Fetch all databases.
 	out, err = service.GetDatabases(ctx)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.Database{db1, db2}, out,
+	require.Empty(t, cmp.Diff([]types.Database{dbBadURI, db1, db2}, out,
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
 	))
 
@@ -118,7 +117,7 @@ func TestDatabasesCRUD(t *testing.T) {
 	require.NoError(t, err)
 	out, err = service.GetDatabases(ctx)
 	require.NoError(t, err)
-	require.Empty(t, cmp.Diff([]types.Database{db2}, out,
+	require.Empty(t, cmp.Diff([]types.Database{dbBadURI, db2}, out,
 		cmpopts.IgnoreFields(types.Metadata{}, "ID"),
 	))
 


### PR DESCRIPTION
Closes #27904 by not calling the `services.ValidateDatabase` on cache initialization and not preventing cache initialization when database validation fails. The `CheckAndSetDefaults` is still being called on the database service.

The `services.ValidateDatabase` call is now into gRPC methods `CreateDatabase` and `UpdateDatabase`. Following other resources that perform their validations on gRPC methods (such as [Access requests](https://github.com/gravitational/teleport/blob/gabrielcorado/change-database-validation/lib/auth/grpcserver.go#L791) and [Users](https://github.com/gravitational/teleport/blob/gabrielcorado/change-database-validation/lib/auth/grpcserver.go#L1043)).

Regarding invalid databases being stored on the database agent cache, this behavior will be similar to before #18776. This PR is not intended to change it, and it will be done in future PRs.