### PR TITLE
update config reference docs

### DIFF
--- a/docs/pages/includes/config-reference/auth-service.yaml
+++ b/docs/pages/includes/config-reference/auth-service.yaml
@@ -135,6 +135,11 @@ auth_service:
         # (https://goteleport.com/docs/enterprise/ssh-kubernetes-fedramp/)
         #local_auth: true
 
+        # Enforce per-session MFA or PIV-hardware key restrictions on user login sessions.
+        # Possible values: true, false, "hardware_key", "hardware_key_touch".
+        # Defaults to false.
+        require_session_mfa: false
+
         # second_factor can be 'off', 'on', 'optional', 'otp' or 'webauthn'.
         # - 'on' requires either otp or webauthn second factor.
         # - 'optional' allows otp and webauthn second factor.

--- a/docs/pages/reference/resources.mdx
+++ b/docs/pages/reference/resources.mdx
@@ -53,10 +53,10 @@ Here's the list of resources currently exposed via [`tctl`](./cli.mdx#tctl):
 | connector | Authentication connectors for [Single Sign-On](../access-controls/sso.mdx) (SSO) for SAML, OIDC and GitHub. |
 | node | A registered SSH node. The same record is displayed via `tctl nodes ls` |
 | cluster | A trusted cluster. See [here](../management/admin/trustedclusters.mdx) for more details on connecting clusters together. |
-| login_rule | A Login Rule, see the [Login Rules guide](../access-controls/login-rules.mdx) for more info. |
-| device | A Teleport Trusted Device, see the [Device Trust guide](../access-controls/device-trust/guide.mdx) for more info. |
+| [login_rule](#login-rules) | A Login Rule, see the [Login Rules guide](../access-controls/login-rules.mdx) for more info. |
+| [device](#device) | A Teleport Trusted Device, see the [Device Trust guide](../access-controls/device-trust/guide.mdx) for more info. |
 | [ui_config](#ui-config) | Configuration for the Web UI served by the Proxy Service |
-| cluster_auth_preference | Configuration for the cluster's auth preferences. |
+| [cluster_auth_preference](#cluster-auth-preferences) | Configuration for the cluster's auth preferences. |
 
 ## User
 
@@ -169,8 +169,9 @@ spec:
     attestation_denied_cas: []
 
   # Enforce per-session MFA or PIV-hardware key restrictions on user login sessions.
-  # Possible values: true, false, "hardware_key", "hardware_key_touch"
-  require_mfa_type: "off"
+  # Possible values: true, false, "hardware_key", "hardware_key_touch".
+  # Defaults to false.
+  require_session_mfa: false
 
   # Sets whether connections with expired client certificates will be disconnected.
   disconnect_expired_cert: false


### PR DESCRIPTION
Docs only PR.

- fixes the reference for dynamic `cluster_auth_preference` to use the correct name for the `require_session_mfa` setting.
- adds `require_session_mfa` to static config reference
- hyperlinks the sections in dynamic config reference
