### PR TITLE
Add discovery for Kubernetes apps

### DIFF
--- a/api/types/common/constants.go
+++ b/api/types/common/constants.go
@@ -57,6 +57,10 @@ const (
 	// OriginIntegrationAWSOIDC is an origin value indicating that the resource was
 	// created from the AWS OIDC Integration.
 	OriginIntegrationAWSOIDC = "integration_awsoidc"
+
+	// OriginDiscoveryKubernetes indicates that the resource was imported
+	// from kubernetes cluster by discovery service.
+	OriginDiscoveryKubernetes = "discovery-kubernetes"
 )
 
 // OriginValues lists all possible origin values.
@@ -67,4 +71,5 @@ var OriginValues = []string{
 	OriginCloud,
 	OriginKubernetes,
 	OriginOkta,
+	OriginDiscoveryKubernetes,
 }

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -564,6 +564,10 @@ const (
 	// created from the AWS OIDC Integration.
 	OriginIntegrationAWSOIDC = common.OriginIntegrationAWSOIDC
 
+	// OriginDiscoveryKubernetes indicates that the resource was imported
+	// from kubernetes cluster by discovery service.
+	OriginDiscoveryKubernetes = common.OriginDiscoveryKubernetes
+
 	// IntegrationLabel is a resource metadata label name used to identify the integration name that created the resource.
 	IntegrationLabel = TeleportNamespace + "/integration"
 

--- a/lib/auth/api.go
+++ b/lib/auth/api.go
@@ -696,6 +696,11 @@ type ReadDiscoveryAccessPoint interface {
 
 	// GetDatabases returns all database resources.
 	GetDatabases(ctx context.Context) ([]types.Database, error)
+
+	// GetApps returns all application resources.
+	GetApps(context.Context) ([]types.Application, error)
+	// GetApp returns the specified application resource.
+	GetApp(ctx context.Context, name string) (types.Application, error)
 }
 
 // DiscoveryAccessPoint is an API interface implemented by a certificate authority (CA) to be
@@ -722,6 +727,13 @@ type DiscoveryAccessPoint interface {
 	DeleteDatabase(ctx context.Context, name string) error
 	// UpsertServerInfo upserts a server info resource.
 	UpsertServerInfo(ctx context.Context, si types.ServerInfo) error
+
+	// CreateApp creates a new application resource.
+	CreateApp(context.Context, types.Application) error
+	// UpdateApp updates an existing application resource.
+	UpdateApp(context.Context, types.Application) error
+	// DeleteApp removes the specified application resource.
+	DeleteApp(ctx context.Context, name string) error
 }
 
 // ReadOktaAccessPoint is a read only API interface to be
@@ -1182,6 +1194,18 @@ func NewDiscoveryWrapper(base DiscoveryAccessPoint, cache ReadDiscoveryAccessPoi
 		accessPoint:              base,
 		ReadDiscoveryAccessPoint: cache,
 	}
+}
+
+func (w *DiscoveryWrapper) CreateApp(ctx context.Context, app types.Application) error {
+	return w.NoCache.CreateApp(ctx, app)
+}
+
+func (w *DiscoveryWrapper) UpdateApp(ctx context.Context, app types.Application) error {
+	return w.NoCache.UpdateApp(ctx, app)
+}
+
+func (w *DiscoveryWrapper) DeleteApp(ctx context.Context, name string) error {
+	return w.NoCache.DeleteApp(ctx, name)
 }
 
 // CreateKubernetesCluster creates a new kubernetes cluster resource.

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -3779,7 +3779,9 @@ func (g *GRPCServer) CreateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	app.SetOrigin(types.OriginDynamic)
+	if app.Origin() == "" {
+		app.SetOrigin(types.OriginDynamic)
+	}
 	if err := auth.CreateApp(ctx, app); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -3792,7 +3794,9 @@ func (g *GRPCServer) UpdateApp(ctx context.Context, app *types.AppV3) (*emptypb.
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	app.SetOrigin(types.OriginDynamic)
+	if app.Origin() == "" {
+		app.SetOrigin(types.OriginDynamic)
+	}
 	if err := auth.UpdateApp(ctx, app); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/grpcserver_test.go
+++ b/lib/auth/grpcserver_test.go
@@ -2679,7 +2679,6 @@ func TestAppsCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fetch all apps.
-	app2.SetOrigin(types.OriginDynamic)
 	out, err = clt.GetApps(ctx)
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff([]types.Application{app1, app2}, out,

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -873,10 +873,12 @@ func definitionForBuiltinRole(clusterName string, recConfig types.SessionRecordi
 						types.NewRule(types.KindKubernetesCluster, services.RW()),
 						types.NewRule(types.KindDatabase, services.RW()),
 						types.NewRule(types.KindServerInfo, services.RW()),
+						types.NewRule(types.KindApp, services.RW()),
 					},
-					// Discovery service should only access kubes/dbs with "cloud" origin.
+					// Discovery service should only access kubes/apps/dbs that originated from discovery.
 					KubernetesLabels: types.Labels{types.OriginLabel: []string{types.OriginCloud}},
 					DatabaseLabels:   types.Labels{types.OriginLabel: []string{types.OriginCloud}},
+					AppLabels:        types.Labels{types.OriginLabel: []string{types.OriginDiscoveryKubernetes}},
 				},
 			})
 	case types.RoleOkta:

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -366,6 +366,7 @@ func ForDiscovery(cfg Config) Config {
 		{Kind: types.KindNode},
 		{Kind: types.KindKubernetesCluster},
 		{Kind: types.KindDatabase},
+		{Kind: types.KindApp},
 	}
 	cfg.QueueSize = defaults.DiscoveryQueueSize
 	return cfg

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1338,6 +1338,16 @@ func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 		cfg.Discovery.GCPMatchers = append(cfg.Discovery.GCPMatchers, m)
 	}
 
