### PR TITLE
remove changes that temporarily kept e builds working

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -181,7 +181,7 @@ func NewServer(cfg *InitConfig, opts ...ServerOption) (*Server, error) {
 		cfg.AuditLog = events.NewDiscardAuditLog()
 	}
 	if cfg.Emitter == nil {
-		cfg.Emitter = events.NewDiscardEmitterReal()
+		cfg.Emitter = events.NewDiscardEmitter()
 	}
 	if cfg.Streamer == nil {
 		cfg.Streamer = events.NewDiscardStreamer()

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4578,7 +4578,7 @@ func createSAMLIdPTestUsers(t *testing.T, server *Server) (string, string) {
 func modifyAndWaitForEvent(t *testing.T, errFn require.ErrorAssertionFunc, client *Client, srv *TestTLSServer, eventCode string, fn func() error) apievents.AuditEvent {
 	// Make sure we ignore events after consuming this one.
 	defer func() {
-		srv.AuthServer.AuthServer.emitter = events.NewDiscardEmitterReal()
+		srv.AuthServer.AuthServer.emitter = events.NewDiscardEmitter()
 	}()
 	chanEmitter := eventstest.NewChannelEmitter(1)
 	srv.AuthServer.AuthServer.emitter = chanEmitter
@@ -5750,28 +5750,32 @@ func TestWatchHeadlessAuthentications_usersCanOnlyWatchThemselves(t *testing.T) 
 			identity:         TestUser(admin),
 			filter:           types.HeadlessAuthenticationFilter{},
 			expectWatchError: "user cannot watch headless authentications without a filter for their username",
-		}, {
+		},
+		{
 			name:     "NOK alice cannot filter for username=bob",
 			identity: TestUser(alice),
 			filter: types.HeadlessAuthenticationFilter{
 				Username: bob,
 			},
 			expectWatchError: "user \"alice\" cannot watch headless authentications of \"bob\"",
-		}, {
+		},
+		{
 			name:     "OK alice can filter for username=alice",
 			identity: TestUser(alice),
 			filter: types.HeadlessAuthenticationFilter{
 				Username: alice,
 			},
 			expectResources: aliceAuthns,
-		}, {
+		},
+		{
 			name:     "OK bob can filter for username=bob",
 			identity: TestUser(bob),
 			filter: types.HeadlessAuthenticationFilter{
 				Username: bob,
 			},
 			expectResources: bobAuthns,
-		}, {
+		},
+		{
 			name:     "OK alice can filter for pending requests",
 			identity: TestUser(alice),
 			filter: types.HeadlessAuthenticationFilter{
@@ -5779,7 +5783,8 @@ func TestWatchHeadlessAuthentications_usersCanOnlyWatchThemselves(t *testing.T) 
 				State:    types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING,
 			},
 			expectResources: []*types.HeadlessAuthentication{aliceAuthns[types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING]},
-		}, {
+		},
+		{
 			name:     "OK alice can filter for a specific request",
 			identity: TestUser(alice),
 			filter: types.HeadlessAuthenticationFilter{

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -129,17 +129,16 @@ func (d *DiscardRecorder) RecordEvent(ctx context.Context, pe apievents.Prepared
 	return nil
 }
 
-// NewDiscardEmitterReal returns a no-op discard emitter
-func NewDiscardEmitterReal() *DiscardEmitterReal {
-	return &DiscardEmitterReal{}
+// NewDiscardEmitter returns a no-op discard emitter
+func NewDiscardEmitter() *DiscardEmitter {
+	return &DiscardEmitter{}
 }
 
 // DiscardEmitter discards all events
-// TODO(capnspacehook): rename to DiscardEmitter after e PR is merged
-type DiscardEmitterReal struct{}
+type DiscardEmitter struct{}
 
 // EmitAuditEvent discards audit event
-func (*DiscardEmitterReal) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (*DiscardEmitter) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
 	log.WithFields(log.Fields{
 		"event_id":    event.GetID(),
 		"event_type":  event.GetType(),
@@ -155,25 +154,8 @@ func NewDiscardStreamer() *DiscardStreamer {
 	return &DiscardStreamer{}
 }
 
-// TODO(capnspacehook): remove after e PR is merged
-func NewDiscardEmitter() *DiscardStreamer {
-	return NewDiscardStreamer()
-}
-
 // DiscardStreamer creates DiscardRecorders
 type DiscardStreamer struct{}
-
-// EmitAuditEvent discards audit event
-// TODO(capnspacehook): remove after e PR is merged
-func (*DiscardStreamer) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
-	log.WithFields(log.Fields{
-		"event_id":    event.GetID(),
-		"event_type":  event.GetType(),
-		"event_time":  event.GetTime(),
-		"event_index": event.GetIndex(),
-	}).Debugf("Discarding event")
-	return nil
-}
 
 // CreateAuditStream creates a stream that discards all events
 func (*DiscardStreamer) CreateAuditStream(ctx context.Context, sid session.ID) (apievents.Stream, error) {

--- a/lib/events/eventstest/mock_recorder_emitter.go
+++ b/lib/events/eventstest/mock_recorder_emitter.go
@@ -24,9 +24,6 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 )
 
-// TODO(capnspacehook): remove after e PR is merged
-type MockEmitter = MockRecorderEmitter
-
 // MockRecorderEmitter is a recorder and emitter that stores all events.
 type MockRecorderEmitter struct {
 	mu     sync.RWMutex

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -401,7 +401,7 @@ func newSession(ctx authContext, forwarder *Forwarder, req *http.Request, params
 		log:                            log,
 		io:                             io,
 		accessEvaluator:                accessEvaluator,
-		emitter:                        events.NewDiscardEmitterReal(),
+		emitter:                        events.NewDiscardEmitter(),
 		terminalSizeQueue:              newMultiResizeQueue(streamContext),
 		started:                        false,
 		sess:                           sess,

--- a/lib/reversetunnel/emit_conn_test.go
+++ b/lib/reversetunnel/emit_conn_test.go
@@ -32,7 +32,7 @@ func TestEmitConnTeleport(t *testing.T) {
 
 	go server.Write([]byte(msg))
 
-	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitterReal(), "serverid")
+	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitter(), "serverid")
 	buffer := make([]byte, 64)
 	n, err := conn.Read(buffer)
 	require.NoError(t, err)
@@ -46,7 +46,7 @@ func TestEmitConnNotTeleport(t *testing.T) {
 
 	go server.Write([]byte(msg))
 
-	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitterReal(), "serverid")
+	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitter(), "serverid")
 	buffer := make([]byte, 64)
 	n, err := conn.Read(buffer)
 	require.NoError(t, err)
@@ -64,7 +64,7 @@ func TestEmitConnTeleportSmallReads(t *testing.T) {
 		}
 	}()
 
-	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitterReal(), "serverid")
+	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitter(), "serverid")
 	buffer := make([]byte, 64)
 
 	for _, chunk := range chunks {
@@ -86,7 +86,7 @@ func TestEmitConnNotTeleportSmallReads(t *testing.T) {
 		}
 	}()
 
-	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitterReal(), "serverid")
+	conn := newEmitConn(context.Background(), client, events.NewDiscardEmitter(), "serverid")
 	buffer := make([]byte, 64)
 
 	for _, chunk := range chunks {

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1537,7 +1537,7 @@ func (process *TeleportProcess) initAuthService() error {
 			"turned off. This is dangerous, you will not be able to view audit events " +
 			"or save and playback recorded sessions."
 		process.log.Warn(warningMessage)
-		emitter, streamer = events.NewDiscardEmitterReal(), events.NewDiscardStreamer()
+		emitter, streamer = events.NewDiscardEmitter(), events.NewDiscardStreamer()
 	} else {
 		// check if session recording has been disabled. note, we will continue
 		// logging audit events, we just won't record sessions.

--- a/lib/srv/app/aws/handler_test.go
+++ b/lib/srv/app/aws/handler_test.go
@@ -512,7 +512,7 @@ func createSuite(t *testing.T, mockAWSHandler http.HandlerFunc, app types.Applic
 	require.NoError(t, err)
 
 	audit, err := common.NewAudit(common.AuditConfig{
-		Emitter:  libevents.NewDiscardEmitterReal(),
+		Emitter:  libevents.NewDiscardEmitter(),
 		Recorder: libevents.WithNoOpPreparer(recorder),
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
Changes for compatibility were added in https://github.com/gravitational/teleport/pull/27873, once https://github.com/gravitational/teleport.e/pull/1800 is merged this can safely be merged without breaking `e` builds.