### PR TITLE
Allow creating a admin `ClusterRoleBinding`

### DIFF
--- a/examples/chart/teleport-kube-agent/templates/NOTES.txt
+++ b/examples/chart/teleport-kube-agent/templates/NOTES.txt
@@ -20,3 +20,23 @@ You will face compatibility issues trying to run a different Teleport version wi
 If you want to run Teleport version {{.Values.teleportVersionOverride}},
 you should use `helm --version {{.Values.teleportVersionOverride}}` instead.
 {{- end }}
+
+
+{{- if contains "-gke." .Capabilities.KubeVersion.Version -}}
+{{- $groupName := (coalesce .Values.adminClusterRolebinding.name "cluster-admin") }}
+
+WARNING: GKE Autopilot clusters forbid users from impersonating system-wide identities.
+This means you won't be able to use the `system:masters` Kubernetes Group in
+the Teleport Roles for GKE Autopilot clusters.
+
+Given that you installed Teleport on a GKE cluster, we recommend you use the
+Kubernetes Group `{{ $groupName }}` instead of `system:masters` in the Teleport Roles
+for GKE Autopilot clusters.
+
+This chart automatically created the `{{ $groupName }}` Kubernetes Group for you and
+assigned it admin privileges on the Kubernetes cluster.
+
+Consult the built-in security features that GKE Autopilot enforces:
+https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security#built-in-security
+
+{{- end }}

--- a/examples/chart/teleport-kube-agent/templates/NOTES.txt
+++ b/examples/chart/teleport-kube-agent/templates/NOTES.txt
@@ -20,10 +20,8 @@ You will face compatibility issues trying to run a different Teleport version wi
 If you want to run Teleport version {{.Values.teleportVersionOverride}},
 you should use `helm --version {{.Values.teleportVersionOverride}}` instead.
 {{- end }}
-
-
 {{- if contains "-gke." .Capabilities.KubeVersion.Version -}}
-{{- $groupName := (coalesce .Values.adminClusterRolebinding.name "cluster-admin") }}
+{{- $groupName := (coalesce .Values.adminClusterRoleBinding.name "cluster-admin") }}
 
 WARNING: GKE Autopilot clusters forbid users from impersonating system-wide identities.
 This means you won't be able to use the `system:masters` Kubernetes Group in

--- a/examples/chart/teleport-kube-agent/templates/NOTES.txt
+++ b/examples/chart/teleport-kube-agent/templates/NOTES.txt
@@ -31,6 +31,19 @@ Given that you installed Teleport on a GKE cluster, we recommend you use the
 Kubernetes Group `{{ $groupName }}` instead of `system:masters` in the Teleport Roles
 for GKE Autopilot clusters.
 
+To do so, you can use the following Teleport Role resource:
+
+ kind: role
+ metadata:
+   name: gke-kube-access
+ version: v7
+ spec:
+   allow:
+     kubernetes_labels:
+       '*': '*'
+     kubernetes_groups:
+     - "{{ $groupName }}"
+
 This chart automatically created the `{{ $groupName }}` Kubernetes Group for you and
 assigned it admin privileges on the Kubernetes cluster.
 

--- a/examples/chart/teleport-kube-agent/templates/admin_clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/admin_clusterrolebinding.yaml
@@ -4,8 +4,8 @@ https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security#buil
 Because of this limitation, users are unable to specify kubernetes_groups=["system:masters"]
 in Teleport, so we create a Kubernetes Group called cluster-admin when we detect
 that the underlying cluster is a GKE cluster.  */}}
