### PR TITLE
[v12] Fix `tsh kube credentials` lock when no-login is required

### DIFF
--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -521,7 +521,7 @@ func VirtualPathEnvNames(kind VirtualPathKind, params VirtualPathParams) []strin
 
 // RetryWithRelogin is a helper error handling method, attempts to relogin and
 // retry the function once.
-func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) error {
+func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error, opts ...RetryWithReloginOption) error {
 	fnErr := fn()
 	switch {
 	case fnErr == nil:
@@ -534,7 +534,11 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 		return trace.Wrap(fnErr)
 	}
 
-	log.Debugf("Activating relogin on error %v.", fnErr)
+	opt := retryWithReloginOptions{}
+	for _, o := range opts {
+		o(&opt)
+	}
+	log.Debugf("Activating relogin on %v.", fnErr)
 
 	// check if the error is a private key policy error.
 	if privateKeyPolicy, err := keys.ParsePrivateKeyPolicyError(fnErr); err == nil {
@@ -547,6 +551,11 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 		tc.PrivateKeyPolicy = privateKeyPolicy
 	}
 
+	if opt.beforeLoginHook != nil {
+		if err := opt.beforeLoginHook(); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	key, err := tc.Login(ctx)
 	if err != nil {
 		if errors.Is(err, prompt.ErrNotTerminal) {
@@ -574,6 +583,24 @@ func RetryWithRelogin(ctx context.Context, tc *TeleportClient, fn func() error) 
 	}
 
 	return fn()
+}
+
+// RetryWithReloginOption is a functional option for configuring the
+// RetryWithRelogin helper.
+type RetryWithReloginOption func(*retryWithReloginOptions)
+
+// retryWithReloginOptions is a struct for configuring the RetryWithRelogin
+type retryWithReloginOptions struct {
+	// beforeLoginHook is a function that will be called before the login attempt.
+	beforeLoginHook func() error
+}
+
+// WithBeforeLogin is a functional option for configuring a function that will
+// be called before the login attempt.
+func WithBeforeLoginHook(fn func() error) RetryWithReloginOption {
+	return func(o *retryWithReloginOptions) {
+		o.beforeLoginHook = fn
+	}
 }
 
 func IsErrorResolvableWithRelogin(err error) bool {

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -699,3 +699,66 @@ func silenceLogger(t *testing.T) {
 	log.SetOutput(io.Discard)
 	log.SetLevel(log.PanicLevel)
 }
+
+func TestRetryWithRelogin(t *testing.T) {
+	clock := clockwork.NewFakeClockAt(time.Now())
+	sa := newStandaloneTeleport(t, clock)
+
+	cfg := client.MakeDefaultConfig()
+	cfg.Username = sa.Username
+	cfg.HostLogin = sa.Username
+	cfg.WebProxyAddr = sa.ProxyWebAddr
+	cfg.KeysDir = t.TempDir()
+	cfg.InsecureSkipVerify = true
+	cfg.AllowStdinHijack = true
+
+	tc, err := client.NewClient(cfg)
+	require.NoError(t, err)
+
+	errorOnTry := func(counter *int, failedTry int) func() error {
+		return func() error {
+			*counter++
+			if *counter == failedTry {
+				return errors.New("ssh: cert has expired")
+			}
+			return nil
+		}
+	}
+
+	t.Run("Does not try login if function succeeds on the first run", func(t *testing.T) {
+		calledTimes := 0
+
+		err = client.RetryWithRelogin(context.Background(), tc, errorOnTry(&calledTimes, -1))
+
+		require.NoError(t, err)
+		require.Equal(t, 1, calledTimes)
+	})
+	t.Run("Runs 'beforeLoginHook' before login, if it's present", func(t *testing.T) {
+		calledTimes := 0
+
+		err = client.RetryWithRelogin(context.Background(), tc, errorOnTry(&calledTimes, 1), client.WithBeforeLoginHook(
+			func() error {
+				return errors.New("hook called")
+			}))
+
+		require.ErrorContains(t, err, "hook called")
+		require.Equal(t, 1, calledTimes)
+	})
+
+	t.Run("Successful retry after login", func(t *testing.T) {
+		solveOTP := func(ctx context.Context) (string, error) {
+			return totp.GenerateCode(sa.OTPKey, clock.Now())
+		}
+		oldStdin := prompt.Stdin()
+		t.Cleanup(func() {
+			prompt.SetStdin(oldStdin)
+		})
+		prompt.SetStdin(prompt.NewFakeReader().AddString(sa.Password).AddReply(solveOTP))
+		calledTimes := 0
+
+		err = client.RetryWithRelogin(context.Background(), tc, errorOnTry(&calledTimes, 1))
+
+		require.NoError(t, err)
+		require.Equal(t, 2, calledTimes)
+	})
+}

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -36,6 +36,11 @@ import (
 // (most probably it was already locked by someone else), another try might succeed.
 var ErrUnsuccessfulLockTry = errors.New("could not acquire lock on the file at this time")
 
+const (
+	// FSLockRetryDelay is a delay between attempts to acquire lock.
+	FSLockRetryDelay = 10 * time.Millisecond
+)
+
 // OpenFileWithFlagsFunc defines a function used to open files providing options.
 type OpenFileWithFlagsFunc func(name string, flag int, perm os.FileMode) (*os.File, error)
 
@@ -178,7 +183,7 @@ func FSTryWriteLockTimeout(ctx context.Context, filePath string, timeout time.Du
 	fileLock := flock.New(getPlatformLockFilePath(filePath))
 	timedCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if _, err := fileLock.TryLockContext(timedCtx, 10*time.Millisecond); err != nil {
+	if _, err := fileLock.TryLockContext(timedCtx, FSLockRetryDelay); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
 
@@ -206,7 +211,7 @@ func FSTryReadLockTimeout(ctx context.Context, filePath string, timeout time.Dur
 	fileLock := flock.New(getPlatformLockFilePath(filePath))
 	timedCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if _, err := fileLock.TryRLockContext(timedCtx, 10*time.Millisecond); err != nil {
+	if _, err := fileLock.TryRLockContext(timedCtx, FSLockRetryDelay); err != nil {
 		return nil, trace.ConvertSystemError(err)
 	}
 

--- a/tool/tsh/kube.go
+++ b/tool/tsh/kube.go
@@ -589,7 +589,7 @@ func getKubeCredLockfilePath(homePath, proxy string) (string, error) {
 // errKubeCredLockfileFound is returned when kube credentials lockfile is found and user should resolve login problems manually.
 var errKubeCredLockfileFound = trace.AlreadyExists("Having problems with relogin, please use 'tsh login/tsh kube login' manually")
 
-func takeKubeCredLock(ctx context.Context, homePath, proxy string) (func(bool), error) {
+func takeKubeCredLock(ctx context.Context, homePath, proxy string, lockTimeout time.Duration) (func(bool), error) {
 	kubeCredLockfilePath, err := getKubeCredLockfilePath(homePath, proxy)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -606,17 +606,25 @@ func takeKubeCredLock(ctx context.Context, homePath, proxy string) (func(bool), 
 		return nil, trace.Wrap(err)
 	}
 	// Take a lock while we're trying to issue certificate and possibly relogin
-	unlock, err := utils.FSTryWriteLockTimeout(ctx, kubeCredLockfilePath, 5*time.Second)
+	unlock, err := utils.FSTryWriteLockTimeout(ctx, kubeCredLockfilePath, lockTimeout)
 	if err != nil {
 		log.Debugf("could not take kube credentials lock: %v", err.Error())
 		return nil, trace.Wrap(errKubeCredLockfileFound)
 	}
 
 	return func(removeFile bool) {
-		if removeFile {
-			os.Remove(kubeCredLockfilePath)
+		// We must unlock the lockfile before removing it, otherwise unlock operation will fail
+		// on Windows.
+		if err := unlock(); err != nil {
+			log.WithError(err).Warnf("could not unlock kube credentials lock")
 		}
-		unlock()
+		if !removeFile {
+			return
+		}
+		// Remove kube credentials lockfile.
+		if err = os.Remove(kubeCredLockfilePath); err != nil && !os.IsNotExist(err) {
+			log.WithError(err).Warnf("could not remove kube credentials lockfile %q", kubeCredLockfilePath)
+		}
 	}, nil
 }
 
@@ -675,25 +683,46 @@ func (c *kubeCredentialsCommand) run(cf *CLIConf) error {
 	}
 
 	log.Debugf("Requesting TLS cert for Kubernetes cluster %q", c.kubeCluster)
-
-	unlockKubeCred, err := takeKubeCredLock(cf.Context, cf.HomePath, cf.Proxy)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	var unlockKubeCred func(bool)
 	deleteKubeCredsLock := false
 	defer func() {
-		unlockKubeCred(deleteKubeCredsLock) // by default (in case of an error) we don't delete lockfile.
+		if unlockKubeCred != nil {
+			unlockKubeCred(deleteKubeCredsLock) // by default (in case of an error) we don't delete lockfile.
+		}
 	}()
 
 	ctx, span := tc.Tracer.Start(cf.Context, "tsh.kubeCredentials/RetryWithRelogin")
-	err = client.RetryWithRelogin(ctx, tc, func() error {
-		var err error
-		k, err = tc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
-			RouteToCluster:    c.teleportCluster,
-			KubernetesCluster: c.kubeCluster,
-		}, nil /*applyOpts*/)
-		return err
-	})
+	err = client.RetryWithRelogin(
+		ctx,
+		tc,
+		func() error {
+			var err error
+			k, err = tc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
+				RouteToCluster:    c.teleportCluster,
+				KubernetesCluster: c.kubeCluster,
+			}, nil /*applyOpts*/)
+			return err
+		},
+		client.WithBeforeLoginHook(
+			// Before login we take a lock on the kube credentials file. This is
+			// done to prevent multiple tsh processes from requesting login and
+			// opening multiple browser tabs.
+			func() error {
+				var err error
+				lockTimeout := 5 * time.Second
+				// If we are under tests, MockSSOLogin is set and we want to allow just one try
+				// to take the lock and fail if the lock is already taken. This is done to prevent
+				// tests from hanging and continue to run once the lock is released.
+				// FSLockRetryDelay is 10ms and we want to fail as fast as possible if the lock is
+				// already taken by another process to validate that the lock is working as expected.
+				if cf.mockSSOLogin != nil {
+					lockTimeout = utils.FSLockRetryDelay
+				}
+				unlockKubeCred, err = takeKubeCredLock(cf.Context, cf.HomePath, cf.Proxy, lockTimeout)
+				return trace.Wrap(err)
+			},
+		),
+	)
 	span.End()
 	if err != nil {
 		// If we've got network error we remove the lockfile, so we could restore from temporary connection


### PR DESCRIPTION
Backport #28435 to branch/v12