### PR TITLE
Add AWS EKS End-To-End tests

### DIFF
--- a/.github/workflows/aws-e2e-non-root-bypass.yaml
+++ b/.github/workflows/aws-e2e-non-root-bypass.yaml
@@ -1,0 +1,43 @@
+# This workflow is required to ensure that required Github check passes even if
+# the actual "Kube Integration Tests (Non-root)" workflow skipped due to path filtering.
+# Otherwise it will stay forever pending.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+
+name: AWS E2E Tests (Non-root)
+run-name: AWS E2E Tests (Non-root) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.github/workflows/aws-e2e-tests-non-root.yaml'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
+      - 'Makefile'
+  merge_group:
+    paths-ignore:
+      - '.github/workflows/aws-e2e-tests-non-root.yaml'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
+      - 'Makefile'
+
+jobs:
+  test:
+    name: AWS E2E Tests (Non-root)
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none
+
+    steps:
+      - run: 'echo "No changes to verify"'

--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -1,0 +1,75 @@
+name: AWS E2E Tests (Non-root)
+run-name: AWS E2E Tests (Non-root) - ${{ github.run_id }} - @${{ github.actor }}
+
+on:
+  push:
+    branches:
+      - master
+      - branch/*
+  pull_request:
+    paths:
+      - '.github/workflows/aws-e2e-tests-non-root.yaml'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
+      - 'Makefile'
+  merge_group:
+    paths:
+      - '.github/workflows/aws-e2e-tests-non-root.yaml'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'build.assets/Makefile'
+      - 'build.assets/Dockerfile*'
+      - 'Makefile'
+
+env:
+  TEST_KUBE: true
+  AWS_REGION: us-west-2
+  GHA_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-aws-e2e-gha-role
+  KUBERNETES_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-kubernetes-service-access-role
+  DISCOVERY_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-discovery-service-access-role
+  DISCOVERED_CLUSTER_NAME: gha-discovery-ci
+jobs:
+  test:
+    name: AWS E2E Tests (Non-root)
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
+    runs-on: ubuntu-22.04-16core
+
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+
+    container:
+      image: ghcr.io/gravitational/teleport-buildbox:teleport14
+      env:
+        WEBASSETS_SKIP_BUILD: 1
+      options: --cap-add=SYS_ADMIN --privileged
+
+    steps:
+      - name: Checkout Teleport
+        uses: actions/checkout@v3
+
+      - name: Prepare workspace
+        uses: ./.github/actions/prepare-workspace
+
+      - name: Chown
+        run: |
+          mkdir -p $(go env GOMODCACHE)
+          mkdir -p $(go env GOCACHE)
+          chown -Rf ci:ci ${GITHUB_WORKSPACE} $(go env GOMODCACHE) $(go env GOCACHE)
+        continue-on-error: true
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.GHA_ASSUME_ROLE }}
+
+      - name: Run tests
+        timeout-minutes: 10
+        run: |
+          runuser -u ci -g ci make e2e-aws RDPCLIENT_SKIP_BUILD=1

--- a/Makefile
+++ b/Makefile
@@ -899,6 +899,16 @@ integration-root: $(TEST_LOG_DIR) $(RENDER_TESTS)
 		| tee $(TEST_LOG_DIR)/integration-root.json \
 		| $(RENDER_TESTS) -report-by test
 
+
+.PHONY: e2e-aws
+e2e-aws: FLAGS ?= -v -race
+e2e-aws: PACKAGES = $(shell go list ./... | grep 'e2e/aws')
+e2e-aws: $(TEST_LOG_DIR) $(RENDER_TESTS)
+	@echo TEST_KUBE: $(TEST_KUBE)
+	$(CGOFLAG) go test -json $(PACKAGES) $(FLAGS) \
+		| tee $(TEST_LOG_DIR)/e2e-aws.json \
+		| $(RENDER_TESTS) -report-by test
+
 #
 # Lint the source code.
 # By default lint scans the entire repo. Pass GO_LINT_FLAGS='--new' to only scan local

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -332,6 +332,11 @@ integration-kube: buildbox
 	docker run $(DOCKERFLAGS) -t $(BUILDBOX) \
 		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' integration-kube"
 
+.PHONY:e2e-aws
+e2e-aws: buildbox
+	docker run $(DOCKERFLAGS) -t $(BUILDBOX) \
+		/bin/bash -c "make -C $(SRCDIR) FLAGS='-cover' e2e-aws"
+
 #
 # Runs linters on new changes inside a build container.
 #

--- a/e2e/aws/eks_test.go
+++ b/e2e/aws/eks_test.go
@@ -1,0 +1,333 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package integration
+
+import (
+	"context"
+	"os"
+	"os/user"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/api/breaker"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/integration/kube"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+var (
+	// Username used for the test.
+	username string
+	// kubernetes groups and users used for the test.
+	// discovery-ci-eks
+	// The kubernetes service IAM role can only impersonate the user and group listed below.
+	// This is a security measure to prevent the kubernetes service from impersonating any user/group
+	// including system:masters.
+	// If you need to impersonate a different user/group, you need to update the RBAC
+	// permissions for the kubernetes service IAM role.
+	kubeGroups = []string{kube.TestImpersonationGroup}
+	kubeUsers  = []string{"alice@example.com"}
+)
+
+func init() {
+	me, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	username = me.Username
+}
+
+func TestKube(t *testing.T) {
+	testEnabled := os.Getenv(teleport.KubeRunTests)
+	if ok, _ := strconv.ParseBool(testEnabled); !ok {
+		t.Skip("Skipping Kubernetes test suite.")
+	}
+
+	t.Run("AWS EKS Discovery - Matched cluster", awsEKSDiscoveryMatchedCluster)
+	t.Run("AWS EKS Discovery - Unmatched cluster", awsEKSDiscoveryUnmatchedCluster)
+}
+
+// awsEKSDiscoveryMatchedCluster tests that the discovery service can discover an EKS
+// cluster and create a KubernetesCluster resource.
+func awsEKSDiscoveryMatchedCluster(t *testing.T) {
+	t.Parallel()
+	teleport := createTeleportClusterWithDiscovery(
+		t,
+		types.Labels{
+			types.Wildcard: {types.Wildcard},
+		},
+	)
+	// Get the auth server.
+	authC := teleport.Process.GetAuthServer()
+	// Wait for the discovery service to discover the cluster and create a
+	// KubernetesCluster resource.
+	// Discovery service will scan the AWS account each minutes.
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		clusters, err := authC.GetKubernetesClusters(ctx)
+		return err == nil && len(clusters) == 1 && clusters[0].GetName() == os.Getenv(discoveredClusterNameEnv)
+	}, 3*time.Minute, 10*time.Second, "wait for the discovery service to create a cluster")
+
+	// Wait for the kubernetes service to create a KubernetesServer resource.
+	// This will happen after the discovery service creates the KubernetesCluster
+	// resource and the kubernetes service receives the event.
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		kubeServers, err := authC.GetKubernetesServers(ctx)
+		return err == nil && len(kubeServers) == 1
+	}, 2*time.Minute, time.Second, "wait for the kubernetes service to create a KubernetesServer")
+
+	// kubeClient is a Kubernetes client for the user created above
+	// that will be used to verify that the user can access the cluster and
+	// the permissions are correct.
+	kubeClient, _, err := kube.ProxyClient(kube.ProxyConfig{
+		T:          teleport,
+		Username:   username,
+		KubeUsers:  kubeUsers,
+		KubeGroups: kubeGroups,
+	})
+	require.NoError(t, err)
+
+	// Retrieve the list of services in the default namespace to verify that
+	// the user can access the cluster and the kubernetes service can
+	// impersonate the user's kubernetes_groups and kubernetes_users.
+	require.Eventually(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		list, err := kubeClient.CoreV1().Services(metav1.NamespaceDefault).List(ctx, metav1.ListOptions{})
+		return err == nil && len(list.Items) > 0
+	}, 30*time.Second, time.Second)
+}
+
+// awsEKSDiscoveryUnmatchedCluster tests a scenario where the discovery service
+// discovers an EKS cluster but the cluster does not match the discovery
+// selectors and therefore no KubernetesCluster resource is created.
+func awsEKSDiscoveryUnmatchedCluster(t *testing.T) {
+	t.Parallel()
+	teleport := createTeleportClusterWithDiscovery(
+		t,
+		types.Labels{
+			// This label will not match the EKS cluster.
+			"env": {"tag_not_found"},
+		},
+	)
+	// Get the auth server.
+	authC := teleport.Process.GetAuthServer()
+	// Wait for the discovery service to not create a KubernetesCluster resource
+	// because the cluster does not match the selectors.
+	require.Never(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		clusters, err := authC.GetKubernetesClusters(ctx)
+		return err == nil && len(clusters) != 0
+	}, 2*time.Minute, 10*time.Second, "discovery service incorrectly created a kube_cluster")
+}
+
+const (
+	// awsRegionEnv is the environment variable that specifies the AWS region
+	// where the EKS cluster is running.
+	awsRegionEnv = "AWS_REGION"
+	// kubernetesServiceAssumeRoleEnv is the environment variable that specifies
+	// the IAM role that Teleport Kubernetes Service will assume to access the EKS cluster.
+	// This role needs to have the following permissions:
+	// - eks:DescribeCluster
+	// But it also requires the role to be mapped to a Kubernetes group with the following RBAC permissions:
+
+	//	apiVersion: rbac.authorization.k8s.io/v1
+	//	kind: ClusterRole
+	//	metadata:
+	//		name: teleport-role
+	//	rules:
+	//	- apiGroups:
+	//		- ""
+	//		resources:
+	//		- users
+	//		- groups
+	//		- serviceaccounts
+	//		verbs:
+	//		- impersonate
+	//	- apiGroups:
+	//		- ""
+	//		resources:
+	//		- pods
+	//		verbs:
+	//		- get
+	//	- apiGroups:
+	//		- "authorization.k8s.io"
+	//		resources:
+	//		- selfsubjectaccessreviews
+	//		- selfsubjectrulesreviews
+	//		verbs:
+	//		- create
+
+	// check modules/eks-discovery-ci/ from cloud-terraform repo for more details.
+	kubernetesServiceAssumeRoleEnv = "KUBERNETES_SERVICE_ASSUME_ROLE"
+	// discoveryServiceAssumeRoleEnv is the environment variable that specifies
+	// the IAM role that Teleport Discovery Service will assume to list the EKS clusters.
+	// This role needs to have the following permissions:
+	// - eks:DescribeCluster
+	// - eks:ListClusters
+	// check modules/eks-discovery-ci/ from cloud-terraform repo for more details.
+	discoveryServiceAssumeRoleEnv = "DISCOVERY_SERVICE_ASSUME_ROLE"
+	// discoveredClusterNameEnv is the environment variable that specifies the name of the EKS cluster
+	// that will be created by Teleport Discovery Service.
+	discoveredClusterNameEnv = "DISCOVERED_CLUSTER_NAME"
+)
+
+// checkRequiredEnvVars ensures that the required environment variables are set.
+func checkRequiredEnvVars(t *testing.T) {
+	require.NotEmpty(t, os.Getenv(awsRegionEnv), "AWS_REGION environment variable must be set")
+	require.NotEmpty(t, os.Getenv(kubernetesServiceAssumeRoleEnv), "KUBERNETES_SERVICE_ASSUME_ROLE environment variable must be set")
+	require.NotEmpty(t, os.Getenv(discoveryServiceAssumeRoleEnv), "DISCOVERY_SERVICE_ASSUME_ROLE environment variable must be set")
+	require.NotEmpty(t, os.Getenv(discoveredClusterNameEnv), "DISCOVERED_CLUSTER_NAME environment variable must be set")
+}
+
+// createTeleportClusterWithDiscovery creates a Teleport cluster with Discovery Service enabled for
+// the given EKS cluster tags.
+func createTeleportClusterWithDiscovery(t *testing.T, tags types.Labels) *helpers.TeleInstance {
+	// ensures that the required environment variables are set.
+	checkRequiredEnvVars(t)
+
+	// Create the CA authority that will be used in Auth.
+	priv, pub, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+	const (
+		host   = helpers.Host
+		site   = helpers.Site
+		hostID = helpers.HostID
+	)
+	log := utils.NewLoggerForTests()
+
+	teleport := helpers.NewInstance(t, helpers.InstanceConfig{
+		ClusterName: site,
+		HostID:      host,
+		NodeName:    host,
+		Priv:        priv,
+		Pub:         pub,
+		Log:         log,
+	})
+
+	// Create a new role with full access to all resources.
+	role, err := types.NewRole(
+		"kubemaster",
+		types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				KubeGroups: kubeGroups,
+				KubeUsers:  kubeUsers,
+				KubernetesLabels: types.Labels{
+					types.Wildcard: {types.Wildcard},
+				},
+				KubernetesResources: []types.KubernetesResource{
+					{
+						Kind: types.Wildcard, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard},
+					},
+				},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	// Create a new user with the role created above.
+	teleport.AddUserWithRole(username, role)
+	// Create a new teleport instance with the auth server.
+	err = teleport.CreateEx(t, nil, newTeleportConfig(t, log, tags))
+	require.NoError(t, err)
+	// Start the teleport instance and wait for it to be ready.
+	err = teleport.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, teleport.StopAll())
+	})
+	return teleport
+}
+
+func newTeleportConfig(t *testing.T, log utils.Logger, tags types.Labels) *servicecfg.Config {
+	tconf := servicecfg.MakeDefaultConfig()
+	// Replace the default auth and proxy listeners with the ones so we can
+	// run multiple tests in parallel.
+	tconf.Auth.ListenAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerAuth, &(tconf.FileDescriptors)))
+	tconf.Proxy.WebAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerProxyWeb, &(tconf.FileDescriptors)))
+	tconf.Proxy.Kube.ListenAddr = *utils.MustParseAddr(helpers.NewListener(t, service.ListenerProxyKube, &(tconf.FileDescriptors)))
+	tconf.DataDir = t.TempDir()
+	tconf.Console = nil
+	tconf.Log = log
+	tconf.SSH.Enabled = true
+	tconf.Proxy.DisableWebInterface = true
+	tconf.PollingPeriod = 500 * time.Millisecond
+	tconf.ClientTimeout = time.Second
+	tconf.ShutdownTimeout = 2 * tconf.ClientTimeout
+	tconf.CircuitBreakerConfig = breaker.NoopBreakerConfig()
+	// Enable kubernetes proxy
+	tconf.Proxy.Kube.Enabled = true
+
+	enableKubeService(t, tconf)
+	enableDiscoveryService(t, tconf, tags)
+	return tconf
+}
+
+// enableKubeService sets up the kubernetes service to watch for kubernetes
+// clusters created by the discovery service.
+func enableKubeService(t *testing.T, cfg *servicecfg.Config) {
+	// set kubernetes specific parameters
+	cfg.Kube.Enabled = true
+	cfg.Kube.ListenAddr = utils.MustParseAddr(helpers.NewListener(t, service.ListenerKube, &(cfg.FileDescriptors)))
+	cfg.Kube.ResourceMatchers = []services.ResourceMatcher{
+		{
+			Labels: types.Labels{
+				types.Wildcard: []string{types.Wildcard},
+			},
+			AWS: services.ResourceMatcherAWS{
+				AssumeRoleARN: os.Getenv(kubernetesServiceAssumeRoleEnv),
+			},
+		},
+	}
+}
+
+// enableDiscoveryService sets up the discovery service to watch for EKS clusters
+// in the AWS account.
+func enableDiscoveryService(t *testing.T, cfg *servicecfg.Config, tags types.Labels) {
+	cfg.Discovery.Enabled = true
+	cfg.Discovery.DiscoveryGroup = "e2e-test"
+	// Reduce the polling interval to speed up the test execution
+	// in the case of a failure of the first attempt.
+	// The default polling interval is 5 minutes.
+	cfg.Discovery.PollInterval = 1 * time.Minute
+	cfg.Discovery.AWSMatchers = []types.AWSMatcher{
+		{
+			Types:   []string{services.AWSMatcherEKS},
+			Tags:    tags,
+			Regions: []string{os.Getenv(awsRegionEnv)},
+			AssumeRole: &types.AssumeRole{
+				RoleARN: os.Getenv(discoveryServiceAssumeRoleEnv),
+			},
+		},
+	}
+}

--- a/e2e/aws/main_test.go
+++ b/e2e/aws/main_test.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package integration
+
+import (
+	"testing"
+
+	"github.com/gravitational/teleport/integration/helpers"
+)
+
+// TestMain will re-execute Teleport to run a command if "exec" is passed to
+// it as an argument. Otherwise, it will run tests as normal.
+func TestMain(m *testing.M) {
+	helpers.TestMainImplementation(m)
+}

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -1213,6 +1213,10 @@ func (i *TeleInstance) Start() error {
 		expectedEvents = append(expectedEvents, service.KubernetesReady)
 	}
 
+	if i.Config.Discovery.Enabled {
+		expectedEvents = append(expectedEvents, service.DiscoveryReady)
+	}
+
 	expectedEvents = append(expectedEvents, service.InstanceReady)
 
 	// Start the process and block until the expected events have arrived.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1278,6 +1278,7 @@ func getInstallerProxyAddr(matcher AzureMatcher, fc *FileConfig) string {
 func applyDiscoveryConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	cfg.Discovery.Enabled = fc.Discovery.Enabled()
 	cfg.Discovery.DiscoveryGroup = fc.Discovery.DiscoveryGroup
+	cfg.Discovery.PollInterval = fc.Discovery.PollInterval
 	for _, matcher := range fc.Discovery.AWSMatchers {
 		installParams, err := matcher.InstallParams.Parse()
 		if err != nil {

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -1589,6 +1589,9 @@ type Discovery struct {
 	// for all discovery services. If different agents are used to discover different
 	// sets of cloud resources, this field must be different for each set of agents.
 	DiscoveryGroup string `yaml:"discovery_group,omitempty"`
+	// PollInterval is the cadence at which the discovery server will run each of its
+	// discovery cycles.
+	PollInterval time.Duration `yaml:"poll_interval,omitempty"`
 }
 
 // GCPMatcher matches GCP resources.

--- a/lib/service/discovery.go
+++ b/lib/service/discovery.go
@@ -64,6 +64,7 @@ func (process *TeleportProcess) initDiscoveryService() error {
 		AccessPoint:    accessPoint,
 		Log:            process.log,
 		ClusterName:    conn.ClientIdentity.ClusterName,
+		PollInterval:   process.Config.Discovery.PollInterval,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/service/servicecfg/discovery.go
+++ b/lib/service/servicecfg/discovery.go
@@ -15,6 +15,8 @@
 package servicecfg
 
 import (
+	"time"
+
 	"github.com/gravitational/teleport/api/types"
 )
 
@@ -34,6 +36,9 @@ type DiscoveryConfig struct {
 	// for all discovery services. If different agents are used to discover different
 	// sets of cloud resources, this field must be different for each set of agents.
 	DiscoveryGroup string
+	// PollInterval is the cadence at which the discovery server will run each of its
+	// discovery cycles.
+	PollInterval time.Duration
 }
 
 // IsEmpty validates if the Discovery Service config has no cloud matchers.

--- a/lib/srv/discovery/database_watcher.go
+++ b/lib/srv/discovery/database_watcher.go
@@ -60,6 +60,7 @@ func (s *Server) startDatabaseWatchers() error {
 		Fetchers:       s.databaseFetchers,
 		Log:            s.Log.WithField("kind", types.KindDatabase),
 		DiscoveryGroup: s.DiscoveryGroup,
+		Interval:       s.PollInterval,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/discovery/discovery.go
+++ b/lib/srv/discovery/discovery.go
@@ -73,6 +73,9 @@ type Config struct {
 	DiscoveryGroup string
 	// ClusterName is the name of the Teleport cluster.
 	ClusterName string
+	// PollInterval is the cadence at which the discovery server will run each of its
+	// discovery cycles.
+	PollInterval time.Duration
 }
 
 func (c *Config) CheckAndSetDefaults() error {
@@ -94,6 +97,10 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 	if c.Log == nil {
 		c.Log = logrus.New()
+	}
+
+	if c.PollInterval == 0 {
+		c.PollInterval = 5 * time.Minute
 	}
 
 	c.Log = c.Log.WithField(trace.Component, teleport.ComponentDiscovery)
@@ -176,7 +183,7 @@ func (s *Server) initAWSWatchers(matchers []types.AWSMatcher) error {
 	var err error
 	if len(ec2Matchers) > 0 {
 		s.caRotationCh = make(chan []types.Server)
-		s.ec2Watcher, err = server.NewEC2Watcher(s.ctx, ec2Matchers, s.Clients, s.caRotationCh)
+		s.ec2Watcher, err = server.NewEC2Watcher(s.ctx, ec2Matchers, s.Clients, s.caRotationCh, server.WithPollInterval(s.PollInterval))
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -255,7 +262,7 @@ func (s *Server) initAzureWatchers(ctx context.Context, matchers []types.AzureMa
 	// VM watcher.
 	if len(vmMatchers) > 0 {
 		var err error
-		s.azureWatcher, err = server.NewAzureWatcher(s.ctx, vmMatchers, s.Clients)
+		s.azureWatcher, err = server.NewAzureWatcher(s.ctx, vmMatchers, s.Clients, server.WithPollInterval(s.PollInterval))
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/srv/discovery/kube_watcher.go
+++ b/lib/srv/discovery/kube_watcher.go
@@ -67,6 +67,7 @@ func (s *Server) startKubeWatchers() error {
 		Fetchers:       s.kubeFetchers,
 		Log:            s.Log.WithField("kind", types.KindKubernetesCluster),
 		DiscoveryGroup: s.DiscoveryGroup,
+		Interval:       s.PollInterval,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/server/azure_watcher.go
+++ b/lib/srv/server/azure_watcher.go
@@ -51,14 +51,17 @@ type AzureInstances struct {
 }
 
 // NewAzureWatcher creates a new Azure watcher instance.
-func NewAzureWatcher(ctx context.Context, matchers []types.AzureMatcher, clients cloud.Clients) (*Watcher, error) {
+func NewAzureWatcher(ctx context.Context, matchers []types.AzureMatcher, clients cloud.Clients, opts ...Option) (*Watcher, error) {
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	watcher := Watcher{
-		fetchers:      []Fetcher{},
-		ctx:           cancelCtx,
-		cancel:        cancelFn,
-		fetchInterval: time.Minute,
-		InstancesC:    make(chan Instances),
+		fetchers:     []Fetcher{},
+		ctx:          cancelCtx,
+		cancel:       cancelFn,
+		pollInterval: time.Minute,
+		InstancesC:   make(chan Instances),
+	}
+	for _, opt := range opts {
+		opt(&watcher)
 	}
 	for _, matcher := range matchers {
 		for _, subscription := range matcher.Subscriptions {

--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -87,7 +87,6 @@ func ToEC2Instances(insts []*ec2.Instance) []EC2Instance {
 		ec2Insts = append(ec2Insts, toEC2Instance(inst))
 	}
 	return ec2Insts
-
 }
 
 // ServerInfos creates a ServerInfo resource for each discovered instance.
@@ -118,18 +117,31 @@ func (i *EC2Instances) ServerInfos() ([]types.ServerInfo, error) {
 	return serverInfos, nil
 }
 
+// Option is a functional option for the Watcher.
+type Option func(*Watcher)
+
+// WithPollInterval sets the interval at which the watcher will fetch
+// instances from AWS.
+func WithPollInterval(interval time.Duration) Option {
+	return func(w *Watcher) {
+		w.pollInterval = interval
+	}
+}
+
 // NewEC2Watcher creates a new EC2 watcher instance.
-func NewEC2Watcher(ctx context.Context, matchers []types.AWSMatcher, clients cloud.Clients, missedRotation <-chan []types.Server) (*Watcher, error) {
+func NewEC2Watcher(ctx context.Context, matchers []types.AWSMatcher, clients cloud.Clients, missedRotation <-chan []types.Server, opts ...Option) (*Watcher, error) {
 	cancelCtx, cancelFn := context.WithCancel(ctx)
 	watcher := Watcher{
 		fetchers:       []Fetcher{},
 		ctx:            cancelCtx,
 		cancel:         cancelFn,
-		fetchInterval:  time.Minute,
+		pollInterval:   time.Minute,
 		InstancesC:     make(chan Instances),
 		missedRotation: missedRotation,
 	}
-
+	for _, opt := range opts {
+		opt(&watcher)
+	}
 	for _, matcher := range matchers {
 		for _, region := range matcher.Regions {
 			// TODO(gavin): support assume_role_arn for ec2.
@@ -357,7 +369,6 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 			}
 			return true
 		})
-
 	if err != nil {
 		return nil, common.ConvertError(err)
 	}

--- a/lib/srv/server/watcher.go
+++ b/lib/srv/server/watcher.go
@@ -47,10 +47,10 @@ type Watcher struct {
 	InstancesC     chan Instances
 	missedRotation <-chan []types.Server
 
-	fetchers      []Fetcher
-	fetchInterval time.Duration
-	ctx           context.Context
-	cancel        context.CancelFunc
+	fetchers     []Fetcher
+	pollInterval time.Duration
+	ctx          context.Context
+	cancel       context.CancelFunc
 }
 
 func (w *Watcher) sendInstancesOrLogError(instancesColl []Instances, err error) {
@@ -74,7 +74,7 @@ func (w *Watcher) Run() {
 	if len(w.fetchers) == 0 {
 		return
 	}
-	ticker := time.NewTicker(w.fetchInterval)
+	ticker := time.NewTicker(w.pollInterval)
 	defer ticker.Stop()
 
 	for _, fetcher := range w.fetchers {


### PR DESCRIPTION
# AWS Integration tests
This PR enables AWS E2E integration tests for EKS auto-discovery.

## Step 1: Github Actions Runner acquires AWS credentials

This process uses Github's OIDC connector to access AWS API by assuming the `arn:aws:iam::307493967395:role/tf-aws-e2e-gha-role` role.

```yaml
      - name: Configure AWS Credentials
        uses: aws-actions/configure-aws-credentials@v2
        with:
          aws-region: ${{ env.AWS_REGION }}
          role-to-assume: ${{ env.GHA_ASSUME_ROLE }}
```

`aws-actions/configure-aws-credentials` action generates a new ID token with the information required and signs it using Github's OIDC workflow.

The role `arn:aws:iam::307493967395:role/tf-aws-e2e-gha-role` is an intermediate role for the runner to be able to assume two distinct roles:

-  `arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-kubernetes-service-access-role` - used by Kubernetes Service
-  `arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-discovery-service-access-role` - used by Discovery Service

## Step 2: EKS auto-discovery

The Discovery service will assume role  `arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-discovery-service-access-role` which defines the following policy:

- `eks:ListClusters`
- `eks:DescribeCluster`

These are the minimal permissions required to list the available clusters and retrieve their state and labels. 

Teleport Discovery Service will pull the EKS cluster available and for each cluster to import, it will create a `kube_cluster` object in Auth Server.

## Step 3: Proxying requests

Once the cluster is discovered and the `kube_cluster` exists in Auth server, the Teleport Kubernetes Service will start proxying the cluster.

For that, it must pull the cluster API endpoint and its CA data to create a client.  Role `arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-kubernetes-service-access-role` allows Kubernetes Service to describe the cluster and retrieve its details.

- `eks:DescribeCluster`

The IAM role used by the Kubernetes Service must be mapped to a Kubernetes Group that allows impersonation in order to be able to proxy requests with the user's permissions.

### ClusterRole and ClusterRoleBinding

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: teleport-role
rules:
- apiGroups:
  - ""
  resources:
  - users
  - groups
  - serviceaccounts
  verbs:
  - impersonate
- apiGroups:
  - ""
  resources:
  - pods
  verbs:
  - get
- apiGroups:
  - "authorization.k8s.io"
  resources:
  - selfsubjectaccessreviews
  - selfsubjectrulesreviews
  verbs:
  - create
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: teleport-crb
roleRef:
  apiGroup: rbac.authorization.k8s.io
  kind: ClusterRole
  name: teleport-role
subjects:
- kind: Group
  name: ${group_name}

```

### IAM mapping via `aws-auth` configmap

During the cluster provisioning phase, we mapped the Kubernetes Service IAM role into a Kubernetes Group ` ${group_name}`.

```yaml

mapRoles:
- groups:
  - ${group_name}
  rolearn:arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-kubernetes-service-access-role
  username: "eleport:{{SessionName}}
```

## Step 4: Test cluster connection and forwarding

The final step is to validate the client is working correctly and that the Kubernetes Service was able to generate a valid token that can impersonate Kubernetes groups and users.

For that, we simulate a user calling `kubectl get services -n default` through Teleport that must return 1 entry, the default service `kubernetes`.

Implements #27156