### PR TITLE
fix: supports newline and whitespace in motd

### DIFF
--- a/web/packages/teleport/src/Login/Motd/Motd.tsx
+++ b/web/packages/teleport/src/Login/Motd/Motd.tsx
@@ -15,20 +15,28 @@ limitations under the License.
 */
 
 import React from 'react';
+import styled from 'styled-components';
+
 import { Card, Box, Text, ButtonPrimary } from 'design';
 
 export function Motd({ message, onClick }: Props) {
   return (
-    <Card bg="levels.surface" my={6} mx="auto" width="464px">
+    <StyledCard bg="levels.surface" my={6} mx="auto">
       <Box p={6}>
-        <Text typography="h5" mb={3} textAlign="center">
+        <StyledText typography="h5" mb={3} textAlign="left">
           {message}
-        </Text>
-        <ButtonPrimary width="100%" mt={3} size="large" onClick={onClick}>
+        </StyledText>
+        <ButtonPrimary
+          width="100%"
+          mt={3}
+          size="large"
+          onClick={onClick}
+          align="center"
+        >
           Acknowledge
         </ButtonPrimary>
       </Box>
-    </Card>
+    </StyledCard>
   );
 }
 
@@ -36,3 +44,14 @@ type Props = {
   message: string;
   onClick(): void;
 };
+
+const StyledCard = styled(Card)`
+  overflow-y: auto;
+  max-width: 600px;
+  max-height: 500px;
+  opacity: 1;
+`;
+
+const StyledText = styled(Text)`
+  white-space: pre-wrap;
+`;


### PR DESCRIPTION
- renders newline and whitespace as configured.
- renders vertical scrollbar for longer message.
- shows "acknowledge" button at the end of the scroll so that users can see all motd message before acknowledging.
- caps width to `600px`, height to `500px`

closes https://github.com/gravitational/teleport/issues/28201
