### PR TITLE
build: Save rpm and deb files in build/artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1313,13 +1313,14 @@ pkg-tsh: | $(RELEASE_DIR)
 
 # build .rpm
 .PHONY: rpm
-rpm:
+rpm: | $(RELEASE_DIR)
 	mkdir -p $(BUILDDIR)/
 	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
 	cp -a ./build.assets/rpm $(BUILDDIR)/
 	cp -a ./build.assets/rpm-sign $(BUILDDIR)/
 	cd $(BUILDDIR) && ./build-package.sh -t oss -v $(VERSION) -p rpm -a $(ARCH) $(RUNTIME_SECTION) $(TARBALL_PATH_SECTION)
+	cp $(BUILDDIR)/teleport-*.rpm* $(RELEASE_DIR)
 	if [ -f e/Makefile ]; then $(MAKE) -C e rpm; fi
 
 # build unsigned .rpm (for testing)
@@ -1329,11 +1330,12 @@ rpm-unsigned:
 
 # build open source .deb only
 .PHONY: oss-deb
-oss-deb:
+oss-deb: | $(RELEASE_DIR)
 	mkdir -p $(BUILDDIR)/
 	cp ./build.assets/build-package.sh ./build.assets/build-common.sh $(BUILDDIR)/
 	chmod +x $(BUILDDIR)/build-package.sh
 	cd $(BUILDDIR) && ./build-package.sh -t oss -v $(VERSION) -p deb -a $(ARCH) $(RUNTIME_SECTION) $(TARBALL_PATH_SECTION)
+	cp $(BUILDDIR)/teleport_*.deb* $(RELEASE_DIR)
 
 # build .deb
 .PHONY: deb

--- a/Makefile
+++ b/Makefile
@@ -427,9 +427,9 @@ clean-ui:
 
 # RELEASE_DIR is where release artifact files are put, such as tarballs, packages, etc.
 $(RELEASE_DIR):
-	mkdir $@
+	mkdir -p $@
 
-.PHONY:
+.PHONY: release
 export
 release:
 	@echo "---> OSS $(RELEASE_MESSAGE)"
@@ -440,6 +440,10 @@ else ifeq ("$(OS)", "darwin")
 else
 	$(MAKE) --no-print-directory release-unix
 endif
+
+.PHONY: release-ent
+release-ent:
+	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
 
 # These are aliases used to make build commands uniform.
 .PHONY: release-amd64
@@ -483,7 +487,7 @@ build-archive: | $(RELEASE_DIR)
 #
 .PHONY:
 release-unix: clean full build-archive
-	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
+	$(MAKE) release-ent
 
 include darwin-signing.mk
 
@@ -497,7 +501,7 @@ release-darwin: ABSOLUTE_BINARY_PATHS:=$(addprefix $(CURDIR)/,$(BINARIES))
 release-darwin: release-darwin-unsigned
 	$(NOTARIZE_BINARIES)
 	$(MAKE) build-archive
-	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
+	$(MAKE) release-ent
 else
 
 # release-darwin for ARCH == universal does not build binaries, but instead
@@ -522,7 +526,7 @@ release-darwin: $(RELEASE_darwin_arm64) $(RELEASE_darwin_amd64)
 	lipo -create -output $(BUILDDIR)/tsh $(BUILDDIR_arm64)/tsh $(BUILDDIR_amd64)/tsh
 	lipo -create -output $(BUILDDIR)/tbot $(BUILDDIR_arm64)/tbot $(BUILDDIR_amd64)/tbot
 	$(MAKE) ARCH=universal build-archive
-	@if [ -f e/Makefile ]; then $(MAKE) -C e release; fi
+	$(MAKE) release-ent
 endif
 
 #

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -442,7 +442,7 @@ release-arm64: buildbox-arm
 release-fips: buildbox-centos7-fips
 	@if [ -z ${VERSION} ]; then echo "VERSION is not set"; exit 1; fi
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
-		/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=yes
+		/usr/bin/make release-ent -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes REPRODUCIBLE=yes
 
 #
 # Create a Teleport package for CentOS 7 using the build container.
@@ -459,7 +459,7 @@ release-centos7: buildbox-centos7
 .PHONY:release-centos7-fips
 release-centos7-fips:
 	docker run $(DOCKERFLAGS) -i $(NOROOT) $(BUILDBOX_CENTOS7_FIPS) \
-		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make -C e release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes VERSION=$(VERSION) GITTAG=v$(VERSION) REPRODUCIBLE=no'
+		/usr/bin/scl enable $(DEVTOOLSET) '/usr/bin/make release-ent -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=$(ARCH) RUNTIME=$(GOLANG_VERSION) FIPS=yes REPRODUCIBLE=no'
 
 #
 # Create a Windows Teleport package using the build container.


### PR DESCRIPTION
After building rpm and deb packages, copy them to the release directory
`build/artifacts` so that the CI workflows can pick them up for release. We
also copy the sha256 files.

Update the `e` ref to bring in the same changes from teleport.e, as well
as a build-linux workflow update that is needed on master.

Issue: https://github.com/gravitational/teleport/issues/20729