### PR TITLE
[v13] Allow login and port to be specified when using `tsh config` to generate openssh configs

### DIFF
--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -31,6 +31,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -50,7 +51,7 @@ Host *.{{ $clusterName }} {{ $dot.ProxyHost }}
 
 # Flags for all {{ $clusterName }} hosts except the proxy
 Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
-    Port 3022
+    Port {{ $dot.Port }}
     {{- if eq $dot.AppName "tsh" }}
     ProxyCommand "{{ $dot.ExecutablePath }}" proxy ssh --cluster={{ $clusterName }} --proxy={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} %r@%h:%p
 {{- end }}{{- if eq $dot.AppName "tbot" }}
@@ -76,6 +77,8 @@ type SSHConfigParameters struct {
 	ExecutablePath      string
 	Username            string
 	DestinationDir      string
+	// Port is the node port to use, defaulting to 3022, if not specified by flag
+	Port int
 }
 
 type sshTmplParams struct {
@@ -212,6 +215,9 @@ func (c *SSHConfig) GetSSHConfig(sb *strings.Builder, config *SSHConfigParameter
 	} else {
 		c.log.Debugf("Found OpenSSH version %s", version)
 		sshOptions = getSSHConfigOptions(version)
+	}
+	if config.Port == 0 {
+		config.Port = defaults.SSHServerListenPort
 	}
 
 	c.log.Debugf("Using SSH options: %s", sshOptions)

--- a/lib/config/openssh/openssh.go
+++ b/lib/config/openssh/openssh.go
@@ -44,6 +44,9 @@ Host *.{{ $clusterName }} {{ $dot.ProxyHost }}
     IdentityFile "{{ $dot.IdentityFilePath }}"
     CertificateFile "{{ $dot.CertificateFilePath }}"
     HostKeyAlgorithms {{ if $dot.NewerHostKeyAlgorithmsSupported }}rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,{{ end }}ssh-rsa-cert-v01@openssh.com
+    {{- if ne $dot.Username "" }}
+    User "{{ $dot.Username }}"
+{{- end }}
 
 # Flags for all {{ $clusterName }} hosts except the proxy
 Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
@@ -53,6 +56,9 @@ Host *.{{ $clusterName }} !{{ $dot.ProxyHost }}
 {{- end }}{{- if eq $dot.AppName "tbot" }}
     ProxyCommand "{{ $dot.ExecutablePath }}" proxy --destination-dir={{ $dot.DestinationDir }} --proxy={{ $dot.ProxyHost }}:{{ $dot.ProxyPort }} ssh --cluster={{ $clusterName }}  %r@%h:%p
 {{- end }}
+{{- end }}
+    {{- if ne $dot.Username "" }}
+    User "{{ $dot.Username }}"
 {{- end }}
 
 # End generated Teleport configuration
@@ -68,6 +74,7 @@ type SSHConfigParameters struct {
 	ProxyHost           string
 	ProxyPort           string
 	ExecutablePath      string
+	Username            string
 	DestinationDir      string
 }
 

--- a/lib/config/openssh/openssh_test.go
+++ b/lib/config/openssh/openssh_test.go
@@ -122,7 +122,7 @@ func TestSSHConfig_GetSSHConfig(t *testing.T) {
 			},
 		},
 		{
-			name:       "modern OpenSSH - single cluster with username",
+			name:       "modern OpenSSH - single cluster with username and custom port",
 			sshVersion: "9.0.0",
 			config: &SSHConfigParameters{
 				AppName:             TshApp,
@@ -134,6 +134,7 @@ func TestSSHConfig_GetSSHConfig(t *testing.T) {
 				ProxyPort:           "443",
 				ExecutablePath:      "/tmp/tsh",
 				Username:            "testuser",
+				Port:                3232,
 			},
 		},
 	}

--- a/lib/config/openssh/openssh_test.go
+++ b/lib/config/openssh/openssh_test.go
@@ -121,6 +121,21 @@ func TestSSHConfig_GetSSHConfig(t *testing.T) {
 				ExecutablePath:      "/tmp/tsh",
 			},
 		},
+		{
+			name:       "modern OpenSSH - single cluster with username",
+			sshVersion: "9.0.0",
+			config: &SSHConfigParameters{
+				AppName:             TshApp,
+				ClusterNames:        []string{"example.com"},
+				KnownHostsPath:      "/home/alice/.tsh/known_hosts",
+				IdentityFilePath:    "/home/alice/.tsh/keys/example.com/bob",
+				CertificateFilePath: "/home/alice/.tsh/keys/example.com/bob-ssh/example.com-cert.pub",
+				ProxyHost:           "proxy.example.com",
+				ProxyPort:           "443",
+				ExecutablePath:      "/tmp/tsh",
+				Username:            "testuser",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_single_cluster_with_username.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_single_cluster_with_username.golden
@@ -1,0 +1,17 @@
+# Begin generated Teleport configuration for proxy.example.com by tsh
+
+# Common flags for all example.com hosts
+Host *.example.com proxy.example.com
+    UserKnownHostsFile "/home/alice/.tsh/known_hosts"
+    IdentityFile "/home/alice/.tsh/keys/example.com/bob"
+    CertificateFile "/home/alice/.tsh/keys/example.com/bob-ssh/example.com-cert.pub"
+    HostKeyAlgorithms rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,ssh-rsa-cert-v01@openssh.com
+    User "testuser"
+
+# Flags for all example.com hosts except the proxy
+Host *.example.com !proxy.example.com
+    Port 3022
+    ProxyCommand "/tmp/tsh" proxy ssh --cluster=example.com --proxy=proxy.example.com:443 %r@%h:%p
+    User "testuser"
+
+# End generated Teleport configuration

--- a/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_single_cluster_with_username_and_custom_port.golden
+++ b/lib/config/openssh/testdata/TestSSHConfig_GetSSHConfig/modern_OpenSSH_-_single_cluster_with_username_and_custom_port.golden
@@ -10,7 +10,7 @@ Host *.example.com proxy.example.com
 
 # Flags for all example.com hosts except the proxy
 Host *.example.com !proxy.example.com
-    Port 3022
+    Port 3232
     ProxyCommand "/tmp/tsh" proxy ssh --cluster=example.com --proxy=proxy.example.com:443 %r@%h:%p
     User "testuser"
 

--- a/tool/tsh/config.go
+++ b/tool/tsh/config.go
@@ -92,6 +92,7 @@ func onConfig(cf *CLIConf) error {
 		ProxyPort:      proxyPort,
 		ExecutablePath: cf.executablePath,
 		Username:       cf.NodeLogin,
+		Port:           int(cf.NodePort),
 	}, nil); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/config.go
+++ b/tool/tsh/config.go
@@ -91,6 +91,7 @@ func onConfig(cf *CLIConf) error {
 		ProxyHost:      proxyHost,
 		ProxyPort:      proxyPort,
 		ExecutablePath: cf.executablePath,
+		Username:       cf.NodeLogin,
 	}, nil); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -990,6 +990,7 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 	mfa := newMFACommand(app)
 
 	config := app.Command("config", "Print OpenSSH configuration details.")
+	config.Flag("port", "SSH port on a remote host").Short('p').Int32Var(&cf.NodePort)
 
 	// FIDO2, TouchID and WebAuthnWin commands.
 	f2 := newFIDO2Command(app)


### PR DESCRIPTION
Backport #28994 to branch/v13