### PR TITLE
[doc] database labels reference

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1134,6 +1134,10 @@
             {
               "title": "AWS IAM",
               "slug": "/database-access/reference/aws/"
+            },
+            {
+              "title": "Database Labels",
+              "slug": "/database-access/reference/labels/"
             }
           ]
         },

--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -114,3 +114,22 @@ check, you can use `mode` under the `tls` option in the Teleport configuration f
 
 For more details please refer to the reference
 [configuration file](./reference/configuration.mdx#database-service-configuration).
+
+## Can I disable read-only and custom endpoints from auto-discovered databases?
+
+Yes, you can use Teleport generated label `endpoint-type` on your `aws` matcher
+to filter the endpoints. For example, to disable read-only and custom endpoints
+for RDS auto-discovery, you can specify other endpoint types to match:
+```
+  aws:
+  - types: ["rds"]
+    regions: ["us-west-1"]
+    tags:
+      "env": "dev"
+      "endpoint-type":
+        - "primary"
+        - "instance"
+```
+
+See [labels reference](./reference/labels.mdx) for a full list of Teleport
+generated labels and values.

--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -117,9 +117,10 @@ For more details please refer to the reference
 
 ## Can I disable read-only and custom endpoints from auto-discovered databases?
 
-Yes, you can use Teleport generated label `endpoint-type` on your `aws` matcher
-to filter the endpoints. For example, to disable read-only and custom endpoints
-for RDS auto-discovery, you can specify other endpoint types to match:
+Yes, you can use the Teleport generated label `endpoint-type` on your `aws`
+matcher to filter the endpoints. For example, to disable read-only and custom
+endpoints for RDS auto-discovery, you can specify other endpoint types to
+match:
 ```
   aws:
   - types: ["rds"]

--- a/docs/pages/database-access/reference.mdx
+++ b/docs/pages/database-access/reference.mdx
@@ -7,3 +7,4 @@ description: Configuration and CLI reference for the Teleport Database Service.
 - [CLI](./reference/cli.mdx)
 - [Audit Events](./reference/audit.mdx)
 - [AWS IAM](./reference/aws.mdx)
+- [Database Labels](./reference/labels.mdx)

--- a/docs/pages/database-access/reference/labels.mdx
+++ b/docs/pages/database-access/reference/labels.mdx
@@ -1,5 +1,5 @@
 ---
-title: Database Access Database Labels Reference
+title: Database Labels Reference
 description: Database labels reference for Teleport database access.
 ---
 
@@ -11,7 +11,7 @@ of the following values:
 | Label Value | Description |
 | - | - |
 | `cloud`   | database resources created by auto-discovery. |
-| `config`  | database resources manually defined in the `database_service.databases` section. |
+| `config`  | database resources manually defined in the `database_service.databases` section of `teleport.yaml`. |
 | `dynamic` | database resources created with "tctl create" command or web interface. |
 
 ## Auto-discovery
@@ -36,7 +36,7 @@ resource attributes:
 | `vpc-id`           | ID of the Amazon VPC the resource resides in, if available. |
 | `workgroup`        | Amazon Redshift Serverless workgroup name. |
 
-### endpoint-type
+### `endpoint-type`
 
 The following values are used to indicate the type of the database endpoint:
 

--- a/docs/pages/database-access/reference/labels.mdx
+++ b/docs/pages/database-access/reference/labels.mdx
@@ -1,0 +1,65 @@
+---
+title: Database Access Database Labels Reference
+description: Database labels reference for Teleport database access.
+---
+
+## Origin
+
+All registered databases have a predefined `teleport.dev/origin` label with one
+of the following values:
+
+| Label Value | Description |
+| - | - |
+| `cloud`   | database resources created by auto-discovery. |
+| `config`  | database resources manually defined in the `database_service.databases` section. |
+| `dynamic` | database resources created with "tctl create" command or web interface. |
+
+## Auto-discovery
+
+The labels of auto-discovered databases primarily come from the tags that are
+assigned to the original cloud resources, such as the resources tags of an
+Amazon RDS instance. 
+
+Additionally, Teleport will generate certain labels derived from the cloud
+resource attributes:
+
+| Label name | Description |
+| - | - |
+| `account-id`       | ID of the AWS account the resource resides in. |
+| `endpoint-type`    | Type of the endpoint. See section below for more details. |
+| `engine`           | Amazon RDS: engine type of the RDS instance or Aurora cluster.<br/>Amazon RDS Proxy: engine family of the proxy.<br/>Azure-hosted databases: resource type of the resource ID. |
+| `engine-version`   | Database engine version, if available. |
+| `namespace`        | Amazon Redshift Serverless namespace name. |
+| `region`           | AWS region or Azure location. |
+| `replication-role` | The replication role of an Azure DB Flexible server. |
+| `source-server`    | The source server of an Azure DB Flexible server replica. |
+| `vpc-id`           | ID of the Amazon VPC the resource resides in, if available. |
+| `workgroup`        | Amazon Redshift Serverless workgroup name. |
+
+### endpoint-type
+
+The following values are used to indicate the type of the database endpoint:
+
+| Database Type | Values |
+| - | - |
+| Amazon RDS instance              | `instance` |
+| Amazon RDS Aurora cluster        | one of `primary`, `reader`, `custom` |
+| Amazon RDS Proxy                 | one of `READ_WRITE`, `READ_ONLY` (custom endpoints only) |
+| Amazon Redshift Serverless       | one of `workgroup`, `vpc-endpoint` |
+| Amazon ElastiCache               | one of `configuration`, `primary`, `reader`, `node` |
+| Amazon MemoryDB                  | one of `cluster`, `node` |
+| Amazon OpenSearch                | one of `default`, `custom`, `vpc` |
+| Azure Redis Enterprise           | one of `EnterpriseCluster`, `OSSCluster` |
+
+## Manual and dynamic registration
+
+Static labels and dynamic labels can be specified in `labels` and
+`dynamic_labels` fields respectively in database definition. See
+[Configuration](./configuration.mdx) for reference.
+
+## Database Service on Amazon EC2
+
+All registered databases can inherit the labels converted from the tags of the
+EC2 instance running the Teleport Database Service. Labels created this way
+will have the `aws/` prefix. See [Sync EC2
+Tags](../../management/guides/ec2-tags.mdx) for more details.

--- a/docs/pages/includes/config-reference/database-config.yaml
+++ b/docs/pages/includes/config-reference/database-config.yaml
@@ -4,15 +4,16 @@ db_service:
 
   # Matchers for database resources created with "tctl create" command or by the
   # discovery service.
-  #
-  # All database resources have a predefined "teleport.dev/origin" label with
-  # one of the following values:
-  # "dynamic": database resources created with "tctl create" command
-  # "cloud": database resources created by the discovery service
-  # "config": database resources defined in the "databases" array below
   resources:
+    # See "Database labels reference" (https://goteleport.com/docs/database-access/reference/labels/)
+    # to learn more on database labels.
   - labels:
       "*": "*"
+    # Optional AWS role that the Database Service will assume to access the
+    # databases.
+    aws:
+      assume_role_arn: "arn:aws:iam::123456789012:role/example-role-name"
+      external_id: "example-external-id"
 
   # Matchers for registering AWS-hosted databases.
   aws:


### PR DESCRIPTION
I was answering `Can I disable read-only and custom endpoints from auto-discovered databases` during my support shift so I think it might be good to document this.

I end up adding a reference page explaining database labels. But I am open to any ideas on how to structure this.

As I am updating the config reference for this, I also added the reference for the new `database_service.resources.aws` field from #28039.