### PR TITLE
DeployService IAM Configure: unescape arguments

### DIFF
--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -213,11 +213,11 @@ func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *htt
 	// teleport integration configure deployservice-iam
 	argsList := []string{
 		"integration", "configure", "deployservice-iam",
-		fmt.Sprintf(`--cluster="%s"`, clusterName),
-		fmt.Sprintf(`--name="%s"`, integrationName),
-		fmt.Sprintf(`--aws-region="%s"`, awsRegion),
-		fmt.Sprintf(`--role="%s"`, role),
-		fmt.Sprintf(`--task-role="%s"`, taskRole),
+		fmt.Sprintf("--cluster=%s", clusterName),
+		fmt.Sprintf("--name=%s", integrationName),
+		fmt.Sprintf("--aws-region=%s", awsRegion),
+		fmt.Sprintf("--role=%s", role),
+		fmt.Sprintf("--task-role=%s", taskRole),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
 		TeleportArgs: strings.Join(argsList, " "),

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -59,11 +59,11 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure deployservice-iam " +
-				`--cluster="localhost" ` +
-				`--name="myintegration" ` +
-				`--aws-region="us-east-1" ` +
-				`--role="myRole" ` +
-				`--task-role="taskRole"`,
+				`--cluster=localhost ` +
+				`--name=myintegration ` +
+				`--aws-region=us-east-1 ` +
+				`--role=myRole ` +
+				`--task-role=taskRole`,
 		},
 		{
 			name: "valid with symbols in role",
@@ -75,11 +75,11 @@ func TestBuildDeployServiceConfigureIAMScript(t *testing.T) {
 			},
 			errCheck: require.NoError,
 			expectedTeleportArgs: "integration configure deployservice-iam " +
-				`--cluster="localhost" ` +
-				`--name="myintegration" ` +
-				`--aws-region="us-east-1" ` +
-				`--role="Test+1=2,3.4@5-6_7" ` +
-				`--task-role="taskRole"`,
+				`--cluster=localhost ` +
+				`--name=myintegration ` +
+				`--aws-region=us-east-1 ` +
+				`--role=Test+1=2,3.4@5-6_7 ` +
+				`--task-role=taskRole`,
 		},
 		{
 			name: "missing aws-region",

--- a/lib/web/scripts/oneoff/oneoff.sh
+++ b/lib/web/scripts/oneoff/oneoff.sh
@@ -38,6 +38,7 @@ function main() {
 
     tarballName=$(teleportTarballName)
     curl --show-error --fail --location --remote-name ${cdnBaseURL}/${tarballName}
+    echo "Extracting teleport to $tempDir ..."
     tar -xzf ${tarballName}
 
     mkdir -p ./bin


### PR DESCRIPTION
We were escaping the command arguments with double quotes. It works with bash4.3+.

However, AWS CloudShell has bash 4.2 which:
>
> zz. When using the pattern substitution word expansion, bash now runs the
>     replacement string through quote removal, since it allows quotes in that
>     string to act as escape characters.  This is not backwards compatible, so
>     it can be disabled by setting the bash compatibility mode to 4.2.

http://tiswww.case.edu/php/chet/bash/CHANGES

When running this script in bash 4.2, the arguments end up being `"xyz"` instead of `xyz`.
So, errors like this happen:
```
ERROR: operation error STS: GetCallerIdentity, https response error StatusCode: 0, RequestID: , request send failed, Post "https://sts.\"us-east-1\".amazonaws.com/": dial tcp: lookup sts."us-east-1".amazonaws.com: no such host
```

Removing the quotes means it will work on older and newer bash versions:

Demo:

```
> ./bin/teleport integration configure deployservice-iam --cluster=kimlisa.cloud.gravitational.io --name=r0mant --aws-region=us-east-1 --role=r0mant-oidc --task-role=Test+1=2,3.4@5-6_7
2023/07/07 08:04:05 TaskRole: Boundary Policy "Test+1=2,3.4@5-6_7Boundary" created.
2023/07/07 08:04:05 TaskRole: Role "Test+1=2,3.4@5-6_7" created with Boundary "arn:aws:iam::278576220453:policy/Test+1=2,3.4@5-6_7Boundary".
2023/07/07 08:04:05 TaskRole: IAM Policy "Test+1=2,3.4@5-6_7" added to Role "Test+1=2,3.4@5-6_7".
2023/07/07 08:04:05 IntegrationRole: IAM Policy "DeployService" added to Role "r0mant-oidc"
```

![image](https://github.com/gravitational/teleport/assets/689271/5c1d25f6-46db-464b-904c-02adacd56f34)
