### PR TITLE
feat: support resource requests via tctl

### DIFF
--- a/api/types/resource_ids.go
+++ b/api/types/resource_ids.go
@@ -119,6 +119,20 @@ func ResourceIDFromString(raw string) (ResourceID, error) {
 	return resourceID, trace.Wrap(resourceID.CheckAndSetDefaults())
 }
 
+// ResourceIDsFromStrings parses a list of ResourceIDs from a list of strings.
+// Each string should have been obtained from ResourceIDToString.
+func ResourceIDsFromStrings(resourceIDStrs []string) ([]ResourceID, error) {
+	resourceIDs := make([]ResourceID, len(resourceIDStrs))
+	var err error
+	for i, resourceIDStr := range resourceIDStrs {
+		resourceIDs[i], err = ResourceIDFromString(resourceIDStr)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+	return resourceIDs, nil
+}
+
 // ResourceIDsToString marshals a list of ResourceIDs to a string.
 func ResourceIDsToString(ids []ResourceID) (string, error) {
 	if len(ids) == 0 {
@@ -138,8 +152,8 @@ func ResourceIDsToString(ids []ResourceID) (string, error) {
 	return string(bytes), nil
 }
 
-// ResourceIDsFromString parses a list for resource IDs from a string. The string
-// should have been obtained from ResourceIDsToString.
+// ResourceIDsFromString parses a list of resource IDs from a single string.
+// The string should have been obtained from ResourceIDsToString.
 func ResourceIDsFromString(raw string) ([]ResourceID, error) {
 	if raw == "" {
 		return nil, nil

--- a/api/types/resource_ids_test.go
+++ b/api/types/resource_ids_test.go
@@ -422,19 +422,33 @@ func TestResourceIDs(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			out, err := ResourceIDsToString(tc.in)
+			resourceIdsStr, err := ResourceIDsToString(tc.in)
 			require.NoError(t, err)
-			require.Equal(t, tc.expected, out)
+			require.Equal(t, tc.expected, resourceIdsStr, "marshaled resource IDs do not match expected")
 
-			// Parse the ids from the string and make sure they match the
-			// original.
-			parsed, err := ResourceIDsFromString(out)
-			if tc.expectParseError {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-			require.Equal(t, tc.in, parsed)
+			t.Run("ResourceIDsFromString", func(t *testing.T) {
+				parsed, err := ResourceIDsFromString(resourceIdsStr)
+				if tc.expectParseError {
+					require.Error(t, err, "expected to get an error parsing resource IDs")
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tc.in, parsed, "parsed resource IDs do not match the originals")
+			})
+
+			t.Run("ResourceIDsFromStrings", func(t *testing.T) {
+				resourceIDStrs := make([]string, len(tc.in))
+				for i, resourceID := range tc.in {
+					resourceIDStrs[i] = ResourceIDToString(resourceID)
+				}
+				parsed, err := ResourceIDsFromStrings(resourceIDStrs)
+				if tc.expectParseError {
+					require.Error(t, err, "expected to get an error parsing resource IDs")
+					return
+				}
+				require.NoError(t, err)
+				require.Equal(t, tc.in, parsed, "parsed resource IDs do not match the originals")
+			})
 		})
 	}
 }

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2412,13 +2412,9 @@ func getAccessRequest(ctx context.Context, tc *client.TeleportClient, requestID,
 func createAccessRequest(cf *CLIConf) (types.AccessRequest, error) {
 	roles := utils.SplitIdentifiers(cf.DesiredRoles)
 	reviewers := utils.SplitIdentifiers(cf.SuggestedReviewers)
-	var requestedResourceIDs []types.ResourceID
-	for _, resourceIDString := range cf.RequestedResourceIDs {
-		resourceID, err := types.ResourceIDFromString(resourceIDString)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		requestedResourceIDs = append(requestedResourceIDs, resourceID)
+	requestedResourceIDs, err := types.ResourceIDsFromStrings(cf.RequestedResourceIDs)
+	if err != nil {
+		return nil, trace.Wrap(err)
 	}
 	req, err := services.NewAccessRequestWithResources(cf.Username, roles, requestedResourceIDs)
 	if err != nil {


### PR DESCRIPTION
This commit adds support for Resource Access Requests to the `tctl request create` command, specifically adding the `--resource` flag already available in `tsh` that was never added to `tctl` (an oversight). It may be useful when creating requests for other users as an admin or an automation.

closes https://github.com/gravitational/teleport/issues/15966