### PR TITLE
docs: bump cloud to 13.2.0

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1512,7 +1512,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.1.5",
+      "version": "13.2.0",
       "major_version": "13",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Cloud will be upgrading to 13.2.0 on 07/11/2023

Helps https://github.com/gravitational/cloud/issues/5179