### PR TITLE
[Docs]: Minor wording change

### DIFF
--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -124,13 +124,13 @@ access to. All agents must run in the same network as their target resources.
 
 ## Teleport editions
 
-Teleport is available in three **editions**. All editions include the same open
+Teleport is available in several **editions**. All editions include the same open
 source core, which is available at the
 [`gravitational/teleport`](https://github.com/gravitational/teleport) repository
 on GitHub.
 
-You can find a detailed comparison of Teleport's editions in our [Choose an
-Edition](./choose-an-edition/introduction.mdx) documentation.
+You can find a detailed comparison of the features available in each Teleport 
+edition in [Choose an edition](./choose-an-edition/introduction.mdx).
 
 ### Teleport Team
 


### PR DESCRIPTION
Change "three" editions to "several" editions for future-proof flexibility.
Remove the possessive (typically frowned upon for company and product naming reasons).