### PR TITLE
Fix proxy protocol support for Kube access flow

### DIFF
--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -96,6 +96,8 @@ type TLSServerConfig struct {
 	// kubernetes_service. The servers are kept in memory to avoid making unnecessary
 	// unmarshal calls followed by filtering and to improve memory usage.
 	KubernetesServersWatcher *services.KubeServerWatcher
+	// EnableProxyProtocol enables proxy protocol support
+	EnableProxyProtocol bool
 }
 
 // CheckAndSetDefaults checks and sets default values
@@ -272,7 +274,7 @@ func (t *TLSServer) Serve(listener net.Listener) error {
 		Context:                     t.Context,
 		Listener:                    listener,
 		Clock:                       t.Clock,
-		EnableExternalProxyProtocol: true,
+		EnableExternalProxyProtocol: t.EnableProxyProtocol,
 		ID:                          t.Component,
 		CertAuthorityGetter:         caGetter,
 		LocalClusterName:            t.ClusterName,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4214,6 +4214,7 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 			Log:                      log,
 			IngressReporter:          ingressReporter,
 			KubernetesServersWatcher: kubeServerWatcher,
+			EnableProxyProtocol:      cfg.Proxy.EnableProxyProtocol,
 		})
 		if err != nil {
 			return trace.Wrap(err)


### PR DESCRIPTION
This PR allows enabling/disabling the support for the proxy protocol in Kubernetes access flow.

Fixes https://github.com/gravitational/teleport-private/issues/795