### PR TITLE
[v13] Log the value of EventsBufferSize instead of the pointer address

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -186,7 +186,7 @@ func New(config *servicecfg.BPFConfig, restrictedSession *servicecfg.RestrictedS
 		"disk=%v, network=%v), restricted session (bufferSize=%v) "+
 		"and cgroup mount path: %v. Took %v.",
 		*s.CommandBufferSize, *s.DiskBufferSize, *s.NetworkBufferSize,
-		restrictedSession.EventsBufferSize,
+		*restrictedSession.EventsBufferSize,
 		s.CgroupPath, time.Since(start))
 
 	go s.processNetworkEvents()


### PR DESCRIPTION
Backport #29031 to branch/v13