### PR TITLE
WebDiscover: Finish auto deploy screen (iam configure script)

### DIFF
--- a/web/packages/teleport/src/Discover/Database/ConnectAwsAccount/ConnectAwsAccount.tsx
+++ b/web/packages/teleport/src/Discover/Database/ConnectAwsAccount/ConnectAwsAccount.tsx
@@ -27,13 +27,14 @@ import {
 } from 'design';
 import FieldSelect from 'shared/components/FieldSelect';
 import useAttempt from 'shared/hooks/useAttemptNext';
-import { Option } from 'shared/components/Select';
+import { Option as BaseOption } from 'shared/components/Select';
 import Validation, { Validator } from 'shared/components/Validation';
 import { requiredField } from 'shared/components/Validation/rules';
 import TextEditor from 'shared/components/TextEditor';
 
 import cfg from 'teleport/config';
 import {
+  Integration,
   IntegrationKind,
   integrationService,
 } from 'teleport/services/integrations';
@@ -47,6 +48,8 @@ import {
   DiscoverUrlLocationState,
   useDiscover,
 } from '../../useDiscover';
+
+type Option = BaseOption<Integration>;
 
 export function ConnectAwsAccount() {
   const { storeUser } = useTeleport();
@@ -86,7 +89,7 @@ export function ConnectAwsAccount() {
         const options = res.items.map(i => {
           if (i.kind === 'aws-oidc') {
             return {
-              value: i.name,
+              value: i,
               label: i.name,
             };
           }
@@ -149,7 +152,7 @@ export function ConnectAwsAccount() {
 
     updateAgentMeta({
       ...(agentMeta as DbMeta),
-      integrationName: selectedAwsIntegration.value,
+      integration: selectedAwsIntegration.value,
     });
 
     nextStep();

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
@@ -31,6 +31,7 @@ import {
   DiscoverProvider,
   DiscoverContextState,
 } from 'teleport/Discover/useDiscover';
+import { IntegrationStatusCode } from 'teleport/services/integrations';
 
 import { AutoDeploy } from './AutoDeploy';
 
@@ -69,6 +70,15 @@ const Provider = props => {
       agentMatcherLabels: [],
       db: {} as any,
       selectedAwsRdsDb: { region: 'us-east-1' } as any,
+      integration: {
+        kind: 'aws-oidc',
+        name: 'aws-oidc-integration',
+        resourceType: 'integration',
+        spec: {
+          roleArn: 'arn-123',
+        },
+        statusCode: IntegrationStatusCode.Running,
+      },
       ...props.agentMeta,
     },
     currentStep: 0,

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.story.tsx
@@ -72,7 +72,7 @@ const Provider = props => {
       selectedAwsRdsDb: { region: 'us-east-1' } as any,
       integration: {
         kind: 'aws-oidc',
-        name: 'aws-oidc-integration',
+        name: 'integration/aws-oidc',
         resourceType: 'integration',
         spec: {
           roleArn: 'arn-123',

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { render, screen, fireEvent, act } from 'design/utils/testing';
+
+import { ContextProvider } from 'teleport';
+import {
+  AwsRdsDatabase,
+  Integration,
+  IntegrationKind,
+  IntegrationStatusCode,
+  Regions,
+  integrationService,
+} from 'teleport/services/integrations';
+import { createTeleportContext } from 'teleport/mocks/contexts';
+import cfg from 'teleport/config';
+import TeleportContext from 'teleport/teleportContext';
+import {
+  DbMeta,
+  DiscoverContextState,
+  DiscoverProvider,
+} from 'teleport/Discover/useDiscover';
+import {
+  DatabaseEngine,
+  DatabaseLocation,
+} from 'teleport/Discover/SelectResource';
+import { FeaturesContextProvider } from 'teleport/FeaturesContext';
+import { PingTeleportProvider } from 'teleport/Discover/Shared/PingTeleportContext';
+import { ResourceKind } from 'teleport/Discover/Shared';
+import { SHOW_HINT_TIMEOUT } from 'teleport/Discover/Shared/useShowHint';
+
+import { AutoDeploy } from './AutoDeploy';
+
+const mockDbLabels = [{ name: 'env', value: 'prod' }];
+
+const integrationName = 'aws-oidc-integration';
+const region: Regions = 'us-east-2';
+const awsoidcRoleArn = 'role-arn';
+
+const mockAwsRdsDb: AwsRdsDatabase = {
+  engine: 'postgres',
+  name: 'rds-1',
+  uri: 'endpoint-1',
+  status: 'available',
+  labels: mockDbLabels,
+  accountId: 'account-id-1',
+  resourceId: 'resource-id-1',
+  region: region,
+  subnets: ['subnet1', 'subnet2'],
+};
+
+const mocKIntegration: Integration = {
+  kind: IntegrationKind.AwsOidc,
+  name: integrationName,
+  resourceType: 'integration',
+  spec: {
+    roleArn: `doncare/${awsoidcRoleArn}`,
+  },
+  statusCode: IntegrationStatusCode.Running,
+};
+
+describe('test AutoDeploy.tsx', () => {
+  jest.useFakeTimers();
+
+  const teleCtx = createTeleportContext();
+  const discoverCtx: DiscoverContextState = {
+    agentMeta: {
+      resourceName: 'db1',
+      integration: mocKIntegration,
+      selectedAwsRdsDb: mockAwsRdsDb,
+      agentMatcherLabels: mockDbLabels,
+    } as DbMeta,
+    currentStep: 0,
+    nextStep: jest.fn(x => x),
+    prevStep: () => null,
+    onSelectResource: () => null,
+    resourceSpec: {
+      dbMeta: {
+        location: DatabaseLocation.Aws,
+        engine: DatabaseEngine.AuroraMysql,
+      },
+    } as any,
+    viewConfig: null,
+    exitFlow: null,
+    indexedViews: [],
+    setResourceSpec: () => null,
+    updateAgentMeta: jest.fn(x => x),
+    emitErrorEvent: () => null,
+    emitEvent: () => null,
+    eventState: null,
+  };
+
+  beforeEach(() => {
+    jest.spyOn(integrationService, 'deployAwsOidcService').mockResolvedValue({
+      clusterArn: 'cluster-arn',
+      serviceArn: 'service-arn',
+      taskDefinitionArn: 'task-definition',
+      serviceDashboardUrl: 'dashboard-url',
+    });
+
+    jest.spyOn(teleCtx.databaseService, 'fetchDatabases').mockResolvedValue({
+      agents: [],
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('init: labels are rendered, command is not rendered yet', () => {
+    renderAutoDeploy(teleCtx, discoverCtx);
+
+    expect(screen.getByText(/env: prod/i)).toBeInTheDocument();
+    expect(screen.queryByText(/copy\/paste/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/curl/i)).not.toBeInTheDocument();
+  });
+
+  test('clicking button renders command', () => {
+    renderAutoDeploy(teleCtx, discoverCtx);
+
+    fireEvent.click(screen.getByText(/generate command/i));
+
+    expect(screen.getByText(/copy\/paste/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /integrationName=aws-oidc-integration&awsRegion=us-east-2&role=role-arn&taskRole=TeleportDatabaseAccess/i
+      )
+    ).toBeInTheDocument();
+  });
+
+  test('invalid role name', () => {
+    renderAutoDeploy(teleCtx, discoverCtx);
+
+    expect(
+      screen.queryByText(/name can only contain/i)
+    ).not.toBeInTheDocument();
+
+    // add invalid characters in role name
+    const inputEl = screen.getByPlaceholderText(/TeleportDatabaseAccess/i);
+    fireEvent.change(inputEl, { target: { value: 'invalidname!@#!$!%' } });
+
+    fireEvent.click(screen.getByText(/generate command/i));
+    expect(screen.getByText(/name can only contain/i)).toBeInTheDocument();
+
+    // change back to valid name
+    fireEvent.change(inputEl, { target: { value: 'llama' } });
+    expect(
+      screen.queryByText(/name can only contain/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('deploy hint states', async () => {
+    renderAutoDeploy(teleCtx, discoverCtx);
+
+    fireEvent.click(screen.getByText(/Deploy Teleport Service/i));
+
+    await screen.findByText(
+      /Teleport is currently deploying a Database Service/i
+    );
+
+    act(() => jest.advanceTimersByTime(SHOW_HINT_TIMEOUT + 1));
+
+    expect(
+      screen.getByText(
+        /We're still in the process of creating your Database Service/i
+      )
+    ).toBeInTheDocument();
+  });
+});
+
+const TEST_PING_INTERVAL = 1000 * 60 * 5; // 5 minutes
+
+function renderAutoDeploy(
+  ctx: TeleportContext,
+  discoverCtx: DiscoverContextState
+) {
+  return render(
+    <MemoryRouter
+      initialEntries={[
+        { pathname: cfg.routes.discover, state: { entity: 'database' } },
+      ]}
+    >
+      <ContextProvider ctx={ctx}>
+        <FeaturesContextProvider value={[]}>
+          <DiscoverProvider mockCtx={discoverCtx}>
+            <PingTeleportProvider
+              interval={TEST_PING_INTERVAL}
+              resourceKind={ResourceKind.Database}
+            >
+              <AutoDeploy />
+            </PingTeleportProvider>
+          </DiscoverProvider>
+        </FeaturesContextProvider>
+      </ContextProvider>
+    </MemoryRouter>
+  );
+}

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.test.tsx
@@ -169,10 +169,12 @@ describe('test AutoDeploy.tsx', () => {
 
     fireEvent.click(screen.getByText(/Deploy Teleport Service/i));
 
+    // test initial loading state
     await screen.findByText(
       /Teleport is currently deploying a Database Service/i
     );
 
+    // test waiting state
     act(() => jest.advanceTimersByTime(SHOW_HINT_TIMEOUT + 1));
 
     expect(
@@ -180,6 +182,14 @@ describe('test AutoDeploy.tsx', () => {
         /We're still in the process of creating your Database Service/i
       )
     ).toBeInTheDocument();
+
+    // test success state
+    jest.spyOn(teleCtx.databaseService, 'fetchDatabases').mockResolvedValue({
+      agents: [{} as any], // the result doesn't matter, just need size one array.
+    });
+
+    act(() => jest.advanceTimersByTime(TEST_PING_INTERVAL + 1));
+    await screen.findByText(/Successfully created/i);
   });
 });
 

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -328,7 +328,7 @@ const CreateAccessRole = ({
             <TextSelectCopyMulti
               lines={[
                 {
-                  text: `sudo bash -c "$(curl '${scriptUrl}')"`,
+                  text: `bash -c "$(curl '${scriptUrl}')"`,
                 },
               ]}
             />

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -239,8 +239,8 @@ const Heading = ({
         database. Teleport can configure the permissions required to spin up an
         ECS Fargate container (2vCPU, 4GB memory) in your Amazon account with
         the ability to access databases in this region (<Mark>{region}</Mark>).
-        You will only need to do this once for all databases per geographical
-        region. <br />
+        You will only need to do this once per geographical region.
+        <br />
         <br />
         Want to deploy a database service manually from one of your existing
         servers?{' '}
@@ -305,8 +305,8 @@ const CreateAccessRole = ({
         width="440px"
         mr="3"
         onChange={e => setTaskRoleArn(e.target.value)}
-        toolTipContent={`Amazon Resource Names (ARNs) uniquely identifies AWS \
-        resources, in this case you will be naming an IAM role that this \
+        toolTipContent={`Amazon Resource Names (ARNs) uniquely identify AWS \
+        resources. In this case you will naming an IAM role that this \
         deployed service will be using`}
       />
       <ButtonSecondary mb={3} onClick={generateAutoConfigScript}>

--- a/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/AutoDeploy/AutoDeploy.tsx
@@ -20,7 +20,6 @@ import { Box, ButtonSecondary, Link, Text } from 'design';
 import * as Icons from 'design/Icon';
 import FieldInput from 'shared/components/FieldInput';
 import Validation, { Validator } from 'shared/components/Validation';
-import { requiredField } from 'shared/components/Validation/rules';
 import useAttempt from 'shared/hooks/useAttemptNext';
 
 import { TextSelectCopyMulti } from 'teleport/components/TextSelectCopy';
@@ -281,15 +280,17 @@ const CreateAccessRole = ({
       <FieldInput
         mb={4}
         disabled={disabled}
-        rule={requiredField('Task Role ARN is required')}
+        rule={roleArnMatcher}
         label="Name a Task Role ARN"
         autoFocus
         value={taskRoleArn}
         placeholder="teleport"
-        width="400px"
+        width="440px"
         mr="3"
         onChange={e => setTaskRoleArn(e.target.value)}
-        toolTipContent="Lorem ipsume dolores"
+        toolTipContent={`Amazon Resource Names (ARNs) uniquely identifies AWS \
+        resources, in this case you will be naming an IAM role that this \
+        deployed service will be using`}
       />
       <Text mb={2}>
         Then open{' '}
@@ -395,3 +396,22 @@ const StyledBox = styled(Box)`
   padding: ${props => `${props.theme.space[3]}px`};
   border-radius: ${props => `${props.theme.space[2]}px`};
 `;
+
+// ROLE_ARN_REGEX uses the same regex matcher used in the backend:
+// https://github.com/gravitational/teleport/blob/2cba82cb332e769ebc8a658d32ff24ddda79daff/api/utils/aws/identifiers.go#L43
+//
+// Regex checks for alphanumerics and select few characters.
+export const ROLE_ARN_REGEX = /^[\w+=,.@-]+$/;
+const roleArnMatcher = value => () => {
+  const isValid = value.match(ROLE_ARN_REGEX);
+  if (!isValid) {
+    return {
+      valid: false,
+      message:
+        'name must be alphanumerics, including characters such as @ = , . + -',
+    };
+  }
+  return {
+    valid: true,
+  };
+};

--- a/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.tsx
+++ b/web/packages/teleport/src/Discover/Database/DeployService/ManualDeploy/ManualDeploy.tsx
@@ -40,7 +40,11 @@ import {
 import { CommandBox } from 'teleport/Discover/Shared/CommandBox';
 import { DbMeta, useDiscover } from 'teleport/Discover/useDiscover';
 import { DatabaseLocation } from 'teleport/Discover/SelectResource';
-import { DiscoverEventStatus } from 'teleport/services/userEvent';
+import {
+  DiscoverEventStatus,
+  DiscoverServiceDeployMethod,
+  DiscoverServiceDeployType,
+} from 'teleport/services/userEvent';
 
 import {
   ActionButtons,
@@ -153,9 +157,13 @@ export function ManualDeploy(props: {
     nextStep();
 
     emitEvent(
-      { stepStatus: DiscoverEventStatus.Success }
-      // TODO(lisa) uncomment after backend handles this field
-      // { deployMethod: 'manual' }
+      { stepStatus: DiscoverEventStatus.Success },
+      {
+        serviceDeploy: {
+          method: DiscoverServiceDeployMethod.Manual,
+          type: DiscoverServiceDeployType.InstallScript,
+        },
+      }
     );
   }
 

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.test.tsx
@@ -21,6 +21,7 @@ import { render, screen, fireEvent } from 'design/utils/testing';
 import { ContextProvider } from 'teleport';
 import {
   AwsRdsDatabase,
+  IntegrationStatusCode,
   integrationService,
 } from 'teleport/services/integrations';
 import { createTeleportContext } from 'teleport/mocks/contexts';
@@ -41,7 +42,17 @@ import { EnrollRdsDatabase } from './EnrollRdsDatabase';
 describe('test EnrollRdsDatabase.tsx', () => {
   const ctx = createTeleportContext();
   const discoverCtx: DiscoverContextState = {
-    agentMeta: {} as any,
+    agentMeta: {
+      integration: {
+        kind: 'aws-oidc',
+        name: 'aws-oidc-integration',
+        resourceType: 'integration',
+        spec: {
+          roleArn: 'arn-123',
+        },
+        statusCode: IntegrationStatusCode.Running,
+      },
+    } as any,
     currentStep: 0,
     nextStep: jest.fn(x => x),
     prevStep: () => null,

--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.tsx
@@ -98,7 +98,7 @@ export function EnrollRdsDatabase() {
   }
 
   async function fetchDatabases(data: TableData) {
-    const integrationName = (agentMeta as DbMeta).integrationName;
+    const integrationName = (agentMeta as DbMeta).integration.name;
 
     setTableData({ ...data, fetchStatus: 'loading' });
     setFetchDbAttempt({ status: 'processing' });

--- a/web/packages/teleport/src/Discover/Database/index.tsx
+++ b/web/packages/teleport/src/Discover/Database/index.tsx
@@ -26,6 +26,7 @@ import {
 
 import { CreateDatabase } from 'teleport/Discover/Database/CreateDatabase';
 import { SetupAccess } from 'teleport/Discover/Database/SetupAccess';
+import { DeployService } from 'teleport/Discover/Database/DeployService';
 import { ManualDeploy } from 'teleport/Discover/Database/DeployService/ManualDeploy';
 import { MutualTls } from 'teleport/Discover/Database/MutualTls';
 import { TestConnection } from 'teleport/Discover/Database/TestConnection';
@@ -68,8 +69,9 @@ export const DatabaseResource: ResourceViewConfig<ResourceSpec> = {
             },
             {
               title: 'Deploy Database Service',
-              component: ManualDeploy,
+              component: DeployService,
               eventName: DiscoverEvent.DeployService,
+              manuallyEmitSuccessEvent: true,
             },
             {
               title: 'Configure IAM Policy',

--- a/web/packages/teleport/src/Discover/Shared/useShowHint.ts
+++ b/web/packages/teleport/src/Discover/Shared/useShowHint.ts
@@ -16,7 +16,7 @@
 
 import { useEffect, useState } from 'react';
 
-const SHOW_HINT_TIMEOUT = 1000 * 60 * 5; // 5 minutes
+export const SHOW_HINT_TIMEOUT = 1000 * 60 * 5; // 5 minutes
 
 export function useShowHint(enabled: boolean) {
   const [showHint, setShowHint] = useState(false);

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -44,7 +44,10 @@ import type { Kube } from 'teleport/services/kube';
 import type { Database } from 'teleport/services/databases';
 import type { AgentLabel } from 'teleport/services/agents';
 import type { ResourceSpec } from './SelectResource';
-import type { AwsRdsDatabase } from 'teleport/services/integrations';
+import type {
+  AwsRdsDatabase,
+  Integration,
+} from 'teleport/services/integrations';
 
 export interface DiscoverContextState<T = any> {
   agentMeta: AgentMeta;
@@ -97,9 +100,8 @@ export type DiscoverUrlLocationState = {
     resourceSpec: ResourceSpec;
     currentStep: number;
   };
-  // integrationName is the name of the created integration
-  // resource name (eg: integration subkind "aws-oidc")
-  integrationName: string;
+  // integration is the created aws-oidc integration
+  integration: Integration;
 };
 
 const discoverContext = React.createContext<DiscoverContextState>(null);
@@ -226,9 +228,9 @@ export function DiscoverProvider({
   // The location.state.discover should contain all the state that allows
   // the user to resume from where they left of.
   function resumeDiscoverFlow() {
-    const { discover, integrationName } = location.state;
+    const { discover, integration } = location.state;
 
-    updateAgentMeta({ integrationName } as DbMeta);
+    updateAgentMeta({ integration } as DbMeta);
 
     startDiscoverFlow(
       discover.resourceSpec,
@@ -471,7 +473,7 @@ export type DbMeta = BaseMeta & {
   // TODO(lisa): when we can enroll multiple RDS's, turn this into an array?
   // The enroll event expects num count of enrolled RDS's, update accordingly.
   db: Database;
-  integrationName?: string;
+  integration?: Integration;
   selectedAwsRdsDb: AwsRdsDatabase;
   // serviceDeployedMethod flag will be undefined if user skipped
   // deploying service (service already existed).

--- a/web/packages/teleport/src/Discover/useDiscover.tsx
+++ b/web/packages/teleport/src/Discover/useDiscover.tsx
@@ -472,9 +472,9 @@ export type NodeMeta = BaseMeta & {
 export type DbMeta = BaseMeta & {
   // TODO(lisa): when we can enroll multiple RDS's, turn this into an array?
   // The enroll event expects num count of enrolled RDS's, update accordingly.
-  db: Database;
+  db?: Database;
   integration?: Integration;
-  selectedAwsRdsDb: AwsRdsDatabase;
+  selectedAwsRdsDb?: AwsRdsDatabase;
   // serviceDeployedMethod flag will be undefined if user skipped
   // deploying service (service already existed).
   serviceDeployedMethod?: ServiceDeployMethod;

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/instructions/Instructions.story.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/instructions/Instructions.story.tsx
@@ -17,6 +17,12 @@
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
+import {
+  Integration,
+  IntegrationKind,
+  IntegrationStatusCode,
+} from 'teleport/services/integrations';
+
 import { FirstStageInstructions } from './FirstStageInstructions';
 import { SecondStageInstructions } from './SecondStageInstructions';
 import { ThirdStageInstructions } from './ThirdStageInstructions';
@@ -50,7 +56,7 @@ export const Step7 = () => (
 export const ConfirmDialog = () => (
   <MemoryRouter>
     <SuccessfullyAddedIntegrationDialog
-      integrationName="some-integration-name"
+      integration={mockIntegration}
       emitEvent={() => null}
     />
   </MemoryRouter>
@@ -61,7 +67,7 @@ export const ConfirmDialogFromDiscover = () => (
     initialEntries={[{ state: { discover: {} } as DiscoverUrlLocationState }]}
   >
     <SuccessfullyAddedIntegrationDialog
-      integrationName="some-integration-name"
+      integration={mockIntegration}
       emitEvent={() => null}
     />
   </MemoryRouter>
@@ -76,4 +82,14 @@ const props: CommonInstructionsProps = {
     integrationName: 'name',
   },
   clusterPublicUri: 'gravitationalwashington.cloud.gravitional.io:4444',
+};
+
+const mockIntegration: Integration = {
+  kind: IntegrationKind.AwsOidc,
+  name: 'aws-oidc-integration',
+  resourceType: 'integration',
+  spec: {
+    roleArn: 'arn-123',
+  },
+  statusCode: IntegrationStatusCode.Running,
 };

--- a/web/packages/teleport/src/Integrations/Enroll/AwsOidc/instructions/SeventhStageInstructions.tsx
+++ b/web/packages/teleport/src/Integrations/Enroll/AwsOidc/instructions/SeventhStageInstructions.tsx
@@ -36,6 +36,7 @@ import {
 } from 'shared/components/Validation/rules';
 
 import {
+  Integration,
   IntegrationKind,
   integrationService,
 } from 'teleport/services/integrations';
@@ -51,7 +52,7 @@ export function SeventhStageInstructions(
   props: PreviousStepProps & { emitEvent: EmitEvent }
 ) {
   const { attempt, setAttempt } = useAttempt('');
-  const [showConfirmBox, setShowConfirmBox] = useState(false);
+  const [createdIntegration, setCreatedIntegration] = useState<Integration>();
   const [roleArn, setRoleArn] = useState(props.awsOidc.roleArn);
   const [name, setName] = useState(props.awsOidc.integrationName);
 
@@ -67,7 +68,7 @@ export function SeventhStageInstructions(
         subKind: IntegrationKind.AwsOidc,
         awsoidc: { roleArn },
       })
-      .then(() => setShowConfirmBox(true))
+      .then(setCreatedIntegration)
       .catch((err: Error) =>
         setAttempt({ status: 'failed', statusText: err.message })
       );
@@ -134,9 +135,9 @@ export function SeventhStageInstructions(
           </>
         )}
       </Validation>
-      {showConfirmBox && (
+      {createdIntegration && (
         <SuccessfullyAddedIntegrationDialog
-          integrationName={name}
+          integration={createdIntegration}
           emitEvent={props.emitEvent}
         />
       )}
@@ -145,10 +146,10 @@ export function SeventhStageInstructions(
 }
 
 export function SuccessfullyAddedIntegrationDialog({
-  integrationName,
+  integration,
   emitEvent,
 }: {
-  integrationName: string;
+  integration: Integration;
   emitEvent: EmitEvent;
 }) {
   const location = useLocation<DiscoverUrlLocationState>();
@@ -174,7 +175,7 @@ export function SuccessfullyAddedIntegrationDialog({
       </DialogHeader>
       <DialogContent>
         <Text textAlign="center">
-          AWS integration "{integrationName}" successfully added
+          AWS integration "{integration.name}" successfully added
         </Text>
       </DialogContent>
       <DialogFooter css={{ margin: '0 auto' }}>
@@ -185,7 +186,7 @@ export function SuccessfullyAddedIntegrationDialog({
             to={{
               pathname: cfg.routes.discover,
               state: {
-                integrationName,
+                integration,
                 discover: location.state.discover,
               },
             }}

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -24,7 +24,7 @@ test('getDeployServiceIamConfigureScriptPath formatting', async () => {
     taskRoleArn: 'task-arn',
   };
   const base =
-    'http://localhost/scripts/integrations/configure/deployservice-iam.sh?';
+    'http://localhost/webapi/scripts/integrations/configure/deployservice-iam.sh?';
   const expected = `integrationName=${'int-name'}&awsRegion=${'us-east-1'}&role=${'oidc-arn'}&taskRole=${'task-arn'}`;
   expect(cfg.getDeployServiceIamConfigureScriptUrl(params)).toBe(
     `${base}${expected}`

--- a/web/packages/teleport/src/config.test.ts
+++ b/web/packages/teleport/src/config.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import cfg, { UrlDeployServiceIamConfigureScriptParams } from './config';
+
+test('getDeployServiceIamConfigureScriptPath formatting', async () => {
+  const params: UrlDeployServiceIamConfigureScriptParams = {
+    integrationName: 'int-name',
+    region: 'us-east-1',
+    awsOidcRoleArn: 'oidc-arn',
+    taskRoleArn: 'task-arn',
+  };
+  const base =
+    'http://localhost/scripts/integrations/configure/deployservice-iam.sh?';
+  const expected = `integrationName=${'int-name'}&awsRegion=${'us-east-1'}&role=${'oidc-arn'}&taskRole=${'task-arn'}`;
+  expect(cfg.getDeployServiceIamConfigureScriptUrl(params)).toBe(
+    `${base}${expected}`
+  );
+});

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -31,7 +31,7 @@ import type {
 import type { SortType } from 'teleport/services/agents';
 import type { RecordingType } from 'teleport/services/recordings';
 import type { WebauthnAssertionResponse } from './services/auth';
-
+import type { Regions } from './services/integrations';
 import type { ParticipantMode } from 'teleport/services/session';
 
 const cfg = {
@@ -186,6 +186,9 @@ const cfg = {
     dbScriptPath: '/scripts/:token/install-database.sh',
     nodeScriptPath: '/scripts/:token/install-node.sh',
     appNodeScriptPath: '/scripts/:token/install-app.sh?name=:name&uri=:uri',
+
+    deployServiceIamConfigureScriptPath:
+      '/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn',
 
     mfaRequired: '/v1/webapi/sites/:clusterId/mfa/required',
     mfaLoginBegin: '/v1/webapi/mfa/login/begin', // creates authnenticate challenge with user and password
@@ -345,6 +348,15 @@ const cfg = {
 
   getNodeScriptUrl(token: string) {
     return cfg.baseUrl + generatePath(cfg.api.nodeScriptPath, { token });
+  },
+
+  getDeployServiceIamConfigureScriptUrl(
+    p: UrlDeployServiceIamConfigureScriptParams
+  ) {
+    return (
+      cfg.baseUrl +
+      generatePath(cfg.api.deployServiceIamConfigureScriptPath, { ...p })
+    );
   },
 
   getDbScriptUrl(token: string) {
@@ -840,6 +852,13 @@ export interface UrlIntegrationExecuteRequestParams {
   // action is the expected backend string value
   // used to describe what to use the integration for.
   action: 'aws-oidc/list_databases';
+}
+
+export interface UrlDeployServiceIamConfigureScriptParams {
+  integrationName: string;
+  region: Regions;
+  awsOidcRoleArn: string;
+  taskRoleArn: string;
 }
 
 export default cfg;

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -188,7 +188,7 @@ const cfg = {
     appNodeScriptPath: '/scripts/:token/install-app.sh?name=:name&uri=:uri',
 
     deployServiceIamConfigureScriptPath:
-      '/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn',
+      '/webapi/scripts/integrations/configure/deployservice-iam.sh?integrationName=:integrationName&awsRegion=:region&role=:awsOidcRoleArn&taskRole=:taskRoleArn',
 
     mfaRequired: '/v1/webapi/sites/:clusterId/mfa/required',
     mfaLoginBegin: '/v1/webapi/mfa/login/begin', // creates authnenticate challenge with user and password

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -47,7 +47,7 @@ export const integrationService = {
   },
 
   createIntegration(req: IntegrationCreateRequest): Promise<Integration> {
-    return api.post(cfg.getIntegrationsUrl(), req);
+    return api.post(cfg.getIntegrationsUrl(), req).then(makeIntegration);
   },
 
   updateIntegration(

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -46,7 +46,7 @@ export const integrationService = {
     });
   },
 
-  createIntegration(req: IntegrationCreateRequest): Promise<void> {
+  createIntegration(req: IntegrationCreateRequest): Promise<Integration> {
     return api.post(cfg.getIntegrationsUrl(), req);
   },
 


### PR DESCRIPTION
do not merge until the following has merged:
- https://github.com/gravitational/teleport/pull/28436
- https://github.com/gravitational/teleport/pull/28537
- https://github.com/gravitational/teleport/pull/28807
- [x] tested flow without problems

This pr:
- enables the auto deploy flow
- defines the script endpoint
- emit events that differentiates between `manual` and `auto` deploy
- previously, we were passing around `integration.name` but now we pass around the full object because we also need to access the `roleArn` for the cfg script

