### PR TITLE
Ignore SIGQUIT in exec sessions

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -26,6 +26,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"os/user"
 	"path/filepath"
 	"strconv"
@@ -192,6 +193,12 @@ type UaccMetadata struct {
 // RunCommand reads in the command to run from the parent process (over a
 // pipe) then constructs and runs the command.
 func RunCommand() (errw io.Writer, code int, err error) {
+	// SIGQUIT is used by teleport to initiate graceful shutdown, waiting for
+	// existing exec sessions to close before ending the process. For this to
+	// work when closing the entire teleport process group, exec sessions must
+	// ignore SIGQUIT signals.
+	signal.Ignore(syscall.SIGQUIT)
+
 	// errorWriter is used to return any error message back to the client. By
 	// default, it writes to stdout, but if a TTY is allocated, it will write
 	// to it instead.


### PR DESCRIPTION
This PR updates teleport SSH sessions to ignore `SIGQUIT` signals. This way, if the Teleport process group receives a `SIGQUIT` signal (e.g. `kill -SIGQUIT $(pidof teleport)`), the Teleport process will still [shutdown gracefully](https://goteleport.com/docs/reference/signals/) by waiting for existing sessions to be closed on their own.

Closes https://github.com/gravitational/teleport/issues/28070