### PR TITLE
adds check in teleport-cluster for same core and audit event tables

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
@@ -22,4 +22,7 @@
     {{- else }}
     auto_scaling: false
     {{- end }}
+  {{ if eq .Values.aws.auditLogTable .Values.aws.backendTable  }}
+    {{- fail "aws.auditLogTable and aws.backendTable must not be the same table" }}
+  {{- end -}}    
 {{- end -}}

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -181,6 +181,16 @@ tests:
           of: ConfigMap
       - matchSnapshot:
           path: data.teleport\.yaml
+  - it: fails when core and audit events dynamodb table are the same
+    values:
+      - ../.lint/aws-ha.yaml
+    set:
+      aws:
+        backendTable: test-dynamodb-same
+        auditLogTable: test-dynamodb-same
+    asserts:
+      - failedTemplate:
+          errorMessage: "aws.auditLogTable and aws.backendTable must not be the same table"
 
   - it: matches snapshot for aws-ha-antiaffinity.yaml
     values:


### PR DESCRIPTION
Adds check core and audit events table aren't the same table in configuration.

Related to issue https://github.com/gravitational/teleport/issues/2542