### PR TITLE
desktop access: clean up error handling

### DIFF
--- a/lib/auth/windows/certificate_authority.go
+++ b/lib/auth/windows/certificate_authority.go
@@ -65,11 +65,15 @@ func (c *CertificateStoreClient) Update(ctx context.Context) error {
 		DomainName: c.cfg.ClusterName,
 	}, false)
 	if err != nil {
-		return trace.Wrap(err, "fetching Teleport CA: %v", err)
+		return trace.Wrap(err, "fetching Teleport CA")
 	}
+
+	keypairs := ca.GetTrustedTLSKeyPairs()
+	c.cfg.Log.Debugf("Teleport CA has %d trusted keypairs", len(keypairs))
+
 	// LDAP stores certs and CRLs in binary DER format, so remove the outer PEM
 	// wrapper.
-	caPEM := ca.GetTrustedTLSKeyPairs()[0].Cert
+	caPEM := keypairs[0].Cert
 	caBlock, _ := pem.Decode(caPEM)
 	if caBlock == nil {
 		return trace.BadParameter("failed to decode CA PEM block")
@@ -78,7 +82,7 @@ func (c *CertificateStoreClient) Update(ctx context.Context) error {
 
 	crlDER, err := c.cfg.AccessPoint.GenerateCertAuthorityCRL(ctx, types.UserCA)
 	if err != nil {
-		return trace.Wrap(err, "generating CRL: %v", err)
+		return trace.Wrap(err, "generating CRL")
 	}
 
 	// To make the CA trusted, we need 3 things:
@@ -89,10 +93,10 @@ func (c *CertificateStoreClient) Update(ctx context.Context) error {
 	//
 	// Below we do #2 and #3.
 	if err := c.updateCAInNTAuthStore(ctx, caDER); err != nil {
-		return trace.Wrap(err, "updating NTAuth store over LDAP: %v", err)
+		return trace.Wrap(err, "updating NTAuth store over LDAP")
 	}
 	if err := c.updateCRL(ctx, crlDER, caType); err != nil {
-		return trace.Wrap(err, "updating CRL over LDAP: %v", err)
+		return trace.Wrap(err, "updating CRL over LDAP")
 	}
 	return nil
 }
@@ -123,7 +127,7 @@ func (c *CertificateStoreClient) updateCAInNTAuthStore(ctx context.Context, caDE
 	ntAuthDN := "CN=NTAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration," + c.cfg.LDAPConfig.DomainDN()
 	entries, err := c.cfg.LC.Read(ntAuthDN, "certificationAuthority", []string{"cACertificate"})
 	if err != nil {
-		return trace.Wrap(err, "fetching existing CAs: %v", err)
+		return trace.Wrap(err, "fetching existing CAs")
 	}
 	if len(entries) != 1 {
 		return trace.BadParameter("expected exactly 1 NTAuthCertificates CA store at %q, but found %d", ntAuthDN, len(entries))
@@ -151,7 +155,7 @@ func (c *CertificateStoreClient) updateCAInNTAuthStore(ctx context.Context, caDE
 	if err := c.cfg.LC.Update(ntAuthDN, map[string][]string{
 		"cACertificate": updatedCAs,
 	}); err != nil {
-		return trace.Wrap(err, "updating CA entry: %v", err)
+		return trace.Wrap(err, "updating CA entry")
 	}
 	c.cfg.Log.Info("Added Teleport CA to NTAuthStore via LDAP")
 	return nil
@@ -176,7 +180,7 @@ func (c *CertificateStoreClient) updateCRL(ctx context.Context, crlDER []byte, c
 
 	// Create the parent container.
 	if err := c.cfg.LC.CreateContainer(containerDN); err != nil {
-		return trace.Wrap(err, "creating CRL container: %v", err)
+		return trace.Wrap(err, "creating CRL container")
 	}
 
 	// Create the CRL object itself.

--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"fmt"
 	"net"
 	"path/filepath"
@@ -67,7 +68,7 @@ const (
 	// ldapRequestTimeout is the timeout for making LDAP requests.
 	// It is larger than the dial timeout because LDAP queries in large
 	// Active Directory environments may take longer to complete.
-	ldapRequestTimeout = 20 * time.Second
+	ldapRequestTimeout = 45 * time.Second
 
 	// windowsDesktopServiceCertTTL is the TTL for certificates issued to the
 	// Windows Desktop Service in order to authenticate with the LDAP server.
@@ -79,6 +80,11 @@ const (
 	// windowsDesktopServiceCertRetryInterval indicates how often to retry
 	// issuing an LDAP certificate if the operation fails.
 	windowsDesktopServiceCertRetryInterval = 10 * time.Minute
+
+	// ldapTimeoutRetryInterval indicates how often to retry LDAP initialization
+	// if it times out. It is set lower than windowsDesktopServiceCertRetryInterval
+	// because LDAP timeouts may indicate a temporary issue.
+	ldapTimeoutRetryInterval = 10 * time.Second
 )
 
 // ComputerAttributes are the attributes we fetch when discovering
@@ -523,7 +529,14 @@ func (s *WindowsService) initializeLDAP() error {
 	if err != nil {
 		s.mu.Lock()
 		s.ldapInitialized = false
-		s.scheduleNextLDAPCertRenewalLocked(windowsDesktopServiceCertRetryInterval)
+
+		// failures due to timeouts might be transient, so retry more frequently
+		retryAfter := windowsDesktopServiceCertRetryInterval
+		if errors.Is(err, context.DeadlineExceeded) {
+			retryAfter = ldapTimeoutRetryInterval
+		}
+
+		s.scheduleNextLDAPCertRenewalLocked(retryAfter)
 		s.mu.Unlock()
 		return trace.Wrap(err, "dial")
 	}


### PR DESCRIPTION
In several places we were effectively wrapping the same error twice. This resulted in an error message that was duplicated and hard to read.

Also improve our handling of LDAP timeouts by:
1. Increase the LDAP request timeout to 45s
2. Retrying LDAP connections sooner if we detect a timeout error (this allows Teleport to recover quicker)