### PR TITLE
Access list backend service and marshal/unmarshal.

### DIFF
--- a/api/types/access_list_test.go
+++ b/api/types/access_list_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2023 Gravitational, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditMarshaling(t *testing.T) {
+	audit := AccessListAudit{
+		Frequency: time.Hour,
+	}
+
+	data, err := json.Marshal(&audit)
+	require.NoError(t, err)
+
+	raw := map[string]interface{}{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	require.Equal(t, "1h0m0s", raw["frequency"])
+}
+
+func TestAuditUnmarshaling(t *testing.T) {
+	raw := map[string]interface{}{
+		"frequency": "1h",
+	}
+
+	data, err := json.Marshal(&raw)
+	require.NoError(t, err)
+
+	var audit AccessListAudit
+	require.NoError(t, json.Unmarshal(data, &audit))
+
+	require.Equal(t, time.Hour, audit.Frequency)
+}

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types/common"
+	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/utils"
 )
 
@@ -365,6 +366,17 @@ func (h *ResourceHeader) CheckAndSetDefaults() error {
 		return trace.BadParameter("resource has an empty Version field")
 	}
 	return trace.Wrap(h.Metadata.CheckAndSetDefaults())
+}
+
+// FromHeaderMetadata will convert a *header.Metadata object to this metadata object.
+// TODO: Remove this once we get rid of the old Metadata object.
+func FromHeaderMetadata(metadata header.Metadata) Metadata {
+	return Metadata{
+		ID:          metadata.ID,
+		Name:        metadata.Name,
+		Description: metadata.Description,
+		Labels:      metadata.Labels,
+	}
 }
 
 // GetID returns resource ID

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1766,7 +1766,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 
 	var hlrs []servicecfg.HostLabelRule
