### PR TITLE
replaces `unsafe.Pointer(&slice[0])` with `unsafe.SliceData(slice)`

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -247,10 +247,10 @@ func (c *Client) connect(ctx context.Context) error {
 			go_username: username,
 			// cert length and bytes.
 			cert_der_len: C.uint32_t(len(userCertDER)),
-			cert_der:     (*C.uint8_t)(unsafe.Pointer(&userCertDER[0])),
+			cert_der:     (*C.uint8_t)(unsafe.SliceData(userCertDER)),
 			// key length and bytes.
 			key_der_len:             C.uint32_t(len(userKeyDER)),
-			key_der:                 (*C.uint8_t)(unsafe.Pointer(&userKeyDER[0])),
+			key_der:                 (*C.uint8_t)(unsafe.SliceData(userKeyDER)),
 			screen_width:            C.uint16_t(c.clientWidth),
 			screen_height:           C.uint16_t(c.clientHeight),
 			allow_clipboard:         C.bool(c.cfg.AllowClipboard),
@@ -433,7 +433,7 @@ func (c *Client) start() {
 				if len(m) > 0 {
 					if errCode := C.update_clipboard(
 						c.rustClient,
-						(*C.uint8_t)(unsafe.Pointer(&m[0])),
+						(*C.uint8_t)(unsafe.SliceData(m)),
 						C.uint32_t(len(m)),
 					); errCode != C.ErrCodeSuccess {
 						c.cfg.Log.Warningf("ClipboardData: update_clipboard (len=%v): %v", len(m), errCode)
@@ -520,13 +520,7 @@ func (c *Client) start() {
 					}
 
 					fsoListLen := len(fsoList)
-					var cgoFsoList *C.CGOFileSystemObject
-
-					if fsoListLen > 0 {
-						cgoFsoList = (*C.CGOFileSystemObject)(unsafe.Pointer(&fsoList[0]))
-					} else {
-						cgoFsoList = (*C.CGOFileSystemObject)(unsafe.Pointer(&fsoList))
-					}
+					cgoFsoList := (*C.CGOFileSystemObject)(unsafe.SliceData(fsoList))
 
 					if errCode := C.handle_tdp_sd_list_response(c.rustClient, C.CGOSharedDirectoryListResponse{
 						completion_id:   C.uint32_t(m.CompletionID),
@@ -540,12 +534,7 @@ func (c *Client) start() {
 				}
 			case tdp.SharedDirectoryReadResponse:
 				if c.cfg.AllowDirectorySharing {
-					var readData *C.uint8_t
-					if m.ReadDataLength > 0 {
-						readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData[0]))
-					} else {
-						readData = (*C.uint8_t)(unsafe.Pointer(&m.ReadData))
-					}
+					readData := (*C.uint8_t)(unsafe.SliceData(m.ReadData))
 
 					if errCode := C.handle_tdp_sd_read_response(c.rustClient, C.CGOSharedDirectoryReadResponse{
 						completion_id:    C.uint32_t(m.CompletionID),

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -240,6 +240,20 @@ func (c *Client) connect(ctx context.Context) error {
 	username := C.CString(c.username)
 	defer C.free(unsafe.Pointer(username))
 
+	cert_der, err := utils.UnsafeSliceData(userCertDER)
+	if err != nil {
+		return trace.Wrap(err)
+	} else if cert_der == nil {
+		return trace.BadParameter("user cert was nil")
+	}
+
+	key_der, err := utils.UnsafeSliceData(userKeyDER)
+	if err != nil {
+		return trace.Wrap(err)
+	} else if key_der == nil {
+		return trace.BadParameter("user key was nil")
+	}
+
 	res := C.connect_rdp(
 		C.uintptr_t(c.handle),
 		C.CGOConnectParams{
@@ -247,10 +261,10 @@ func (c *Client) connect(ctx context.Context) error {
 			go_username: username,
 			// cert length and bytes.
 			cert_der_len: C.uint32_t(len(userCertDER)),
-			cert_der:     (*C.uint8_t)(unsafe.SliceData(userCertDER)),
+			cert_der:     (*C.uint8_t)(cert_der),
 			// key length and bytes.
 			key_der_len:             C.uint32_t(len(userKeyDER)),
-			key_der:                 (*C.uint8_t)(unsafe.SliceData(userKeyDER)),
+			key_der:                 (*C.uint8_t)(key_der),
 			screen_width:            C.uint16_t(c.clientWidth),
 			screen_height:           C.uint16_t(c.clientHeight),
 			allow_clipboard:         C.bool(c.cfg.AllowClipboard),
@@ -431,9 +445,15 @@ func (c *Client) start() {
 				}
 			case tdp.ClipboardData:
 				if len(m) > 0 {
+					data, err := utils.UnsafeSliceData(m)
+					if err != nil {
+						c.cfg.Log.Errorf("ClipboardData: %v", err)
+						return
+					}
+					// data will not be nil because len(m) > 0
 					if errCode := C.update_clipboard(
 						c.rustClient,
-						(*C.uint8_t)(unsafe.SliceData(m)),
+						(*C.uint8_t)(data),
 						C.uint32_t(len(m)),
 					); errCode != C.ErrCodeSuccess {
 						c.cfg.Log.Warningf("ClipboardData: update_clipboard (len=%v): %v", len(m), errCode)
@@ -520,7 +540,10 @@ func (c *Client) start() {
 					}
 
 					fsoListLen := len(fsoList)
-					cgoFsoList := (*C.CGOFileSystemObject)(unsafe.SliceData(fsoList))
+					cgoFsoList, err := utils.UnsafeSliceData(fsoList)
+					if err != nil {
+						c.cfg.Log.Errorf("SharedDirectoryListResponse: %v", err)
+					}
 
 					if errCode := C.handle_tdp_sd_list_response(c.rustClient, C.CGOSharedDirectoryListResponse{
 						completion_id:   C.uint32_t(m.CompletionID),
@@ -534,13 +557,16 @@ func (c *Client) start() {
 				}
 			case tdp.SharedDirectoryReadResponse:
 				if c.cfg.AllowDirectorySharing {
-					readData := (*C.uint8_t)(unsafe.SliceData(m.ReadData))
+					readData, err := utils.UnsafeSliceData(m.ReadData)
+					if err != nil {
+						c.cfg.Log.Errorf("SharedDirectoryReadResponse: %v", err)
+					}
 
 					if errCode := C.handle_tdp_sd_read_response(c.rustClient, C.CGOSharedDirectoryReadResponse{
 						completion_id:    C.uint32_t(m.CompletionID),
 						err_code:         m.ErrCode,
 						read_data_length: C.uint32_t(m.ReadDataLength),
-						read_data:        readData,
+						read_data:        (*C.uint8_t)(readData),
 					}); errCode != C.ErrCodeSuccess {
 						c.cfg.Log.Errorf("SharedDirectoryReadResponse failed: %v", errCode)
 						return

--- a/lib/utils/unsafe.go
+++ b/lib/utils/unsafe.go
@@ -1,0 +1,34 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"unsafe"
+
+	"github.com/gravitational/trace"
+)
+
+// UnsafeSliceData is a wrapper around unsafe.SliceData
+// which ensures that instead of ever returning
+// "a non-nil pointer to an unspecified memory address"
+// (see unsafe.SliceData documentation), an error is
+// returned instead.
+func UnsafeSliceData[T any](slice []T) (*T, error) {
+	if slice == nil || cap(slice) > 0 {
+		return unsafe.SliceData(slice), nil
+	}
+
+	return nil, trace.BadParameter("non-nil slice had a capacity of zero")
+}


### PR DESCRIPTION
Go 1.20 added [`unsafe.SliceData`](https://pkg.go.dev/unsafe#SliceData) which provides a cleaner API for this type of operation.