### PR TITLE
Clarify that Team requires Enterprise tctl

### DIFF
--- a/docs/pages/includes/edition-prereqs-tabs.mdx
+++ b/docs/pages/includes/edition-prereqs-tabs.mdx
@@ -4,17 +4,17 @@
 - A Teleport Team account. If you do not have one, visit the [signup
   page](https://goteleport.com/signup/) to begin your free trial.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+- The Enterprise `tctl` admin tool and `tsh` client tool version >=
+  (=teleport.version=), which you can download by visiting your [Teleport
+  account](https://teleport.sh).
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
 
   $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport v(=cloud.version=) go(=teleport.golang=)
   ```
-
-  See [Installation](../installation.mdx) for details.
 
 </TabItem>
 <TabItem scope={["oss"]} label="Teleport Community Edition">
@@ -41,8 +41,9 @@
 - A running Teleport Enterprise cluster. For details on how to set this up, see our Enterprise
   [Getting Started](../choose-an-edition/teleport-enterprise/introduction.mdx) guide.
 
-- The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=),
-  which you can download by visiting your [Teleport account](https://teleport.sh).
+- The Enterprise `tctl` admin tool and `tsh` client tool version >=
+  (=teleport.version=), which you can download by visiting your [Teleport
+  account](https://teleport.sh).
 
   ```code
   $ tctl version

--- a/docs/pages/includes/no-oss-prereqs-tabs.mdx
+++ b/docs/pages/includes/no-oss-prereqs-tabs.mdx
@@ -4,17 +4,17 @@
 - A Teleport Team account. If you do not have one, visit the [signup
   page](https://goteleport.com/signup/) to begin your free trial.
 
-- The `tctl` admin tool and `tsh` client tool version >= (=teleport.version=).
+- The Enterprise `tctl` admin tool and `tsh` client tool version >=
+  (=teleport.version=), which you can download by visiting your [Teleport
+  account](https://teleport.sh).
 
   ```code
   $ tctl version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
 
   $ tsh version
-  # Teleport v(=teleport.version=) go(=teleport.golang=)
+  # Teleport v(=cloud.version=) go(=teleport.golang=)
   ```
-
-  See [Installation](../installation.mdx) for details.
 
 </TabItem>
 <TabItem


### PR DESCRIPTION
The current docs refer Team users to download `tctl` from the Installation page, when they should be installing the Enterprise edition of `tctl`.

All three backport branches for my `team` scope additions are still open, so I will edit those backport branches to include these changes.