+	for _, matcher := range fc.Discovery.KubernetesMatchers {
+		cfg.Discovery.KubernetesMatchers = append(cfg.Discovery.KubernetesMatchers,
+			types.KubernetesMatcher{
+				Types:      matcher.Types,
+				Namespaces: matcher.Namespaces,
+				Labels:     matcher.Labels,
+			},
+		)
+	}
+
 	return nil
 }
 

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -483,8 +483,8 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 	if len(conf.Discovery.KubernetesMatchers) > 0 {
 		if conf.Discovery.DiscoveryGroup == "" {
 			// TODO(anton): add link to documentation when it's available
-			return trace.BadParameter(`Parameter 'discovery_group' should be defined for discovery service if
-kubernetes matchers are present.`)
+			return trace.BadParameter(`parameter 'discovery_group' should be defined for discovery service if
+kubernetes matchers are present`)
 		}
 		if err := checkAndSetDefaultsForKubeMatchers(conf.Discovery.KubernetesMatchers); err != nil {
 			return trace.Wrap(err)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -480,6 +480,15 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 	if err := checkAndSetDefaultsForGCPMatchers(conf.Discovery.GCPMatchers); err != nil {
 		return trace.Wrap(err)
 	}
+	if len(conf.Discovery.KubernetesMatchers) > 0 {
+		if conf.Discovery.DiscoveryGroup == "" {
+			return trace.BadParameter(`Parameter 'discovery_group' should be defined for discovery service if
+kubernetes matchers are present.`)
+		}
+		if err := checkAndSetDefaultsForKubeMatchers(conf.Discovery.KubernetesMatchers); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 
 	return nil
 }
@@ -741,6 +750,35 @@ func checkAndSetDefaultsForGCPInstaller(matcher *GCPMatcher) error {
 	if installer := matcher.InstallParams.ScriptName; installer == "" {
 		matcher.InstallParams.ScriptName = installers.InstallerScriptName
 	}
+	return nil
+}
+
+// checkAndSetDefaultsForKubeMatchers sets the default values for Kubernetes matchers
+// and validates the provided types.
+func checkAndSetDefaultsForKubeMatchers(matchers []KubernetesMatcher) error {
+	for i := range matchers {
+		matcher := &matchers[i]
+
+		if len(matcher.Types) == 0 {
+			matcher.Types = []string{services.KubernetesMatchersApp}
+		}
+
+		for _, t := range matcher.Types {
+			if !slices.Contains(services.SupportedKubernetesMatchers, t) {
+				return trace.BadParameter("Kubernetes discovery does not support %q resource type; supported resource types are: %v",
+					t, services.SupportedKubernetesMatchers)
+			}
+		}
+
+		if len(matcher.Namespaces) == 0 {
+			matcher.Namespaces = []string{types.Wildcard}
+		}
+
+		if len(matcher.Labels) == 0 {
+			matcher.Labels = map[string]apiutils.Strings{types.Wildcard: {types.Wildcard}}
+		}
+	}
+
 	return nil
 }
 
@@ -1618,6 +1656,9 @@ type Discovery struct {
 	// GCPMatchers are used to match GCP resources.
 	GCPMatchers []GCPMatcher `yaml:"gcp,omitempty"`
 
+	// KubernetesMatchers are used to match services inside Kubernetes cluster for auto discovery
+	KubernetesMatchers []KubernetesMatcher `yaml:"kubernetes,omitempty"`
+
 	// DiscoveryGroup is the name of the discovery group that the current
 	// discovery service is a part of.
 	// It is used to filter out discovered resources that belong to another
@@ -1869,6 +1910,13 @@ type AzureMatcher struct {
 	// InstallParams sets the join method when installing on
 	// discovered Azure nodes.
 	InstallParams *InstallParams `yaml:"install,omitempty"`
+}
+
+// KubernetesMatcher matches Kubernetes resources.
+type KubernetesMatcher struct {
+	Types      []string                    `yaml:"types,omitempty"`
+	Namespaces []string                    `yaml:"namespaces,omitempty"`
+	Labels     map[string]apiutils.Strings `yaml:"labels,omitempty"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -760,15 +760,15 @@ func checkAndSetDefaultsForKubeMatchers(matchers []KubernetesMatcher) error {
 	for i := range matchers {
 		matcher := &matchers[i]
 
-		if len(matcher.Types) == 0 {
-			matcher.Types = []string{services.KubernetesMatchersApp}
-		}
-
 		for _, t := range matcher.Types {
 			if !slices.Contains(services.SupportedKubernetesMatchers, t) {
 				return trace.BadParameter("Kubernetes discovery does not support %q resource type; supported resource types are: %v",
 					t, services.SupportedKubernetesMatchers)
 			}
+		}
+
+		if len(matcher.Types) == 0 {
+			matcher.Types = []string{services.KubernetesMatchersApp}
 		}
 
 		if len(matcher.Namespaces) == 0 {
@@ -1915,9 +1915,12 @@ type AzureMatcher struct {
 
 // KubernetesMatcher matches Kubernetes resources.
 type KubernetesMatcher struct {
-	Types      []string                    `yaml:"types,omitempty"`
-	Namespaces []string                    `yaml:"namespaces,omitempty"`
-	Labels     map[string]apiutils.Strings `yaml:"labels,omitempty"`
+	// Types are Kubernetes services types to match. Currently only 'app' is supported.
+	Types []string `yaml:"types,omitempty"`
+	// Namespaces are Kubernetes namespaces in which to discover services
+	Namespaces []string `yaml:"namespaces,omitempty"`
+	// Labels are Kubernetes services labels to match.
+	Labels map[string]apiutils.Strings `yaml:"labels,omitempty"`
 }
 
 // Database represents a single database proxied by the service.

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -482,6 +482,7 @@ func (conf *FileConfig) CheckAndSetDefaults() error {
 	}
 	if len(conf.Discovery.KubernetesMatchers) > 0 {
 		if conf.Discovery.DiscoveryGroup == "" {
+			// TODO(anton): add link to documentation when it's available
 			return trace.BadParameter(`Parameter 'discovery_group' should be defined for discovery service if
 kubernetes matchers are present.`)
 		}

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -59,13 +59,13 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		AWSMatchers:        process.Config.Discovery.AWSMatchers,
 		AzureMatchers:      process.Config.Discovery.AzureMatchers,
 		GCPMatchers:        process.Config.Discovery.GCPMatchers,
+		KubernetesMatchers: process.Config.Discovery.KubernetesMatchers,
 		DiscoveryGroup:     process.Config.Discovery.DiscoveryGroup,
 		Emitter:            asyncEmitter,
 		AccessPoint:        accessPoint,
 		Log:                process.log,
 		ClusterName:        conn.ClientIdentity.ClusterName,
 		PollInterval:       process.Config.Discovery.PollInterval,
-		KubernetesMatchers: process.Config.Discovery.KubernetesMatchers,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -56,15 +56,16 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 
 	discoveryService, err := discovery.New(process.ExitContext(), &discovery.Config{
-		AWSMatchers:    process.Config.Discovery.AWSMatchers,
-		AzureMatchers:  process.Config.Discovery.AzureMatchers,
-		GCPMatchers:    process.Config.Discovery.GCPMatchers,
-		DiscoveryGroup: process.Config.Discovery.DiscoveryGroup,
-		Emitter:        asyncEmitter,
-		AccessPoint:    accessPoint,
-		Log:            process.log,
-		ClusterName:    conn.ClientIdentity.ClusterName,
-		PollInterval:   process.Config.Discovery.PollInterval,
+		AWSMatchers:        process.Config.Discovery.AWSMatchers,
+		AzureMatchers:      process.Config.Discovery.AzureMatchers,
+		GCPMatchers:        process.Config.Discovery.GCPMatchers,
+		DiscoveryGroup:     process.Config.Discovery.DiscoveryGroup,
+		Emitter:            asyncEmitter,
+		AccessPoint:        accessPoint,
+		Log:                process.log,
+		ClusterName:        conn.ClientIdentity.ClusterName,
+		PollInterval:       process.Config.Discovery.PollInterval,
+		KubernetesMatchers: process.Config.Discovery.KubernetesMatchers,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -56,16 +56,18 @@ func (process *TeleportProcess) initDiscoveryService() error {
 	}
 
 	discoveryService, err := discovery.New(process.ExitContext(), &discovery.Config{
-		AWSMatchers:        process.Config.Discovery.AWSMatchers,
-		AzureMatchers:      process.Config.Discovery.AzureMatchers,
-		GCPMatchers:        process.Config.Discovery.GCPMatchers,
-		KubernetesMatchers: process.Config.Discovery.KubernetesMatchers,
-		DiscoveryGroup:     process.Config.Discovery.DiscoveryGroup,
-		Emitter:            asyncEmitter,
-		AccessPoint:        accessPoint,
-		Log:                process.log,
-		ClusterName:        conn.ClientIdentity.ClusterName,
-		PollInterval:       process.Config.Discovery.PollInterval,
+		Matchers: discovery.Matchers{
+			AWS:        process.Config.Discovery.AWSMatchers,
+			Azure:      process.Config.Discovery.AzureMatchers,
+			GCP:        process.Config.Discovery.GCPMatchers,
+			Kubernetes: process.Config.Discovery.KubernetesMatchers,
+		},
+		DiscoveryGroup: process.Config.Discovery.DiscoveryGroup,
+		Emitter:        asyncEmitter,
+		AccessPoint:    accessPoint,
+		Log:            process.log,
+		ClusterName:    conn.ClientIdentity.ClusterName,
+		PollInterval:   process.Config.Discovery.PollInterval,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/servicecfg/discovery.go
+++ b/lib/service/servicecfg/discovery.go
@@ -28,6 +28,8 @@ type DiscoveryConfig struct {
 	AzureMatchers []types.AzureMatcher
 	// GCPMatchers are used to match GCP resources for auto discovery.
 	GCPMatchers []types.GCPMatcher
+	// KubernetesMatchers are used to match services inside Kubernetes cluster for auto discovery
+	KubernetesMatchers []types.KubernetesMatcher
 	// DiscoveryGroup is the name of the discovery group that the current
 	// discovery service is a part of.
 	// It is used to filter out discovered resources that belong to another
@@ -43,6 +45,6 @@ type DiscoveryConfig struct {
 
 // IsEmpty validates if the Discovery Service config has no cloud matchers.
 func (d DiscoveryConfig) IsEmpty() bool {
-	return len(d.AWSMatchers) == 0 &&
-		len(d.AzureMatchers) == 0 && len(d.GCPMatchers) == 0
+	return len(d.AWSMatchers) == 0 && len(d.AzureMatchers) == 0 &&
+		len(d.GCPMatchers) == 0 && len(d.KubernetesMatchers) == 0
 }

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -203,6 +203,12 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 }
 
 func getServiceFQDN(s corev1.Service) string {
+	// If service type is ExternalName it points to external DNS name, to keep correct
+	// HOST for HTTP requests we return already final external DNS name.
+	// https://kubernetes.io/docs/concepts/services-networking/service/#externalname
+	if s.Spec.Type == corev1.ServiceTypeExternalName {
+		return s.Spec.ExternalName
+	}
 	return fmt.Sprintf("%s.%s.svc.cluster.local", s.GetName(), s.GetNamespace())
 }
 

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -151,7 +151,7 @@ func TestGetServiceFQDN(t *testing.T) {
 			name:         "service2",
 			externalName: "external-service2",
 			namespace:    "ns2",
-			expected:     "service2.ns2.svc.cluster.local",
+			expected:     "external-service2",
 		},
 	}
 

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -117,6 +117,7 @@ func (s *Server) startCloudWatcher(ctx context.Context) error {
 	watcher, err := discovery.NewWatcher(ctx, discovery.WatcherConfig{
 		Fetchers: append(awsFetchers, azureFetchers...),
 		Log:      logrus.WithField(trace.Component, "watcher:cloud"),
+		Origin:   types.OriginCloud,
 	})
 	if err != nil {
 		if trace.IsNotFound(err) {

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -153,7 +153,9 @@ func (w *Watcher) fetchAndSend() {
 
 				// Set the origin label to provide information where resource comes from
 				staticLabels[types.OriginLabel] = w.cfg.Origin
-				staticLabels[types.CloudLabel] = lFetcher.Cloud()
+				if c := lFetcher.Cloud(); c != "" {
+					staticLabels[types.CloudLabel] = c
+				}
 
 				r.SetStaticLabels(staticLabels)
 			}

--- a/lib/srv/discovery/common/watcher.go
+++ b/lib/srv/discovery/common/watcher.go
@@ -51,6 +51,8 @@ type WatcherConfig struct {
 	// for all discovery services. If different agents are used to discover different
 	// sets of cloud resources, this field must be different for each set of agents.
 	DiscoveryGroup string
+	// Origin is used to specify what type of origin watcher's resources are
+	Origin string
 }
 
 // CheckAndSetDefaults validates the config.
@@ -66,6 +68,9 @@ func (c *WatcherConfig) CheckAndSetDefaults() error {
 	}
 	if len(c.Fetchers) == 0 {
 		return trace.NotFound("missing fetchers")
+	}
+	if c.Origin == "" {
+		return trace.BadParameter("origin is not set")
 	}
 	return nil
 }
@@ -146,8 +151,8 @@ func (w *Watcher) fetchAndSend() {
 					staticLabels[types.TeleportInternalDiscoveryGroupName] = w.cfg.DiscoveryGroup
 				}
 
-				// Set the origin to Cloud indicating that the resource was imported from a cloud provider.
-				staticLabels[types.OriginLabel] = types.OriginCloud
+				// Set the origin label to provide information where resource comes from
+				staticLabels[types.OriginLabel] = w.cfg.Origin
 				staticLabels[types.CloudLabel] = lFetcher.Cloud()
 
 				r.SetStaticLabels(staticLabels)

--- a/lib/srv/discovery/common/watcher_test.go
+++ b/lib/srv/discovery/common/watcher_test.go
@@ -63,6 +63,7 @@ func TestWatcher(t *testing.T) {
 		Fetchers: []Fetcher{appFetcher, noAuthFetcher, dbFetcher},
 		Interval: time.Hour,
 		Clock:    clock,
+		Origin:   types.OriginCloud,
 	})
 	require.NoError(t, err)
 	go watcher.Start()

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -61,6 +61,7 @@ func (s *Server) startDatabaseWatchers() error {
 		Log:            s.Log.WithField("kind", types.KindDatabase),
 		DiscoveryGroup: s.DiscoveryGroup,
 		Interval:       s.PollInterval,
+		Origin:         types.OriginCloud,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -140,7 +141,7 @@ func (s *Server) onDatabaseDelete(ctx context.Context, resource types.ResourceWi
 func filterResources[T types.ResourceWithLabels, S ~[]T](all S, wantOrigin, wantResourceGroup string) (filtered S) {
 	for _, resource := range all {
 		resourceDiscoveryGroup, _ := resource.GetLabel(types.TeleportInternalDiscoveryGroupName)
-		if resource.Origin() != wantOrigin || resourceDiscoveryGroup != wantResourceGroup {
+		if (wantOrigin != "" && resource.Origin() != wantOrigin) || resourceDiscoveryGroup != wantResourceGroup {
 			continue
 		}
 		filtered = append(filtered, resource)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v3"
@@ -30,6 +31,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
@@ -37,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/cloud"
 	"github.com/gravitational/teleport/lib/cloud/gcp"
+	kubeutils "github.com/gravitational/teleport/lib/kube/utils"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 	"github.com/gravitational/teleport/lib/srv/discovery/fetchers"
@@ -46,16 +49,29 @@ import (
 
 var errNoInstances = errors.New("all fetched nodes already enrolled")
 
+// KubernetesClient is an interface for providing client for accessing Kubernetes cluster
+type KubernetesClient interface {
+	GetKubernetesClient(kubeClusterName string) (kubernetes.Interface, error)
+}
+
+// Clients is and interface for retrieving clients needed for discovery.
+type Clients interface {
+	cloud.Clients
+	KubernetesClient
+}
+
 // Config provides configuration for the discovery server.
 type Config struct {
-	// Clients is an interface for retrieving cloud clients.
-	Clients cloud.Clients
+	// Clients is used for retrieving clients needed for discovery.
+	Clients Clients
 	// AWSMatchers is a list of AWS EC2 matchers.
 	AWSMatchers []types.AWSMatcher
 	// AzureMatchers is a list of Azure matchers to discover resources.
 	AzureMatchers []types.AzureMatcher
 	// GCPMatchers is a list of GCP matchers to discover resources.
 	GCPMatchers []types.GCPMatcher
+	// KubernetesMatchers is a list of Kubernetes matchers to discovery resources.
+	KubernetesMatchers []types.KubernetesMatcher
 	// Emitter is events emitter, used to submit discrete events
 	Emitter apievents.Emitter
 	// AccessPoint is a discovery access point
@@ -79,15 +95,49 @@ type Config struct {
 	PollInterval time.Duration
 }
 
-func (c *Config) CheckAndSetDefaults() error {
-	if c.Clients == nil {
-		cloudClients, err := cloud.NewClients()
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		c.Clients = cloudClients
+type discoveryClients struct {
+	cloud.Clients
+	KubernetesClient
+}
+
+type kubeClientGetter struct {
+	mu         sync.RWMutex
+	kubeClient kubernetes.Interface
+}
+
+func newKubeClientGetter() KubernetesClient {
+	return &kubeClientGetter{}
+}
+
+func (k *kubeClientGetter) GetKubernetesClient(kubeClusterName string) (kubernetes.Interface, error) {
+	k.mu.RLock()
+	if k.kubeClient != nil {
+		defer k.mu.RUnlock()
+		return k.kubeClient, nil
 	}
-	if len(c.AWSMatchers) == 0 && len(c.AzureMatchers) == 0 && len(c.GCPMatchers) == 0 {
+	k.mu.RUnlock()
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.kubeClient != nil {
+		return k.kubeClient, nil
+	}
+
+	cfg, err := kubeutils.GetKubeConfig("", false, kubeClusterName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	client, err := kubernetes.NewForConfig(cfg.Contexts[kubeClusterName])
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	k.kubeClient = client
+
+	return k.kubeClient, nil
+}
+
+func (c *Config) CheckAndSetDefaults() error {
+	if len(c.AWSMatchers) == 0 && len(c.AzureMatchers) == 0 && len(c.GCPMatchers) == 0 && len(c.KubernetesMatchers) == 0 {
 		return trace.BadParameter("no matchers configured for discovery")
 	}
 	if c.Emitter == nil {
@@ -96,6 +146,23 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.AccessPoint == nil {
 		return trace.BadParameter("no AccessPoint configured for discovery")
 	}
+	if len(c.KubernetesMatchers) > 0 && c.DiscoveryGroup == "" {
+		return trace.BadParameter(`Discovery group name should be set for discovery server if
+kubernetes matchers are present.`)
+	}
+	if c.Clients == nil {
+		clients := discoveryClients{}
+		cloudClients, err := cloud.NewClients()
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		clients.Clients = cloudClients
+		clients.KubernetesClient = newKubeClientGetter()
+
+		c.Clients = clients
+	}
+
 	if c.Log == nil {
 		c.Log = logrus.New()
 	}
@@ -136,6 +203,8 @@ type Server struct {
 	gcpInstaller *server.GCPInstaller
 	// kubeFetchers holds all kubernetes fetchers for Azure and other clouds.
 	kubeFetchers []common.Fetcher
+	// kubeAppsFetchers holds all kubernetes fetchers for apps.
+	kubeAppsFetchers []common.Fetcher
 	// databaseFetchers holds all database fetchers.
 	databaseFetchers []common.Fetcher
 	// caRotationCh receives nodes that need to have their CAs rotated.
@@ -174,6 +243,10 @@ func New(ctx context.Context, cfg *Config) (*Server, error) {
 		if err := s.initTeleportNodeWatcher(); err != nil {
 			return nil, trace.Wrap(err)
 		}
+	}
+
+	if err := s.initKubeAppWatchers(cfg.KubernetesMatchers); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	return s, nil
@@ -256,6 +329,33 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 		}
 	}
 
+	return nil
+}
+
+func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
+	kubeClient, err := s.Clients.GetKubernetesClient(s.DiscoveryGroup)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	for _, matcher := range matchers {
+		if !slices.Contains(matcher.Types, services.KubernetesMatchersApp) {
+			continue
+		}
+
+		fetcher, err := fetchers.NewKubeAppsFetcher(fetchers.KubeAppsFetcherConfig{
+			KubernetesClient: kubeClient,
+			FilterLabels:     matcher.Labels,
+			Namespaces:       matcher.Namespaces,
+			Log:              s.Log,
+			ClusterName:      s.DiscoveryGroup,
+		})
+
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		s.kubeAppsFetchers = append(s.kubeAppsFetchers, fetcher)
+	}
 	return nil
 }
 
@@ -747,6 +847,9 @@ func (s *Server) Start() error {
 		go s.handleGCPDiscovery()
 	}
 	if err := s.startKubeWatchers(); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := s.startKubeAppsWatchers(); err != nil {
 		return trace.Wrap(err)
 	}
 	if err := s.startDatabaseWatchers(); err != nil {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -143,7 +143,7 @@ kubernetes matchers are present.`)
 		c.Log = logrus.New()
 	}
 	if c.protocolChecker == nil {
-		c.protocolChecker = &fetchers.ProtoChecker{}
+		c.protocolChecker = fetchers.NewProtoChecker(false)
 	}
 	if c.PollInterval == 0 {
 		c.PollInterval = 5 * time.Minute
@@ -325,18 +325,13 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 			continue
 		}
 
-		pc := s.Config.protocolChecker
-		if pc == nil {
-			pc = &fetchers.ProtoChecker{}
-		}
-
 		fetcher, err := fetchers.NewKubeAppsFetcher(fetchers.KubeAppsFetcherConfig{
 			KubernetesClient: kubeClient,
 			FilterLabels:     matcher.Labels,
 			Namespaces:       matcher.Namespaces,
 			Log:              s.Log,
 			ClusterName:      s.DiscoveryGroup,
-			ProtocolChecker:  pc,
+			ProtocolChecker:  s.Config.protocolChecker,
 		})
 		if err != nil {
 			return trace.Wrap(err)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -48,11 +48,15 @@ import (
 
 var errNoInstances = errors.New("all fetched nodes already enrolled")
 
+// Clients contains all clients used by discovery service
 type Clients struct {
-	Cloud      cloud.Clients
+	// Cloud are cloud clients
+	Cloud cloud.Clients
+	// Kubernetes is Kubernetes client
 	Kubernetes kubernetes.Interface
 }
 
+// Matchers contains all matchers used by discovery service
 type Matchers struct {
 	// AWS is a list of AWS EC2 matchers.
 	AWS []types.AWSMatcher
@@ -111,7 +115,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if len(c.Matchers.Kubernetes) > 0 && c.DiscoveryGroup == "" {
-		return trace.BadParameter(`Discovery group name should be set for discovery server if
+		return trace.BadParameter(`the DiscoveryGroup name should be set for discovery server if
 kubernetes matchers are present.`)
 	}
 	if c.Clients.Cloud == nil {
@@ -124,11 +128,12 @@ kubernetes matchers are present.`)
 	if c.Clients.Kubernetes == nil && len(c.Matchers.Kubernetes) > 0 {
 		cfg, err := rest.InClusterConfig()
 		if err != nil {
-			return trace.Wrap(err, "kubernetes discovery is only available for incluster configurations")
+			return trace.Wrap(err,
+				"kubernetes discovery is only available for Teleport kube agent running inside Kubernetes cluster")
 		}
 		kubeClient, err := kubernetes.NewForConfig(cfg)
 		if err != nil {
-			return trace.Wrap(err, "unable to create kubernetes client")
+			return trace.Wrap(err, "unable to create Kubernetes client")
 		}
 
 		c.Clients.Kubernetes = kubeClient
@@ -333,7 +338,6 @@ func (s *Server) initKubeAppWatchers(matchers []types.KubernetesMatcher) error {
 			ClusterName:      s.DiscoveryGroup,
 			ProtocolChecker:  pc,
 		})
-
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -143,14 +143,12 @@ func (c *Config) CheckAndSetDefaults() error {
 kubernetes matchers are present.`)
 	}
 	if c.Clients == nil {
-		clients := discoveryClients{}
 		cloudClients, err := cloud.NewClients()
 		if err != nil {
 			return trace.Wrap(err)
 		}
 
-		clients.Clients = cloudClients
-		clients.KubernetesClient = newKubeClientGetter()
+		clients := discoveryClients{Clients: cloudClients, KubernetesClient: newKubeClientGetter()}
 
 		if len(c.KubernetesMatchers) > 0 {
 			_, err = clients.KubernetesClient.GetKubernetesClient()

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -417,7 +417,7 @@ func (s *Server) initGCPWatchers(ctx context.Context, matchers []types.GCPMatche
 	// VM watcher.
 	if len(vmMatchers) > 0 {
 		var err error
-		s.gcpWatcher, err = server.NewGCPWatcher(s.ctx, vmMatchers, s.Clients)
+		s.gcpWatcher, err = server.NewGCPWatcher(s.ctx, vmMatchers, s.Clients.Cloud)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -766,7 +766,7 @@ outer:
 }
 
 func (s *Server) handleGCPInstances(instances *server.GCPInstances) error {
-	client, err := s.Clients.GetGCPInstancesClient(s.ctx)
+	client, err := s.Clients.Cloud.GetGCPInstancesClient(s.ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -129,7 +129,7 @@ kubernetes matchers are present.`)
 		cfg, err := rest.InClusterConfig()
 		if err != nil {
 			return trace.Wrap(err,
-				"kubernetes discovery is only available for Teleport kube agent running inside Kubernetes cluster")
+				"the Kubernetes App Discovery requires a Teleport Kube Agent running on a Kubernetes cluster")
 		}
 		kubeClient, err := kubernetes.NewForConfig(cfg)
 		if err != nil {

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -49,7 +49,7 @@ import (
 
 var errNoInstances = errors.New("all fetched nodes already enrolled")
 
-// KubernetesClient is an interface for providing client for accessing Kubernetes cluster
+// KubernetesClient is an interface for providing clients which can access a Kubernetes cluster.
 type KubernetesClient interface {
 	GetKubernetesClient() (kubernetes.Interface, error)
 }

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -68,7 +68,7 @@ func (m Matchers) IsEmpty() bool {
 type Config struct {
 	// CloudClients is an interface for retrieving cloud clients.
 	CloudClients cloud.Clients
-	// Kubernetes is the Kubernetes client interface
+	// KubernetesClient is the Kubernetes client interface
 	KubernetesClient kubernetes.Interface
 	// Matchers stores all types of matchers to discover resources
 	Matchers Matchers

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -576,6 +576,20 @@ func TestDiscoveryKubeServices(t *testing.T) {
 				require.NoError(t, err)
 			}
 
+			// Wait for the apps to be fully created
+			timeout := time.Now().Add(1 * time.Second)
+			for {
+				existingApps, err := tlsServer.Auth().GetApps(ctx)
+				require.NoError(t, err)
+				if len(existingApps) == len(tt.existingApps) {
+					break
+				}
+				if time.Now().After(timeout) {
+					require.FailNow(t, "")
+				}
+				time.Sleep(100 * time.Millisecond)
+			}
+
 			discServer, err := New(
 				ctx,
 				&Config{

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -486,11 +486,11 @@ func TestDiscoveryKubeServices(t *testing.T) {
 					Labels:     map[string]utils.Strings{"test-label": {"testval"}},
 				},
 			},
-			expectedAppsToExistInAuth: types.Apps{app1, app2},
+			expectedAppsToExistInAuth: types.Apps{app1.Copy(), app2.Copy()},
 		},
 		{
 			name:         "one app in auth server, import 1 apps",
-			existingApps: types.Apps{app1},
+			existingApps: types.Apps{app1.Copy()},
 			kubernetesMatchers: []types.KubernetesMatcher{
 				{
 					Types:      []string{"app"},
@@ -498,11 +498,11 @@ func TestDiscoveryKubeServices(t *testing.T) {
 					Labels:     map[string]utils.Strings{"test-label": {"testval"}},
 				},
 			},
-			expectedAppsToExistInAuth: types.Apps{app1, app2},
+			expectedAppsToExistInAuth: types.Apps{app1.Copy(), app2.Copy()},
 		},
 		{
 			name:         "two apps in the auth server, one updated one imported",
-			existingApps: types.Apps{modifiedApp1, app2},
+			existingApps: types.Apps{modifiedApp1.Copy(), app2.Copy()},
 			kubernetesMatchers: []types.KubernetesMatcher{
 				{
 					Types:      []string{"app"},
@@ -510,11 +510,11 @@ func TestDiscoveryKubeServices(t *testing.T) {
 					Labels:     map[string]utils.Strings{"test-label": {"testval"}},
 				},
 			},
-			expectedAppsToExistInAuth: types.Apps{app1, app2},
+			expectedAppsToExistInAuth: types.Apps{app1.Copy(), app2.Copy()},
 		},
 		{
 			name:         "one app in auth server, discovery doesn't match another app",
-			existingApps: types.Apps{app1},
+			existingApps: types.Apps{app1.Copy()},
 			kubernetesMatchers: []types.KubernetesMatcher{
 				{
 					Types:      []string{"app"},
@@ -522,11 +522,11 @@ func TestDiscoveryKubeServices(t *testing.T) {
 					Labels:     map[string]utils.Strings{"test-label": {"testval"}},
 				},
 			},
-			expectedAppsToExistInAuth: types.Apps{app1},
+			expectedAppsToExistInAuth: types.Apps{app1.Copy()},
 		},
 		{
 			name:         "one app in auth server from another discovery group, import 2 apps",
-			existingApps: types.Apps{otherGroupApp1},
+			existingApps: types.Apps{otherGroupApp1.Copy()},
 			kubernetesMatchers: []types.KubernetesMatcher{
 				{
 					Types:      []string{"app"},
@@ -534,7 +534,7 @@ func TestDiscoveryKubeServices(t *testing.T) {
 					Labels:     map[string]utils.Strings{"test-label": {"testval"}},
 				},
 			},
-			expectedAppsToExistInAuth: types.Apps{app1, otherGroupApp1, app2},
+			expectedAppsToExistInAuth: types.Apps{app1.Copy(), otherGroupApp1.Copy(), app2.Copy()},
 		},
 	}
 

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -545,7 +545,7 @@ func TestDiscoveryKubeServices(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			objects := []runtime.Object{}
+			var objects []runtime.Object
 			for _, s := range mockKubeServices {
 				objects = append(objects, s)
 			}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1918,9 +1918,12 @@ func TestGCPVMDiscovery(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			testClients := cloud.TestCloudClients{
-				GCPInstances: &mockGCPClient{
-					vms: tc.foundGCPVMs,
+			testClients := Clients{
+				Kubernetes: fake.NewSimpleClientset(),
+				Cloud: &cloud.TestCloudClients{
+					GCPInstances: &mockGCPClient{
+						vms: tc.foundGCPVMs,
+					},
 				},
 			}
 
@@ -1949,14 +1952,16 @@ func TestGCPVMDiscovery(t *testing.T) {
 			emitter := &mockEmitter{}
 
 			server, err := New(context.Background(), &Config{
-				Clients:     &testClients,
+				Clients:     testClients,
 				AccessPoint: tlsServer.Auth(),
-				GCPMatchers: []types.GCPMatcher{{
-					Types:      []string{"gce"},
-					ProjectIDs: []string{"myproject"},
-					Locations:  []string{"myzone"},
-					Tags:       types.Labels{"teleport": {"yes"}},
-				}},
+				Matchers: Matchers{
+					GCP: []types.GCPMatcher{{
+						Types:      []string{"gce"},
+						ProjectIDs: []string{"myproject"},
+						Locations:  []string{"myzone"},
+						Tags:       types.Labels{"teleport": {"yes"}},
+					}},
+				},
 				Emitter: emitter,
 				Log:     logger,
 			})

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -1186,7 +1186,7 @@ type mockKubeClientGetter struct {
 	kubeClient kubernetes.Interface
 }
 
-func (m *mockKubeClientGetter) GetKubernetesClient(_ string) (kubernetes.Interface, error) {
+func (m *mockKubeClientGetter) GetKubernetesClient() (kubernetes.Interface, error) {
 	if m.kubeClient == nil {
 		return fake.NewSimpleClientset(), nil
 	}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -572,8 +572,7 @@ func TestDiscoveryKubeServices(t *testing.T) {
 
 			require.Eventually(t, func() bool {
 				existingApps, err := tlsServer.Auth().GetApps(ctx)
-				require.NoError(t, err)
-				return len(existingApps) == len(tt.existingApps)
+				return err == nil && len(existingApps) == len(tt.existingApps)
 			}, time.Second, 100*time.Millisecond)
 
 			discServer, err := New(
@@ -599,19 +598,18 @@ func TestDiscoveryKubeServices(t *testing.T) {
 
 			require.Eventually(t, func() bool {
 				existingApps, err := tlsServer.Auth().GetApps(ctx)
-				require.NoError(t, err)
-				if len(existingApps) == len(tt.expectedAppsToExistInAuth) {
-					a1 := types.Apps(existingApps)
-					a2 := types.Apps(tt.expectedAppsToExistInAuth)
-					for k := range a1 {
-						if services.CompareResources(a1[k], a2[k]) != services.Equal {
-							return false
-						}
-					}
-					return true
+				if err != nil || len(existingApps) != len(tt.expectedAppsToExistInAuth) {
+					return false
 				}
+				a1 := types.Apps(existingApps)
+				a2 := types.Apps(tt.expectedAppsToExistInAuth)
+				for k := range a1 {
+					if services.CompareResources(a1[k], a2[k]) != services.Equal {
+						return false
+					}
+				}
+				return true
 
-				return false
 			}, 5*time.Second, 200*time.Millisecond)
 		})
 	}

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -374,15 +374,17 @@ func TestDiscoveryServer(t *testing.T) {
 			server, err := New(context.Background(), &Config{
 				Clients:     testClients,
 				AccessPoint: tlsServer.Auth(),
-				AWSMatchers: []types.AWSMatcher{{
-					Types:   []string{"ec2"},
-					Regions: []string{"eu-central-1"},
-					Tags:    map[string]utils.Strings{"teleport": {"yes"}},
-					SSM:     &types.AWSSSM{DocumentName: "document"},
-					Params: &types.InstallerParams{
-						InstallTeleport: true,
-					},
-				}},
+				Matchers: Matchers{
+					AWS: []types.AWSMatcher{{
+						Types:   []string{"ec2"},
+						Regions: []string{"eu-central-1"},
+						Tags:    map[string]utils.Strings{"teleport": {"yes"}},
+						SSM:     &types.AWSSSM{DocumentName: "document"},
+						Params: &types.InstallerParams{
+							InstallTeleport: true,
+						},
+					}},
+				},
 				Emitter: tc.emitter,
 				Log:     logger,
 			})
@@ -609,12 +611,14 @@ func TestDiscoveryKubeServices(t *testing.T) {
 			discServer, err := New(
 				ctx,
 				&Config{
-					Clients:            testClients,
-					AccessPoint:        tlsServer.Auth(),
-					KubernetesMatchers: tt.kubernetesMatchers,
-					Emitter:            authClient,
-					Log:                logger,
-					DiscoveryGroup:     mainDiscoveryGroup,
+					Clients:     testClients,
+					AccessPoint: tlsServer.Auth(),
+					Matchers: Matchers{
+						Kubernetes: tt.kubernetesMatchers,
+					},
+					Emitter:        authClient,
+					Log:            logger,
+					DiscoveryGroup: mainDiscoveryGroup,
 				})
 
 			require.NoError(t, err)
@@ -931,11 +935,13 @@ func TestDiscoveryInCloudKube(t *testing.T) {
 			discServer, err := New(
 				ctx,
 				&Config{
-					Clients:        testClients,
-					AccessPoint:    tlsServer.Auth(),
-					AWSMatchers:    tc.awsMatchers,
-					AzureMatchers:  tc.azureMatchers,
-					GCPMatchers:    tc.gcpMatchers,
+					Clients:     testClients,
+					AccessPoint: tlsServer.Auth(),
+					Matchers: Matchers{
+						AWS:   tc.awsMatchers,
+						Azure: tc.azureMatchers,
+						GCP:   tc.gcpMatchers,
+					},
 					Emitter:        authClient,
 					Log:            logger,
 					DiscoveryGroup: mainDiscoveryGroup,
@@ -1470,11 +1476,13 @@ func TestDiscoveryDatabase(t *testing.T) {
 			srv, err := New(
 				ctx,
 				&Config{
-					Clients:       testClients,
-					AccessPoint:   tlsServer.Auth(),
-					AWSMatchers:   tc.awsMatchers,
-					AzureMatchers: tc.azureMatchers,
-					Emitter:       authClient,
+					Clients:     testClients,
+					AccessPoint: tlsServer.Auth(),
+					Matchers: Matchers{
+						AWS:   tc.awsMatchers,
+						Azure: tc.azureMatchers,
+					},
+					Emitter: authClient,
 					onDatabaseReconcile: func() {
 						waitForReconcile <- struct{}{}
 					},
@@ -1766,13 +1774,15 @@ func TestAzureVMDiscovery(t *testing.T) {
 			server, err := New(context.Background(), &Config{
 				Clients:     testClients,
 				AccessPoint: tlsServer.Auth(),
-				AzureMatchers: []types.AzureMatcher{{
-					Types:          []string{"vm"},
-					Subscriptions:  []string{"testsub"},
-					ResourceGroups: []string{"testrg"},
-					Regions:        []string{"westcentralus"},
-					ResourceTags:   types.Labels{"teleport": {"yes"}},
-				}},
+				Matchers: Matchers{
+					Azure: []types.AzureMatcher{{
+						Types:          []string{"vm"},
+						Subscriptions:  []string{"testsub"},
+						ResourceGroups: []string{"testrg"},
+						Regions:        []string{"westcentralus"},
+						ResourceTags:   types.Labels{"teleport": {"yes"}},
+					}},
+				},
 				Emitter: emitter,
 				Log:     logger,
 			})

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -576,19 +576,11 @@ func TestDiscoveryKubeServices(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			// Wait for the apps to be fully created
-			timeout := time.Now().Add(1 * time.Second)
-			for {
+			require.Eventually(t, func() bool {
 				existingApps, err := tlsServer.Auth().GetApps(ctx)
 				require.NoError(t, err)
-				if len(existingApps) == len(tt.existingApps) {
-					break
-				}
-				if time.Now().After(timeout) {
-					require.FailNow(t, "")
-				}
-				time.Sleep(100 * time.Millisecond)
-			}
+				return len(existingApps) == len(tt.existingApps)
+			}, time.Second, 100*time.Millisecond)
 
 			discServer, err := New(
 				ctx,

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -156,8 +156,10 @@ func (f *kubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 	g.SetLimit(10)
 
 	// Convert services to resources
-	var appsMu sync.Mutex
-	var apps types.Apps
+	var (
+		appsMu sync.Mutex
+		apps types.Apps
+	)
 	for _, service := range kubeServices {
 		service := service
 

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -53,7 +53,7 @@ type KubeAppsFetcherConfig struct {
 // CheckAndSetDefaults validates and sets the defaults values.
 func (k *KubeAppsFetcherConfig) CheckAndSetDefaults() error {
 	if k.FilterLabels == nil {
-		return trace.BadParameter("missing parameter AccessPoint")
+		return trace.BadParameter("missing parameter FilterLabels")
 	}
 	if k.KubernetesClient == nil {
 		return trace.BadParameter("missing parameter KubernetesClient")

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -187,8 +187,9 @@ func (f *kubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 		})
 	}
 
-	// We already logged individual errors of converting service to apps, there are never errors returned.
-	_ = g.Wait()
+	if err := g.Wait(); err != nil {
+		return trace.Wrap(err)
+	}
 
 	return apps.AsResources(), nil
 }

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -103,7 +103,7 @@ func isInternalKubeService(s v1.Service) bool {
 }
 
 func (f *kubeAppFetcher) getServices(ctx context.Context) ([]v1.Service, error) {
-	result := []v1.Service{}
+	var result []v1.Service
 	nextToken := ""
 	namespaceFilter := func(ns string) bool {
 		return slices.Contains(f.Namespaces, types.Wildcard) || slices.Contains(f.Namespaces, ns)

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fetchers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/discovery/common"
+)
+
+// KubeAppsFetcherConfig configures kubeAppFetcher
+type KubeAppsFetcherConfig struct {
+	// Name of the kubernetes cluster
+	ClusterName string
+	// KubernetesClient is a client for Kubernetes API
+	KubernetesClient kubernetes.Interface
+	// FilterLabels are the filter criteria.
+	FilterLabels types.Labels
+	// Namespaces are the kubernetes namespaces in which to discover services
+	Namespaces []string
+	// Log is a logger to use
+	Log logrus.FieldLogger
+	// PI inspects port to find your whether they are HTTP/HTTPS or not.
+	protocolChecker services.ProtocolChecker
+}
+
+// CheckAndSetDefaults validates and sets the defaults values.
+func (k *KubeAppsFetcherConfig) CheckAndSetDefaults() error {
+	if k.FilterLabels == nil {
+		return trace.BadParameter("missing parameter AccessPoint")
+	}
+	if k.KubernetesClient == nil {
+		return trace.BadParameter("missing parameter KubernetesClient")
+	}
+	if k.Log == nil {
+		return trace.BadParameter("missing parameter Log")
+	}
+	if k.ClusterName == "" {
+		return trace.BadParameter("missing parameter ClusterName")
+	}
+	if k.protocolChecker == nil {
+		k.protocolChecker = &noopProtocolChecker{}
+	}
+
+	return nil
+}
+
+// kubeAppFetcher fetches app resources from Kubernetes services
+type kubeAppFetcher struct {
+	KubeAppsFetcherConfig
+}
+
+// Default implementation, doesn't actually performs HTTP request.
+type noopProtocolChecker struct{}
+
+// CheckProtocol for noopProtocolChecker just returns 'tcp'
+func (*noopProtocolChecker) CheckProtocol(uri string) string {
+	return "tcp"
+}
+
+// NewKubeAppsFetcher creates new Kubernetes app fetcher
+func NewKubeAppsFetcher(cfg KubeAppsFetcherConfig) (common.Fetcher, error) {
+	if err := cfg.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &kubeAppFetcher{
+		KubeAppsFetcherConfig: cfg,
+	}, nil
+}
+
+func isInternalKubeService(s v1.Service) bool {
+	return (s.GetNamespace() == "default" && s.GetName() == "kubernetes") ||
+		(s.GetNamespace() == "kube-system" && s.GetName() == "kube-dns")
+}
+
+func (f *kubeAppFetcher) getServices(ctx context.Context) ([]v1.Service, error) {
+	result := []v1.Service{}
+	for _, namespace := range f.Namespaces {
+		ns := namespace
+		if namespace == types.Wildcard {
+			ns = ""
+		}
+		kubeServices, err := f.KubernetesClient.CoreV1().Services(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		for _, s := range kubeServices.Items {
+			match, _, err := services.MatchLabels(f.FilterLabels, s.Labels)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			} else if match {
+				result = append(result, s)
+			} else {
+				f.Log.WithField("service_name", s.Name).Debug("Service doesn't match labels.")
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// Get fetches Kubernetes apps from the cluster
+func (f *kubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
+	kubeServices, err := f.getServices(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Converting service to apps can involve performing a HTTP ping to the service ports to determine protocol.
+	// Both services and ports inside services are processed in parallel to minimize time.
+	// We also set limit to prevent potential spike load on a cluster in case there are a lot of services.
+	g, _ := errgroup.WithContext(ctx)
+	g.SetLimit(10)
+
+	// Convert services to resources
+	var appsMu sync.Mutex
+	var apps types.Apps
+	for _, service := range kubeServices {
+		service := service
+
+		g.Go(func() error {
+			// Skip kubernetes own internal services
+			if isInternalKubeService(service) {
+				return nil
+			}
+
+			// Skip service if it has type annotation and it's not 'app'
+			for k, v := range service.GetAnnotations() {
+				if k == types.DiscoveryTypeLabel && v != services.KubernetesMatchersApp {
+					return nil
+				}
+			}
+
+			serviceApps, err := services.NewApplicationsFromKubeService(service, f.ClusterName, f.protocolChecker)
+			if err != nil {
+				f.Log.Warnf("Could not get app from Kubernetes service: %v", err)
+				return nil
+			}
+
+			appsMu.Lock()
+			apps = append(apps, serviceApps...)
+			appsMu.Unlock()
+			return nil
+		})
+	}
+
+	// We already logged individual errors of converting service to apps, there are never errors returned.
+	_ = g.Wait()
+
+	return apps.AsResources(), nil
+}
+
+func (f *kubeAppFetcher) ResourceType() string {
+	return types.KindApp
+}
+
+func (f *kubeAppFetcher) Cloud() string {
+	return ""
+}
+
+func (f *kubeAppFetcher) String() string {
+	return fmt.Sprintf("kubeAppFetcher(Namespaces=%v, Labels=%v)", f.Namespaces, f.FilterLabels)
+}

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -158,7 +158,7 @@ func (f *kubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 	// Convert services to resources
 	var (
 		appsMu sync.Mutex
-		apps types.Apps
+		apps   types.Apps
 	)
 	for _, service := range kubeServices {
 		service := service
@@ -188,7 +188,7 @@ func (f *kubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 	}
 
 	if err := g.Wait(); err != nil {
-		return trace.Wrap(err)
+		return nil, trace.Wrap(err)
 	}
 
 	return apps.AsResources(), nil

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -314,26 +314,22 @@ type ProtoChecker struct {
 func NewProtoChecker(insecureSkipVerify bool) *ProtoChecker {
 	p := &ProtoChecker{
 		InsecureSkipVerify: insecureSkipVerify,
+		client: &http.Client{
+			Timeout: 5 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{
+					InsecureSkipVerify: insecureSkipVerify,
+				},
+			},
+		},
 	}
-	p.createClient()
 
 	return p
 }
 
-func (p *ProtoChecker) createClient() {
-	p.client = &http.Client{
-		Timeout: 5 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: p.InsecureSkipVerify,
-			},
-		},
-	}
-}
-
 func (p *ProtoChecker) CheckProtocol(uri string) string {
 	if p.client == nil {
-		p.createClient()
+		return protoTCP
 	}
 
 	resp, err := p.client.Head(fmt.Sprintf("https://%s", uri))

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -322,7 +322,7 @@ func NewProtoChecker(insecureSkipVerify bool) *ProtoChecker {
 
 func (p *ProtoChecker) createClient() {
 	p.client = &http.Client{
-		Timeout: 2 * time.Second,
+		Timeout: 5 * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
 				InsecureSkipVerify: p.InsecureSkipVerify,

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -36,10 +36,9 @@ import (
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
-// KubeAppsFetcherConfig configures kubeAppFetcher
+// KubeAppsFetcherConfig configures KubeAppFetcher
 type KubeAppsFetcherConfig struct {
 	// Name of the kubernetes cluster
 	ClusterName string
@@ -76,18 +75,18 @@ func (k *KubeAppsFetcherConfig) CheckAndSetDefaults() error {
 	return nil
 }
 
-// kubeAppFetcher fetches app resources from Kubernetes services
-type kubeAppFetcher struct {
+// KubeAppFetcher fetches app resources from Kubernetes services
+type KubeAppFetcher struct {
 	KubeAppsFetcherConfig
 }
 
 // NewKubeAppsFetcher creates new Kubernetes app fetcher
-func NewKubeAppsFetcher(cfg KubeAppsFetcherConfig) (common.Fetcher, error) {
+func NewKubeAppsFetcher(cfg KubeAppsFetcherConfig) (*KubeAppFetcher, error) {
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return &kubeAppFetcher{
+	return &KubeAppFetcher{
 		KubeAppsFetcherConfig: cfg,
 	}, nil
 }
@@ -99,7 +98,7 @@ func isInternalKubeService(s v1.Service) bool {
 		s.GetNamespace() == metav1.NamespacePublic
 }
 
-func (f *kubeAppFetcher) getServices(ctx context.Context) ([]v1.Service, error) {
+func (f *KubeAppFetcher) getServices(ctx context.Context) ([]v1.Service, error) {
 	var result []v1.Service
 	nextToken := ""
 	namespaceFilter := func(ns string) bool {
@@ -146,7 +145,7 @@ const (
 )
 
 // Get fetches Kubernetes apps from the cluster
-func (f *kubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
+func (f *KubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, error) {
 	kubeServices, err := f.getServices(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -226,16 +225,16 @@ func (f *kubeAppFetcher) Get(ctx context.Context) (types.ResourcesWithLabels, er
 	return apps.AsResources(), nil
 }
 
-func (f *kubeAppFetcher) ResourceType() string {
+func (f *KubeAppFetcher) ResourceType() string {
 	return types.KindApp
 }
 
-func (f *kubeAppFetcher) Cloud() string {
+func (f *KubeAppFetcher) Cloud() string {
 	return ""
 }
 
-func (f *kubeAppFetcher) String() string {
-	return fmt.Sprintf("kubeAppFetcher(Namespaces=%v, Labels=%v)", f.Namespaces, f.FilterLabels)
+func (f *KubeAppFetcher) String() string {
+	return fmt.Sprintf("KubeAppFetcher(Namespaces=%v, Labels=%v)", f.Namespaces, f.FilterLabels)
 }
 
 // autoProtocolDetection tries to determine port's protocol. It uses heuristics and port HTTP pinging if needed, provided

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -285,7 +285,7 @@ func getServicePorts(s v1.Service) ([]v1.ServicePort, error) {
 			preferredPort = v
 		}
 	}
-	availablePorts := []v1.ServicePort{}
+	var availablePorts []v1.ServicePort
 	for _, p := range s.Spec.Ports {
 		// Only supporting TCP ports.
 		if p.Protocol != v1.ProtocolTCP {

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -241,9 +241,9 @@ func (f *KubeAppFetcher) String() string {
 // by protocol checker. It is used when no explicit annotation for port's protocol was provided.
 func autoProtocolDetection(serviceFQDN string, port v1.ServicePort, pc ProtocolChecker) string {
 	if port.AppProtocol != nil {
-		switch strings.ToLower(*port.AppProtocol) {
+		switch p := strings.ToLower(*port.AppProtocol); p {
 		case protoHTTP, protoHTTPS:
-			return strings.ToLower(*port.AppProtocol)
+			return p
 		}
 	}
 

--- a/lib/srv/discovery/fetchers/kube_services.go
+++ b/lib/srv/discovery/fetchers/kube_services.go
@@ -300,7 +300,7 @@ func getServicePorts(s v1.Service) ([]v1.ServicePort, error) {
 
 	// If preferred port is specified and we're here, it means we couldn't find it in service's ports.
 	if preferredPort != "" {
-		return nil, trace.BadParameter("Specified preferred port %s is absent among available service ports", preferredPort)
+		return nil, trace.BadParameter("specified preferred port %s is absent among available service ports", preferredPort)
 	}
 
 	return availablePorts, nil

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -172,7 +172,6 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 	}{
 		{
 			desc:              "No services",
-			services:          []*corev1.Service{},
 			matcherNamespaces: []string{"ns1"},
 			matcherLabels:     types.Labels{"test-label": []string{"testval"}},
 			expected:          types.Apps{},

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -1,0 +1,328 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fetchers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestKubeAppFetcher_Get(t *testing.T) {
+	t.Parallel()
+
+	appProtocolHTTP := "http"
+	mockServices := []*corev1.Service{
+		newMockService("service1", "ns1", "", map[string]string{"test-label": "testval"}, nil,
+			[]corev1.ServicePort{{Port: 42, Name: "http", Protocol: corev1.ProtocolTCP}}),
+		newMockService("service2", "ns2", "", map[string]string{"test-label": "testval",
+			"test-label2": "testval2"}, nil, []corev1.ServicePort{{Port: 42, Name: "custom", AppProtocol: &appProtocolHTTP, Protocol: corev1.ProtocolTCP}}),
+		newMockService("service3", "ns2", "", map[string]string{"test-label2": "testval2"}, nil,
+			[]corev1.ServicePort{
+				{Port: 42, Name: "custom", Protocol: corev1.ProtocolTCP},
+				{Port: 80, Name: "http", Protocol: corev1.ProtocolTCP},
+				{Port: 443, Name: "https", Protocol: corev1.ProtocolTCP},
+				{Port: 43, Name: "custom-udp", Protocol: corev1.ProtocolUDP},
+			}),
+		newMockService("service4", "ns3", "", map[string]string{"test-label2": "testval2"}, map[string]string{
+			types.DiscoveryProtocolLabel: "https",
+			types.DiscoveryPortLabel:     "42",
+		},
+			[]corev1.ServicePort{
+				{Port: 42, Name: "custom", Protocol: corev1.ProtocolTCP},
+				{Port: 80, Name: "http", Protocol: corev1.ProtocolTCP},
+				{Port: 443, Name: "https", Protocol: corev1.ProtocolTCP},
+				{Port: 43, Name: "custom-udp", Protocol: corev1.ProtocolUDP},
+			}),
+		newMockService("service5", "ns3", "", map[string]string{"test-label3": "testval3"}, map[string]string{
+			types.DiscoveryProtocolLabel: "tcp",
+		},
+			[]corev1.ServicePort{
+				{Port: 42, Name: "custom", Protocol: corev1.ProtocolTCP},
+				{Port: 43, Name: "custom-udp", Protocol: corev1.ProtocolUDP},
+			}),
+	}
+
+	apps := map[string]*types.AppV3{
+		"service1.app1": {
+			Kind:    "app",
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service1-ns1-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels:      map[string]string{"test-label": "testval", types.KubernetesClusterLabel: "test-cluster"},
+			},
+			Spec: types.AppSpecV3{
+				URI: "http://service1.ns1.svc.cluster.local:42",
+			},
+		},
+		"service2.app1": {
+			Kind:    "app",
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service2-ns2-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels:      map[string]string{"test-label": "testval", "test-label2": "testval2", types.KubernetesClusterLabel: "test-cluster"},
+			},
+			Spec: types.AppSpecV3{
+				URI: "http://service2.ns2.svc.cluster.local:42",
+			},
+		},
+		"service3.app1": {
+			Kind:    "app",
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service3-http-ns2-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels:      map[string]string{"test-label2": "testval2", types.KubernetesClusterLabel: "test-cluster"},
+			},
+			Spec: types.AppSpecV3{
+				URI: "http://service3.ns2.svc.cluster.local:80",
+			},
+		},
+		"service3.app2": {
+			Kind:    "app",
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service3-https-ns2-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels:      map[string]string{"test-label2": "testval2", types.KubernetesClusterLabel: "test-cluster"},
+			},
+			Spec: types.AppSpecV3{
+				URI: "https://service3.ns2.svc.cluster.local:443",
+			},
+		},
+		"service3.app4": {
+			Kind:    "app",
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service3-custom-ns2-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels:      map[string]string{"test-label2": "testval2", types.KubernetesClusterLabel: "test-cluster"},
+			},
+			Spec: types.AppSpecV3{
+				URI: "http://service3.ns2.svc.cluster.local:42",
+			},
+		},
+		"service4.app1": {
+			Kind:    "app",
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service4-ns3-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels:      map[string]string{"test-label2": "testval2", types.KubernetesClusterLabel: "test-cluster"},
+			},
+			Spec: types.AppSpecV3{
+				URI: "https://service4.ns3.svc.cluster.local:42",
+			},
+		},
+		"service5.app1": {
+			Kind:    "app",
+			Version: "v3",
+			Metadata: types.Metadata{
+				Name:        "service5-ns3-test-cluster",
+				Namespace:   "default",
+				Description: "Discovered application in Kubernetes cluster \"test-cluster\"",
+				Labels:      map[string]string{"test-label3": "testval3", types.KubernetesClusterLabel: "test-cluster"},
+			},
+			Spec: types.AppSpecV3{
+				URI: "tcp://service5.ns3.svc.cluster.local:42",
+			},
+		},
+	}
+
+	tests := []struct {
+		desc              string
+		services          []*corev1.Service
+		matcherNamespaces []string
+		matcherLabels     types.Labels
+		expected          types.Apps
+		protoChecker      services.ProtocolChecker
+	}{
+		{
+			desc:              "No services",
+			services:          []*corev1.Service{},
+			matcherNamespaces: []string{"ns1"},
+			matcherLabels:     types.Labels{"test-label": []string{"testval"}},
+			expected:          types.Apps{},
+		},
+		{
+			desc:              "One service - one http app",
+			services:          []*corev1.Service{mockServices[0]},
+			matcherNamespaces: []string{"ns1"},
+			matcherLabels:     types.Labels{"test-label": []string{"testval"}},
+			expected:          types.Apps{apps["service1.app1"]},
+		},
+		{
+			desc:              "No matching services in the namespace",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns5"},
+			matcherLabels:     types.Labels{"test-label": []string{"testval"}},
+			expected:          types.Apps{},
+		},
+		{
+			desc:              "No matching services by the labels",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns1"},
+			matcherLabels:     types.Labels{"test-label": []string{"wrongval"}},
+			expected:          types.Apps{},
+		},
+		{
+			desc:              "Matching all namespaces",
+			services:          mockServices,
+			matcherNamespaces: []string{"*"},
+			matcherLabels:     types.Labels{"test-label": []string{"testval"}},
+			expected:          types.Apps{apps["service1.app1"], apps["service2.app1"]},
+		},
+		{
+			desc:              "Matching all labels in a namespace",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns1"},
+			matcherLabels:     types.Labels{"*": []string{"*"}},
+			expected:          types.Apps{apps["service1.app1"]},
+		},
+		{
+			desc:              "Matching 2 services by a label in 2 namespaces",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns1", "ns2"},
+			matcherLabels:     types.Labels{"test-label": []string{"testval"}},
+			expected:          types.Apps{apps["service1.app1"], apps["service2.app1"]},
+		},
+		{
+			desc:              "Matching 2 services by a label in all namespaces",
+			services:          mockServices,
+			matcherNamespaces: []string{"*"},
+			matcherLabels:     types.Labels{"test-label": []string{"testval"}},
+			expected:          types.Apps{apps["service1.app1"], apps["service2.app1"]},
+		},
+		{
+			desc:              "Matching services by 2 labels in all namespaces",
+			services:          mockServices,
+			matcherNamespaces: []string{"*"},
+			matcherLabels:     types.Labels{"test-label": []string{"testval"}, "test-label2": []string{"testval2"}},
+			expected:          types.Apps{apps["service2.app1"]},
+		},
+		{
+			desc:              "Matching 2 services into 3 apps by a label in a namespace",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns2"},
+			matcherLabels:     types.Labels{"test-label2": []string{"testval2"}},
+			expected:          types.Apps{apps["service2.app1"], apps["service3.app1"], apps["service3.app2"]},
+		},
+		{
+			desc:              "Service with annotations",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns3"},
+			matcherLabels:     types.Labels{"test-label2": []string{"testval2"}},
+			expected:          types.Apps{apps["service4.app1"]},
+		},
+		{
+			desc:              "Service with protocol annotation 'tcp'",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns3"},
+			matcherLabels:     types.Labels{"test-label3": []string{"testval3"}},
+			expected:          types.Apps{apps["service5.app1"]},
+		},
+		{
+			desc:              "Matching service with protocol checker",
+			services:          mockServices,
+			matcherNamespaces: []string{"ns2"},
+			matcherLabels:     types.Labels{"test-label2": []string{"testval2"}},
+			protoChecker:      &mockProtocolChecker{results: map[string]string{"service3.ns2.svc.cluster.local:42": "http"}},
+			expected:          types.Apps{apps["service2.app1"], apps["service3.app4"], apps["service3.app1"], apps["service3.app2"]},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			objects := []runtime.Object{}
+			for _, s := range tt.services {
+				objects = append(objects, s)
+			}
+			fakeClient := fake.NewSimpleClientset(objects...)
+
+			fetcher, err := NewKubeAppsFetcher(KubeAppsFetcherConfig{
+				ClusterName:      "test-cluster",
+				KubernetesClient: fakeClient,
+				FilterLabels:     tt.matcherLabels,
+				Namespaces:       tt.matcherNamespaces,
+				protocolChecker:  tt.protoChecker,
+				Log:              utils.NewLogger(),
+			})
+			require.NoError(t, err)
+
+			result, err := fetcher.Get(context.Background())
+			require.NoError(t, err)
+			require.Equal(t, len(tt.expected), len(result))
+			slices.SortFunc(result, func(a, b types.ResourceWithLabels) bool {
+				return a.GetName() < b.GetName()
+			})
+			require.Empty(t, cmp.Diff(tt.expected.AsResources(), result))
+		})
+
+	}
+}
+
+type mockProtocolChecker struct {
+	results map[string]string
+}
+
+func (m *mockProtocolChecker) CheckProtocol(uri string) string {
+	if result, ok := m.results[uri]; ok {
+		return result
+	}
+	return "tcp"
+}
+
+func newMockService(name, namespace, externalName string, labels, annotations map[string]string, ports []corev1.ServicePort) *corev1.Service {
+	serviceType := corev1.ServiceTypeClusterIP
+	if externalName != "" {
+		serviceType = corev1.ServiceTypeExternalName
+	}
+	return &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Labels:      labels,
+			Annotations: annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports:        ports,
+			ClusterIP:    "192.168.100.100",
+			ClusterIPs:   []string{"192.168.100.100"},
+			Type:         serviceType,
+			ExternalName: externalName,
+		},
+	}
+}

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -269,7 +269,7 @@ func TestKubeAppFetcher_Get(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			objects := []runtime.Object{}
+			var objects []runtime.Object
 			for _, s := range tt.services {
 				objects = append(objects, s)
 			}

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -331,6 +331,7 @@ func newMockService(name, namespace, externalName string, labels, annotations ma
 }
 
 func TestGetServicePorts(t *testing.T) {
+    t.Parallel()
 	tests := []struct {
 		desc        string
 		annotations map[string]string

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -448,8 +448,6 @@ func TestGetServicePorts(t *testing.T) {
 }
 
 func TestProtoChecker_CheckProtocol(t *testing.T) {
-	t.Parallel()
-
 	checker := ProtoChecker{
 		InsecureSkipVerify: true,
 	}

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -341,14 +341,14 @@ func TestGetServicePorts(t *testing.T) {
 	}{
 		{
 			desc:     "Empty input",
-			expected: []corev1.ServicePort{},
+			expected: nil,
 		},
 		{
 			desc: "One unsupported port (UDP)",
 			ports: []corev1.ServicePort{
 				{Port: 80, Protocol: corev1.ProtocolUDP},
 			},
-			expected: []corev1.ServicePort{},
+			expected: nil,
 		},
 		{
 			desc: "One supported port",
@@ -420,8 +420,8 @@ func TestGetServicePorts(t *testing.T) {
 				{Port: 80, Protocol: corev1.ProtocolTCP},
 				{Port: 42, Protocol: corev1.ProtocolTCP},
 			},
-			expected: []corev1.ServicePort{},
-			wantErr:  "Specified preferred port",
+			expected: nil,
+			wantErr:  "specified preferred port",
 		},
 	}
 

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -448,6 +448,7 @@ func TestGetServicePorts(t *testing.T) {
 }
 
 func TestProtoChecker_CheckProtocol(t *testing.T) {
+	t.Parallel()
 	checker := ProtoChecker{
 		InsecureSkipVerify: true,
 	}

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -449,9 +449,7 @@ func TestGetServicePorts(t *testing.T) {
 
 func TestProtoChecker_CheckProtocol(t *testing.T) {
 	t.Parallel()
-	checker := ProtoChecker{
-		InsecureSkipVerify: true,
-	}
+	checker := NewProtoChecker(true)
 
 	httpsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = fmt.Fprintln(w, "httpsServer")

--- a/lib/srv/discovery/fetchers/kube_services_test.go
+++ b/lib/srv/discovery/fetchers/kube_services_test.go
@@ -331,7 +331,7 @@ func newMockService(name, namespace, externalName string, labels, annotations ma
 }
 
 func TestGetServicePorts(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 	tests := []struct {
 		desc        string
 		annotations map[string]string
@@ -341,7 +341,6 @@ func TestGetServicePorts(t *testing.T) {
 	}{
 		{
 			desc:     "Empty input",
-			ports:    []corev1.ServicePort{},
 			expected: []corev1.ServicePort{},
 		},
 		{

--- a/lib/srv/discovery/kube_services_watcher.go
+++ b/lib/srv/discovery/kube_services_watcher.go
@@ -56,9 +56,9 @@ func (s *Server) startKubeAppsWatchers() error {
 				return appResources.ToMap()
 			},
 			Log:      s.Log.WithField("kind", types.KindApp),
-			OnCreate: s.onKubeAppCreate,
-			OnUpdate: s.onKubeAppUpdate,
-			OnDelete: s.onKubeAppDelete,
+			OnCreate: s.onAppCreate,
+			OnUpdate: s.onAppUpdate,
+			OnDelete: s.onAppDelete,
 		},
 	)
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *Server) startKubeAppsWatchers() error {
 	return nil
 }
 
-func (s *Server) onKubeAppCreate(ctx context.Context, rwl types.ResourceWithLabels) error {
+func (s *Server) onAppCreate(ctx context.Context, rwl types.ResourceWithLabels) error {
 	app, ok := rwl.(types.Application)
 	if !ok {
 		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
@@ -111,12 +111,12 @@ func (s *Server) onKubeAppCreate(ctx context.Context, rwl types.ResourceWithLabe
 	// discovery group label to ensure the user doesn't have to manually delete
 	// the resource.
 	if trace.IsAlreadyExists(err) {
-		return trace.Wrap(s.onKubeAppUpdate(ctx, rwl))
+		return trace.Wrap(s.onAppUpdate(ctx, rwl))
 	}
 	return trace.Wrap(err)
 }
 
-func (s *Server) onKubeAppUpdate(ctx context.Context, rwl types.ResourceWithLabels) error {
+func (s *Server) onAppUpdate(ctx context.Context, rwl types.ResourceWithLabels) error {
 	app, ok := rwl.(types.Application)
 	if !ok {
 		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
@@ -125,7 +125,7 @@ func (s *Server) onKubeAppUpdate(ctx context.Context, rwl types.ResourceWithLabe
 	return trace.Wrap(s.AccessPoint.UpdateApp(ctx, app))
 }
 
-func (s *Server) onKubeAppDelete(ctx context.Context, rwl types.ResourceWithLabels) error {
+func (s *Server) onAppDelete(ctx context.Context, rwl types.ResourceWithLabels) error {
 	app, ok := rwl.(types.Application)
 	if !ok {
 		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)

--- a/lib/srv/discovery/kube_services_watcher.go
+++ b/lib/srv/discovery/kube_services_watcher.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Gravitational, Inc.
+Copyright 2023 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package discovery
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
 
@@ -27,36 +28,37 @@ import (
 	"github.com/gravitational/teleport/lib/srv/discovery/common"
 )
 
-func (s *Server) startKubeWatchers() error {
-	if len(s.kubeFetchers) == 0 {
+func (s *Server) startKubeAppsWatchers() error {
+	if len(s.kubeAppsFetchers) == 0 {
 		return nil
 	}
+
 	var (
-		kubeResources types.ResourcesWithLabels
-		mu            sync.Mutex
+		appResources types.ResourcesWithLabels
+		mu           sync.Mutex
 	)
 
 	reconciler, err := services.NewReconciler(
 		services.ReconcilerConfig{
 			Matcher: func(_ types.ResourceWithLabels) bool { return true },
 			GetCurrentResources: func() types.ResourcesWithLabelsMap {
-				kcs, err := s.AccessPoint.GetKubernetesClusters(s.ctx)
+				apps, err := s.AccessPoint.GetApps(s.ctx)
 				if err != nil {
-					s.Log.WithError(err).Warn("Unable to get Kubernetes clusters from cache.")
+					s.Log.WithError(err).Warn("Unable to get applications from cache.")
 					return nil
 				}
 
-				return types.KubeClusters(filterResources(kcs, types.OriginCloud, s.DiscoveryGroup)).AsResources().ToMap()
+				return types.Apps(filterResources(apps, types.OriginDiscoveryKubernetes, s.DiscoveryGroup)).AsResources().ToMap()
 			},
 			GetNewResources: func() types.ResourcesWithLabelsMap {
 				mu.Lock()
 				defer mu.Unlock()
-				return kubeResources.ToMap()
+				return appResources.ToMap()
 			},
-			Log:      s.Log.WithField("kind", types.KindKubernetesCluster),
-			OnCreate: s.onKubeCreate,
-			OnUpdate: s.onKubeUpdate,
-			OnDelete: s.onKubeDelete,
+			Log:      s.Log.WithField("kind", types.KindApp),
+			OnCreate: s.onKubeAppCreate,
+			OnUpdate: s.onKubeAppUpdate,
+			OnDelete: s.onKubeAppDelete,
 		},
 	)
 	if err != nil {
@@ -64,11 +66,11 @@ func (s *Server) startKubeWatchers() error {
 	}
 
 	watcher, err := common.NewWatcher(s.ctx, common.WatcherConfig{
-		Fetchers:       s.kubeFetchers,
-		Log:            s.Log.WithField("kind", types.KindKubernetesCluster),
+		Fetchers:       s.kubeAppsFetchers,
+		Interval:       5 * time.Minute,
+		Log:            s.Log.WithField("kind", types.KindApp),
 		DiscoveryGroup: s.DiscoveryGroup,
-		Interval:       s.PollInterval,
-		Origin:         types.OriginCloud,
+		Origin:         types.OriginDiscoveryKubernetes,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -80,7 +82,7 @@ func (s *Server) startKubeWatchers() error {
 			select {
 			case newResources := <-watcher.ResourcesC():
 				mu.Lock()
-				kubeResources = newResources
+				appResources = newResources
 				mu.Unlock()
 
 				if err := reconciler.Reconcile(s.ctx); err != nil {
@@ -95,40 +97,39 @@ func (s *Server) startKubeWatchers() error {
 	return nil
 }
 
-func (s *Server) onKubeCreate(ctx context.Context, rwl types.ResourceWithLabels) error {
-	kubeCluster, ok := rwl.(types.KubeCluster)
+func (s *Server) onKubeAppCreate(ctx context.Context, rwl types.ResourceWithLabels) error {
+	app, ok := rwl.(types.Application)
 	if !ok {
-		return trace.BadParameter("invalid type received; expected types.KubeCluster, received %T", kubeCluster)
+		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
 	}
-	s.Log.Debugf("Creating kube_cluster %s.", kubeCluster.GetName())
-	err := s.AccessPoint.CreateKubernetesCluster(ctx, kubeCluster)
+	s.Log.Debugf("Creating app %s", app.GetName())
+	err := s.AccessPoint.CreateApp(ctx, app)
 	// If the resource already exists, it means that the resource was created
 	// by a previous discovery_service instance that didn't support the discovery
 	// group feature or the discovery group was changed.
 	// In this case, we need to update the resource with the
 	// discovery group label to ensure the user doesn't have to manually delete
 	// the resource.
-	// TODO(tigrato): DELETE on 15.0.0
 	if trace.IsAlreadyExists(err) {
-		return trace.Wrap(s.onKubeUpdate(ctx, rwl))
+		return trace.Wrap(s.onKubeAppUpdate(ctx, rwl))
 	}
 	return trace.Wrap(err)
 }
 
-func (s *Server) onKubeUpdate(ctx context.Context, rwl types.ResourceWithLabels) error {
-	kubeCluster, ok := rwl.(types.KubeCluster)
+func (s *Server) onKubeAppUpdate(ctx context.Context, rwl types.ResourceWithLabels) error {
+	app, ok := rwl.(types.Application)
 	if !ok {
-		return trace.BadParameter("invalid type received; expected types.KubeCluster, received %T", kubeCluster)
+		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
 	}
-	s.Log.Debugf("Updating kube_cluster %s.", kubeCluster.GetName())
-	return trace.Wrap(s.AccessPoint.UpdateKubernetesCluster(ctx, kubeCluster))
+	s.Log.Debugf("Updating app %s.", app.GetName())
+	return trace.Wrap(s.AccessPoint.UpdateApp(ctx, app))
 }
 
-func (s *Server) onKubeDelete(ctx context.Context, rwl types.ResourceWithLabels) error {
-	kubeCluster, ok := rwl.(types.KubeCluster)
+func (s *Server) onKubeAppDelete(ctx context.Context, rwl types.ResourceWithLabels) error {
+	app, ok := rwl.(types.Application)
 	if !ok {
-		return trace.BadParameter("invalid type received; expected types.KubeCluster, received %T", kubeCluster)
+		return trace.BadParameter("invalid type received; expected types.Application, received %T", app)
 	}
-	s.Log.Debugf("Deleting kube_cluster %s.", kubeCluster.GetName())
-	return trace.Wrap(s.AccessPoint.DeleteKubernetesCluster(ctx, kubeCluster.GetName()))
+	s.Log.Debugf("Deleting app %s.", app.GetName())
+	return trace.Wrap(s.AccessPoint.DeleteApp(ctx, app.GetName()))
 }


### PR DESCRIPTION
This PR adds support for discovery of apps inside Kubernetes clusters.
We add new type of matchers for Discovery service and build watcher infrastructure similar to other matchers types.
Implements [RFD 135](https://github.com/gravitational/teleport/pull/28071)

Part of https://github.com/gravitational/teleport/issues/25538