### PR TITLE
Athena: accept events without timestamp

### DIFF
--- a/examples/dynamoathenamigration/migration.go
+++ b/examples/dynamoathenamigration/migration.go
@@ -416,6 +416,12 @@ func (t *task) fromS3ToChan(ctx context.Context, dataObj dataObjectInfo, eventsC
 		if ev.GetID() == "" || ev.GetID() == uuid.Nil.String() {
 			ev.SetID(uuid.NewString())
 		}
+		// Typically there should not be event without time, however it happen
+		// in past due to some bugs. We decided it's better to keep in athena
+		// then drop it. 1970-01-01 is used to provide valid unix timestamp.
+		if ev.GetTime().IsZero() {
+			ev.SetTime(time.Unix(0, 0))
+		}
 
 		// if checkpoint is present, it means that previous run ended with error
 		// and we want to continue from last valid checkpoint.


### PR DESCRIPTION
When migrating old events from Dynamo to Athena , it can happen that there will be events without timestamp (before implementing checkingEmitter or when it was incorrectly used due to bug). 
This PR makes sure we will store those events anyway in athena with time.Unix(0) as timestamp. 
On meeting we decided that's better to keep it with dummy timestamp then to drop it. 

I have tested manually and Athena supports time.Unix(0).