### PR TITLE
[RFD] 0143 - External Kubernetes Joining

### DIFF
--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -222,8 +222,9 @@ This does raise a few concerns:
   into a cluster.
 - This raises the potential fallout from a compromised Kubernetes Agent. A
   compromised agent could be used to impersonate any service account.
-- It is relatively unusual in the Teleport codebase for the Auth Server to
-  rely on connectivity to an agent to function.
+- There is no prior art for the Auth Server connecting directly to an Agent.
+  It's also possible that a Kubernetes Agent may not live within a Kubernetes
+  Cluster when using auto-discovery.
 
 We should revisit this in the long term and determine if there are more
 elegant ways for us to allow external Kubernetes cluster joining with the

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -49,3 +49,35 @@ experience.
 ## Alternatives
 
 ### Extending the existing Kubernetes join method
+
+Extending the existing Kubernetes join method to support external joining
+has two key issues.
+
+The first issue is connectivity. The existing Kubernetes join method relies on
+the Auth Service's ability to call the TokenReview endpoint exposed by the
+Kubernetes API server. This means there must be some sort of network
+connectivity and the appropriate firewall rules to allow the request to pass.
+
+The second issue is authentication. Calling the TokenReview RPC requires some 
+form of authentication. At the moment, the Auth Service relies on a Kubernetes
+service account available to it by virtue of running in the cluster. 
+
+The issue with authentication could be solved by allowing an operator to
+configure credentials for the Kubernetes cluster as part of the join token
+specification. This, however, does not solve the issue of connectivity.
+
+One solution that would solve the connectivity and authentication problems
+would be to use an existing Teleport Kubernetes Agent deployed into a
+Kubernetes Cluster as a "stepping stone". This Agent would have a service
+account with a role that granted it the ability to call TokenReview, hence
+solving the authentication problem, and the Auth Service would be able to
+communicate with the Kubernetes Agent over the Proxy reverse tunnel.
+
+This solution has two key problems:
+
+- It presents a "chicken and egg" problem. The initial Kubernetes Agent
+  deployed to the cluster would not be able to use the Kubernetes Join method.
+- It grants a potentially dangerous amount of access to the Kubernetes Agent.
+  As it would complete the TokenReview, a hijacked Kubernetes Agent could be
+  used to trick the Auth Service into accepting any token as legitimate for
+  that cluster. This presents a pathway for privilege escalation.

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -95,6 +95,7 @@ This configuration is defined in Protobuf form as:
 
 ```protobuf
 syntax = "proto3";
+
 message ProvisionTokenSpecV2KubernetesJWKS {
   // Rule is a set of properties the Kubernetes-issued token might have to be
   // allowed to use this ProvisionToken
@@ -182,8 +183,6 @@ subjects:
 
 ### Implementation
 
-<-- TODO: Specs for RegisterUsingKubernetesJWKS RPC -->
-
 The `kubernetes-jwks` flow will leverage a challenge and response flow, similar
 to that implemented for IAM joining. The flow will run as follows:
 
@@ -210,6 +209,12 @@ to that implemented for IAM joining. The flow will run as follows:
     matches one of those configured in the allow rules of the token resource.
 6. If the JWT passes validation, certificates are signed and returned to the 
   client.
+
+This flow leverages the follow gRPC RPCs and Protobuf messages:
+
+```protobuf
+syntax = "proto3";
+```
 
 ## Security Considerations
 

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -229,8 +229,32 @@ However, this join method is still more secure than the long-lived secret
 based `token` join method that operators are forced to use due to this
 external Kubernetes join method not existing.
 
-The risk of token reuse will be mitigated by the inclusion of a nonce within
-the audience of the JWT, as described under details.
+### Token reuse
+
+Token reuse refers to the potential for a malicious actor to intercept
+communications between the client and the server, and to use this interception
+to capture the JWT and then use this elsewhere to obtain credentials.
+
+Token reuse is mitigated in two ways:
+
+- A challenge and solution flow is used with a nonce. This means that each
+  JWT is only valid once for a specific join. In order to use this JWT, the
+  malicious actor would need to cause the real join flow to fail.
+- A short time-to-live will be used on JWTs issued for the join process. This
+  limits the malicious actors options and forces them to use the JWT
+  immediately.
+
+### Kubernetes CA Compromise
+
+One of the largest risks to any delegated join method is the trusted parties
+issuer becoming compromised. This is no different for this new Kubernetes join
+method. If the Kubernetes Cluster's JWT CA is compromised, then a malicious 
+actor will be able to issue a JWT posing as any theoretical service account.
+
+There is no mitigation route for this risk. It is up to the operator to secure
+their Kubernetes cluster appropriately and to ensure that join tokens that
+delegate trust to this cluster are appropriately scoped in privileges to reduce
+the blast radius if their Kubernetes CA were to become compromised.
 
 ## Alternatives
 

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -182,7 +182,6 @@ subjects:
 
 ### Implementation
 
-<-- TODO: Write this in more detail -->
 <-- TODO: Specs for RegisterUsingKubernetesJWKS RPC -->
 
 The `kubernetes-jwks` flow will leverage a challenge and response flow, similar

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -1,0 +1,51 @@
+---
+authors: Noah Stride (noah.stride@goteleport.com)
+state: draft
+---
+
+# RFD 00143 - External Kubernetes joining
+
+## Required approvers
+
+* Engineering: @zmb3 && (@hugoShaka || @tigrato)
+* Product: @klizhentas || @xinding33
+* Security: @reedloden
+
+## What
+
+This RFD proposes a method for allowing entities (such as a Machine ID instance
+or an Agent) to join Teleport Clusters via federation between the Kubernetes 
+Cluster they reside in and a Teleport Cluster, where that Teleport Cluster does 
+not reside in the same Kubernetes Cluster.
+
+This is distinct from 
+[RFD 0094 - Kubernetes node joining](./0094-kubernetes-node-joining.md) which
+only supports the joining entity existing within the same Kubernetes Cluster
+as the Teleport Cluster.
+
+## Why
+
+It is not unusual for users to wish to deploy Machine ID bots and Teleport
+Agents in Kubernetes Clusters which is not the same cluster in which their
+Auth Service resides. For example, they may operate many Kubernetes Clusters or
+they may use Teleport Cloud (in which we host their Teleport Cluster).
+
+Currently, these users must use a different join method, and, for users
+deploying into environments where there is no platform-specific delegated
+join method, they must fallback to using the `token` join method which is a
+sensitive, long-lived, secret. This also requires some element of state, and
+is inconvenient in more ephemeral use-cases.
+
+To provide a more concrete use-case, many users currently deploy Teleport
+Plugins (such as the Slack Access Request plugin). Adding support for External
+Kubernetes Joining will provide a golden pathway for this deployment using
+Machine ID that avoids long-lived shared secrets and provides a seamless 
+experience.
+
+## Details
+
+## Security Considerations
+
+## Alternatives
+
+### Extending the existing Kubernetes join method

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -178,6 +178,9 @@ as the `in_cluster` variant.
     ProvisionToken.
   b. The JWT is not expired, and at the time of issue, the JWTs TTL was short.
     This ensures that users are using the recommended configured TTL value.
+    As the Kubernetes minimum TTL is 10 minutes, we will ensure that this has
+    been configured to at most 30 minutes to allow for some flexibility in
+    configuration.
   c. The JWTs audience claim matches the cluster name.
   d. The JWT includes the `kubernetes.io` claim which binds it to a specified
     namespace and pod.

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -49,7 +49,7 @@ experience.
 This join method will be added to the existing `ProvisionTokenV2` specification.
 
 In order to clearly distinguish this new join method from the existing
-`kubernetes` join method, this method will be named `kubernetes-jwks`.
+`kubernetes` join method, this method will be named `kubernetes-remote`.
 
 Similar to other join methods, users will be able to configure a list of allow
 rules. If a joining entities presented token matches any of the allow rules 
@@ -65,12 +65,12 @@ Example token configuration:
 kind: token
 version: v2
 metadata:
-  name: kubernetes-jwks-token
+  name: kubernetes-remote-token
 spec:
   roles: ["Bot"]
   bot_name: argocd
-  join_method: "kubernetes-jwks",
-  kubernetes_jwks:
+  join_method: "kubernetes-remote",
+  kubernetes_remote:
     clusters:
     - name: my-cluster
       # static_jwks is obtained by the user by following the steps after this 
@@ -142,7 +142,7 @@ In the case that an operator rotates the certificate authority used by their
 Kubernetes Cluster to sign Service Account JWTS, the `jwks` field will also
 need to be updated.
 
-#### Configuring a pod for `kubernetes-jwks` joining
+#### Configuring a pod for `kubernetes-remote` joining
 
 The Pod will require a service account with a role granting it the ability to
 call the TokenRequest endpoint for itself. This allows the creation of a token
@@ -183,7 +183,7 @@ subjects:
 
 ### Implementation
 
-The `kubernetes-jwks` flow will leverage a challenge and response flow, similar
+The `kubernetes-remote` flow will leverage a challenge and response flow, similar
 to that implemented for IAM joining. The flow will run as follows:
 
 1. The client wishing to join calls the `RegisterUsingKubernetesJWKS` RPC. It

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -51,11 +51,11 @@ To configure the Teleport for external Kubernetes joining, the existing
 
 A new `type` field will be introduced with two possible values:
 
-- `incluster`: the current behaviour of Kubernetes joining based on TokenReview.
+- `in_cluster`: the current behaviour of Kubernetes joining based on TokenReview.
 - `static_jwks`: enables the new behaviour based on validation of the token
   against a known JWKS.
 
-Where no value has been provided, this will default to `incluster`.
+Where no value has been provided, this will default to `in_cluster`.
 
 Example token configuration:
 
@@ -106,9 +106,9 @@ message ProvisionTokenSpecV2Kubernetes{
 
   // Type specifies what behaviour should be used for validating a
   // Kubernetes Service Account token. This must be
-  // - `incluster`
+  // - `in_cluster`
   // - `static_jwks`
-  // If omitted, it will default to `incluster`.
+  // If omitted, it will default to `in_cluster`.
   string Type = 2;
 
   // StaticJWKS contains configuration specific to the `static_jwks` type.
@@ -165,14 +165,14 @@ spec:
 ### Implementation
 
 The `static_jwks` variant will leverage some of the same parts of the flow
-as the `incluster` variant.
+as the `in_cluster` variant.
 
-1. As with `incluster`, the client loads the service account JWT from the
+1. As with `in_cluster`, the client loads the service account JWT from the
   filesystem that was mounted by Kubelet and calls `RegisterUsingToken` with 
   this JWT and the name of the token it wishes to join using.
 2. The Auth Server finds the ProvisionToken matching the name of token. If this
   is a ProvisionToken with `type: static_jwks`, the flow now diverges from the
-  existing `incluster` implementation.
+  existing `in_cluster` implementation.
 5. The Auth Server validates:
   a. The JWT is signed by the keys present in the `jwks` field of the 
     ProvisionToken.
@@ -191,10 +191,10 @@ This flow requires no modifications to the existing RPC protobufs.
 ## Security Considerations
 
 It's important to note that this join method will be less secure than the 
-`incluster` variant. This should be explicitly mentioned in documentation
-for this join method, and encourage the use of `incluster` where possible.
+`in_cluster` variant. This should be explicitly mentioned in documentation
+for this join method, and encourage the use of `in_cluster` where possible.
 
-This is because the `incluster` join method makes use of the TokenReview 
+This is because the `in_cluster` join method makes use of the TokenReview 
 endpoint which performs additional checks to the validity of the token. This 
 includes checking that the pod and service account listed within the JWT claims 
 exist and are running. This increases the complexity of falsifying a 

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -9,7 +9,7 @@ state: draft
 
 * Engineering: @zmb3 && (@hugoShaka || @tigrato)
 * Product: @klizhentas || @xinding33
-* Security: @reedloden
+* Security: @reedloden || @jentfoo
 
 ## What
 

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -234,6 +234,13 @@ However, this join method is still more secure than the long-lived secret
 based `token` join method that operators are forced to use due to this
 external Kubernetes join method not existing.
 
+As with any delegated join method, sufficient compromise of the trusted party 
+(in this case, the Kubernetes Clusters OIDC CA private key) means that a
+malicious actor is able to use any join token that delegates trust to the
+compromised party. There is little mitigation we can apply here, beyond
+reminding operators of this fact and encouraging them to use security best
+practices to secure the Kubernetes CAs. 
+
 ### Token reuse
 
 Token reuse refers to the potential for a malicious actor to intercept

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -3,7 +3,7 @@ authors: Noah Stride (noah.stride@goteleport.com)
 state: draft
 ---
 
-# RFD 00143 - External Kubernetes delegated joining (jwks)
+# RFD 00143 - Static JWKS External Kubernetes Joining
 
 ## Required approvers
 
@@ -18,10 +18,10 @@ or an Agent) to join Teleport Clusters via federation between the Kubernetes
 Cluster they reside in and a Teleport Cluster, where that Teleport Cluster does 
 not reside in the same Kubernetes Cluster.
 
-This is distinct from 
+This extends
 [RFD 0094 - Kubernetes node joining](./0094-kubernetes-node-joining.md) which
 only supports the joining entity existing within the same Kubernetes Cluster
-as the Teleport Cluster.
+as the Teleport Cluster at this time.
 
 ## Why
 
@@ -46,18 +46,16 @@ experience.
 
 ### Configuration
 
-This join method will be added to the existing `ProvisionTokenV2` specification.
+To configure the Teleport for external Kubernetes joining, the existing
+`kubernetes` join method will be used.
 
-In order to clearly distinguish this new join method from the existing
-`kubernetes` join method, this method will be named `kubernetes-remote`.
+A new `type` field will be introduced with two possible values:
 
-Similar to other join methods, users will be able to configure a list of allow
-rules. If a joining entities presented token matches any of the allow rules 
-then it will be allowed to join.
+- `incluster`: the current behaviour of Kubernetes joining based on TokenReview.
+- `static_jwks`: enables the new behaviour based on validation of the token
+  against a known JWKS.
 
-Each join token will be linked to a specific Kubernetes Cluster. It will not
-be possible to create a join token which can be used for joining from multiple
-Kubernetes Clusters.
+Where no value has been provided, this will default to `incluster`.
 
 Example token configuration:
 
@@ -69,26 +67,16 @@ metadata:
 spec:
   roles: ["Bot"]
   bot_name: argocd
-  join_method: "kubernetes-remote",
-  kubernetes_remote:
-    clusters:
-    - name: my-cluster
-      # static_jwks is obtained by the user by following the steps after this 
-      # example configuration.
-      static_jwks: |
-        {"keys":[{"use":"sig","kty":"RSA","kid":"-snip-","alg":"RS256","n":"-snip-","e":"-snip-"}]}
-    - name: my-other-cluster
-      static_jwks: |
+  join_method: "kubernetes"
+  kubernetes:
+    type: static_jwks
+    static_jwks:
+    - jwks: |
         {"keys":[{"use":"sig","kty":"RSA","kid":"-snip-","alg":"RS256","n":"-snip-","e":"-snip-"}]}
     allow:
     # Matches a SA JWT from any configured cluster in the namespace
     # `my-namespace` and named `my-service-account`.
     - service_account: "my-namespace:my-service-account"
-    # Matches only SA JWT signed by the configured cluster above named
-    # `my-other-cluster` and from the `my-namespace` namespace and named
-    # `my-other-service-account`.
-    - service_account: "my-namespace:my-other-service-account"
-      cluster: my-other-cluster
 ```
 
 This configuration is defined in Protobuf form as:
