### PR TITLE
DeployService: use correct version when auto-upgrades are enabled

### DIFF
--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -141,6 +141,13 @@ type DeployServiceRequest struct {
 	// DatabaseResourceMatcherLabels contains the set of labels to be used by the DatabaseService.
 	// This is used when the deployment mode creates a Database Service.
 	DatabaseResourceMatcherLabels types.Labels
+
+	// TeleportVersionTag is the version of teleport to install.
+	// Ensure the tag exists in:
+	// public.ecr.aws/gravitational/teleport-distroless:<TeleportVersionTag>
+	// Eg, 13.2.0
+	// Optional. Defaults to the current version.
+	TeleportVersionTag string
 }
 
 // normalizeECSResourceName converts a name into a valid ECS Resource Name.
@@ -172,6 +179,10 @@ func (r *DeployServiceRequest) CheckAndSetDefaults() error {
 		return trace.BadParameter("teleport cluster name is required")
 	}
 	baseResourceName := normalizeECSResourceName(r.TeleportClusterName)
+
+	if r.TeleportVersionTag == "" {
+		r.TeleportVersionTag = teleport.Version
+	}
 
 	if r.TeleportIAMTokenName == nil || *r.TeleportIAMTokenName == "" {
 		r.TeleportIAMTokenName = &defaultTeleportIAMTokenName
@@ -414,7 +425,7 @@ func DeployService(ctx context.Context, clt DeployServiceClient, req DeployServi
 
 // upsertTask ensures a TaskDefinition with TaskName exists
 func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceRequest, configB64 string) (*ecsTypes.TaskDefinition, error) {
-	taskAgentContainerImage := fmt.Sprintf(teleportContainerImageFmt, teleport.Version)
+	taskAgentContainerImage := fmt.Sprintf(teleportContainerImageFmt, req.TeleportVersionTag)
 
 	taskDefOut, err := clt.RegisterTaskDefinition(ctx, &ecs.RegisterTaskDefinitionInput{
 		Family: req.TaskName,

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -136,6 +137,7 @@ func TestDeployServiceRequest(t *testing.T) {
 			errCheck: require.NoError,
 			reqWithDefaults: DeployServiceRequest{
 				TeleportClusterName:  "mycluster",
+				TeleportVersionTag:   teleport.Version,
 				Region:               "r",
 				SubnetIDs:            []string{"1"},
 				TaskRoleARN:          "arn",

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -22,9 +22,11 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/julienschmidt/httprouter"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/api/utils/aws"
+	"github.com/gravitational/teleport/lib/automaticupgrades"
 	"github.com/gravitational/teleport/lib/httplib"
 	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -145,6 +147,17 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 		databaseAgentMatcherLabels[label.Name] = utils.Strings{label.Value}
 	}
 
+	teleportVersionTag := teleport.Version
+	if automaticUpgrades(h.ClusterFeatures) {
+		cloudStableVersion, err := automaticupgrades.Version(ctx, "" /* use default version server */)
+		if err != nil {
+			return "", trace.Wrap(err)
+		}
+
+		// cloudStableVersion has vX.Y.Z format, however the container image tag does not include the `v`.
+		teleportVersionTag = strings.TrimPrefix(cloudStableVersion, "v")
+	}
+
 	deployServiceResp, err := awsoidc.DeployService(ctx, deployDBServiceClient, awsoidc.DeployServiceRequest{
 		Region:                        req.Region,
 		AccountID:                     req.AccountID,
@@ -155,6 +168,7 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 		TaskRoleARN:                   req.TaskRoleARN,
 		ProxyServerHostPort:           h.PublicProxyAddr(),
 		TeleportClusterName:           h.auth.clusterName,
+		TeleportVersionTag:            teleportVersionTag,
 		DeploymentMode:                req.DeploymentMode,
 		IntegrationName:               awsClientReq.IntegrationName,
 		DatabaseResourceMatcherLabels: databaseAgentMatcherLabels,


### PR DESCRIPTION
For customers with Automatic Upgrades enabled, the teleport version to install must be the one provided by the Version server.