### PR TITLE
[Assist] Only parse messages from Assist as markdown

### DIFF
--- a/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/CommandResultSummaryEntry.tsx
@@ -17,11 +17,9 @@
 import React from 'react';
 import styled from 'styled-components';
 
-import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
-
 import { markdownCSS } from 'teleport/Assist/markdown';
 import { MonospacedOutput } from 'teleport/Assist/shared/MonospacedOutput';
+import { Markdown } from 'teleport/Assist/Conversation/Markdown';
 
 interface CommandResultSummaryEntryProps {
   command: string;
@@ -63,9 +61,7 @@ export function CommandResultSummaryEntry(
       <MonospacedOutput>{props.command}</MonospacedOutput>
 
       <Summary>
-        <ReactMarkdown remarkPlugins={[remarkGfm]}>
-          {props.summary}
-        </ReactMarkdown>
+        <Markdown content={props.summary} />
       </Summary>
     </Container>
   );

--- a/web/packages/teleport/src/Assist/Conversation/Markdown.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Markdown.tsx
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 import React from 'react';
 
 import ReactMarkdown from 'react-markdown';

--- a/web/packages/teleport/src/Assist/Conversation/Markdown.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Markdown.tsx
@@ -13,37 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import React from 'react';
-import styled from 'styled-components';
 
-import { markdownCSS } from 'teleport/Assist/markdown';
-import { Markdown } from 'teleport/Assist/Conversation/Markdown';
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 
-interface MessageEntryProps {
+interface MarkdownProps {
   content: string;
-  markdown: boolean;
 }
 
-const Container = styled.div`
-  padding: 10px 15px 0 17px;
-  word-break: break-word;
-
-  ${markdownCSS}
-`;
-
-export function MessageEntry(props: MessageEntryProps) {
-  if (!props.markdown) {
-    return (
-      <Container>
-        <p>{props.content}</p>
-      </Container>
-    );
-  }
-
+export function Markdown(props: MarkdownProps) {
   return (
-    <Container>
-      <Markdown content={props.content} />
-    </Container>
+    <ReactMarkdown remarkPlugins={[remarkGfm]} disallowedElements={['img']}>
+      {props.content}
+    </ReactMarkdown>
   );
 }

--- a/web/packages/teleport/src/Assist/Conversation/Message.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Message.tsx
@@ -108,7 +108,12 @@ function createComponentForEntry(
     case ServerMessageType.Assist:
     case ServerMessageType.User:
     case ServerMessageType.Error:
-      return <MessageEntry content={entry.message} />;
+      return (
+        <MessageEntry
+          content={entry.message}
+          markdown={entry.type === ServerMessageType.Assist}
+        />
+      );
 
     case ServerMessageType.Command:
       return (

--- a/web/packages/teleport/src/Assist/Conversation/MessageEntry.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/MessageEntry.tsx
@@ -24,15 +24,25 @@ import { markdownCSS } from 'teleport/Assist/markdown';
 
 interface MessageEntryProps {
   content: string;
+  markdown: boolean;
 }
 
 const Container = styled.div`
   padding: 10px 15px 0 17px;
+  word-break: break-word;
 
   ${markdownCSS}
 `;
 
 export function MessageEntry(props: MessageEntryProps) {
+  if (!props.markdown) {
+    return (
+      <Container>
+        <p>{props.content}</p>
+      </Container>
+    );
+  }
+
   return (
     <Container>
       <ReactMarkdown remarkPlugins={[remarkGfm]}>{props.content}</ReactMarkdown>


### PR DESCRIPTION
There's no need to parse any messages that aren't from Assist as markdown, nor for images to be displayed

This also fixes long messages from a user not wrapping correctly.