@@ -96,42 +84,35 @@ This configuration is defined in Protobuf form as:
 ```protobuf
 syntax = "proto3";
 
-message ProvisionTokenSpecV2KubernetesJWKS {
+message ProvisionTokenSpecV2KubernetesStaticJWKS{
+  // JWKS contains the JSON Web Keys to validate a service account token
+  // against. This should be copied from the Kubernetes server's JWKS endpoint
+  // (/openid/v1/jwks).
+  string JWKS = 1;
+}
+
+message ProvisionTokenSpecV2Kubernetes{
   // Rule is a set of properties the Kubernetes-issued token might have to be
   // allowed to use this ProvisionToken
   message Rule {
     // ServiceAccount is the namespaced name of the Kubernetes service account.
     // Its format is "namespace:service-account".
     string ServiceAccount = 1;
-    // Clusters specifies which of the clusters this allow rule applies to.
-    // If unspecified, this allow rule will not be restricted to a specific
-    // cluster.
-    repeated string Clusters = 2;
-  }
-
-  // Cluster is a set of properties that describe a cluster that an entity may
-  // attempt to join from.
-  message Cluster {
-    // Name is an identifier configured for the cluster. This value is chosen
-    // by the user, and does not have to match a specific value configured in
-    // Kubernetes.
-    string Name = 1;
-    // Source is how the public signing keys for the cluster will be obtained
-    // to use for validating a provided JWT.
-    oneof Source {
-      // StaticJWKS allows the public signing keys for a cluster to be
-      // specified statically with the JSON body of the JWKS endpoint.
-      string StaticJWKS = 2;
-    }
   }
   
-  // Clusters is a list of Cluster that are accepted sources of JWTs to use
-  // against this token. A Service Account JWT signed by a cluster not listed
-  // here will be rejected.
-  repeated Cluster Clusters = 1;
   // Allow is a list of Rules, nodes using this token must match one
   // allow rule to use this token.
-  repeated Rule Allow = 2;
+  repeated Rule Allow = 1;
+
+  // Type specifies what behaviour should be used for validating a
+  // Kubernetes Service Account token. This must be
+  // - `incluster`
+  // - `static_jwks`
+  // If omitted, it will default to `incluster`.
+  string Type = 2;
+
+  // StaticJWKS contains configuration specific to the `static_jwks` type.
+  ProvisionTokenSpecV2KubernetesStaticJWKS StaticJWKS = 3;
 }
 ```
 
