### PR TITLE
Update database cloud labels on local server

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events/eventstest"
 	"github.com/gravitational/teleport/lib/fixtures"
+	"github.com/gravitational/teleport/lib/labels"
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
@@ -2064,6 +2065,8 @@ type agentParams struct {
 	AWSMatchers []types.AWSMatcher
 	// AzureMatchers is a list of Azure databases matchers.
 	AzureMatchers []types.AzureMatcher
+	// CloudLabels defines the cloud labels importer.
+	CloudLabels labels.Importer
 }
 
 func (p *agentParams) setDefaults(c *testContext) {
@@ -2186,6 +2189,7 @@ func (c *testContext) setupDatabaseServer(ctx context.Context, t *testing.T, p a
 		AWSMatchers:              p.AWSMatchers,
 		AzureMatchers:            p.AzureMatchers,
 		ShutdownPollPeriod:       100 * time.Millisecond,
+		CloudLabels:              p.CloudLabels,
 		discoveryResourceChecker: &fakeDiscoveryResourceChecker{},
 	})
 	require.NoError(t, err)

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -655,15 +655,16 @@ func (s *Server) getServerInfoFunc(database types.Database) func() (types.Resour
 // getServerInfo returns up-to-date database resource e.g. with updated dynamic
 // labels.
 func (s *Server) getServerInfo(database types.Database) (types.Resource, error) {
+	s.mu.Lock()
 	if s.cfg.CloudLabels != nil {
 		s.cfg.CloudLabels.Apply(database)
 	}
 
 	// Make sure to return a new object, because it gets cached by
 	// heartbeat and will always compare as equal otherwise.
-	s.mu.RLock()
 	copy := database.Copy()
-	s.mu.RUnlock()
+	s.mu.Unlock()
+
 	// Update dynamic labels if the database has them.
 	labels := s.getDynamicLabels(copy.GetName())
 	if labels != nil {

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -655,6 +655,10 @@ func (s *Server) getServerInfoFunc(database types.Database) func() (types.Resour
 // getServerInfo returns up-to-date database resource e.g. with updated dynamic
 // labels.
 func (s *Server) getServerInfo(database types.Database) (types.Resource, error) {
+	if s.cfg.CloudLabels != nil {
+		s.cfg.CloudLabels.Apply(database)
+	}
+
 	// Make sure to return a new object, because it gets cached by
 	// heartbeat and will always compare as equal otherwise.
 	s.mu.RLock()
@@ -664,9 +668,6 @@ func (s *Server) getServerInfo(database types.Database) (types.Resource, error) 
 	labels := s.getDynamicLabels(copy.GetName())
 	if labels != nil {
 		copy.SetDynamicLabels(labels.Get())
-	}
-	if s.cfg.CloudLabels != nil {
-		s.cfg.CloudLabels.Apply(copy)
 	}
 	expires := s.cfg.Clock.Now().UTC().Add(apidefaults.ServerAnnounceTTL)
 	server, err := types.NewDatabaseServerV3(types.Metadata{


### PR DESCRIPTION
Closes #28390.

Changes the cloud labels update to be done on the `database` struct inside the server instead of on the database copy announced to the auth server. This way, the auth server, and the local database have the same cloud labels.

**Note:** Dynamic labels are not covered on this PR but might require the same change. I haven't done it led to some data race errors, meaning it would need a different approach.