### PR TITLE
Fix theme not loading on first login & overflowing command result summary

### DIFF
--- a/web/packages/teleport/src/Assist/Conversation/CommandResultEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultEntry.tsx
@@ -17,6 +17,8 @@
 import React from 'react';
 import styled, { keyframes } from 'styled-components';
 
+import { MonospacedOutput } from 'teleport/Assist/shared/MonospacedOutput';
+
 interface CommandResultEntryProps {
   nodeId: string;
   nodeName: string;
@@ -35,16 +37,6 @@ const Title = styled.div`
   font-size: 15px;
   font-weight: 600;
   padding: 10px 15px;
-`;
-
-const Output = styled.pre.attrs({ 'data-scrollbar': 'default' })`
-  background: #161b22;
-  color: white;
-  padding: 10px 15px;
-  margin: 0;
-  overflow-x: auto;
-  font-family: ${p => p.theme.fonts.mono};
-  font-size: 13px;
 `;
 
 const Header = styled.div`
@@ -94,7 +86,9 @@ export function CommandResultEntry(props: CommandResultEntryProps) {
         )}
       </Header>
 
-      <Output>{props.errorMessage ? props.errorMessage : props.output}</Output>
+      <MonospacedOutput>
+        {props.errorMessage ? props.errorMessage : props.output}
+      </MonospacedOutput>
     </Container>
   );
 }

--- a/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
@@ -21,6 +21,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 
 import { markdownCSS } from 'teleport/Assist/markdown';
+import { MonospacedOutput } from 'teleport/Assist/shared/MonospacedOutput';
 
 interface CommandResultSummaryEntryProps {
   command: string;
@@ -56,10 +57,10 @@ export function CommandResultSummaryEntry(
   return (
     <Container>
       <Header>
-        <Title>
-          Summary of command execution <pre>{props.command}</pre>
-        </Title>
+        <Title>Summary of command execution</Title>
       </Header>
+
+      <MonospacedOutput>{props.command}</MonospacedOutput>
 
       <Summary>
         <ReactMarkdown remarkPlugins={[remarkGfm]}>

--- a/web/packages/teleport/src/Assist/shared/MonospacedOutput.tsx
+++ b/web/packages/teleport/src/Assist/shared/MonospacedOutput.tsx
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from 'styled-components';
+
+export const MonospacedOutput = styled.pre.attrs({
+  'data-scrollbar': 'default',
+})`
+  background: #161b22;
+  color: white;
+  padding: 10px 18px;
+  margin: 0;
+  overflow-x: auto;
+  font-family: ${p => p.theme.fonts.mono};
+  font-size: 13px;
+`;

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -125,14 +125,22 @@ const storage = {
       return userPreferences.theme;
     }
 
-    const theme = window.localStorage.getItem(
-      KeysEnum.THEME
-    ) as DeprecatedThemeOption;
+    const theme = this.getDeprecatedThemePreference();
     if (theme) {
       return theme === 'light' ? ThemePreference.Light : ThemePreference.Dark;
     }
 
     return ThemePreference.Light;
+  },
+
+  // TODO(ryan): remove in v15
+  getDeprecatedThemePreference(): DeprecatedThemeOption {
+    return window.localStorage.getItem(KeysEnum.THEME) as DeprecatedThemeOption;
+  },
+
+  // TODO(ryan): remove in v15
+  clearDeprecatedThemePreference() {
+    window.localStorage.removeItem(KeysEnum.THEME);
   },
 
   broadcast(messageType, messageBody) {

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -133,7 +133,7 @@ const storage = {
     return ThemePreference.Light;
   },
 
-  // TODO(ryan): remove in v15
+  // DELETE IN 15 (ryan)
   getDeprecatedThemePreference(): DeprecatedThemeOption {
     return window.localStorage.getItem(KeysEnum.THEME) as DeprecatedThemeOption;
   },

--- a/web/packages/teleport/src/services/userPreferences/types.ts
+++ b/web/packages/teleport/src/services/userPreferences/types.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { DeprecatedThemeOption } from 'design/theme';
+
 import type { AssistUserPreferences } from 'teleport/Assist/types';
 import type { Resource } from 'teleport/Welcome/Questionnaire/types';
 
@@ -34,3 +36,14 @@ export interface UserPreferences {
 
 export type UserPreferencesSubset = Subset<UserPreferences>;
 export type GetUserPreferencesResponse = UserPreferences;
+
+export function deprecatedThemeToThemePreference(
+  theme: DeprecatedThemeOption
+): ThemePreference {
+  switch (theme) {
+    case 'light':
+      return ThemePreference.Light;
+    case 'dark':
+      return ThemePreference.Dark;
+  }
+}


### PR DESCRIPTION
This fixes https://github.com/gravitational/teleport.e/issues/1780 where the theme is not correctly being set on first login (when there are no user preferences saved in local storage, e.g. incognito mode).  To do this, I changed the logic to only update the theme if the legacy theme preference exists in local storage. It's then removed after.

This also fixes https://github.com/gravitational/teleport.e/issues/1781 where the command in the result summary overflowing by sharing the same monospaced output component that the command result uses.

<img width="476" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/1b184e47-14e5-4a10-a1fb-383a24022d77">