@@ -146,84 +127,58 @@ In the case that an operator rotates the certificate authority used by their
 Kubernetes Cluster to sign Service Account JWTS, the `jwks` field will also
 need to be updated.
 
-#### Configuring Kubernetes RBAC
+#### Configuring Kubernetes
 
-The pod will require a service account that grants it access to generate a token
-for the service account used for joining. It is our recommendation that these
-two service accounts are seperate. The Kubernetes RBAC for generating tokens
-is not finely grained, and creating a service account which can impersonate
-itself gives a bad actor who has access to the pod the ability to create
-long-lived and unbound tokens. By using a second service account for joining, 
-the primary service account is no longer given the permission to generate a
-token for itself and can instead only generate tokens for the permissionless
-secondary service account.
+The joining entity will need to exist in a pod where a Service Account token
+has been projected with an audience equal to the name of the Teleport cluster.
 
-E.g for a service account named: "foo":
+E.g for a Teleport cluster named: "example.teleport.sh":
 
 ```yaml
-# This is the primary SA that will be bound to the pod.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: foo
+  name: my-service-account
 ---
-# This is the secondary SA that has no permissions within Kubernetes but is 
-# used by Teleport for joining.
 apiVersion: v1
-kind: ServiceAccount
+kind: Pod
 metadata:
-  name: foo-join
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: Role
-metadata:
-  name: foo-join-impersonator
-rules:
-- apiGroups: [""]
-  resources:
-  - "serviceaccounts/token"
-  verbs:
-  - "create"
-  # Only grant the ability to create tokens for the secondary service account.
-  # WARNING: Missing this field leads to a dangerously powerful role.
-  resourceNames:
-    - foo-join
----
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
-metadata:
-  name: foo-join-impersonator
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: Role
-  name: foo-join-impersonator
-subjects:
-- kind: ServiceAccount
-  name: foo
+  name: nginx
+spec:
+  containers:
+    - image: nginx
+      name: nginx
+      volumeMounts:
+        - mountPath: /var/run/secrets/tokens
+          name: my-service-account
+  serviceAccountName: my-service-account
+  volumes:
+    - name: my-service-account
+      projected:
+        sources:
+          - serviceAccountToken:
+              path: my-service-account
+              expirationSeconds: 600
+              audience: example.teleport.sh
 ```
 
 ### Implementation
 
