### PR TITLE
[v11] lib/teleterm: Remove misleading error log after LocalAgent.GetKey

### DIFF
--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -215,7 +215,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 			return nil, trace.Wrap(err)
 		}
 	}
-
 	if err == nil && cfg.Username != "" {
 		status, err = client.ReadProfileStatus(s.Dir, profileName)
 		if err != nil {
@@ -228,9 +227,6 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 				return nil, trace.Wrap(err)
 			}
 		}
-	}
-	if err != nil && !trace.IsNotFound(err) {
-		return nil, trace.Wrap(err)
 	}
 
 	return &Cluster{

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -209,7 +209,11 @@ func (s *Storage) fromProfile(profileName, leafClusterName string) (*Cluster, er
 	// load profile status if key exists
 	_, err = clusterClient.LocalAgent().GetKey(clusterNameForKey)
 	if err != nil {
-		s.Log.WithError(err).Infof("Unable to load the keys for cluster %v.", clusterNameForKey)
+		if trace.IsNotFound(err) {
+			s.Log.Infof("No keys found for cluster %v.", clusterNameForKey)
+		} else {
+			return nil, trace.Wrap(err)
+		}
 	}
 
 	if err == nil && cfg.Username != "" {


### PR DESCRIPTION
Backport #28662 to branch/v11