### PR TITLE
[v13] `GenerateToken` should call `CreateToken` not `UpsertToken`

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3393,7 +3393,7 @@ func (a *Server) GenerateToken(ctx context.Context, req *proto.GenerateTokenRequ
 		token.SetMetadata(meta)
 	}
 
-	if err := a.UpsertToken(ctx, token); err != nil {
+	if err := a.CreateToken(ctx, token); err != nil {
 		return "", trace.Wrap(err)
 	}
 

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -4294,7 +4294,7 @@ func TestGRPCServer_GenerateToken(t *testing.T) {
 			},
 		},
 		{
-			name:              "failure (already exists)",
+			name:              "can't override existing token",
 			identity:          TestUser(privilegedUser.GetName()),
 			overrideTokenName: alreadyExistsToken.GetName(),
 			roles:             types.SystemRoles{types.RoleTrustedCluster},


### PR DESCRIPTION
Backport #29342 to branch/v13