### PR TITLE
Adjust indentation in Assist YAML conf reference

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -378,15 +378,15 @@ auth_service:
     # in a leaf cluster. Defaults to false.
     load_all_cas: false
 
-  # Configuration for the Teleport Assist functionality
-  assist:
-    openai:
-      # An absolute path to the file containing the API token for OpenAI.
-      # This is required for Assist functionality.
-      api_token_path: /etc/teleport/openai_key
+    # Configuration for the Teleport Assist functionality
+    assist:
+      openai:
+        # An absolute path to the file containing the API token for OpenAI.
+        # This is required for Assist functionality.
+        api_token_path: /etc/teleport/openai_key
 
-    # When executing commands on servers through Teleport Assist,
-    # this is the maximum number of servers that Assist will connect to in parallel.
-    # This only applies in the context of a single command execution -
-    # if multiple users are using Assist concurrently, more connections may be made.
-    command_execution_workers: 30
+      # When executing commands on servers through Teleport Assist,
+      # this is the maximum number of servers that Assist will connect to in parallel.
+      # This only applies in the context of a single command execution -
+      # if multiple users are using Assist concurrently, more connections may be made.
+      command_execution_workers: 30

--- a/docs/pages/includes/config-reference/proxy-service.yaml
+++ b/docs/pages/includes/config-reference/proxy-service.yaml
@@ -148,9 +148,9 @@ proxy_service:
     # one IPs will be rejected.
     trust_x_forwarded_for: false
 
-  # Configuration for the Teleport Assist functionality
-  assist:
-    openai:
-      # An absolute path to the file containing the API token for OpenAI.
-      # This is required for Assist functionality.
-      api_token_path: /etc/teleport/openai_key
+    # Configuration for the Teleport Assist functionality
+    assist:
+      openai:
+        # An absolute path to the file containing the API token for OpenAI.
+        # This is required for Assist functionality.
+        api_token_path: /etc/teleport/openai_key


### PR DESCRIPTION
These files are not consistently formatted in general: first-level under `auth_service` or `proxy_service` is indented by 4 spaces, further levels are then indented by either 2 or 4 spaces. This tries to follow the format of other recently-added fields.