### PR TITLE
Add a way to construct Teleport app from Kubernetes service

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -614,7 +614,6 @@ const (
 	// DiscoveryAppRewriteLabel specifies rewrite rules for a discovered app created from Kubernetes service.
 	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
 
-
 	// ReqAnnotationSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationSchedulesLabel = "/schedules"
 

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -602,6 +602,19 @@ const (
 	// kubernetes cluster name override for discovered GCP kube clusters.
 	GCPKubeClusterNameOverrideLabel = cloudKubeClusterNameOverrideLabel
 
+	// KubernetesClusterLabel indicates name of the kubernetes cluster for auto-discovered services inside kubernetes.
+	KubernetesClusterLabel = TeleportNamespace + "/kubernetes-cluster"
+
+	// DiscoveryTypeLabel specifies type of discovered service that should be created from Kubernetes service.
+	DiscoveryTypeLabel = TeleportNamespace + "/discovery-type"
+	// DiscoveryPortLabel specifies preferred port for a discovered app created from Kubernetes service.
+	DiscoveryPortLabel = TeleportNamespace + "/port"
+	// DiscoveryProtocolLabel specifies protocol for a discovered app created from Kubernetes service.
+	DiscoveryProtocolLabel = TeleportNamespace + "/protocol"
+	// DiscoveryAppRewriteLabel specifies rewrite rules for a discovered app created from Kubernetes service.
+	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
+
+
 	// ReqAnnotationSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationSchedulesLabel = "/schedules"
 

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -613,6 +613,8 @@ const (
 	DiscoveryProtocolLabel = TeleportNamespace + "/protocol"
 	// DiscoveryAppRewriteLabel specifies rewrite rules for a discovered app created from Kubernetes service.
 	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
+	// DiscoveryAppNameLabel specifies explicitly name of an app created from Kubernetes service.
+	DiscoveryAppNameLabel = TeleportNamespace + "/app-name"
 
 	// ReqAnnotationSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationSchedulesLabel = "/schedules"

--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -614,7 +614,7 @@ const (
 	// DiscoveryAppRewriteLabel specifies rewrite rules for a discovered app created from Kubernetes service.
 	DiscoveryAppRewriteLabel = TeleportNamespace + "/app-rewrite"
 	// DiscoveryAppNameLabel specifies explicitly name of an app created from Kubernetes service.
-	DiscoveryAppNameLabel = TeleportNamespace + "/app-name"
+	DiscoveryAppNameLabel = TeleportNamespace + "/name"
 
 	// ReqAnnotationSchedulesLabel is the request annotation key at which schedules are stored for access plugins.
 	ReqAnnotationSchedulesLabel = "/schedules"

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -18,8 +18,19 @@ package services
 
 import (
 	"context"
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
+	kyaml "k8s.io/apimachinery/pkg/util/yaml"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
@@ -157,4 +168,218 @@ func UnmarshalAppServer(data []byte, opts ...MarshalOption) (types.AppServer, er
 		return &s, nil
 	}
 	return nil, trace.BadParameter("unsupported app server resource version %q", h.Version)
+}
+
+// NewApplicationsFromKubeService creates application resources from kubernetes service. One service result
+// in multiple application resources if there are multiple ports exposed.
+func NewApplicationsFromKubeService(service v1.Service, clusterName string, pi ProtocolChecker) ([]types.Application, error) {
+	var apps types.Apps
+	protocol := service.GetAnnotations()[types.DiscoveryProtocolLabel]
+
+	ports, err := getServicePorts(service)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var appsMu sync.Mutex
+	g := errgroup.Group{}
+	g.SetLimit(5)
+	for _, port := range ports {
+		port := port
+		g.Go(func() error {
+			appURI := getAppURI(getServiceFQDN(service), port, protocol, pi)
+
+			// By default we are looking for http apps, we only create tcp apps if protocol annotation
+			// explicitly specifies it.
+			if strings.HasPrefix(appURI, protoTCP) && protocol != protoTCP {
+				return nil
+			}
+
+			rewriteConfig, err := getAppRewriteConfig(service.GetAnnotations())
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			a, err := types.NewAppV3(types.Metadata{
+				Name:        getAppName(service.GetName(), service.GetNamespace(), clusterName, ""),
+				Description: fmt.Sprintf("Discovered application in Kubernetes cluster %q", clusterName),
+				Labels:      getAppLabels(service.GetLabels(), clusterName),
+			}, types.AppSpecV3{
+				URI: appURI,
+				// Temporary usage to have app's name with port name, in case there are more than one app
+				// created from this service.
+				PublicAddr: getAppName(service.GetName(), service.GetNamespace(), clusterName, port.Name),
+				Rewrite:    rewriteConfig,
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			appsMu.Lock()
+			apps = append(apps, a)
+			appsMu.Unlock()
+			return nil
+		})
+	}
+	err = g.Wait()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// If we ended up with more than one app from the service, we'll have port name in the app name to distinguish them.
+	// We can only do this now because we don't know how many apps there will be until all ports are processed by errgroup.
+	for i := range apps {
+		if len(apps) > 1 {
+			apps[i].SetName(apps[i].(*types.AppV3).Spec.PublicAddr)
+		}
+		apps[i].(*types.AppV3).Spec.PublicAddr = "" // Clear temporary used for name field.
+	}
+
+	return apps, nil
+}
+
+// ProtocolChecker is an interface used to check what protocol uri serves
+type ProtocolChecker interface {
+	CheckProtocol(uri string) string
+}
+
+func getServiceFQDN(s v1.Service) string {
+	host := s.GetName()
+	if s.Spec.Type == v1.ServiceTypeExternalName {
+		host = s.Spec.ExternalName
+	}
+	return fmt.Sprintf("%s.%s.svc.cluster.local", host, s.GetNamespace())
+}
+
+const (
+	protoHTTPS = "https"
+	protoHTTP  = "http"
+	protoTCP   = "tcp"
+)
+
+func getAppURI(serviceFQDN string, port v1.ServicePort, protocolAnnotation string, pc ProtocolChecker) string {
+	constructURI := func(p string) string { return fmt.Sprintf("%s://%s:%d", p, serviceFQDN, port.Port) }
+
+	proto := strings.ToLower(protocolAnnotation)
+	if proto == protoHTTP || proto == protoHTTPS {
+		return constructURI(proto)
+	}
+
+	if port.AppProtocol != nil {
+		switch strings.ToLower(*port.AppProtocol) {
+		case protoHTTP:
+			return constructURI(protoHTTP)
+		case protoHTTPS:
+			return constructURI(protoHTTPS)
+		}
+	}
+
+	if port.Port == 443 || strings.ToLower(port.Name) == protoHTTPS {
+		return constructURI(protoHTTPS)
+	}
+
+	if pc != nil {
+		result := pc.CheckProtocol(fmt.Sprintf("%s:%d", serviceFQDN, port.Port))
+		if result != protoTCP {
+			return constructURI(result)
+		}
+	}
+
+	if port.Port == 80 || port.Port == 8080 || strings.ToLower(port.Name) == protoHTTP {
+		return constructURI(protoHTTP)
+	}
+
+	return constructURI(protoTCP)
+}
+
+func getAppRewriteConfig(annotations map[string]string) (*types.Rewrite, error) {
+	rewrite := annotations[types.DiscoveryAppRewriteLabel]
+	if rewrite == "" {
+		return nil, nil
+	}
+
+	rw := types.Rewrite{}
+	reader := strings.NewReader(rewrite)
+	decoder := kyaml.NewYAMLOrJSONDecoder(reader, 32*1024)
+	err := decoder.Decode(&rw)
+	if err != nil {
+		return nil, trace.Wrap(err, "failed decoding rewrite config")
+	}
+
+	return &rw, nil
+}
+
+func getAppName(serviceName, namespace, clusterName, portName string) string {
+	clusterName = strings.ReplaceAll(clusterName, ".", "-")
+	if portName != "" {
+		return fmt.Sprintf("%s-%s-%s-%s", serviceName, portName, namespace, clusterName)
+	}
+	return fmt.Sprintf("%s-%s-%s", serviceName, namespace, clusterName)
+}
+
+func getAppLabels(serviceLabels map[string]string, clusterName string) map[string]string {
+	result := make(map[string]string, len(serviceLabels)+1)
+
+	for k, v := range serviceLabels {
+		if !types.IsValidLabelKey(k) {
+			logrus.Debugf("Skipping label %q as invalid while creating app labels from service", k)
+			continue
+		}
+
+		result[k] = v
+	}
+	result[types.KubernetesClusterLabel] = clusterName
+
+	return result
+}
+
+func getServicePorts(s v1.Service) ([]v1.ServicePort, error) {
+	preferredPort := ""
+	for k, v := range s.GetAnnotations() {
+		if k == types.DiscoveryPortLabel {
+			preferredPort = v
+		}
+	}
+	availablePorts := []v1.ServicePort{}
+	for _, p := range s.Spec.Ports {
+		// Only supporting TCP ports.
+		if p.Protocol != v1.ProtocolTCP {
+			continue
+		}
+		availablePorts = append(availablePorts, p)
+		// If preferred port is specified and we found it in available ports, use this one
+		if preferredPort != "" && (preferredPort == strconv.Itoa(int(p.Port)) || p.Name == preferredPort) {
+			return []v1.ServicePort{p}, nil
+		}
+	}
+
+	// If preferred port is specified and we're here, it means we couldn't find it in service's ports.
+	if preferredPort != "" {
+		return nil, trace.BadParameter("Specified preferred port %s is absent among available service ports", preferredPort)
+	}
+
+	return availablePorts, nil
+}
+
+type protoChecker struct {
+	InsecureSkipVerify bool
+}
+
+func (p *protoChecker) CheckProtocol(uri string) string {
+	client := http.Client{
+		Timeout: 2 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: p.InsecureSkipVerify,
+			},
+		},
+	}
+
+	resp, err := client.Head(fmt.Sprintf("https://%s", uri))
+	if err == nil {
+		_ = resp.Body.Close()
+		return protoHTTPS
+	} else if strings.Contains(err.Error(), "server gave HTTP response to HTTPS client") {
+		return protoHTTP
+	}
+
+	return protoTCP
 }

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -213,7 +213,9 @@ func NewApplicationsFromKubeService(service v1.Service, clusterName string, pc P
 
 			rewriteConfig, err := getAppRewriteConfig(service.GetAnnotations())
 			if err != nil {
-				return trace.Wrap(err)
+				logger.Errorf(
+					"could not get app rewrite config from annotation for discovered Kubernetes service %q: %v", service.GetName(), err)
+				return nil
 			}
 			a, err := types.NewAppV3(types.Metadata{
 				Name:        getAppName(service.GetName(), service.GetNamespace(), clusterName, ""),
@@ -228,7 +230,8 @@ func NewApplicationsFromKubeService(service v1.Service, clusterName string, pc P
 				PublicAddr: getAppName(service.GetName(), service.GetNamespace(), clusterName, port.Name),
 			})
 			if err != nil {
-				return trace.Wrap(err)
+				logger.Errorf("could not create an app from discovered Kubernetes service %q: %v", service.GetName(), err)
+				return nil
 			}
 			appsMu.Lock()
 			apps = append(apps, a)

--- a/lib/services/app.go
+++ b/lib/services/app.go
@@ -203,11 +203,7 @@ func NewApplicationFromKubeService(service corev1.Service, clusterName, protocol
 }
 
 func getServiceFQDN(s corev1.Service) string {
-	host := s.GetName()
-	if s.Spec.Type == corev1.ServiceTypeExternalName {
-		host = s.Spec.ExternalName
-	}
-	return fmt.Sprintf("%s.%s.svc.cluster.local", host, s.GetNamespace())
+	return fmt.Sprintf("%s.%s.svc.cluster.local", s.GetName(), s.GetNamespace())
 }
 
 func buildAppURI(protocol, serviceFQDN string, port int32) string {

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -17,9 +17,16 @@ limitations under the License.
 package services
 
 import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/utils"
@@ -68,3 +75,451 @@ metadata:
     env: dev
 spec:
   uri: "http://localhost:8080"`
+
+func TestGetAppName(t *testing.T) {
+	tests := []struct {
+		serviceName string
+		namespace   string
+		clusterName string
+		portName    string
+		expected    string
+	}{
+		{
+			serviceName: "service1",
+			namespace:   "ns1",
+			clusterName: "cluster1",
+			portName:    "port1",
+			expected:    "service1-port1-ns1-cluster1",
+		},
+		{
+			serviceName: "service2",
+			namespace:   "ns2",
+			clusterName: "cluster2",
+			portName:    "",
+			expected:    "service2-ns2-cluster2",
+		},
+		{
+			serviceName: "service3",
+			namespace:   "ns3",
+			clusterName: "cluster.3",
+			portName:    "",
+			expected:    "service3-ns3-cluster-3",
+		},
+	}
+
+	for _, tt := range tests {
+		result := getAppName(tt.serviceName, tt.namespace, tt.clusterName, tt.portName)
+
+		require.Equal(t, tt.expected, result)
+	}
+}
+
+func TestGetServiceFQDN(t *testing.T) {
+	tests := []struct {
+		name         string
+		namespace    string
+		externalName string
+		expected     string
+	}{
+		{
+			name:      "service1",
+			namespace: "ns1",
+			expected:  "service1.ns1.svc.cluster.local",
+		},
+		{
+			externalName: "external-service2",
+			namespace:    "ns2",
+			expected:     "external-service2.ns2.svc.cluster.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			service := v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tt.name,
+					Namespace: tt.namespace,
+				},
+				Spec: v1.ServiceSpec{
+					ExternalName: tt.externalName,
+				},
+			}
+			if tt.externalName != "" {
+				service.Spec.Type = v1.ServiceTypeExternalName
+			}
+			require.Equal(t, tt.expected, getServiceFQDN(service))
+		})
+	}
+}
+
+func TestGetAppURI(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		serviceIP   string
+		portName    string
+		portNumber  int32
+		appProtocol string
+		annotation  string
+		expected    string
+	}{
+		{
+			serviceIP:  "192.1.1.1",
+			portName:   "http",
+			portNumber: 80,
+			expected:   "http://192.1.1.1:80",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portName:   "https",
+			portNumber: 443,
+			expected:   "https://192.1.1.1:443",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 4242,
+			expected:   "tcp://192.1.1.1:4242",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 8080,
+			expected:   "http://192.1.1.1:8080",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 4242,
+			portName:   "http",
+			expected:   "http://192.1.1.1:4242",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 4242,
+			portName:   "https",
+			expected:   "https://192.1.1.1:4242",
+		},
+		{
+			serviceIP:   "192.1.1.1",
+			portNumber:  4242,
+			appProtocol: "http",
+			expected:    "http://192.1.1.1:4242",
+		},
+		{
+			serviceIP:   "192.1.1.1",
+			portNumber:  80,
+			appProtocol: "https",
+			expected:    "https://192.1.1.1:80",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 80,
+			annotation: "http",
+			expected:   "http://192.1.1.1:80",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 443,
+			annotation: "https",
+			expected:   "https://192.1.1.1:443",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 8080,
+			annotation: "https",
+			expected:   "https://192.1.1.1:8080",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 4242,
+			annotation: "https",
+			expected:   "https://192.1.1.1:4242",
+		},
+		{
+			serviceIP:  "192.1.1.1",
+			portNumber: 4242,
+			portName:   "dns",
+			expected:   "tcp://192.1.1.1:4242",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("serviceIP: %s, portNumber: %d, portName: %s", tt.serviceIP, tt.portNumber, tt.portName), func(t *testing.T) {
+			port := v1.ServicePort{
+				Name: tt.portName,
+				Port: tt.portNumber,
+			}
+			if tt.appProtocol != "" {
+				port.AppProtocol = &tt.appProtocol
+			}
+
+			result := getAppURI(tt.serviceIP, port, tt.annotation, nil)
+
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetAppRewriteConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected types.Rewrite
+		wantErr  string
+	}{
+		{
+			input: `redirect:
+  - "redirect1"
+  - "redirect2"`,
+			expected: types.Rewrite{
+				Redirect: []string{"redirect1", "redirect2"},
+			},
+		},
+		{
+			input:    `wrong:"`,
+			expected: types.Rewrite{},
+			wantErr:  "failed decoding rewrite config",
+		},
+		{
+			input: `redirect:
+  - "localhost"
+  - "jenkins.internal.dev"
+headers:
+  - name: "X-Custom-Header"
+    value: "example"
+  - name: "Authorization"
+    value: "Bearer {{internal.jwt}}"`,
+			expected: types.Rewrite{
+				Redirect: []string{"localhost", "jenkins.internal.dev"},
+				Headers: []*types.Header{
+					{
+						Name:  "X-Custom-Header",
+						Value: "example",
+					},
+					{
+						Name:  "Authorization",
+						Value: "Bearer {{internal.jwt}}",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		result, err := getAppRewriteConfig(map[string]string{types.DiscoveryAppRewriteLabel: tt.input})
+		if tt.wantErr != "" {
+			require.ErrorContains(t, err, tt.wantErr)
+		} else {
+			require.NoError(t, err)
+			require.Equal(t, tt.expected, *result)
+		}
+	}
+}
+
+func TestGetAppLabels(t *testing.T) {
+	tests := []struct {
+		labels      map[string]string
+		clusterName string
+		expected    map[string]string
+	}{
+		{
+			labels:      map[string]string{"label1": "value1"},
+			clusterName: "cluster1",
+			expected:    map[string]string{"label1": "value1", types.KubernetesClusterLabel: "cluster1"},
+		},
+		{
+			labels:      map[string]string{"label1": "value1", "label2": "value2"},
+			clusterName: "cluster2",
+			expected:    map[string]string{"label1": "value1", "label2": "value2", types.KubernetesClusterLabel: "cluster2"},
+		},
+	}
+
+	for _, tt := range tests {
+		result := getAppLabels(tt.labels, tt.clusterName)
+
+		require.Equal(t, tt.expected, result)
+	}
+}
+
+func TestGetServicePorts(t *testing.T) {
+	tests := []struct {
+		desc        string
+		annotations map[string]string
+		ports       []v1.ServicePort
+		expected    []v1.ServicePort
+		wantErr     string
+	}{
+		{
+			desc:     "Empty input",
+			ports:    []v1.ServicePort{},
+			expected: []v1.ServicePort{},
+		},
+		{
+			desc: "One unsupported port (UDP)",
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolUDP},
+			},
+			expected: []v1.ServicePort{},
+		},
+		{
+			desc: "One supported port",
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+			},
+			expected: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+			},
+		},
+		{
+			desc: "One supported port, one unsupported port",
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+				{Port: 81, Protocol: v1.ProtocolUDP},
+			},
+			expected: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+			},
+		},
+		{
+			desc: "One supported port, one unsupported port",
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+				{Port: 81, Protocol: v1.ProtocolUDP},
+			},
+			expected: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+			},
+		},
+		{
+			desc: "Two supported ports",
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+				{Port: 81, Protocol: v1.ProtocolTCP},
+			},
+			expected: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+				{Port: 81, Protocol: v1.ProtocolTCP},
+			},
+		},
+		{
+			desc:        "Two supported ports with numeric annotation",
+			annotations: map[string]string{types.DiscoveryPortLabel: "42"},
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+				{Port: 42, Protocol: v1.ProtocolTCP},
+			},
+			expected: []v1.ServicePort{
+				{Port: 42, Protocol: v1.ProtocolTCP},
+			},
+		},
+		{
+			desc:        "Two supported ports with name annotation",
+			annotations: map[string]string{types.DiscoveryPortLabel: "right-port"},
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+				{Port: 42, Protocol: v1.ProtocolTCP},
+				{Port: 43, Protocol: v1.ProtocolTCP, Name: "right-port"},
+			},
+			expected: []v1.ServicePort{
+				{Port: 43, Protocol: v1.ProtocolTCP, Name: "right-port"},
+			},
+		},
+		{
+			desc:        "Annotation doesn't match available port, want error",
+			annotations: map[string]string{types.DiscoveryPortLabel: "43"},
+			ports: []v1.ServicePort{
+				{Port: 80, Protocol: v1.ProtocolTCP},
+				{Port: 42, Protocol: v1.ProtocolTCP},
+			},
+			expected: []v1.ServicePort{},
+			wantErr:  "Specified preferred port",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			service := v1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: tt.annotations,
+				},
+				Spec: v1.ServiceSpec{
+					Ports: tt.ports,
+				},
+			}
+
+			result, err := getServicePorts(service)
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestProtoChecker_CheckProtocol(t *testing.T) {
+	t.Parallel()
+
+	checker := protoChecker{
+		InsecureSkipVerify: true,
+	}
+
+	httpsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, "httpsServer")
+	}))
+	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintln(w, "httpServer")
+	}))
+	tcpServer := newTCPServer(t, func(conn net.Conn) {
+		_, _ = conn.Write([]byte("tcpServer"))
+		_ = conn.Close()
+	})
+	t.Cleanup(func() {
+		httpsServer.Close()
+		httpServer.Close()
+		_ = tcpServer.Close()
+	})
+
+	tests := []struct {
+		uri      string
+		expected string
+	}{
+		{
+			uri:      strings.TrimPrefix(httpServer.URL, "http://"),
+			expected: "http",
+		},
+		{
+			uri:      strings.TrimPrefix(httpsServer.URL, "https://"),
+			expected: "https",
+		},
+		{
+			uri:      tcpServer.Addr().String(),
+			expected: "tcp",
+		},
+	}
+
+	for _, tt := range tests {
+		res := checker.CheckProtocol(tt.uri)
+		require.Equal(t, tt.expected, res)
+	}
+}
+
+func newTCPServer(t *testing.T, handleConn func(net.Conn)) net.Listener {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	go func() {
+		for {
+			conn, err := listener.Accept()
+			if err == nil {
+				go handleConn(conn)
+			}
+			if err != nil && !utils.IsOKNetworkError(err) {
+				t.Error(err)
+				return
+			}
+		}
+	}()
+
+	return listener
+}

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -17,11 +17,6 @@ limitations under the License.
 package services
 
 import (
-	"fmt"
-	"net"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -162,96 +157,25 @@ func TestBuildAppURI(t *testing.T) {
 		{
 			serviceFQDN: "service.example",
 			port:        8080,
-			protocol:    protoHTTP,
+			protocol:    "http",
 			expected:    "http://service.example:8080",
 		},
 		{
 			serviceFQDN: "service.example",
 			port:        443,
-			protocol:    protoHTTPS,
+			protocol:    "https",
 			expected:    "https://service.example:443",
 		},
 		{
 			serviceFQDN: "special.service.example",
 			port:        42,
-			protocol:    protoTCP,
+			protocol:    "tcp",
 			expected:    "tcp://special.service.example:42",
 		},
 	}
 
 	for _, tt := range tests {
 		require.Equal(t, buildAppURI(tt.protocol, tt.serviceFQDN, tt.port), tt.expected)
-	}
-}
-
-func TestAutoProtocolDetection(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		portName    string
-		portNumber  int32
-		appProtocol string
-		expected    string
-	}{
-		{
-			portName:   "http",
-			portNumber: 80,
-			expected:   protoHTTP,
-		},
-		{
-			portName:   "https",
-			portNumber: 443,
-			expected:   protoHTTPS,
-		},
-		{
-			portNumber: 4242,
-			expected:   protoTCP,
-		},
-		{
-			portNumber: 8080,
-			expected:   protoHTTP,
-		},
-		{
-			portNumber: 4242,
-			portName:   "http",
-			expected:   protoHTTP,
-		},
-		{
-			portNumber: 4242,
-			portName:   "https",
-			expected:   protoHTTPS,
-		},
-		{
-			portNumber:  4242,
-			appProtocol: "http",
-			expected:    protoHTTP,
-		},
-		{
-			portNumber:  80,
-			appProtocol: "https",
-			expected:    protoHTTPS,
-		},
-		{
-			portNumber: 4242,
-			portName:   "dns",
-			expected:   protoTCP,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(fmt.Sprintf("portNumber: %d, portName: %s", tt.portNumber, tt.portName), func(t *testing.T) {
-			port := v1.ServicePort{
-				Name: tt.portName,
-				Port: tt.portNumber,
-			}
-			if tt.appProtocol != "" {
-				port.AppProtocol = &tt.appProtocol
-			}
-
-			result := autoProtocolDetection("192.1.1.1", port, nil)
-
-			require.Equal(t, tt.expected, result)
-		})
 	}
 }
 
