### PR TITLE
Fix rough edges with usage script

### DIFF
--- a/examples/teleport-usage/README.md
+++ b/examples/teleport-usage/README.md
@@ -18,11 +18,15 @@ DynamoDB events table.
 > policy `AmazonDynamoDBReadOnlyAccess`
 The following information is required:
 
-| Environment Variable | Description                                                         |
-| ---------------------|---------------------------------------------------------------------|
-| `TABLE_NAME`         | DynamoDB Events Table Name                                          |
-| `AWS_REGION`         | AWS Region where the dynamoDB table is deployed                     |
-| `START_DATE`         | The date for when to start the query. The format must be YYYY-MM-DD |
+| Environment Variable    | Description                                                         |
+|-------------------------|---------------------------------------------------------------------|
+| `TABLE_NAME`            | DynamoDB Events Table Name                                          |
+| `AWS_REGION`            | AWS Region where the dynamoDB table is deployed                     |
+| `START_DATE`            | The date for when to start the query. The format must be YYYY-MM-DD |
+
+
+You may optionally specify the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` environment variables
+to run the script from another location.
 
 ## Running Docker Container
 

--- a/examples/teleport-usage/main.go
+++ b/examples/teleport-usage/main.go
@@ -66,8 +66,9 @@ func main() {
 	session, err := awssession.NewSessionWithOptions(awssession.Options{
 		SharedConfigState: awssession.SharedConfigEnable,
 		Config: aws.Config{
-			Retryer: limiter,
-			Region:  aws.String(params.awsRegion),
+			Retryer:                       limiter,
+			Region:                        aws.String(params.awsRegion),
+			CredentialsChainVerboseErrors: aws.Bool(true),
 		},
 	})
 	if err != nil {
@@ -307,7 +308,12 @@ func (a *adaptiveRateLimiter) reportThrottleError() {
 	}
 
 	old := a.permitCapacity
-	a.permitCapacity = math.Abs(a.high-a.low)/2 + a.low
+	capacity := math.Abs(a.high-a.low)/2 + a.low
+	// A capacity of zero is not valid and results in requests to be rejected.
+	if capacity < 1 {
+		capacity = 1.0
+	}
+	a.permitCapacity = capacity
 	fmt.Printf("  throttled by DynamoDB. adjusting request rate from %v RCUs to %v RCUs\n", int(old), int(a.permitCapacity))
 }
 

--- a/examples/teleport-usage/main_test.go
+++ b/examples/teleport-usage/main_test.go
@@ -63,6 +63,18 @@ func TestRateLimiter(t *testing.T) {
 	}
 }
 
+func TestRateLimiterMinimumValue(t *testing.T) {
+	limiter := newAdaptiveRateLimiter(5)
+
+	for i := 0; i < 20; i++ {
+		limiter.reportThrottleError()
+
+		if limiter.currentCapacity() < 1 {
+			t.Fatal("read capacity reached zero")
+		}
+	}
+}
+
 // TestDateSet tests that we query the appropriate set of days for an MAU calculation correctly.
 func TestDateSet(t *testing.T) {
 	startDates := []struct {


### PR DESCRIPTION
When the script detects throttling it automatically scales the RCU, however it was allowing the RCU to reach 0 which is an invalid value. Any subsequent requests with a 0 RCU end up terminating the script due to errors from the request. The RCU is now capped at a minimum value of 1 to prevent this.

CredentialsChainVerboseErrors is now set in the aws.Config to provide more actionable error messages when credentials are not configured correctly. Users who had authentication issues would previously see the following:

> 2023/07/11 16:50:25 NoCredentialProviders: no valid providers in chain. Deprecated.
>	For verbose messaging see aws.Config.CredentialsChainVerboseErrors

By setting the config value to true users will now see more detailed output:

> 2023/07/12 10:56:06 NoCredentialProviders: no valid providers in chain
> caused by: EnvAccessKeyNotFound: failed to find credentials in the environment.
> SharedCredsLoad: failed to load profile, .
> EC2RoleRequestError: no EC2 instance role found
> caused by: RequestError: send request failed

The README was also updated to include instructions on how to authenticate and run the script from outside the Auth server if they so choose.