### PR TITLE
Encode URI for `sqlite` properly

### DIFF
--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -178,7 +178,7 @@ func (cfg *Config) ConnectionURI() string {
 
 	u := url.URL{
 		Scheme:   "file",
-		Opaque:   url.QueryEscape(filepath.Join(cfg.Path, defaultDBFile)),
+		Path:     filepath.Join(cfg.Path, defaultDBFile),
 		RawQuery: params.Encode(),
 	}
 	return u.String()

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -220,7 +220,10 @@ func NewWithConfig(ctx context.Context, cfg Config) (*Backend, error) {
 
 	if setPermissions {
 		// Ensure the database has restrictive access permissions.
-		db.PingContext(ctx)
+		err = db.PingContext(ctx)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 		err = os.Chmod(path, dbMode)
 		if err != nil {
 			return nil, trace.ConvertSystemError(err)

--- a/lib/backend/lite/lite_test.go
+++ b/lib/backend/lite/lite_test.go
@@ -19,6 +19,7 @@ package lite
 import (
 	"context"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -54,7 +55,7 @@ func TestLite(t *testing.T) {
 		}
 
 		backend, err := NewWithConfig(context.Background(), Config{
-			Path:             t.TempDir(),
+			Path:             filepath.Join(t.TempDir(), "directory with spaces"), // checks if spaces are encoded correctly
 			PollStreamPeriod: 300 * time.Millisecond,
 			Clock:            clock,
 		})


### PR DESCRIPTION
When a path passed to `data_dir` contains spaces, teleport does not start:
`ERROR: initialization failed
chmod /Users/grzegorz/Library/Application Support/Electron/agents/mercury.cloud.gravitational.io/data/proc/sqlite.db: no such file or directory`

The first issue is that error from `db.PingContext` is not handled, so we don't know what exactly failed.

The second thing is DB path encoding. It uses `url.QueryEscape` which replaces spaces with `+`:
`file:%2FUsers%2Fgrzegorz%2FLibrary%2FApplication+Support%2FElectron%2Fagents%2Fmercury.cloud.gravitational.io%2Fdata%2Fproc%2Fsqlite.db?_busy_timeout=10000&_sync=FULL&_txlock=immediate`

We could change it to `url.PathEscape`, but I think it is better to leave the encoding to `URL` and pass the file path as `Path`. It produces the following string:
`file:///Users/grzegorz/Library/Application%20Support/Electron/agents/mercury.cloud.gravitational.io/data/proc/sqlite.db?_busy_timeout=10000&_sync=FULL&_txlock=immediate`