### PR TITLE
tctl alerts ack: Make --reason optional

### DIFF
--- a/tool/tctl/common/alert_command.go
+++ b/tool/tctl/common/alert_command.go
@@ -76,9 +76,12 @@ func (c *AlertCommand) Initialize(app *kingpin.Application, config *servicecfg.C
 	c.alertCreate.Flag("labels", "List of labels to attach to the alert. For example: key1=value1,key2=value2.").StringVar(&c.labels)
 
 	c.alertAck = alert.Command("ack", "Acknowledge cluster alerts.")
+	// Be wary of making any of these flags required. Because `tctl alerts ack ls` is not an actual
+	// command but is handled by alertAck, any flag that is required for `tctl alerts ack` will be
+	// required for `tctl alerts ack ls` as well.
 	c.alertAck.Flag("ttl", "Time duration to acknowledge the cluster alert for.").DurationVar(&c.ttl)
 	c.alertAck.Flag("clear", "Clear the acknowledgment for the cluster alert.").BoolVar(&c.clear)
-	c.alertAck.Flag("reason", "The reason for acknowledging the cluster alert.").Required().StringVar(&c.reason)
+	c.alertAck.Flag("reason", "The reason for acknowledging the cluster alert.").StringVar(&c.reason)
 	c.alertAck.Arg("id", "The cluster alert ID.").Required().StringVar(&c.alertID)
 
 	// We add "ack ls" as a command so kingpin shows it in the help dialog - as there is a space, `tctl ack xyz` will always be


### PR DESCRIPTION
Fixes #28809.

This fixes `tctl alerts ack ls` which used to not work unless `--reason` was provided. That is because `tctl alerts ack ls` is not a real kingpin command – it's handled by `tctl alerts ack`. Since `--reason` was required for `tctl alerts ack`, it was required for `tctl alerts ack ls` as well, even though that a human can interpret those as two different commands.

`--reason` was made required in #26029, in order to have tctl fail immediately if `tctl alerts ack` was called without `--reason`. After this change, providing a reason is still required. The only difference is that instead of having the CLI fail immediately, the CLI will issue a request to the cluster which will fail due to a missing reason.