### PR TITLE
tctl users add: Point towards `users update` on AlreadyExists err

### DIFF
--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -273,9 +273,10 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 
 	if err := client.CreateUser(ctx, user); err != nil {
 		if trace.IsAlreadyExists(err) {
-			usersUpdateCmd := fmt.Sprintf("> tctl users update %v --set-roles %v # replace roles",
-				u.login, strings.Join(u.allowedRoles, ","))
-			fmt.Printf("NOTE: To update an existing local user:\n%v\n\n", usersUpdateCmd)
+			fmt.Printf(`NOTE: To update an existing local user:
+> tctl users update %v --set-roles %v # replace roles
+
+`, u.login, strings.Join(u.allowedRoles, ","))
 		}
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -273,10 +273,9 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 
 	if err := client.CreateUser(ctx, user); err != nil {
 		if trace.IsAlreadyExists(err) {
-			editUserCmd := fmt.Sprintf("> tctl edit user/%v # edit a YAML representation of the account", u.login)
-			usersUpdateCmd := fmt.Sprintf("> tctl users update %v # replace specific fields with --set flags, e.g. --set-roles", u.login)
-			fmt.Printf("NOTE: This command creates a new user account. To update an existing account, use one of the following:\n%v\n%v\n\n",
-				editUserCmd, usersUpdateCmd)
+			usersUpdateCmd := fmt.Sprintf("> tctl users update %v --set-roles %v # replace roles",
+				u.login, strings.Join(u.allowedRoles, ","))
+			fmt.Printf("NOTE: Use tctl users update to update an existing account:\n%v\n\n", usersUpdateCmd)
 		}
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -275,7 +275,7 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 		if trace.IsAlreadyExists(err) {
 			usersUpdateCmd := fmt.Sprintf("> tctl users update %v --set-roles %v # replace roles",
 				u.login, strings.Join(u.allowedRoles, ","))
-			fmt.Printf("NOTE: Use tctl users update to update an existing account:\n%v\n\n", usersUpdateCmd)
+			fmt.Printf("NOTE: To update an existing local user:\n%v\n\n", usersUpdateCmd)
 		}
 		return trace.Wrap(err)
 	}

--- a/tool/tctl/common/user_command.go
+++ b/tool/tctl/common/user_command.go
@@ -272,6 +272,12 @@ func (u *UserCommand) Add(ctx context.Context, client auth.ClientI) error {
 	user.SetRoles(u.allowedRoles)
 
 	if err := client.CreateUser(ctx, user); err != nil {
+		if trace.IsAlreadyExists(err) {
+			editUserCmd := fmt.Sprintf("> tctl edit user/%v # edit a YAML representation of the account", u.login)
+			usersUpdateCmd := fmt.Sprintf("> tctl users update %v # replace specific fields with --set flags, e.g. --set-roles", u.login)
+			fmt.Printf("NOTE: This command creates a new user account. To update an existing account, use one of the following:\n%v\n%v\n\n",
+				editUserCmd, usersUpdateCmd)
+		}
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
[One of our customers](https://gravitational.zendesk.com/agent/tickets/7662) was following [the Resource Access Requests guide](https://goteleport.com/docs/access-controls/access-requests/resource-requests/?scope=enterprise#step-38-grant-the-roles-to-users) and got confused as to why `tctl users add bob --roles reviewer` doesn't work with an existing user account.

Halfway through creating a ticket for the docs team, I thought "Instead of updating the docs, wouldn't it be better if `tctl users add` told you about`users update` if we see that the account already exists?" This is exactly what this PR does.

Before:

```
$ tctl users add rav --roles access,editor,reviewer
ERROR: user "rav" already registered

```

After:

```
$ tctl users add rav --roles access,editor,reviewer
NOTE: To update an existing local user:
> tctl users update rav --set-roles access,editor,reviewer # replace roles

ERROR: user "rav" already registered

```

The pattern with ">" is already used by `tctl users add` to show an example command when calling `tctl users add --help`. "NOTE:" is already used by `tctl users reset`.

Copy suggestions are welcome!