### PR TITLE
Log the value of EventsBufferSize instead of the pointer address

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -186,7 +186,7 @@ func New(config *servicecfg.BPFConfig, restrictedSession *servicecfg.RestrictedS
 		"disk=%v, network=%v), restricted session (bufferSize=%v) "+
 		"and cgroup mount path: %v. Took %v.",
 		*s.CommandBufferSize, *s.DiskBufferSize, *s.NetworkBufferSize,
-		restrictedSession.EventsBufferSize,
+		*restrictedSession.EventsBufferSize,
 		s.CgroupPath, time.Since(start))
 
 	go s.processNetworkEvents()


### PR DESCRIPTION
Before:
>2023-07-12T14:24:03Z DEBU [BPF]       Started enhanced session recording with buffer sizes (command=8, disk=128, network=8), restricted session (bufferSize=0xc001ff0078) and cgroup mount path: /cgroup2. Took 136.895546ms. bpf/bpf.go:184

After:
>2023-07-12T14:24:03Z DEBU [BPF]       Started enhanced session recording with buffer sizes (command=8, disk=128, network=8), restricted session (bufferSize=8) and cgroup mount path: /cgroup2. Took 136.895546ms. bpf/bpf.go:184
