### PR TITLE
[v12] docs: bump cloud to 13.2.0

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1418,7 +1418,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.1.5",
+      "version": "13.2.0",
       "major_version": "13",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/28776 to branch/v12