### PR TITLE
Fix Azure join for identities across resource groups

### DIFF
--- a/lib/auth/join_azure.go
+++ b/lib/auth/join_azure.go
@@ -268,7 +268,7 @@ func verifyVMIdentity(ctx context.Context, cfg *azureRegisterConfig, accessToken
 		// If the token is from a user-assigned managed identity, the resource ID is
 		// for the identity and we need to look the VM up by VM ID.
 	} else {
-		vm, err = vmClient.GetByVMID(ctx, resourceID.ResourceGroupName, vmID)
+		vm, err = vmClient.GetByVMID(ctx, types.Wildcard, vmID)
 		if err != nil {
 			if trace.IsNotFound(err) {
 				return nil, trace.AccessDenied("no VM found with matching VM ID")

--- a/lib/cloud/azure/mocks.go
+++ b/lib/cloud/azure/mocks.go
@@ -508,6 +508,25 @@ func (m *ARMComputeMock) NewListPager(resourceGroup string, _ *armcompute.Virtua
 	})
 }
 
+func (m *ARMComputeMock) NewListAllPager(_ *armcompute.VirtualMachinesClientListAllOptions) *runtime.Pager[armcompute.VirtualMachinesClientListAllResponse] {
+	var vms []*armcompute.VirtualMachine
+	for _, resourceGroupVMs := range m.VirtualMachines {
+		vms = append(vms, resourceGroupVMs...)
+	}
+	return runtime.NewPager(runtime.PagingHandler[armcompute.VirtualMachinesClientListAllResponse]{
+		More: func(page armcompute.VirtualMachinesClientListAllResponse) bool {
+			return page.NextLink != nil && len(*page.NextLink) > 0
+		},
+		Fetcher: func(ctx context.Context, page *armcompute.VirtualMachinesClientListAllResponse) (armcompute.VirtualMachinesClientListAllResponse, error) {
+			return armcompute.VirtualMachinesClientListAllResponse{
+				VirtualMachineListResult: armcompute.VirtualMachineListResult{
+					Value: vms,
+				},
+			}, nil
+		},
+	})
+}
+
 func (m *ARMComputeMock) Get(_ context.Context, _ string, _ string, _ *armcompute.VirtualMachinesClientGetOptions) (armcompute.VirtualMachinesClientGetResponse, error) {
 	return armcompute.VirtualMachinesClientGetResponse{
 		VirtualMachine: m.GetResult,

--- a/lib/cloud/azure/vm_test.go
+++ b/lib/cloud/azure/vm_test.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func TestGetVirtualMachine(t *testing.T) {
@@ -168,6 +170,11 @@ func TestListVirtualMachines(t *testing.T) {
 			name:          "nonexistant resource group",
 			resourceGroup: "rgfake",
 			wantIDs:       []string{},
+		},
+		{
+			name:          "all resource groups",
+			resourceGroup: types.Wildcard,
+			wantIDs:       []string{"vm1", "vm2", "vm3", "vm4"},
 		},
 	}
 


### PR DESCRIPTION
This PR fixes a bug in the Azure join method where a VM's identity can't be verified if it's in a different resource group from its managed identity.

Resolves #24551.