### PR TITLE
add means to expose healthcheck port

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/service.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/service.yaml
@@ -37,6 +37,12 @@ spec:
     port: 443
     targetPort: 3080
     protocol: TCP
+{{- if $proxy.exposeDiagPort }}
+  - name: health
+    port: 3000
+    targetPort: 3000
+    protocol: TCP
+{{- end }}
 {{- if ne $proxy.proxyListenerMode "multiplex" }}
   - name: sshproxy
     port: 3023

--- a/examples/chart/teleport-cluster/templates/proxy/service.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/service.yaml
@@ -38,7 +38,7 @@ spec:
     targetPort: 3080
     protocol: TCP
 {{- if $proxy.exposeDiagPort }}
-  - name: health
+  - name: diag
     port: 3000
     targetPort: 3000
     protocol: TCP

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -149,6 +149,9 @@ authentication:
 # Possible values are 'separate' and 'multiplex'
 proxyListenerMode: "separate"
 
+# Expose the healthcheck port in the Kubernetes Service, to make /healthz and /readyz available externally
+exposeDiagPort: false
+
 # Optional setting for configuring session recording.
 # See `session_recording` under https://goteleport.com/docs/setup/reference/config/#teleportyaml
 sessionRecording: ""


### PR DESCRIPTION
This allows external monitoring services to monitor the uptime of the teleport instance properly.

Closes https://github.com/gravitational/teleport/issues/29315