### PR TITLE
Add in user login state.

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -435,6 +435,9 @@ const (
 	// KindAccessList is an AccessList resource
 	KindAccessList = "access_list"
 
+	// KindUserLoginState is a UserLoginState resource
+	KindUserLoginState = "user_login_state"
+
 	// V7 is the seventh version of resources.
 	V7 = "v7"
 

--- a/api/types/userloginstate/user_login_state.go
+++ b/api/types/userloginstate/user_login_state.go
@@ -26,7 +26,11 @@ import (
 )
 
 // UserLoginState is the ephemeral user login state. This will hold data to differentiate
-// from the User object.
+// from the User object. This will allow us to store derived roles and traits from
+// access lists, login rules, and other mechanisms to more easily incorporate these
+// bits of data into user created certificates. It will also allow us to leave the user
+// object itself unmodified despite this ephemeral data, which is frequently needed
+// despite the dynamic nature of user access.
 type UserLoginState struct {
 	// ResourceHeader is the common resource header for all resources.
 	header.ResourceHeader
@@ -35,7 +39,7 @@ type UserLoginState struct {
 	Spec Spec `json:"spec" yaml:"spec"`
 }
 
-// Spec is the specification for the user login st ate.
+// Spec is the specification for the user login state.
 type Spec struct {
 	// Roles is the list of roles attached to the user login state.
 	Roles []string `json:"roles" yaml:"roles"`
@@ -44,7 +48,7 @@ type Spec struct {
 	Traits trait.Traits `json:"traits" yaml:"traits"`
 }
 
-// New will create a new user login state.
+// New creates a new user login state.
 func New(metadata header.Metadata, spec Spec) (*UserLoginState, error) {
 	userLoginState := &UserLoginState{
 		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
@@ -63,11 +67,7 @@ func (u *UserLoginState) CheckAndSetDefaults() error {
 	u.SetKind(types.KindUserLoginState)
 	u.SetVersion(types.V1)
 
-	if err := u.ResourceHeader.CheckAndSetDefaults(); err != nil {
-		return trace.Wrap(err)
-	}
-
-	return nil
+	return trace.Wrap(u.ResourceHeader.CheckAndSetDefaults())
 }
 
 // GetRoles returns the roles attached to the user login state.

--- a/api/types/userloginstate/userloginstate.go
+++ b/api/types/userloginstate/userloginstate.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userloginstate
+
+import (
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/header/convert/legacy"
+	"github.com/gravitational/teleport/api/types/trait"
+	"github.com/gravitational/trace"
+)
+
+// UserLoginState is the ephemeral user login state. This will hold data to differentiate
+// from the User object.
+type UserLoginState struct {
+	// ResourceHeader is the common resource header for all resources.
+	header.ResourceHeader
+
+	// Spec is the specification for the user login state.
+	Spec Spec `json:"spec" yaml:"spec"`
+}
+
+// Spec is the specification for the user login st ate.
+type Spec struct {
+	// Roles is the list of roles attached to the user login state.
+	Roles []string `json:"roles" yaml:"roles"`
+
+	// Traits are the traits attached to the user login state.
+	Traits trait.Traits `json:"traits" yaml:"traits"`
+}
+
+// New will create a new user login state.
+func New(metadata header.Metadata, spec Spec) (*UserLoginState, error) {
+	userLoginState := &UserLoginState{
+		ResourceHeader: header.ResourceHeaderFromMetadata(metadata),
+		Spec:           spec,
+	}
+
+	if err := userLoginState.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return userLoginState, nil
+}
+
+// CheckAndSetDefaults validates fields and populates empty fields with default values.
+func (u *UserLoginState) CheckAndSetDefaults() error {
+	u.SetKind(types.KindUserLoginState)
+	u.SetVersion(types.V1)
+
+	if err := u.ResourceHeader.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+// GetRoles returns the roles attached to the user login state.
+func (u *UserLoginState) GetRoles() []string {
+	return u.Spec.Roles
+}
+
+// GetTraits returns the traits attached to the user login state.
+func (u *UserLoginState) GetTraits() trait.Traits {
+	return u.Spec.Traits
+}
+
+// GetMetadata returns metadata. This is specifically for conforming to the Resource interface,
+// and should be removed when possible.
+func (u *UserLoginState) GetMetadata() types.Metadata {
+	return legacy.FromHeaderMetadata(u.Metadata)
+}

--- a/api/types/userloginstate/userloginstate.go
+++ b/api/types/userloginstate/userloginstate.go
@@ -17,11 +17,12 @@ limitations under the License.
 package userloginstate
 
 import (
+	"github.com/gravitational/trace"
+
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/types/header"
 	"github.com/gravitational/teleport/api/types/header/convert/legacy"
 	"github.com/gravitational/teleport/api/types/trait"
-	"github.com/gravitational/trace"
 )
 
 // UserLoginState is the ephemeral user login state. This will hold data to differentiate

--- a/lib/services/local/user_login_state.go
+++ b/lib/services/local/user_login_state.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local/generic"
+)
+
+const (
+	userLoginStatePrefix = "user_login_state"
+)
+
+// UserLoginStateService manages user login state resources in the Backend.
+type UserLoginStateService struct {
+	log logrus.FieldLogger
+	svc *generic.Service[*userloginstate.UserLoginState]
+}
+
+// NewUserLoginStateService creates a new UserLoginStateService.
+func NewUserLoginStateService(backend backend.Backend) (*UserLoginStateService, error) {
+	svc, err := generic.NewService(&generic.ServiceConfig[*userloginstate.UserLoginState]{
+		Backend:       backend,
+		ResourceKind:  types.KindUserLoginState,
+		BackendPrefix: userLoginStatePrefix,
+		MarshalFunc:   services.MarshalUserLoginState,
+		UnmarshalFunc: services.UnmarshalUserLoginState,
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &UserLoginStateService{
+		log: logrus.WithFields(logrus.Fields{trace.Component: "user-login-state:local-service"}),
+		svc: svc,
+	}, nil
+}
+
+// GetUserLoginState returns the specified user login state resource.
+func (u *UserLoginStateService) GetUserLoginState(ctx context.Context, name string) (*userloginstate.UserLoginState, error) {
+	userLoginState, err := u.svc.GetResource(ctx, name)
+	return userLoginState, trace.Wrap(err)
+}
+
+// UpsertUserLoginState creates or updates a user login state resource.
+func (u *UserLoginStateService) UpsertUserLoginState(ctx context.Context, userLoginState *userloginstate.UserLoginState) (*userloginstate.UserLoginState, error) {
+	if err := trace.Wrap(u.svc.UpsertResource(ctx, userLoginState)); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return userLoginState, nil
+}
+
+// DeleteUserLoginState removes the specified user login state resource.
+func (u *UserLoginStateService) DeleteUserLoginState(ctx context.Context, name string) error {
+	return trace.Wrap(u.svc.DeleteResource(ctx, name))
+}

--- a/lib/services/local/user_login_state_test.go
+++ b/lib/services/local/user_login_state_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package local
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/lib/backend/memory"
+)
+
+// TestUserLoginStateCRUD tests backend operations with user login state resources.
+func TestUserLoginStateCRUD(t *testing.T) {
+	ctx := context.Background()
+	clock := clockwork.NewFakeClock()
+
+	backend, err := memory.New(memory.Config{
+		Context: ctx,
+	})
+	require.NoError(t, err)
+
+	service, err := NewUserLoginStateService(backend)
+	require.NoError(t, err)
+
+	// Create a couple user login states.
+	state1 := newUserLoginState(t, "state1")
+	state2 := newUserLoginState(t, "state2")
+
+	cmpOpts := []cmp.Option{
+		cmpopts.IgnoreFields(header.Metadata{}, "ID"),
+	}
+
+	// Neither state should exist.
+	_, err = service.GetUserLoginState(ctx, state1.GetName())
+	require.True(t, trace.IsNotFound(err))
+	_, err = service.GetUserLoginState(ctx, state2.GetName())
+	require.True(t, trace.IsNotFound(err))
+
+	// Create both states.
+	state, err := service.UpsertUserLoginState(ctx, state1)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(state1, state, cmpOpts...))
+	state, err = service.UpsertUserLoginState(ctx, state2)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(state2, state, cmpOpts...))
+
+	// Fetch a specific state.
+	state, err = service.GetUserLoginState(ctx, state2.GetName())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(state2, state, cmpOpts...))
+
+	// Update a state.
+	state1.SetExpiry(clock.Now().Add(30 * time.Minute))
+	state, err = service.UpsertUserLoginState(ctx, state1)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(state1, state, cmpOpts...))
+	state, err = service.GetUserLoginState(ctx, state1.GetName())
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(state1, state, cmpOpts...))
+
+	// Delete a state.
+	err = service.DeleteUserLoginState(ctx, state1.GetName())
+	require.NoError(t, err)
+	_, err = service.GetUserLoginState(ctx, state1.GetName())
+	require.True(t, trace.IsNotFound(err))
+
+	// Try to delete a state that doesn't exist.
+	err = service.DeleteUserLoginState(ctx, "doesnotexist")
+	require.True(t, trace.IsNotFound(err), "expected not found error, got %v", err)
+}
+
+func newUserLoginState(t *testing.T, name string) *userloginstate.UserLoginState {
+	t.Helper()
+
+	userLoginState, err := userloginstate.New(
+		header.Metadata{
+			Name: name,
+		},
+		userloginstate.Spec{
+			Roles: []string{
+				"role1",
+				"role2",
+				"role3",
+			},
+			Traits: map[string][]string{
+				"trait1": {"value1", "value2"},
+				"trait2": {"value3", "value4"},
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	return userLoginState
+}

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// UserLoginStateGetter defines an interface for reading user login states.
+type UserLoginStateGetter interface {
+	// GetUserLoginState returns the specified user login state resource.
+	GetUserLoginState(context.Context, string) (*userloginstate.UserLoginState, error)
+}
+
+// UserLoginStates defines an interface for managing user login states.
+type UserLoginStates interface {
+	UserLoginStateGetter
+
+	// UpsertUserLoginState creates or updates a user login state resource.
+	UpsertUserLoginState(context.Context, *userloginstate.UserLoginState) (*userloginstate.UserLoginState, error)
+
+	// DeletetUserLoginState deletes a user login state resource.
+	DeleteUserLoginState(context.Context, string) error
+}
+
+// MarshalUserLoginState marshals the user login state resource to JSON.
+func MarshalUserLoginState(userLoginState *userloginstate.UserLoginState, opts ...MarshalOption) ([]byte, error) {
+	if err := userLoginState.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if !cfg.PreserveResourceID {
+		copy := *userLoginState
+		copy.SetResourceID(0)
+		userLoginState = &copy
+	}
+	return utils.FastMarshal(userLoginState)
+}
+
+// UnmarshalUserLoginState unmarshals the user login state resource from JSON.
+func UnmarshalUserLoginState(data []byte, opts ...MarshalOption) (*userloginstate.UserLoginState, error) {
+	if len(data) == 0 {
+		return nil, trace.BadParameter("missing user login state data")
+	}
+	cfg, err := CollectOptions(opts)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	var userLoginState *userloginstate.UserLoginState
+	if err := utils.FastUnmarshal(data, &userLoginState); err != nil {
+		return nil, trace.BadParameter(err.Error())
+	}
+	if err := userLoginState.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	if cfg.ID != 0 {
+		userLoginState.SetResourceID(cfg.ID)
+	}
+	if !cfg.Expires.IsZero() {
+		userLoginState.SetExpiry(cfg.Expires)
+	}
+	return userLoginState, nil
+}

--- a/lib/services/user_login_state.go
+++ b/lib/services/user_login_state.go
@@ -44,9 +44,6 @@ func MarshalUserLoginState(userLoginState *userloginstate.UserLoginState, opts .
 
 // UnmarshalUserLoginState unmarshals the user login state resource from JSON.
 func UnmarshalUserLoginState(data []byte, opts ...MarshalOption) (*userloginstate.UserLoginState, error) {
-	//if len(data) == 0 {
-	//	return nil, trace.BadParameter("missing user login state data")
-	//}
 	cfg, err := CollectOptions(opts)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/user_login_state_test.go
+++ b/lib/services/user_login_state_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 // TestUserLoginStateUnmarshal verifies a user login state resource can be unmarshaled.
-func TestUserLoginState(t *testing.T) {
+func TestUserLoginStateUnmarshal(t *testing.T) {
 	expected, err := userloginstate.New(
 		header.Metadata{
 			Name: "test-user",
@@ -45,7 +45,24 @@ func TestUserLoginState(t *testing.T) {
 		},
 	)
 	require.NoError(t, err)
-	data, err := utils.ToJSON([]byte(userLoginStateYAML))
+	data, err := utils.ToJSON([]byte(`---
+kind: user_login_state
+version: v1
+metadata:
+  name: test-user
+spec:
+  roles:
+  - role1
+  - role2
+  - role3
+  traits:
+    trait1:
+    - value1
+    - value2
+    trait2:
+    - value3
+    - value4
+`))
 	require.NoError(t, err)
 	actual, err := UnmarshalUserLoginState(data)
 	require.NoError(t, err)
@@ -77,22 +94,3 @@ func TestUserLoginStateMarshal(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
 }
-
-var userLoginStateYAML = `---
-kind: user_login_state
-version: v1
-metadata:
-  name: test-user
-spec:
-  roles:
-  - role1
-  - role2
-  - role3
-  traits:
-    trait1:
-    - value1
-    - value2
-    trait2:
-    - value3
-    - value4
-`

--- a/lib/services/user_login_state_test.go
+++ b/lib/services/user_login_state_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/api/types/userloginstate"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+// TestUserLoginStateUnmarshal verifies a user login state resource can be unmarshaled.
+func TestUserLoginState(t *testing.T) {
+	expected, err := userloginstate.New(
+		header.Metadata{
+			Name: "test-user",
+		},
+		userloginstate.Spec{
+			Roles: []string{
+				"role1",
+				"role2",
+				"role3",
+			},
+			Traits: map[string][]string{
+				"trait1": {"value1", "value2"},
+				"trait2": {"value3", "value4"},
+			},
+		},
+	)
+	require.NoError(t, err)
+	data, err := utils.ToJSON([]byte(userLoginStateYAML))
+	require.NoError(t, err)
+	actual, err := UnmarshalUserLoginState(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+// TestUserLoginStateMarshal verifies a marshaled user login state resource can be unmarshaled back.
+func TestUserLoginStateMarshal(t *testing.T) {
+	expected, err := userloginstate.New(
+		header.Metadata{
+			Name: "test-user",
+		},
+		userloginstate.Spec{
+			Roles: []string{
+				"role1",
+				"role2",
+				"role3",
+			},
+			Traits: map[string][]string{
+				"trait1": {"value1", "value2"},
+				"trait2": {"value3", "value4"},
+			},
+		},
+	)
+	require.NoError(t, err)
+	data, err := MarshalUserLoginState(expected)
+	require.NoError(t, err)
+	actual, err := UnmarshalUserLoginState(data)
+	require.NoError(t, err)
+	require.Equal(t, expected, actual)
+}
+
+var userLoginStateYAML = `---
+kind: user_login_state
+version: v1
+metadata:
+  name: test-user
+spec:
+  roles:
+  - role1
+  - role2
+  - role3
+  traits:
+    trait1:
+    - value1
+    - value2
+    trait2:
+    - value3
+    - value4
+`


### PR DESCRIPTION
The user login state has been introduced, which will house ephemeral data associated with users that lives separately from the fixed user definition. This object will only live on the auth server and only be used during very specific circumstances, so for now it will not be cached and it will not be exposed via the API. As such, the object and its backend have been introduced in one commit.

Reference: https://github.com/gravitational/teleport.e/blob/master/rfd/0006e-access-lists.md#userloginstate-object

Note: I put this in `api/types` in case we need to expand this object into the cache in the future, which will require it to live here so that cache propagation will work as expected.