### PR TITLE
Set lower temperature to ChatGPT calls

### DIFF
--- a/lib/ai/model/agent.go
+++ b/lib/ai/model/agent.go
@@ -244,9 +244,10 @@ func (a *Agent) plan(ctx context.Context, state *executionState) (*AgentAction, 
 	stream, err := state.llm.CreateChatCompletionStream(
 		ctx,
 		openai.ChatCompletionRequest{
-			Model:    openai.GPT4,
-			Messages: prompt,
-			Stream:   true,
+			Model:       openai.GPT4,
+			Messages:    prompt,
+			Temperature: 0.3,
+			Stream:      true,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Updated the ChatCompletionRequest in the agent model to include temperature parameter. The temperature parameter controls the randomness of the AI's responses, making the model more conservative and focused with a lower value. In this case, the temperature is set to 0.3 to produce more focused and consistent results. Default is 1.0. Max is 2.0.