### PR TITLE
Clarify API GetDatabases vs GetDatabaseServers

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -2638,10 +2638,10 @@ func (c *Client) UpdateApp(ctx context.Context, app types.Application) error {
 // Note that application resources here refers to "dynamically-added"
 // applications such as applications created by `tctl create`, or the CreateApp
 // API. Applications defined in the `app_service.apps` section of the service
-// yaml configuration are not collected in this API.
+// YAML configuration are not collected in this API.
 //
 // For a full list of registered applications that are served by an application
-// service service, use GetApplicationServers instead.
+// service, use GetApplicationServers instead.
 func (c *Client) GetApp(ctx context.Context, name string) (types.Application, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing application name")
@@ -2658,10 +2658,10 @@ func (c *Client) GetApp(ctx context.Context, name string) (types.Application, er
 // Note that application resources here refers to "dynamically-added"
 // applications such as applications created by `tctl create`, or the CreateApp
 // API. Applications defined in the `app_service.apps` section of the service
-// yaml configuration are not collected in this API.
+// YAML configuration are not collected in this API.
 //
 // For a full list of registered applications that are served by an application
-// service service, use GetApplicationServers instead.
+// service, use GetApplicationServers instead.
 func (c *Client) GetApps(ctx context.Context) ([]types.Application, error) {
 	items, err := c.grpc.GetApps(ctx, &emptypb.Empty{})
 	if err != nil {
@@ -2770,7 +2770,7 @@ func (c *Client) UpdateDatabase(ctx context.Context, database types.Database) er
 // CreateDatabase API. Databases discovered by the database agent (legacy
 // discovery flow using `database_service.aws/database_service.azure`) and
 // static databases defined in the `database_service.databases` section of the
-// service yaml configuration are not collected in this API.
+// service YAML configuration are not collected in this API.
 //
 // For a full list of registered databases that are served by a database
 // service, use GetDatabaseServers instead.
@@ -2792,7 +2792,7 @@ func (c *Client) GetDatabase(ctx context.Context, name string) (types.Database, 
 // CreateDatabase API. Databases discovered by the database agent (legacy
 // discovery flow using `database_service.aws/database_service.azure`) and
 // static databases defined in the `database_service.databases` section of the
-// service yaml configuration are not collected in this API.
+// service YAML configuration are not collected in this API.
 //
 // For a full list of registered databases that are served by a database
 // service, use GetDatabaseServers instead.

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -1453,6 +1453,10 @@ func (c *Client) GenerateSnowflakeJWT(ctx context.Context, req types.GenerateSno
 }
 
 // GetDatabaseServers returns all registered database proxy servers.
+//
+// Note that in HA setups, a registered database may have multiple
+// DatabaseServer entries. Web UI and `tsh db ls` extract databases from this
+// list and remove duplicates by name.
 func (c *Client) GetDatabaseServers(ctx context.Context, namespace string) ([]types.DatabaseServer, error) {
 	servers, err := GetAllResources[types.DatabaseServer](ctx, c, &proto.ListResourcesRequest{
 		Namespace:    namespace,
@@ -2630,6 +2634,14 @@ func (c *Client) UpdateApp(ctx context.Context, app types.Application) error {
 }
 
 // GetApp returns the specified application resource.
+//
+// Note that application resources here refers to "dynamically-added"
+// applications such as applications created by `tctl create`, or the CreateApp
+// API. Applications defined in the `app_service.apps` section of the service
+// yaml configuration are not collected in this API.
+//
+// For a full list of registered applications that are served by an application
+// service service, use GetApplicationServers instead.
 func (c *Client) GetApp(ctx context.Context, name string) (types.Application, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing application name")
@@ -2642,6 +2654,14 @@ func (c *Client) GetApp(ctx context.Context, name string) (types.Application, er
 }
 
 // GetApps returns all application resources.
+//
+// Note that application resources here refers to "dynamically-added"
+// applications such as applications created by `tctl create`, or the CreateApp
+// API. Applications defined in the `app_service.apps` section of the service
+// yaml configuration are not collected in this API.
+//
+// For a full list of registered applications that are served by an application
+// service service, use GetApplicationServers instead.
 func (c *Client) GetApps(ctx context.Context) ([]types.Application, error) {
 	items, err := c.grpc.GetApps(ctx, &emptypb.Empty{})
 	if err != nil {
@@ -2744,6 +2764,16 @@ func (c *Client) UpdateDatabase(ctx context.Context, database types.Database) er
 }
 
 // GetDatabase returns the specified database resource.
+//
+// Note that database resources here refers to "dynamically-added" databases
+// such as databases created by `tctl create`, the discovery service, or the
+// CreateDatabase API. Databases discovered by the database agent (legacy
+// discovery flow using `database_service.aws/database_service.azure`) and
+// static databases defined in the `database_service.databases` section of the
+// service yaml configuration are not collected in this API.
+//
+// For a full list of registered databases that are served by a database
+// service, use GetDatabaseServers instead.
 func (c *Client) GetDatabase(ctx context.Context, name string) (types.Database, error) {
 	if name == "" {
 		return nil, trace.BadParameter("missing database name")
@@ -2756,6 +2786,16 @@ func (c *Client) GetDatabase(ctx context.Context, name string) (types.Database, 
 }
 
 // GetDatabases returns all database resources.
+//
+// Note that database resources here refers to "dynamically-added" databases
+// such as databases created by `tctl create`, the discovery service, or the
+// CreateDatabase API. Databases discovered by the database agent (legacy
+// discovery flow using `database_service.aws/database_service.azure`) and
+// static databases defined in the `database_service.databases` section of the
+// service yaml configuration are not collected in this API.
+//
+// For a full list of registered databases that are served by a database
+// service, use GetDatabaseServers instead.
 func (c *Client) GetDatabases(ctx context.Context) ([]types.Database, error) {
 	items, err := c.grpc.GetDatabases(ctx, &emptypb.Empty{})
 	if err != nil {


### PR DESCRIPTION
Was asked why `GetDatabases` returns 0 databases and doesn't match `tsh db ls` during support shift.