### PR TITLE
upload completer: suppress stack trace for S3 access denied errors

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -145,8 +145,11 @@ func (u *UploadCompleter) Serve(ctx context.Context) error {
 	for {
 		select {
 		case <-periodic.Next():
-			if err := u.CheckUploads(ctx); err != nil {
-				u.log.WithError(err).Warningf("Failed to check uploads.")
+			if err := u.CheckUploads(ctx); trace.IsAccessDenied(err) {
+				u.log.Warn("Teleport does not have permission to list uploads. " +
+					"The upload completer will be unable to complete uploads of partial session recordings.")
+			} else if err != nil {
+				u.log.WithError(err).Warn("Failed to check uploads.")
 			}
 		case <-u.closeC:
 			return nil


### PR DESCRIPTION
If the upload completer fails due to a permissions error with S3, emit a warning indicating that the upload completer will not function properly, but suppress the stack trace.

Closes #28999