### PR TITLE
Fix Device Trust Logins

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3393,6 +3393,10 @@ func (tc *TeleportClient) AttemptDeviceLogin(ctx context.Context, key *Key, root
 		Bytes: newCerts.X509Der,
 	})
 
+	if err := tc.localAgent.AddKey(&cp); err != nil {
+		return trace.Wrap(err)
+	}
+
 	// Get the list of host certificates that this cluster knows about.
 	hostCerts, err := rootAuthClient.GetCertAuthorities(ctx, types.HostCA, false)
 	if err != nil {


### PR DESCRIPTION
#28499 missed adding the augmented device certificates retrieved from DeviceLogin to the local agent which causes TestNodeAccess to fail because device logins are using incorrect certs. This was not caught in #28499 because TestNodeAccess is in `e` and tests from `e` are not run on `oss` PRs.