### PR TITLE
Prevent creating Kube resources forbidden by `kubernetes_resources`

### DIFF
--- a/api/types/role.go
+++ b/api/types/role.go
@@ -432,7 +432,9 @@ func (r *RoleV6) convertKubernetesResourcesBetweenRoleVersions(resources []Kuber
 			for _, resource := range KubernetesResourcesKinds {
 				// Ignore Pod resources for older roles because Pods were already supported
 				// so we don't need to keep backwards compatibility for them.
-				if resource == KindKubePod {
+				// Also ignore Namespace resources because it grants access to all resources
+				// in the namespace.
+				if resource == KindKubePod || resource == KindNamespace {
 					continue
 				}
 				resources = append(resources, KubernetesResource{Kind: resource, Name: Wildcard, Namespace: Wildcard, Verbs: []string{Wildcard}})

--- a/api/types/role_test.go
+++ b/api/types/role_test.go
@@ -351,7 +351,7 @@ func appendV7KubeResources() []KubernetesResource {
 	resources := []KubernetesResource{}
 	// append other kubernetes resources
 	for _, resource := range KubernetesResourcesKinds {
-		if resource == KindKubePod {
+		if resource == KindKubePod || resource == KindKubeNamespace {
 			continue
 		}
 		resources = append(resources, KubernetesResource{

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -570,7 +570,11 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 
 	// kubeResource is the Kubernetes Resource the request is targeted at.
 	// Currently only supports Pods and it includes the pod name and namespace.
-	kubeResource, apiResource := getResourceFromRequest(req)
+	kubeResource, apiResource, err := getResourceFromRequest(req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	fmt.Println("kubeResource", kubeResource)
 	authContext, err := f.setupContext(ctx, *userContext, req, isRemoteUser, apiResource, kubeResource)
 	if err != nil {
 		f.log.WithError(err).Warn("Unable to setup context.")

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -574,7 +574,6 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	fmt.Println("kubeResource", kubeResource)
 	authContext, err := f.setupContext(ctx, *userContext, req, isRemoteUser, apiResource, kubeResource)
 	if err != nil {
 		f.log.WithError(err).Warn("Unable to setup context.")


### PR DESCRIPTION
This PR prevents users from creating resources that their user is forbidden to access.

This requires parsing the request body to extract the resource name.

Fixes #29245