### PR TITLE
Filter out cluster ID in Connect logs

### DIFF
--- a/web/packages/teleterm/src/services/tshd/middleware.ts
+++ b/web/packages/teleterm/src/services/tshd/middleware.ts
@@ -19,7 +19,7 @@ import { isObject } from 'shared/utils/highbar';
 
 import Logger from 'teleterm/logger';
 
-const SENSITIVE_PROPERTIES = ['passw'];
+const SENSITIVE_PROPERTIES = ['passw', 'authClusterId'];
 
 export type UnaryInterceptor = (
   options: grpc.InterceptorOptions,


### PR DESCRIPTION
In [telemetry docs for Connect](https://goteleport.com/docs/connect-your-client/teleport-connect/#telemetry) we say:

> Each event includes the cluster name and user name anonymized with HMAC using the cluster's internal random UUID as the key. It is infeasible to associate this back to a specific cluster or user without access to the cluster's internal datastore.

This internal random UUID is `ClusterID`. We return it from the `GetCluster` RPC as `authClusterId`.

https://github.com/gravitational/teleport/blob/b3323db7db4819e31bedc960c9b78db4d17c723c/lib/teleterm/clusters/cluster.go#L118

Unfortunately, we log every payload received over gRPC from TerminalService, so we end up storing that random UUID in the logs.

We already have the infrastructure in place to filter out specific fields from the logs, so let's add `authClusterId` there to avoid logging `ClusterID` to disk.