### PR TITLE
tctl alert ls: Always show alert ID

### DIFF
--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -218,9 +218,9 @@ func displayAlertsText(alerts []types.ClusterAlert, verbose bool) {
 		}
 		fmt.Println(table.AsBuffer().String())
 	} else {
-		table := asciitable.MakeTable([]string{"Severity", "Message"})
+		table := asciitable.MakeTable([]string{"ID", "Severity", "Message"})
 		for _, alert := range alerts {
-			table.AddRow([]string{alert.Spec.Severity.String(), fmt.Sprintf("%q", alert.Spec.Message)})
+			table.AddRow([]string{alert.GetName(), alert.Spec.Severity.String(), fmt.Sprintf("%q", alert.Spec.Message)})
 		}
 		fmt.Println(table.AsBuffer().String())
 	}


### PR DESCRIPTION
I assume that most of the time if you use tctl to list alerts, you do so to ack them. A list of them without IDs is otherwise available in a lot of other places. But you can't ack them without an ID which is confusing for users.

See [a triage thread](https://goteleport.slack.com/archives/C0582MBSMHN/p1688549211627799) where a customer tried to ack an alert and `alerts ls` did not return the ID. Then the customer proceeded to use `alerts ls --format json` which lists the ID but as the `name` field, due to how our backend resources work.

<details open>
<summary>Before & after</summary>

Before:

```
$ sudo tctl -c teleport-local.yaml alerts ls
Severity Message
-------- ---------------------------------------------------------------------------------------------------------------------------------
HIGH     "siema elo 320"
MEDIUM   "Sed ut dictum dolor. Nam consectetur convallis leo at euismod. Suspendisse eget ipsum dolor. Ut pharetra scelerisque tincidunt."
LOW      "Aenean augue nunc, dapibus at mauris in, eleifend consequat libero."
```

After:

```
$ sudo tctl -c teleport-local.yaml alerts ls
ID                                   Severity Message
------------------------------------ -------- ---------------------------------------------------------------------------------------------------------------------------------
fc76030b-bdbf-47b3-a66b-8839926986ef HIGH     "siema elo 320"
5e8a02c1-92ba-4746-abef-0dc5245b653d MEDIUM   "Sed ut dictum dolor. Nam consectetur convallis leo at euismod. Suspendisse eget ipsum dolor. Ut pharetra scelerisque tincidunt."
3949a16a-0d06-41f8-9ff8-57a93865fcf9 LOW      "Aenean augue nunc, dapibus at mauris in, eleifend consequat libero."
```
</details>

## Alternatives

Alternatively, if we deem that `alerts ls` should not list IDs, we could extend the help text of the verbose flag to say "Show detailed alert info, including alert IDs and acknowledged alerts."