### PR TITLE
Add an option to bootstrap database service to `teleport discovery boostrap`

### DIFF
--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -36,6 +36,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/api/types"
+	apiutils "github.com/gravitational/teleport/api/utils"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
 	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/configurators"
@@ -48,8 +49,8 @@ import (
 )
 
 const (
-	// DefaultPolicyName default policy name.
-	DefaultPolicyName = "DatabaseAccess"
+	// DatabasePolicyName is the policy name for database access.
+	DatabasePolicyName = "DatabaseAccess"
 	// databasePolicyDescription description used on the policy created.
 	databasePolicyDescription = "Used by Teleport database agents for discovering AWS-hosted databases."
 	// discoveryServicePolicyDescription description used on the policy created.
@@ -70,39 +71,71 @@ type databaseActions struct {
 	// iamAuth is a list of actions used for enabling IAM auth.
 	iamAuth []string
 	// metadata is a list of actions used for fetching database metadata
-	// (excluding the ones already in "discovery").
 	metadata []string
 	// managedUsers is a list of actions used for managing database users.
 	managedUsers []string
-	// boundary is a list of actions only used for boundary policies.
-	boundary []string
+	// authBoundary is a list of actions for authorization that need to added
+	// to boundary policies.
+	authBoundary []string
 
 	requireIAMEdit        bool
 	requireSecretsManager bool
 }
 
-func (a databaseActions) buildStatementForDiscovery() *awslib.Statement {
-	// Note that currently extra boundary policies are not required for discovery service.
+func (a databaseActions) buildStatement(opt databaseActionsBuildOption) *awslib.Statement {
+	var actions []string
+	if opt.withDiscovery {
+		actions = append(actions, a.discovery...)
+	}
+	if opt.withMetadata {
+		actions = append(actions, a.metadata...)
+	}
+	if opt.withAuth {
+		actions = append(actions, a.iamAuth...)
+		actions = append(actions, a.managedUsers...)
+	}
+	if opt.withAuthBoundary {
+		actions = append(actions, a.authBoundary...)
+	}
 	return &awslib.Statement{
 		Effect:    awslib.EffectAllow,
-		Actions:   a.discovery,
+		Actions:   apiutils.Deduplicate(actions),
 		Resources: []string{"*"},
 	}
 }
 
-func (a databaseActions) buildStatement(boundary bool) *awslib.Statement {
-	var actions []string
-	actions = append(actions, a.discovery...)
-	actions = append(actions, a.iamAuth...)
-	actions = append(actions, a.metadata...)
-	actions = append(actions, a.managedUsers...)
-	if boundary {
-		actions = append(actions, a.boundary...)
-	}
-	return &awslib.Statement{
-		Effect:    awslib.EffectAllow,
-		Actions:   actions,
-		Resources: []string{"*"},
+type databaseActionsBuildOption struct {
+	withDiscovery    bool
+	withMetadata     bool
+	withAuth         bool
+	withAuthBoundary bool
+}
+
+func makeDatabaseActionsBuildOption(flags configurators.BootstrapFlags, targetCfg targetConfig, boundary bool) databaseActionsBuildOption {
+	switch {
+	// Bootstrap discovery service.
+	case flags.DiscoveryService:
+		return databaseActionsBuildOption{
+			withDiscovery: true,
+		}
+
+	// Bootstrap database service using discovery service config.
+	case flags.DiscoveryServiceConfig:
+		return databaseActionsBuildOption{
+			withDiscovery:    false,
+			withMetadata:     false, // Discovered databases should have correct metadata.
+			withAuth:         true,
+			withAuthBoundary: boundary,
+		}
+
+	// Default is database service.
+	default:
+		return databaseActionsBuildOption{
+			withDiscovery:    true,
+			withMetadata:     true,
+			withAuth:         true,
+			withAuthBoundary: boundary,
+		}
 	}
 }
 
@@ -142,8 +175,9 @@ var (
 	// instances and Aurora clusters).
 	rdsActions = databaseActions{
 		discovery:      []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters"},
+		metadata:       []string{"rds:DescribeDBInstances", "rds:DescribeDBClusters"},
 		iamAuth:        []string{"rds:ModifyDBInstance", "rds:ModifyDBCluster"},
-		boundary:       []string{"rds-db:connect"},
+		authBoundary:   []string{"rds-db:connect"},
 		requireIAMEdit: true,
 	}
 	// rdsProxyActions contains IAM actions for services.AWSMatcherRDSProxy.
@@ -154,13 +188,18 @@ var (
 			"rds:DescribeDBProxyTargets",
 			"rds:ListTagsForResource",
 		},
-		boundary:       []string{"rds-db:connect"},
+		metadata: []string{
+			"rds:DescribeDBProxies",
+			"rds:DescribeDBProxyEndpoints",
+		},
+		authBoundary:   []string{"rds-db:connect"},
 		requireIAMEdit: true,
 	}
 	// redshiftActions contains IAM actions for services.AWSMatcherRedshift.
 	redshiftActions = databaseActions{
 		discovery:      []string{"redshift:DescribeClusters"},
-		boundary:       []string{"redshift:GetClusterCredentials"},
+		metadata:       []string{"redshift:DescribeClusters"},
+		authBoundary:   []string{"redshift:GetClusterCredentials"},
 		requireIAMEdit: true,
 	}
 	// redshiftServerlessActions contains IAM actions for services.AWSMatcherRedshiftServerless.
@@ -174,7 +213,7 @@ var (
 			"redshift-serverless:GetEndpointAccess",
 			"redshift-serverless:GetWorkgroup",
 		},
-		boundary: stsActions,
+		authBoundary: stsActions,
 	}
 	// elastiCacheActions contains IAM actions for services.AWSMatcherElastiCache.
 	elastiCacheActions = databaseActions{
@@ -184,12 +223,15 @@ var (
 			"elasticache:DescribeCacheClusters",
 			"elasticache:DescribeCacheSubnetGroups",
 		},
+		metadata: []string{
+			"elasticache:DescribeReplicationGroups",
+		},
 		managedUsers: []string{
 			"elasticache:DescribeUsers",
 			"elasticache:ModifyUser",
 		},
 		requireSecretsManager: true,
-		boundary:              []string{"elasticache:Connect"},
+		authBoundary:          []string{"elasticache:Connect"},
 		requireIAMEdit:        true,
 	}
 	// memoryDBActions contains IAM actions for services.AWSMatcherMemoryDB.
@@ -199,6 +241,9 @@ var (
 			"memorydb:DescribeClusters",
 			"memorydb:DescribeSubnetGroups",
 		},
+		metadata: []string{
+			"memorydb:DescribeClusters",
+		},
 		managedUsers: []string{
 			"memorydb:DescribeUsers",
 			"memorydb:UpdateUser",
@@ -207,11 +252,11 @@ var (
 	}
 	// awsKeyspacesActions contains IAM actions for static AWS Keyspaces databases.
 	awsKeyspacesActions = databaseActions{
-		boundary: stsActions,
+		authBoundary: stsActions,
 	}
 	// dynamodbActions contains IAM actions for static AWS DynamoDB databases.
 	dynamodbActions = databaseActions{
-		boundary: stsActions,
+		authBoundary: stsActions,
 	}
 )
 
@@ -313,6 +358,15 @@ func (a *awsConfigurator) IsEmpty() bool {
 // Name returns human-readable configurator name.
 func (a *awsConfigurator) Name() string {
 	return "AWS"
+}
+
+// Description returns a brief description of the configurator.
+func (a *awsConfigurator) Description() string {
+	serviceName := "Database Service"
+	if a.config.Flags.DiscoveryService {
+		serviceName = "Discovery Service"
+	}
+	return "Configure AWS for " + serviceName
 }
 
 // Actions list of configurator actions.
@@ -622,13 +676,10 @@ func buildPolicyDocument(flags configurators.BootstrapFlags, targetCfg targetCon
 		allActions = append(allActions, dynamodbActions)
 	}
 
+	dbOption := makeDatabaseActionsBuildOption(flags, targetCfg, boundary)
 	for _, dbActions := range allActions {
-		if flags.DiscoveryService {
-			policyDoc.EnsureStatements(dbActions.buildStatementForDiscovery())
-		} else {
-			policyDoc.EnsureStatements(dbActions.buildStatement(boundary))
-
-			// Skip these for discovery service.
+		policyDoc.EnsureStatements(dbActions.buildStatement(dbOption))
+		if dbOption.withAuth {
 			requireSecretsManager = requireSecretsManager || dbActions.requireSecretsManager
 			requireIAMEdit = requireIAMEdit || dbActions.requireIAMEdit
 		}
@@ -1066,7 +1117,7 @@ func getTargetConfig(flags configurators.BootstrapFlags, cfg *servicecfg.Config,
 // awsMatchersFromConfig is a helper function that extracts database AWS matchers
 // from the service configuration based on cli flags.
 func awsMatchersFromConfig(flags configurators.BootstrapFlags, cfg *servicecfg.Config) []types.AWSMatcher {
-	if flags.DiscoveryService {
+	if flags.DiscoveryService || flags.DiscoveryServiceConfig {
 		return cfg.Discovery.AWSMatchers
 	}
 	return cfg.Databases.AWSMatchers
@@ -1075,7 +1126,7 @@ func awsMatchersFromConfig(flags configurators.BootstrapFlags, cfg *servicecfg.C
 // databasesFromConfig is a helper function that extracts databases
 // from the service configuration based on cli flags.
 func databasesFromConfig(flags configurators.BootstrapFlags, cfg *servicecfg.Config) []*servicecfg.Database {
-	if flags.DiscoveryService {
+	if flags.DiscoveryService || flags.DiscoveryServiceConfig {
 		return nil
 	}
 	databases := make([]*servicecfg.Database, 0, len(cfg.Databases.Databases))
@@ -1086,7 +1137,7 @@ func databasesFromConfig(flags configurators.BootstrapFlags, cfg *servicecfg.Con
 }
 
 func resourceMatchersFromConfig(flags configurators.BootstrapFlags, cfg *servicecfg.Config) []services.ResourceMatcher {
-	if flags.DiscoveryService {
+	if flags.DiscoveryService || flags.DiscoveryServiceConfig {
 		return nil
 	}
 	return cfg.Databases.ResourceMatchers

--- a/lib/configurators/aws/aws.go
+++ b/lib/configurators/aws/aws.go
@@ -49,8 +49,8 @@ import (
 )
 
 const (
-	// DatabasePolicyName is the policy name for database access.
-	DatabasePolicyName = "DatabaseAccess"
+	// DatabaseAccessPolicyName is the policy name for database access.
+	DatabaseAccessPolicyName = "DatabaseAccess"
 	// databasePolicyDescription description used on the policy created.
 	databasePolicyDescription = "Used by Teleport database agents for discovering AWS-hosted databases."
 	// discoveryServicePolicyDescription description used on the policy created.

--- a/lib/configurators/aws/aws_test.go
+++ b/lib/configurators/aws/aws_test.go
@@ -539,7 +539,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 		},
 		"AutoDiscovery EC2": {
 			target: roleTarget,
-			flags:  configurators.BootstrapFlags{DiscoveryService: true},
+			flags:  configurators.BootstrapFlags{Service: configurators.DiscoveryService},
 			fileConfig: &config.FileConfig{
 				Discovery: config.Discovery{
 					Service: config.Service{EnabledFlag: "true"},
@@ -1040,7 +1040,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 			},
 		}
 
-		flags := configurators.BootstrapFlags{DiscoveryService: true}
+		flags := configurators.BootstrapFlags{Service: configurators.DiscoveryService}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
 				targetCfg := mustGetTargetConfig(t, flags, roleTarget, test.fileConfig)
@@ -1322,8 +1322,7 @@ func TestAWSIAMDocuments(t *testing.T) {
 		}
 
 		flags := configurators.BootstrapFlags{
-			DiscoveryService:       false,
-			DiscoveryServiceConfig: true,
+			Service: configurators.DatabaseServiceByDiscoveryServiceConfig,
 		}
 		for name, test := range tests {
 			t.Run(name, func(t *testing.T) {
@@ -1692,7 +1691,7 @@ func TestAWSDocumentConfigurator(t *testing.T) {
 		},
 		ServiceConfig: serviceConfig,
 		Flags: configurators.BootstrapFlags{
-			DiscoveryService:    true,
+			Service:             configurators.DiscoveryService,
 			ForceEC2Permissions: true,
 		},
 		Policies: &policiesMock{
@@ -1743,7 +1742,7 @@ func TestAWSConfigurator(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	config.Flags.DiscoveryService = true
+	config.Flags.Service = configurators.DiscoveryService
 	config.Flags.ForceEC2Permissions = true
 	config.Flags.Proxy = "proxy.xyz"
 
@@ -1815,7 +1814,7 @@ func TestExtractTargetConfig(t *testing.T) {
 		},
 		"target in discovery assume roles": {
 			target: roleTarget,
-			flags:  configurators.BootstrapFlags{ForceAssumesRoles: role1, DiscoveryService: true},
+			flags:  configurators.BootstrapFlags{ForceAssumesRoles: role1, Service: configurators.DiscoveryService},
 			cfg: &servicecfg.Config{
 				Discovery: servicecfg.DiscoveryConfig{
 					AWSMatchers: []types.AWSMatcher{
@@ -1842,7 +1841,7 @@ func TestExtractTargetConfig(t *testing.T) {
 		},
 		"target in discovery assume roles (boostrapping database service)": {
 			target: roleTarget,
-			flags:  configurators.BootstrapFlags{ForceAssumesRoles: role1, DiscoveryServiceConfig: true},
+			flags:  configurators.BootstrapFlags{ForceAssumesRoles: role1, Service: configurators.DatabaseServiceByDiscoveryServiceConfig},
 			cfg: &servicecfg.Config{
 				Discovery: servicecfg.DiscoveryConfig{
 					AWSMatchers: []types.AWSMatcher{
@@ -1909,7 +1908,7 @@ func TestExtractTargetConfig(t *testing.T) {
 		},
 		"target not in discovery roles": {
 			target: roleTarget,
-			flags:  configurators.BootstrapFlags{ForceAssumesRoles: role1, DiscoveryService: true},
+			flags:  configurators.BootstrapFlags{ForceAssumesRoles: role1, Service: configurators.DiscoveryService},
 			cfg: &servicecfg.Config{
 				Discovery: servicecfg.DiscoveryConfig{
 					AWSMatchers: []types.AWSMatcher{

--- a/lib/configurators/common.go
+++ b/lib/configurators/common.go
@@ -18,19 +18,54 @@ import (
 	"context"
 )
 
+// TargetService is the target service for bootstrapping.
+type TargetService int
+
+const (
+	// DatabaseService indicates the bootstrap is for database service. Cloud
+	// matchers and static databases are scanned from `database_service` and
+	// both discovery and access/auth permissions will be collected.
+	DatabaseService TargetService = iota
+	// DiscoveryService indicates the bootstrap is for discovery service. Cloud
+	// matchers are scanned from `discovery_service` and discovery permissions
+	// will be collected.
+	DiscoveryService
+	// DatabaseServiceByDiscoveryServiceConfig indicates the bootstrap is for
+	// database service that is receiving dynamic/discovered resources from the
+	// discovery service. Cloud matchers are scanned from `discovery_service`
+	// and access/auth permissions will be collected.
+	DatabaseServiceByDiscoveryServiceConfig
+)
+
+// Name returns the target service name.
+func (t TargetService) Name() string {
+	switch t {
+	case DatabaseService,
+		DatabaseServiceByDiscoveryServiceConfig:
+		return "Database Service"
+	case DiscoveryService:
+		return "Discovery Service"
+	default:
+		return "unknown service"
+	}
+}
+
+// IsDiscovery returns true if target is discovery service.
+func (t TargetService) IsDiscovery() bool {
+	return t == DiscoveryService
+}
+
+// UseDiscoveryServiceConfig returns true if target is using discovery service
+// config.
+func (t TargetService) UseDiscoveryServiceConfig() bool {
+	return t == DiscoveryService || t == DatabaseServiceByDiscoveryServiceConfig
+}
+
 // BootstrapFlags flags provided by users to configure and define how the
 // configurators will work.
 type BootstrapFlags struct {
-	// DiscoveryService indicates the bootstrap is for the discovery service.
-	DiscoveryService bool
-	// DiscoveryServiceConfig indicates that discovery service config is
-	// provided for bootstrapping.
-	//
-	// Note that this value can be true even when DiscoveryService is false.
-	// For example, discovery service config can be used to bootstrap database
-	// service for accessing dynamic resources/databases discovered by the
-	// discovery service.
-	DiscoveryServiceConfig bool
+	// Service specifies the target service for bootstrapping.
+	Service TargetService
 	// ConfigPath database agent configuration path.
 	ConfigPath string
 	// Manual boolean indicating if the configurator will perform the

--- a/lib/configurators/common.go
+++ b/lib/configurators/common.go
@@ -23,6 +23,14 @@ import (
 type BootstrapFlags struct {
 	// DiscoveryService indicates the bootstrap is for the discovery service.
 	DiscoveryService bool
+	// DiscoveryServiceConfig indicates that discovery service config is
+	// provided for bootstrapping.
+	//
+	// Note that this value can be true even when DiscoveryService is false.
+	// For example, discovery service config can be used to bootstrap database
+	// service for accessing dynamic resources/databases discovered by the
+	// discovery service.
+	DiscoveryServiceConfig bool
 	// ConfigPath database agent configuration path.
 	ConfigPath string
 	// Manual boolean indicating if the configurator will perform the
@@ -94,6 +102,8 @@ type Configurator interface {
 	Actions() []ConfiguratorAction
 	// Name returns the configurator name.
 	Name() string
+	// Description returns a brief description of the configurator.
+	Description() string
 	// IsEmpty defines if the configurator will have to perform any action.
 	IsEmpty() bool
 }

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -292,7 +292,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	dbConfigureBootstrap := dbConfigure.Command("bootstrap", "Bootstrap the necessary configuration for the database agent. It reads the provided agent configuration to determine what will be bootstrapped.")
 	dbConfigureBootstrap.Flag("config", fmt.Sprintf("Path to a configuration file [%v].", defaults.ConfigFilePath)).Short('c').Default(defaults.ConfigFilePath).ExistingFileVar(&configureDiscoveryBootstrapFlags.config.ConfigPath)
 	dbConfigureBootstrap.Flag("manual", "When executed in \"manual\" mode, it will print the instructions to complete the configuration instead of applying them directly.").BoolVar(&configureDiscoveryBootstrapFlags.config.Manual)
-	dbConfigureBootstrap.Flag("policy-name", fmt.Sprintf("Name of the Teleport Database agent policy. Default: %q.", awsconfigurators.DefaultPolicyName)).Default(awsconfigurators.DefaultPolicyName).StringVar(&configureDiscoveryBootstrapFlags.config.PolicyName)
+	dbConfigureBootstrap.Flag("policy-name", fmt.Sprintf("Name of the Teleport Database agent policy. Default: %q.", awsconfigurators.DatabaseAccessPolicyName)).Default(awsconfigurators.DatabaseAccessPolicyName).StringVar(&configureDiscoveryBootstrapFlags.config.PolicyName)
 	dbConfigureBootstrap.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDiscoveryBootstrapFlags.confirm)
 	dbConfigureBootstrap.Flag("attach-to-role", "Role name to attach policy to. Mutually exclusive with --attach-to-user. If none of the attach-to flags is provided, the command will try to attach the policy to the current user/role based on the credentials.").StringVar(&configureDiscoveryBootstrapFlags.config.AttachToRole)
 	dbConfigureBootstrap.Flag("attach-to-user", "User name to attach policy to. Mutually exclusive with --attach-to-role. If none of the attach-to flags is provided, the command will try to attach the policy to the current user/role based on the credentials.").StringVar(&configureDiscoveryBootstrapFlags.config.AttachToUser)
@@ -318,7 +318,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		fmt.Sprintf("Comma-separated list of database types to include in the policy. Any of %s", strings.Join(awsDatabaseTypes, ","))).
 		Short('r').
 		StringVar(&configureDatabaseAWSCreateFlags.types)
-	dbConfigureAWSCreateIAM.Flag("name", "Created policy name. Defaults to empty. Will be auto-generated if not provided.").Default(awsconfigurators.DefaultPolicyName).StringVar(&configureDatabaseAWSCreateFlags.policyName)
+	dbConfigureAWSCreateIAM.Flag("name", "Created policy name. Defaults to empty. Will be auto-generated if not provided.").Default(awsconfigurators.DatabaseAccessPolicyName).StringVar(&configureDatabaseAWSCreateFlags.policyName)
 	// --attach flag is deprecated.
 	dbConfigureAWSCreateIAM.Flag("attach", "Try to attach the policy to the IAM identity.").Hidden().Default("true").BoolVar(&configureDatabaseAWSCreateFlags.attach)
 	dbConfigureAWSCreateIAM.Flag("confirm", "Do not prompt user and auto-confirm all actions.").BoolVar(&configureDatabaseAWSCreateFlags.confirm)
@@ -342,7 +342,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		StringVar(&configureDiscoveryBootstrapFlags.config.ForceAssumesRoles)
 	discoveryBootstrapCmd.Flag("manual", "When executed in \"manual\" mode, it will print the instructions to complete the configuration instead of applying them directly.").BoolVar(&configureDiscoveryBootstrapFlags.config.Manual)
 	discoveryBootstrapCmd.Flag("database-service-role", "Role name to attach database access policies to. If specified, bootstrap for the database service that accesses the databases discovered by this discovery service.").StringVar(&configureDiscoveryBootstrapFlags.databaseServiceRole)
-	discoveryBootstrapCmd.Flag("database-service-policy-name", "Name of the policy for bootstrapping database service when database-service-role is provided. ").Default(awsconfigurators.DatabasePolicyName).StringVar(&configureDiscoveryBootstrapFlags.databaseServicePolicyName)
+	discoveryBootstrapCmd.Flag("database-service-policy-name", "Name of the policy for bootstrapping database service when database-service-role is provided. ").Default(awsconfigurators.DatabaseAccessPolicyName).StringVar(&configureDiscoveryBootstrapFlags.databaseServicePolicyName)
 
 	// "teleport install" command and its subcommands
 	installCmd := app.Command("install", "Teleport install commands.")

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/config"
+	"github.com/gravitational/teleport/lib/configurators"
 	awsconfigurators "github.com/gravitational/teleport/lib/configurators/aws"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
@@ -513,13 +514,12 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	case dbConfigureAWSCreateIAM.FullCommand():
 		err = onConfigureDatabasesAWSCreate(configureDatabaseAWSCreateFlags)
 	case dbConfigureBootstrap.FullCommand():
-		configureDiscoveryBootstrapFlags.config.DiscoveryService = false
+		configureDiscoveryBootstrapFlags.config.Service = configurators.DatabaseService
 		err = onConfigureDiscoveryBootstrap(configureDiscoveryBootstrapFlags)
 	case systemdInstall.FullCommand():
 		err = onDumpSystemdUnitFile(systemdInstallFlags)
 	case discoveryBootstrapCmd.FullCommand():
-		configureDiscoveryBootstrapFlags.config.DiscoveryService = true
-		configureDiscoveryBootstrapFlags.config.DiscoveryServiceConfig = true
+		configureDiscoveryBootstrapFlags.config.Service = configurators.DiscoveryService
 		err = onConfigureDiscoveryBootstrap(configureDiscoveryBootstrapFlags)
 	case joinOpenSSH.FullCommand():
 		err = onJoinOpenSSH(ccf, conf)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -340,6 +340,9 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	discoveryBootstrapCmd.Flag("assumes-roles",
 		"Comma-separated list of additional IAM roles that the IAM identity should be able to assume. Each role can be either an IAM role ARN or the name of a role in the identity's account.").
 		StringVar(&configureDiscoveryBootstrapFlags.config.ForceAssumesRoles)
+	discoveryBootstrapCmd.Flag("manual", "When executed in \"manual\" mode, it will print the instructions to complete the configuration instead of applying them directly.").BoolVar(&configureDiscoveryBootstrapFlags.config.Manual)
+	discoveryBootstrapCmd.Flag("database-service-role", "Role name to attach database access policies to. If specified, bootstrap for the database service that accesses the databases discovered by this discovery service.").StringVar(&configureDiscoveryBootstrapFlags.databaseServiceRole)
+	discoveryBootstrapCmd.Flag("database-service-policy-name", "Name of the policy for bootstrapping database service when database-service-role is provided. ").Default(awsconfigurators.DatabasePolicyName).StringVar(&configureDiscoveryBootstrapFlags.databaseServicePolicyName)
 
 	// "teleport install" command and its subcommands
 	installCmd := app.Command("install", "Teleport install commands.")
@@ -516,6 +519,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		err = onDumpSystemdUnitFile(systemdInstallFlags)
 	case discoveryBootstrapCmd.FullCommand():
 		configureDiscoveryBootstrapFlags.config.DiscoveryService = true
+		configureDiscoveryBootstrapFlags.config.DiscoveryServiceConfig = true
 		err = onConfigureDiscoveryBootstrap(configureDiscoveryBootstrapFlags)
 	case joinOpenSSH.FullCommand():
 		err = onJoinOpenSSH(ccf, conf)


### PR DESCRIPTION
Implements #27737

UX:
```
$ teleport discovery bootstrap --attach-to-role <discovery-service-role> --database-service-role <database-service-role> 

Reading configuration at "teleport.yaml"...

Configure AWS for Discovery Service
1. Create IAM Policy "<discovery-service-policy-name>":
...

2. Create IAM Policy "<discovery-service-policy-name>Boundary":
...

3. Attach IAM policies to "<discovery-service-role>".

Configure AWS for Database Service
1. Create IAM Policy "<database-service-polcy-name>":
...

2. Create IAM Policy "<database-service-polcy-name>Boundary":
...

3. Attach IAM policies to "<database-service-role>".

Confirm? [y/N]: y
✅[AWS] Create IAM Policy "<discovery-service-policy-name>"... done.
✅[AWS] Create IAM Policy "<discovery-service-policy-name>Boundary"... done.
✅[AWS] Attach IAM policies to "<discovery-service-role>"... done.
✅[AWS] Create IAM Policy <database-service-polcy-name>"... done.
✅[AWS] Create IAM Policy "<database-service-polcy-name>Boundary"... done.
✅[AWS] Attach IAM policies to "<database-service-role>"... done.
```