### PR TITLE
lib/teleterm: Remove misleading error log after LocalAgent.GetKey

### DIFF
--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -223,7 +223,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 			return nil, trace.Wrap(err)
 		}
 	}
-
 	if err == nil && cfg.Username != "" {
 		status, err = clusterClient.ProfileStatus()
 		if err != nil {
@@ -233,9 +232,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 		if err := clusterClient.LoadKeyForCluster(context.Background(), status.Cluster); err != nil {
 			return nil, trace.Wrap(err)
 		}
-	}
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
 	}
 
 	return &Cluster{

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -217,7 +217,11 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 	// load profile status if key exists
 	_, err = clusterClient.LocalAgent().GetKey(clusterNameForKey)
 	if err != nil {
-		s.Log.WithError(err).Infof("Unable to load the keys for cluster %v.", clusterNameForKey)
+		if trace.IsNotFound(err) {
+			s.Log.Infof("No keys found for cluster %v.", clusterNameForKey)
+		} else {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	if err == nil && cfg.Username != "" {


### PR DESCRIPTION
When you first login to a cluster in Connect and provide the cluster address, Connect creates a profile file for the cluster in Connect's tsh home. Naturally, at this point there's no keys for the cluster. So when you then submit your login credentials and we call `clusters.Storage.fromProfile`, `LocalAgent.GetKey` returns a not found error.

In that case we should just continue, similar to how other places in tsh do this:

https://github.com/gravitational/teleport/blob/2cba82cb332e769ebc8a658d32ff24ddda79daff/tool/tsh/common/kube.go#L142-L146

Instead, the previous version would log the error as if something bad has happened:

<details>
<summary>Error log</summary>

```
TSHD INFO [CONN:STOR] Unable to load the keys for cluster teleport-local.dev. error:[
TSHD ERROR REPORT:
TSHD Original Error: *trace.NotFoundError open /Users/rav/Library/Application Support/Electron/tsh/keys/teleport-local.dev/rav-x509.pem: no such file or directory
TSHD Stack Trace:
TSHD 	github.com/gravitational/teleport/lib/client/keystore.go:322 github.com/gravitational/teleport/lib/client.(*FSKeyStore).GetKey
TSHD 	github.com/gravitational/teleport/lib/client/client_store.go:82 github.com/gravitational/teleport/lib/client.(*Store).GetKey
TSHD 	github.com/gravitational/teleport/lib/client/keyagent.go:298 github.com/gravitational/teleport/lib/client.(*LocalKeyAgent).GetKey
TSHD 	github.com/gravitational/teleport/lib/teleterm/clusters/storage.go:218 github.com/gravitational/teleport/lib/teleterm/clusters.(*Storage).fromProfile
TSHD 	github.com/gravitational/teleport/lib/teleterm/clusters/storage.go:66 github.com/gravitational/teleport/lib/teleterm/clusters.(*Storage).GetByURI
TSHD 	github.com/gravitational/teleport/lib/teleterm/clusters/storage.go:82 github.com/gravitational/teleport/lib/teleterm/clusters.(*Storage).GetByResourceURI
TSHD 	github.com/gravitational/teleport/lib/teleterm/daemon/daemon.go:131 github.com/gravitational/teleport/lib/teleterm/daemon.(*Service).ResolveCluster
TSHD 	github.com/gravitational/teleport/lib/teleterm/apiserver/handler/handler_auth.go:27 github.com/gravitational/teleport/lib/teleterm/apiserver/handler.(*Handler).Login
TSHD 	github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1/service_grpc.pb.go:1076 github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1._TerminalService_Login_Handler.func1
TSHD 	github.com/gravitational/teleport/lib/teleterm/apiserver/middleware.go:36 github.com/gravitational/teleport/lib/teleterm/apiserver.withErrorHandling.func1
TSHD 	github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1/service_grpc.pb.go:1078 github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1._TerminalService_Login_Handler
TSHD 	google.golang.org/grpc@v1.55.0/server.go:1337 google.golang.org/grpc.(*Server).processUnaryRPC
TSHD 	google.golang.org/grpc@v1.55.0/server.go:1714 google.golang.org/grpc.(*Server).handleStream
TSHD 	google.golang.org/grpc@v1.55.0/server.go:959 google.golang.org/grpc.(*Server).serveStreams.func1.1
TSHD 	runtime/asm_arm64.s:1172 runtime.goexit
TSHD User Message: open /Users/rav/Library/Application Support/Electron/tsh/keys/teleport-local.dev/rav-x509.pem: no such file or directory] clusters/storage.go:220
```
</details>

This was spammed frequently enough in the logs that was plain confusing for users submitting logs for troubleshooting – I've seen at least two instances of that.

This PR makes it so that we just log the fact that the keys were not found, without including the error.