### PR TITLE
Add Connect ads to tsh login and tsh proxy db

### DIFF
--- a/tool/tsh/common/proxy.go
+++ b/tool/tsh/common/proxy.go
@@ -892,10 +892,15 @@ func generateDBLocalProxyCert(key *libclient.Key, profile *libclient.ProfileStat
 	return nil
 }
 
+const dbProxyConnectAd = `Teleport Connect is a desktop app that can manage database proxies for you.
+Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
+`
+
 // dbProxyTpl is the message that gets printed to a user when a database proxy is started.
 var dbProxyTpl = template.Must(template.New("").Parse(`Started DB proxy on {{.address}}
 {{if .randomPort}}To avoid port randomization, you can choose the listening port using the --port flag.
 {{end}}
+` + dbProxyConnectAd + `
 Use following credentials to connect to the {{.database}} proxy:
   ca_file={{.ca}}
   cert_file={{.cert}}
@@ -911,6 +916,7 @@ var dbProxyAuthTpl = template.Must(template.New("").Parse(
 	`Started authenticated tunnel for the {{.type}} database "{{.database}}" in cluster "{{.cluster}}" on {{.address}}.
 {{if .randomPort}}To avoid port randomization, you can choose the listening port using the --port flag.
 {{end}}
+` + dbProxyConnectAd + `
 Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
   $ {{.command}}
 `))
@@ -920,6 +926,7 @@ var dbProxyOracleAuthTpl = template.Must(template.New("").Funcs(templateFunction
 	`Started authenticated tunnel for the {{.type}} database "{{.database}}" in cluster "{{.cluster}}" on {{.address}}.
 {{if .randomPort}}To avoid port randomization, you can choose the listening port using the --port flag.
 {{end}}
+` + dbProxyConnectAd + `
 Use the following command to connect to the Oracle database server using CLI:
   $ {{.command}}
 
@@ -936,6 +943,7 @@ var dbProxyAuthMultiTpl = template.Must(template.New("").Parse(
 	`Started authenticated tunnel for the {{.type}} database "{{.database}}" in cluster "{{.cluster}}" on {{.address}}.
 {{if .randomPort}}To avoid port randomization, you can choose the listening port using the --port flag.
 {{end}}
+` + dbProxyConnectAd + `
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 {{range $item := .commands}}
   * {{$item.Description}}: 

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -928,6 +928,9 @@ func Test_chooseProxyCommandTemplate(t *testing.T) {
 			wantTemplateArgs: map[string]any{"command": "echo \"hello world\""},
 			wantOutput: `Started authenticated tunnel for the MySQL database "mydb" in cluster "mycluster" on 127.0.0.1:64444.
 
+Teleport Connect is a desktop app that can manage database proxies for you.
+Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
+
 Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
   $ echo "hello world"
 `,
@@ -952,6 +955,9 @@ Use the following command to connect to the database or to the address above usi
 				},
 			},
 			wantOutput: `Started authenticated tunnel for the MySQL database "mydb" in cluster "mycluster" on 127.0.0.1:64444.
+
+Teleport Connect is a desktop app that can manage database proxies for you.
+Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
 
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 
@@ -979,6 +985,9 @@ Use one of the following commands to connect to the database or to the address a
 			wantOutput: `Started authenticated tunnel for the MySQL database "mydb" in cluster "mycluster" on 127.0.0.1:64444.
 To avoid port randomization, you can choose the listening port using the --port flag.
 
+Teleport Connect is a desktop app that can manage database proxies for you.
+Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
+
 Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
   $ echo "hello world"
 `,
@@ -1005,6 +1014,9 @@ Use the following command to connect to the database or to the address above usi
 			},
 			wantOutput: `Started authenticated tunnel for the MySQL database "mydb" in cluster "mycluster" on 127.0.0.1:64444.
 To avoid port randomization, you can choose the listening port using the --port flag.
+
+Teleport Connect is a desktop app that can manage database proxies for you.
+Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
 
 Use one of the following commands to connect to the database or to the address above using other database GUI/CLI clients:
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1953,7 +1953,7 @@ func onLogin(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	fmt.Printf("Did you know? Teleport Connect offers the power of tsh in a desktop app.\nLearn more at https://goteleport.com/docs/connect-your-client/teleport-connect/\n\n")
+	fmt.Fprint(os.Stderr, "Did you know? Teleport Connect offers the power of tsh in a desktop app.\nLearn more at https://goteleport.com/docs/connect-your-client/teleport-connect/\n\n")
 
 	// NOTE: we currently print all alerts that are marked as `on-login`, because we
 	// don't use the alert API very heavily. If we start to make more use of it, we

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1953,6 +1953,8 @@ func onLogin(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
+	fmt.Printf("Did you know? Teleport Connect offers the power of tsh in a desktop app.\nLearn more at https://goteleport.com/docs/connect-your-client/teleport-connect/\n\n")
+
 	// NOTE: we currently print all alerts that are marked as `on-login`, because we
 	// don't use the alert API very heavily. If we start to make more use of it, we
 	// could probably add a separate `tsh alerts ls` command, and truncate the list


### PR DESCRIPTION
Closes #28991.

The motivation behind this is described in #28991.

I've tried to always show the ad before any more important messages so that the most important message is at the end of the output where the user is most likely to see it (that is my assumption). In `tsh login`, the ad is shown before the alerts. In `tsh proxy db`, the ad is shown before the instructions on how to use the newly set up proxy.

Copy suggestions are welcome. I'm particularly not sure about the `tsh proxy db`. Adding "Did you know?" there felt unnatural as, unlike in `tsh login`, the ad there is not completely random but rather directly related to what you're attempting to do.

This PR will be followed by some updates to the Connect page in docs. I want to add a section at the top describing why someone would want to use Connect over tsh.

---

Ad in `tsh login`:

```
Did you know? Teleport Connect offers the power of tsh in a desktop app.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/
```

Ad in `tsh proxy db`:

```
Teleport Connect is a desktop app that can manage database proxies for you.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database
```

Examples:

<details>
<summary>tsh login</summary>

local login with no motd and alerts

```
~teleport(master) ✗: tsh login --proxy=enterprise-local:3030
Enter password for Teleport user rav:
> Profile URL:        https://enterprise-local:3030
  Logged in as:       rav
  Cluster:            enterprise-local
  Roles:              access, auditor, connect-my-computer-rav, db, editor, kube-access, sbar-admins
  Logins:             root, rav
  Kubernetes:         enabled
  Kubernetes users:   minikube
  Kubernetes groups:  viewers
  Valid until:        2023-07-12 22:55:46 +0200 CEST [valid for 10h10m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

  Profile URL:        https://teleport-local.dev:3090
  Logged in as:       rav
  Cluster:            teleport-local
  Roles:              access, connect-my-computer-rav, editor, role-with-label-expressions
  Logins:             root, rav
  Kubernetes:         enabled
  Kubernetes users:   minikube
  Kubernetes groups:  viewers
  Valid until:        2023-07-12 20:44:13 +0200 CEST [valid for 7h59m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

Did you know? Teleport Connect offers the power of tsh in a desktop app.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/

~teleport(master) ✗:
```

local login with motd and three alerts

```
~teleport(master) ✗: tsh login --proxy=teleport-local.dev:3090
=====================================================
Welcome to Zion's Teleport Cluster.

Remember, you are no longer in the Matrix:

1. All actions performed here are free from the Machines' surveillance.
2. Unauthorized access will face the wrath of the Oracle.
3. System maintenance window: When the Matrix resets.

Remember: The Matrix is not real. Our fight for freedom is.

For any issues, contact the Oracle or Morpheus.

=====================================================

Press [ENTER] to continue.
Enter password for Teleport user rav:
> Profile URL:        https://teleport-local.dev:3090
  Logged in as:       rav
  Cluster:            teleport-local
  Roles:              access, connect-my-computer-rav, editor, role-with-label-expressions
  Logins:             root, rav
  Kubernetes:         enabled
  Kubernetes users:   minikube
  Kubernetes groups:  viewers
  Valid until:        2023-07-12 20:44:13 +0200 CEST [valid for 8h0m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

Did you know? Teleport Connect offers the power of tsh in a desktop app.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/

All systems down. Contact IT Emergency: it-emergency@zion.com immediately.

Unusual system activity detected. Please save work often and report any anomalies.

Minor network issues detected. No immediate action required, but expect possible slowdowns.

~teleport(master) ✗:
```

SSO with an upgrade alert:

```
~teleport(master) ✗: tsh login --proxy=teleport-13-ent.asteroid.earth --auth=github
If browser window does not open automatically, open it by clicking on the link:
 http://127.0.0.1:61653/35ec203f-68b6-4f76-856f-795d674cd5b6
> Profile URL:        https://teleport-13-ent.asteroid.earth:443
  Logged in as:       ravicious
  Cluster:            teleport-13-ent.asteroid.earth
  Roles:              access
  Logins:             ravicious, ubuntu
  Kubernetes:         enabled
  Kubernetes groups:  system:masters
  Valid until:        2023-07-13 00:49:44 +0200 CEST [valid for 12h0m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

  Profile URL:        https://enterprise-local:3030
  Logged in as:       rav
  Cluster:            enterprise-local
  Roles:              access, auditor, connect-my-computer-rav, db, editor, kube-access, sbar-admins
  Logins:             root, rav
  Kubernetes:         enabled
  Kubernetes users:   minikube
  Kubernetes groups:  viewers
  Valid until:        2023-07-12 22:55:46 +0200 CEST [valid for 10h6m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

  Profile URL:        https://teleport-local.dev:3090
  Logged in as:       rav
  Cluster:            teleport-local
  Roles:              access, connect-my-computer-rav, editor, role-with-label-expressions
  Logins:             root, rav
  Kubernetes:         enabled
  Kubernetes users:   minikube
  Kubernetes groups:  viewers
  Valid until:        2023-07-12 20:44:13 +0200 CEST [valid for 7h54m0s]
  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy

Did you know? Teleport Connect offers the power of tsh in a desktop app.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/

Teleport v13.2.0 is now available, please consider upgrading your Cluster.

~teleport(master) ✗:
```

</details>

<details>
<summary>tsh proxy db</summary>

tunnel with random port

```
teleport(master) ✗: tsh proxy db postgres --db-user postgres --db-name postgres --tunnel
Started authenticated tunnel for the PostgreSQL database "postgres" in cluster "teleport-local" on 127.0.0.1:56158.
To avoid port randomization, you can choose the listening port using the --port flag.

Teleport Connect is a desktop app that can manage database proxies for you.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database

Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
  $ psql postgres://postgres@localhost:56158/postgres

teleport(master) ✗:
```

tunnel with specific port

```
teleport(master) ✗: tsh proxy db postgres --db-user postgres --db-name postgres --tunnel --port 12345
Started authenticated tunnel for the PostgreSQL database "postgres" in cluster "teleport-local" on 127.0.0.1:12345.

Teleport Connect is a desktop app that can manage database proxies for you.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database

Use the following command to connect to the database or to the address above using other database GUI/CLI clients:
  $ psql postgres://postgres@localhost:12345/postgres

teleport(master) ✗:
```

regular proxy with random port

```
teleport(master) ✗: tsh proxy db postgres --db-user postgres --db-name postgres
Started DB proxy on 127.0.0.1:56169
To avoid port randomization, you can choose the listening port using the --port flag.

Teleport Connect is a desktop app that can manage database proxies for you.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database

Use following credentials to connect to the postgres proxy:
  ca_file=/Users/rav/.tsh/keys/teleport-local.dev/cas/teleport-local.pem
  cert_file=/Users/rav/.tsh/keys/teleport-local.dev/rav-db/teleport-local/postgres-x509.pem
  key_file=/Users/rav/.tsh/keys/teleport-local.dev/rav

teleport(master) ✗:
```

regular proxy with specific port

```
teleport(master) ✗: tsh proxy db postgres --db-user postgres --db-name postgres --port 12345
Started DB proxy on 127.0.0.1:12345

Teleport Connect is a desktop app that can manage database proxies for you.
Learn more at https://goteleport.com/docs/connect-your-client/teleport-connect/#connecting-to-a-database

Use following credentials to connect to the postgres proxy:
  ca_file=/Users/rav/.tsh/keys/teleport-local.dev/cas/teleport-local.pem
  cert_file=/Users/rav/.tsh/keys/teleport-local.dev/rav-db/teleport-local/postgres-x509.pem
  key_file=/Users/rav/.tsh/keys/teleport-local.dev/rav

teleport(master) ✗:
```
</details>