### PR TITLE
Deduplicate resources for `tsh request search` when `replicas>1`

### DIFF
--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -450,6 +450,7 @@ func onRequestSearch(cf *CLIConf) error {
 
 	var rows [][]string
 	var resourceIDs []string
+	deduplicateResourceIDs := map[string]struct{}{}
 	for _, resource := range resources {
 		var row []string
 		switch r := resource.(type) {
@@ -460,6 +461,9 @@ func onRequestSearch(cf *CLIConf) error {
 				Name:            cf.KubernetesCluster,
 				SubResourceName: fmt.Sprintf("%s/%s", r.Spec.Namespace, resource.GetName()),
 			})
+			if ignoreDuplicateResourceId(deduplicateResourceIDs, resourceID) {
+				continue
+			}
 			resourceIDs = append(resourceIDs, resourceID)
 
 			row = []string{
@@ -475,6 +479,10 @@ func onRequestSearch(cf *CLIConf) error {
 				Kind:        resource.GetKind(),
 				Name:        resource.GetName(),
 			})
+			if ignoreDuplicateResourceId(deduplicateResourceIDs, resourceID) {
+				continue
+			}
+
 			resourceIDs = append(resourceIDs, resourceID)
 			hostName := ""
 			if r, ok := resource.(interface{ GetHostname() string }); ok {
@@ -505,6 +513,18 @@ To request access to these resources, run
 	}
 
 	return nil
+}
+
+// ignoreDuplicateResourceId returns true if the resource ID is a duplicate
+// and should be ignored. Otherwise, it returns false and adds the resource ID
+// to the deduplicateResourceIDs map.
+func ignoreDuplicateResourceId(deduplicateResourceIDs map[string]struct{}, resourceID string) bool {
+	// Ignore duplicate resource IDs.
+	if _, ok := deduplicateResourceIDs[resourceID]; ok {
+		return true
+	}
+	deduplicateResourceIDs[resourceID] = struct{}{}
+	return false
 }
 
 func onRequestDrop(cf *CLIConf) error {


### PR DESCRIPTION
When the number of replicas of a resource is bigger than 1 - i.e. `kube_cluster`, `app`, `db` - `tsh request search` printed all the registered resources instead of ignoring the repeated rows.

This PR excludes the repeated resource ids from the table and request command.

Before:
```
$ tsh request search --kind kube_cluster
Name       Hostname Labels                                                             Resource ID
---------- -------- ------------------------------------------------------------------ -----------------------------------
local               env=tiago                                                          /tele.local/kube_cluster/local
my-cluster          teleport.internal/resource-id=89b78b53-600f-4545-922c-96d20ee15182 /tele.local/kube_cluster/my-cluster
my-cluster          teleport.internal/resource-id=89b78b53-600f-4545-922c-96d20ee15182 /tele.local/kube_cluster/my-cluster
my-cluster          teleport.internal/resource-id=89b78b53-600f-4545-922c-96d20ee15182 /tele.local/kube_cluster/my-cluster

To request access to these resources, run
> tsh request create --resource /tele.local/kube_cluster/local --resource /tele.local/kube_cluster/my-cluster --resource /tele.local/kube_cluster/my-cluster --resource /tele.local/kube_cluster/my-cluster \
    --reason <request reason>

```

After:

```
$ tsh request search --kind kube_cluster
Name       Hostname Labels                                                             Resource ID
---------- -------- ------------------------------------------------------------------ -----------------------------------
local               env=tiago                                                          /tele.local/kube_cluster/local
my-cluster          teleport.internal/resource-id=89b78b53-600f-4545-922c-96d20ee15182 /tele.local/kube_cluster/my-cluster

To request access to these resources, run
> tsh request create --resource /tele.local/kube_cluster/local --resource /tele.local/kube_cluster/my-cluster \
    --reason <request reason>

```