### PR TITLE
[v12] Log the value of EventsBufferSize instead of the pointer address

### DIFF
--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -185,7 +185,7 @@ func New(config *Config, restrictedSession *RestrictedSessionConfig) (BPF, error
 		"disk=%v, network=%v), restricted session (bufferSize=%v) "+
 		"and cgroup mount path: %v. Took %v.",
 		*s.CommandBufferSize, *s.DiskBufferSize, *s.NetworkBufferSize,
-		restrictedSession.EventsBufferSize,
+		*restrictedSession.EventsBufferSize,
 		s.CgroupPath, time.Since(start))
 
 	go s.processNetworkEvents()


### PR DESCRIPTION
Backport #29031 to branch/v12