### PR TITLE
Docs: Ordered and unordered list changes for lint update

### DIFF
--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -66,10 +66,10 @@ which cluster the current tab is bound to, and the **Share Feedback** button in 
 
 ## Connecting to an SSH server
 
-- Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
+1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
    You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-- Look for the SSH server you want to connect to and click the Connect button to the right.
-- Select or enter the SSH user you wish to log in as and press `Enter`.
+1. Look for the SSH server you want to connect to and click the Connect button to the right.
+1. Select or enter the SSH user you wish to log in as and press `Enter`.
 
 A new tab will open with a shell session on the chosen server.
 
@@ -91,10 +91,10 @@ reflected in both the tab title and the status bar.
 
 ## Connecting to a Kubernetes cluster
 
-- Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
+1. Open a tab with cluster resources by clicking on the plus symbol at the right end of the tab bar.
    You can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-- Select the Kubes section.
-- Look for the cluster you wish to connect to and click the Connect button to the right.
+1. Select the Kubes section.
+1. Look for the cluster you wish to connect to and click the Connect button to the right.
 
 A new local terminal tab will open which is preconfigured with the `$KUBECONFIG` environment variable
 pointing to a configuration for the specified cluster. Any tools that you have installed that respect
@@ -105,11 +105,11 @@ Alternatively, you can look for the cluster in the search bar and press `Enter` 
 
 ## Connecting to a database
 
-- Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
+1. Open a tab with cluster resources by clicking on the plus symbol at the end of the tab bar. You
   can also press <span style="white-space: nowrap;">`Ctrl/Cmd + T`</span> to achieve the same result.
-- Select the Databases section.
-- Look for the database server you wish to connect to and click the Connect button to the right.
-- Select or enter the database user you wish to use and press `Enter`.
+1. Select the Databases section.
+1. Look for the database server you wish to connect to and click the Connect button to the right.
+1. Select or enter the database user you wish to use and press `Enter`.
 
 A new tab will open with a new connection established between your device and the database server.
 
@@ -136,10 +136,9 @@ Teleport Connect allows you to log in to multiple clusters at the same time. Aft
 your first cluster, open the profile selector at the top right and click the *+Add another cluster*
 button. You can switch between active profiles in multiple ways:
 
-- Click at the profile selector button at the top right.
-- Open the profile selector with a shortcut (<span style="white-space: nowrap;">`Ctrl/Cmd + I`</span>).
-- Using the connection list at the top left to select a connection will automatically switch you to
-  the right profile.
+1. Click at the profile selector button at the top right.
+1. Open the profile selector with a shortcut (<span style="white-space: nowrap;">`Ctrl/Cmd + I`</span>).
+1. Select a connection from the connection list at the top to automatically switch to the right profile.
 
 At the moment Teleport Connect supports only one user per cluster. To log in as a different user,
 log out of the cluster first.

--- a/docs/pages/desktop-access/active-directory-manual.mdx
+++ b/docs/pages/desktop-access/active-directory-manual.mdx
@@ -35,12 +35,13 @@ This guide requires you to have:
 <Admonition title="Azure AD" type="warning">
 
 Microsoft's Azure Active Directory (Azure AD) offering does not support the
-Kerberos authentication protocol, which is required the certificate-based 
+Kerberos authentication protocol, which is required for the certificate-based 
 authentication described in this section.
 
-For information about configuring Teleport to work with Azure Active Directory,
-see [Teleport Authentication with Azure Active Directory (AD)](../access-controls/sso/azuread.mdx).
-
+At this time, Teleport does not support integration with Azure AD, however
+Teleport Enterprise customers can access Windows desktops (including those
+joined to Azure AD) using local accounts via the process described in [Getting
+Started with Desktop Access](./getting-started.mdx).
 </Admonition>
 
 - Access to a Domain Controller


### PR DESCRIPTION
Fix lint warning prior to making the change to the behavior implemented in https://github.com/gravitational/docs/pull/341.
Some of these files used numbers (ordered) lists but should have used bullets (unordered) lists.
Lint Docs will fail until the change in https://github.com/gravitational/docs/pull/341 is merged.