### PR TITLE
Remove dependency of etcd from tctl

### DIFF
--- a/lib/backend/backend.go
+++ b/lib/backend/backend.go
@@ -42,6 +42,9 @@ const (
 // Item keys are assumed to be valid UTF8, which may be enforced by the
 // various Backend implementations.
 type Backend interface {
+	// GetName returns the implementation driver name.
+	GetName() string
+
 	// Create creates item if it does not exist
 	Create(ctx context.Context, i Item) (*Lease, error)
 

--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -342,6 +342,10 @@ func New(ctx context.Context, params backend.Params) (*Backend, error) {
 	return b, nil
 }
 
+func (b *Backend) GetName() string {
+	return GetName()
+}
+
 // Create creates item if it does not exist
 func (b *Backend) Create(ctx context.Context, item backend.Item) (*backend.Lease, error) {
 	err := b.create(ctx, item, modeCreate)

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -342,6 +342,10 @@ func (cfg *Config) Validate() error {
 	return nil
 }
 
+func (b *EtcdBackend) GetName() string {
+	return GetName()
+}
+
 func (b *EtcdBackend) Clock() clockwork.Clock {
 	return b.clock
 }

--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -338,6 +338,10 @@ func New(ctx context.Context, params backend.Params, options Options) (*Backend,
 	return b, nil
 }
 
+func (b *Backend) GetName() string {
+	return GetName()
+}
+
 // Create creates item if it does not exist
 func (b *Backend) Create(ctx context.Context, item backend.Item) (*backend.Lease, error) {
 	r := newRecord(item, b.clock)

--- a/lib/backend/kubernetes/kubernetes.go
+++ b/lib/backend/kubernetes/kubernetes.go
@@ -200,6 +200,10 @@ func NewWithConfig(conf Config) (*Backend, error) {
 	}, nil
 }
 
+func (b *Backend) GetName() string {
+	return "kubernetes"
+}
+
 // Exists checks if the secret already exists in Kubernetes.
 // It's used to determine if the agent never created a secret and might upgrade from
 // local SQLite database. In that case, the agent reads local database and

--- a/lib/backend/lite/lite.go
+++ b/lib/backend/lite/lite.go
@@ -275,6 +275,10 @@ type Backend struct {
 	closedFlag int32
 }
 
+func (l *Backend) GetName() string {
+	return GetName()
+}
+
 // showPragmas is used to debug SQLite database connection
 // parameters, when called, logs some key PRAGMA values
 func (l *Backend) showPragmas() error {

--- a/lib/backend/memory/memory.go
+++ b/lib/backend/memory/memory.go
@@ -134,6 +134,10 @@ type Memory struct {
 	buf *backend.CircularBuffer
 }
 
+func (m *Memory) GetName() string {
+	return GetName()
+}
+
 // Close closes memory backend
 func (m *Memory) Close() error {
 	m.cancel()

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -109,6 +109,10 @@ func NewReporter(cfg ReporterConfig) (*Reporter, error) {
 	return r, nil
 }
 
+func (s *Reporter) GetName() string {
+	return s.Backend.GetName()
+}
+
 // GetRange returns query range
 func (s *Reporter) GetRange(ctx context.Context, startKey []byte, endKey []byte, limit int) (*GetResult, error) {
 	ctx, span := s.Tracer.Start(

--- a/lib/backend/sanitize.go
+++ b/lib/backend/sanitize.go
@@ -163,7 +163,6 @@ func (s *Sanitizer) CloseWatchers() {
 	s.backend.CloseWatchers()
 }
 
-// Inner returns the underlying backend, should be used with care.
-func (s *Sanitizer) Inner() Backend {
-	return s.backend
+func (s *Sanitizer) GetName() string {
+	return s.backend.GetName()
 }

--- a/lib/backend/sanitize_test.go
+++ b/lib/backend/sanitize_test.go
@@ -90,6 +90,10 @@ func TestSanitize(t *testing.T) {
 
 type nopBackend struct{}
 
+func (n *nopBackend) GetName() string {
+	return "nop"
+}
+
 func (n *nopBackend) Get(_ context.Context, _ []byte) (*Item, error) {
 	return &Item{}, nil
 }

--- a/lib/backend/wrap.go
+++ b/lib/backend/wrap.go
@@ -42,6 +42,10 @@ func NewWrapper(backend Backend) *Wrapper {
 	}
 }
 
+func (s *Wrapper) GetName() string {
+	return s.backend.GetName()
+}
+
 // GetReadError returns error to be returned by
 // read backend operations
 func (s *Wrapper) GetReadError() error {

--- a/lib/services/local/assistant.go
+++ b/lib/services/local/assistant.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
 	"github.com/gravitational/teleport/lib/backend"
-	"github.com/gravitational/teleport/lib/backend/etcdbk"
 )
 
 // Conversation is a conversation entry in the backend.
@@ -280,17 +279,6 @@ func (s *AssistService) CreateAssistantMessage(ctx context.Context, req *assist.
 }
 
 // IsAssistEnabled returns true if the assist is enabled or not on the auth level.
-func (a *AssistService) IsAssistEnabled(ctx context.Context) (*assist.IsAssistEnabledResponse, error) {
-	reporter, ok := a.Backend.(*backend.Reporter)
-	if !ok {
-		return &assist.IsAssistEnabledResponse{Enabled: true}, nil
-	}
-
-	sanitizer, ok := reporter.Backend.(*backend.Sanitizer)
-	if !ok {
-		return &assist.IsAssistEnabledResponse{Enabled: true}, nil
-	}
-
-	_, ok = sanitizer.Inner().(*etcdbk.EtcdBackend)
-	return &assist.IsAssistEnabledResponse{Enabled: !ok}, nil
+func (s *AssistService) IsAssistEnabled(ctx context.Context) (*assist.IsAssistEnabledResponse, error) {
+	return &assist.IsAssistEnabledResponse{Enabled: s.Backend.GetName() != "etcd"}, nil
 }


### PR DESCRIPTION
The following import tree resulted in tctl depending on etcd:

```
| github.com/gravitational/teleport/tool/tctl
|--> github.com/gravitational/teleport/tool/tctl/common 
|---> github.com/gravitational/teleport/lib/auth
|----> github.com/gravitational/teleport/lib/auth/okta 
|-----> github.com/gravitational/teleport/lib/services/local 
|-------> github.com/gravitational/teleport/lib/backend/etcdbk 
|--------> go.etcd.io/etcd/client/v3
```

This stems from the assistant service which checks if the backend is etcd by using type assertion. A new GetName method is added to backend.Backend so that the storage mechanism can be determined via string comparison instead of importing backend implementations to do type assertion.
