### PR TITLE
Send the whole user preferences object to the backend when saving

### DIFF
--- a/lib/services/local/userpreferences.go
+++ b/lib/services/local/userpreferences.go
@@ -111,7 +111,7 @@ func (u *UserPreferencesService) getUserPreferences(ctx context.Context, usernam
 		return nil, trace.Wrap(err)
 	}
 
-	// Appy the default values to the existing preferences.
+	// Apply the default values to the existing preferences.
 	// This allows updating the preferences schema without returning empty values
 	// for new fields in the existing preferences.
 	df := DefaultUserPreferences()

--- a/web/packages/teleport/src/Assist/Settings/Settings.tsx
+++ b/web/packages/teleport/src/Assist/Settings/Settings.tsx
@@ -156,7 +156,9 @@ export function Settings(props: SettingsProps) {
     window.clearTimeout(savingTimeoutRef.current);
 
     try {
-      await updatePreferences({ assist: settings });
+      await updatePreferences({
+        assist: { ...preferences.assist, ...settings },
+      });
     } catch {
       setErrorMessage('Failed to save settings');
     }

--- a/web/packages/teleport/src/User/UserContext.test.tsx
+++ b/web/packages/teleport/src/User/UserContext.test.tsx
@@ -71,7 +71,7 @@ describe('user context - success state', () => {
   });
 
   it('should migrate the previous theme setting from local storage', async () => {
-    let updateBody = {};
+    let updateBody: { theme?: ThemePreference } = {};
 
     server.use(
       rest.put(cfg.api.userPreferencesPath, async (req, res, ctx) => {
@@ -89,11 +89,7 @@ describe('user context - success state', () => {
       </UserContextProvider>
     );
 
-    await waitFor(() =>
-      expect(updateBody).toEqual({
-        theme: ThemePreference.Dark,
-      })
-    );
+    await waitFor(() => expect(updateBody.theme).toEqual(ThemePreference.Dark));
 
     const theme = await screen.findByText(/theme: dark/i);
 

--- a/web/packages/teleport/src/User/UserContext.tsx
+++ b/web/packages/teleport/src/User/UserContext.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React, {
   createContext,
   PropsWithChildren,
@@ -38,14 +39,11 @@ import {
 
 import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
 
-import type {
-  UserPreferences,
-  UserPreferencesSubset,
-} from 'teleport/services/userPreferences/types';
+import type { UserPreferences } from 'teleport/services/userPreferences/types';
 
 export interface UserContextValue {
   preferences: UserPreferences;
-  updatePreferences: (preferences: UserPreferencesSubset) => Promise<void>;
+  updatePreferences: (preferences: UserPreferences) => Promise<void>;
 }
 
 export const UserContext = createContext<UserContextValue>(null);
@@ -78,7 +76,7 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
 
           if (preferences.theme !== ThemePreference.Light) {
             // the light theme is the default, so only update the backend if it is not light
-            updatePreferences({ theme: preferences.theme });
+            updatePreferences(preferences);
           }
 
           storage.clearDeprecatedThemePreference();
@@ -103,7 +101,7 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
     }
   }
 
-  function updatePreferences(newPreferences: UserPreferencesSubset) {
+  function updatePreferences(newPreferences: UserPreferences) {
     const nextPreferences = {
       ...preferences,
       ...newPreferences,

--- a/web/packages/teleport/src/User/UserContext.tsx
+++ b/web/packages/teleport/src/User/UserContext.tsx
@@ -120,7 +120,7 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
     setPreferences(nextPreferences);
     storage.setUserPreferences(nextPreferences);
 
-    return service.updateUserPreferences(newPreferences);
+    return service.updateUserPreferences(nextPreferences);
   }
 
   useEffect(() => {

--- a/web/packages/teleport/src/User/UserContext.tsx
+++ b/web/packages/teleport/src/User/UserContext.tsx
@@ -43,7 +43,7 @@ import type { UserPreferences } from 'teleport/services/userPreferences/types';
 
 export interface UserContextValue {
   preferences: UserPreferences;
-  updatePreferences: (preferences: UserPreferences) => Promise<void>;
+  updatePreferences: (preferences: Partial<UserPreferences>) => Promise<void>;
 }
 
 export const UserContext = createContext<UserContextValue>(null);
@@ -101,7 +101,7 @@ export function UserContextProvider(props: PropsWithChildren<unknown>) {
     }
   }
 
-  function updatePreferences(newPreferences: UserPreferences) {
+  function updatePreferences(newPreferences: Partial<UserPreferences>) {
     const nextPreferences = {
       ...preferences,
       ...newPreferences,

--- a/web/packages/teleport/src/services/userPreferences/types.ts
+++ b/web/packages/teleport/src/services/userPreferences/types.ts
@@ -42,7 +42,6 @@ export interface UserPreferences {
   onboard: OnboardUserPreferences;
 }
 
-export type UserPreferencesSubset = Subset<UserPreferences>;
 export type GetUserPreferencesResponse = UserPreferences;
 
 export function deprecatedThemeToThemePreference(

--- a/web/packages/teleport/src/services/userPreferences/userPreferences.ts
+++ b/web/packages/teleport/src/services/userPreferences/userPreferences.ts
@@ -33,7 +33,7 @@ export async function getUserPreferences() {
   return res;
 }
 
-export function updateUserPreferences(preferences: UserPreferences) {
+export function updateUserPreferences(preferences: Partial<UserPreferences>) {
   return api.put(cfg.api.userPreferencesPath, preferences);
 }
 

--- a/web/packages/teleport/src/services/userPreferences/userPreferences.ts
+++ b/web/packages/teleport/src/services/userPreferences/userPreferences.ts
@@ -23,7 +23,6 @@ import { ViewMode } from 'teleport/Assist/types';
 import type {
   GetUserPreferencesResponse,
   UserPreferences,
-  UserPreferencesSubset,
 } from 'teleport/services/userPreferences/types';
 
 export async function getUserPreferences() {
@@ -34,7 +33,7 @@ export async function getUserPreferences() {
   return res;
 }
 
-export function updateUserPreferences(preferences: UserPreferencesSubset) {
+export function updateUserPreferences(preferences: UserPreferences) {
   return api.put(cfg.api.userPreferencesPath, preferences);
 }
 


### PR DESCRIPTION
This changes the UI to always send the whole user preferences object when the user changes a preference. This is so we can support `bool` and `int` values in the future.