### PR TITLE
Increased the gh-trigger-workflow polling period

### DIFF
--- a/build.assets/tooling/cmd/gh-trigger-workflow/main.go
+++ b/build.assets/tooling/cmd/gh-trigger-workflow/main.go
@@ -224,7 +224,7 @@ func waitForActiveWorkflowRuns(ctx context.Context, gh *ghapi.Client, args args)
 
 func waitForNewWorkflowRun(ctx context.Context, gh *ghapi.Client, args args, tag string, baselineTime time.Time, existingRuns github.RunIDSet) (*ghapi.WorkflowRun, error) {
 	// Now we need to wait and see if a new workflow is spawned
-	ticker := time.NewTicker(1 * time.Second)
+	ticker := time.NewTicker(5 * time.Second)
 	defer ticker.Stop()
 
 	for {

--- a/build.assets/tooling/lib/github/workflows.go
+++ b/build.assets/tooling/lib/github/workflows.go
@@ -140,7 +140,7 @@ func ListWorkflowJobs(ctx context.Context, lister WorkflowJobLister, owner, repo
 // WaitForRun blocks until the specified workflow run completes, and returns the overall
 // workflow status.
 func WaitForRun(ctx context.Context, actions WorkflowRuns, owner, repo, path string, runID int64) (string, error) {
-	ticker := time.NewTicker(30 * time.Second)
+	ticker := time.NewTicker(1 * time.Minute)
 	defer ticker.Stop()
 
 	for {


### PR DESCRIPTION
We're running into API rate limit issues, so I'm increasing the polling period.

Note that I have not tested this change, but it is so minor that I don't think the effort required to test it is worth the value gained by doing so.