### PR TITLE
Fix listing nodes when creating a new lock via webui

### DIFF
--- a/web/packages/teleport/src/LocksV2/NewLock/common.tsx
+++ b/web/packages/teleport/src/LocksV2/NewLock/common.tsx
@@ -118,7 +118,7 @@ export const baseResourceKindOpts: LockResourceOption[] = [
     listKind: 'logins',
   },
   {
-    value: 'server_id',
+    value: 'node',
     label: 'Servers',
     listKind: 'server-side',
   },


### PR DESCRIPTION
This PR fixes the property `value` used by Servers when listing connected nodes. The value was incorrectly switched from `node` to `server_id` by mistake which crashed the list of Servers.

This regression was introduced in #27395.

Fixes #28948