### PR TITLE
Update discovery installers to work with zypper

### DIFF
--- a/api/types/installers/agentless-installer.sh.tmpl
+++ b/api/types/installers/agentless-installer.sh.tmpl
@@ -109,6 +109,16 @@ install_teleport() {
     sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
     sudo yum install -y ${PACKAGE_LIST}
+  elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then
+    if [ "$ID" = "opensuse-tumbleweed" ]; then
+      VERSION_ID="15" # tumbleweed uses dated VERSION_IDs like 20230702
+    else
+      VERSION_ID="${VERSION_ID//.*/}" # convert version numbers like '7.2' to only include the major version
+    fi
+    sudo rpm --import "https://zypper.releases.teleport.dev/gpg"
+    sudo zypper --non-interactive addrepo "$(rpm --eval "https://yum.releases.teleport.dev/sles/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
+    sudo zypper --gpg-auto-import-keys refresh
+    sudo zypper --non-interactive install ${PACKAGE_LIST}
   else
     echo "Unsupported distro: $ID"
     exit 1

--- a/api/types/installers/installer.sh.tmpl
+++ b/api/types/installers/installer.sh.tmpl
@@ -55,6 +55,16 @@ on_gcp() {
     sudo yum-config-manager --add-repo \
       "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
     sudo yum install -y ${PACKAGE_LIST}
+  elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then
+    if [ "$ID" = "opensuse-tumbleweed" ]; then
+      VERSION_ID="15" # tumbleweed uses dated VERSION_IDs like 20230702
+    else
+      VERSION_ID=$(echo "$VERSION_ID" | sed 's/\..*//') # convert version numbers like '7.2' to only include the major version
+    fi
+    sudo rpm --import "https://zypper.releases.teleport.dev/gpg"
+    sudo zypper --non-interactive addrepo "$(rpm --eval "https://zypper.releases.teleport.dev/sles/$VERSION_ID/Teleport/%{_arch}/{{ .RepoChannel }}/teleport.repo")"
+    sudo zypper --gpg-auto-import-keys refresh
+    sudo zypper --non-interactive install ${PACKAGE_LIST}
   else
     echo "Unsupported distro: $ID"
     exit 1

--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -610,7 +610,7 @@ else
 fi
 
 # use OSTYPE variable to figure out host type/arch
-if [[ "${OSTYPE}" == "linux-gnu"* ]]; then
+if [[ "${OSTYPE}" == "linux"* ]]; then
     # linux host, now detect arch
     TELEPORT_BINARY_TYPE="linux"
     ARCH=$(uname -m)
@@ -661,7 +661,8 @@ if [[ "${OSTYPE}" == "linux-gnu"* ]]; then
             fi
             if [[ ${DISTRO_TYPE} =~ "debian" ]]; then
                 TELEPORT_FORMAT="deb"
-            elif [[ "$DISTRO_TYPE" =~ "amzn"* ]] || [[ ${DISTRO_TYPE} =~ "centos"* ]] || [[ ${DISTRO_TYPE} =~ "rhel" ]] || [[ ${DISTRO_TYPE} =~ "fedora"* ]]; then
+            elif [[ "$DISTRO_TYPE" =~ "amzn"* ]] || [[ ${DISTRO_TYPE} =~ "centos"* ]] || [[ ${DISTRO_TYPE} =~ "rhel" ]] || [[ ${DISTRO_TYPE} =~ "fedora"* ]] || \
+                     [[ ${DISTRO_TYPE} == *"suse"* ]] || [[ ${DISTRO_TYPE} =~ "sles"* ]]; then
                 TELEPORT_FORMAT="rpm"
             else
                 log "Couldn't match a distro type using /etc/os-release, falling back to tarball installer"
@@ -817,6 +818,9 @@ install_from_file() {
         elif check_exists yum; then
             log "Found 'yum' package manager, using it"
             PACKAGE_MANAGER_COMMAND="yum -y localinstall"
+        elif check_exists zypper; then
+            log "Found 'zypper' package manager, using it"
+            PACKAGE_MANAGER_COMMAND="zypper --non-interactive install"
         else
             PACKAGE_MANAGER_COMMAND=""
             log "Cannot find 'yum' or 'dnf' package manager commands, will try installing the rpm manually instead"
@@ -885,6 +889,16 @@ install_from_repo() {
         yum --disablerepo="*" --enablerepo="teleport" clean metadata
 
         yum install -y ${PACKAGE_LIST}
+    elif [ "$ID" = "sles" ] || [ "$ID" = "opensuse-tumbleweed" ] || [ "$ID" = "opensuse-leap" ]; then
+        if [ "$ID" = "opensuse-tumbleweed" ]; then
+          VERSION_ID="15" # tumbleweed uses dated VERSION_IDs like 20230702
+        else
+          VERSION_ID="${VERSION_ID//.*/}" # convert version numbers like '7.2' to only include the major version
+        fi
+        sudo rpm --import "https://zypper.releases.teleport.dev/gpg"
+        sudo zypper --non-interactive addrepo "$(rpm --eval "https://zypper.releases.teleport.dev/sles/$VERSION_ID/Teleport/%{_arch}/${REPO_CHANNEL}/teleport.repo")"
+        sudo zypper --gpg-auto-import-keys refresh
+        sudo zypper --non-interactive install ${PACKAGE_LIST}
     else
         echo "Unsupported distro: $ID"
         exit 1
@@ -919,7 +933,7 @@ package_list() {
 }
 
 is_repo_available() {
-    if [[ "${OSTYPE}" != "linux-gnu" ]]; then
+    if [[ "${OSTYPE}" != "linux"* ]]; then
         return 1
     fi
 
@@ -933,7 +947,8 @@ is_repo_available() {
         debian-9* | debian-10* | debian-11* | \
         rhel-7* | rhel-8* | rhel-9* | \
         centos-7* | centos-8* | centos-9* | \
-        amzn-2 | amzn-2023)
+        amzn-2 | amzn-2023 | \
+        opensuse-tumbleweed* | sles-12* | sles-15* | opensuse-leap-15*)
             return 0;;
     esac
 


### PR DESCRIPTION
This updates the automatic server discovery scripts to work with zypper

As it stands it hard-codes that its using the RHEL v8 teleport RPM repo, though I'm not sure if this is the best idea, and if we should instead host suse specific RPMs

Part of https://github.com/gravitational/teleport/issues/29267