-{{- if or (contains "-gke." .Capabilities.KubeVersion.Version) (.Values.adminClusterRolebinding.create) -}}
-{{- $groupName := (coalesce .Values.adminClusterRolebinding.name "cluster-admin") }}
+{{- if or (contains "-gke." .Capabilities.KubeVersion.Version) (.Values.adminClusterRoleBinding.create) -}}
+{{- $groupName := (coalesce .Values.adminClusterRoleBinding.name "cluster-admin") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/examples/chart/teleport-kube-agent/templates/admin_clusterrolebinding.yaml
+++ b/examples/chart/teleport-kube-agent/templates/admin_clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{/* GKE Autopilot clusters forbid users from impersonating system:masters
+Groups. This is a security measure released under the GKE Warden authz module
+https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security#built-in-security
+Because of this limitation, users are unable to specify kubernetes_groups=["system:masters"]
+in Teleport, so we create a Kubernetes Group called cluster-admin when we detect
+that the underlying cluster is a GKE cluster.  */}}
+{{- if or (contains "-gke." .Capabilities.KubeVersion.Version) (.Values.adminClusterRolebinding.create) -}}
+{{- $groupName := (coalesce .Values.adminClusterRolebinding.name "cluster-admin") }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: admin-k8s-cluster-group
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+# This is the built-in cluster-admin role that exists in all K8S clusters.
+# We are binding the cluster-admin role to the cluster-admin group.
+# See https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles
+  name: cluster-admin
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: {{ $groupName }}
+{{- end }}

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/admin_clusterrolebinding_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/admin_clusterrolebinding_test.yaml.snap
@@ -1,0 +1,28 @@
+generate a admin cluster role binding when adminClusterRolebinding.create is true:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: admin-k8s-cluster-group
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-admin
+    subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: cluster-admin
+generate a admin cluster role binding when adminClusterRolebinding.create is true and adminClusterRolebinding.name is set:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRoleBinding
+    metadata:
+      name: admin-k8s-cluster-group
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: ClusterRole
+      name: cluster-admin
+    subjects:
+    - apiGroup: rbac.authorization.k8s.io
+      kind: Group
+      name: my-cluster-admin

--- a/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
@@ -2,13 +2,13 @@ suite: AdminClusterRoleBinding
 templates:
   - admin_clusterrolebinding.yaml
 tests:
-  - it: don't generate a admin cluster role binding when adminClusterRolebinding.create is false
+  - it: don't generate a admin cluster role binding when adminClusterRoleBinding.create is false
     asserts:
       - hasDocuments:
           count: 0
-  - it: generate a admin cluster role binding when adminClusterRolebinding.create is true
+  - it: generate a admin cluster role binding when adminClusterRoleBinding.create is true
     set:
-      adminClusterRolebinding:
+      adminClusterRoleBinding:
         create: true
     asserts:
       - hasDocuments:
@@ -19,9 +19,9 @@ tests:
           path: subjects[0].name
           value: cluster-admin
       - matchSnapshot: {}
-  - it: generate a admin cluster role binding when adminClusterRolebinding.create is true and adminClusterRolebinding.name is set
+  - it: generate a admin cluster role binding when adminClusterRoleBinding.create is true and adminClusterRoleBinding.name is set
     set:
-      adminClusterRolebinding:
+      adminClusterRoleBinding:
         create: true
         name: my-cluster-admin
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/admin_clusterrolebinding_test.yaml
@@ -1,0 +1,35 @@
+suite: AdminClusterRoleBinding
+templates:
+  - admin_clusterrolebinding.yaml
+tests:
+  - it: don't generate a admin cluster role binding when adminClusterRolebinding.create is false
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: generate a admin cluster role binding when adminClusterRolebinding.create is true
+    set:
+      adminClusterRolebinding:
+        create: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: subjects[0].name
+          value: cluster-admin
+      - matchSnapshot: {}
+  - it: generate a admin cluster role binding when adminClusterRolebinding.create is true and adminClusterRolebinding.name is set
+    set:
+      adminClusterRolebinding:
+        create: true
+        name: my-cluster-admin
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: subjects[0].name
+          value: my-cluster-admin
+      - matchSnapshot: {}

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -201,6 +201,15 @@ storage:
   storageClassName: ""
   requests: 128Mi
 
+# Settings for configuring an cluster admin role binding.
+# This is useful for granting cluster admin permissions to a Kubernetes Group
+# other than the default "system:masters" group.
+# GKE Autopilot clusters forbid using the "system:masters" group for impersonation
+# and require a custom group to be used instead.
+adminClusterRolebinding:
+  create: false
+  name: "cluster-admin"
+
 ################################################################
 # Values that you shouldn't need to change.
 ################################################################

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -206,7 +206,7 @@ storage:
 # other than the default "system:masters" group.
 # GKE Autopilot clusters forbid using the "system:masters" group for impersonation
 # and require a custom group to be used instead.
-adminClusterRolebinding:
+adminClusterRoleBinding:
   create: false
   name: "cluster-admin"
 


### PR DESCRIPTION
This PR adds the possibility of creating a cluster role binding between a group whose name is defined by `adminClusterRolebinding.name` and the built-in `cluster-admin` `ClusterRole`. This is particularly useful for GKE Autopilot clusters where it's not possible to use the default `system:masters` group because authz Warden security module prevents impersonating system-wide identities.

When the chart detects that the target cluster is a GKE cluster - `version: v1.x.x-gke.<build>` - it will automatically create the `ClusterRoleBinding` and print a warning message with the following payload:

```
NOTES:
WARNING: GKE Autopilot clusters forbid users from impersonating system-wide identities.
This means you won't be able to use the `system:masters` Kubernetes Group in
the Teleport Roles for GKE Autopilot clusters.

Given that you installed Teleport on a GKE cluster, we recommend you use the
Kubernetes Group `cluster-admin` instead of `system:masters` in the Teleport Roles
for GKE Autopilot clusters.

To do so, you can use the following Teleport Role resource:

 kind: role
 metadata:
   name: gke-kube-access
 version: v7
 spec:
   allow:
     kubernetes_labels:
       '*': '*'
     kubernetes_groups:
     - "cluster-admin"


This chart automatically created the `cluster-admin` Kubernetes Group for you and
assigned it admin privileges on the Kubernetes cluster.

Consult the built-in security features that GKE Autopilot enforces:
https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security#built-in-security
```

Part of #28506