-	{
+	for _, rule := range fc.WindowsDesktop.HostLabels {
 		r, err := regexp.Compile(rule.Match)
 		if err != nil {
 			return trace.BadParameter("WindowsDesktopService specifies invalid regexp %q", rule.Match)

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1766,7 +1766,7 @@ func applyWindowsDesktopConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	}
 
 	var hlrs []servicecfg.HostLabelRule
-	for _, rule := range fc.WindowsDesktop.HostLabels {
+	{
 		r, err := regexp.Compile(rule.Match)
 		if err != nil {
 			return trace.BadParameter("WindowsDesktopService specifies invalid regexp %q", rule.Match)

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -73,10 +73,6 @@ func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*types.AccessList,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	var h types.ResourceHeader
-	if err := utils.FastUnmarshal(data, &h); err != nil {
-		return nil, trace.Wrap(err)
-	}
 	var accessList *types.AccessList
 	if err := utils.FastUnmarshal(data, &accessList); err != nil {
 		return nil, trace.BadParameter(err.Error())

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// AccessListsGetter defines an interface for reading access lists.
+type AccessListsGetter interface {
+	// GetAccessLists returns a list of all access lists.
+	GetAccessLists(context.Context) ([]*types.AccessList, error)
+	// GetAccessList returns the specified access list resource.
+	GetAccessList(context.Context, string) (*types.AccessList, error)
+}
+
+// AccessLists defines an interface for managing AccessLists.
+type AccessLists interface {
+	AccessListsGetter
+
+	// UpsertAccessList creates or updates an access list resource.
+	UpsertAccessList(context.Context, *types.AccessList) error
+	// DeleteAccessList removes the specified access list resource.
+	DeleteAccessList(context.Context, string) error
+	// DeleteAllAccessLists removes all access lists.
+	DeleteAllAccessLists(context.Context) error
+}
+
+// MarshalAccessList marshals the access list resource to JSON.
+func MarshalAccessList(accessList *types.AccessList, opts ...MarshalOption) ([]byte, error) {
+	if err := accessList.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !cfg.PreserveResourceID {
+		copy := *accessList
+		copy.SetResourceID(0)
+		accessList = &copy
+	}
+	return utils.FastMarshal(accessList)
+}
+
+// UnmarshalAccessList unmarshals the access list resource from JSON.
+func UnmarshalAccessList(data []byte, opts ...MarshalOption) (*types.AccessList, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("missing access list data")
+	}
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var h types.ResourceHeader
+	if err := utils.FastUnmarshal(data, &h); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var accessList *types.AccessList
+	if err := utils.FastUnmarshal(data, &accessList); err != nil {
+		return nil, trace.BadParameter(err.Error())
+	}
+	if err := accessList.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cfg.ID != 0 {
+		accessList.SetResourceID(cfg.ID)
+	}
+	if !cfg.Expires.IsZero() {
+		accessList.SetExpiry(cfg.Expires)
+	}
+	return accessList, nil
+}

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// TestAccessListUnmarshal verifies an access list resource can be unmarshaled.
+func TestAccessListUnmarshal(t *testing.T) {
+	expected, err := types.NewAccessList(
+		header.Metadata{
+			Name: "test-access-list",
+		},
+		types.AccessListSpec{
+			Description: "test access list",
+			Owners: []types.AccessListOwner{
+				{
+					Name:        "test-user1",
+					Description: "test user 1",
+				},
+				{
+					Name:        "test-user2",
+					Description: "test user 2",
+				},
+			},
+			Audit: types.AccessListAudit{
+				Frequency: time.Hour,
+			},
+			MembershipRequires: types.AccessListRequires{
+				Roles: []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			OwnershipRequires: types.AccessListRequires{
+				Roles: []string{"orole1", "orole2"},
+				Traits: map[string][]string{
+					"otrait1": {"ovalue1", "ovalue2"},
+					"otrait2": {"ovalue3", "ovalue4"},
+				},
+			},
+			Grants: types.AccessListGrants{
+				Roles: []string{"grole1", "grole2"},
+				Traits: map[string][]string{
+					"gtrait1": {"gvalue1", "gvalue2"},
+					"gtrait2": {"gvalue3", "gvalue4"},
+				},
+			},
+			Members: []types.AccessListMember{
+				{
+					Name:    "member1",
+					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					Reason:  "because",
+					AddedBy: "test-user1",
+				},
+				{
+					Name:    "member2",
+					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					Reason:  "because again",
+					AddedBy: "test-user2",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	data, err := utils.ToJSON([]byte(accessListYAML))
+	require.NoError(t, err)
+	actual, err := UnmarshalAccessList(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+// TestAccessListMarshal verifies a marshaled access list resource can be unmarshaled back.
+func TestAccessListMarshal(t *testing.T) {
+	expected, err := types.NewAccessList(
+		header.Metadata{
+			Name: "test-rule",
+		},
+		types.AccessListSpec{
+			Description: "test access list",
+			Owners: []types.AccessListOwner{
+				{
+					Name:        "test-user1",
+					Description: "test user 1",
+				},
+				{
+					Name:        "test-user2",
+					Description: "test user 2",
+				},
+			},
+			Audit: types.AccessListAudit{
+				Frequency: time.Hour,
+			},
+			MembershipRequires: types.AccessListRequires{
+				Roles: []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			OwnershipRequires: types.AccessListRequires{
+				Roles: []string{"orole1", "orole2"},
+				Traits: map[string][]string{
+					"otrait1": {"ovalue1", "ovalue2"},
+					"otrait2": {"ovalue3", "ovalue4"},
+				},
+			},
+			Grants: types.AccessListGrants{
+				Roles: []string{"grole1", "grole2"},
+				Traits: map[string][]string{
+					"gtrait1": {"gvalue1", "gvalue2"},
+					"gtrait2": {"gvalue3", "gvalue4"},
+				},
+			},
+			Members: []types.AccessListMember{
+				{
+					Name:    "member1",
+					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					Reason:  "because",
+					AddedBy: "test-user1",
+				},
+				{
+					Name:    "member2",
+					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					Reason:  "because again",
+					AddedBy: "test-user2",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+	data, err := MarshalAccessList(expected)
+	require.NoError(t, err)
+	actual, err := UnmarshalAccessList(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+var accessListYAML = `---
+kind: access_list
+version: v1
+metadata:
+  name: test-access-list
+spec:
+  description: "test access list"  
+  owners:
+  - name: test-user1
+    description: "test user 1"
+  - name: test-user2
+    description: "test user 2"
+  audit:
+    frequency: "1h"
+  membership_requires:
+    roles:
+    - mrole1
+    - mrole2
+    traits:
+      mtrait1:
+      - mvalue1
+      - mvalue2
+      mtrait2:
+      - mvalue3
+      - mvalue4
+  ownership_requires:
+    roles:
+    - orole1
+    - orole2
+    traits:
+      otrait1:
+      - ovalue1
+      - ovalue2
+      otrait2:
+      - ovalue3
+      - ovalue4
+  grants:
+    roles:
+    - grole1
+    - grole2
+    traits:
+      gtrait1:
+      - gvalue1
+      - gvalue2
+      gtrait2:
+      - gvalue3
+      - gvalue4
+  members:
+  - name: member1
+    joined: 2023-01-01T00:00:00Z
+    expires: 2024-01-01T00:00:00Z
+    reason: "because"
+    added_by: "test-user1"
+  - name: member2
+    joined: 2022-01-01T00:00:00Z
+    expires: 2025-01-01T00:00:00Z
+    reason: "because again"
+    added_by: "test-user2"
+`

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+const (
+	accessListPrefix = "access_list"
+)
+
+// AccessListService manages Access List resources in the Backend.
+type AccessListService struct {
+	log   logrus.FieldLogger
+	clock clockwork.Clock
+	svc   *generic.Service[*types.AccessList]
+}
+
+// NewAccessListService creates a new AccessListService.
+func NewAccessListService(backend backend.Backend, clock clockwork.Clock) (*AccessListService, error) {
+	svc, err := generic.NewService(&generic.ServiceConfig[*types.AccessList]{
+		Backend:       backend,
+		ResourceKind:  types.KindAccessList,
+		BackendPrefix: accessListPrefix,
+		MarshalFunc:   services.MarshalAccessList,
+		UnmarshalFunc: services.UnmarshalAccessList,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &AccessListService{
+		log:   logrus.WithFields(logrus.Fields{trace.Component: "access-list:local-service"}),
+		clock: clock,
+		svc:   svc,
+	}, nil
+}
+
+// GetAccessLists returns a list of all access lists.
+func (a *AccessListService) GetAccessLists(ctx context.Context) ([]*types.AccessList, error) {
+	accessLists, err := a.svc.GetResources(ctx)
+	return accessLists, trace.Wrap(err)
+}
+
+// GetAccessList returns the specified access list resource.
+func (a *AccessListService) GetAccessList(ctx context.Context, name string) (*types.AccessList, error) {
+	accessList, err := a.svc.GetResource(ctx, name)
+	return accessList, trace.Wrap(err)
+}
+
+// UpsertAccessList creates or updates an access list resource.
+func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *types.AccessList) error {
+	return trace.Wrap(a.svc.UpsertResource(ctx, accessList))
+}
+
+// DeleteAccessList removes the specified access list resource.
+func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) error {
+	return trace.Wrap(a.svc.DeleteResource(ctx, name))
+}
+
+// DeleteAllAccessLists removes all access lists.
+func (a *AccessListService) DeleteAllAccessLists(ctx context.Context) error {
+	return trace.Wrap(a.svc.DeleteAllResources(ctx))
+}

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -23,12 +23,13 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/teleport/api/types/header"
-	"github.com/gravitational/teleport/lib/backend/memory"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
 // TestAccessListCRUD tests backend operations with access list resources.

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAccessListCRUD tests backend operations with access list resources.
+func TestAccessListCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+		Clock:   clock,
+	})
+	require.NoError(t, err)
+
+	service, err := NewAccessListService(backend, clock)
+	require.NoError(t, err)
+
+	// Create a couple access lists.
+	accessList1 := newAccessList(t, "accessList1")
+	accessList2 := newAccessList(t, "accessList2")
+
+	// Initially we expect no access lists.
+	out, err := service.GetAccessLists(ctx)
+	require.NoError(t, err)
+	require.Empty(t, out)
+
+	// Create both access lists.
+	err = service.UpsertAccessList(ctx, accessList1)
+	require.NoError(t, err)
+	err = service.UpsertAccessList(ctx, accessList2)
+	require.NoError(t, err)
+
+	// Fetch all access lists.
+	out, err = service.GetAccessLists(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*types.AccessList{accessList1, accessList2}, out,
+		cmpopts.IgnoreFields(header.Metadata{}, "ID"),
+	))
+
+	// Fetch a specific access list.
+	accessList, err := service.GetAccessList(ctx, accessList2.GetName())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(accessList2, accessList,
+		cmpopts.IgnoreFields(header.Metadata{}, "ID"),
+	))
+
+	// Try to fetch an access list that doesn't exist.
+	_, err = service.GetAccessList(ctx, "doesnotexist")
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+	// Update an access list.
+	accessList1.SetExpiry(clock.Now().Add(30 * time.Minute))
+	err = service.UpsertAccessList(ctx, accessList1)
+	require.NoError(t, err)
+	accessList, err = service.GetAccessList(ctx, accessList1.GetName())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(accessList1, accessList,
+		cmpopts.IgnoreFields(header.Metadata{}, "ID"),
+	))
+
+	// Delete an access list.
+	err = service.DeleteAccessList(ctx, accessList1.GetName())
+	require.NoError(t, err)
+	out, err = service.GetAccessLists(ctx)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff([]*types.AccessList{accessList2}, out,
+		cmpopts.IgnoreFields(header.Metadata{}, "ID"),
+	))
+
+	// Try to delete an access list that doesn't exist.
+	err = service.DeleteAccessList(ctx, "doesnotexist")
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+
+	// Delete all access lists.
+	err = service.DeleteAllAccessLists(ctx)
+	require.NoError(t, err)
+	out, err = service.GetAccessLists(ctx)
+	require.NoError(t, err)
+	require.Empty(t, out)
+}
+
+func newAccessList(t *testing.T, name string) *types.AccessList {
+	t.Helper()
+
+	accessList, err := types.NewAccessList(
+		header.Metadata{
+			Name: name,
+		},
+		types.AccessListSpec{
+			Description: "test access list",
+			Owners: []types.AccessListOwner{
+				{
+					Name:        "test-user1",
+					Description: "test user 1",
+				},
+				{
+					Name:        "test-user2",
+					Description: "test user 2",
+				},
+			},
+			Audit: types.AccessListAudit{
+				Frequency: time.Hour,
+			},
+			MembershipRequires: types.AccessListRequires{
+				Roles: []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			OwnershipRequires: types.AccessListRequires{
+				Roles: []string{"orole1", "orole2"},
+				Traits: map[string][]string{
+					"otrait1": {"ovalue1", "ovalue2"},
+					"otrait2": {"ovalue3", "ovalue4"},
+				},
+			},
+			Grants: types.AccessListGrants{
+				Roles: []string{"grole1", "grole2"},
+				Traits: map[string][]string{
+					"gtrait1": {"gvalue1", "gvalue2"},
+					"gtrait2": {"gvalue3", "gvalue4"},
+				},
+			},
+			Members: []types.AccessListMember{
+				{
+					Name:    "member1",
+					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+					Reason:  "because",
+					AddedBy: "test-user1",
+				},
+				{
+					Name:    "member2",
+					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+					Reason:  "because again",
+					AddedBy: "test-user2",
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	return accessList
+}


### PR DESCRIPTION
The access list backend service and marshaling/unmarshaling functions have been implemented. This will allow for CRUD operations for access lists.

[RFD-6E](https://github.com/gravitational/teleport.e/blob/master/rfd/0006e-access-lists.md) for context.