### PR TITLE
v13: dronegen: Switch linux-based push builds to GitHub

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,17 +30,12 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go (main.pushPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: push-build-linux-amd64
-environment:
-  BUILDBOX_VERSION: teleport13
-  GID: "1000"
-  RUNTIME: go1.20.6
-  UID: "1000"
 trigger:
   event:
     include:
@@ -78,44 +73,18 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "release-target=release-amd64-centos7" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-amd64-centos7
-  - make -C build.assets teleterm
-  environment:
-    ARCH: amd64
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
 - name: Send Slack notification
   image: plugins/slack:1.4.1
   settings:
@@ -127,18 +96,6 @@ steps:
   when:
     status:
     - failure
-services:
-- name: Start Docker
-  image: docker:23.0-dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -146,17 +103,12 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go (main.pushPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: push-build-linux-386
-environment:
-  BUILDBOX_VERSION: teleport13
-  GID: "1000"
-  RUNTIME: go1.20.6
-  UID: "1000"
 trigger:
   event:
     include:
@@ -194,42 +146,18 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "release-target=release-386" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-386
-  environment:
-    ARCH: "386"
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
 - name: Send Slack notification
   image: plugins/slack:1.4.1
   settings:
@@ -241,18 +169,6 @@ steps:
   when:
     status:
     - failure
-services:
-- name: Start Docker
-  image: docker:23.0-dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -260,17 +176,12 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go (main.pushPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: push-build-linux-amd64-fips
-environment:
-  BUILDBOX_VERSION: teleport13
-  GID: "1000"
-  RUNTIME: go1.20.6
-  UID: "1000"
 trigger:
   event:
     include:
@@ -305,49 +216,21 @@ steps:
   - git submodule update --init e
   - mkdir -pv /go/cache
   - rm -f /root/.ssh/id_rsa
-  - if [[ "${DRONE_TAG}" != "" ]]; then echo "${DRONE_TAG##v}" > /go/.version.txt;
-    else egrep ^VERSION Makefile | cut -d= -f2 > /go/.version.txt; fi; cat /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "release-target=release-amd64-centos7-fips" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-amd64-centos7-fips
-  environment:
-    ARCH: amd64
-    FIPS: "yes"
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
 - name: Send Slack notification
   image: plugins/slack:1.4.1
   settings:
@@ -359,18 +242,6 @@ steps:
   when:
     status:
     - failure
-services:
-- name: Start Docker
-  image: docker:23.0-dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -378,17 +249,12 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go (main.pushPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: push-build-windows-amd64
-environment:
-  BUILDBOX_VERSION: teleport13
-  GID: "1000"
-  RUNTIME: go1.20.6
-  UID: "1000"
 trigger:
   event:
     include:
@@ -426,42 +292,18 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "release-target=release-windows-unsigned" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-windows-unsigned
-  environment:
-    ARCH: amd64
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: windows
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
 - name: Send Slack notification
   image: plugins/slack:1.4.1
   settings:
@@ -473,18 +315,6 @@ steps:
   when:
     status:
     - failure
-services:
-- name: Start Docker
-  image: docker:23.0-dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -1106,17 +936,12 @@ steps:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/push.go (main.pushPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: push-build-linux-arm
-environment:
-  BUILDBOX_VERSION: teleport13
-  GID: "1000"
-  RUNTIME: go1.20.6
-  UID: "1000"
 trigger:
   event:
     include:
@@ -1154,42 +979,18 @@ steps:
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
+    -input "release-target=release-arm" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-arm
-  environment:
-    ARCH: arm
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
 - name: Send Slack notification
   image: plugins/slack:1.4.1
   settings:
@@ -1201,18 +1002,6 @@ steps:
   when:
     status:
     - failure
-services:
-- name: Start Docker
-  image: docker:23.0-dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -17303,6 +17092,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 32f5af12453e18903e5ad1e4c15f36a4350f60a8bf2ce1405a15961bb4b58ba3
+hmac: e8967daaf34c8a5a834ec2b87e0d61ed2b2f0fde185bf6653db4659cb43d9e62
 
 ...

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -19,11 +19,6 @@ import (
 	"time"
 )
 
-// pushCheckoutCommands builds a list of commands for Drone to check out a git commit on a push build
-func pushCheckoutCommands(b buildType) []string {
-	return pushCheckoutCommandsWithPath(b, "/go/src/github.com/gravitational/teleport")
-}
-
 func pushCheckoutCommandsWithPath(b buildType, checkoutPath string) []string {
 	var commands []string
 	commands = append(commands, cloneRepoCommands(checkoutPath, "${DRONE_COMMIT_SHA}")...)
@@ -41,40 +36,14 @@ func pushCheckoutCommandsWithPath(b buildType, checkoutPath string) []string {
 	return commands
 }
 
-// pushBuildCommands generates a list of commands for Drone to build an artifact as part of a push build
-func pushBuildCommands(b buildType) []string {
-	commands := []string{
-		`apk add --no-cache make`,
-		`chown -R $UID:$GID /go`,
-		`cd /go/src/github.com/gravitational/teleport`,
-	}
-	if b.fips || b.hasTeleportConnect() {
-		commands = append(commands,
-			`export VERSION=$(cat /go/.version.txt)`,
-		)
-	}
-	commands = append(commands,
-		fmt.Sprintf(`make -C build.assets %s`, releaseMakefileTarget(b)),
-	)
-
-	if b.hasTeleportConnect() {
-		commands = append(commands, `make -C build.assets teleterm`)
-	}
-	return commands
-}
-
 // pushPipelines builds all applicable push pipeline combinations
 func pushPipelines() []pipeline {
 	var ps []pipeline
-	for _, arch := range []string{"amd64", "386", "arm"} {
-		for _, fips := range []bool{false, true} {
-			if arch != "amd64" && fips {
-				// FIPS mode only supported on linux/amd64
-				continue
-			}
-			ps = append(ps, pushPipeline(buildType{os: "linux", arch: arch, fips: fips}))
-		}
-	}
+
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: false}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: true}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "386", fips: false}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm", fips: false}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
 		buildType:    buildType{os: "linux", arch: "arm64"},
@@ -94,15 +63,20 @@ func pushPipelines() []pipeline {
 	}))
 
 	// Only amd64 Windows is supported for now.
-	ps = append(ps, pushPipeline(buildType{os: "windows", arch: "amd64", windowsUnsigned: true}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "windows", arch: "amd64", windowsUnsigned: true}))
 
 	ps = append(ps, darwinPushPipelineGHA())
 	ps = append(ps, windowsPushPipeline())
 	return ps
 }
 
