### PR TITLE
Change default SQL Server database command to `sqlcmd`

### DIFF
--- a/lib/client/db/dbcmd/dbcmd.go
+++ b/lib/client/db/dbcmd/dbcmd.go
@@ -60,6 +60,8 @@ const (
 	redisBin = "redis-cli"
 	// mssqlBin is the SQL Server client program name.
 	mssqlBin = "mssql-cli"
+	// sqlcmd is the SQL Server client program name.
+	sqlcmdBin = "sqlcmd"
 	// snowsqlBin is the Snowflake client program name.
 	snowsqlBin = "snowsql"
 	// cqlshBin is the Cassandra client program name.
@@ -429,6 +431,12 @@ func (c *CLICommandBuilder) isMySQLBinMariaDBFlavor() (bool, error) {
 	return strings.Contains(strings.ToLower(string(mysqlVer)), "mariadb"), nil
 }
 
+// isSqlcmdAvailable returns true if "sqlcmd" binary is fouind in the system
+// PATH.
+func (c *CLICommandBuilder) isSqlcmdAvailable() bool {
+	return c.isBinAvailable(sqlcmdBin)
+}
+
 func (c *CLICommandBuilder) shouldUseMongoshBin() bool {
 	// Use "mongosh" if available.
 	// If not, use legacy "mongo" if available.
@@ -554,6 +562,8 @@ func (c *CLICommandBuilder) getRedisCommand() *exec.Cmd {
 	return exec.Command(redisBin, args...)
 }
 
+// getSQLServerCommand returns a command to connect to SQL Server.
+// mssql-cli and sqlcmd commands have the same argument names.
 func (c *CLICommandBuilder) getSQLServerCommand() *exec.Cmd {
 	args := []string{
 		// Host and port must be comma-separated.
@@ -566,6 +576,10 @@ func (c *CLICommandBuilder) getSQLServerCommand() *exec.Cmd {
 
 	if c.db.Database != "" {
 		args = append(args, "-d", c.db.Database)
+	}
+
+	if c.isSqlcmdAvailable() {
+		return exec.Command(sqlcmdBin, args...)
 	}
 
 	return exec.Command(mssqlBin, args...)

--- a/lib/client/db/dbcmd/dbcmd_test.go
+++ b/lib/client/db/dbcmd/dbcmd_test.go
@@ -417,6 +417,23 @@ func TestCLICommandBuilderGetConnectCommand(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:         "sqlserver sqlcmd",
+			dbProtocol:   defaults.ProtocolSQLServer,
+			databaseName: "mydb",
+			execer: &fakeExec{
+				execOutput: map[string][]byte{
+					"sqlcmd": {},
+				},
+			},
+			cmd: []string{sqlcmdBin,
+				"-S", "localhost,12345",
+				"-U", "myUser",
+				"-P", fixtures.UUID,
+				"-d", "mydb",
+			},
+			wantErr: false,
+		},
+		{
 			name:       "redis-cli",
 			dbProtocol: defaults.ProtocolRedis,
 			execer:     &fakeExec{},


### PR DESCRIPTION
[Given `mssql-cli` is being deprecated in favor of `sqlcmd`](https://github.com/dbcli/mssql-cli#mssql-cli), we're switching it to be the default command, with fallback to `mssql-cli` when it is not present on `PATH`.

**Note:** Both, Golang and ODBC-based implementations are supported.