### PR TITLE
[v12] update database and kube name validation

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -19,6 +19,7 @@ package types
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -502,6 +503,24 @@ func (d *DatabaseV3) MatchSearch(values []string) bool {
 func (d *DatabaseV3) setStaticFields() {
 	d.Kind = KindDatabase
 	d.Version = V3
+}
+
+// validDatabaseNameRegexp filters the allowed characters in database names.
+// This is the (almost) the same regexp used to check for valid DNS 1035 labels,
+// except we allow uppercase chars.
+var validDatabaseNameRegexp = regexp.MustCompile(`^[a-zA-Z]([-a-zA-Z0-9]*[a-zA-Z0-9])?$`)
+
+// ValidateDatabaseName returns an error if a given string is not a valid
+// Database name.
+// Unlike application access proxy, database name doesn't necessarily
+// need to be a valid subdomain but use the same validation logic for the
+// simplicity and consistency, except two differences: don't restrict names to
+// 63 chars in length and allow upper case chars.
+// This was added in v14 and backported, except that it's intentionally called
+// in lib/services:ValidateDatabase instead of within CheckAndSetDefaults below
+// for backwards compatibility.
+func ValidateDatabaseName(name string) error {
+	return ValidateResourceName(validDatabaseNameRegexp, name)
 }
 
 // CheckAndSetDefaults checks and sets default values for any missing fields.

--- a/api/types/database_test.go
+++ b/api/types/database_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package types
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -727,6 +728,43 @@ func TestAWSIsEmpty(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			test.assert(t, test.input.IsEmpty())
+		})
+	}
+}
+
+func TestValidateDatabaseName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		dbName            string
+		expectErrContains string
+	}{
+		{
+			name:   "valid long name and uppercase chars",
+			dbName: strings.Repeat("aA", 100),
+		},
+		{
+			name:              "invalid trailing hyphen",
+			dbName:            "invalid-database-name-",
+			expectErrContains: `"invalid-database-name-" does not match regex`,
+		},
+		{
+			name:              "invalid first character",
+			dbName:            "1-invalid-database-name",
+			expectErrContains: `"1-invalid-database-name" does not match regex`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateDatabaseName(test.dbName)
+			if test.expectErrContains != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, test.expectErrContains)
+				return
+			}
+			require.NoError(t, err)
 		})
 	}
 }

--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -512,3 +512,14 @@ type ListResourcesResponse struct {
 	// TotalCount is the total number of resources available as a whole.
 	TotalCount int
 }
+
+// ValidateResourceName validates a resource name using a given regexp.
+func ValidateResourceName(validationRegex *regexp.Regexp, name string) error {
+	if validationRegex.MatchString(name) {
+		return nil
+	}
+	return trace.BadParameter(
+		"%q does not match regex used for validation %q",
+		name, validationRegex.String(),
+	)
+}

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -18,7 +18,6 @@ package types
 
 import (
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -436,8 +435,8 @@ func (s *ServerV2) CheckAndSetDefaults() error {
 		}
 	}
 	for _, kc := range s.Spec.KubernetesClusters {
-		if !validKubeClusterName.MatchString(kc.Name) {
-			return trace.BadParameter("invalid kubernetes cluster name: %q", kc.Name)
+		if err := ValidateKubeClusterName(kc.Name); err != nil {
+			return trace.Wrap(err, "invalid kubernetes cluster name")
 		}
 	}
 
@@ -554,12 +553,6 @@ func LabelsToV2(labels map[string]CommandLabel) map[string]CommandLabelV2 {
 	}
 	return out
 }
-
-// validKubeClusterName filters the allowed characters in kubernetes cluster
-// names. We need this because cluster names are used for cert filenames on the
-// client side, in the ~/.tsh directory. Restricting characters helps with
-// sneaky cluster names being used for client directory traversal and exploits.
-var validKubeClusterName = regexp.MustCompile(`^[a-zA-Z0-9._-]+$`)
 
 // Servers represents a list of servers.
 type Servers []Server

--- a/api/types/server_test.go
+++ b/api/types/server_test.go
@@ -29,7 +29,7 @@ func getTestVal(isTestField bool, testVal string) string {
 		return testVal
 	}
 
