### PR TITLE
[v11] tctl: fix error reporting when server is down

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -193,9 +193,10 @@ func TryRun(commands []CLICommand, args []string) error {
 		if utils.IsUntrustedCertErr(err) {
 			err = trace.WrapWithMessage(err, utils.SelfSignedCertsMsg)
 		}
-		log.Errorf("Cannot connect to the auth server. Is the auth server running on %q? %v",
-			cfg.AuthServerAddresses()[0].Addr, err)
-		return trace.NewAggregate(&toolcommon.ExitCodeError{Code: 1}, err)
+		fmt.Fprintf(os.Stderr,
+			"ERROR: Cannot connect to the auth server. Is the auth server running on %q?\n",
+			cfg.AuthServerAddresses()[0].Addr)
+		return trace.NewAggregate(&common.ExitCodeError{Code: 1}, err)
 	}
 
 	// execute whatever is selected:


### PR DESCRIPTION
Backport #29281 to branch/v11