### PR TITLE
[v12] lib/teleterm: Remove misleading error log after LocalAgent.GetKey

### DIFF
--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -211,7 +211,11 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 	// load profile status if key exists
 	_, err = clusterClient.LocalAgent().GetKey(clusterNameForKey)
 	if err != nil {
-		s.Log.WithError(err).Infof("Unable to load the keys for cluster %v.", clusterNameForKey)
+		if trace.IsNotFound(err) {
+			s.Log.Infof("No keys found for cluster %v.", clusterNameForKey)
+		} else {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	if err == nil && cfg.Username != "" {

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -217,7 +217,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 			return nil, trace.Wrap(err)
 		}
 	}
-
 	if err == nil && cfg.Username != "" {
 		status, err = clusterClient.ProfileStatus()
 		if err != nil {
@@ -227,9 +226,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 		if err := clusterClient.LoadKeyForCluster(context.Background(), status.Cluster); err != nil {
 			return nil, trace.Wrap(err)
 		}
-	}
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
 	}
 
 	return &Cluster{


### PR DESCRIPTION
Backport #28662 to branch/v12