### PR TITLE
Reduce embedding period to 20 minutes

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -265,7 +265,7 @@ const (
 	embeddingInitialDelay = 10 * time.Second
 	// embeddingPeriod is the time between two embedding routines.
 	// A seventh jitter is applied on the period.
-	embeddingPeriod = time.Hour
+	embeddingPeriod = 20 * time.Minute
 )
 
 // Connector has all resources process needs to connect to other parts of the


### PR DESCRIPTION
The embedding period in the service code was previously set to 1 hour. This change reduces it to 20 minutes, in order to allow the embedding routines to run more frequently for better UX - people won't need to wait an hour to use Assist after a node is added.

Updates https://github.com/gravitational/teleport.e/issues/1820