-The `kubernetes-remote` flow will leverage a challenge and response flow, similar
-to that implemented for IAM joining. The flow will run as follows:
+The `static_jwks` variant will leverage some of the same parts of the flow
+as the `incluster` variant.
 
-1. The client wishing to join calls the `RegisterUsingKubernetesRemoteMethod`
-  RPC. It submits the name of the token it wants to use.
-2. The Auth Server sends a response with the audience that should be set in the 
-  token. This audience is a concatenation of the cluster name, and 24 bytes of
-  cryptographically random data encoded in base64 URL encoding, e.g:
-  `example.teleport.sh/YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4`
-3. The client uses its Kubernetes Service Account to call TokenRequest. It
-  requests a JWT for the secondary service account, with the audience specified
-  by the Auth Server and with a short time-to-live.
-4. The client sends a further request up the stream including this token.
-5. The server validates:
-  a. The JWT is signed by the keys present in the `jwks` field of the token 
-    resource.
-  b. The JWT is not expired, and at the time of issue, the JWTs TTL was short
-   (e.g within a similar TTL to the 30s TTL we set)
-  c. The JWTs audience claim matches the one the server challenged the client
-    with.
+1. As with `incluster`, the client loads the service account JWT from the
+  filesystem that was mounted by Kubelet and calls `RegisterUsingToken` with 
+  this JWT and the name of the token it wishes to join using.
+2. The Auth Server finds the ProvisionToken matching the name of token. If this
+  is a ProvisionToken with `type: static_jwks`, the flow now diverges from the
+  existing `incluster` implementation.
+5. The Auth Server validates:
+  a. The JWT is signed by the keys present in the `jwks` field of the 
+    ProvisionToken.
+  b. The JWT is not expired, and at the time of issue, the JWTs TTL was short.
+    This ensures that users are using the recommended configured TTL value.
+  c. The JWTs audience claim matches the cluster name.
   d. The JWT includes the `kubernetes.io` claim which binds it to a specified
     namespace and pod.
   e. The JWT subject claim is for a service account, and this service account 
