### PR TITLE
[v12] update discovery labels

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -462,6 +462,32 @@ const (
 	// CloudLabel is used to identify the cloud where the resource was discovered.
 	CloudLabel = TeleportNamespace + "/cloud"
 
+	// cloudKubeClusterNameOverrideLabel is a cloud agnostic label key for
+	// overriding kubernetes cluster name in discovered cloud kube clusters.
+	// It's used for AWS, GCP, and Azure, but not exported to decouple the
+	// cloud-specific labels from eachother.
+	cloudKubeClusterNameOverrideLabel = "TeleportKubernetesName"
+
+	// cloudDatabaseNameOverrideLabel is a cloud agnostic label key for
+	// overriding the database name in discovered cloud databases.
+	// It's used for AWS, GCP, and Azure, but not exported to decouple the
+	// cloud-specific labels from eachother.
+	cloudDatabaseNameOverrideLabel = "TeleportDatabaseName"
+
+	// AzureDatabaseNameOverrideLabel is the label key containing the database
+	// name override for discovered Azure databases.
+	// Azure tags cannot contain these characters: "<>%&\?/", so it doesn't
+	// start with the namespace prefix.
+	AzureDatabaseNameOverrideLabel = cloudDatabaseNameOverrideLabel
+
+	// AzureKubeClusterNameOverrideLabel is the label key containing the
+	// kubernetes cluster name override for discovered Azure kube clusters.
+	AzureKubeClusterNameOverrideLabel = cloudKubeClusterNameOverrideLabel
+
+	// GCPKubeClusterNameOverrideLabel is the label key containing the
+	// kubernetes cluster name override for discovered GCP kube clusters.
+	GCPKubeClusterNameOverrideLabel = cloudKubeClusterNameOverrideLabel
+
 	// CloudAWS identifies that a resource was discovered in AWS.
 	CloudAWS = "AWS"
 	// CloudAzure identifies that a resource was discovered in Azure.
@@ -471,6 +497,97 @@ const (
 
 	// TeleportAzureMSIEndpoint is a special URL intercepted by TSH local proxy, serving Azure credentials.
 	TeleportAzureMSIEndpoint = "azure-msi." + TeleportNamespace
+)
+
+var (
+	// AWSKubeClusterNameOverrideLabels are the label keys that Teleport
+	// supports to override the kubernetes cluster name of discovered AWS kube
+	// clusters.
+	// Originally Teleport supported just the namespaced label
+	// "teleport.dev/kubernetes-name", but this was an invalid label key in
+	// other clouds.
+	// For consistency and backwards compatibility, Teleport now supports both
+	// the generic cloud kube cluster name override label and the original
+	// namespaced label.
+	AWSKubeClusterNameOverrideLabels = []string{
+		cloudKubeClusterNameOverrideLabel,
+		// This is a legacy label that should continue to be supported, but
+		// don't reference it in documentation or error messages anymore.
+		// The generic label takes precedence.
+		TeleportNamespace + "/kubernetes-name",
+	}
+	// AWSDatabaseNameOverrideLabels are the label keys that Teleport
+	// supports to override the database name of discovered AWS databases.
+	// Originally Teleport supported just the namespaced label
+	// "teleport.dev/database_name", but this was an invalid label key in
+	// other clouds.
+	// For consistency and backwards compatibility, Teleport now supports both
+	// the generic cloud database name override label and the original
+	// namespaced label.
+	AWSDatabaseNameOverrideLabels = []string{
+		cloudDatabaseNameOverrideLabel,
+		// This is a legacy label that should continue to be supported, but
+		// don't reference it in documentation or error messages anymore.
+		// The generic label takes precedence.
+		TeleportNamespace + "/database_name",
+	}
+)
+
+// Labels added by the discovery service to discovered databases,
+// Kubernetes clusters, and Windows desktops.
+const (
+	// DiscoveryLabelRegion identifies a discovered cloud resource's region.
+	DiscoveryLabelRegion = "region"
+	// DiscoveryLabelAccountID is the label key containing AWS account ID.
+	DiscoveryLabelAccountID = "account-id"
+	// DiscoveryLabelEngine is the label key containing database engine name.
+	DiscoveryLabelEngine = "engine"
+	// DiscoveryLabelEngineVersion is the label key containing database engine version.
+	DiscoveryLabelEngineVersion = "engine-version"
+	// DiscoveryLabelEndpointType is the label key containing the endpoint type.
+	DiscoveryLabelEndpointType = "endpoint-type"
+	// DiscoveryLabelVPCID is the label key containing the VPC ID.
+	DiscoveryLabelVPCID = "vpc-id"
+	// DiscoveryLabelNamespace is the label key for namespace name.
+	DiscoveryLabelNamespace = "namespace"
+	// DiscoveryLabelWorkgroup is the label key for workgroup name.
+	DiscoveryLabelWorkgroup = "workgroup"
+	// DiscoveryLabelStatus is the label key containing the database status, e.g. "available"
+	DiscoveryLabelStatus = "status"
+
+	// DiscoveryLabelAzureSubscriptionID is the label key for Azure subscription ID.
+	DiscoveryLabelAzureSubscriptionID = "subscription-id"
+	// DiscoveryLabelAzureResourceGroup is the label key for the Azure resource group name.
+	DiscoveryLabelAzureResourceGroup = "resource-group"
+	// DiscoveryLabelAzureReplicationRole is the replication role of an Azure DB Flexible server, e.g. "Source" or "Replica".
+	DiscoveryLabelAzureReplicationRole = "replication-role"
+	// DiscoveryLabelAzureSourceServer is the source server for replica Azure DB Flexible servers.
+	// This is the source (primary) database resource name.
+	DiscoveryLabelAzureSourceServer = "source-server"
+
+	// DiscoveryLabelGCPProjectID is the label key for GCP project ID.
+	DiscoveryLabelGCPProjectID = "project-id"
+	// DiscoveryLabelGCPLocation is the label key for GCP location.
+	DiscoveryLabelGCPLocation = "location"
+
+	// DiscoveryLabelWindowsDNSHostName is the DNS hostname of an LDAP object.
+	DiscoveryLabelWindowsDNSHostName = TeleportNamespace + "/dns_host_name"
+	//DiscoveryLabelWindowsComputerName is the name of an LDAP object.
+	DiscoveryLabelWindowsComputerName = TeleportNamespace + "/computer_name"
+	//DiscoveryLabelWindowsOS is the operating system of an LDAP object.
+	DiscoveryLabelWindowsOS = TeleportNamespace + "/os"
+	//DiscoveryLabelWindowsOSVersion operating system version of an LDAP object.
+	DiscoveryLabelWindowsOSVersion = TeleportNamespace + "/os_version"
+	//DiscoveryLabelWindowsOU is an LDAP objects's OU.
+	DiscoveryLabelWindowsOU = TeleportNamespace + "/ou"
+	//DiscoveryLabelWindowsIsDomainController is whether an LDAP object is a
+	// domain controller.
+	DiscoveryLabelWindowsIsDomainController = TeleportNamespace + "/is_domain_controller"
+	//DiscoveryLabelWindowsDomain is an Active Directory domain name.
+	DiscoveryLabelWindowsDomain = TeleportNamespace + "/windows_domain"
+	// DiscoveryLabelLDAPPrefix is the prefix used when applying any custom
+	// labels per the discovery LDAP attribute labels configuration.
+	DiscoveryLabelLDAPPrefix = "ldap/"
 )
 
 const (

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -128,7 +128,7 @@ $ tsh db ls
 </ScopedBlock>
 
 <Admonition type="note" title="Note">
-  You can override the database name by applying the `teleport.dev/database_name` AWS tag to the resource. The value of the tag will be used as the database name.
+  You can override the database name by applying the `TeleportDatabaseName` AWS tag to the resource. The value of the tag will be used as the database name.
 </Admonition>
 
 To retrieve credentials for a database and connect to it:

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -179,7 +179,7 @@ $ tsh db ls
   `<cluster-id>`, `<cluster-id>-reader`, and
   `<cluster-id>-custom-<endpoint-name>` respectively.
 
-  You can override the `<cluster-id>` part of the name with `teleport.dev/database_name` AWS tag.
+  You can override the `<cluster-id>` part of the name with `TeleportDatabaseName` AWS tag.
 </Admonition>
 
 To retrieve credentials for a database and connect to it:

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -177,7 +177,7 @@ $ tsh db ls
 </ScopedBlock>
 
 <Admonition type="note" title="Note">
-  You can override the database name by applying the `teleport.dev/database_name` AWS tag to the resource. The value of the tag will be used as the database name.
+  You can override the database name by applying the `TeleportDatabaseName` AWS tag to the resource. The value of the tag will be used as the database name.
 </Admonition>
 
 To retrieve credentials for a database and connect to it:

--- a/docs/pages/database-access/guides/redshift-serverless.mdx
+++ b/docs/pages/database-access/guides/redshift-serverless.mdx
@@ -300,7 +300,7 @@ my-redshift Redshift cluster in us-east-1  ...
 
 <Admonition type="note" title="Note">
 
-You can override the database name by applying the `teleport.dev/database_name`
+You can override the database name by applying the `TeleportDatabaseName`
 AWS tag to the resource. The value of the tag will be used as the database name.
 
 </Admonition>

--- a/docs/pages/kubernetes-access/discovery.mdx
+++ b/docs/pages/kubernetes-access/discovery.mdx
@@ -38,8 +38,8 @@ cloud provider such as:
 
 <Notice type="tip">
 You can import the cluster under a different name into Teleport's registry.
-To achieve this, you must attach the following tag to the resources — EKS and AKS — in your cloud provider:
- - ***key***: `teleport.dev/kubernetes-name`
+To achieve this, you must attach the following tag to the resources — EKS, AKS, GKE — in your cloud provider:
+ - ***key***: `TeleportKubernetesName`
  - ***value***: desired name
 
 The Discovery Service will check if the cluster includes the tag and use its value

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -314,12 +314,14 @@ func TestDatabaseFromAzureDBServer(t *testing.T) {
 		Name:        "testdb",
 		Description: "Azure MySQL server in eastus",
 		Labels: map[string]string{
-			labelRegion:         "eastus",
-			labelEngine:         "Microsoft.DBforMySQL/servers",
-			labelEngineVersion:  "5.7",
-			labelResourceGroup:  "defaultRG",
-			labelSubscriptionID: "sub1",
-			"foo":               "bar",
+			types.DiscoveryLabelRegion:              "eastus",
+			types.DiscoveryLabelEngine:              "Microsoft.DBforMySQL/servers",
+			types.DiscoveryLabelEngineVersion:       "5.7",
+			types.DiscoveryLabelAzureResourceGroup:  "defaultRG",
+			types.OriginLabel:                       types.OriginCloud,
+			types.CloudLabel:                        types.CloudAzure,
+			types.DiscoveryLabelAzureSubscriptionID: "sub1",
+			"foo":                                   "bar",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolMySQL,
@@ -361,12 +363,14 @@ func TestDatabaseFromAzureRedis(t *testing.T) {
 		Name:        name,
 		Description: "Azure Redis server in eastus",
 		Labels: map[string]string{
-			labelRegion:         region,
-			labelEngine:         "Microsoft.Cache/Redis",
-			labelEngineVersion:  "6.0",
-			labelResourceGroup:  group,
-			labelSubscriptionID: subscription,
-			"foo":               "bar",
+			types.DiscoveryLabelRegion:              region,
+			types.DiscoveryLabelEngine:              "Microsoft.Cache/Redis",
+			types.DiscoveryLabelEngineVersion:       "6.0",
+			types.DiscoveryLabelAzureResourceGroup:  group,
+			types.OriginLabel:                       types.OriginCloud,
+			types.CloudLabel:                        types.CloudAzure,
+			types.DiscoveryLabelAzureSubscriptionID: subscription,
+			"foo":                                   "bar",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -418,13 +422,15 @@ func TestDatabaseFromAzureRedisEnterprise(t *testing.T) {
 		Name:        name,
 		Description: "Azure Redis Enterprise server in eastus",
 		Labels: map[string]string{
-			labelRegion:         region,
-			labelEngine:         "Microsoft.Cache/redisEnterprise",
-			labelEngineVersion:  "6.0",
-			labelResourceGroup:  group,
-			labelSubscriptionID: subscription,
-			labelEndpointType:   "OSSCluster",
-			"foo":               "bar",
+			types.DiscoveryLabelRegion:              region,
+			types.DiscoveryLabelEngine:              "Microsoft.Cache/redisEnterprise",
+			types.DiscoveryLabelEngineVersion:       "6.0",
+			types.DiscoveryLabelAzureResourceGroup:  group,
+			types.OriginLabel:                       types.OriginCloud,
+			types.CloudLabel:                        types.CloudAzure,
+			types.DiscoveryLabelAzureSubscriptionID: subscription,
+			types.DiscoveryLabelEndpointType:        "OSSCluster",
+			"foo":                                   "bar",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -467,12 +473,14 @@ func TestDatabaseFromRDSInstance(t *testing.T) {
 		Name:        "instance-1",
 		Description: "RDS instance in us-west-1",
 		Labels: map[string]string{
-			labelAccountID:     "123456789012",
-			labelRegion:        "us-west-1",
-			labelEngine:        RDSEnginePostgres,
-			labelEngineVersion: "13.0",
-			labelEndpointType:  "instance",
-			"key":              "val",
+			types.DiscoveryLabelAccountID:     "123456789012",
+			types.OriginLabel:                 types.OriginCloud,
+			types.CloudLabel:                  types.CloudAWS,
+			types.DiscoveryLabelRegion:        "us-west-1",
+			types.DiscoveryLabelEngine:        RDSEnginePostgres,
+			types.DiscoveryLabelEngineVersion: "13.0",
+			types.DiscoveryLabelEndpointType:  "instance",
+			"key":                             "val",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
@@ -518,13 +526,15 @@ func TestDatabaseFromRDSV2Instance(t *testing.T) {
 		Name:        "instance-1",
 		Description: "RDS instance in us-west-1",
 		Labels: map[string]string{
-			labelAccountID:     "123456789012",
-			labelRegion:        "us-west-1",
-			labelEngine:        RDSEnginePostgres,
-			labelEngineVersion: "13.0",
-			labelEndpointType:  "instance",
-			labelStatus:        "available",
-			"key":              "val",
+			types.DiscoveryLabelAccountID:     "123456789012",
+			types.OriginLabel:                 types.OriginCloud,
+			types.CloudLabel:                  types.CloudAWS,
+			types.DiscoveryLabelRegion:        "us-west-1",
+			types.DiscoveryLabelEngine:        RDSEnginePostgres,
+			types.DiscoveryLabelEngineVersion: "13.0",
+			types.DiscoveryLabelEndpointType:  "instance",
+			types.DiscoveryLabelStatus:        "available",
+			"key":                             "val",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
@@ -545,72 +555,80 @@ func TestDatabaseFromRDSV2Instance(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(expected, actual))
 
-	t.Run("with name override", func(t *testing.T) {
-		newName := "override-1"
+	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+		t.Run("with name override via "+overrideLabel, func(t *testing.T) {
+			newName := "override-1"
+			instance := instance
+			instance.TagList = append(instance.TagList,
+				rdsTypesV2.Tag{
+					Key:   aws.String(overrideLabel),
+					Value: aws.String(newName),
+				},
+			)
+			expected.Metadata.Name = newName
 
-		instance.TagList = append(instance.TagList,
-			rdsTypesV2.Tag{
-				Key:   aws.String(labelTeleportDBName),
-				Value: aws.String(newName),
-			},
-		)
-		expected.Metadata.Name = newName
-
-		actual, err := NewDatabaseFromRDSV2Instance(instance)
-		require.NoError(t, err)
-		require.Equal(t, actual.GetName(), newName)
-	})
+			actual, err := NewDatabaseFromRDSV2Instance(instance)
+			require.NoError(t, err)
+			require.Equal(t, actual.GetName(), newName)
+		})
+	}
 }
 
 // TestDatabaseFromRDSInstance tests converting an RDS instance to a database resource.
 func TestDatabaseFromRDSInstanceNameOverride(t *testing.T) {
-	instance := &rds.DBInstance{
-		DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:123456789012:db:instance-1"),
-		DBInstanceIdentifier:             aws.String("instance-1"),
-		DBClusterIdentifier:              aws.String("cluster-1"),
-		DbiResourceId:                    aws.String("resource-1"),
-		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
-		Engine:                           aws.String(RDSEnginePostgres),
-		EngineVersion:                    aws.String("13.0"),
-		Endpoint: &rds.Endpoint{
-			Address: aws.String("localhost"),
-			Port:    aws.Int64(5432),
-		},
-		TagList: []*rds.Tag{
-			{Key: aws.String("key"), Value: aws.String("val")},
-			{Key: aws.String(labelTeleportDBName), Value: aws.String("override-1")},
-		},
-	}
-	expected, err := types.NewDatabaseV3(types.Metadata{
-		Name:        "override-1",
-		Description: "RDS instance in us-west-1",
-		Labels: map[string]string{
-			labelAccountID:      "123456789012",
-			labelRegion:         "us-west-1",
-			labelEngine:         RDSEnginePostgres,
-			labelEngineVersion:  "13.0",
-			labelEndpointType:   "instance",
-			labelTeleportDBName: "override-1",
-			"key":               "val",
-		},
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolPostgres,
-		URI:      "localhost:5432",
-		AWS: types.AWS{
-			AccountID: "123456789012",
-			Region:    "us-west-1",
-			RDS: types.RDS{
-				InstanceID: "instance-1",
-				ClusterID:  "cluster-1",
-				ResourceID: "resource-1",
-				IAMAuth:    true,
+	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+		instance := &rds.DBInstance{
+			DBInstanceArn:                    aws.String("arn:aws:rds:us-west-1:123456789012:db:instance-1"),
+			DBInstanceIdentifier:             aws.String("instance-1"),
+			DBClusterIdentifier:              aws.String("cluster-1"),
+			DbiResourceId:                    aws.String("resource-1"),
+			IAMDatabaseAuthenticationEnabled: aws.Bool(true),
+			Engine:                           aws.String(RDSEnginePostgres),
+			EngineVersion:                    aws.String("13.0"),
+			Endpoint: &rds.Endpoint{
+				Address: aws.String("localhost"),
+				Port:    aws.Int64(5432),
 			},
-		},
-	})
-	require.NoError(t, err)
-	actual, err := NewDatabaseFromRDSInstance(instance)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(expected, actual))
+			TagList: []*rds.Tag{
+				{Key: aws.String("key"), Value: aws.String("val")},
+				{Key: aws.String(overrideLabel), Value: aws.String("override-1")},
+			},
+		}
+		t.Run("via "+overrideLabel, func(t *testing.T) {
+			expected, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "override-1",
+				Description: "RDS instance in us-west-1",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:     "123456789012",
+					types.OriginLabel:                 types.OriginCloud,
+					types.CloudLabel:                  types.CloudAWS,
+					types.DiscoveryLabelRegion:        "us-west-1",
+					types.DiscoveryLabelEngine:        RDSEnginePostgres,
+					types.DiscoveryLabelEngineVersion: "13.0",
+					types.DiscoveryLabelEndpointType:  "instance",
+					overrideLabel:                     "override-1",
+					"key":                             "val",
+				},
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolPostgres,
+				URI:      "localhost:5432",
+				AWS: types.AWS{
+					AccountID: "123456789012",
+					Region:    "us-west-1",
+					RDS: types.RDS{
+						InstanceID: "instance-1",
+						ClusterID:  "cluster-1",
+						ResourceID: "resource-1",
+						IAMAuth:    true,
+					},
+				},
+			})
+			require.NoError(t, err)
+			actual, err := NewDatabaseFromRDSInstance(instance)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expected, actual))
+		})
+	}
 }
 
 // TestDatabaseFromRDSCluster tests converting an RDS cluster to a database resource.
@@ -650,12 +668,14 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 			Name:        "cluster-1",
 			Description: "Aurora cluster in us-east-1",
 			Labels: map[string]string{
-				labelAccountID:     "123456789012",
-				labelRegion:        "us-east-1",
-				labelEngine:        RDSEngineAuroraMySQL,
-				labelEngineVersion: "8.0.0",
-				labelEndpointType:  "primary",
-				"key":              "val",
+				types.DiscoveryLabelAccountID:     "123456789012",
+				types.OriginLabel:                 types.OriginCloud,
+				types.CloudLabel:                  types.CloudAWS,
+				types.DiscoveryLabelRegion:        "us-east-1",
+				types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+				types.DiscoveryLabelEngineVersion: "8.0.0",
+				types.DiscoveryLabelEndpointType:  "primary",
+				"key":                             "val",
 			},
 		}, types.DatabaseSpecV3{
 			Protocol: defaults.ProtocolMySQL,
@@ -673,12 +693,14 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 			Name:        "cluster-1-reader",
 			Description: "Aurora cluster in us-east-1 (reader endpoint)",
 			Labels: map[string]string{
-				labelAccountID:     "123456789012",
-				labelRegion:        "us-east-1",
-				labelEngine:        RDSEngineAuroraMySQL,
-				labelEngineVersion: "8.0.0",
-				labelEndpointType:  "reader",
-				"key":              "val",
+				types.DiscoveryLabelAccountID:     "123456789012",
+				types.OriginLabel:                 types.OriginCloud,
+				types.CloudLabel:                  types.CloudAWS,
+				types.DiscoveryLabelRegion:        "us-east-1",
+				types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+				types.DiscoveryLabelEngineVersion: "8.0.0",
+				types.DiscoveryLabelEndpointType:  "reader",
+				"key":                             "val",
 			},
 		}, types.DatabaseSpecV3{
 			Protocol: defaults.ProtocolMySQL,
@@ -693,12 +715,14 @@ func TestDatabaseFromRDSCluster(t *testing.T) {
 
 	t.Run("custom endpoints", func(t *testing.T) {
 		expectedLabels := map[string]string{
-			labelAccountID:     "123456789012",
-			labelRegion:        "us-east-1",
-			labelEngine:        RDSEngineAuroraMySQL,
-			labelEngineVersion: "8.0.0",
-			labelEndpointType:  "custom",
-			"key":              "val",
+			types.DiscoveryLabelAccountID:     "123456789012",
+			types.OriginLabel:                 types.OriginCloud,
+			types.CloudLabel:                  types.CloudAWS,
+			types.DiscoveryLabelRegion:        "us-east-1",
+			types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+			types.DiscoveryLabelEngineVersion: "8.0.0",
+			types.DiscoveryLabelEndpointType:  "custom",
+			"key":                             "val",
 		}
 
 		expectedMyEndpoint1, err := types.NewDatabaseV3(types.Metadata{
@@ -784,13 +808,15 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 			Name:        "cluster-1",
 			Description: "Aurora cluster in us-east-1",
 			Labels: map[string]string{
-				labelAccountID:     "123456789012",
-				labelRegion:        "us-east-1",
-				labelEngine:        RDSEngineAuroraMySQL,
-				labelEngineVersion: "8.0.0",
-				labelEndpointType:  "primary",
-				labelStatus:        "available",
-				"key":              "val",
+				types.DiscoveryLabelAccountID:     "123456789012",
+				types.OriginLabel:                 types.OriginCloud,
+				types.CloudLabel:                  types.CloudAWS,
+				types.DiscoveryLabelRegion:        "us-east-1",
+				types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+				types.DiscoveryLabelEngineVersion: "8.0.0",
+				types.DiscoveryLabelEndpointType:  "primary",
+				types.DiscoveryLabelStatus:        "available",
+				"key":                             "val",
 			},
 		}, types.DatabaseSpecV3{
 			Protocol: defaults.ProtocolMySQL,
@@ -802,157 +828,167 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(expected, actual))
 
-		t.Run("with name override", func(t *testing.T) {
-			newName := "override-1"
+		for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+			t.Run("with name override via "+overrideLabel, func(t *testing.T) {
+				newName := "override-1"
 
-			cluster.TagList = append(cluster.TagList,
-				rdsTypesV2.Tag{
-					Key:   aws.String(labelTeleportDBName),
-					Value: aws.String(newName),
-				},
-			)
-			expected.Metadata.Name = newName
+				cluster.TagList = append(cluster.TagList,
+					rdsTypesV2.Tag{
+						Key:   aws.String(overrideLabel),
+						Value: aws.String(newName),
+					},
+				)
+				expected.Metadata.Name = newName
 
-			actual, err := NewDatabaseFromRDSV2Cluster(cluster)
-			require.NoError(t, err)
-			require.Equal(t, actual.GetName(), newName)
-		})
+				actual, err := NewDatabaseFromRDSV2Cluster(cluster)
+				require.NoError(t, err)
+				require.Equal(t, actual.GetName(), newName)
+			})
+		}
 	})
 }
 
 // TestDatabaseFromRDSClusterNameOverride tests converting an RDS cluster to a database resource with overridden name.
 func TestDatabaseFromRDSClusterNameOverride(t *testing.T) {
-	cluster := &rds.DBCluster{
-		DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:123456789012:cluster:cluster-1"),
-		DBClusterIdentifier:              aws.String("cluster-1"),
-		DbClusterResourceId:              aws.String("resource-1"),
-		IAMDatabaseAuthenticationEnabled: aws.Bool(true),
-		Engine:                           aws.String(RDSEngineAuroraMySQL),
-		EngineVersion:                    aws.String("8.0.0"),
-		Endpoint:                         aws.String("localhost"),
-		ReaderEndpoint:                   aws.String("reader.host"),
-		Port:                             aws.Int64(3306),
-		CustomEndpoints: []*string{
-			aws.String("myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com"),
-			aws.String("myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com"),
-		},
-		TagList: []*rds.Tag{
-			{Key: aws.String("key"), Value: aws.String("val")},
-			{Key: aws.String(labelTeleportDBName), Value: aws.String("mycluster-2")},
-		},
-	}
-
-	expectedAWS := types.AWS{
-		AccountID: "123456789012",
-		Region:    "us-east-1",
-		RDS: types.RDS{
-			ClusterID:  "cluster-1",
-			ResourceID: "resource-1",
-			IAMAuth:    true,
-		},
-	}
-
-	t.Run("primary", func(t *testing.T) {
-		expected, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "mycluster-2",
-			Description: "Aurora cluster in us-east-1",
-			Labels: map[string]string{
-				labelAccountID:      "123456789012",
-				labelRegion:         "us-east-1",
-				labelEngine:         RDSEngineAuroraMySQL,
-				labelEngineVersion:  "8.0.0",
-				labelEndpointType:   "primary",
-				labelTeleportDBName: "mycluster-2",
-				"key":               "val",
+	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+		cluster := &rds.DBCluster{
+			DBClusterArn:                     aws.String("arn:aws:rds:us-east-1:123456789012:cluster:cluster-1"),
+			DBClusterIdentifier:              aws.String("cluster-1"),
+			DbClusterResourceId:              aws.String("resource-1"),
+			IAMDatabaseAuthenticationEnabled: aws.Bool(true),
+			Engine:                           aws.String(RDSEngineAuroraMySQL),
+			EngineVersion:                    aws.String("8.0.0"),
+			Endpoint:                         aws.String("localhost"),
+			ReaderEndpoint:                   aws.String("reader.host"),
+			Port:                             aws.Int64(3306),
+			CustomEndpoints: []*string{
+				aws.String("myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com"),
+				aws.String("myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com"),
 			},
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "localhost:3306",
-			AWS:      expectedAWS,
-		})
-		require.NoError(t, err)
-		actual, err := NewDatabaseFromRDSCluster(cluster)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
-	})
-
-	t.Run("reader", func(t *testing.T) {
-		expected, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "mycluster-2-reader",
-			Description: "Aurora cluster in us-east-1 (reader endpoint)",
-			Labels: map[string]string{
-				labelAccountID:      "123456789012",
-				labelRegion:         "us-east-1",
-				labelEngine:         RDSEngineAuroraMySQL,
-				labelEngineVersion:  "8.0.0",
-				labelEndpointType:   "reader",
-				labelTeleportDBName: "mycluster-2",
-				"key":               "val",
+			TagList: []*rds.Tag{
+				{Key: aws.String("key"), Value: aws.String("val")},
+				{Key: aws.String(overrideLabel), Value: aws.String("mycluster-2")},
 			},
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "reader.host:3306",
-			AWS:      expectedAWS,
-		})
-		require.NoError(t, err)
-		actual, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
-	})
-
-	t.Run("custom endpoints", func(t *testing.T) {
-		expectedLabels := map[string]string{
-			labelAccountID:      "123456789012",
-			labelRegion:         "us-east-1",
-			labelEngine:         RDSEngineAuroraMySQL,
-			labelEngineVersion:  "8.0.0",
-			labelEndpointType:   "custom",
-			labelTeleportDBName: "mycluster-2",
-			"key":               "val",
 		}
 
-		expectedMyEndpoint1, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "mycluster-2-custom-myendpoint1",
-			Description: "Aurora cluster in us-east-1 (custom endpoint)",
-			Labels:      expectedLabels,
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
-			AWS:      expectedAWS,
-			TLS: types.DatabaseTLS{
-				ServerName: "localhost",
+		expectedAWS := types.AWS{
+			AccountID: "123456789012",
+			Region:    "us-east-1",
+			RDS: types.RDS{
+				ClusterID:  "cluster-1",
+				ResourceID: "resource-1",
+				IAMAuth:    true,
 			},
-		})
-		require.NoError(t, err)
-
-		expectedMyEndpoint2, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "mycluster-2-custom-myendpoint2",
-			Description: "Aurora cluster in us-east-1 (custom endpoint)",
-			Labels:      expectedLabels,
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolMySQL,
-			URI:      "myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
-			AWS:      expectedAWS,
-			TLS: types.DatabaseTLS{
-				ServerName: "localhost",
-			},
-		})
-		require.NoError(t, err)
-
-		databases, err := NewDatabasesFromRDSClusterCustomEndpoints(cluster)
-		require.NoError(t, err)
-		require.Equal(t, types.Databases{expectedMyEndpoint1, expectedMyEndpoint2}, databases)
-	})
-
-	t.Run("bad custom endpoints ", func(t *testing.T) {
-		badCluster := *cluster
-		badCluster.CustomEndpoints = []*string{
-			aws.String("badendpoint1"),
-			aws.String("badendpoint2"),
 		}
-		_, err := NewDatabasesFromRDSClusterCustomEndpoints(&badCluster)
-		require.Error(t, err)
-	})
+
+		t.Run("primary", func(t *testing.T) {
+			expected, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "mycluster-2",
+				Description: "Aurora cluster in us-east-1",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:     "123456789012",
+					types.OriginLabel:                 types.OriginCloud,
+					types.CloudLabel:                  types.CloudAWS,
+					types.DiscoveryLabelRegion:        "us-east-1",
+					types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+					types.DiscoveryLabelEngineVersion: "8.0.0",
+					types.DiscoveryLabelEndpointType:  "primary",
+					overrideLabel:                     "mycluster-2",
+					"key":                             "val",
+				},
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolMySQL,
+				URI:      "localhost:3306",
+				AWS:      expectedAWS,
+			})
+			require.NoError(t, err)
+			actual, err := NewDatabaseFromRDSCluster(cluster)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expected, actual))
+		})
+
+		t.Run("reader", func(t *testing.T) {
+			expected, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "mycluster-2-reader",
+				Description: "Aurora cluster in us-east-1 (reader endpoint)",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:     "123456789012",
+					types.OriginLabel:                 types.OriginCloud,
+					types.CloudLabel:                  types.CloudAWS,
+					types.DiscoveryLabelRegion:        "us-east-1",
+					types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+					types.DiscoveryLabelEngineVersion: "8.0.0",
+					types.DiscoveryLabelEndpointType:  "reader",
+					overrideLabel:                     "mycluster-2",
+					"key":                             "val",
+				},
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolMySQL,
+				URI:      "reader.host:3306",
+				AWS:      expectedAWS,
+			})
+			require.NoError(t, err)
+			actual, err := NewDatabaseFromRDSClusterReaderEndpoint(cluster)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expected, actual))
+		})
+
+		t.Run("custom endpoints", func(t *testing.T) {
+			expectedLabels := map[string]string{
+				types.DiscoveryLabelAccountID:     "123456789012",
+				types.OriginLabel:                 types.OriginCloud,
+				types.CloudLabel:                  types.CloudAWS,
+				types.DiscoveryLabelRegion:        "us-east-1",
+				types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+				types.DiscoveryLabelEngineVersion: "8.0.0",
+				types.DiscoveryLabelEndpointType:  "custom",
+				overrideLabel:                     "mycluster-2",
+				"key":                             "val",
+			}
+
+			expectedMyEndpoint1, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "mycluster-2-custom-myendpoint1",
+				Description: "Aurora cluster in us-east-1 (custom endpoint)",
+				Labels:      expectedLabels,
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolMySQL,
+				URI:      "myendpoint1.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
+				AWS:      expectedAWS,
+				TLS: types.DatabaseTLS{
+					ServerName: "localhost",
+				},
+			})
+			require.NoError(t, err)
+
+			expectedMyEndpoint2, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "mycluster-2-custom-myendpoint2",
+				Description: "Aurora cluster in us-east-1 (custom endpoint)",
+				Labels:      expectedLabels,
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolMySQL,
+				URI:      "myendpoint2.cluster-custom-example.us-east-1.rds.amazonaws.com:3306",
+				AWS:      expectedAWS,
+				TLS: types.DatabaseTLS{
+					ServerName: "localhost",
+				},
+			})
+			require.NoError(t, err)
+
+			databases, err := NewDatabasesFromRDSClusterCustomEndpoints(cluster)
+			require.NoError(t, err)
+			require.Equal(t, types.Databases{expectedMyEndpoint1, expectedMyEndpoint2}, databases)
+		})
+
+		t.Run("bad custom endpoints ", func(t *testing.T) {
+			badCluster := *cluster
+			badCluster.CustomEndpoints = []*string{
+				aws.String("badendpoint1"),
+				aws.String("badendpoint2"),
+			}
+			_, err := NewDatabasesFromRDSClusterCustomEndpoints(&badCluster)
+			require.Error(t, err)
+		})
+	}
 }
 
 func TestDatabaseFromRDSProxy(t *testing.T) {
@@ -983,11 +1019,13 @@ func TestDatabaseFromRDSProxy(t *testing.T) {
 			Name:        "testproxy",
 			Description: "RDS Proxy in ca-central-1",
 			Labels: map[string]string{
-				"key":          "val",
-				labelAccountID: "123456789012",
-				labelRegion:    "ca-central-1",
-				labelEngine:    "MYSQL",
-				labelVPCID:     "test-vpc-id",
+				"key":                         "val",
+				types.DiscoveryLabelAccountID: "123456789012",
+				types.OriginLabel:             types.OriginCloud,
+				types.CloudLabel:              types.CloudAWS,
+				types.DiscoveryLabelRegion:    "ca-central-1",
+				types.DiscoveryLabelEngine:    "MYSQL",
+				types.DiscoveryLabelVPCID:     "test-vpc-id",
 			},
 		}, types.DatabaseSpecV3{
 			Protocol: defaults.ProtocolMySQL,
@@ -1013,12 +1051,14 @@ func TestDatabaseFromRDSProxy(t *testing.T) {
 			Name:        "testproxy-custom",
 			Description: "RDS Proxy endpoint in ca-central-1",
 			Labels: map[string]string{
-				"key":             "val",
-				labelAccountID:    "123456789012",
-				labelRegion:       "ca-central-1",
-				labelEngine:       "MYSQL",
-				labelVPCID:        "test-vpc-id",
-				labelEndpointType: "READ_ONLY",
+				"key":                            "val",
+				types.DiscoveryLabelAccountID:    "123456789012",
+				types.OriginLabel:                types.OriginCloud,
+				types.CloudLabel:                 types.CloudAWS,
+				types.DiscoveryLabelRegion:       "ca-central-1",
+				types.DiscoveryLabelEngine:       "MYSQL",
+				types.DiscoveryLabelVPCID:        "test-vpc-id",
+				types.DiscoveryLabelEndpointType: "READ_ONLY",
 			},
 		}, types.DatabaseSpecV3{
 			Protocol: defaults.ProtocolMySQL,
@@ -1175,8 +1215,14 @@ func TestAzureTagsToLabels(t *testing.T) {
 		"Name":    "test",
 	}
 	labels := azureTagsToLabels(azureTags)
-	require.Equal(t, map[string]string{"Name": "test", "Env": "dev",
-		"foo:bar": "some-id"}, labels)
+	wantLabels := map[string]string{
+		"Name":            "test",
+		"Env":             "dev",
+		"foo:bar":         "some-id",
+		types.OriginLabel: types.OriginCloud,
+		types.CloudLabel:  types.CloudAzure,
+	}
+	require.Equal(t, wantLabels, labels)
 }
 
 // TestDatabaseFromRedshiftCluster tests converting an Redshift cluster to a database resource.
@@ -1204,8 +1250,10 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 			Name:        "mycluster",
 			Description: "Redshift cluster in us-east-1",
 			Labels: map[string]string{
-				labelAccountID:                    "123456789012",
-				labelRegion:                       "us-east-1",
+				types.DiscoveryLabelAccountID:     "123456789012",
+				types.OriginLabel:                 types.OriginCloud,
+				types.CloudLabel:                  types.CloudAWS,
+				types.DiscoveryLabelRegion:        "us-east-1",
 				"key":                             "val",
 				"elasticbeanstalk:environment-id": "id",
 			},
@@ -1228,65 +1276,69 @@ func TestDatabaseFromRedshiftCluster(t *testing.T) {
 		require.Empty(t, cmp.Diff(expected, actual))
 	})
 
-	t.Run("success with name override", func(t *testing.T) {
-		cluster := &redshift.Cluster{
-			ClusterIdentifier:   aws.String("mycluster"),
-			ClusterNamespaceArn: aws.String("arn:aws:redshift:us-east-1:123456789012:namespace:u-u-i-d"),
-			Endpoint: &redshift.Endpoint{
-				Address: aws.String("localhost"),
-				Port:    aws.Int64(5439),
-			},
-			Tags: []*redshift.Tag{
-				{
-					Key:   aws.String("key"),
-					Value: aws.String("val"),
+	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+		t.Run("success with name override via"+overrideLabel, func(t *testing.T) {
+			cluster := &redshift.Cluster{
+				ClusterIdentifier:   aws.String("mycluster"),
+				ClusterNamespaceArn: aws.String("arn:aws:redshift:us-east-1:123456789012:namespace:u-u-i-d"),
+				Endpoint: &redshift.Endpoint{
+					Address: aws.String("localhost"),
+					Port:    aws.Int64(5439),
 				},
-				{
-					Key:   aws.String("elasticbeanstalk:environment-id"),
-					Value: aws.String("id"),
+				Tags: []*redshift.Tag{
+					{
+						Key:   aws.String("key"),
+						Value: aws.String("val"),
+					},
+					{
+						Key:   aws.String("elasticbeanstalk:environment-id"),
+						Value: aws.String("id"),
+					},
+					{
+						Key:   aws.String(overrideLabel),
+						Value: aws.String("mycluster-override-2"),
+					},
 				},
-				{
-					Key:   aws.String(labelTeleportDBName),
-					Value: aws.String("mycluster-override-2"),
+			}
+			expected, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "mycluster-override-2",
+				Description: "Redshift cluster in us-east-1",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:     "123456789012",
+					types.OriginLabel:                 types.OriginCloud,
+					types.CloudLabel:                  types.CloudAWS,
+					types.DiscoveryLabelRegion:        "us-east-1",
+					overrideLabel:                     "mycluster-override-2",
+					"key":                             "val",
+					"elasticbeanstalk:environment-id": "id",
 				},
-			},
-		}
-		expected, err := types.NewDatabaseV3(types.Metadata{
-			Name:        "mycluster-override-2",
-			Description: "Redshift cluster in us-east-1",
-			Labels: map[string]string{
-				labelAccountID:                    "123456789012",
-				labelRegion:                       "us-east-1",
-				labelTeleportDBName:               "mycluster-override-2",
-				"key":                             "val",
-				"elasticbeanstalk:environment-id": "id",
-			},
-		}, types.DatabaseSpecV3{
-			Protocol: defaults.ProtocolPostgres,
-			URI:      "localhost:5439",
-			AWS: types.AWS{
-				AccountID: "123456789012",
-				Region:    "us-east-1",
-				Redshift: types.Redshift{
-					ClusterID: "mycluster",
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolPostgres,
+				URI:      "localhost:5439",
+				AWS: types.AWS{
+					AccountID: "123456789012",
+					Region:    "us-east-1",
+					Redshift: types.Redshift{
+						ClusterID: "mycluster",
+					},
 				},
-			},
+			})
+
+			require.NoError(t, err)
+
+			actual, err := NewDatabaseFromRedshiftCluster(cluster)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expected, actual))
 		})
 
-		require.NoError(t, err)
-
-		actual, err := NewDatabaseFromRedshiftCluster(cluster)
-		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
-	})
-
-	t.Run("missing endpoint", func(t *testing.T) {
-		_, err := NewDatabaseFromRedshiftCluster(&redshift.Cluster{
-			ClusterIdentifier: aws.String("still-creating"),
+		t.Run("missing endpoint", func(t *testing.T) {
+			_, err := NewDatabaseFromRedshiftCluster(&redshift.Cluster{
+				ClusterIdentifier: aws.String("still-creating"),
+			})
+			require.Error(t, err)
+			require.True(t, trace.IsBadParameter(err), "Expected trace.BadParameter, got %v", err)
 		})
-		require.Error(t, err)
-		require.True(t, trace.IsBadParameter(err), "Expected trace.BadParameter, got %v", err)
-	})
+	}
 }
 
 func TestDatabaseFromElastiCacheConfigurationEndpoint(t *testing.T) {
@@ -1332,10 +1384,12 @@ func TestDatabaseFromElastiCacheConfigurationEndpoint(t *testing.T) {
 		Name:        "my-cluster",
 		Description: "ElastiCache cluster in us-east-1 (configuration endpoint)",
 		Labels: map[string]string{
-			labelAccountID:    "123456789012",
-			labelRegion:       "us-east-1",
-			labelEndpointType: "configuration",
-			"key":             "value",
+			types.DiscoveryLabelAccountID:    "123456789012",
+			types.OriginLabel:                types.OriginCloud,
+			types.CloudLabel:                 types.CloudAWS,
+			types.DiscoveryLabelRegion:       "us-east-1",
+			types.DiscoveryLabelEndpointType: "configuration",
+			"key":                            "value",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -1359,76 +1413,82 @@ func TestDatabaseFromElastiCacheConfigurationEndpoint(t *testing.T) {
 }
 
 func TestDatabaseFromElastiCacheConfigurationEndpointNameOverride(t *testing.T) {
-	cluster := &elasticache.ReplicationGroup{
-		ARN:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:replicationgroup:my-cluster"),
-		ReplicationGroupId:       aws.String("my-cluster"),
-		Status:                   aws.String("available"),
-		TransitEncryptionEnabled: aws.Bool(true),
-		ClusterEnabled:           aws.Bool(true),
-		ConfigurationEndpoint: &elasticache.Endpoint{
-			Address: aws.String("configuration.localhost"),
-			Port:    aws.Int64(6379),
-		},
-		UserGroupIds: []*string{aws.String("my-user-group")},
-		NodeGroups: []*elasticache.NodeGroup{
-			{
-				NodeGroupId: aws.String("0001"),
-				NodeGroupMembers: []*elasticache.NodeGroupMember{
+	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+		t.Run("via "+overrideLabel, func(t *testing.T) {
+			cluster := &elasticache.ReplicationGroup{
+				ARN:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:replicationgroup:my-cluster"),
+				ReplicationGroupId:       aws.String("my-cluster"),
+				Status:                   aws.String("available"),
+				TransitEncryptionEnabled: aws.Bool(true),
+				ClusterEnabled:           aws.Bool(true),
+				ConfigurationEndpoint: &elasticache.Endpoint{
+					Address: aws.String("configuration.localhost"),
+					Port:    aws.Int64(6379),
+				},
+				UserGroupIds: []*string{aws.String("my-user-group")},
+				NodeGroups: []*elasticache.NodeGroup{
 					{
-						CacheClusterId: aws.String("my-cluster-0001-001"),
+						NodeGroupId: aws.String("0001"),
+						NodeGroupMembers: []*elasticache.NodeGroupMember{
+							{
+								CacheClusterId: aws.String("my-cluster-0001-001"),
+							},
+							{
+								CacheClusterId: aws.String("my-cluster-0001-002"),
+							},
+						},
 					},
 					{
-						CacheClusterId: aws.String("my-cluster-0001-002"),
+						NodeGroupId: aws.String("0002"),
+						NodeGroupMembers: []*elasticache.NodeGroupMember{
+							{
+								CacheClusterId: aws.String("my-cluster-0002-001"),
+							},
+							{
+								CacheClusterId: aws.String("my-cluster-0002-002"),
+							},
+						},
 					},
 				},
-			},
-			{
-				NodeGroupId: aws.String("0002"),
-				NodeGroupMembers: []*elasticache.NodeGroupMember{
-					{
-						CacheClusterId: aws.String("my-cluster-0002-001"),
-					},
-					{
-						CacheClusterId: aws.String("my-cluster-0002-002"),
+			}
+			extraLabels := map[string]string{
+				overrideLabel: "my-override-cluster-2",
+				"key":         "value",
+			}
+
+			expected, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "my-override-cluster-2",
+				Description: "ElastiCache cluster in us-east-1 (configuration endpoint)",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:    "123456789012",
+					types.OriginLabel:                types.OriginCloud,
+					types.CloudLabel:                 types.CloudAWS,
+					types.DiscoveryLabelRegion:       "us-east-1",
+					types.DiscoveryLabelEndpointType: "configuration",
+					overrideLabel:                    "my-override-cluster-2",
+					"key":                            "value",
+				},
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolRedis,
+				URI:      "configuration.localhost:6379",
+				AWS: types.AWS{
+					AccountID: "123456789012",
+					Region:    "us-east-1",
+					ElastiCache: types.ElastiCache{
+						ReplicationGroupID:       "my-cluster",
+						UserGroupIDs:             []string{"my-user-group"},
+						TransitEncryptionEnabled: true,
+						EndpointType:             awsutils.ElastiCacheConfigurationEndpoint,
 					},
 				},
-			},
-		},
-	}
-	extraLabels := map[string]string{
-		labelTeleportDBName: "my-override-cluster-2",
-		"key":               "value",
-	}
+			})
+			require.NoError(t, err)
 
-	expected, err := types.NewDatabaseV3(types.Metadata{
-		Name:        "my-override-cluster-2",
-		Description: "ElastiCache cluster in us-east-1 (configuration endpoint)",
-		Labels: map[string]string{
-			labelAccountID:      "123456789012",
-			labelRegion:         "us-east-1",
-			labelEndpointType:   "configuration",
-			labelTeleportDBName: "my-override-cluster-2",
-			"key":               "value",
-		},
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolRedis,
-		URI:      "configuration.localhost:6379",
-		AWS: types.AWS{
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			ElastiCache: types.ElastiCache{
-				ReplicationGroupID:       "my-cluster",
-				UserGroupIDs:             []string{"my-user-group"},
-				TransitEncryptionEnabled: true,
-				EndpointType:             awsutils.ElastiCacheConfigurationEndpoint,
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	actual, err := NewDatabaseFromElastiCacheConfigurationEndpoint(cluster, extraLabels)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(expected, actual))
+			actual, err := NewDatabaseFromElastiCacheConfigurationEndpoint(cluster, extraLabels)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expected, actual))
+		})
+	}
 }
 
 func TestDatabaseFromElastiCacheNodeGroups(t *testing.T) {
@@ -1459,10 +1519,12 @@ func TestDatabaseFromElastiCacheNodeGroups(t *testing.T) {
 		Name:        "my-cluster",
 		Description: "ElastiCache cluster in us-east-1 (primary endpoint)",
 		Labels: map[string]string{
-			labelAccountID:    "123456789012",
-			labelRegion:       "us-east-1",
-			labelEndpointType: "primary",
-			"key":             "value",
+			types.DiscoveryLabelAccountID:    "123456789012",
+			types.OriginLabel:                types.OriginCloud,
+			types.CloudLabel:                 types.CloudAWS,
+			types.DiscoveryLabelRegion:       "us-east-1",
+			types.DiscoveryLabelEndpointType: "primary",
+			"key":                            "value",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -1484,10 +1546,12 @@ func TestDatabaseFromElastiCacheNodeGroups(t *testing.T) {
 		Name:        "my-cluster-reader",
 		Description: "ElastiCache cluster in us-east-1 (reader endpoint)",
 		Labels: map[string]string{
-			labelAccountID:    "123456789012",
-			labelRegion:       "us-east-1",
-			labelEndpointType: "reader",
-			"key":             "value",
+			types.DiscoveryLabelAccountID:    "123456789012",
+			types.OriginLabel:                types.OriginCloud,
+			types.CloudLabel:                 types.CloudAWS,
+			types.DiscoveryLabelRegion:       "us-east-1",
+			types.DiscoveryLabelEndpointType: "reader",
+			"key":                            "value",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -1511,87 +1575,95 @@ func TestDatabaseFromElastiCacheNodeGroups(t *testing.T) {
 }
 
 func TestDatabaseFromElastiCacheNodeGroupsNameOverride(t *testing.T) {
-	cluster := &elasticache.ReplicationGroup{
-		ARN:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:replicationgroup:my-cluster"),
-		ReplicationGroupId:       aws.String("my-cluster"),
-		Status:                   aws.String("available"),
-		TransitEncryptionEnabled: aws.Bool(true),
-		ClusterEnabled:           aws.Bool(false),
-		UserGroupIds:             []*string{aws.String("my-user-group")},
-		NodeGroups: []*elasticache.NodeGroup{
-			{
-				NodeGroupId: aws.String("0001"),
-				PrimaryEndpoint: &elasticache.Endpoint{
-					Address: aws.String("primary.localhost"),
-					Port:    aws.Int64(6379),
+	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+		t.Run("via "+overrideLabel, func(t *testing.T) {
+			cluster := &elasticache.ReplicationGroup{
+				ARN:                      aws.String("arn:aws:elasticache:us-east-1:123456789012:replicationgroup:my-cluster"),
+				ReplicationGroupId:       aws.String("my-cluster"),
+				Status:                   aws.String("available"),
+				TransitEncryptionEnabled: aws.Bool(true),
+				ClusterEnabled:           aws.Bool(false),
+				UserGroupIds:             []*string{aws.String("my-user-group")},
+				NodeGroups: []*elasticache.NodeGroup{
+					{
+						NodeGroupId: aws.String("0001"),
+						PrimaryEndpoint: &elasticache.Endpoint{
+							Address: aws.String("primary.localhost"),
+							Port:    aws.Int64(6379),
+						},
+						ReaderEndpoint: &elasticache.Endpoint{
+							Address: aws.String("reader.localhost"),
+							Port:    aws.Int64(6379),
+						},
+					},
 				},
-				ReaderEndpoint: &elasticache.Endpoint{
-					Address: aws.String("reader.localhost"),
-					Port:    aws.Int64(6379),
+			}
+			extraLabels := map[string]string{
+				overrideLabel: "my-override-cluster-2",
+				"key":         "value",
+			}
+
+			expectedPrimary, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "my-override-cluster-2",
+				Description: "ElastiCache cluster in us-east-1 (primary endpoint)",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:    "123456789012",
+					types.OriginLabel:                types.OriginCloud,
+					types.CloudLabel:                 types.CloudAWS,
+					types.DiscoveryLabelRegion:       "us-east-1",
+					types.DiscoveryLabelEndpointType: "primary",
+					overrideLabel:                    "my-override-cluster-2",
+					"key":                            "value",
 				},
-			},
-		},
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolRedis,
+				URI:      "primary.localhost:6379",
+				AWS: types.AWS{
+					AccountID: "123456789012",
+					Region:    "us-east-1",
+					ElastiCache: types.ElastiCache{
+						ReplicationGroupID:       "my-cluster",
+						UserGroupIDs:             []string{"my-user-group"},
+						TransitEncryptionEnabled: true,
+						EndpointType:             awsutils.ElastiCachePrimaryEndpoint,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			expectedReader, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "my-override-cluster-2-reader",
+				Description: "ElastiCache cluster in us-east-1 (reader endpoint)",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:    "123456789012",
+					types.OriginLabel:                types.OriginCloud,
+					types.CloudLabel:                 types.CloudAWS,
+					types.DiscoveryLabelRegion:       "us-east-1",
+					types.DiscoveryLabelEndpointType: "reader",
+					overrideLabel:                    "my-override-cluster-2",
+					"key":                            "value",
+				},
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolRedis,
+				URI:      "reader.localhost:6379",
+				AWS: types.AWS{
+					AccountID: "123456789012",
+					Region:    "us-east-1",
+					ElastiCache: types.ElastiCache{
+						ReplicationGroupID:       "my-cluster",
+						UserGroupIDs:             []string{"my-user-group"},
+						TransitEncryptionEnabled: true,
+						EndpointType:             awsutils.ElastiCacheReaderEndpoint,
+					},
+				},
+			})
+			require.NoError(t, err)
+
+			actual, err := NewDatabasesFromElastiCacheNodeGroups(cluster, extraLabels)
+			require.NoError(t, err)
+			require.Equal(t, types.Databases{expectedPrimary, expectedReader}, actual)
+		})
 	}
-	extraLabels := map[string]string{
-		labelTeleportDBName: "my-override-cluster-2",
-		"key":               "value",
-	}
-
-	expectedPrimary, err := types.NewDatabaseV3(types.Metadata{
-		Name:        "my-override-cluster-2",
-		Description: "ElastiCache cluster in us-east-1 (primary endpoint)",
-		Labels: map[string]string{
-			labelAccountID:      "123456789012",
-			labelRegion:         "us-east-1",
-			labelEndpointType:   "primary",
-			labelTeleportDBName: "my-override-cluster-2",
-			"key":               "value",
-		},
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolRedis,
-		URI:      "primary.localhost:6379",
-		AWS: types.AWS{
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			ElastiCache: types.ElastiCache{
-				ReplicationGroupID:       "my-cluster",
-				UserGroupIDs:             []string{"my-user-group"},
-				TransitEncryptionEnabled: true,
-				EndpointType:             awsutils.ElastiCachePrimaryEndpoint,
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	expectedReader, err := types.NewDatabaseV3(types.Metadata{
-		Name:        "my-override-cluster-2-reader",
-		Description: "ElastiCache cluster in us-east-1 (reader endpoint)",
-		Labels: map[string]string{
-			labelAccountID:      "123456789012",
-			labelRegion:         "us-east-1",
-			labelEndpointType:   "reader",
-			labelTeleportDBName: "my-override-cluster-2",
-			"key":               "value",
-		},
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolRedis,
-		URI:      "reader.localhost:6379",
-		AWS: types.AWS{
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			ElastiCache: types.ElastiCache{
-				ReplicationGroupID:       "my-cluster",
-				UserGroupIDs:             []string{"my-user-group"},
-				TransitEncryptionEnabled: true,
-				EndpointType:             awsutils.ElastiCacheReaderEndpoint,
-			},
-		},
-	})
-	require.NoError(t, err)
-
-	actual, err := NewDatabasesFromElastiCacheNodeGroups(cluster, extraLabels)
-	require.NoError(t, err)
-	require.Equal(t, types.Databases{expectedPrimary, expectedReader}, actual)
 }
 
 func TestDatabaseFromMemoryDBCluster(t *testing.T) {
@@ -1612,10 +1684,12 @@ func TestDatabaseFromMemoryDBCluster(t *testing.T) {
 		Name:        "my-cluster",
 		Description: "MemoryDB cluster in us-east-1",
 		Labels: map[string]string{
-			labelAccountID:    "123456789012",
-			labelRegion:       "us-east-1",
-			labelEndpointType: "cluster",
-			"key":             "value",
+			types.DiscoveryLabelAccountID:    "123456789012",
+			types.OriginLabel:                types.OriginCloud,
+			types.CloudLabel:                 types.CloudAWS,
+			types.DiscoveryLabelRegion:       "us-east-1",
+			types.DiscoveryLabelEndpointType: "cluster",
+			"key":                            "value",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolRedis,
@@ -1645,12 +1719,14 @@ func TestDatabaseFromRedshiftServerlessWorkgroup(t *testing.T) {
 		Name:        "my-workgroup",
 		Description: "Redshift Serverless workgroup in eu-west-2",
 		Labels: map[string]string{
-			labelAccountID:    "123456789012",
-			labelRegion:       "eu-west-2",
-			labelEndpointType: "workgroup",
-			labelNamespace:    "my-namespace",
-			labelVPCID:        "vpc-id",
-			"env":             "prod",
+			types.DiscoveryLabelAccountID:    "123456789012",
+			types.OriginLabel:                types.OriginCloud,
+			types.CloudLabel:                 types.CloudAWS,
+			types.DiscoveryLabelRegion:       "eu-west-2",
+			types.DiscoveryLabelEndpointType: "workgroup",
+			types.DiscoveryLabelNamespace:    "my-namespace",
+			types.DiscoveryLabelVPCID:        "vpc-id",
+			"env":                            "prod",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
@@ -1679,13 +1755,15 @@ func TestDatabaseFromRedshiftServerlessVPCEndpoint(t *testing.T) {
 		Name:        "my-workgroup-my-endpoint",
 		Description: "Redshift Serverless endpoint in eu-west-2",
 		Labels: map[string]string{
-			labelAccountID:    "123456789012",
-			labelRegion:       "eu-west-2",
-			labelEndpointType: "vpc-endpoint",
-			labelWorkgroup:    "my-workgroup",
-			labelNamespace:    "my-namespace",
-			labelVPCID:        "vpc-id",
-			"env":             "prod",
+			types.DiscoveryLabelAccountID:    "123456789012",
+			types.OriginLabel:                types.OriginCloud,
+			types.CloudLabel:                 types.CloudAWS,
+			types.DiscoveryLabelRegion:       "eu-west-2",
+			types.DiscoveryLabelEndpointType: "vpc-endpoint",
+			types.DiscoveryLabelWorkgroup:    "my-workgroup",
+			types.DiscoveryLabelNamespace:    "my-namespace",
+			types.DiscoveryLabelVPCID:        "vpc-id",
+			"env":                            "prod",
 		},
 	}, types.DatabaseSpecV3{
 		Protocol: defaults.ProtocolPostgres,
@@ -1711,51 +1789,57 @@ func TestDatabaseFromRedshiftServerlessVPCEndpoint(t *testing.T) {
 }
 
 func TestDatabaseFromMemoryDBClusterNameOverride(t *testing.T) {
-	cluster := &memorydb.Cluster{
-		ARN:        aws.String("arn:aws:memorydb:us-east-1:123456789012:cluster:my-cluster"),
-		Name:       aws.String("my-cluster"),
-		Status:     aws.String("available"),
-		TLSEnabled: aws.Bool(true),
-		ACLName:    aws.String("my-user-group"),
-		ClusterEndpoint: &memorydb.Endpoint{
-			Address: aws.String("memorydb.localhost"),
-			Port:    aws.Int64(6379),
-		},
-	}
-	extraLabels := map[string]string{
-		labelTeleportDBName: "override-1",
-		"key":               "value",
-	}
+	for _, overrideLabel := range types.AWSDatabaseNameOverrideLabels {
+		t.Run("via "+overrideLabel, func(t *testing.T) {
+			cluster := &memorydb.Cluster{
+				ARN:        aws.String("arn:aws:memorydb:us-east-1:123456789012:cluster:my-cluster"),
+				Name:       aws.String("my-cluster"),
+				Status:     aws.String("available"),
+				TLSEnabled: aws.Bool(true),
+				ACLName:    aws.String("my-user-group"),
+				ClusterEndpoint: &memorydb.Endpoint{
+					Address: aws.String("memorydb.localhost"),
+					Port:    aws.Int64(6379),
+				},
+			}
+			extraLabels := map[string]string{
+				overrideLabel: "override-1",
+				"key":         "value",
+			}
 
-	expected, err := types.NewDatabaseV3(types.Metadata{
-		Name:        "override-1",
-		Description: "MemoryDB cluster in us-east-1",
-		Labels: map[string]string{
-			labelAccountID:      "123456789012",
-			labelRegion:         "us-east-1",
-			labelEndpointType:   "cluster",
-			labelTeleportDBName: "override-1",
-			"key":               "value",
-		},
-	}, types.DatabaseSpecV3{
-		Protocol: defaults.ProtocolRedis,
-		URI:      "memorydb.localhost:6379",
-		AWS: types.AWS{
-			AccountID: "123456789012",
-			Region:    "us-east-1",
-			MemoryDB: types.MemoryDB{
-				ClusterName:  "my-cluster",
-				ACLName:      "my-user-group",
-				TLSEnabled:   true,
-				EndpointType: awsutils.MemoryDBClusterEndpoint,
-			},
-		},
-	})
-	require.NoError(t, err)
+			expected, err := types.NewDatabaseV3(types.Metadata{
+				Name:        "override-1",
+				Description: "MemoryDB cluster in us-east-1",
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID:    "123456789012",
+					types.OriginLabel:                types.OriginCloud,
+					types.CloudLabel:                 types.CloudAWS,
+					types.DiscoveryLabelRegion:       "us-east-1",
+					types.DiscoveryLabelEndpointType: "cluster",
+					overrideLabel:                    "override-1",
+					"key":                            "value",
+				},
+			}, types.DatabaseSpecV3{
+				Protocol: defaults.ProtocolRedis,
+				URI:      "memorydb.localhost:6379",
+				AWS: types.AWS{
+					AccountID: "123456789012",
+					Region:    "us-east-1",
+					MemoryDB: types.MemoryDB{
+						ClusterName:  "my-cluster",
+						ACLName:      "my-user-group",
+						TLSEnabled:   true,
+						EndpointType: awsutils.MemoryDBClusterEndpoint,
+					},
+				},
+			})
+			require.NoError(t, err)
 
-	actual, err := NewDatabaseFromMemoryDBCluster(cluster, extraLabels)
-	require.NoError(t, err)
-	require.Empty(t, cmp.Diff(expected, actual))
+			actual, err := NewDatabaseFromMemoryDBCluster(cluster, extraLabels)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expected, actual))
+		})
+	}
 }
 
 func TestExtraElastiCacheLabels(t *testing.T) {
@@ -1898,16 +1982,16 @@ func TestGetLabelEngineVersion(t *testing.T) {
 		{
 			name: "mysql-8.0.0",
 			labels: map[string]string{
-				labelEngine:        RDSEngineMySQL,
-				labelEngineVersion: "8.0.0",
+				types.DiscoveryLabelEngine:        RDSEngineMySQL,
+				types.DiscoveryLabelEngineVersion: "8.0.0",
 			},
 			want: "8.0.0",
 		},
 		{
 			name: "mariadb returns nothing",
 			labels: map[string]string{
-				labelEngine:        RDSEngineMariaDB,
-				labelEngineVersion: "10.6.7",
+				types.DiscoveryLabelEngine:        RDSEngineMariaDB,
+				types.DiscoveryLabelEngineVersion: "10.6.7",
 			},
 			want: "",
 		},
@@ -1919,16 +2003,16 @@ func TestGetLabelEngineVersion(t *testing.T) {
 		{
 			name: "azure-mysql-8.0.0",
 			labels: map[string]string{
-				labelEngine:        AzureEngineMySQL,
-				labelEngineVersion: "8.0.0",
+				types.DiscoveryLabelEngine:        AzureEngineMySQL,
+				types.DiscoveryLabelEngineVersion: "8.0.0",
 			},
 			want: "8.0.0",
 		},
 		{
 			name: "azure-mysql-8.0.0 flex server",
 			labels: map[string]string{
-				labelEngine:        AzureEngineMySQLFlex,
-				labelEngineVersion: string(armmysqlflexibleservers.ServerVersionEight021),
+				types.DiscoveryLabelEngine:        AzureEngineMySQLFlex,
+				types.DiscoveryLabelEngineVersion: string(armmysqlflexibleservers.ServerVersionEight021),
 			},
 			want: "8.0.21",
 		},
@@ -1942,51 +2026,6 @@ func TestGetLabelEngineVersion(t *testing.T) {
 			if got := GetMySQLEngineVersion(tt.labels); got != tt.want {
 				t.Errorf("GetMySQLEngineVersion() = %v, want %v", got, tt.want)
 			}
-		})
-	}
-}
-
-func Test_setDBName(t *testing.T) {
-	tests := []struct {
-		name           string
-		meta           types.Metadata
-		firstNamePart  string
-		extraNameParts []string
-		want           types.Metadata
-	}{
-		{
-			name:           "no override, one part name",
-			meta:           types.Metadata{},
-			firstNamePart:  "foo",
-			extraNameParts: nil,
-			want:           types.Metadata{Name: "foo"},
-		},
-		{
-			name:           "no override, multi part name",
-			meta:           types.Metadata{},
-			firstNamePart:  "foo",
-			extraNameParts: []string{"bar", "baz"},
-			want:           types.Metadata{Name: "foo-bar-baz"},
-		},
-		{
-			name:           "override, one part name",
-			meta:           types.Metadata{Labels: map[string]string{labelTeleportDBName: "gizmo"}},
-			firstNamePart:  "foo",
-			extraNameParts: nil,
-			want:           types.Metadata{Name: "gizmo", Labels: map[string]string{labelTeleportDBName: "gizmo"}},
-		},
-		{
-			name:           "override, multi part name",
-			meta:           types.Metadata{Labels: map[string]string{labelTeleportDBName: "gizmo"}},
-			firstNamePart:  "foo",
-			extraNameParts: []string{"bar", "baz"},
-			want:           types.Metadata{Name: "gizmo-bar-baz", Labels: map[string]string{labelTeleportDBName: "gizmo"}},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := setDBName(tt.meta, tt.firstNamePart, tt.extraNameParts...)
-			require.Equal(t, tt.want, result)
 		})
 	}
 }
@@ -2022,8 +2061,8 @@ func TestNewDatabaseFromAzureSQLServer(t *testing.T) {
 
 				// Assert labels
 				labels := db.GetMetadata().Labels
-				require.Equal(t, "westus", labels[labelRegion])
-				require.Equal(t, "12.0", labels[labelEngineVersion])
+				require.Equal(t, "westus", labels[types.DiscoveryLabelRegion])
+				require.Equal(t, "12.0", labels[types.DiscoveryLabelEngineVersion])
 			},
 		},
 		{
@@ -2077,7 +2116,7 @@ func TestNewDatabaseFromAzureManagedSQLServer(t *testing.T) {
 
 				// Assert labels
 				labels := db.GetMetadata().Labels
-				require.Equal(t, "westus", labels[labelRegion])
+				require.Equal(t, "westus", labels[types.DiscoveryLabelRegion])
 			},
 		},
 		{
@@ -2163,18 +2202,20 @@ func TestDatabaseFromAzureMySQLFlexServer(t *testing.T) {
 			}
 
 			wantLabels := map[string]string{
-				labelRegion:         region,
-				labelEngine:         provider,
-				labelEngineVersion:  "8.0.21",
-				labelResourceGroup:  group,
-				labelSubscriptionID: subID,
-				"foo":               "bar",
+				types.DiscoveryLabelRegion:              region,
+				types.DiscoveryLabelEngine:              provider,
+				types.DiscoveryLabelEngineVersion:       "8.0.21",
+				types.DiscoveryLabelAzureResourceGroup:  group,
+				types.OriginLabel:                       types.OriginCloud,
+				types.CloudLabel:                        types.CloudAzure,
+				types.DiscoveryLabelAzureSubscriptionID: subID,
+				"foo":                                   "bar",
 			}
 			if tt.wantReplicationRoleLabel != "" {
-				wantLabels[labelReplicationRole] = tt.wantReplicationRoleLabel
+				wantLabels[types.DiscoveryLabelAzureReplicationRole] = tt.wantReplicationRoleLabel
 			}
 			if tt.wantSourceServerLabel != "" {
-				wantLabels[labelSourceServer] = tt.wantSourceServerLabel
+				wantLabels[types.DiscoveryLabelAzureSourceServer] = tt.wantSourceServerLabel
 			}
 			wantDB, err := types.NewDatabaseV3(types.Metadata{
 				Name:        tt.serverName,
@@ -2193,7 +2234,7 @@ func TestDatabaseFromAzureMySQLFlexServer(t *testing.T) {
 
 			actual, err := NewDatabaseFromAzureMySQLFlexServer(&server)
 			require.NoError(t, err)
-			require.Equal(t, wantDB, actual)
+			require.Empty(t, cmp.Diff(wantDB, actual))
 		})
 	}
 }
@@ -2238,12 +2279,14 @@ func TestDatabaseFromAzurePostgresFlexServer(t *testing.T) {
 			}
 
 			wantLabels := map[string]string{
-				labelRegion:         region,
-				labelEngine:         provider,
-				labelEngineVersion:  "14",
-				labelResourceGroup:  group,
-				labelSubscriptionID: subID,
-				"foo":               "bar",
+				types.DiscoveryLabelRegion:              region,
+				types.DiscoveryLabelEngine:              provider,
+				types.DiscoveryLabelEngineVersion:       "14",
+				types.DiscoveryLabelAzureResourceGroup:  group,
+				types.OriginLabel:                       types.OriginCloud,
+				types.CloudLabel:                        types.CloudAzure,
+				types.DiscoveryLabelAzureSubscriptionID: subID,
+				"foo":                                   "bar",
 			}
 			wantDB, err := types.NewDatabaseV3(types.Metadata{
 				Name:        tt.serverName,
@@ -2262,7 +2305,7 @@ func TestDatabaseFromAzurePostgresFlexServer(t *testing.T) {
 
 			actual, err := NewDatabaseFromAzurePostgresFlexServer(&server)
 			require.NoError(t, err)
-			require.Equal(t, wantDB, actual)
+			require.Empty(t, cmp.Diff(wantDB, actual))
 		})
 	}
 }
@@ -2334,12 +2377,14 @@ func TestMakeAzureDatabaseLoginUsername(t *testing.T) {
 				Name:        serverName,
 				Description: "test azure db server",
 				Labels: map[string]string{
-					labelRegion:         "eastus",
-					labelEngine:         tt.engine,
-					labelEngineVersion:  "1.2.3",
-					labelResourceGroup:  group,
-					labelSubscriptionID: subID,
-					"foo":               "bar",
+					types.DiscoveryLabelRegion:              "eastus",
+					types.DiscoveryLabelEngine:              tt.engine,
+					types.DiscoveryLabelEngineVersion:       "1.2.3",
+					types.DiscoveryLabelAzureResourceGroup:  group,
+					types.OriginLabel:                       types.OriginCloud,
+					types.CloudLabel:                        types.CloudAzure,
+					types.DiscoveryLabelAzureSubscriptionID: subID,
+					"foo":                                   "bar",
 				},
 			}, types.DatabaseSpecV3{
 				Protocol: tt.protocol,

--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -19,7 +19,6 @@ package services
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go/aws"
@@ -170,32 +169,32 @@ func UnmarshalKubeCluster(data []byte, opts ...MarshalOption) (types.KubeCluster
 	return nil, trace.BadParameter("unsupported kube cluster resource version %q", h.Version)
 }
 
-const (
-	// labelTeleportKubeClusterName is the label key containing the kubernetes cluster name override.
-	labelTeleportKubeClusterName = types.TeleportNamespace + "/kubernetes-name"
-)
+// setAWSKubeName modifies the types.Metadata in place, overriding the first
+// part if the kube cluster override label for AWS is present, and setting the
+// kube cluster name.
+func setAWSKubeName(meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
+	return setResourceName(types.AWSKubeClusterNameOverrideLabels, meta, firstNamePart, extraNameParts...)
+}
 
-// setKubeName modifies the types.Metadata argument in place, setting the kubernetes cluster name.
-// The name is calculated based on nameParts arguments which are joined by hyphens "-".
-// If the kube_cluster name override label is present (setKubeName), it will replace the *first* name part.
-func setKubeName(meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
-	nameParts := append([]string{firstNamePart}, extraNameParts...)
+// setAzureKubeName modifies the types.Metadata in place, overriding the first
+// part if the AKS kube cluster override label is present, and setting the kube
+// cluster name.
+func setAzureKubeName(meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
+	return setResourceName([]string{types.AzureKubeClusterNameOverrideLabel}, meta, firstNamePart, extraNameParts...)
+}
 
-	// apply override
-	if override, found := meta.Labels[labelTeleportKubeClusterName]; found && override != "" {
-		nameParts[0] = override
-	}
-
-	meta.Name = strings.Join(nameParts, "-")
-
-	return meta
+// setGCPKubeName modifies the types.Metadata in place, overriding the first
+// part if the GKE kube cluster override label is present, and setting the kube
+// cluster name.
+func setGCPKubeName(meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
+	return setResourceName([]string{types.GCPKubeClusterNameOverrideLabel}, meta, firstNamePart, extraNameParts...)
 }
 
 // NewKubeClusterFromAzureAKS creates a kube_cluster resource from an AKSCluster.
 func NewKubeClusterFromAzureAKS(cluster *azure.AKSCluster) (types.KubeCluster, error) {
 	labels := labelsFromAzureKubeCluster(cluster)
 	return types.NewKubernetesClusterV3(
-		setKubeName(types.Metadata{
+		setAzureKubeName(types.Metadata{
 			Description: fmt.Sprintf("Azure AKS cluster %q in %v",
 				cluster.Name,
 				cluster.Location),
@@ -216,17 +215,17 @@ func labelsFromAzureKubeCluster(cluster *azure.AKSCluster) map[string]string {
 	labels := azureTagsToLabels(cluster.Tags)
 	labels[types.OriginLabel] = types.OriginCloud
 	labels[types.CloudLabel] = types.CloudAzure
-	labels[labelRegion] = cluster.Location
+	labels[types.DiscoveryLabelRegion] = cluster.Location
 
-	labels[labelResourceGroup] = cluster.GroupName
-	labels[labelSubscriptionID] = cluster.SubscriptionID
+	labels[types.DiscoveryLabelAzureResourceGroup] = cluster.GroupName
+	labels[types.DiscoveryLabelAzureSubscriptionID] = cluster.SubscriptionID
 	return labels
 }
 
 // NewKubeClusterFromGCPGKE creates a kube_cluster resource from an GKE cluster.
 func NewKubeClusterFromGCPGKE(cluster gcp.GKECluster) (types.KubeCluster, error) {
 	return types.NewKubernetesClusterV3(
-		setKubeName(types.Metadata{
+		setGCPKubeName(types.Metadata{
 			Description: getOrSetDefaultGCPDescription(cluster),
 			Labels:      labelsFromGCPKubeCluster(cluster),
 		}, cluster.Name),
@@ -255,9 +254,9 @@ func labelsFromGCPKubeCluster(cluster gcp.GKECluster) map[string]string {
 	labels := maps.Clone(cluster.Labels)
 	labels[types.OriginLabel] = types.OriginCloud
 	labels[types.CloudLabel] = types.CloudGCP
-	labels[labelLocation] = cluster.Location
+	labels[types.DiscoveryLabelGCPLocation] = cluster.Location
 
-	labels[labelProjectID] = cluster.ProjectID
+	labels[types.DiscoveryLabelGCPProjectID] = cluster.ProjectID
 	return labels
 }
 
@@ -270,7 +269,7 @@ func NewKubeClusterFromAWSEKS(cluster *eks.Cluster) (types.KubeCluster, error) {
 	labels := labelsFromAWSKubeCluster(cluster, parsedARN)
 
 	return types.NewKubernetesClusterV3(
-		setKubeName(types.Metadata{
+		setAWSKubeName(types.Metadata{
 			Description: fmt.Sprintf("AWS EKS cluster %q in %s",
 				aws.StringValue(cluster.Name),
 				parsedARN.Region),
@@ -290,9 +289,9 @@ func labelsFromAWSKubeCluster(cluster *eks.Cluster, parsedARN arn.ARN) map[strin
 	labels := awsEKSTagsToLabels(cluster.Tags)
 	labels[types.OriginLabel] = types.OriginCloud
 	labels[types.CloudLabel] = types.CloudAWS
-	labels[labelRegion] = parsedARN.Region
+	labels[types.DiscoveryLabelRegion] = parsedARN.Region
 
-	labels[labelAccountID] = parsedARN.AccountID
+	labels[types.DiscoveryLabelAccountID] = parsedARN.AccountID
 	return labels
 }
 
@@ -308,10 +307,3 @@ func awsEKSTagsToLabels(tags map[string]*string) map[string]string {
 	}
 	return labels
 }
-
-const (
-	// labelProjectID is the label key for GCP project ID.
-	labelProjectID = "project-id"
-	// labelLocation is the label key for GCP location.
-	labelLocation = "location"
-)

--- a/lib/services/kubernetes_test.go
+++ b/lib/services/kubernetes_test.go
@@ -19,9 +19,15 @@ package services
 import (
 	"testing"
 
+	"cloud.google.com/go/container/apiv1/containerpb"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/eks"
+	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/cloud/azure"
+	"github.com/gravitational/teleport/lib/cloud/gcp"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -75,6 +81,136 @@ func TestKubernetesServerMarshal(t *testing.T) {
 	actual, err := UnmarshalKubeServer(data)
 	require.NoError(t, err)
 	require.Equal(t, expected, actual)
+}
+
+func TestNewKubeClusterFromAWSEKS(t *testing.T) {
+	for _, overrideLabel := range types.AWSKubeClusterNameOverrideLabels {
+		t.Run("with name override via "+overrideLabel, func(t *testing.T) {
+			expected, err := types.NewKubernetesClusterV3(types.Metadata{
+				Name:        "override-1",
+				Description: `AWS EKS cluster "cluster1" in eu-west-1`,
+				Labels: map[string]string{
+					types.DiscoveryLabelAccountID: "123456789012",
+					types.DiscoveryLabelRegion:    "eu-west-1",
+					types.OriginLabel:             types.OriginCloud,
+					types.CloudLabel:              types.CloudAWS,
+					overrideLabel:                 "override-1",
+					"env":                         "prod",
+				},
+			}, types.KubernetesClusterSpecV3{
+				AWS: types.KubeAWS{
+					Name:      "cluster1",
+					Region:    "eu-west-1",
+					AccountID: "123456789012",
+				},
+			})
+			require.NoError(t, err)
+
+			cluster := &eks.Cluster{
+				Name:   aws.String("cluster1"),
+				Arn:    aws.String("arn:aws:eks:eu-west-1:123456789012:cluster/cluster1"),
+				Status: aws.String(eks.ClusterStatusActive),
+				Tags: map[string]*string{
+					overrideLabel: aws.String("override-1"),
+					"env":         aws.String("prod"),
+				},
+			}
+			actual, err := NewKubeClusterFromAWSEKS(cluster)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(expected, actual))
+			require.NoError(t, err)
+			require.True(t, actual.IsAWS())
+			require.False(t, actual.IsAzure())
+			require.False(t, actual.IsGCP())
+		})
+	}
+}
+
+func TestNewKubeClusterFromAzureAKS(t *testing.T) {
+	overrideLabel := types.AzureKubeClusterNameOverrideLabel
+	expected, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name:        "override-1",
+		Description: `Azure AKS cluster "aks-cluster1" in uswest1`,
+		Labels: map[string]string{
+			types.DiscoveryLabelRegion:              "uswest1",
+			types.DiscoveryLabelAzureResourceGroup:  "group1",
+			types.DiscoveryLabelAzureSubscriptionID: "subID",
+			types.OriginLabel:                       types.OriginCloud,
+			types.CloudLabel:                        types.CloudAzure,
+			overrideLabel:                           "override-1",
+			"env":                                   "prod",
+		},
+	}, types.KubernetesClusterSpecV3{
+		Azure: types.KubeAzure{
+			ResourceName:   "aks-cluster1",
+			ResourceGroup:  "group1",
+			TenantID:       "tenantID",
+			SubscriptionID: "subID",
+		},
+	})
+	require.NoError(t, err)
+
+	cluster := &azure.AKSCluster{
+		Name:           "aks-cluster1",
+		GroupName:      "group1",
+		TenantID:       "tenantID",
+		Location:       "uswest1",
+		SubscriptionID: "subID",
+		Tags: map[string]string{
+			"env":         "prod",
+			overrideLabel: "override-1",
+		},
+		Properties: azure.AKSClusterProperties{},
+	}
+	actual, err := NewKubeClusterFromAzureAKS(cluster)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected, actual))
+	require.NoError(t, err)
+	require.True(t, actual.IsAzure())
+	require.False(t, actual.IsGCP())
+	require.False(t, actual.IsAWS())
+}
+
+func TestNewKubeClusterFromGCPGKE(t *testing.T) {
+	overrideLabel := types.GCPKubeClusterNameOverrideLabel
+	expected, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name:        "override-1",
+		Description: "desc1",
+		Labels: map[string]string{
+			types.DiscoveryLabelGCPLocation:  "central-1",
+			types.DiscoveryLabelGCPProjectID: "p1",
+			types.OriginLabel:                types.OriginCloud,
+			types.CloudLabel:                 types.CloudGCP,
+			overrideLabel:                    "override-1",
+			"env":                            "prod",
+		},
+	}, types.KubernetesClusterSpecV3{
+		GCP: types.KubeGCP{
+			Name:      "cluster1",
+			ProjectID: "p1",
+			Location:  "central-1",
+		},
+	})
+	require.NoError(t, err)
+
+	cluster := gcp.GKECluster{
+		Name:   "cluster1",
+		Status: containerpb.Cluster_RUNNING,
+		Labels: map[string]string{
+			overrideLabel: "override-1",
+			"env":         "prod",
+		},
+		ProjectID:   "p1",
+		Location:    "central-1",
+		Description: "desc1",
+	}
+	actual, err := NewKubeClusterFromGCPGKE(cluster)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected, actual))
+	require.NoError(t, err)
+	require.True(t, actual.IsGCP())
+	require.False(t, actual.IsAzure())
+	require.False(t, actual.IsAWS())
 }
 
 var kubeServerYAML = `---

--- a/lib/services/resource.go
+++ b/lib/services/resource.go
@@ -638,3 +638,22 @@ func (u *UnknownResource) UnmarshalJSON(raw []byte) error {
 	copy(u.Raw, raw)
 	return nil
 }
+
+// setResourceName modifies the types.Metadata argument in place, setting the resource name.
+// The name is calculated based on nameParts arguments which are joined by hyphens "-".
+// If a name override label is present, it will replace the *first* name part.
+func setResourceName(overrideLabels []string, meta types.Metadata, firstNamePart string, extraNameParts ...string) types.Metadata {
+	nameParts := append([]string{firstNamePart}, extraNameParts...)
+
+	// apply override
+	for _, overrideLabel := range overrideLabels {
+		if override, found := meta.Labels[overrideLabel]; found && override != "" {
+			nameParts[0] = override
+			break
+		}
+	}
+
+	meta.Name = strings.Join(nameParts, "-")
+
+	return meta
+}

--- a/lib/services/resource_test.go
+++ b/lib/services/resource_test.go
@@ -179,3 +179,59 @@ func TestParseShortcut(t *testing.T) {
 		})
 	}
 }
+
+func Test_setResourceName(t *testing.T) {
+	tests := []struct {
+		name           string
+		meta           types.Metadata
+		overrideLabels []string
+		firstNamePart  string
+		extraNameParts []string
+		want           types.Metadata
+	}{
+		{
+			name:           "no override, one part name",
+			meta:           types.Metadata{},
+			firstNamePart:  "foo",
+			extraNameParts: nil,
+			want:           types.Metadata{Name: "foo"},
+		},
+		{
+			name:           "no override, multi part name",
+			meta:           types.Metadata{},
+			firstNamePart:  "foo",
+			extraNameParts: []string{"bar", "baz"},
+			want:           types.Metadata{Name: "foo-bar-baz"},
+		},
+		{
+			name:           "override by generic cloud label, one part name",
+			meta:           types.Metadata{Labels: map[string]string{types.AWSDatabaseNameOverrideLabels[0]: "gizmo"}},
+			overrideLabels: types.AWSDatabaseNameOverrideLabels,
+			firstNamePart:  "foo",
+			extraNameParts: nil,
+			want:           types.Metadata{Name: "gizmo", Labels: map[string]string{types.AWSDatabaseNameOverrideLabels[0]: "gizmo"}},
+		},
+		{
+			name:           "override by original AWS label, one part name",
+			meta:           types.Metadata{Labels: map[string]string{types.AWSDatabaseNameOverrideLabels[1]: "gizmo"}},
+			overrideLabels: types.AWSDatabaseNameOverrideLabels,
+			firstNamePart:  "foo",
+			extraNameParts: nil,
+			want:           types.Metadata{Name: "gizmo", Labels: map[string]string{types.AWSDatabaseNameOverrideLabels[1]: "gizmo"}},
+		},
+		{
+			name:           "override, multi part name",
+			meta:           types.Metadata{Labels: map[string]string{types.AzureDatabaseNameOverrideLabel: "gizmo"}},
+			overrideLabels: []string{types.AzureDatabaseNameOverrideLabel},
+			firstNamePart:  "foo",
+			extraNameParts: []string{"bar", "baz"},
+			want:           types.Metadata{Name: "gizmo-bar-baz", Labels: map[string]string{types.AzureDatabaseNameOverrideLabel: "gizmo"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := setResourceName(tt.overrideLabels, tt.meta, tt.firstNamePart, tt.extraNameParts...)
+			require.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/lib/srv/desktop/discovery.go
+++ b/lib/srv/desktop/discovery.go
@@ -154,29 +154,29 @@ func (s *WindowsService) deleteDesktop(ctx context.Context, r types.ResourceWith
 func (s *WindowsService) applyLabelsFromLDAP(entry *ldap.Entry, labels map[string]string) {
 	// apply common LDAP labels by default
 	labels[types.OriginLabel] = types.OriginDynamic
-	labels[types.TeleportNamespace+"/dns_host_name"] = entry.GetAttributeValue(windows.AttrDNSHostName)
-	labels[types.TeleportNamespace+"/computer_name"] = entry.GetAttributeValue(windows.AttrName)
-	labels[types.TeleportNamespace+"/os"] = entry.GetAttributeValue(windows.AttrOS)
-	labels[types.TeleportNamespace+"/os_version"] = entry.GetAttributeValue(windows.AttrOSVersion)
+	labels[types.DiscoveryLabelWindowsDNSHostName] = entry.GetAttributeValue(windows.AttrDNSHostName)
+	labels[types.DiscoveryLabelWindowsComputerName] = entry.GetAttributeValue(windows.AttrName)
+	labels[types.DiscoveryLabelWindowsOS] = entry.GetAttributeValue(windows.AttrOS)
+	labels[types.DiscoveryLabelWindowsOSVersion] = entry.GetAttributeValue(windows.AttrOSVersion)
 
 	// attempt to compute the desktop's OU from its DN
 	dn := entry.GetAttributeValue(windows.AttrDistinguishedName)
 	cn := entry.GetAttributeValue(windows.AttrCommonName)
 	if len(dn) > 0 && len(cn) > 0 {
 		ou := strings.TrimPrefix(dn, "CN="+cn+",")
-		labels[types.TeleportNamespace+"/ou"] = ou
+		labels[types.DiscoveryLabelWindowsOU] = ou
 	}
 
 	// label domain controllers
 	switch entry.GetAttributeValue(windows.AttrPrimaryGroupID) {
 	case windows.WritableDomainControllerGroupID, windows.ReadOnlyDomainControllerGroupID:
-		labels[types.TeleportNamespace+"/is_domain_controller"] = "true"
+		labels[types.DiscoveryLabelWindowsIsDomainController] = "true"
 	}
 
 	// apply any custom labels per the discovery configuration
 	for _, attr := range s.cfg.DiscoveryLDAPAttributeLabels {
 		if v := entry.GetAttributeValue(attr); v != "" {
-			labels["ldap/"+attr] = v
+			labels[types.DiscoveryLabelLDAPPrefix+attr] = v
 		}
 	}
 }
@@ -208,7 +208,7 @@ func (s *WindowsService) ldapEntryToWindowsDesktop(ctx context.Context, entry *l
 		return nil, trace.BadParameter("LDAP entry missing hostname, has attributes: %v", entry.Attributes)
 	}
 	labels := getHostLabels(hostname)
-	labels[types.TeleportNamespace+"/windows_domain"] = s.cfg.Domain
+	labels[types.DiscoveryLabelWindowsDomain] = s.cfg.Domain
 	s.applyLabelsFromLDAP(entry, labels)
 
 	addrs, err := s.lookupDesktop(ctx, hostname)

--- a/lib/srv/desktop/discovery_test.go
+++ b/lib/srv/desktop/discovery_test.go
@@ -84,13 +84,13 @@ func TestAppliesLDAPLabels(t *testing.T) {
 
 	// check default labels
 	require.Equal(t, l[types.OriginLabel], types.OriginDynamic)
-	require.Equal(t, l[types.TeleportNamespace+"/dns_host_name"], "foo.example.com")
-	require.Equal(t, l[types.TeleportNamespace+"/computer_name"], "foo")
-	require.Equal(t, l[types.TeleportNamespace+"/os"], "Windows Server")
-	require.Equal(t, l[types.TeleportNamespace+"/os_version"], "6.1")
+	require.Equal(t, l[types.DiscoveryLabelWindowsDNSHostName], "foo.example.com")
+	require.Equal(t, l[types.DiscoveryLabelWindowsComputerName], "foo")
+	require.Equal(t, l[types.DiscoveryLabelWindowsOS], "Windows Server")
+	require.Equal(t, l[types.DiscoveryLabelWindowsOSVersion], "6.1")
 
 	// check OU label
-	require.Equal(t, l[types.TeleportNamespace+"/ou"], "OU=IT,DC=goteleport,DC=com")
+	require.Equal(t, l[types.DiscoveryLabelWindowsOU], "OU=IT,DC=goteleport,DC=com")
 
 	// check custom labels
 	require.Equal(t, l["ldap/bar"], "baz")
@@ -130,7 +130,7 @@ func TestLabelsDomainControllers(t *testing.T) {
 			l := make(map[string]string)
 			s.applyLabelsFromLDAP(test.entry, l)
 
-			b, _ := strconv.ParseBool(l[types.TeleportNamespace+"/is_domain_controller"])
+			b, _ := strconv.ParseBool(l[types.DiscoveryLabelWindowsIsDomainController])
 			test.assert(t, b)
 		})
 	}

--- a/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
+++ b/web/packages/teleport/src/Discover/Database/CreateDatabase/useCreateDatabase.ts
@@ -221,7 +221,7 @@ export function useCreateDatabase() {
     const preErrMsg = 'failed to register database: ';
     const nonAwsMsg = `use a different name and try again`;
     const awsMsg = `change (or define) the value of the \
-    tag "teleport.dev/database_name" on the RDS instance and try again`;
+    tag "TeleportDatabaseName" on the RDS instance and try again`;
 
     try {
       await ctx.databaseService.fetchDatabase(clusterId, dbName);


### PR DESCRIPTION
Backport #28917 to branch/v12

there were some minor merge conflicts, all of which came from the cherry-pick including things that weren't in v12 unrelated to this PR's intended changes to discovery labels.