### PR TITLE
v13: [ci] Change macOS GHA runner to `macos-latest-xl-arm64`

### DIFF
--- a/.github/workflows/build-macos.yaml
+++ b/.github/workflows/build-macos.yaml
@@ -19,12 +19,17 @@ jobs:
   build:
     name: Build on Mac OS
     if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
-    runs-on: macos-12-xl
+    runs-on: macos-13-xl-arm64
 
     permissions:
       contents: read
 
     steps:
+      # This is necessary on macos arm64 runners because the .cache and
+      # .config dirs on the runner are owned by root not the "runner" user.
+      - name: Fix home dir perms
+        run: sudo chown -R $(id -u):$(id -g) $HOME/.cache $HOME/.config
+
       - name: Checkout Teleport
         uses: actions/checkout@v3
 


### PR DESCRIPTION
* [ci] Change macOS GHA runner to `macos-13-xl-arm64`

Swap from Intel-based `macos-12-xl` to Apple silicon-based `macos-13-xl-arm64` runner.

* Fix /Users/runner home dir permissions

.cache and .config are root owned. change that to the runner user.

Backport: https://github.com/gravitational/teleport/pull/28741