### PR TITLE
[v13] Dont allow cloud tenants to update certain cluster networking config fields

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -4074,12 +4074,8 @@ func (a *ServerWithRoles) SetClusterNetworkingConfig(ctx context.Context, newNet
 	}
 
 	return a.authServer.SetClusterNetworkingConfig(ctx, newNetConfig)
-}
 
-func cloudTenantNetworkingError(field string) string {
-	return fmt.Sprintf("cloud tenants cannot update %q", field)
 }
-
 func (a *ServerWithRoles) validateCloudNetworkConfigUpdate(newConfig, oldConfig types.ClusterNetworkingConfig) error {
 	if a.hasBuiltinRole(types.RoleAdmin) {
 		return nil
@@ -4089,21 +4085,23 @@ func (a *ServerWithRoles) validateCloudNetworkConfigUpdate(newConfig, oldConfig 
 		return nil
 	}
 
+	const cloudUpdateFailureMsg = "cloud tenants cannot update %q"
+
 	if newConfig.GetProxyListenerMode() != oldConfig.GetProxyListenerMode() {
-		return trace.BadParameter(cloudTenantNetworkingError("proxy_listener_mode"))
+		return trace.BadParameter(cloudUpdateFailureMsg, "proxy_listener_mode")
 	}
-	newtst, newerr := newConfig.GetTunnelStrategyType()
-	oldtst, olderr := oldConfig.GetTunnelStrategyType()
-	if newerr != olderr || newtst != oldtst {
-		return trace.BadParameter(cloudTenantNetworkingError("tunnel_strategy"))
+	newtst, _ := newConfig.GetTunnelStrategyType()
+	oldtst, _ := oldConfig.GetTunnelStrategyType()
+	if newtst != oldtst {
+		return trace.BadParameter(cloudUpdateFailureMsg, "tunnel_strategy")
 	}
 
 	if newConfig.GetKeepAliveInterval() != oldConfig.GetKeepAliveInterval() {
-		return trace.BadParameter(cloudTenantNetworkingError("keep_alive_interval"))
+		return trace.BadParameter(cloudUpdateFailureMsg, "keep_alive_interval")
 	}
 
 	if newConfig.GetKeepAliveCountMax() != oldConfig.GetKeepAliveCountMax() {
-		return trace.BadParameter(cloudTenantNetworkingError("keep_alive_count_max"))
+		return trace.BadParameter(cloudUpdateFailureMsg, "keep_alive_count_max")
 	}
 
 	return nil

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -1246,7 +1246,7 @@ func TestClusterNetworkingCloudUpdates(t *testing.T) {
 			err = client.SetClusterNetworkingConfig(ctx, tc.clusterNetworkingConfig)
 			if err != nil {
 				require.NotEmpty(t, tc.expectSetErr)
-				require.ErrorContains(t, err, fmt.Sprintf("%q", tc.expectSetErr))
+				require.ErrorContains(t, err, tc.expectSetErr)
 			} else {
 				require.Empty(t, tc.expectSetErr)
 			}

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -53,6 +53,7 @@ import (
 	libdefaults "github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/events/eventstest"
+	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -1135,6 +1136,104 @@ func TestAuthPreferenceRBAC(t *testing.T) {
 		},
 		alwaysReadable: true,
 	})
+}
+
+func TestClusterNetworkingCloudUpdates(t *testing.T) {
+	srv := newTestTLSServer(t)
+	ctx := context.Background()
+	srv.Auth().SetClusterNetworkingConfig(ctx, types.DefaultClusterNetworkingConfig())
+
+	user, _, err := CreateUserAndRole(srv.Auth(), "username", []string{}, []types.Rule{
+		{
+			Resources: []string{
+				types.KindClusterNetworkingConfig,
+			},
+			Verbs: services.RW(),
+		},
+	})
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		cloud                   bool
+		identity                TestIdentity
+		expectSetErr            string
+		clusterNetworkingConfig types.ClusterNetworkingConfig
+		name                    string
+	}{
+		{
+			name:                    "non admin user can set existing values to the same value",
+			cloud:                   true,
+			identity:                TestUser(user.GetName()),
+			clusterNetworkingConfig: types.DefaultClusterNetworkingConfig(),
+		},
+		{
+			name:         "non admin user cannot set keep_alive_interval",
+			cloud:        true,
+			identity:     TestUser(user.GetName()),
+			expectSetErr: cloudTenantNetworkingError("keep_alive_interval"),
+			clusterNetworkingConfig: newClusterNetworkingConf(t, types.ClusterNetworkingConfigSpecV2{
+				KeepAliveInterval: types.Duration(time.Second * 20),
+			}),
+		},
+		{
+			name:     "non admin user can set client_idle_timeout",
+			cloud:    true,
+			identity: TestUser(user.GetName()),
+			clusterNetworkingConfig: newClusterNetworkingConf(t, types.ClusterNetworkingConfigSpecV2{
+				ClientIdleTimeout: types.Duration(time.Second * 67),
+			}),
+		},
+		{
+			name:     "admin user can set keep_alive_interval",
+			cloud:    true,
+			identity: TestAdmin(),
+			clusterNetworkingConfig: newClusterNetworkingConf(t, types.ClusterNetworkingConfigSpecV2{
+				KeepAliveInterval: types.Duration(time.Second * 67),
+			}),
+		},
+		{
+			name:     "non admin user can set keep_alive_interval on non cloud cluster",
+			cloud:    false,
+			identity: TestUser(user.GetName()),
+			clusterNetworkingConfig: newClusterNetworkingConf(t, types.ClusterNetworkingConfigSpecV2{
+				KeepAliveInterval: types.Duration(time.Second * 67),
+			}),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			modules.SetTestModules(t, &modules.TestModules{
+				TestBuildType: modules.BuildEnterprise,
+				TestFeatures: modules.Features{
+					Cloud: tc.cloud,
+				},
+			})
+
+			client, err := srv.NewClient(tc.identity)
+			require.NoError(t, err)
+
+			err = client.SetClusterNetworkingConfig(ctx, tc.clusterNetworkingConfig)
+			if err != nil {
+				require.NotEmpty(t, tc.expectSetErr)
+				require.ErrorContains(t, err, tc.expectSetErr)
+			} else {
+				require.Empty(t, tc.expectSetErr)
+			}
+		})
+	}
+}
+
+func newClusterNetworkingConf(t *testing.T, spec types.ClusterNetworkingConfigSpecV2) types.ClusterNetworkingConfig {
+	c := &types.ClusterNetworkingConfigV2{
+		Metadata: types.Metadata{
+			Labels: map[string]string{
+				types.OriginLabel: types.OriginDynamic,
+			},
+		},
+		Spec: spec,
+	}
+	err := c.CheckAndSetDefaults()
+	require.NoError(t, err)
+	return c
 }
 
 func TestClusterNetworkingConfigRBAC(t *testing.T) {


### PR DESCRIPTION
Backport #28634 to branch/v13