### PR TITLE
Ensure that all scoped components match forScopes

### DIFF
--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -124,8 +124,49 @@ Install and configure Teleport where you will run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux-enterprise.mdx!)
 
-(!docs/pages/includes/database-access/db-configure-start.mdx dbName="oracle" dbProtocol="oracle" databaseAddress="oracle.example.com:2484" dbName="oracle" !)
+On the host where you will run the Teleport Database Service, start Teleport
+with the appropriate configuration.
 
+Note that a single Teleport process can run multiple different services, for
+example multiple Database Service agents as well as the SSH Service or Application
+Service. The step below will overwrite an existing configuration file, so if
+you're running multiple services add `--output=stdout` to print the config in
+your terminal, and manually adjust `/etc/teleport.yaml`.
+
+Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
+
+<Tabs>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise/Enterprise Cloud">
+
+```code
+$ teleport db configure create \
+   -o file \
+   --token=/tmp/token \
+   --proxy=teleport.example.com:443 \
+   --name=oracle \
+   --protocol=oracle \
+   --uri=oracle.example.com:2484 \
+   --labels=env=dev 
+```
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Team/Community Edition">
+
+```code
+$ teleport db configure create \
+   -o file \
+   --token=/tmp/token \
+   --proxy=mytenant.teleport.sh:443 \
+   --name=oracle \
+   --protocol=oracle \
+   --uri=oracle.example.com:2484 \
+   --labels=env=dev
+```
+
+</TabItem>
+</Tabs>
+
+(!docs/pages/includes/start-teleport.mdx service="the Teleport Database Service"!)
 </TabItem>
 <TabItem label="Kubernetes Cluster">
   Teleport provides Helm charts for installing the Teleport Database Service in Kubernetes Clusters.

--- a/docs/pages/includes/enterprise/samlauthentication.mdx
+++ b/docs/pages/includes/enterprise/samlauthentication.mdx
@@ -3,13 +3,13 @@
 Configure Teleport to use SAML authentication as the default instead of the local
 user database.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<ScopedBlock scope={["enterprise"]}>
 You can either edit the Teleport Auth Service configuration file or create a dynamic
 resource.
 </ScopedBlock>
 
 <Tabs>
-<TabItem scope={["cloud", "team"]} label="Dynamic Resources (All Editions)">
+<TabItem scope={["cloud"]} label="Dynamic Resources (All Editions)">
 
 Use `tctl` to edit the `cluster_auth_preference` value:
 
@@ -38,7 +38,7 @@ cluster auth preference has been updated
 ```
 
 </TabItem>
-<TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
+<TabItem label="Static Config (Self-Hosted)" scope={["enterprise"]}>
 
 Update `/etc/teleport.yaml` in the `auth_service` section and restart the `teleport` daemon.
 


### PR DESCRIPTION
For nearly all scoped components in the docs, the value of the `scope` attribute matches the scopes configured in the `forScopes` field for the component's page.

This change corrects the components that _don't_ match a page's `forScopes` configuration. This anticipates a new docs linter to check the scopes of each component.