### PR TITLE
docs: mention that other text can be included in sso display names for icons

### DIFF
--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -531,7 +531,8 @@ SAML and OIDC types:
 ## SSO customization
 
 Use the `display` field in an authentication connector to control the appearance
-of SSO buttons in the Teleport Web UI.
+of SSO buttons in the Teleport Web UI. The icons below will show including just the provider 
+name or additional text, e.g. "Microsoft Dev".
 
 | Provider | YAML | Example |
 | - | - | - |


### PR DESCRIPTION
To display the Microsoft sso icon you can have "Microsoft", "Microsoftdev", "microsofttest".  Some folks weren't clear what you could do.