### PR TITLE
[Assist] UI tweaks

### DIFF
--- a/web/packages/teleport/src/Assist/Assist.tsx
+++ b/web/packages/teleport/src/Assist/Assist.tsx
@@ -29,6 +29,7 @@ import { ViewMode } from 'teleport/Assist/types';
 import { Settings } from 'teleport/Assist/Settings';
 import { ErrorBanner, ErrorList } from 'teleport/Assist/ErrorBanner';
 import { useUser } from 'teleport/User/UserContext';
+import { LandingPage } from 'teleport/Assist/LandingPage';
 
 interface AssistProps {
   onClose: () => void;
@@ -377,7 +378,11 @@ function AssistContent(props: AssistProps) {
             />
           )}
           <AssistConversation>
-            <ConversationList viewMode={preferences.assist.viewMode} />
+            {conversations.selectedId ? (
+              <ConversationList viewMode={preferences.assist.viewMode} />
+            ) : (
+              <LandingPage />
+            )}
           </AssistConversation>
         </Content>
       </AssistContainer>

--- a/web/packages/teleport/src/Assist/Conversation/Conversation.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Conversation.tsx
@@ -25,6 +25,7 @@ import {
 } from 'teleport/Assist/Conversation/Typing';
 import AuthnDialog from 'teleport/components/AuthnDialog';
 import { makeWebauthnAssertionResponse } from 'teleport/services/auth';
+import { TeleportAvatar } from 'teleport/Assist/Conversation/Avatar';
 
 const Container = styled.ul`
   list-style: none;
@@ -40,6 +41,13 @@ const Loading = styled.div`
   justify-content: center;
   height: calc(100% - 10px);
   width: inherit;
+`;
+
+const Typing = styled.div`
+  padding: 0 20px 20px;
+  display: flex;
+  align-items: center;
+  margin-top: -20px;
 `;
 
 export function Conversation() {
@@ -109,6 +117,17 @@ export function Conversation() {
       )}
 
       <Container>{items}</Container>
+
+      {messages.streaming && (
+        <Typing>
+          <TeleportAvatar /> <strong>Teleport</strong>
+          <TypingContainer>
+            <TypingDot style={{ animationDelay: '0s' }} />
+            <TypingDot style={{ animationDelay: '0.2s' }} />
+            <TypingDot style={{ animationDelay: '0.4s' }} />
+          </TypingContainer>
+        </Typing>
+      )}
     </>
   );
 }

--- a/web/packages/teleport/src/Assist/Conversation/Message.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Message.tsx
@@ -196,8 +196,11 @@ export function Message(props: MessageProps) {
   );
 
   const authorIsTeleport = props.message.author === Author.Teleport;
-  const showFooter =
-    !authorIsTeleport || (props.lastMessage ? !messages.streaming : true);
+  const showFooter = !(
+    authorIsTeleport &&
+    props.lastMessage &&
+    messages.streaming
+  );
 
   return (
     <Container>

--- a/web/packages/teleport/src/Assist/Conversation/Message.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Message.tsx
@@ -196,39 +196,34 @@ export function Message(props: MessageProps) {
   );
 
   const authorIsTeleport = props.message.author === Author.Teleport;
-  const typing = authorIsTeleport && props.lastMessage && messages.streaming;
+  const showFooter =
+    !authorIsTeleport || (props.lastMessage ? !messages.streaming : true);
 
   return (
     <Container>
       <Entries>{entries}</Entries>
 
-      <Footer
-        style={{
-          justifyContent: authorIsTeleport ? 'flex-start' : 'flex-end',
-        }}
-      >
-        {authorIsTeleport ? (
-          <>
-            <TeleportAvatar /> <strong>Teleport</strong>
-          </>
-        ) : (
-          <>
-            <UserAvatar /> <strong>You</strong>
-          </>
-        )}
+      {showFooter && (
+        <Footer
+          style={{
+            justifyContent: authorIsTeleport ? 'flex-start' : 'flex-end',
+          }}
+        >
+          {authorIsTeleport ? (
+            <>
+              <TeleportAvatar /> <strong>Teleport</strong>
+            </>
+          ) : (
+            <>
+              <UserAvatar /> <strong>You</strong>
+            </>
+          )}
 
-        {typing ? (
-          <TypingContainer>
-            <TypingDot style={{ animationDelay: '0s' }} />
-            <TypingDot style={{ animationDelay: '0.2s' }} />
-            <TypingDot style={{ animationDelay: '0.4s' }} />
-          </TypingContainer>
-        ) : (
           <TimestampContainer>
             <Timestamp timestamp={props.message.timestamp} />
           </TimestampContainer>
-        )}
-      </Footer>
+        </Footer>
+      )}
     </Container>
   );
 }

--- a/web/packages/teleport/src/Assist/Conversation/Typing.ts
+++ b/web/packages/teleport/src/Assist/Conversation/Typing.ts
@@ -21,7 +21,7 @@ const loading = keyframes`
     opacity: 0;
   }
   50% {
-    opacity: 0.8;
+    opacity: 1;
   }
   100% {
     opacity: 0;
@@ -39,10 +39,10 @@ export const TypingContainer = styled.div`
 `;
 
 export const TypingDot = styled.div`
-  width: 8px;
-  height: 8px;
-  margin-right: 8px;
-  background: #8d8c91;
+  width: 6px;
+  height: 6px;
+  margin-right: 6px;
+  background: ${p => p.theme.colors.spotBackground[2]};
   border-radius: 50%;
   opacity: 0;
   animation: ${loading} 1.5s ease-in-out infinite;


### PR DESCRIPTION
This changes the typing indicator to always display whilst Assist is generating a response

<img width="576" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/6b98091c-6481-4434-b0f1-890f1327ee22">

The dots in the typing indicator now use an alpha value from the theme, so they're no longer grey on the dark theme.

Finally, this changes the chat window to stop auto scrolling to the bottom if the user scrolls more than 50px away from the bottom. It will resume auto scrolling when they scroll back down to the bottom.