### PR TITLE
checks core table and audit tables are unique

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -100,7 +100,6 @@ type Config struct {
 // CheckAndSetDefaults is a helper returns an error if the supplied configuration
 // is not enough to connect to DynamoDB
 func (cfg *Config) CheckAndSetDefaults() error {
-
 	// Table name is required.
 	if cfg.TableName == "" {
 		return trace.BadParameter("DynamoDB: table_name is not specified")

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -107,10 +107,10 @@ func (cfg *Config) CheckAndSetDefaults() error {
 	}
 
 	// Check the TableName is not being used within the audit uri list
-	dynamoDBURI := regexp.MustCompile(`((?i)dynamodb)://` + cfg.TableName)
+	dynamodbUriRe := regexp.MustCompile(`((?i)dynamodb)://` + cfg.TableName)
 	for _, auditURI := range cfg.AuditEventsURIs {
-		if dynamoDBURI.MatchString(auditURI) {
-			return trace.BadParameter(("DynamoDB: Same table used for table_name and audit_events_uri. Separate DynamoDB tables are required."))
+		if dynamodbUriRe.MatchString(auditURI) {
+			return trace.BadParameter("DynamoDB: Same table used for table_name and audit_events_uri. Separate DynamoDB tables are required.")
 		}
 	}
 

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -79,10 +79,10 @@ func (cfg *backendConfig) CheckAndSetDefaults() error {
 		return trace.BadParameter("firestore: collection_name is not specified")
 	}
 	// Check the TableName is not being used within the audit uri list
-	googleURI := regexp.MustCompile(`((?i)firestore)://` + cfg.CollectionName)
+	googleUriRe := regexp.MustCompile(`((?i)firestore)://` + cfg.CollectionName)
 	for _, auditURI := range cfg.AuditEventsURIs {
-		if googleURI.MatchString(auditURI) {
-			return trace.BadParameter(("firestore: Same collection name used for collection_name and audit_events_uri. Separate Firestore collections are required."))
+		if googleUriRe.MatchString(auditURI) {
+			return trace.BadParameter("firestore: Same collection name used for collection_name and audit_events_uri. Separate Firestore collections are required.")
 		}
 	}
 	if cfg.ProjectID == "" {


### PR DESCRIPTION
fixes #2542

Checks firestore and dynamodbo configurations do not have the same tables (collections for firestore) in core and audit events.