### PR TITLE
[v11] docs: use -o file instead of sudo tee for teleport configure example

### DIFF
--- a/docs/pages/includes/tls-certificate-setup.mdx
+++ b/docs/pages/includes/tls-certificate-setup.mdx
@@ -18,7 +18,9 @@ deployments, use your own private key and certificate.
     an email address used for notifications (you can use any domain):
 
     ```code
-    $ teleport configure --acme --acme-email=<Var name="user@example.com" description="Your email address to register with Let's Encrypt for TLS certificates" /> --cluster-name=<Var name="tele.example.com" description="The domain name of your Teleport cluster" /> | sudo tee /etc/teleport.yaml > /dev/null
+    $ sudo teleport configure -o file \
+        --acme --acme-email=<Var name="user@example.com" description="Your email address to register with Let's Encrypt for TLS certificates" /> \
+        --cluster-name=<Var name="tele.example.com" description="The domain name of your Teleport cluster" />
     ```
 
     The `--acme`, `--acme-email`, and `--cluster-name` flags will add the following


### PR DESCRIPTION
Backport #28688 to branch/v11