### PR TITLE
[v12] docs: edits to the headless webauthn guide

### DIFF
--- a/docs/pages/access-controls/guides/headless.mdx
+++ b/docs/pages/access-controls/guides/headless.mdx
@@ -32,8 +32,9 @@ For example:
 - A v12.2+ Teleport cluster with WebAuthn configured.
   See the [Second Factor: WebAuthn](./webauthn.mdx) guide.
 - WebAuthn hardware device, such as YubiKey.
-- A Web browser with [WebAuthn support](
-  https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/).
+- Machines for Headless WebAuthn activities have [Linux](../../installation.mdx#linux), [macOS](../../installation.mdx#macos) or [Windows](../../installation.mdx#windows-tsh-client-only) `tsh` binary v12.2+ installed.
+- Machines used to approve Headless WebAuthn requests have a Web browser with [WebAuthn support](
+  https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) or `tsh` binary v12.2+ installed.
 
 ## Step 1/3. Configuration
 
@@ -102,6 +103,14 @@ $ tctl create -f cap.yaml
 
 ## Step 2/3. Initiate Headless WebAuthn
 
+First open a terminal on the remote machine and confirm the `tsh` binary
+is v12.2+ with `tsh version`.
+
+```code
+$ tsh version
+Teleport v(=teleport.version=) git: go(=teleport.golang=)
+```
+
 Run a headless `tsh` command with the `--headless` flag. This will initiate
 headless authentication, printing a URL and `tsh` command.
 
@@ -127,6 +136,7 @@ Unlike a standard login session, headless sessions are only available for the
 lifetime of a single `tsh` request. This means that for each `tsh --headless`
 command, you will need to go through the Headless WebAuthn flow:
 
+### Example: Listing SSH servers
 ```code 
 $ tsh ls --headless --proxy=proxy.example.com --user=alice
 # Complete headless authentication in your local web browser:
@@ -140,7 +150,10 @@ $ tsh ls --headless --proxy=proxy.example.com --user=alice
 # Node Name Address        Labels                                                                             
 # --------- -------------- -----------
 # server01  127.0.0.1:3022 arch=x86_64
-#
+```
+
+### Example: Initiating an SSH session
+```code
 $ tsh ssh --headless --proxy=proxy.example.com --user=alice server01
 # Complete headless authentication in your local web browser:
 # 
@@ -149,8 +162,21 @@ $ tsh ssh --headless --proxy=proxy.example.com --user=alice server01
 # or execute this command in your local terminal:
 # 
 # tsh headless approve --user=alice --proxy=proxy.example.com 864cccd9-2425-46d9-a9f2-636387e66ebf
-# # User approves through link
+# # User approves through link and a ssh terminal starts
+alice@server01 $
 ```
+
+<Notice type="note">
+ The Teleport user, `--user` parameter, is the Teleport user requesting Headless WebAuthn activity. 
+  If no `--user` parameter or environment variables set the OS user in the machine terminal is used.
+
+  The login username, `--login` parameter or login@hostname, for `tsh ssh` commands is the user
+  to open a SSH session as. If no login username for the SSH session is set the OS terminal username is used. 
+  A Teleport user must have access to that login user for that server or they will receive 
+  an access denied message. The user could receive an access denied message after being approved
+  for their Headless WebAuthn activity since the same access rights are granted or denied as if running from
+  your local terminal.
+</Notice>
 
 ## Troubleshooting
 


### PR DESCRIPTION
backport #24328 to branch/v12