### PR TITLE
Fix imports on non-linting files

### DIFF
--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/lib/utils/registry/registry_windows.go
+++ b/lib/utils/registry/registry_windows.go
@@ -21,10 +21,9 @@ import (
 	"os"
 	"strconv"
 
-	"golang.org/x/sys/windows/registry"
-
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
+	"golang.org/x/sys/windows/registry"
 )
 
 // GetOrCreateRegistryKey loads or creates a registry key handle.

--- a/tool/tsh/common/putty_config_windows.go
+++ b/tool/tsh/common/putty_config_windows.go
@@ -21,11 +21,12 @@ import (
 	"net"
 	"syscall"
 
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/lib/puttyhosts"
 	"github.com/gravitational/teleport/lib/utils/registry"
-	"github.com/gravitational/trace"
 )
 
 // the key should not include HKEY_CURRENT_USER


### PR DESCRIPTION
Our linter does not run on all files, so the incorrect sorting is not reported, but GCI keeps fixing these imports each time I run it, hence the PR.