### PR TITLE
Docs: Jamf Pro 

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -365,7 +365,7 @@
               ]
             },
             {
-              "title": "Jamf Integration",
+              "title": "Jamf Pro Integration",
               "slug": "/access-controls/device-trust/jamf-integration/",
               "forScopes": [
                 "enterprise",

--- a/docs/pages/access-controls/device-trust.mdx
+++ b/docs/pages/access-controls/device-trust.mdx
@@ -28,4 +28,4 @@ Teleport versions.
 
 - [Set Up Device Trust](./device-trust/guide.mdx)
 - [Set Up Auto-Enrollment](./device-trust/auto-enrollment.mdx)
-- [Jamf Integration](./device-trust/jamf-integration.mdx)
+- [Jamf Pro Integration](./device-trust/jamf-integration.mdx)

--- a/docs/pages/access-controls/device-trust/auto-enrollment.mdx
+++ b/docs/pages/access-controls/device-trust/auto-enrollment.mdx
@@ -6,7 +6,7 @@ description: Set Up Automatic Enrollment for Registered Devices
 Auto-enrollment allows `tsh` to automatically enroll devices already registered
 in Teleport during the user's login. The registration may be
 [manual](./guide.mdx#step-12-register-a-trusted-device) or performed using an
-integration, like the [Jamf integration](./jamf-integration.mdx).
+integration, like the [Jamf Pro integration](./jamf-integration.mdx).
 
 <Admonition type="warning">
 Device Trust is currently in Preview mode.

--- a/docs/pages/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/access-controls/device-trust/jamf-integration.mdx
@@ -1,17 +1,17 @@
 ---
-title: Jamf Integration (Preview)
-description: Sync your Jamf inventory into Teleport
+title: Jamf Pro Integration (Preview)
+description: Sync your Jamf Pro inventory into Teleport
 ---
 
-Device Trust Jamf integration lets you automatically sync your Jamf computer
+Device Trust Jamf Pro integration lets you automatically sync your Jamf Pro computer
 inventory into Teleport.
 
-The Teleport Jamf service is a distinct `teleport` process that periodically
-reads your computer inventory from Jamf and syncs it to Teleport. It performs
+The Teleport Jamf Pro service is a distinct `teleport` process that periodically
+reads your computer inventory from Jamf Pro and syncs it to Teleport. It performs
 both incremental (called "partial") and full syncs, as well as removals from
-Teleport if a computer is removed from Jamf.
+Teleport if a computer is removed from Jamf Pro.
 
-Syncing devices from Jamf is an **inventory management** step, equivalent to
+Syncing devices from Jamf Pro is an **inventory management** step, equivalent to
 automatically running the corresponding `tctl devices add` commands. If you want
 to automatically enroll synced devices on user login, refer to the
 [auto-enrollment](#optional-enable-auto-enrollment) section.

--- a/docs/pages/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/access-controls/device-trust/jamf-integration.mdx
@@ -161,7 +161,8 @@ When using the minimal configuration, described in the steps above, Jamf service
 utilizes a default sync schedule. It is possible to customize sync intervals, as
 well as the set of devices synced from Jamf, by applying RSQL filters provided
 by the [Jamf Pro API](
-https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory).
+https://developer.jamf.com/jamf-pro/reference/get_v1-computers-inventory). 
+Jamf recommends a full sync no more than once every 24 hours.
 
 The default "inventory" configuration is roughly equivalent to the one below:
 


### PR DESCRIPTION
Jamf is a large company with a lot of different product offerings. Teleport integrates with Jamf Pro; we've been recommended to use Jamf Pro vs Jamf. 