### PR TITLE
DeployService: use teleport-ent image for ent clusters

### DIFF
--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -58,9 +58,6 @@ var (
 )
 
 const (
-	// teleportContainerImageFmt is the Teleport Container Image to be used
-	teleportContainerImageFmt = "public.ecr.aws/gravitational/%s-distroless:%s"
-
 	// teleportOSS is the prefix for the image name when deploying the OSS version of Teleport
 	teleportOSS = "teleport"
 
@@ -436,8 +433,7 @@ func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceR
 	if modules.GetModules().BuildType() == modules.BuildEnterprise {
 		teleportFlavor = teleportEnt
 	}
-
-	taskAgentContainerImage := fmt.Sprintf(teleportContainerImageFmt, teleportFlavor, req.TeleportVersionTag)
+	taskAgentContainerImage := fmt.Sprintf("public.ecr.aws/gravitational/%s-distroless:%s", teleportFlavor, req.TeleportVersionTag)
 
 	taskDefOut, err := clt.RegisterTaskDefinition(ctx, &ecs.RegisterTaskDefinitionInput{
 		Family: req.TaskName,

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/retryutils"
+	"github.com/gravitational/teleport/lib/modules"
 )
 
 var (
@@ -58,7 +59,13 @@ var (
 
 const (
 	// teleportContainerImageFmt is the Teleport Container Image to be used
-	teleportContainerImageFmt = "public.ecr.aws/gravitational/teleport-distroless:%s"
+	teleportContainerImageFmt = "public.ecr.aws/gravitational/%s-distroless:%s"
+
+	// teleportOSS is the prefix for the image name when deploying the OSS version of Teleport
+	teleportOSS = "teleport"
+
+	// teleportEnt is the prefix for the image name when deploying the Enterprise version of Teleport
+	teleportEnt = "teleport-ent"
 
 	// clusterStatusActive is the string representing an ACTIVE ECS Cluster.
 	clusterStatusActive = "ACTIVE"
@@ -425,7 +432,12 @@ func DeployService(ctx context.Context, clt DeployServiceClient, req DeployServi
 
 // upsertTask ensures a TaskDefinition with TaskName exists
 func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceRequest, configB64 string) (*ecsTypes.TaskDefinition, error) {
-	taskAgentContainerImage := fmt.Sprintf(teleportContainerImageFmt, req.TeleportVersionTag)
+	teleportFlavor := teleportOSS
+	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+		teleportFlavor = teleportEnt
+	}
+
+	taskAgentContainerImage := fmt.Sprintf(teleportContainerImageFmt, teleportFlavor, req.TeleportVersionTag)
 
 	taskDefOut, err := clt.RegisterTaskDefinition(ctx, &ecs.RegisterTaskDefinitionInput{
 		Family: req.TaskName,


### PR DESCRIPTION
When deploying a new service to Amazon ECS, using the AWS OIDC Integration, we must ensure the right version is used.

Until now, only the OSS was used.
After this PR, the ENT version is picked in when the cluster is an enterprise deployment.