### PR TITLE
Introduce the `UpdateAndSwapUser` function

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3175,12 +3175,12 @@ func (a *ServerWithRoles) UpsertUser(u types.User) error {
 	return a.authServer.UpsertUser(u)
 }
 
-// UpdateUserFunc exists on [ServerWithRoles] only for compatibility with
+// UpdateAndSwapUser exists on [ServerWithRoles] only for compatibility with
 // [ClientI], it is not implemented here.
-// See [local.IdentityService.UpdateUserFunc].
-func (a *ServerWithRoles) UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error) {
+// See [local.IdentityService.UpdateAndSwapUser].
+func (a *ServerWithRoles) UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error) {
 	// To the reader: consider writing this function if it's useful to you.
-	return nil, trace.NotImplemented("func UpdateUserFunc is not implemented by ServerWithRoles")
+	return nil, trace.NotImplemented("func UpdateAndSwapUser is not implemented by ServerWithRoles")
 }
 
 // CompareAndSwapUser updates an existing user in a backend, but fails if the

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3175,6 +3175,14 @@ func (a *ServerWithRoles) UpsertUser(u types.User) error {
 	return a.authServer.UpsertUser(u)
 }
 
+// UpdateUserFunc exists on [ServerWithRoles] only for compatibility with
+// [ClientI], it is not implemented here.
+// See [local.IdentityService.UpdateUserFunc].
+func (a *ServerWithRoles) UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error) {
+	// To the reader: consider writing this function if it's useful to you.
+	return nil, trace.NotImplemented("func UpdateUserFunc is not implemented by ServerWithRoles")
+}
+
 // CompareAndSwapUser updates an existing user in a backend, but fails if the
 // backend's value does not match the expected value.
 // Captures the auth user who modified the user record.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -239,8 +239,8 @@ func (c *Client) DeleteAuthServer(name string) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
-// UpdateUserFunc not implemented: can only be called locally.
-func (c *Client) UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (bool, error)) (types.User, error) {
+// UpdateAndSwapUser not implemented: can only be called locally.
+func (c *Client) UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (bool, error)) (types.User, error) {
 	return nil, trace.NotImplemented(notImplementedMessage)
 }
 
@@ -531,11 +531,11 @@ type IdentityService interface {
 	// UpdateUser updates an existing user in a backend.
 	UpdateUser(ctx context.Context, user types.User) error
 
-	// UpdateUserFunc reads an existing user, runs `fn` against it and writes the
-	// result to storage. Return `false` from `fn` to avoid storage changes.
+	// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes
+	// the result to storage. Return `false` from `fn` to avoid storage changes.
 	// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
 	// Returns the storage user.
-	UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
+	UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
 
 	// UpsertUser user updates or inserts user entry
 	UpsertUser(user types.User) error

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -239,6 +239,11 @@ func (c *Client) DeleteAuthServer(name string) error {
 	return trace.NotImplemented(notImplementedMessage)
 }
 
+// UpdateUserFunc not implemented: can only be called locally.
+func (c *Client) UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (bool, error)) (types.User, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
 // CompareAndSwapUser not implemented: can only be called locally
 func (c *Client) CompareAndSwapUser(ctx context.Context, new, expected types.User) error {
 	return trace.NotImplemented(notImplementedMessage)
@@ -525,6 +530,12 @@ type IdentityService interface {
 
 	// UpdateUser updates an existing user in a backend.
 	UpdateUser(ctx context.Context, user types.User) error
+
+	// UpdateUserFunc reads an existing user, runs `fn` against it and writes the
+	// result to storage. Return `false` from `fn` to avoid storage changes.
+	// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
+	// Returns the storage user.
+	UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
 
 	// UpsertUser user updates or inserts user entry
 	UpsertUser(user types.User) error

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -45,6 +45,11 @@ type UsersService interface {
 	UserGetter
 	// UpdateUser updates an existing user.
 	UpdateUser(ctx context.Context, user types.User) error
+	// UpdateUserFunc reads an existing user, runs `fn` against it and writes the
+	// result to storage. Return `false` from `fn` to avoid storage changes.
+	// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
+	// Returns the storage user.
+	UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
 	// UpsertUser updates parameters about user
 	UpsertUser(user types.User) error
 	// CompareAndSwapUser updates an existing user, but fails if the user does

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -45,11 +45,11 @@ type UsersService interface {
 	UserGetter
 	// UpdateUser updates an existing user.
 	UpdateUser(ctx context.Context, user types.User) error
-	// UpdateUserFunc reads an existing user, runs `fn` against it and writes the
-	// result to storage. Return `false` from `fn` to avoid storage changes.
+	// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes
+	// the result to storage. Return `false` from `fn` to avoid storage changes.
 	// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
 	// Returns the storage user.
-	UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
+	UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
 	// UpsertUser updates parameters about user
 	UpsertUser(user types.User) error
 	// CompareAndSwapUser updates an existing user, but fails if the user does

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -193,11 +193,11 @@ func (s *IdentityService) UpdateUser(ctx context.Context, user types.User) error
 	return nil
 }
 
-// UpdateUserFunc reads an existing user, runs `fn` against it and writes the
+// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes the
 // result to storage. Return `false` from `fn` to avoid storage changes.
 // Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
 // Returns the storage user.
-func (s *IdentityService) UpdateUserFunc(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error) {
+func (s *IdentityService) UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error) {
 	u, items, err := s.getUser(ctx, user, withSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -941,7 +941,7 @@ func TestIdentityService_GetKeyAttestationDataV11Fingerprint(t *testing.T) {
 	require.Equal(t, attestationData, retrievedAttestationData)
 }
 
-func TestIdentityService_UpdateUserFunc(t *testing.T) {
+func TestIdentityService_UpdateAndSwapUser(t *testing.T) {
 	t.Parallel()
 	identity := newIdentityService(t, clockwork.NewFakeClock())
 	ctx := context.Background()
@@ -1058,9 +1058,9 @@ func TestIdentityService_UpdateUserFunc(t *testing.T) {
 				}
 			}
 
-			updated, err := identity.UpdateUserFunc(ctx, test.user, test.withSecrets, test.fn)
+			updated, err := identity.UpdateAndSwapUser(ctx, test.user, test.withSecrets, test.fn)
 			if test.wantErr != "" {
-				assert.ErrorContains(t, err, test.wantErr, "UpdateUserFunc didn't error")
+				assert.ErrorContains(t, err, test.wantErr, "UpdateAndSwapUser didn't error")
 				return
 			}
 
@@ -1075,14 +1075,14 @@ func TestIdentityService_UpdateUserFunc(t *testing.T) {
 
 			// Assert update response.
 			if diff := cmp.Diff(want, updated); diff != "" {
-				t.Errorf("UpdateUserFunc return mismatch (-want +got)\n%s", diff)
+				t.Errorf("UpdateAndSwapUser return mismatch (-want +got)\n%s", diff)
 			}
 
 			// Assert stored.
 			stored, err := identity.GetUser(test.user, test.withSecrets)
 			require.NoError(t, err, "GetUser failed")
 			if diff := cmp.Diff(want, stored); diff != "" {
-				t.Errorf("UpdateUserFunc storage mismatch (-want +got)\n%s", diff)
+				t.Errorf("UpdateAndSwapUser storage mismatch (-want +got)\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
Add a single function to IdentityService - `UpdateAndSwapUser` - that combines `GetUser`, `CompareAndSwapUser` and the necessary glue code in a single operation.