### PR TITLE
[v12] chore: Bump Go to 1.20.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -39,7 +39,7 @@ name: push-build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
   UID: "1000"
 trigger:
   event:
@@ -155,7 +155,7 @@ name: push-build-linux-386
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
   UID: "1000"
 trigger:
   event:
@@ -269,7 +269,7 @@ name: push-build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
   UID: "1000"
 trigger:
   event:
@@ -387,7 +387,7 @@ name: push-build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
   UID: "1000"
 trigger:
   event:
@@ -1115,7 +1115,7 @@ name: push-build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport12
   GID: "1000"
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
   UID: "1000"
 trigger:
   event:
@@ -1636,7 +1636,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -1845,7 +1845,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -2053,7 +2053,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -2268,7 +2268,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -3568,7 +3568,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -4394,7 +4394,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -5723,7 +5723,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport12
-  RUNTIME: go1.20.5
+  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -19879,6 +19879,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 1b68d1289d8b42e11536881819b42be1e6b778d561a7d1b0ef932f82c5a99256
+hmac: 95983f9e5718804524d0e92165e936225c2db12e3d610e6ac9cb239e4101a72d
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -19,7 +19,7 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.20.5
+GOLANG_VERSION ?= go1.20.6
 
 NODE_VERSION ?= 16.18.1
 


### PR DESCRIPTION
Update Go to the latest patch.

* https://go.dev/doc/devel/release#go1.20.6