### PR TITLE
[v12] [Docs] Add IdP-initiated SSO instructions to Grafana SAML guide 

### DIFF
--- a/docs/pages/access-controls/idps/saml-grafana.mdx
+++ b/docs/pages/access-controls/idps/saml-grafana.mdx
@@ -70,6 +70,8 @@ From the Grafana host, edit `grafana.ini` by adding a `[auth.saml]` section:
 [auth.saml]
 enabled = true
 auto_login = false
+allow_idp_initiated = true
+relay_state = ""
 private_key_path = '/path/to/certs/grafana-host-key.pem'
 certificate_path = '/path/to/certs/grafana-host.pem'
 idp_metadata = 'PEVudGl0eURl.....'
@@ -79,14 +81,16 @@ assertion_attribute_email = uid
 assertion_attribute_groups = eduPersonAffiliation
 ```
 
-| Key                | Value                                                          |
-|--------------------|----------------------------------------------------------------|
-| `enabled`          | Set to `true` to enable SAML authentication.                   |
-| `auto_login`       | When set to `true`, enables auto-login using SAML.             |
-| `private_key_path` | Path to the TLS key used to identify Grafana.                  |
-| `certificate_path` | Path to the TLS certificate used to identify Grafana.          |
-| `idp_metadata`     | The base64-encoded contents of the Teleport metadata XML file. |
-| `assertion_*`      | Various Grafana user fields to be mapped to SAML assertions.   |
+| Key                   | Value                                                                                 |
+|-----------------------|---------------------------------------------------------------------------------------|
+| `enabled`             | Set to `true` to enable SAML authentication.                                          |
+| `auto_login`          | When set to `true`, enables auto-login using SAML.                                    |
+| `allow_idp_initiated` | Set to `true` to allow IdP-initiated login.                                           |
+| `relay_state`         | Relay state for IdP-initiated login. Must be set to `""` to work with Teleport's IdP. |
+| `private_key_path`    | Path to the TLS key used to identify Grafana.                                         |
+| `certificate_path`    | Path to the TLS certificate used to identify Grafana.                                 |
+| `idp_metadata`        | The base64-encoded contents of the Teleport metadata XML file.                        |
+| `assertion_*`         | Various Grafana user fields to be mapped to SAML assertions.                          |
 
 For more information on editing `grafana.ini` for SAML, you can review their [Configure
 SAML authentication in Grafana](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/)


### PR DESCRIPTION
Backport #28058 to branch/v12