### PR TITLE
EC2 Instance Connect Endpoint: List EC2 Instances

### DIFF
--- a/api/types/server.go
+++ b/api/types/server.go
@@ -377,13 +377,13 @@ func (s *ServerV2) IsOpenSSHNode() bool {
 // They include SubKindOpenSSHNode and SubKindOpenSSHEICENode.
 func (s *ServerV2) openSSHNodeCheckAndSetDefaults() error {
 	if s.Spec.Addr == "" {
-		return trace.BadParameter(`addr must be set when server SubKind is "openssh"`)
+		return trace.BadParameter("addr must be set when server SubKind is %q", s.GetSubKind())
 	}
 	if len(s.GetPublicAddrs()) != 0 {
-		return trace.BadParameter(`publicAddrs must not be set when server SubKind is "openssh"`)
+		return trace.BadParameter("publicAddrs must not be set when server SubKind is %q", s.GetSubKind())
 	}
 	if s.Spec.Hostname == "" {
-		return trace.BadParameter(`hostname must be set when server SubKind is "openssh"`)
+		return trace.BadParameter("hostname must be set when server SubKind is %q", s.GetSubKind())
 	}
 
 	_, _, err := net.SplitHostPort(s.Spec.Addr)

--- a/lib/automaticupgrades/version_test.go
+++ b/lib/automaticupgrades/version_test.go
@@ -30,7 +30,7 @@ import (
 func TestVersion(t *testing.T) {
 	ctx := context.Background()
 
-	isBadParameterErr := func(tt require.TestingT, err error, i ...interface{}) {
+	isBadParameterErr := func(tt require.TestingT, err error, i ...any) {
 		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 	}
 

--- a/lib/cloud/aws/labels.go
+++ b/lib/cloud/aws/labels.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aws
+
+// Labels to add to Teleport Resources when importing them from AWS
+const (
+	labelAccountID = "account-id"
+	labelRegion    = "region"
+)
+
+// AddMetadataLabels adds the AccountID and Region as labels.
+func AddMetadataLabels(labels map[string]string, accountID, region string) {
+	labels[labelAccountID] = accountID
+	labels[labelRegion] = region
+}

--- a/lib/cloud/aws/labels.go
+++ b/lib/cloud/aws/labels.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Gravitational, Inc.
+Copyright 2023 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,14 +16,10 @@ limitations under the License.
 
 package aws
 
-// Labels to add to Teleport Resources when importing them from AWS
-const (
-	labelAccountID = "account-id"
-	labelRegion    = "region"
-)
+import "github.com/gravitational/teleport/api/types"
 
 // AddMetadataLabels adds the AccountID and Region as labels.
 func AddMetadataLabels(labels map[string]string, accountID, region string) {
-	labels[labelAccountID] = accountID
-	labels[labelRegion] = region
+	labels[types.DiscoveryLabelAccountID] = accountID
+	labels[types.DiscoveryLabelRegion] = region
 }

--- a/lib/cloud/aws/tags_helpers.go
+++ b/lib/cloud/aws/tags_helpers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package aws
 
 import (
+	ec2TypesV2 "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	rdsTypesV2 "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/elasticache"
@@ -37,6 +38,7 @@ type ResourceTag interface {
 	// TODO Go generic does not allow access common fields yet. List all types
 	//  here and use a type switch for now.
 	rdsTypesV2.Tag |
+		ec2TypesV2.Tag |
 		*rds.Tag |
 		*redshift.Tag |
 		*elasticache.Tag |
@@ -77,6 +79,8 @@ func resourceTagToKeyValue[Tag ResourceTag](tag Tag) (string, string) {
 	case *redshiftserverless.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case rdsTypesV2.Tag:
+		return aws.StringValue(v.Key), aws.StringValue(v.Value)
+	case ec2TypesV2.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)
 	case *opensearchservice.Tag:
 		return aws.StringValue(v.Key), aws.StringValue(v.Value)

--- a/lib/integrations/awsoidc/clients.go
+++ b/lib/integrations/awsoidc/clients.go
@@ -22,6 +22,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -119,6 +120,16 @@ func newSTSClient(ctx context.Context, req *AWSClientRequest) (*sts.Client, erro
 	}
 
 	return sts.NewFromConfig(*cfg), nil
+}
+
+// newEC2Client creates an [ec2.Client] using the provided Token, RoleARN and Region.
+func newEC2Client(ctx context.Context, req *AWSClientRequest) (*ec2.Client, error) {
+	cfg, err := newAWSConfig(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ec2.NewFromConfig(*cfg), nil
 }
 
 // IdentityToken is an implementation of [stscreds.IdentityTokenRetriever] for returning a static token.

--- a/lib/integrations/awsoidc/listdatabases_test.go
+++ b/lib/integrations/awsoidc/listdatabases_test.go
@@ -338,9 +338,7 @@ func TestListDatabases(t *testing.T) {
 				Engines:   []string{"postgres"},
 				NextToken: "",
 			},
-			errCheck: func(err error) bool {
-				return trace.IsBadParameter(err)
-			},
+			errCheck: trace.IsBadParameter,
 		},
 		{
 			name: "invalid rds type",
@@ -350,9 +348,7 @@ func TestListDatabases(t *testing.T) {
 				Engines:   []string{"postgres"},
 				NextToken: "",
 			},
-			errCheck: func(err error) bool {
-				return trace.IsBadParameter(err)
-			},
+			errCheck: trace.IsBadParameter,
 		},
 		{
 			name: "empty engines list",
@@ -362,9 +358,7 @@ func TestListDatabases(t *testing.T) {
 				Engines:   []string{},
 				NextToken: "",
 			},
-			errCheck: func(err error) bool {
-				return trace.IsBadParameter(err)
-			},
+			errCheck: trace.IsBadParameter,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/lib/integrations/awsoidc/listec2.go
+++ b/lib/integrations/awsoidc/listec2.go
@@ -84,7 +84,7 @@ type ListEC2Response struct {
 
 // ListEC2Client describes the required methods to List EC2 Instances using a 3rd Party API.
 type ListEC2Client interface {
-	// Describes the specified instances or all instances.
+	// DescribeInstances describes the specified instances or all instances.
 	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
 
 	// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
@@ -132,6 +132,9 @@ func ListEC2(ctx context.Context, clt ListEC2Client, req ListEC2Request) (*ListE
 		return nil, trace.Wrap(err)
 	}
 	accountID := aws.ToString(callerIdentity.Account)
+	if accountID == "" {
+		return nil, trace.BadParameter("failed to get AWS AccountID using GetCallerIdentity")
+	}
 
 	describeEC2Instances := &ec2.DescribeInstancesInput{
 		Filters: []ec2Types.Filter{

--- a/lib/integrations/awsoidc/listec2.go
+++ b/lib/integrations/awsoidc/listec2.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/services"
+)
+
+const (
+	// awsInstanceStateName represents the state of the AWS EC2
+	// instance - (pending | running | shutting-down | terminated | stopping | stopped )
+	// https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html
+	// Used for filtering instances.
+	awsInstanceStateName = "instance-state-name"
+)
+
+var (
+	// filterRunningEC2Instance is an EC2 DescribeInstances Filter to filter running instances.
+	filterRunningEC2Instance = ec2Types.Filter{
+		Name:   aws.String(awsInstanceStateName),
+		Values: []string{string(ec2Types.InstanceStateNameRunning)},
+	}
+)
+
+// ListEC2Request contains the required fields to list AWS EC2 Instances.
+type ListEC2Request struct {
+	// Integration is the AWS OIDC Integration name.
+	// This is used to populate the Server resource.
+	// When connecting to the Node, this is the integration that is going to be used.
+	Integration string
+
+	// Region is the AWS Region.
+	Region string
+
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string
+}
+
+// CheckAndSetDefaults checks if the required fields are present.
+func (req *ListEC2Request) CheckAndSetDefaults() error {
+	if req.Integration == "" {
+		return trace.BadParameter("integration is required")
+	}
+	if req.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	return nil
+}
+
+// ListEC2Response contains a page of AWS EC2 Instances as Teleport Servers.
+type ListEC2Response struct {
+	// Servers contains the page of Servers.
+	Servers []types.Server
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string
+}
+
+// ListEC2Client describes the required methods to List EC2 Instances using a 3rd Party API.
+type ListEC2Client interface {
+	// Describes the specified instances or all instances.
+	DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error)
+
+	// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+type defaultListEC2Client struct {
+	*ec2.Client
+	stsClient *sts.Client
+}
+
+// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
+func (d defaultListEC2Client) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return d.stsClient.GetCallerIdentity(ctx, params, optFns...)
+}
+
+// NewListEC2Client creates a new ListEC2Client using a AWSClientRequest.
+func NewListEC2Client(ctx context.Context, req *AWSClientRequest) (ListEC2Client, error) {
+	ec2Client, err := newEC2Client(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	stsClient, err := newSTSClient(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultListEC2Client{
+		Client:    ec2Client,
+		stsClient: stsClient,
+	}, nil
+}
+
+// ListEC2 calls the following AWS API:
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstances.html
+// It returns a list of EC2 Instances and an optional NextToken that can be used to fetch the next page
+func ListEC2(ctx context.Context, clt ListEC2Client, req ListEC2Request) (*ListEC2Response, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	callerIdentity, err := clt.GetCallerIdentity(ctx, nil)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	accountID := aws.ToString(callerIdentity.Account)
+
+	describeEC2Instances := &ec2.DescribeInstancesInput{
+		Filters: []ec2Types.Filter{
+			filterRunningEC2Instance,
+		},
+	}
+	if req.NextToken != "" {
+		describeEC2Instances.NextToken = &req.NextToken
+	}
+
+	ec2Instances, err := clt.DescribeInstances(ctx, describeEC2Instances)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ret := &ListEC2Response{}
+
+	if aws.ToString(ec2Instances.NextToken) != "" {
+		ret.NextToken = *ec2Instances.NextToken
+	}
+
+	ret.Servers = make([]types.Server, 0, len(ec2Instances.Reservations))
+	for _, reservation := range ec2Instances.Reservations {
+		for _, instance := range reservation.Instances {
+			awsInfo := &types.AWSInfo{
+				AccountID:   accountID,
+				Region:      req.Region,
+				Integration: req.Integration,
+			}
+
+			server, err := services.NewAWSNodeFromEC2Instance(instance, awsInfo)
+			if err != nil {
+				return nil, trace.Wrap(err)
+			}
+
+			ret.Servers = append(ret.Servers, server)
+		}
+	}
+
+	return ret, nil
+}

--- a/lib/integrations/awsoidc/listec2_test.go
+++ b/lib/integrations/awsoidc/listec2_test.go
@@ -1,0 +1,233 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+type mockListEC2Client struct {
+	pageSize     int
+	accountID    string
+	ec2Instances []ec2Types.Instance
+}
+
+// GetCallerIdentity returns information about the caller identity.
+func (m *mockListEC2Client) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: &m.accountID,
+	}, nil
+}
+
+// Returns information about ec2 instances.
+// This API supports pagination.
+func (m mockListEC2Client) DescribeInstances(ctx context.Context, params *ec2.DescribeInstancesInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstancesOutput, error) {
+	requestedPage := 1
+
+	totalInstances := len(m.ec2Instances)
+
+	if params.NextToken != nil {
+		currentMarker, err := strconv.Atoi(*params.NextToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		requestedPage = currentMarker
+	}
+
+	sliceStart := m.pageSize * (requestedPage - 1)
+	sliceEnd := m.pageSize * requestedPage
+	if sliceEnd > totalInstances {
+		sliceEnd = totalInstances
+	}
+
+	ret := &ec2.DescribeInstancesOutput{
+		Reservations: []ec2Types.Reservation{{
+			Instances: m.ec2Instances[sliceStart:sliceEnd],
+		}},
+	}
+
+	if sliceEnd < totalInstances {
+		nextToken := fmt.Sprintf("%d", requestedPage+1)
+		ret.NextToken = stringPointer(nextToken)
+	}
+
+	return ret, nil
+}
+
+func TestListEC2(t *testing.T) {
+	ctx := context.Background()
+
+	noErrorFunc := func(err error) bool {
+		return err == nil
+	}
+
+	pageSize := 100
+	t.Run("pagination", func(t *testing.T) {
+		totalEC2s := 203
+
+		allInstances := make([]ec2Types.Instance, 0, totalEC2s)
+		for i := 0; i < totalEC2s; i++ {
+			allInstances = append(allInstances, ec2Types.Instance{
+				PrivateDnsName:   aws.String("my-private-dns.compute.aws"),
+				InstanceId:       aws.String("i-123456789abcedf"),
+				VpcId:            aws.String("vpc-abcd"),
+				PrivateIpAddress: aws.String("172.31.1.1"),
+			})
+		}
+
+		mockListClient := &mockListEC2Client{
+			pageSize:     pageSize,
+			accountID:    "123456789012",
+			ec2Instances: allInstances,
+		}
+
+		// First page must return pageSize number of Servers
+		resp, err := ListEC2(ctx, mockListClient, ListEC2Request{
+			Region:      "us-east-1",
+			Integration: "myintegration",
+			NextToken:   "",
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.NextToken)
+		require.Len(t, resp.Servers, pageSize)
+		nextPageToken := resp.NextToken
+
+		// Second page must return pageSize number of Servers
+		resp, err = ListEC2(ctx, mockListClient, ListEC2Request{
+			Region:      "us-east-1",
+			Integration: "myintegration",
+			NextToken:   nextPageToken,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.NextToken)
+		require.Len(t, resp.Servers, pageSize)
+		nextPageToken = resp.NextToken
+
+		// Third page must return only the remaining Servers and an empty nextToken
+		resp, err = ListEC2(ctx, mockListClient, ListEC2Request{
+			Region:      "us-east-1",
+			Integration: "myintegration",
+			NextToken:   nextPageToken,
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.NextToken)
+		require.Len(t, resp.Servers, 3)
+	})
+
+	for _, tt := range []struct {
+		name          string
+		req           ListEC2Request
+		mockInstances []ec2Types.Instance
+		errCheck      func(error) bool
+		respCheck     func(*testing.T, *ListEC2Response)
+	}{
+		{
+			name: "valid for listing instances",
+			req: ListEC2Request{
+				Region:      "us-east-1",
+				Integration: "myintegration",
+				NextToken:   "",
+			},
+			mockInstances: []ec2Types.Instance{{
+				PrivateDnsName:   aws.String("my-private-dns.compute.aws"),
+				InstanceId:       aws.String("i-123456789abcedf"),
+				VpcId:            aws.String("vpc-abcd"),
+				PrivateIpAddress: aws.String("172.31.1.1"),
+			},
+			},
+			respCheck: func(t *testing.T, ldr *ListEC2Response) {
+				require.Len(t, ldr.Servers, 1, "expected 1 server, got %d", len(ldr.Servers))
+				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
+
+				expectedServer := &types.ServerV2{
+					Kind:    "node",
+					Version: "v2",
+					SubKind: "openssh-ec2-ice",
+					Metadata: types.Metadata{
+						Labels: map[string]string{
+							"account-id": "123456789012",
+							"region":     "us-east-1",
+						},
+						Namespace: "default",
+					},
+					Spec: types.ServerSpecV2{
+						Addr:     "172.31.1.1:22",
+						Hostname: "my-private-dns.compute.aws",
+						CloudMetadata: &types.CloudMetadata{
+							AWS: &types.AWSInfo{
+								AccountID:   "123456789012",
+								InstanceID:  "i-123456789abcedf",
+								Region:      "us-east-1",
+								VPCID:       "vpc-abcd",
+								Integration: "myintegration",
+							},
+						},
+					},
+				}
+				require.Empty(t, cmp.Diff(expectedServer, ldr.Servers[0], cmpopts.IgnoreFields(types.ServerV2{}, "Metadata.Name")))
+			},
+			errCheck: noErrorFunc,
+		},
+		{
+			name: "no region",
+			req: ListEC2Request{
+				Integration: "myintegration",
+			},
+			errCheck: func(err error) bool {
+				return trace.IsBadParameter(err)
+			},
+		},
+		{
+			name: "no integration",
+			req: ListEC2Request{
+				Region: "us-east-1",
+			},
+			errCheck: func(err error) bool {
+				return trace.IsBadParameter(err)
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockListClient := &mockListEC2Client{
+				pageSize:     pageSize,
+				accountID:    "123456789012",
+				ec2Instances: tt.mockInstances,
+			}
+			resp, err := ListEC2(ctx, mockListClient, tt.req)
+			require.True(t, tt.errCheck(err), "unexpected err: %v", err)
+			if err != nil {
+				return
+			}
+
+			tt.respCheck(t, resp)
+		})
+	}
+}

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -455,7 +455,7 @@ func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *typ
 
 	server, err := types.NewNode(
 		uuid.NewString(),
-		types.SubKindOpenSSHEC2InstanceConnectEndpointNode,
+		types.SubKindOpenSSHEICENode,
 		types.ServerSpecV2{
 			Hostname: aws.ToString(instance.PrivateDnsName),
 			Addr:     addr,

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -43,6 +43,9 @@ const (
 	OnlyTimestampsDifferent = iota
 	// Different means that some fields are different
 	Different = iota
+
+	// defaultSSHPort is the default port for the OpenSSH Service.
+	defaultSSHPort = "22"
 )
 
 // CompareServers compares two provided servers.
@@ -448,7 +451,7 @@ func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *typ
 	}
 	// Address requires the Port.
 	// We use the default port for the OpenSSH daemon.
-	addr := net.JoinHostPort(aws.ToString(instance.PrivateIpAddress), "22")
+	addr := net.JoinHostPort(aws.ToString(instance.PrivateIpAddress), defaultSSHPort)
 
 	server, err := types.NewNode(
 		uuid.NewString(),

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -19,14 +19,19 @@ package services
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	apiutils "github.com/gravitational/teleport/api/utils"
+	libaws "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -424,4 +429,42 @@ func MarshalServers(s []types.Server) ([]byte, error) {
 func NodeHasMissedKeepAlives(s types.Server) bool {
 	serverExpiry := s.Expiry()
 	return serverExpiry.Before(time.Now().Add(apidefaults.ServerAnnounceTTL - (apidefaults.ServerKeepAliveTTL() * 2)))
+}
+
+// NewAWSNodeFromEC2Instance creates a Node resource from an EC2 Instance.
+// It has a pre-populated spec which contains info that is not available in the ec2.Instance object.
+func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *types.AWSInfo) (types.Server, error) {
+	labels := libaws.TagsToLabels(instance.Tags)
+	if labels == nil {
+		labels = make(map[string]string)
+	}
+	libaws.AddMetadataLabels(labels, awsCloudMetadata.AccountID, awsCloudMetadata.Region)
+
+	awsCloudMetadata.InstanceID = aws.ToString(instance.InstanceId)
+	awsCloudMetadata.VPCID = aws.ToString(instance.VpcId)
+
+	if aws.ToString(instance.PrivateIpAddress) == "" {
+		return nil, trace.BadParameter("private ip address is required from ec2 instance")
+	}
+	// Address requires the Port.
+	// We use the default port for the OpenSSH daemon.
+	addr := net.JoinHostPort(aws.ToString(instance.PrivateIpAddress), "22")
+
+	server, err := types.NewNode(
+		uuid.NewString(),
+		types.SubKindOpenSSHEC2InstanceConnectEndpointNode,
+		types.ServerSpecV2{
+			Hostname: aws.ToString(instance.PrivateDnsName),
+			Addr:     addr,
+			CloudMetadata: &types.CloudMetadata{
+				AWS: awsCloudMetadata,
+			},
+		},
+		labels,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return server, nil
 }

--- a/lib/services/server_test.go
+++ b/lib/services/server_test.go
@@ -101,6 +101,10 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 					Key:   aws.String("region"),
 					Value: aws.String("evil"),
 				})
+				i.Tags = append(i.Tags, ec2Types.Tag{
+					Key:   aws.String("account-id"),
+					Value: aws.String("evil"),
+				})
 			}),
 			awsCloudMetadata: &types.AWSInfo{
 				AccountID:   "1234567889012",

--- a/lib/services/server_test.go
+++ b/lib/services/server_test.go
@@ -30,7 +30,7 @@ import (
 )
 
 func TestNewAWSNodeFromEC2Instance(t *testing.T) {
-	isBadParameterErr := func(tt require.TestingT, err error, i ...interface{}) {
+	isBadParameterErr := func(tt require.TestingT, err error, i ...any) {
 		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 	}
 

--- a/lib/services/server_test.go
+++ b/lib/services/server_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func TestNewAWSNodeFromEC2Instance(t *testing.T) {
+	isBadParameterErr := func(tt require.TestingT, err error, i ...interface{}) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	makeEC2Instance := func(fn func(*ec2Types.Instance)) ec2Types.Instance {
+		s := ec2Types.Instance{
+			PrivateDnsName:   aws.String("my-private-dns.compute.aws"),
+			InstanceId:       aws.String("i-123456789abcedf"),
+			VpcId:            aws.String("vpc-abcd"),
+			PrivateIpAddress: aws.String("172.31.1.1"),
+			Tags: []ec2Types.Tag{
+				{
+					Key:   aws.String("MyTag"),
+					Value: aws.String("MyTagValue"),
+				},
+			},
+		}
+		fn(&s)
+		return s
+	}
+
+	for _, tt := range []struct {
+		name             string
+		ec2Instance      ec2Types.Instance
+		awsCloudMetadata *types.AWSInfo
+		errCheck         require.ErrorAssertionFunc
+		expectedServer   types.Server
+	}{
+		{
+			name:        "valid",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: require.NoError,
+			expectedServer: &types.ServerV2{
+				Kind:    "node",
+				Version: "v2",
+				SubKind: "openssh-ec2-ice",
+				Metadata: types.Metadata{
+					Labels: map[string]string{
+						"account-id": "1234567889012",
+						"region":     "us-east-1",
+						"MyTag":      "MyTagValue",
+					},
+					Namespace: "default",
+				},
+				Spec: types.ServerSpecV2{
+					Addr:     "172.31.1.1:22",
+					Hostname: "my-private-dns.compute.aws",
+					CloudMetadata: &types.CloudMetadata{
+						AWS: &types.AWSInfo{
+							AccountID:   "1234567889012",
+							InstanceID:  "i-123456789abcedf",
+							Region:      "us-east-1",
+							VPCID:       "vpc-abcd",
+							Integration: "myintegration",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "missing ec2 private dns name",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+				i.PrivateDnsName = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "missing ec2 instance id",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+				i.InstanceId = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "missing ec2 vpc id",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+				i.VpcId = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name: "missing ec2 private ip address",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {
+				i.PrivateDnsName = nil
+			}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name:        "missing account id",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				Region:      "us-east-1",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name:        "missing region",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID:   "1234567889012",
+				Integration: "myintegration",
+			},
+			errCheck: isBadParameterErr,
+		},
+		{
+			name:        "missing integration name",
+			ec2Instance: makeEC2Instance(func(i *ec2Types.Instance) {}),
+			awsCloudMetadata: &types.AWSInfo{
+				AccountID: "1234567889012",
+				Region:    "us-east-1",
+			},
+			errCheck: isBadParameterErr,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := NewAWSNodeFromEC2Instance(tt.ec2Instance, tt.awsCloudMetadata)
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Empty(t, cmp.Diff(tt.expectedServer, s, cmpopts.IgnoreFields(types.ServerV2{}, "Metadata.Name")))
+		})
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -774,6 +774,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/databases", h.WithClusterAuth(h.awsOIDCListDatabases))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))
 
 	// AWS OIDC Integration specific endpoints:
 	// Unauthenticated access to OpenID Configuration - used for AWS OIDC IdP integration

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -245,3 +245,50 @@ func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *htt
 
 	return nil, trace.Wrap(err)
 }
+
+// awsOIDCListEC2 returns a list of EC2 Instances using the ListEC2 action of the AWS OIDC Integration.
+func (h *Handler) awsOIDCListEC2(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+	ctx := r.Context()
+
+	var req ui.AWSOIDCListEC2Request
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	accessChecker, err := sctx.GetUserAccessChecker()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	listDBsClient, err := awsoidc.NewListEC2Client(ctx, awsClientReq)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := awsoidc.ListEC2(ctx,
+		listDBsClient,
+		awsoidc.ListEC2Request{
+			Integration: awsClientReq.IntegrationName,
+			Region:      req.Region,
+			NextToken:   req.NextToken,
+		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	servers, err := ui.MakeServers(h.auth.clusterName, resp.Servers, accessChecker)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.AWSOIDCListEC2Response{
+		NextToken: resp.NextToken,
+		Servers:   servers,
+	}, nil
+}

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -183,3 +183,22 @@ type AWSOIDCDeployServiceResponse struct {
 	// ServiceDashboardURL is a link to the service's Dashboard URL in Amazon Console.
 	ServiceDashboardURL string `json:"serviceDashboardUrl"`
 }
+
+// AWSOIDCListEC2Request is a request to ListEC2s using the AWS OIDC Integration.
+type AWSOIDCListEC2Request struct {
+	// Region is the AWS Region.
+	Region string `json:"region"`
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string `json:"nextToken"`
+}
+
+// AWSOIDCListEC2Response contains a list of Servers and a next token if more pages are available.
+type AWSOIDCListEC2Response struct {
+	// Servers contains the page of Servers
+	Servers []Server `json:"servers"`
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string `json:"nextToken,omitempty"`
+}


### PR DESCRIPTION
We must list the EC2 instances to the user, so they can pick one and then add them as a Node.

This PR adds EC2 Instance Listing.
To do this, we convert the EC2 Instance into Teleport Server with a special subkind: SubKindOpenSSHEC2InstanceConnectEndpointNode.

This is similar to the ListDatabases endpoint.

Demo:
```
dinis@lenix ~> curl 'https://teleport-local.marcoandredinis.com/v1/webapi/sites/lenix/integrations/aws-oidc/teleportdev/ec2' ... --data '{"region":"us-east-1"}' | jq
{
  "servers": [
    {
      "tunnel": false,
      "id": "d3199db5-88a0-4bf9-9fc6-e904df613883",
      "siteId": "lenix",
      "hostname": "ip-172-31-31-200.ec2.internal",
      "addr": "172.31.31.220:22",
      "tags": [
        {
          "name": "Name",
          "value": "win"
        },
        {
          "name": "account-id",
          "value": "accd"
        },
        {
          "name": "region",
          "value": "us-east-1"
        }
      ],
      "sshLogins": [
        "dinis",
        "ubuntu",
        "root"
      ],
      "aws": {
        "account_id": "a",
        "instance_id": "i-z",
        "region": "us-east-1",
        "vpc_id": "vpc-x",
        "integration": "teleportdev"
      }
    },
///
```