-	return "_"
+	return "foo"
 }
 
 func TestServerSorter(t *testing.T) {

--- a/lib/integrations/awsoidc/listdatabases_test.go
+++ b/lib/integrations/awsoidc/listdatabases_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
-	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 
@@ -99,7 +98,7 @@ func TestListDatabases(t *testing.T) {
 		for i := 0; i < totalDBs; i++ {
 			allInstances = append(allInstances, rdsTypes.DBInstance{
 				DBInstanceStatus:     stringPointer("available"),
-				DBInstanceIdentifier: stringPointer(uuid.NewString()),
+				DBInstanceIdentifier: stringPointer(fmt.Sprintf("db-%v", i)),
 				DbiResourceId:        stringPointer("db-123"),
 				DBInstanceArn:        stringPointer("arn:aws:iam::123456789012:role/MyARN"),
 				Engine:               stringPointer("postgres"),

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -123,19 +123,6 @@ func TestValidateDatabase(t *testing.T) {
 		expectError bool
 	}{
 		{
-			// Captured error:
-			// a DNS-1035 label must consist of lower case alphanumeric
-			// characters or '-', start with an alphabetic character, and end
-			// with an alphanumeric character (e.g. 'my-name',  or 'abc-123',
-			// regex used for validation is '[a-z]([-a-z0-9]*[a-z0-9])?')
-			inputName: "invalid-database-name-",
-			inputSpec: types.DatabaseSpecV3{
-				Protocol: defaults.ProtocolPostgres,
-				URI:      "localhost:5432",
-			},
-			expectError: true,
-		},
-		{
 			inputName: "invalid-database-protocol",
 			inputSpec: types.DatabaseSpecV3{
 				Protocol: "unknown",

--- a/lib/srv/db/sqlserver/connect_test.go
+++ b/lib/srv/db/sqlserver/connect_test.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	_ "embed"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/client/proto"
@@ -48,7 +48,7 @@ func TestConnectorSelection(t *testing.T) {
 
 	connector := &connector{DBAuth: &mockDBAuth{}}
 
-	for _, tt := range []struct {
+	for i, tt := range []struct {
 		desc         string
 		databaseSpec types.DatabaseSpecV3
 		errAssertion require.ErrorAssertionFunc
@@ -100,7 +100,7 @@ func TestConnectorSelection(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			database, err := types.NewDatabaseV3(types.Metadata{
-				Name: uuid.NewString(),
+				Name: fmt.Sprintf("db-%v", i),
 			}, tt.databaseSpec)
 			require.NoError(t, err)
 
@@ -225,7 +225,7 @@ func TestConnectorKInitClient(t *testing.T) {
 	err := os.WriteFile(krbConfPath, []byte(krb5Conf), 0664)
 	require.NoError(t, err)
 
-	for _, tt := range []struct {
+	for i, tt := range []struct {
 		desc         string
 		databaseSpec types.DatabaseSpecV3
 		errAssertion require.ErrorAssertionFunc
@@ -286,7 +286,7 @@ func TestConnectorKInitClient(t *testing.T) {
 	} {
 		t.Run(tt.desc, func(t *testing.T) {
 			database, err := types.NewDatabaseV3(types.Metadata{
-				Name: uuid.NewString(),
+				Name: fmt.Sprintf("db-%v", i),
 			}, tt.databaseSpec)
 			require.NoError(t, err)
 

--- a/lib/srv/db/watcher_test.go
+++ b/lib/srv/db/watcher_test.go
@@ -334,7 +334,7 @@ func makeAzureSQLServer(t *testing.T, name, group string) (*armsql.Server, types
 
 	server := &armsql.Server{
 		ID:   to.Ptr(fmt.Sprintf("/subscriptions/sub-id/resourceGroups/%v/providers/Microsoft.Sql/servers/%v", group, name)),
-		Name: to.Ptr(fmt.Sprintf("%s.database.windows.net", name)),
+		Name: to.Ptr(fmt.Sprintf("%s-database-windows-net", name)),
 		Properties: &armsql.ServerProperties{
 			FullyQualifiedDomainName: to.Ptr("localhost"),
 		},

--- a/tool/tsh/tsh_test.go
+++ b/tool/tsh/tsh_test.go
@@ -3509,7 +3509,7 @@ func TestSerializeDatabases(t *testing.T) {
     "kind": "db",
     "version": "v3",
     "metadata": {
-      "name": "my db",
+      "name": "my-db",
       "description": "this is the description",
       "labels": {"a": "1", "b": "2"}
     },
@@ -3560,7 +3560,7 @@ func TestSerializeDatabases(t *testing.T) {
   }]
 	`
 	db, err := types.NewDatabaseV3(types.Metadata{
-		Name:        "my db",
+		Name:        "my-db",
 		Description: "this is the description",
 		Labels:      map[string]string{"a": "1", "b": "2"},
 	}, types.DatabaseSpecV3{


### PR DESCRIPTION
Backport #28841 to branch/v12

The main difference from the original PR is I kept the name checking in `ValidateDatabase` instead of moving it to `CheckAndSetDefaults`, for backwards compatibility reasons.

@tigrato I also added a call to `ValidateKubeClusterName` in `api/types.KubernetesClusterV3.CheckAndSetDefaults()` - I don't think that presents a breaking change since we were already using the same regex in `api/types.ServerV2.CheckAndSetDefaults()` for kube cluster names (I guess v12 is before we removed kube clusters from the server spec).