### PR TITLE
Install Script: don't install upgrader (Automatic Upgrades) for non-systemd systems.

### DIFF
--- a/lib/web/join_tokens_test.go
+++ b/lib/web/join_tokens_test.go
@@ -951,7 +951,8 @@ func TestJoinScript(t *testing.T) {
 				"    # (warning): This expression is constant. Did you forget the $ on a variable?\n"+
 				"    # Disabling the warning above because expression is templated.\n"+
 				"    # shellcheck disable=SC2050\n"+
-				"    if [[ \"true\" == \"true\" ]]; then\n"+
+				"    if is_using_systemd && [[ \"true\" == \"true\" ]]; then\n"+
+				"        # Teleport Updater requires systemd.\n"+
 				"        PACKAGE_LIST+=\" ${TELEPORT_UPDATER_PIN_VERSION}\"\n"+
 				"    fi\n",
 			)
@@ -968,7 +969,8 @@ func TestJoinScript(t *testing.T) {
 				"    # (warning): This expression is constant. Did you forget the $ on a variable?\n"+
 				"    # Disabling the warning above because expression is templated.\n"+
 				"    # shellcheck disable=SC2050\n"+
-				"    if [[ \"false\" == \"true\" ]]; then\n"+
+				"    if is_using_systemd && [[ \"false\" == \"true\" ]]; then\n"+
+				"        # Teleport Updater requires systemd.\n"+
 				"        PACKAGE_LIST+=\" ${TELEPORT_UPDATER_PIN_VERSION}\"\n"+
 				"    fi\n",
 			)

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -911,7 +911,8 @@ package_list() {
     # (warning): This expression is constant. Did you forget the $ on a variable?
     # Disabling the warning above because expression is templated.
     # shellcheck disable=SC2050
-    if [[ "{{.installUpdater}}" == "true" ]]; then
+    if is_using_systemd && [[ "{{.installUpdater}}" == "true" ]]; then
+        # Teleport Updater requires systemd.
         PACKAGE_LIST+=" ${TELEPORT_UPDATER_PIN_VERSION}"
     fi
     echo ${PACKAGE_LIST}


### PR DESCRIPTION
Automatic Upgrades require systemd.
So, for systems without systemd, the upgrader must not be installed.

The script re-uses a previous check to detect systemd systems (it looks for the existence of the `/run/systemd/system` folder).

Demo:

```
root@tmpubuntu2204:/# bash -c "$(curl -fsSL -k https://127.0.0.1.nip.io:3080/scripts/741c1ba04f9d17b2f0ccad5c986cc568/install-node.sh)"
2023-07-11 17:56:51 UTC [teleport-installer] TELEPORT_VERSION: 13.1.5
2023-07-11 17:56:51 UTC [teleport-installer] TARGET_HOSTNAME: 127.0.0.1.nip.io
2023-07-11 17:56:51 UTC [teleport-installer] TARGET_PORT: 3080
2023-07-11 17:56:51 UTC [teleport-installer] JOIN_TOKEN: 741c1ba04f9d17b2f0ccad5c986cc568
2023-07-11 17:56:51 UTC [teleport-installer] CA_PIN_HASHES: sha256:b417e9b27c97e5ce707ff6e93059cedf2dba59b16663a9d47a617e8baa64c7da
2023-07-11 17:56:51 UTC [teleport-installer] Checking TCP connectivity to Teleport server (127.0.0.1.nip.io:3080)
2023-07-11 17:56:51 UTC [teleport-installer] Couldn't find nc, telnet or /dev/tcp to do a connection test
2023-07-11 17:56:51 UTC [teleport-installer] Going to blindly continue without testing connectivity
2023-07-11 17:56:51 UTC [teleport-installer] Detected host: linux-gnu, using Teleport binary type linux
2023-07-11 17:56:51 UTC [teleport-installer] Detected arch: x86_64, using Teleport arch amd64
2023-07-11 17:56:51 UTC [teleport-installer] Detected distro type: debian
2023-07-11 17:56:51 UTC [teleport-installer] Using Teleport distribution: deb
2023-07-11 17:56:51 UTC [teleport-installer] Created temp dir /tmp/teleport-Qd43vhmw8r
2023-07-11 17:56:51 UTC [teleport-installer] Installing repo for distro ubuntu.
Hit:1 http://security.ubuntu.com/ubuntu jammy-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu jammy InRelease                      
Hit:3 http://archive.ubuntu.com/ubuntu jammy-updates InRelease              
Hit:4 https://apt.releases.teleport.dev/ubuntu jammy InRelease
Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  teleport-ent
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 146 MB of archives.
After this operation, 516 MB of additional disk space will be used.
Get:1 https://apt.releases.teleport.dev/ubuntu jammy/stable/cloud amd64 teleport-ent amd64 13.1.5 [146 MB]
6% [1 teleport-ent 11.4 MB/146 MB 8%]^C
```

Adding the `/run/systemd/system` folder to simulate a systemd system.
```
root@tmpubuntu2204:/# mkdir -p /run/systemd/system    
root@tmpubuntu2204:/# bash -c "$(curl -fsSL -k https://127.0.0.1.nip.io:3080/scripts/741c1ba04f9d17b2f0ccad5c986cc568/install-node.sh)"
2023-07-11 17:57:35 UTC [teleport-installer] TELEPORT_VERSION: 13.1.5
2023-07-11 17:57:35 UTC [teleport-installer] TARGET_HOSTNAME: 127.0.0.1.nip.io
2023-07-11 17:57:35 UTC [teleport-installer] TARGET_PORT: 3080
2023-07-11 17:57:35 UTC [teleport-installer] JOIN_TOKEN: 741c1ba04f9d17b2f0ccad5c986cc568
2023-07-11 17:57:35 UTC [teleport-installer] CA_PIN_HASHES: sha256:b417e9b27c97e5ce707ff6e93059cedf2dba59b16663a9d47a617e8baa64c7da
2023-07-11 17:57:35 UTC [teleport-installer] Checking TCP connectivity to Teleport server (127.0.0.1.nip.io:3080)
2023-07-11 17:57:35 UTC [teleport-installer] Couldn't find nc, telnet or /dev/tcp to do a connection test
2023-07-11 17:57:35 UTC [teleport-installer] Going to blindly continue without testing connectivity
2023-07-11 17:57:35 UTC [teleport-installer] Detected host: linux-gnu, using Teleport binary type linux
2023-07-11 17:57:35 UTC [teleport-installer] Detected arch: x86_64, using Teleport arch amd64
2023-07-11 17:57:35 UTC [teleport-installer] Detected distro type: debian
2023-07-11 17:57:35 UTC [teleport-installer] Using Teleport distribution: deb
2023-07-11 17:57:35 UTC [teleport-installer] Created temp dir /tmp/teleport-s2kIkIXX02
2023-07-11 17:57:35 UTC [teleport-installer] Installing repo for distro ubuntu.
Hit:1 https://apt.releases.teleport.dev/ubuntu jammy InRelease
Hit:2 http://security.ubuntu.com/ubuntu jammy-security InRelease          
Hit:3 http://archive.ubuntu.com/ubuntu jammy InRelease                    
Hit:4 http://archive.ubuntu.com/ubuntu jammy-updates InRelease
Hit:5 http://archive.ubuntu.com/ubuntu jammy-backports InRelease
Reading package lists... Done
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following NEW packages will be installed:
  teleport-ent teleport-ent-updater
0 upgraded, 2 newly installed, 0 to remove and 0 not upgraded.
Need to get 146 MB of archives.
After this operation, 516 MB of additional disk space will be used.
```