### PR TITLE
removed cloud warning

### DIFF
--- a/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
+++ b/docs/pages/management/operations/enroll-agent-into-automatic-updates.mdx
@@ -20,7 +20,6 @@ description: How to enroll an agent into automatic updates
   min="13.0"
 >
   Automatic agent update is available starting from Teleport `13.0`.
-  Teleport Cloud does not run Teleport 13 yet.
 </Details>
 
 Teleport supports automatic agent updates for


### PR DESCRIPTION
Removing text "Teleport Cloud does not run Teleport 13 yet" from warning on page.