### PR TITLE
Update Operator CRDs and add a Lint check to prevent drifts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -44,6 +44,10 @@ jobs:
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $(realpath .) && make protos-up-to-date/host
 
+      - name: Check if Operator CRDs are up to date
+        # We have to add the current directory as a safe directory or else git commands will not work as expected.
+        run: git config --global --add safe.directory $(realpath .) && make crds-up-to-date
+
       # The `buf breaking` check is twofold: we always check for compatibility
       # breaks against the base of the PR, and in backports we check for
       # compatibility breaks _from_ the tip of master. It's possible to add

--- a/Makefile
+++ b/Makefile
@@ -1239,6 +1239,15 @@ must-start-clean/host:
 		exit 1; \
 	fi
 
+# crds-up-to-date checks if the generated CRDs from the protobuf stubs are up to date.
+.PHONY: crds-up-to-date
+crds-up-to-date: must-start-clean/host
+	$(MAKE) -C integrations/operator manifests
+	@if ! $(GIT) diff --quiet; then \
+		echo 'Please run make -C integrations/operator manifests.'; \
+		exit 1; \
+	fi
+
 print/env:
 	env
 

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_oktaimportrules.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_oktaimportrules.yaml
@@ -44,8 +44,11 @@ spec:
                       description: AddLabels specifies which labels to add if any
                         of the previous matches match.
                       nullable: true
-                      additionalProperties:
-                        type: string
+                      properties:
+                        key:
+                          type: string
+                        value:
+                          type: string
                       type: object
                     match:
                       description: Match is a set of matching rules for this mapping.

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_roles.yaml
@@ -236,6 +236,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -297,6 +304,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -684,6 +697,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -745,6 +765,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -977,6 +1003,11 @@ spec:
                     description: CreateHostUser allows users to be automatically created
                       on a host
                     type: boolean
+                  create_host_user_mode:
+                    description: CreateHostUserMode allows users to be automatically
+                      created on a host when not set to off
+                    format: int32
+                    type: integer
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
                       is allowed between the user's workstation and the remote desktop.
@@ -1402,6 +1433,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -1463,6 +1501,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -1850,6 +1894,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -1911,6 +1962,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -2143,6 +2200,11 @@ spec:
                     description: CreateHostUser allows users to be automatically created
                       on a host
                     type: boolean
+                  create_host_user_mode:
+                    description: CreateHostUserMode allows users to be automatically
+                      created on a host when not set to off
+                    format: int32
+                    type: integer
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
                       is allowed between the user's workstation and the remote desktop.

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_roles.yaml
@@ -236,6 +236,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -297,6 +304,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -684,6 +697,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -745,6 +765,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -977,6 +1003,11 @@ spec:
                     description: CreateHostUser allows users to be automatically created
                       on a host
                     type: boolean
+                  create_host_user_mode:
+                    description: CreateHostUserMode allows users to be automatically
+                      created on a host when not set to off
+                    format: int32
+                    type: integer
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
                       is allowed between the user's workstation and the remote desktop.
@@ -1402,6 +1433,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -1463,6 +1501,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -1850,6 +1894,13 @@ spec:
                           description: Namespace is the resource namespace. It supports
                             wildcards.
                           type: string
+                        verbs:
+                          description: Verbs are the allowed Kubernetes verbs for
+                            the following resource.
+                          items:
+                            type: string
+                          nullable: true
+                          type: array
                       type: object
                     type: array
                   kubernetes_users:
@@ -1911,6 +1962,12 @@ spec:
                               type: string
                           type: object
                         type: array
+                      max_duration:
+                        description: MaxDuration is the amount of time the access
+                          will be granted for. If this is zero, the default duration
+                          is used.
+                        format: duration
+                        type: string
                       roles:
                         description: Roles is the name of roles which will match the
                           request rule.
@@ -2143,6 +2200,11 @@ spec:
                     description: CreateHostUser allows users to be automatically created
                       on a host
                     type: boolean
+                  create_host_user_mode:
+                    description: CreateHostUserMode allows users to be automatically
+                      created on a host when not set to off
+                    format: int32
+                    type: integer
                   desktop_clipboard:
                     description: DesktopClipboard indicates whether clipboard sharing
                       is allowed between the user's workstation and the remote desktop.


### PR DESCRIPTION
This PR fixes the operator's CRDs drift between the CRD and the proto stubs they are derived from.

It also adds a check to prevent future drifts by forcing the manifest generation and requiring an empty diff.

Fixes #29438
Fixes #13849