@@ -335,188 +259,4 @@ func TestGetAppLabels(t *testing.T) {
 
 		require.Equal(t, tt.expected, result)
 	}
-}
-
-func TestGetServicePorts(t *testing.T) {
-	tests := []struct {
-		desc        string
-		annotations map[string]string
-		ports       []v1.ServicePort
-		expected    []v1.ServicePort
-		wantErr     string
-	}{
-		{
-			desc:     "Empty input",
-			ports:    []v1.ServicePort{},
-			expected: []v1.ServicePort{},
-		},
-		{
-			desc: "One unsupported port (UDP)",
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolUDP},
-			},
-			expected: []v1.ServicePort{},
-		},
-		{
-			desc: "One supported port",
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-			},
-			expected: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			desc: "One supported port, one unsupported port",
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-				{Port: 81, Protocol: v1.ProtocolUDP},
-			},
-			expected: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			desc: "One supported port, one unsupported port",
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-				{Port: 81, Protocol: v1.ProtocolUDP},
-			},
-			expected: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			desc: "Two supported ports",
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-				{Port: 81, Protocol: v1.ProtocolTCP},
-			},
-			expected: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-				{Port: 81, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			desc:        "Two supported ports with numeric annotation",
-			annotations: map[string]string{types.DiscoveryPortLabel: "42"},
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-				{Port: 42, Protocol: v1.ProtocolTCP},
-			},
-			expected: []v1.ServicePort{
-				{Port: 42, Protocol: v1.ProtocolTCP},
-			},
-		},
-		{
-			desc:        "Two supported ports with name annotation",
-			annotations: map[string]string{types.DiscoveryPortLabel: "right-port"},
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-				{Port: 42, Protocol: v1.ProtocolTCP},
-				{Port: 43, Protocol: v1.ProtocolTCP, Name: "right-port"},
-			},
-			expected: []v1.ServicePort{
-				{Port: 43, Protocol: v1.ProtocolTCP, Name: "right-port"},
-			},
-		},
-		{
-			desc:        "Annotation doesn't match available port, want error",
-			annotations: map[string]string{types.DiscoveryPortLabel: "43"},
-			ports: []v1.ServicePort{
-				{Port: 80, Protocol: v1.ProtocolTCP},
-				{Port: 42, Protocol: v1.ProtocolTCP},
-			},
-			expected: []v1.ServicePort{},
-			wantErr:  "Specified preferred port",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.desc, func(t *testing.T) {
-			service := v1.Service{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: tt.annotations,
-				},
-				Spec: v1.ServiceSpec{
-					Ports: tt.ports,
-				},
-			}
-
-			result, err := getServicePorts(service)
-			if tt.wantErr != "" {
-				require.ErrorContains(t, err, tt.wantErr)
-			} else {
-				require.NoError(t, err)
-				require.Equal(t, tt.expected, result)
-			}
-		})
-	}
-}
-
-func TestProtoChecker_CheckProtocol(t *testing.T) {
-	t.Parallel()
-
-	checker := protoChecker{
-		InsecureSkipVerify: true,
-	}
-
-	httpsServer := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintln(w, "httpsServer")
-	}))
-	httpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintln(w, "httpServer")
-	}))
-	tcpServer := newTCPServer(t, func(conn net.Conn) {
-		_, _ = conn.Write([]byte("tcpServer"))
-		_ = conn.Close()
-	})
-	t.Cleanup(func() {
-		httpsServer.Close()
-		httpServer.Close()
-		_ = tcpServer.Close()
-	})
-
-	tests := []struct {
-		uri      string
-		expected string
-	}{
-		{
-			uri:      strings.TrimPrefix(httpServer.URL, "http://"),
-			expected: "http",
-		},
-		{
-			uri:      strings.TrimPrefix(httpsServer.URL, "https://"),
-			expected: "https",
-		},
-		{
-			uri:      tcpServer.Addr().String(),
-			expected: "tcp",
-		},
-	}
-
-	for _, tt := range tests {
-		res := checker.CheckProtocol(tt.uri)
-		require.Equal(t, tt.expected, res)
-	}
-}
-
-func newTCPServer(t *testing.T, handleConn func(net.Conn)) net.Listener {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	go func() {
-		for {
-			conn, err := listener.Accept()
-			if err == nil {
-				go handleConn(conn)
-			}
-			if err != nil && !utils.IsOKNetworkError(err) {
-				t.Error(err)
-				return
-			}
-		}
-	}()
-
-	return listener
 }

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -281,7 +281,8 @@ func TestGetAppLabels(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := getAppLabels(tt.labels, tt.clusterName)
+		result, err := getAppLabels(tt.labels, tt.clusterName)
+		require.NoError(t, err)
 
 		require.Equal(t, tt.expected, result)
 	}

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -77,6 +77,8 @@ func TestGetAppName(t *testing.T) {
 		namespace   string
 		clusterName string
 		portName    string
+		annotation  string
+		wantErr     string
 		expected    string
 	}{
 		{
@@ -90,22 +92,46 @@ func TestGetAppName(t *testing.T) {
 			serviceName: "service2",
 			namespace:   "ns2",
 			clusterName: "cluster2",
-			portName:    "",
 			expected:    "service2-ns2-cluster2",
 		},
 		{
 			serviceName: "service3",
 			namespace:   "ns3",
 			clusterName: "cluster.3",
-			portName:    "",
 			expected:    "service3-ns3-cluster-3",
+		},
+		{
+			serviceName: "service3",
+			namespace:   "ns3",
+			clusterName: "cluster.3",
+			annotation:  "overridden-name",
+			expected:    "overridden-name",
+		},
+		{
+			serviceName: "service3",
+			namespace:   "ns3",
+			clusterName: "cluster.3",
+			portName:    "http",
+			annotation:  "overridden-name",
+			expected:    "overridden-name-http",
+		},
+		{
+			serviceName: "service3",
+			namespace:   "ns3",
+			clusterName: "cluster.3",
+			portName:    "http",
+			annotation:  "overridden*name",
+			wantErr:     "s",
 		},
 	}
 
 	for _, tt := range tests {
-		result := getAppName(tt.serviceName, tt.namespace, tt.clusterName, tt.portName)
-
-		require.Equal(t, tt.expected, result)
+		result, err := getAppName(tt.serviceName, tt.namespace, tt.clusterName, tt.portName, tt.annotation)
+		if tt.wantErr != "" {
+			require.ErrorContains(t, err, tt.wantErr)
+		} else {
+			require.Equal(t, tt.expected, result)
+		}
 	}
 }
 

