### PR TITLE
Fix a panic in the S3 uploader

### DIFF
--- a/lib/events/s3sessions/s3stream.go
+++ b/lib/events/s3sessions/s3stream.go
@@ -201,7 +201,7 @@ func (h *Handler) ListUploads(ctx context.Context) ([]events.StreamUpload, error
 				Initiated: *upload.Initiated,
 			})
 		}
-		if !*re.IsTruncated {
+		if !aws.BoolValue(re.IsTruncated) {
 			break
 		}
 		keyMarker = re.KeyMarker


### PR DESCRIPTION
The truncated field is a *bool and should not be dereferenced without first checking for nil.

Fixes #29413