-// pushPipeline generates a push pipeline for a given combination of os/arch/FIPS
-func pushPipeline(b buildType) pipeline {
+// ghaLinuxPushPipeline generates a push pipeline for a given combination of
+// os/arch/FIPS that calls a GitHub Actions workflow to perform the build on
+// a Linux buildbox. This dispatches to the release-linux.yaml workflow in
+// the teleport.e repo, which is a little more generic than the
+// release-linux-arm64.yml workflow used for the arm64 build. The two will
+// be unified shortly.
+func ghaLinuxPushPipeline(b buildType) pipeline {
 	if b.os == "" {
 		panic("b.os must be set")
 	}
@@ -111,54 +85,25 @@ func pushPipeline(b buildType) pipeline {
 	}
 
 	pipelineName := fmt.Sprintf("push-build-%s-%s", b.os, b.arch)
-	pushEnvironment := map[string]value{
-		"UID":     {raw: "1000"},
-		"GID":     {raw: "1000"},
-		"GOCACHE": {raw: "/go/cache"},
-		"GOPATH":  {raw: "/go"},
-		"OS":      {raw: b.os},
-		"ARCH":    {raw: b.arch},
-	}
 	if b.fips {
 		pipelineName += "-fips"
-		pushEnvironment["FIPS"] = value{raw: "yes"}
 	}
-
-	p := newKubePipeline(pipelineName)
-	p.Environment = map[string]value{
-		"BUILDBOX_VERSION": buildboxVersion,
-		"RUNTIME":          goRuntime,
-		"UID":              {raw: "1000"},
-		"GID":              {raw: "1000"},
+	wf := ghaWorkflow{
+		name:              "release-linux.yaml",
+		timeout:           150 * time.Minute,
+		slackOnError:      true,
+		srcRefVar:         "DRONE_COMMIT",
+		ref:               "${DRONE_BRANCH}",
+		shouldTagWorkflow: true,
+		inputs:            map[string]string{"release-target": releaseMakefileTarget(b)},
 	}
-	p.Trigger = triggerPush
-	p.Workspace = workspace{Path: "/go"}
-	p.Volumes = []volume{volumeDocker, volumeDockerConfig}
-	p.Services = []service{
-		dockerService(),
+	bt := ghaBuildType{
+		buildType:    buildType{os: b.os, arch: b.arch},
+		trigger:      triggerPush,
+		pipelineName: pipelineName,
+		workflows:    []ghaWorkflow{wf},
 	}
-	p.Steps = []step{
-		{
-			Name:  "Check out code",
-			Image: "docker:git",
-			Pull:  "if-not-exists",
-			Environment: map[string]value{
-				"GITHUB_PRIVATE_KEY": {fromSecret: "GITHUB_PRIVATE_KEY"},
-			},
-			Commands: pushCheckoutCommands(b),
-		},
-		waitForDockerStep(),
-		{
-			Name:        "Build artifacts",
-			Image:       "docker",
-			Pull:        "if-not-exists",
-			Environment: pushEnvironment,
-			Volumes:     []volumeRef{volumeRefDocker, volumeRefDockerConfig},
-			Commands:    pushBuildCommands(b),
-		},
-		sendErrorToSlackStep(),
-	}
-	return p
+	return ghaBuildPipeline(bt)
 }
 
 func sendErrorToSlackStep() step {


### PR DESCRIPTION
Change the drone pipelines for linux-based push builds to call a GitHub
actions workflow instead of running on drone runners. This includes one
of the builds for Windows which is done in a Linux container.

The old push pipelines that run the build on drone runners is now
removed as it is no longer used.

Update `.drone.yml` to use the new GitHub actions push pipelines.

Update e ref for push linux workflows.

Backport: https://github.com/gravitational/teleport/pull/28805