### PR TITLE
[v12] upload completer: suppress stack trace for access denied errors

### DIFF
--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -147,8 +147,11 @@ func (u *UploadCompleter) Serve(ctx context.Context) error {
 	for {
 		select {
 		case <-periodic.Next():
-			if err := u.checkUploads(ctx); err != nil {
-				u.log.WithError(err).Warningf("Failed to check uploads.")
+			if err := u.checkUploads(ctx); trace.IsAccessDenied(err) {
+				u.log.Warn("Teleport does not have permission to list uploads. " +
+					"The upload completer will be unable to complete uploads of partial session recordings.")
+			} else if err != nil {
+				u.log.WithError(err).Warn("Failed to check uploads.")
 			}
 		case <-u.closeC:
 			return nil

--- a/lib/events/s3sessions/s3handler.go
+++ b/lib/events/s3sessions/s3handler.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"net/url"
 	"path/filepath"
 	"sort"
@@ -439,6 +440,9 @@ func (h *Handler) ensureBucket(ctx context.Context) error {
 func ConvertS3Error(err error, args ...interface{}) error {
 	if err == nil {
 		return nil
+	}
+	if rerr, ok := err.(awserr.RequestFailure); ok && rerr.StatusCode() == http.StatusForbidden {
+		return trace.AccessDenied(rerr.Message())
 	}
 	if aerr, ok := err.(awserr.Error); ok {
 		switch aerr.Code() {


### PR DESCRIPTION
If the upload completer fails due to a permissions error, emit a warning indicating that the upload completer will not function properly, but suppress the stack trace.

Closes #28999
Backports #29023