@@ -231,47 +186,15 @@ to that implemented for IAM joining. The flow will run as follows:
 6. If the JWT passes validation, certificates are signed and returned to the 
   client.
 
-This flow leverages the follow gRPC RPCs and Protobuf messages:
-
-```protobuf
-syntax = "proto3";
-
-package proto;
-
-message RegisterUsingKubernetesRemoteMethodRequest {
-  oneof payload {
-    // register_using_token_request holds registration parameters common to all
-    // join methods.
-    types.RegisterUsingTokenRequest register_using_token_request = 1;
-    // jwt is the solution to the registration challenge-response. It is a
-    // JWT issued by the Kubernetes CA containing the challenge audience sent by
-    // the Auth Server.
-    string jwt = 2;
-  }
-}
-
-message RegisterUsingKubernetesRemoteMethodResponse {
-  oneof payload {
-    // challenge_audience is the audience that the client should use when
-    // calling the Kubernetes API TokenRequest method.
-    string challenge_audience = 1;
-    // certs is the returned signed certs if registration succeeds.
-    Certs certs = 2;
-  }
-}
-
-service JoinService {
-  rpc RegisterUsingKubernetesRemoteMethod(stream RegisterUsingKubernetesRemoteMethodRequest) returns (stream RegisterUsingKubernetesRemoteMethodResponse);
-}
-```
+This flow requires no modifications to the existing RPC protobufs.
 
 ## Security Considerations
 
 It's important to note that this join method will be less secure than the 
