### PR TITLE
Document backend_write_requests_total

### DIFF
--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -16,6 +16,7 @@
 | `backend_read_requests_total`                            | counter   | cache               | Number of read requests to the backend.                                                            |
 | `backend_read_seconds`                                   | histogram | cache               | Latency for read operations.                                                                       |
 | `backend_requests`                                       | counter   | cache               | Number of requests to the backend (reads, writes, and keepalives).                                                           |
+| `backend_write_requests_total`                           | counter   | cache               | Number of write requests to the backend. |
 | `backend_write_seconds`                                  | histogram | cache               | Latency for backend write operations.                                                              |
 | `cluster_name_not_found_total`                           | counter   | Teleport Auth       | Number of times a cluster was not found.                                                           |
 | `dynamo_requests_total`                                  | counter   | DynamoDB            | Total number of requests to the DynamoDB API.                                                      |


### PR DESCRIPTION
Fixes #10925

The backend_write_requests_total metric was missing from the metrics reference. This change documents the metric using its Prometheus help text.