### PR TITLE
Remove session condition from Firestore events query

### DIFF
--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -383,7 +383,6 @@ func (l *Log) searchEventsWithFilter(fromUTC, toUTC time.Time, namespace string,
 	}
 
 	query := l.svc.Collection(l.CollectionName).
-		Where(sessionIDDocProperty, "!=", ""). // exclude any non audit event documents in the collection
 		Where(eventNamespaceDocProperty, "==", apidefaults.Namespace).
 		Where(createdAtDocProperty, ">=", fromUTC.Unix()).
 		Where(createdAtDocProperty, "<=", toUTC.Unix())


### PR DESCRIPTION
Firestore only allows a single equality operation on queriers. Reverting to prevent errors when viewing Audit Logs.