### PR TITLE
resolveNetworkAddress: Listen for `close` instead of `exit`; Fix FailedApp theme

### DIFF
--- a/web/packages/design/src/Card/Card.jsx
+++ b/web/packages/design/src/Card/Card.jsx
@@ -26,7 +26,7 @@ const Card = styled(Box)`
 `;
 
 Card.defaultProps = {
-  theme: { darkTheme },
+  theme: darkTheme,
 };
 
 Card.displayName = 'Card';

--- a/web/packages/teleterm/src/ui/App.tsx
+++ b/web/packages/teleterm/src/ui/App.tsx
@@ -26,7 +26,8 @@ import { AppInitializer } from 'teleterm/ui/AppInitializer';
 import CatchError from './components/CatchError';
 import AppContextProvider from './appContextProvider';
 import AppContext from './appContext';
-import { ThemeProvider } from './ThemeProvider';
+import { StaticThemeProvider, ThemeProvider } from './ThemeProvider';
+import { darkTheme } from './ThemeProvider/theme';
 
 export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
   return (
@@ -47,7 +48,9 @@ export const App: React.FC<{ ctx: AppContext }> = ({ ctx }) => {
 export const FailedApp = (props: { message: string }) => {
   return (
     <StyledApp>
-      <Failed alignSelf={'baseline'} message={props.message} />
+      <StaticThemeProvider theme={darkTheme}>
+        <Failed alignSelf={'baseline'} message={props.message} />
+      </StaticThemeProvider>
     </StyledApp>
   );
 };


### PR DESCRIPTION
We had [another instance](https://github.com/gravitational/teleport/actions/runs/5522916733/jobs/10073152045) of a flaky `resolveNetworkAddress` test. We already tried to deal with this in the past (#25249), but we might have as well fixed one or zero problems at that time while there was another lurking under the surface.

`resolveNetworkAddress` receives a child process. It listens to both `process.stdout.on('data')` and `process.on('exit')`. `resolveNetworkAddress` resolves when the child process prints a specific string to stdout or rejects with an error if the process exits before printing the string.

The problem is that [the fake process we use in tests](https://github.com/gravitational/teleport/blob/fbba4c2bfada1dbae5f87eaa9ac8289a6e701738/web/packages/teleterm/src/mainProcess/testProcess.mjs) exits almost immediately after printing since there's nothing else to do.

To guarantee that `resolveNetworkAddress` processes the data listener before the exit listener, we have to listen for `close` instead of `exit` [as the docs say](https://nodejs.org/api/child_process.html#event-close)):

> The 'close' event is emitted after a process has ended and the stdio streams of a child process have been closed. This is distinct from the ['exit'](https://nodejs.org/api/child_process.html#event-exit) event, since multiple processes might share the same stdio streams. The 'close' event will always emit after ['exit'](https://nodejs.org/api/child_process.html#event-exit) was already emitted, or ['error'](https://nodejs.org/api/child_process.html#event-error) if the child failed to spawn.

---

That's the original issue fixed by this PR. However, while testing the fix in dev version of Connect, by doing `os.Exit` [right before the port is logged](https://github.com/gravitational/teleport/blob/fbba4c2bfada1dbae5f87eaa9ac8289a6e701738/lib/teleterm/apiserver/apiserver.go#L85) and making the app failed to start, I discovered another problem. The error component AKA `FailedApp` was not being rendered successfully.

Because of the theme changes, the `Card` component, used in `FailedApp`, now requires a theme to be rendered. I thought the issue was simply that `Card.defaultProps` were incorrect, but after fixing that I discovered that there's a slew of other components which also require a theme or typography but don't have those props set by default.

Instead of fixing them one by one, I decided to simply add a static theme provider so that those components can render. I picked the dark theme so that we don't flash people with a white screen in case of an error.