### PR TITLE
Add --self-terminate-when-orphaned to teleport start

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -198,6 +198,10 @@ type CommandLineFlags struct {
 	// IntegrationConfDeployServiceIAMArguments contains the arguments of
 	// `teleport integration configure deployservice-iam` command
 	IntegrationConfDeployServiceIAMArguments IntegrationConfDeployServiceIAM
+
+	// SelfTerminateWhenOrphaned makes the start command terminate the process if it detects that its
+	// parent has been terminated. See common.selfTerminateWhenOrphaned.
+	SelfTerminateWhenOrphaned bool
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of


### PR DESCRIPTION
In [Connect My Computer](https://github.com/gravitational/teleport/blob/master/rfd/0133-connect-my-computer.md), the Electron app manages the lifecycle of the teleport agent. During normal operation, the agent is stopped before the app exits. However, if the Electron app gets unexpectedly killed, we want to terminate the agent as well. See:

* https://github.com/gravitational/teleport/blob/master/rfd/0133-connect-my-computer.md#access-to-ui-and-autostart
* https://github.com/gravitational/teleport/blob/master/rfd/0133-connect-my-computer.md#ensuring-the-agent-is-killed-together-with-the-electron-app

Initially I wanted to use PPID polling, as described in the RFD, but I realized that it's not the best solution. With the help of Edoardo, I was able to write a simple, Unix-compatible solution which, from what I gathered reading various Stack Overflow posts on this topic, is quite popular.

When `--self-terminate-when-orphaned` is passed, `teleport start` assumes that `os.Stdin` is piped from the parent. It attempts to read from the pipe. As soon as the pipe is closed, we know that the parent has died.

I made a simple Node.js program which you can execute as `node childtest.mjs` to test the solution:

<details>
<summary>childtest.mjs</summary>

```javascript
import process from 'process';
import { setTimeout } from 'node:timers/promises';
import { spawn } from 'node:child_process';

console.log('parent ' + process.pid);

const child = spawn(
  './build/teleport',
  [
    'start',
    '--config',
    'cluster/config.yaml',
    '--self-terminate-when-orphaned',
  ],
  { stdio: ['pipe', 'inherit', 'inherit'] }
);

console.log('child ' + child.pid);

setTimeout(500000);
```

</details>

---

Unresolved questions:

* [x] Is sending SIGTERM instead of SIGQUIT there okay?
   * `--self-terminate-when-orphaned` is reserved for an unusual situation, so I think it's fine if we stop the agent ASAP.
* [x] Should this be integrated more closely with `service.Process.WaitForSignals`?
   * In theory, when we send SIGTERM, the process might not be listening for it yet. I worked around this by doing `os.Exit(1)`, which from what I see is not used anywhere else in the agent code. Perhaps I should just send SIGKILL instead of SIGTERM?
* [x] Should I pass an extra pipe instead of using stdin for this purpose?
* [ ] How do I test this?
   * [I got some pointers from Jakub](https://gravitational.slack.com/archives/C0DF0TPMY/p1689948758410249?thread_ts=1689870048.305229&cid=C0DF0TPMY), ~I'm yet to investigate them~.
   * In tests, I need to spawn a process which spawn another one and somehow reports both pids. Do I just create a hidden sub command for that, such as `exec`, `forward` or `park`?
* [ ] Does it need to account for a situation where Teleport forks itself and how?
   * When does a Teleport process fork itself?
* [ ] [Jakub argues](https://gravitational.slack.com/archives/C0DF0TPMY/p1689961869085879?thread_ts=1689870048.305229&cid=C0DF0TPMY) that the parent should be responsible for managing the lifecycle of the child and that we should consider using a process group or a cleanup daemon instead. I don't really know how to respond to it yet.

---

TODO:

* [ ] Use an extra pipe instead of stdin.