### PR TITLE
[v13] update database and kube name validation

### DIFF
--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -334,6 +334,12 @@ func (k *KubernetesClusterV3) setStaticFields() {
 // sneaky cluster names being used for client directory traversal and exploits.
 var validKubeClusterName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
+// ValidateKubeClusterName returns an error if a given string is not a valid
+// KubeCluster name.
+func ValidateKubeClusterName(name string) error {
+	return ValidateResourceName(validKubeClusterName, name)
+}
+
 // CheckAndSetDefaults checks and sets default values for any missing fields.
 func (k *KubernetesClusterV3) CheckAndSetDefaults() error {
 	k.setStaticFields()
@@ -346,8 +352,8 @@ func (k *KubernetesClusterV3) CheckAndSetDefaults() error {
 		}
 	}
 
-	if !validKubeClusterName.MatchString(k.Metadata.Name) {
-		return trace.BadParameter("invalid kubernetes cluster name: %q", k.Metadata.Name)
+	if err := ValidateKubeClusterName(k.Metadata.Name); err != nil {
+		return trace.Wrap(err, "invalid kubernetes cluster name")
 	}
 
 	if err := k.Spec.Azure.CheckAndSetDefaults(); err != nil && k.IsAzure() {

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -524,3 +524,14 @@ type ListResourcesResponse struct {
 	// TotalCount is the total number of resources available as a whole.
 	TotalCount int
 }
+
+// ValidateResourceName validates a resource name using a given regexp.
+func ValidateResourceName(validationRegex *regexp.Regexp, name string) error {
+	if validationRegex.MatchString(name) {
+		return nil
+	}
+	return trace.BadParameter(
+		"%q does not match regex used for validation %q",
+		name, validationRegex.String(),
+	)
+}

--- a/api/types/resource_test.go
+++ b/api/types/resource_test.go
@@ -128,12 +128,12 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		// searchNotDefined refers to resources where the searcheable field values are not defined.
 		searchNotDefined   bool
 		matchingSearchVals []string
-		newResource        func() ResourceWithLabels
+		newResource        func(*testing.T) ResourceWithLabels
 	}{
 		{
 			name:               "node",
 			matchingSearchVals: []string{"foo", "bar", "prod", "os"},
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				server, err := NewServerWithLabels("_", KindNode, ServerSpecV2{
 					Hostname: "foo",
 					Addr:     "bar",
@@ -146,7 +146,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:               "node using tunnel",
 			matchingSearchVals: []string{"tunnel"},
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				server, err := NewServer("_", KindNode, ServerSpecV2{
 					UseTunnel: true,
 				})
@@ -158,7 +158,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:               "windows desktop",
 			matchingSearchVals: []string{"foo", "bar", "env", "prod", "os"},
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				desktop, err := NewWindowsDesktopV3("foo", labels, WindowsDesktopSpecV3{
 					Addr: "bar",
 				})
@@ -170,7 +170,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:               "application",
 			matchingSearchVals: []string{"foo", "bar", "baz", "mac"},
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				app, err := NewAppV3(Metadata{
 					Name:        "foo",
 					Description: "bar",
@@ -187,7 +187,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:               "kube cluster",
 			matchingSearchVals: []string{"foo", "prod", "env"},
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				kc, err := NewKubernetesClusterV3FromLegacyCluster("_", &KubernetesCluster{
 					Name:         "foo",
 					StaticLabels: labels,
@@ -200,7 +200,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:               "database",
 			matchingSearchVals: []string{"foo", "bar", "baz", "prod", DatabaseTypeRedshift},
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				db, err := NewDatabaseV3(Metadata{
 					Name:        "foo",
 					Description: "bar",
@@ -222,9 +222,9 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:               "database with gcp keywords",
 			matchingSearchVals: []string{"cloud", "cloud sql"},
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				db, err := NewDatabaseV3(Metadata{
-					Name:   "_",
+					Name:   "foo",
 					Labels: labels,
 				}, DatabaseSpecV3{
 					Protocol: "_",
@@ -242,9 +242,9 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:             "app server",
 			searchNotDefined: true,
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				appServer, err := NewAppServerV3(Metadata{
-					Name: "_",
+					Name: "foo",
 				}, AppServerSpecV3{
 					HostID: "_",
 					App:    &AppV3{Metadata: Metadata{Name: "_"}, Spec: AppSpecV3{URI: "_"}},
@@ -257,9 +257,9 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:             "db server",
 			searchNotDefined: true,
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				dbServer, err := NewDatabaseServerV3(Metadata{
-					Name: "_",
+					Name: "foo",
 				}, DatabaseServerSpecV3{
 					HostID:   "_",
 					Hostname: "_",
@@ -272,10 +272,10 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:             "kube server",
 			searchNotDefined: true,
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				kubeServer, err := NewKubernetesServerV3(
 					Metadata{
-						Name: "_",
+						Name: "foo",
 					}, KubernetesServerSpecV3{
 						HostID:   "_",
 						Hostname: "_",
@@ -293,7 +293,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		{
 			name:             "desktop service",
 			searchNotDefined: true,
-			newResource: func() ResourceWithLabels {
+			newResource: func(t *testing.T) ResourceWithLabels {
 				desktopService, err := NewWindowsDesktopServiceV3(Metadata{
 					Name: "foo",
 				}, WindowsDesktopServiceSpecV3{
@@ -312,7 +312,7 @@ func TestMatchSearch_ResourceSpecific(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			resource := tc.newResource()
+			resource := tc.newResource(t)
 
 			// Nil search values, should always return true
 			match := resource.MatchSearch(nil)

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -31,7 +31,7 @@ func getTestVal(isTestField bool, testVal string) string {
 		return testVal
 	}
 
-	return "_"
+	return "foo"
 }
 
 func TestServerSorter(t *testing.T) {

--- a/lib/integrations/awsoidc/listdatabases_test.go
+++ b/lib/integrations/awsoidc/listdatabases_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -99,7 +98,7 @@ func TestListDatabases(t *testing.T) {
 		for i := 0; i < totalDBs; i++ {
 			allInstances = append(allInstances, rdsTypes.DBInstance{
 				DBInstanceStatus:     stringPointer("available"),
-				DBInstanceIdentifier: stringPointer(uuid.NewString()),
+				DBInstanceIdentifier: stringPointer(fmt.Sprintf("db-%v", i)),
 				DbiResourceId:        stringPointer("db-123"),
 				DBInstanceArn:        stringPointer("arn:aws:iam::123456789012:role/MyARN"),
 				Engine:               stringPointer("postgres"),

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -44,7 +44,6 @@ import (
 	"go.mongodb.org/mongo-driver/mongo/readpref"
 	"go.mongodb.org/mongo-driver/x/mongo/driver/connstring"
 	"golang.org/x/exp/slices"
-	"k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/gravitational/teleport/api/types"
 	apiawsutils "github.com/gravitational/teleport/api/utils/aws"
@@ -147,11 +146,11 @@ func ValidateDatabase(db types.Database) error {
 		return trace.Wrap(err)
 	}
 
-	// Unlike application access proxy, database proxy name doesn't necessarily
-	// need to be a valid subdomain but use the same validation logic for the
-	// simplicity and consistency.
-	if errs := validation.IsDNS1035Label(db.GetName()); len(errs) > 0 {
-		return trace.BadParameter("invalid database %q name: %v", db.GetName(), errs)
+	// This was added in v14 and backported, except that it's intentionally
+	// called here instead of in CheckAndSetDefaults for backwards
+	// compatibility.
+	if err := types.ValidateDatabaseName(db.GetName()); err != nil {
+		return trace.Wrap(err, "invalid database name")
 	}
 
 	if !slices.Contains(defaults.DatabaseProtocols, db.GetProtocol()) {

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -123,19 +123,6 @@ func TestValidateDatabase(t *testing.T) {
 		expectError bool
 	}{
 		{
-			// Captured error:
-			// a DNS-1035 label must consist of lower case alphanumeric
-			// characters or '-', start with an alphabetic character, and end
-			// with an alphanumeric character (e.g. 'my-name',  or 'abc-123',
-			// regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
-			inputName: "invalid-database-name-",
-			inputSpec: types.DatabaseSpecV3{
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-			},
-			expectError: true,
-		},
-		{
 			inputName: "invalid-database-protocol",
 			inputSpec: types.DatabaseSpecV3{
 				Protocol: "unknown",

--- a/lib/srv/db/sqlserver/connect_test.go
+++ b/lib/srv/db/sqlserver/connect_test.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -48,7 +48,7 @@ func TestConnectorSelection(t *testing.T) {
 
 	connector := &connector{DBAuth: &mockDBAuth{}}
 
-	for _, tt := range []struct {
+	for i, tt := range []struct {
 		desc         string
 		databaseSpec types.DatabaseSpecV3
 		errAssertion require.ErrorAssertionFunc
@@ -118,7 +118,7 @@ func TestConnectorSelection(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			database, err := types.NewDatabaseV3(types.Metadata{
-				Name: uuid.NewString(),
+				Name: fmt.Sprintf("db-%v", i),
 			}, tt.databaseSpec)
 			require.NoError(t, err)
 
@@ -240,7 +240,7 @@ func TestConnectorKInitClient(t *testing.T) {
 	err := os.WriteFile(krbConfPath, []byte(krb5Conf), 0664)
 	require.NoError(t, err)
 
-	for _, tt := range []struct {
+	for i, tt := range []struct {
 		desc         string
 		databaseSpec types.DatabaseSpecV3
 		errAssertion require.ErrorAssertionFunc
@@ -301,7 +301,7 @@ func TestConnectorKInitClient(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			database, err := types.NewDatabaseV3(types.Metadata{
-				Name: uuid.NewString(),
+				Name: fmt.Sprintf("db-%v", i),
 			}, tt.databaseSpec)
 			require.NoError(t, err)
 

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -368,7 +368,7 @@ func makeAzureSQLServer(t *testing.T, name, group string) (*armsql.Server, types
 
 	server := &armsql.Server{
 		ID:   to.Ptr(fmt.Sprintf("/subscriptions/sub-id/resourceGroups/%v/providers/Microsoft.Sql/servers/%v", group, name)),
-		Name: to.Ptr(fmt.Sprintf("%s.database.windows.net", name)),
+		Name: to.Ptr(fmt.Sprintf("%s-database-windows-net", name)),
 		Properties: &armsql.ServerProperties{
 			FullyQualifiedDomainName: to.Ptr("localhost"),
 		},

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -3512,7 +3512,7 @@ func TestSerializeDatabases(t *testing.T) {
     "kind": "db",
     "version": "v3",
     "metadata": {
-      "name": "my db",
+      "name": "my-db",
       "description": "this is the description",
       "labels": {"a": "1", "b": "2"}
     },
@@ -3566,7 +3566,7 @@ func TestSerializeDatabases(t *testing.T) {
   }]
 	`
 	db, err := types.NewDatabaseV3(types.Metadata{
-		Name:        "my db",
+		Name:        "my-db",
 		Description: "this is the description",
 		Labels:      map[string]string{"a": "1", "b": "2"},
 	}, types.DatabaseSpecV3{


### PR DESCRIPTION
Backport #28841 to branch/v13

Only difference from the original PR is I kept the name checking in `ValidateDatabase` instead of moving it to `CheckAndSetDefaults`, for backwards compatibility reasons.