-`kubernetes` join method. This should be explicitly mentioned in documentation
-for this join method, and encourage the use of `kubernetes` where possible.
+`incluster` variant. This should be explicitly mentioned in documentation
+for this join method, and encourage the use of `incluster` where possible.
 
-This is because the `kubernetes` join method makes use of the TokenReview 
+This is because the `incluster` join method makes use of the TokenReview 
 endpoint which performs additional checks to the validity of the token. This 
 includes checking that the pod and service account listed within the JWT claims 
 exist and are running. This increases the complexity of falsifying a 
@@ -280,15 +203,7 @@ pod it is bound to. We can mimic this by using a very short time to live for
 the JWT (30 seconds).
 
 However, this join method is still more secure than the long-lived secret
-based `token` join method that operators are forced to use due to this
-external Kubernetes join method not existing.
-
-As with any delegated join method, sufficient compromise of the trusted party 
-(in this case, the Kubernetes Clusters OIDC CA private key) means that a
-malicious actor is able to use any join token that delegates trust to the
-compromised party. There is little mitigation we can apply here, beyond
-reminding operators of this fact and encouraging them to use security best
-practices to secure the Kubernetes CAs. 
+based `token` join method.
 
 ### Token reuse
 
@@ -296,14 +211,13 @@ Token reuse refers to the potential for a malicious actor to intercept
 communications between the client and the server, and to use this interception
 to capture the JWT and then use this elsewhere to obtain credentials.
 
-Token reuse is mitigated in two ways:
+To mitigate this, a short time-to-live will be used on JWTs issued for the join 
+process. This limits the malicious actors options and forces them to use the JWT
+immediately.
 
