### PR TITLE
[Web] Fix `StyledPanel` CSS

### DIFF
--- a/web/packages/design/src/DataTable/StyledTable.tsx
+++ b/web/packages/design/src/DataTable/StyledTable.tsx
@@ -116,7 +116,7 @@ export const StyledPanel = styled.nav<{ showTopBorder: boolean }>`
   border-top: ${props =>
     props.showTopBorder
       ? '1px solid ' + props.theme.colors.spotBackground[0]
-      : undefined}
+      : undefined};
 `;
 
 export const StyledTableWrapper = styled.div`


### PR DESCRIPTION
## Purpose

Minor fix that adds a missing semi-colon to the `StyledPanel`'s CSS. This fixes a misalignment bug caused by this in the Access Request table: 

### Before
<img width="1213" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/28875f9f-ddf9-4212-b3f7-53894f8fb8fd">
<img width="291" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/379204e2-cadd-4072-aa3e-0a9498941378">

### After
<img width="1211" alt="image" src="https://github.com/gravitational/teleport/assets/56373201/bfb08025-a486-4750-b759-74015725ca25">



