### PR TITLE
Allow relative file URIs to `sqlite`

### DIFF
--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -178,6 +178,7 @@ func (cfg *Config) ConnectionURI() string {
 
 	u := url.URL{
 		Scheme:   "file",
+		OmitHost: true,
 		Path:     filepath.Join(cfg.Path, defaultDBFile),
 		RawQuery: params.Encode(),
 	}


### PR DESCRIPTION
In my previous PR (https://github.com/gravitational/teleport/pull/29099) I fixed URI generation for paths that contain spaces but broke it for relative paths :(

When `data_dir` points to a non-absolute path (let's say `data`), teleport fails to start with the following error: 
```
Original sqlite3.Error invalid uri authority: data
```
This happens because the generated file URI starts with two slashes and then it expects a hostname (or another slash), but we don't provide any. In that case, `data` is mistakenly treated as a hostname.

To fix this, we can explicitly omit the host, so the URI doesn't start with `//` (and it will work as before).