-- A challenge and solution flow is used with a nonce. This means that each
-  JWT is only valid once for a specific join. In order to use this JWT, the
-  malicious actor would need to cause the real join flow to fail.
-- A short time-to-live will be used on JWTs issued for the join process. This
-  limits the malicious actors options and forces them to use the JWT
-  immediately.
+In addition, the audience field is used to ensure that the Teleport Cluster is
+the intended recipient of the JWT and that this has not been stolen from another
+relying party.
 
 ### Kubernetes CA Compromise
 
@@ -319,47 +233,29 @@ the blast radius if their Kubernetes CA were to become compromised.
 
 ## Alternatives
 
-### Extending the existing `kubernetes` join method
+### Introducing a seperate `kubernetes_remote` join method
 
-Extending the existing `kubernetes` join method to support external joining
-has two key issues.
+One alternative implementation was to introduce a new `kubernetes_remote` join
+method that would use a bi-di gRPC RPC to create a challenge and response flow
+using the audience field of the token.
 
-The first issue is connectivity. The `kubernetes` join method relies on the Auth
-Service's ability to call the TokenReview endpoint exposed by the Kubernetes API
-server. This means there must be network connectivity and the appropriate 
-firewall rules to allow the request to pass. Many users operate clusters that
-are not exposed to the internet, and this means Teleport Cloud would not work
-without some additional way to pass traffic to the external Kubernetes cluster
-API server.
+The Pod would use the TokenRequest Kubernetes API endpoint to request a JWT for
+a Service Account including the challenge audience.
 
-The second issue is authentication. Calling the TokenReview RPC requires some 
-form of authentication. At the moment, the Auth Service relies on a Kubernetes
-service account available to it by virtue of being a workload within the
-cluster.
+This implementation had the following concerns:
+- We could no longer determine reliably the Pod that the Service Account was
+  linked to. This reduced audit visibility.
+- The challenge and response flow did not fully mitigate man-in-the-middle
+  attacks.
+- Limitations of the Kubernetes RBAC model meant we would need to leverage
+  two service accounts in order to prevent TokenRequest being used to create
+  an infinitely long-lived token. This was also more complex as two service
+  accounts would be to be created, as well as roles and role bindings.
+- A bi-di challenge-response flow is more technically complex and has more 
+  points of failure.
 
-The issue with authentication could be solved by allowing an operator to
-configure credentials for the Kubernetes cluster as part of the join token
-specification. This, however, does not solve the issue of connectivity and
-introduces further complexities as to how we would safeguard customer
-credentials in Teleport Cloud.
-
-One solution that would solve the connectivity and authentication problems
-would be to use an existing Teleport Kubernetes Agent deployed into a
-Kubernetes Cluster as a "stepping stone". Existing methods for executing a
-Kubernetes request could be leveraged by the Auth Server and identity
-impersonation used to ensure the request is completed with a group that has
-access to the TokenReview RPC.
-
-This does raise a few concerns:
-
-- This method would not be suitable for deploying the first Kubernetes Agent
-  into a cluster.
-- This raises the potential fallout from a compromised Kubernetes Agent. A
-  compromised agent could be used to impersonate any service account.
-- There is no prior art for the Auth Server connecting directly to an Agent.
-  It's also possible that a Kubernetes Agent may not live within a Kubernetes
-  Cluster when using auto-discovery.
-
-We should revisit this in the long term and determine if there are more
-elegant ways for us to allow external Kubernetes cluster joining with the
-`kubernetes` join method.
+As well as the technical concerns, the UX was also more complex. Users would
+need to understand the two Kubernetes join methods and configuration would
+often involve similar, but subtly different, options. The proposed
+implementation is this RFD is simpler and reuses the same concepts as used in
+the existing Kubernetes join method (providing better uniformity).

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -214,6 +214,34 @@ This flow leverages the follow gRPC RPCs and Protobuf messages:
 
 ```protobuf
 syntax = "proto3";
+
+package proto;
+
+message RegisterUsingKubernetesRemoteMethodRequest {
+  oneof payload {
+    // register_using_token_request holds registration parameters common to all
+    // join methods.
+    types.RegisterUsingTokenRequest register_using_token_request = 1;
+    // jwt is the solution to the registration challenge-response. It is a
+    // JWT issued by the Kubernetes CA containing the challenge audience sent by
+    // the Auth Server.
+    string jwt = 2;
+  }
+}
+
+message RegisterUsingKubernetesRemoteMethodResponse {
+  oneof payload {
+    // challenge_audience is the audience that the client should use when
+    // calling the Kubernetes API TokenRequest method.
+    string challenge_audience = 1;
+    // certs is the returned signed certs if registration succeeds.
+    Certs certs = 2;
+  }
+}
+
+service JoinService {
+  rpc RegisterUsingKubernetesRemote(stream RegisterUsingKubernetesRemoteMethodRequest) returns (stream RegisterUsingKubernetesRemoteMethodResponse);
+}
 ```
 
 ## Security Considerations

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -231,6 +231,64 @@ their Kubernetes cluster appropriately and to ensure that join tokens that
 delegate trust to this cluster are appropriately scoped in privileges to reduce
 the blast radius if their Kubernetes CA were to become compromised.
 
