### PR TITLE
Add changelog script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1394,3 +1394,11 @@ rustup-install-target-toolchain: RUST_VERSION := $(shell $(MAKE) --no-print-dire
 rustup-install-target-toolchain:
 	rustup override set $(RUST_VERSION)
 	rustup target add $(RUST_TARGET_ARCH)
+
+# changelog generates PR changelog between the provided base tag and the tip of
+# the specified branch.
+#
+# usage: BASE_BRANCH=branch/v13 BASE_TAG=13.2.0 make changelog
+.PHONY: changelog
+changelog:
+	@./build.assets/changelog.sh BASE_BRANCH=$(BASE_BRANCH) BASE_TAG=$(BASE_TAG)

--- a/build.assets/changelog.sh
+++ b/build.assets/changelog.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# This script generates a PR diff between the provided base tag and the tip of
+# the specified base branch.
+set -eu
+
+COMMIT=$(git rev-list -n 1 v$BASE_TAG)
+
+DATE=$(git show -s --date=format:'%Y-%m-%dT%H:%M:%S%z' --format=%cd $COMMIT)
+
+gh pr list \
+    --search "base:$BASE_BRANCH merged:>$DATE" \
+    --limit 200 \
+    --json number,title \
+    --template "{{range .}}{{printf \"* %v [#%v](https://github.com/gravitational/teleport/pull/%v)\n\" .title .number .number}}{{end}}"


### PR DESCRIPTION
Add a script I use for compiling the release changelog in preparation for the internal tools team to start participating in release publishing duties.

The script just collects all merged PRs between since the specified tag and the resulting list still requires manual work to remove irrelevant items and some wordsmithing to convert PRs titles to human-readable suitable for changelog descriptions and grouping things in sections.

We may be able to use OpenAI API in future to process this list and generate a more human-readable version of the changelog to further remove the manual component. I've played with it a little bit before and had moderate success, although it still mostly depends on the PRs having reasonably good titles.