### PR TITLE
Backport 28721 branch/v11

### DIFF
--- a/docs/pages/core-concepts.mdx
+++ b/docs/pages/core-concepts.mdx
@@ -124,13 +124,18 @@ access to. All agents must run in the same network as their target resources.
 
 ## Teleport editions
 
-Teleport is available in three **editions**. All editions include the same open
+Teleport is available in several **editions**. All editions include the same open
 source core, which is available at the
 [`gravitational/teleport`](https://github.com/gravitational/teleport) repository
 on GitHub.
 
+<<<<<<< HEAD
 You can find a detailed comparison of Teleport's editions in our [Frequently
 Asked Questions](./faq.mdx#how-is-open-source-different-from-enterprise) page.
+=======
+You can find a detailed comparison of the features available in each Teleport 
+edition in [Choose an edition](./choose-an-edition/introduction.mdx).
+>>>>>>> aa3d51de6f (Minor wording change)
 
 ### Teleport Community Edition
 


### PR DESCRIPTION
Automated backport for [Docs]: Minor wording change #28721 failed for v11 https://github.com/gravitational/teleport/pull/28721
I wasn't sure what to do, so I made a bold attempt to fix the merge conflict. Closing as probably a bad idea