+### Audit Events
+
+The existing audit events for token creation, bot and agent joins cover the
+functionality introduced by this PR - therefore no new audit event needs to be
+added.
+
+However, the bot and agent join audit event for Kubernetes joins will be
+extended to include additional attributes from the Service Account token used
+to join. This is similar to the behaviour we already have implemented for
+GitHub and GitLab joining. This will provide an additional level of insight into
+the join, allowing it to be traced back to the individual pod.
+
+The fields that will be introduced can be seen under `attributes` in this
+example:
+
+```json
+{
+  "attributes": {
+    "raw": {
+      "aud": [
+        "leaf.tele.ottr.sh"
+      ],
+      "exp": 1692026408,
+      "iat": 1692025808,
+      "iss": "https://kubernetes.default.svc.cluster.local",
+      "kubernetes.io": {
+        "namespace": "default",
+        "pod": {
+          "name": "ubuntu",
+          "uid": "f6dd8b5e-cafc-4d92-b5ac-1a124a019d72"
+        },
+        "serviceaccount": {
+          "name": "tbot",
+          "uid": "8b77ea6d-3144-4203-9a8b-36eb5ad65596"
+        }
+      },
+      "nbf": 1692025808,
+      "sub": "system:serviceaccount:default:tbot"
+    },
+    "type": "static_jwks",
+    "username": "system:serviceaccount:default:tbot"
+  },
+  "bot_name": "my-bot",
+  "cluster_name": "leaf.tele.ottr.sh",
+  "code": "TJ001I",
+  "ei": 0,
+  "event": "bot.join",
+  "method": "kubernetes",
+  "success": true,
+  "time": "2023-08-14T15:15:59.91Z",
+  "token_name": "my-bot-kubernetes-token",
+  "uid": "84922598-1ba6-499f-a8cf-0dba96cab1d5"
+}
+```
+
+This will provide a more in-depth audit event that allows the join to be
+traced back to a specific Kubernetes pod.
+
 ## Alternatives
 
 ### Introducing a seperate `kubernetes_remote` join method

--- a/rfd/0143-external-k8s-joining.md
+++ b/rfd/0143-external-k8s-joining.md
@@ -186,8 +186,8 @@ subjects:
 The `kubernetes-remote` flow will leverage a challenge and response flow, similar
 to that implemented for IAM joining. The flow will run as follows:
 
-1. The client wishing to join calls the `RegisterUsingKubernetesJWKS` RPC. It
-  submits the name of the token it wants to use.
+1. The client wishing to join calls the `RegisterUsingKubernetesRemoteMethod`
+  RPC. It submits the name of the token it wants to use.
 2. The Auth Server sends a response with the audience that should be set in the 
   token. This audience is a concatenation of the cluster name, and 24 bytes of
   cryptographically random data encoded in base64 URL encoding, e.g:
@@ -240,7 +240,7 @@ message RegisterUsingKubernetesRemoteMethodResponse {
 }
 
 service JoinService {
-  rpc RegisterUsingKubernetesRemote(stream RegisterUsingKubernetesRemoteMethodRequest) returns (stream RegisterUsingKubernetesRemoteMethodResponse);
+  rpc RegisterUsingKubernetesRemoteMethod(stream RegisterUsingKubernetesRemoteMethodRequest) returns (stream RegisterUsingKubernetesRemoteMethodResponse);
 }
 ```
 


### PR DESCRIPTION
This RFD proposes a method for allowing entities (such as a Machine ID instance
or an Agent) to join Teleport Clusters via federation between the Kubernetes 
Cluster they reside in and a Teleport Cluster, where that Teleport Cluster does 
not reside in the same Kubernetes Cluster.

Part of https://github.com/gravitational/teleport/issues/25543