### PR TITLE
Update host-user-creation.mdx

### DIFF
--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -171,11 +171,16 @@ The Teleport SSH Service also creates a file in `/etc/sudoers.d` with the
 contents of the `host_sudoers` file written with one entry per line, each
 prefixed with the username of the user that has logged in.
 
-The session can then proceed as usual, however once the SSH session ends, the user
-will be automatically removed and their home directory will be deleted, as the
-matching role specified they should be dropped. Files owned by the deleted user,
-created outside the home directory, will remain in place. Groups that were created
-will remain on the system after the session ends.
+The session can then proceed as usual. When a user's SSH session ends, Teleport
+automatically removes that user and their home directory, as specified by their
+role. However, any files created outside of their home directory, or any groups
+that were formed, will still remain.
+
+If Teleport is managing other active sessions or if there are any running
+processes that belong to the user, it will delay the cleanup. Teleport will then
+try again every five minutes until it's successful. Once it can delete the user,
+it also removes any sudoers entries that were made for them. Teleport uses a
+specific pattern when it creates and deletes these sudoers entries.
 
 Should a Teleport SSH instance be restarted while a session is in progress, the user
 will be cleaned up at the next Teleport restart.

--- a/docs/pages/server-access/guides/host-user-creation.mdx
+++ b/docs/pages/server-access/guides/host-user-creation.mdx
@@ -179,8 +179,7 @@ that were formed, will still remain.
 If Teleport is managing other active sessions or if there are any running
 processes that belong to the user, it will delay the cleanup. Teleport will then
 try again every five minutes until it's successful. Once it can delete the user,
-it also removes any sudoers entries that were made for them. Teleport uses a
-specific pattern when it creates and deletes these sudoers entries.
+it also removes any sudoers entries that were made for them.
 
 Should a Teleport SSH instance be restarted while a session is in progress, the user
 will be cleaned up at the next Teleport restart.

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -52,10 +52,10 @@ spec:
       # the list example above can be expressed as:
       'reg': '^us-west-1|eu-central-1$'
 
+    # Options specific to users create by Teleport via the create_host_user role option
     # List of host groups the created user will be added to. Any that don't already exist are created.
     host_groups: [ubuntu, nginx, other]
-
-    # Assign the user to the sudoers group
+    # List of sudoers entries that the created user will be added to. Only applies to create_host_user
     host_sudoers:
     - 'ALL=(ALL) NOPASSWD: ALL'
 

--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -52,7 +52,7 @@ spec:
       # the list example above can be expressed as:
       'reg': '^us-west-1|eu-central-1$'
 
-    # Options specific to users create by Teleport via the create_host_user role option
+    # Options specific to users create by Teleport via the create_host_user_mode role option
     # List of host groups the created user will be added to. Any that don't already exist are created.
     host_groups: [ubuntu, nginx, other]
     # List of sudoers entries that the created user will be added to. Only applies to create_host_user


### PR DESCRIPTION
Added more info about what Teleport cleans up when temporary host users are supposed to be dropped.