--- a/lib/services/app_test.go
+++ b/lib/services/app_test.go
@@ -148,9 +148,10 @@ func TestGetServiceFQDN(t *testing.T) {
 			expected:  "service1.ns1.svc.cluster.local",
 		},
 		{
+			name:         "service2",
 			externalName: "external-service2",
 			namespace:    "ns2",
-			expected:     "external-service2.ns2.svc.cluster.local",
+			expected:     "service2.ns2.svc.cluster.local",
 		},
 	}
 

--- a/lib/services/matchers.go
+++ b/lib/services/matchers.go
@@ -360,3 +360,14 @@ const (
 var SupportedGCPMatchers = []string{
 	GCPMatcherKubernetes,
 }
+
+const (
+	// KubernetesMatchersApp is app matcher type for Kubernetes services
+	KubernetesMatchersApp = "app"
+)
+
+// SupportedKubernetesMatchers is a list of Kubernetes matchers supported by
+// Teleport discovery service
+var SupportedKubernetesMatchers = []string{
+	KubernetesMatchersApp,
+}


### PR DESCRIPTION
This PR adds function `NewApplicationsFromKubeService()` that can convert Kubernetes service into Teleport app(s) resource.
Part of implementation of [RFD 135](https://github.com/gravitational/teleport/pull/28071)
Part of https://github.com/gravitational/teleport/issues/25538