### PR TITLE
Correct the clock passed to `dynamicCredsConfig`

### DIFF
--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -60,6 +60,8 @@ type clusterDetailsConfig struct {
 	// resourceMatchers is the list of resource matchers to match the cluster against
 	// to determine if we should assume the role or not for AWS.
 	resourceMatchers []services.ResourceMatcher
+	// clock is the clock to use.
+	clock clockwork.Clock
 }
 
 // newClusterDetails creates a proxied kubeDetails structure given a dynamic cluster.
@@ -102,7 +104,7 @@ func (k *kubeDetails) Close() {
 
 // getKubeClusterCredentials generates kube credentials for dynamic clusters.
 func getKubeClusterCredentials(ctx context.Context, cfg clusterDetailsConfig) (kubeCreds, error) {
-	dynCredsCfg := dynamicCredsConfig{kubeCluster: cfg.cluster, log: cfg.log, checker: cfg.checker, resourceMatchers: cfg.resourceMatchers}
+	dynCredsCfg := dynamicCredsConfig{kubeCluster: cfg.cluster, log: cfg.log, checker: cfg.checker, resourceMatchers: cfg.resourceMatchers, clock: cfg.clock}
 	switch {
 	case cfg.cluster.IsKubeconfig():
 		return getStaticCredentialsFromKubeconfig(ctx, cfg.cluster, cfg.log, cfg.checker)

--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -178,16 +178,21 @@ func (m *monitoredKubeClusters) get() types.ResourcesWithLabelsMap {
 	return append(m.static, m.resources...).AsResources().ToMap()
 }
 
+func (s *TLSServer) buildClusterDetailsConfigForCluster(cluster types.KubeCluster) clusterDetailsConfig {
+	return clusterDetailsConfig{
+		cloudClients:     s.CloudClients,
+		cluster:          cluster,
+		log:              s.log,
+		checker:          s.CheckImpersonationPermissions,
+		resourceMatchers: s.ResourceMatchers,
+		clock:            s.Clock,
+	}
+}
+
 func (s *TLSServer) registerKubeCluster(ctx context.Context, cluster types.KubeCluster) error {
 	clusterDetails, err := newClusterDetails(
 		ctx,
-		clusterDetailsConfig{
-			cloudClients:     s.CloudClients,
-			cluster:          cluster,
-			log:              s.log,
-			checker:          s.CheckImpersonationPermissions,
-			resourceMatchers: s.ResourceMatchers,
-		},
+		s.buildClusterDetailsConfigForCluster(cluster),
 	)
 	if err != nil {
 		return trace.Wrap(err)
@@ -199,13 +204,7 @@ func (s *TLSServer) registerKubeCluster(ctx context.Context, cluster types.KubeC
 func (s *TLSServer) updateKubeCluster(ctx context.Context, cluster types.KubeCluster) error {
 	clusterDetails, err := newClusterDetails(
 		ctx,
-		clusterDetailsConfig{
-			cloudClients:     s.CloudClients,
-			cluster:          cluster,
-			log:              s.log,
-			checker:          s.CheckImpersonationPermissions,
-			resourceMatchers: s.ResourceMatchers,
-		},
+		s.buildClusterDetailsConfigForCluster(cluster),
 	)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR corrects the clock passed to `dynamicCredsConfig` and used for generating credentials for dynamic clusters.