### PR TITLE
[v13] Change signup links to mention Teleport Team

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/introduction.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/introduction.mdx
@@ -7,9 +7,10 @@ videoBanner: 1jhKOtBinm4
 Teleport Enterprise Cloud is a managed service to provide access to secure
 infrastructure all over the world without passwords or shared secrets.
 
-When you [sign up for a Teleport Enterprise Cloud account](https://goteleport.com/signup/), you will receive a subdomain of
-`teleport.sh` that is dedicated to your tenant and points to the Teleport Proxy
-Service. 
+When you [sign up for a Teleport Team account](https://goteleport.com/signup/)
+(which you can upgrade to a Teleport Enterprise Cloud account), you will receive
+a subdomain of `teleport.sh` that is dedicated to your tenant and points to the
+Teleport Proxy Service. 
 
 Our Teleport Enterprise Cloud team handles the following tasks for you:
 

--- a/docs/pages/choose-an-edition/teleport-enterprise/introduction.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/introduction.mdx
@@ -22,7 +22,14 @@ The table below gives a quick overview of the benefits of Teleport Enterprise.
   type="tip"
   title="Contact Information"
 >
-  Try Teleport Enterprise for [free in the cloud](https://goteleport.com/signup/) or [contact sales](https://goteleport.com/signup/enterprise/).
+
+  To get started with self-hosted Teleport Enterprise, [contact
+  sales](https://goteleport.com/signup/enterprise/).
+
+  You can also sign up for a [free trial](https://goteleport.com/signup) of
+  Teleport Team, which manages the Auth Service and Proxy Service for you. You
+  can then upgrade your account to Teleport Enterprise Cloud.
+
 </Admonition>
 
 ## SSO
@@ -52,13 +59,6 @@ valid credentials, Teleport will issue an SSH certificate.
 Moreover, SSO can be used in combination with role-based access control (RBAC)
 to enforce SSH access policies like *"developers must not touch production data"*.
 See the [SSO](../../access-controls/sso.mdx) chapter for more details.
-
-<Admonition
-  type="tip"
-  title="Contact Information"
->
-  Try Teleport Enterprise for [free in the cloud](https://goteleport.com/signup/) or [contact sales](https://goteleport.com/signup/enterprise/).
-</Admonition>
 
 ## FedRAMP/FIPS
 
@@ -122,5 +122,5 @@ Unless your organization requires the Enterprise-specific features we outlined
 above, you can use Teleport Enterprise Cloud to achieve secure access to your
 infrastructure without needing to maintain the Auth and Proxy Services. 
 
-[Sign up for a free trial of Teleport Enterprise
-Cloud](https://goteleport.com/signup/).
+[Sign up for a free trial of Teleport Team](https://goteleport.com/signup/),
+which you can upgrade to a Teleport Enterprise Cloud account.

--- a/docs/pages/includes/cloud/call-to-action.mdx
+++ b/docs/pages/includes/cloud/call-to-action.mdx
@@ -3,10 +3,10 @@ type="tip"
 scope={["oss", "enterprise"]} 
 >
 
-Teleport Cloud takes care of this setup for you so you can provide secure access
+Teleport Team takes care of this setup for you so you can provide secure access
 to your infrastructure right away.
 
 Get started with a [free trial](https://goteleport.com/signup?t_source=docs) of
-Teleport Cloud.
+Teleport Team.
 
 </Notice>

--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -21,9 +21,9 @@
 <TabItem scope={["cloud"]}
   label="Teleport Enterprise Cloud">
 
-- A Teleport Enterprise Cloud account, which includes a running Auth Service and Proxy
-  Service. If you do not have a Teleport Cloud account, visit the [sign up
-  page](https://goteleport.com/signup/) to begin your free trial.
+- A Teleport Enterprise Cloud account. If you do not have one, visit the [signup
+  page](https://goteleport.com/signup/) to begin a free trial of Teleport Team
+  and upgrade to Teleport Enterprise Cloud. 
 
 - The `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
   To download these tools, visit the [Downloads](../choose-an-edition/teleport-cloud/downloads.mdx) page.

--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -38,8 +38,9 @@
 <TabItem scope={["cloud"]}
   label="Teleport Cloud">
 
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
+- A Teleport Enterprise Cloud account. If you do not have one, visit the [signup
+  page](https://goteleport.com/signup/) to begin a free trial of Teleport Team
+  and upgrade to Teleport Enterprise Cloud. 
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
   To download these tools, visit the [Downloads](../choose-an-edition/teleport-cloud/downloads.mdx) page.

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -78,8 +78,9 @@ This guide will explain how to:
 <TabItem scope={["cloud"]}
   label="Teleport Cloud">
 
-- A Teleport Cloud account. If you do not have one, visit the
-  [sign up page](https://goteleport.com/signup/) to begin your free trial.
+- A Teleport Enterprise Cloud account. If you do not have one, visit the [sign
+  up page](https://goteleport.com/signup/) to begin a free trial of Teleport
+  Team and upgrade to Teleport Enterprise Cloud. 
 
 - A second Teleport cluster, which will act as the leaf cluster. For details on
 how to set up this cluster, see our

--- a/docs/pages/management/operations/tls-routing.mdx
+++ b/docs/pages/management/operations/tls-routing.mdx
@@ -33,9 +33,9 @@ Teleport installation to TLS routing.
 
 <Notice type="tip">
 
-Teleport Cloud manages the Proxy Service's networking configuration for you.
+Teleport Team manages the Proxy Service's networking configuration for you.
 Get started with a [free trial](https://goteleport.com/signup?t_source=docs) of
-Teleport Cloud.
+Teleport Team.
 
 To see which ports and networking settings the Proxy Service is configured to
 use in your Teleport Cloud tenant, run the following command, replacing


### PR DESCRIPTION
Fixes #28547

The free trial a user can sign up for is a Teleport Team trial, not an Enterprise Cloud trial. This change reflects this.