### PR TITLE
Speed up Auth initialization

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5373,63 +5373,6 @@ func (a *Server) ensureLocalAdditionalKeys(ctx context.Context, ca types.CertAut
 	return nil
 }
 
-// createSelfSignedCA creates a new self-signed CA and writes it to the
-// backend, with the type and clusterName given by the argument caID.
-func (a *Server) createSelfSignedCA(ctx context.Context, caID types.CertAuthID) error {
-	keySet, err := newKeySet(ctx, a.keyStore, caID)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
-		Type:        caID.Type,
-		ClusterName: caID.DomainName,
-		ActiveKeys:  keySet,
-	})
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	if err := a.CreateCertAuthority(ctx, ca); err != nil {
-		return trace.Wrap(err)
-	}
-	return nil
-}
-
-// deleteUnusedKeys deletes all teleport keys held in a connected HSM for this
-// auth server which are not currently used in any CAs.
-func (a *Server) deleteUnusedKeys(ctx context.Context) error {
-	clusterName, err := a.Services.GetClusterName()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	var activeKeys [][]byte
-	for _, caType := range types.CertAuthTypes {
-		caID := types.CertAuthID{Type: caType, DomainName: clusterName.GetClusterName()}
-		ca, err := a.Services.GetCertAuthority(ctx, caID, true)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		for _, keySet := range []types.CAKeySet{ca.GetActiveKeys(), ca.GetAdditionalTrustedKeys()} {
-			for _, sshKeyPair := range keySet.SSH {
-				activeKeys = append(activeKeys, sshKeyPair.PrivateKey)
-			}
-			for _, tlsKeyPair := range keySet.TLS {
-				activeKeys = append(activeKeys, tlsKeyPair.Key)
-			}
-			for _, jwtKeyPair := range keySet.JWT {
-				activeKeys = append(activeKeys, jwtKeyPair.PrivateKey)
-			}
-		}
-	}
-	if err := a.keyStore.DeleteUnusedKeys(ctx, activeKeys); err != nil {
-		// Key deletion is best-effort, log a warning if it fails and carry on.
-		// We don't want to prevent a CA rotation, which may be necessary in
-		// some cases where this would fail.
-		log.WithError(err).Warning("Failed attempt to delete unused HSM keys")
-	}
-	return nil
-}
-
 // GetLicense return the license used the start the teleport enterprise auth server
 func (a *Server) GetLicense(ctx context.Context) (string, error) {
 	if modules.GetModules().Features().Cloud {

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -22,13 +22,17 @@ import (
 	"crypto/x509"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
@@ -245,10 +249,16 @@ type InitConfig struct {
 
 	// EmbeddingClient is a client that allows generating embeddings.
 	EmbeddingClient ai.Embedder
+
+	// Tracer used to create spans.
+	Tracer oteltrace.Tracer
 }
 
 // Init instantiates and configures an instance of AuthServer
-func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
+func Init(ctx context.Context, cfg InitConfig, opts ...ServerOption) (*Server, error) {
+	ctx, span := cfg.Tracer.Start(ctx, "auth/Init")
+	defer span.End()
+
 	if cfg.DataDir == "" {
 		return nil, trace.BadParameter("DataDir: data dir can not be empty")
 	}
@@ -256,7 +266,10 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 		return nil, trace.BadParameter("HostUUID: host UUID can not be empty")
 	}
 
-	ctx := context.TODO()
+	asrv, err := NewServer(&cfg, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 
 	domainName := cfg.ClusterName.GetClusterName()
 	lock, err := backend.AcquireLock(ctx, backend.LockConfiguration{
@@ -269,8 +282,7 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	}
 	defer lock.Release(ctx, cfg.Backend)
 
-	// check that user CA and host CA are present and set the certs if needed
-	asrv, err := NewServer(&cfg, opts...)
+	firstStart, err := isFirstStart(ctx, asrv, cfg)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -278,10 +290,6 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	// if bootstrap resources are supplied, use them to bootstrap backend state
 	// on initial startup.
 	if len(cfg.BootstrapResources) > 0 {
-		firstStart, err := isFirstStart(ctx, asrv, cfg)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
 		if firstStart {
 			log.Infof("Applying %v bootstrap resources (first initialization)", len(cfg.BootstrapResources))
 			if err := checkResourceConsistency(ctx, asrv.keyStore, domainName, cfg.BootstrapResources...); err != nil {
@@ -342,40 +350,68 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 		log.Infof("Created reverse tunnel: %v.", tunnel)
 	}
 
-	err = asrv.SetClusterAuditConfig(ctx, cfg.ClusterAuditConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	g, gctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
+		ctx, span := cfg.Tracer.Start(gctx, "auth/SetClusterAuditConfig")
+		defer span.End()
+		return trace.Wrap(asrv.SetClusterAuditConfig(ctx, cfg.ClusterAuditConfig))
+	})
 
-	err = initSetClusterNetworkingConfig(ctx, asrv, cfg.ClusterNetworkingConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	g.Go(func() error {
+		ctx, span := cfg.Tracer.Start(gctx, "auth/SetClusterNetworkingConfig")
+		defer span.End()
+		return trace.Wrap(initSetClusterNetworkingConfig(ctx, asrv, cfg.ClusterNetworkingConfig))
+	})
 
-	err = initSetSessionRecordingConfig(ctx, asrv, cfg.SessionRecordingConfig)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	g.Go(func() error {
+		ctx, span := cfg.Tracer.Start(gctx, "auth/SetSessionRecordingConfig")
+		defer span.End()
+		return trace.Wrap(initSetSessionRecordingConfig(ctx, asrv, cfg.SessionRecordingConfig))
+	})
 
-	err = initSetAuthPreference(ctx, asrv, cfg.AuthPreference)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	g.Go(func() error {
+		ctx, span := cfg.Tracer.Start(gctx, "auth/SetAuthPreference")
+		defer span.End()
+		return trace.Wrap(initSetAuthPreference(ctx, asrv, cfg.AuthPreference))
+	})
 
-	// The first Auth Server that starts gets to set the name of the cluster.
-	// If a cluster name/ID is already stored in the backend, the attempt to set
-	// a new name returns an AlreadyExists error.
-	err = asrv.SetClusterName(cfg.ClusterName)
-	if err != nil && !trace.IsAlreadyExists(err) {
-		return nil, trace.Wrap(err)
-	}
-	// If the cluster name has already been set, log a warning if the user
-	// is trying to change the name.
-	if trace.IsAlreadyExists(err) {
-		// Get current name of cluster from the backend.
-		cn, err := asrv.Services.GetClusterName()
+	g.Go(func() error {
+		_, span := cfg.Tracer.Start(gctx, "auth/SetStaticTokens")
+		defer span.End()
+		log.Infof("Updating cluster configuration: %v.", cfg.StaticTokens)
+		return trace.Wrap(asrv.SetStaticTokens(cfg.StaticTokens))
+	})
+
+	g.Go(func() error {
+		_, span := cfg.Tracer.Start(gctx, "auth/SetClusterNamespace")
+		defer span.End()
+		log.Infof("Creating namespace: %q.", apidefaults.Namespace)
+		return trace.Wrap(asrv.UpsertNamespace(types.DefaultNamespace()))
+	})
+
+	var cn types.ClusterName
+	g.Go(func() error {
+		_, span := cfg.Tracer.Start(gctx, "auth/SetClusterName")
+		defer span.End()
+
+		// The first Auth Server that starts gets to set the name of the cluster.
+		// If a cluster name/ID is already stored in the backend, the attempt to set
+		// a new name returns an AlreadyExists error.
+		err := asrv.SetClusterName(cfg.ClusterName)
+		if err == nil {
+			cn = cfg.ClusterName
+			return nil
+		}
+
+		if !trace.IsAlreadyExists(err) {
+			return trace.Wrap(err)
+		}
+
+		// If the cluster name has already been set, log a warning if the user
+		// is trying to change the name.
+		cn, err = asrv.Services.GetClusterName()
 		if err != nil {
-			return nil, trace.Wrap(err)
+			return trace.Wrap(err)
 		}
 		if cn.GetClusterName() != cfg.ClusterName.GetClusterName() {
 			warnMessage := "Cannot rename cluster to %q: continuing with %q. Teleport " +
@@ -383,27 +419,19 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 				"warning for one of two reasons. Either you have not set \"cluster_name\" in " +
 				"Teleport configuration and changed the hostname of the auth server or you " +
 				"are trying to change the value of \"cluster_name\"."
-			log.Warnf(warnMessage,
-				cfg.ClusterName.GetClusterName(),
-				cn.GetClusterName())
+			log.Warnf(warnMessage, cfg.ClusterName.GetClusterName(), cn.GetClusterName())
 		}
-		// Override user passed in cluster name with what is in the backend.
-		cfg.ClusterName = cn
-	}
-	log.Debugf("Cluster configuration: %v.", cfg.ClusterName)
 
-	err = asrv.SetStaticTokens(cfg.StaticTokens)
-	if err != nil {
+		log.Debugf("Cluster configuration: %v.", cn.GetClusterName())
+		return nil
+	})
+
+	if err := g.Wait(); err != nil {
 		return nil, trace.Wrap(err)
 	}
-	log.Infof("Updating cluster configuration: %v.", cfg.StaticTokens)
 
-	// always create the default namespace
-	err = asrv.UpsertNamespace(types.DefaultNamespace())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	log.Infof("Created namespace: %q.", apidefaults.Namespace)
+	// Override user passed in cluster name with what is in the backend.
+	cfg.ClusterName = cn
 
 	// Migrate Host CA as Database CA before certificates generation. Otherwise, the Database CA will be
 	// generated which we don't want for existing installations.
@@ -412,74 +440,111 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	}
 
 	// generate certificate authorities if they don't exist
+	var (
+		mu         sync.Mutex
+		activeKeys [][]byte
+	)
+	g, gctx = errgroup.WithContext(ctx)
 	for _, caType := range types.CertAuthTypes {
-		caID := types.CertAuthID{Type: caType, DomainName: cfg.ClusterName.GetClusterName()}
-		ca, err := asrv.Services.GetCertAuthority(ctx, caID, true)
-		if err != nil {
-			if !trace.IsNotFound(err) {
-				return nil, trace.Wrap(err)
-			}
-			log.Infof("First start: generating %s certificate authority.", caID.Type)
-			if err := asrv.createSelfSignedCA(ctx, caID); err != nil {
-				return nil, trace.Wrap(err)
-			}
-		} else {
-			// Already have a CA. Make sure the keyStore has usable keys.
-			hasUsableActiveKeys, err := asrv.keyStore.HasUsableActiveKeys(ctx, ca)
+		caType := caType
+		g.Go(func() error {
+			ctx, span := cfg.Tracer.Start(gctx, "auth/initializeAuthority", oteltrace.WithAttributes(attribute.String("type", string(caType))))
+			defer span.End()
+
+			caID := types.CertAuthID{Type: caType, DomainName: cfg.ClusterName.GetClusterName()}
+			ca, err := asrv.Services.GetCertAuthority(ctx, caID, true)
 			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if !hasUsableActiveKeys {
-				// This could be one of a few cases:
-				// 1. A new auth server with an HSM being added to an HA cluster.
-				// 2. A new auth server with no HSM being added to an HA cluster
-				//    where all current auth servers have HSMs.
-				// 3. An existing auth server has restarted with a new HSM configured.
-				// 4. An existing HSM auth server has restarted no HSM configured.
-				// 5. An existing HSM auth server has restarted with a new UUID.
-				if ca.GetType() == types.HostCA {
-					// We need local keys to sign the Admin identity to support
-					// tctl. For this special case we add AdditionalTrustedKeys
-					// without any active keys. These keys will not be used for
-					// any signing operations until a CA rotation. Only the Host
-					// CA is necessary to issue the Admin identity.
-					if err := asrv.ensureLocalAdditionalKeys(ctx, ca); err != nil {
-						return nil, trace.Wrap(err)
-					}
-					// reload updated CA for below checks
-					if ca, err = asrv.Services.GetCertAuthority(ctx, caID, true); err != nil {
-						return nil, trace.Wrap(err)
+				if !trace.IsNotFound(err) {
+					return trace.Wrap(err)
+				}
+
+				log.Infof("First start: generating %s certificate authority.", caID.Type)
+				if ca, err = generateAuthority(ctx, asrv, caID); err != nil {
+					return trace.Wrap(err)
+				}
+
+				if err := asrv.CreateCertAuthority(ctx, ca); err != nil {
+					return trace.Wrap(err)
+				}
+			} else {
+				// Already have a CA. Make sure the keyStore has usable keys.
+				hasUsableActiveKeys, err := asrv.keyStore.HasUsableActiveKeys(ctx, ca)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				if !hasUsableActiveKeys {
+					// This could be one of a few cases:
+					// 1. A new auth server with an HSM being added to an HA cluster.
+					// 2. A new auth server with no HSM being added to an HA cluster
+					//    where all current auth servers have HSMs.
+					// 3. An existing auth server has restarted with a new HSM configured.
+					// 4. An existing HSM auth server has restarted no HSM configured.
+					// 5. An existing HSM auth server has restarted with a new UUID.
+					if ca.GetType() == types.HostCA {
+						// We need local keys to sign the Admin identity to support
+						// tctl. For this special case we add AdditionalTrustedKeys
+						// without any active keys. These keys will not be used for
+						// any signing operations until a CA rotation. Only the Host
+						// CA is necessary to issue the Admin identity.
+						if err := asrv.ensureLocalAdditionalKeys(ctx, ca); err != nil {
+							return trace.Wrap(err)
+						}
+						// reload updated CA for below checks
+						if ca, err = asrv.Services.GetCertAuthority(ctx, caID, true); err != nil {
+							return trace.Wrap(err)
+						}
 					}
 				}
+				hasUsableActiveKeys, err = asrv.keyStore.HasUsableActiveKeys(ctx, ca)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				hasUsableAdditionalKeys, err := asrv.keyStore.HasUsableAdditionalKeys(ctx, ca)
+				if err != nil {
+					return trace.Wrap(err)
+				}
+				if !hasUsableActiveKeys && hasUsableAdditionalKeys {
+					log.Warn("This auth server has a newly added or removed HSM and will not " +
+						"be able to perform any signing operations. You must rotate all CAs " +
+						"before routing traffic to this auth server. See https://goteleport.com/docs/management/operations/ca-rotation/")
+				}
+				allKeyTypes := ca.AllKeyTypes()
+				numKeyTypes := len(allKeyTypes)
+				if numKeyTypes > 1 {
+					log.Warnf("%s CA contains a combination of %s and %s keys. If you are attempting to"+
+						" configure HSM or KMS support, make sure it is configured on all auth servers in"+
+						" this cluster and then perform a CA rotation: https://goteleport.com/docs/management/operations/ca-rotation/",
+						caID.Type, strings.Join(allKeyTypes[:numKeyTypes-1], ", "), allKeyTypes[numKeyTypes-1])
+				}
 			}
-			hasUsableActiveKeys, err = asrv.keyStore.HasUsableActiveKeys(ctx, ca)
-			if err != nil {
-				return nil, trace.Wrap(err)
+
+			mu.Lock()
+			defer mu.Unlock()
+			for _, keySet := range []types.CAKeySet{ca.GetActiveKeys(), ca.GetAdditionalTrustedKeys()} {
+				for _, sshKeyPair := range keySet.SSH {
+					activeKeys = append(activeKeys, sshKeyPair.PrivateKey)
+				}
+				for _, tlsKeyPair := range keySet.TLS {
+					activeKeys = append(activeKeys, tlsKeyPair.Key)
+				}
+				for _, jwtKeyPair := range keySet.JWT {
+					activeKeys = append(activeKeys, jwtKeyPair.PrivateKey)
+				}
 			}
-			hasUsableAdditionalKeys, err := asrv.keyStore.HasUsableAdditionalKeys(ctx, ca)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
-			if !hasUsableActiveKeys && hasUsableAdditionalKeys {
-				log.Warn("This auth server has a newly added or removed HSM and will not " +
-					"be able to perform any signing operations. You must rotate all CAs " +
-					"before routing traffic to this auth server. See https://goteleport.com/docs/management/operations/ca-rotation/")
-			}
-			allKeyTypes := ca.AllKeyTypes()
-			numKeyTypes := len(allKeyTypes)
-			if numKeyTypes > 1 {
-				log.Warnf("%s CA contains a combination of %s and %s keys. If you are attempting to"+
-					" configure HSM or KMS support, make sure it is configured on all auth servers in"+
-					" this cluster and then perform a CA rotation: https://goteleport.com/docs/management/operations/ca-rotation/",
-					caID.Type, strings.Join(allKeyTypes[:numKeyTypes-1], ", "), allKeyTypes[numKeyTypes-1])
-			}
-		}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return nil, trace.Wrap(err)
 	}
 
 	// Delete any unused keys from the keyStore. This is to avoid exhausting
 	// (or wasting) HSM resources.
-	if err := asrv.deleteUnusedKeys(ctx); err != nil {
-		return nil, trace.Wrap(err)
+	if err := asrv.keyStore.DeleteUnusedKeys(ctx, activeKeys); err != nil {
+		// Key deletion is best-effort, log a warning if it fails and carry on.
+		// We don't want to prevent a CA rotation, which may be necessary in
+		// some cases where this would fail.
+		log.WithError(err).Warning("Failed attempt to delete unused HSM keys")
 	}
 
 	if lib.IsInsecureDevMode() {
@@ -489,22 +554,25 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 		log.Warn(warningMessage)
 	}
 
+	span.AddEvent("migrating legacy resources")
 	// Migrate any legacy resources to new format.
-	err = migrateLegacyResources(ctx, asrv)
-	if err != nil {
+	if err := migrateLegacyResources(ctx, asrv); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	span.AddEvent("completed migration legacy resources")
 
+	span.AddEvent("creating preset roles")
 	// Create presets - convenience and example resources.
-	err = createPresetRoles(ctx, asrv)
-	if err != nil {
+	if err := createPresetRoles(ctx, asrv); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	span.AddEvent("completed creating preset roles")
 
-	err = createPresetUsers(ctx, asrv)
-	if err != nil {
+	span.AddEvent("creating preset users")
+	if err := createPresetUsers(ctx, asrv); err != nil {
 		return nil, trace.Wrap(err)
 	}
+	span.AddEvent("completed creating preset users")
 
 	if !cfg.SkipPeriodicOperations {
 		log.Infof("Auth server is running periodic operations.")
@@ -514,6 +582,26 @@ func Init(cfg InitConfig, opts ...ServerOption) (*Server, error) {
 	}
 
 	return asrv, nil
+}
+
+// generateAuthority creates a new self-signed authority of the provided type
+// and returns it to the caller. It is the responsibility of callers to persist
+// the authority.
+func generateAuthority(ctx context.Context, asrv *Server, caID types.CertAuthID) (types.CertAuthority, error) {
+	keySet, err := newKeySet(ctx, asrv.keyStore, caID)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        caID.Type,
+		ClusterName: caID.DomainName,
+		ActiveKeys:  keySet,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ca, nil
 }
 
 func initSetAuthPreference(ctx context.Context, asrv *Server, newAuthPref types.AuthPreference) error {
@@ -643,46 +731,51 @@ func createPresetRoles(ctx context.Context, rm PresetRoleManager) error {
 		services.NewPresetRequesterRole(),
 		services.NewSystemAutomaticAccessApproverRole(),
 	}
+
+	g, gctx := errgroup.WithContext(ctx)
 	for _, role := range roles {
 		// If the role is nil, skip because it doesn't apply to this Teleport installation.
 		if role == nil {
 			continue
 		}
 
-		if types.IsSystemResource(role) {
-			// System resources *always* get reset on every auth startup
-			if err := rm.UpsertRole(ctx, role); err != nil {
-				return trace.Wrap(err, "failed upserting system role %s", role.GetName())
-			}
-			continue
-		}
+		role := role
+		g.Go(func() error {
+			if types.IsSystemResource(role) {
+				// System resources *always* get reset on every auth startup
+				if err := rm.UpsertRole(gctx, role); err != nil {
+					return trace.Wrap(err, "failed upserting system role %s", role.GetName())
+				}
 
-		err := rm.CreateRole(ctx, role)
-		if err != nil {
-			if !trace.IsAlreadyExists(err) {
-				return trace.WrapWithMessage(err, "failed to create preset role %v", role.GetName())
+				return nil
 			}
 
-			currentRole, err := rm.GetRole(ctx, role.GetName())
-			if err != nil {
-				return trace.Wrap(err)
-			}
+			if err := rm.CreateRole(gctx, role); err != nil {
+				if !trace.IsAlreadyExists(err) {
+					return trace.WrapWithMessage(err, "failed to create preset role %v", role.GetName())
+				}
 
-			role, err := services.AddRoleDefaults(currentRole)
-			if trace.IsAlreadyExists(err) {
-				continue
-			}
-			if err != nil {
-				return trace.Wrap(err)
-			}
+				currentRole, err := rm.GetRole(gctx, role.GetName())
+				if err != nil {
+					return trace.Wrap(err)
+				}
 
-			err = rm.UpsertRole(ctx, role)
-			if err != nil {
-				return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
+				role, err := services.AddRoleDefaults(currentRole)
+				if trace.IsAlreadyExists(err) {
+					return nil
+				}
+				if err != nil {
+					return trace.Wrap(err)
+				}
+
+				if err := rm.UpsertRole(gctx, role); err != nil {
+					return trace.WrapWithMessage(err, "failed to update preset role %v", role.GetName())
+				}
 			}
-		}
+			return nil
+		})
 	}
-	return nil
+	return trace.Wrap(g.Wait())
 }
 
 // PresetUsers contains the required User Management methods to
@@ -719,14 +812,7 @@ func createPresetUsers(ctx context.Context, um PresetUsers) error {
 			continue
 		}
 
-		err := um.CreateUser(ctx, user)
-		if err == nil {
-			// Success! The rest of the loop body is immaterial. Move on to
-			// the next user.
-			continue
-		}
-
-		if !trace.IsAlreadyExists(err) {
+		if err := um.CreateUser(ctx, user); err != nil && !trace.IsAlreadyExists(err) {
 			return trace.Wrap(err, "failed creating preset user %s", user.GetName())
 		}
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -1649,64 +1649,67 @@ func (process *TeleportProcess) initAuthService() error {
 	embeddingsRetriever := ai.NewSimpleRetriever()
 
 	// first, create the AuthServer
-	authServer, err := auth.Init(auth.InitConfig{
-		Backend:                 b,
-		Authority:               cfg.Keygen,
-		ClusterConfiguration:    cfg.ClusterConfiguration,
-		ClusterAuditConfig:      cfg.Auth.AuditConfig,
-		ClusterNetworkingConfig: cfg.Auth.NetworkingConfig,
-		SessionRecordingConfig:  cfg.Auth.SessionRecordingConfig,
-		ClusterName:             cfg.Auth.ClusterName,
-		AuthServiceName:         cfg.Hostname,
-		DataDir:                 cfg.DataDir,
-		HostUUID:                cfg.HostUUID,
-		NodeName:                cfg.Hostname,
-		Authorities:             cfg.Auth.Authorities,
-		ApplyOnStartupResources: cfg.Auth.ApplyOnStartupResources,
-		BootstrapResources:      cfg.Auth.BootstrapResources,
-		ReverseTunnels:          cfg.ReverseTunnels,
-		Trust:                   cfg.Trust,
-		Presence:                cfg.Presence,
-		Events:                  cfg.Events,
-		Provisioner:             cfg.Provisioner,
-		Identity:                cfg.Identity,
-		Access:                  cfg.Access,
-		UsageReporter:           cfg.UsageReporter,
-		StaticTokens:            cfg.Auth.StaticTokens,
-		Roles:                   cfg.Auth.Roles,
-		AuthPreference:          cfg.Auth.Preference,
-		OIDCConnectors:          cfg.OIDCConnectors,
-		AuditLog:                process.auditLog,
-		CipherSuites:            cfg.CipherSuites,
-		KeyStoreConfig:          cfg.Auth.KeyStore,
-		Emitter:                 checkingEmitter,
-		Streamer:                events.NewReportingStreamer(streamer, process.Config.UploadEventsC),
-		TraceClient:             traceClt,
-		FIPS:                    cfg.FIPS,
-		LoadAllCAs:              cfg.Auth.LoadAllCAs,
-		Clock:                   cfg.Clock,
-		HTTPClientForAWSSTS:     cfg.Auth.HTTPClientForAWSSTS,
-		EmbeddingRetriever:      embeddingsRetriever,
-		EmbeddingClient:         embedderClient,
-	}, func(as *auth.Server) error {
-		if !process.Config.CachePolicy.Enabled {
+	authServer, err := auth.Init(
+		process.ExitContext(),
+		auth.InitConfig{
+			Backend:                 b,
+			Authority:               cfg.Keygen,
+			ClusterConfiguration:    cfg.ClusterConfiguration,
+			ClusterAuditConfig:      cfg.Auth.AuditConfig,
+			ClusterNetworkingConfig: cfg.Auth.NetworkingConfig,
+			SessionRecordingConfig:  cfg.Auth.SessionRecordingConfig,
+			ClusterName:             cfg.Auth.ClusterName,
+			AuthServiceName:         cfg.Hostname,
+			DataDir:                 cfg.DataDir,
+			HostUUID:                cfg.HostUUID,
+			NodeName:                cfg.Hostname,
+			Authorities:             cfg.Auth.Authorities,
+			ApplyOnStartupResources: cfg.Auth.ApplyOnStartupResources,
+			BootstrapResources:      cfg.Auth.BootstrapResources,
+			ReverseTunnels:          cfg.ReverseTunnels,
+			Trust:                   cfg.Trust,
+			Presence:                cfg.Presence,
+			Events:                  cfg.Events,
+			Provisioner:             cfg.Provisioner,
+			Identity:                cfg.Identity,
+			Access:                  cfg.Access,
+			UsageReporter:           cfg.UsageReporter,
+			StaticTokens:            cfg.Auth.StaticTokens,
+			Roles:                   cfg.Auth.Roles,
+			AuthPreference:          cfg.Auth.Preference,
+			OIDCConnectors:          cfg.OIDCConnectors,
+			AuditLog:                process.auditLog,
+			CipherSuites:            cfg.CipherSuites,
+			KeyStoreConfig:          cfg.Auth.KeyStore,
+			Emitter:                 checkingEmitter,
+			Streamer:                events.NewReportingStreamer(streamer, process.Config.UploadEventsC),
+			TraceClient:             traceClt,
+			FIPS:                    cfg.FIPS,
+			LoadAllCAs:              cfg.Auth.LoadAllCAs,
+			Clock:                   cfg.Clock,
+			HTTPClientForAWSSTS:     cfg.Auth.HTTPClientForAWSSTS,
+			EmbeddingRetriever:      embeddingsRetriever,
+			EmbeddingClient:         embedderClient,
+			Tracer:                  process.TracingProvider.Tracer(teleport.ComponentAuth),
+		}, func(as *auth.Server) error {
+			if !process.Config.CachePolicy.Enabled {
+				return nil
+			}
+
+			cache, err := process.newAccessCache(accessCacheConfig{
+				services:  as.Services,
+				setup:     cache.ForAuth,
+				cacheName: []string{teleport.ComponentAuth},
+				events:    true,
+				unstarted: true,
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			as.Cache = cache
+
 			return nil
-		}
-
-		cache, err := process.newAccessCache(accessCacheConfig{
-			services:  as.Services,
-			setup:     cache.ForAuth,
-			cacheName: []string{teleport.ComponentAuth},
-			events:    true,
-			unstarted: true,
 		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		as.Cache = cache
-
-		return nil
-	})
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Reduces execution time of `auth.Init` by ~50% for both brand new clusters and existing clusters. Achieves the improvements by performing backend operations that set cluster configuration and CA generation in parallel instead of serially. Key generation is still the most expensive part of initialization, but should be reduced further by switching algorithms to something other than RSA.

Of note though is that due to how the pksc11 store generated key ids that it cannot generate keys in parallel. To prevent data races it serializes all key generation requests via a semaphore.

Additionally, the procedure to cleanup unused keys from HSMs has been improved by reusing the CAs that were already retrieved to determine the active keys instead of fetching them all a second time.