### PR TITLE
Make dependabot ignore go-tpm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
       - dependency-name: github.com/gravitational/ttlmap
       # Breaks backwards compatibility
       - dependency-name: github.com/go-webauthn/webauthn
+      # Requires github.com/go-webauthn/webauthn upgrade
+      - dependency-name: github.com/google/go-attestation # requires go-tpm
+      - dependency-name: github.com/google/go-tpm         # requires newer go-webauthn/webauthn
+      - dependency-name: github.com/google/go-tpm-tools   # requires go-tpm
       # Must be kept in-sync with libbpf
       - dependency-name: github.com/aquasecurity/libbpfgo
       # Forked/replaced dependencies


### PR DESCRIPTION
Ignore go-tpm (and related) updates. Follow up from #28572.

go-tpm version v0.9.0 broke compatibility by moving a package around. This breaks go-webauthn/webauthn in its current imported version, because it requires packages that don't exist anymore. Upgrading webauthn is also non-trivial, as it comes with its own separate set of breaking changes (see #20122).

For now we'll ignore those packages in automated updates.