### PR TITLE
Mention agentless in the OpenSSH guide for better SEO

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -842,7 +842,7 @@
               "slug": "/server-access/guides/ssh-pam/"
             },
             {
-              "title": "OpenSSH Guide",
+              "title": "Agentless OpenSSH Integration",
               "slug": "/server-access/guides/openssh/"
             },
             {

--- a/docs/pages/server-access/guides.mdx
+++ b/docs/pages/server-access/guides.mdx
@@ -5,7 +5,7 @@ layout: tocless-doc
 ---
 
 - [Using Teleport with PAM](./guides/ssh-pam.mdx): How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
-- [OpenSSH Guide](./guides/openssh.mdx): How to use Teleport on legacy systems with OpenSSH and sshd.
+- [Agentless OpenSSH Integration](./guides/openssh.mdx): How to use Teleport in agentless mode on systems with OpenSSH and `sshd`.
 - [Recording Proxy Mode](./guides/recording-proxy-mode.mdx): How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
 - [BPF Session Recording](./guides/bpf-session-recording.mdx): How to use BPF to record SSH session commands, modified files and network connections.
 - [Restricted Session](./guides/restricted-session.mdx): How to configure and use Restricted Session to apply security policies to SSH sessions.
@@ -16,4 +16,4 @@ layout: tocless-doc
 - [EC2 Instance Discovery (Preview)](./guides/ec2-discovery.mdx): How to configure Teleport to automatically enroll EC2 instances.
 - [Azure Instance Discovery (Preview)](./guides/azure-discovery.mdx): How to configure Teleport to automatically enroll Azure virtual machines.
 - [Using Teleport with Ansible](./guides/ansible.mdx): How to use Ansible with
-  Teleport-issued SSH credentials. 
+  Teleport-issued SSH credentials.

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -6,7 +6,7 @@ videoBanner: x0eYFUEIOrM
 ---
 
 In this guide, we will show you how to configure Teleport in agentless mode and
-have the OpenSSH server `sshd` to join a Teleport cluster. Existing fleets of
+have the OpenSSH server `sshd` join a Teleport cluster. Existing fleets of
 OpenSSH servers can be configured to accept SSH certificates dynamically issued
 by a Teleport CA.
 

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -1,12 +1,14 @@
 ---
-title: Using Teleport with OpenSSH
-description: This guide shows you how to set up Teleport to enable secure access to OpenSSH servers so you can protect legacy systems that do not run a Teleport binary.
+title: Using Teleport with OpenSSH in agentless mode
+description: This guide shows you how to set up Teleport in agentless mode to enable secure access to OpenSSH servers so you can protect systems that do not run a Teleport binary.
+keywords: [openssh, teleport, agentless]
 videoBanner: x0eYFUEIOrM
 ---
 
-In this guide, we will show you how to configure the OpenSSH server `sshd` to
-join a Teleport cluster. Existing fleets of OpenSSH servers can be configured to
-accept SSH certificates dynamically issued by a Teleport CA.
+In this guide, we will show you how to configure Teleport in agentless mode and
+have the OpenSSH server `sshd` to join a Teleport cluster. Existing fleets of
+OpenSSH servers can be configured to accept SSH certificates dynamically issued
+by a Teleport CA.
 
 Using Teleport and OpenSSH has the advantage of getting you up
 and running, but in the long run, we would recommend replacing `sshd` with `teleport`.

--- a/docs/pages/server-access/introduction.mdx
+++ b/docs/pages/server-access/introduction.mdx
@@ -19,14 +19,11 @@ Teleport server access is designed for the following kinds of scenarios:
 
 - [Get started](getting-started.mdx): Get started using Teleport server access
   in 10 minutes. Server access for most common SSH use-cases.
-- [Integrate with OpenSSH](guides/openssh.mdx): You can use Teleport-issued
-  certificates to access legacy OpenSSH servers on hosts where there is no
-  Teleport installation.
 
 ## Guides
 
 - [Using Teleport with PAM](./guides/ssh-pam.mdx): How to configure Teleport SSH with PAM (Pluggable Authentication Modules).
-- [OpenSSH Guide](./guides/openssh.mdx): How to use Teleport on legacy systems with OpenSSH and sshd.
+- [Agentless OpenSSH Integration](./guides/openssh.mdx): How to use Teleport in agentless mode on systems with OpenSSH and `sshd`.
 - [Recording Proxy Mode](./guides/recording-proxy-mode.mdx): How to use Teleport Recording Proxy Mode to capture activity on OpenSSH servers.
 - [BPF Session Recording](./guides/bpf-session-recording.mdx): How to use BPF to record SSH session commands, modified files and network connections.
 - [Restricted Session](./guides/restricted-session.mdx): How to configure and use Restricted Session to apply security policies to SSH sessions.


### PR DESCRIPTION
Right now searching for "agentless" in the docs does not bring up any results. This PR updates the OpenSSH guide to mention agentless mode explicitly so it shows up in the search results.

I have also removed the word "legacy" from "OpenSSH systems" because it feels like it has a bit of a negative/condescending connotation to it which I'm not sure we want to imply.