### PR TITLE
Update keep_alive comments auth-service.yaml

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -303,11 +303,12 @@ auth_service:
     # certificates expire in the middle of an active session. (default is 'no')
     disconnect_expired_cert: no
 
-    # Determines the interval at which Teleport will send keep-alive messages.
+    # keep_alive_interval determines the interval at which Teleport will 
+    # send keep-alive messages for client and reverse tunnel connections.
     # The default is set to 5 minutes (300 seconds) to stay lower than the
     # common load balancer timeout of 350 seconds.
     # keep_alive_count_max is the number of missed keep-alive messages before
-    # the server tears down the connection to the client.
+    # the Teleport cluster tears down the connection to the client or service.
     keep_alive_interval: 5m
     keep_alive_count_max: 3
 


### PR DESCRIPTION
based on conversations internally, adding more clarity around keep alive to indicate it affects reverse tunnel connections as well

https://github.com/gravitational/teleport/blob/4e3c3bb728d656b3b628fa4563e4143fb59383d7/lib/reversetunnel/agentpool.go#L744