### PR TITLE
Fix reference to azure identity in GCP app

### DIFF
--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -18,7 +18,7 @@ interact with Google Cloud APIs.
 
 The Teleport Application Service connects to the Teleport Proxy Service over a
 reverse tunnel, so you can run the Application Service in a private network and
-prevent unauthorized access to your organization's Google Cloud service accounts. 
+prevent unauthorized access to your organization's Google Cloud service accounts.
 
 ## Prerequisites
 
@@ -27,10 +27,10 @@ prevent unauthorized access to your organization's Google Cloud service accounts
 - A Google Cloud account with permissions to create IAM roles and service
   accounts, as well as create IAM role bindings for service accounts and
   projects.
-  
+
 - The `gcloud` CLI tool. Follow the [Google Cloud documentation
   page](https://cloud.google.com/sdk/docs/install-sdk) to install and
-  authenticate to `gcloud`. 
+  authenticate to `gcloud`.
 
   <Notice type="tip">
 
@@ -160,13 +160,13 @@ $ gcloud iam service-accounts add-iam-policy-binding \
  teleport-vm-viewer@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
  --member=serviceAccount:teleport-google-cloud-cli@<Var name="google-cloud-project" />.iam.gserviceaccount.com \
   --role="roles/iam.serviceAccountTokenCreator"
-```  
+```
 
 ## Step 2/4. Deploy the Teleport Application Service
 
 At this point, you have created a controlling service account and enabled this
 service account to impersonate the service accounts you would like Teleport
-users to access. 
+users to access.
 
 In this step, you will attach the controlling service account to a Google
 Compute Engine VM, then run the Teleport Application Service.
@@ -299,7 +299,7 @@ and port of your Teleport Proxy Service or Teleport Cloud tenant, e.g.,
 `mytenant.teleport.sh:443`.
 
 The `app_service` field configures the Teleport Application Service. Each item
-within `app_service.apps` is an application configuration. 
+within `app_service.apps` is an application configuration.
 
 In the example above, we have enabled Google Cloud CLI access by registering an
 application called `google-cloud-cli` with the `cloud` field set to `GCP`. The
@@ -389,11 +389,11 @@ In your identity provider, define a custom SAML attribute or OIDC claim called
 must be a list of Google Cloud service account URIs, using the following format:
 
 ```text
-/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/RESOURCE_GROUP_NAME/providers/Microsoft.ManagedIdentity/userAssignedIdentities/IDENTITY_NAME
+<service_account_name>@<project_id>.iam.gserviceaccount.com
 ```
 
 For example, you can set a user's `gcp_service_accounts` to `teleport-vm-viewer`
-by using the following URI, replacing `my-project` with the name of your Google
+by using the following URI, replacing `<project_id>` with the name of your Google
 Cloud project:
 
 ```text
@@ -467,7 +467,7 @@ $ tctl create -f google-cloud-cli-access.yaml
 
 You can define a Teleport role that denies a user access to one or more Google
 Cloud service accounts. To do so, assign values to the `gcp_service_accounts`
-field within the `spec.deny` section of a `role` resource. 
+field within the `spec.deny` section of a `role` resource.
 
 For example, this role denies the user access to all Google Cloud service accounts:
 
@@ -488,7 +488,7 @@ spec:
 The `no-google-cloud` role enables the user to access all registered
 applications, but makes use of the wildcard character (`*`) within the
 `deny.gcp_service_accounts` field to prevent the user from assuming any Google
-Cloud service account. 
+Cloud service account.
 
 Unlike values of `allow.gcp_service_accounts`, values of
 `deny.gcp_service_accounts` can include wildcard expressions in addition to the
@@ -531,7 +531,7 @@ $ tsh apps login google-cloud-cli --gcp-service-account teleport-vm-viewer
 This command validates the value of the `--gcp-service-account` flag against the
 ones the user is authorized to assume. The value of the flag can either be the
 full URI of the service account or the name of the identity, e.g.,
-`teleport-vm-viewer`. 
+`teleport-vm-viewer`.
 
 A user can omit the `--gcp-service-account` flag if they are only authorized to
 access a single Google Cloud service account, but otherwise an empty
@@ -551,7 +551,7 @@ Example command: tsh gcloud compute instances list
 At this point, you can run `gcloud` commands using the Teleport Application
 Service by prefixing them with `tsh`. Since your user authenticated to your
 Google Cloud CLI application with a service account that can list VMs, for
-example, run this command to do so: 
+example, run this command to do so:
 
 ```code
 $ tsh gcloud compute instances list
@@ -597,7 +597,7 @@ authenticate requests to Google Cloud's APIs.
 To start the local proxy, run the following `tsh` command:
 
 ```code
-$ tsh proxy gcloud 
+$ tsh proxy gcloud
 ```
 
 The command will print the address of the local proxy server along with


### PR DESCRIPTION
This PR fixes a typo on our Google Cloud guide that incorrectly refers to the azure identity format instead of the GCP format.