### PR TITLE
[v11] Introduce the `UpdateAndSwapUser` function

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2924,6 +2924,14 @@ func (a *ServerWithRoles) UpsertUser(u types.User) error {
 	return a.authServer.UpsertUser(u)
 }
 
+// UpdateAndSwapUser exists on [ServerWithRoles] only for compatibility with
+// [ClientI], it is not implemented here.
+// See [local.IdentityService.UpdateAndSwapUser].
+func (a *ServerWithRoles) UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error) {
+	// To the reader: consider writing this function if it's useful to you.
+	return nil, trace.NotImplemented("func UpdateAndSwapUser is not implemented by ServerWithRoles")
+}
+
 // CompareAndSwapUser updates an existing user in a backend, but fails if the
 // backend's value does not match the expected value.
 // Captures the auth user who modified the user record.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -835,6 +835,11 @@ func (c *Client) UpsertUser(user types.User) error {
 	return trace.Wrap(err)
 }
 
+// UpdateAndSwapUser not implemented: can only be called locally.
+func (c *Client) UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (bool, error)) (types.User, error) {
+	return nil, trace.NotImplemented(notImplementedMessage)
+}
+
 // CompareAndSwapUser not implemented: can only be called locally
 func (c *Client) CompareAndSwapUser(ctx context.Context, new, expected types.User) error {
 	return trace.NotImplemented(notImplementedMessage)
@@ -1526,6 +1531,12 @@ type IdentityService interface {
 
 	// UpdateUser updates an existing user in a backend.
 	UpdateUser(ctx context.Context, user types.User) error
+
+	// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes
+	// the result to storage. Return `false` from `fn` to avoid storage changes.
+	// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
+	// Returns the storage user.
+	UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
 
 	// UpsertUser user updates or inserts user entry
 	UpsertUser(user types.User) error

--- a/lib/services/identity.go
+++ b/lib/services/identity.go
@@ -45,6 +45,11 @@ type UsersService interface {
 	UserGetter
 	// UpdateUser updates an existing user.
 	UpdateUser(ctx context.Context, user types.User) error
+	// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes
+	// the result to storage. Return `false` from `fn` to avoid storage changes.
+	// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
+	// Returns the storage user.
+	UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error)
 	// UpsertUser updates parameters about user
 	UpsertUser(user types.User) error
 	// CompareAndSwapUser updates an existing user, but fails if the user does

--- a/lib/services/local/users.go
+++ b/lib/services/local/users.go
@@ -192,6 +192,41 @@ func (s *IdentityService) UpdateUser(ctx context.Context, user types.User) error
 	return nil
 }
 
+// UpdateAndSwapUser reads an existing user, runs `fn` against it and writes the
+// result to storage. Return `false` from `fn` to avoid storage changes.
+// Roughly equivalent to [GetUser] followed by [CompareAndSwapUser].
+// Returns the storage user.
+func (s *IdentityService) UpdateAndSwapUser(ctx context.Context, user string, withSecrets bool, fn func(types.User) (changed bool, err error)) (types.User, error) {
+	u, items, err := s.getUser(ctx, user, withSecrets)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	// Take a "copy" of `u`. It is never modified.
+	existing, err := userFromUserItems(user, *items)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	switch changed, err := fn(u); {
+	case err != nil:
+		return nil, trace.Wrap(err)
+	case !changed:
+		// Return user before modifications.
+		return existing, nil
+	}
+
+	// Don't write secrets if we didn't read secrets.
+	if !withSecrets {
+		u = u.WithoutSecrets().(types.User)
+	}
+
+	if err := s.CompareAndSwapUser(ctx, u, existing); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return u, nil
+}
+
 // UpsertUser updates parameters about user, or creates an entry if not exist.
 func (s *IdentityService) UpsertUser(user types.User) error {
 	if err := services.ValidateUser(user); err != nil {
@@ -275,46 +310,55 @@ func (s *IdentityService) CompareAndSwapUser(ctx context.Context, new, existing 
 
 // GetUser returns a user by name
 func (s *IdentityService) GetUser(user string, withSecrets bool) (types.User, error) {
-	if withSecrets {
-		return s.getUserWithSecrets(user)
-	}
-	if user == "" {
-		return nil, trace.BadParameter("missing user name")
-	}
-	item, err := s.Get(context.TODO(), backend.Key(webPrefix, usersPrefix, user, paramsPrefix))
-	if err != nil {
-		return nil, trace.NotFound("user %q is not found", user)
-	}
-	u, err := services.UnmarshalUser(
-		item.Value, services.WithResourceID(item.ID), services.WithExpires(item.Expires))
+	u, _, err := s.getUser(context.TODO(), user, withSecrets)
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-	if !withSecrets {
-		u.SetLocalAuth(nil)
 	}
 	return u, nil
 }
 
-func (s *IdentityService) getUserWithSecrets(user string) (types.User, error) {
+func (s *IdentityService) getUser(ctx context.Context, user string, withSecrets bool) (types.User, *userItems, error) {
 	if user == "" {
-		return nil, trace.BadParameter("missing user name")
+		return nil, nil, trace.BadParameter("missing user name")
 	}
-	startKey := backend.Key(webPrefix, usersPrefix, user)
-	result, err := s.GetRange(context.TODO(), startKey, backend.RangeEnd(startKey), backend.NoLimit)
+
+	if withSecrets {
+		u, items, err := s.getUserWithSecrets(ctx, user)
+		return u, items, trace.Wrap(err)
+	}
+
+	item, err := s.Get(ctx, backend.Key(webPrefix, usersPrefix, user, paramsPrefix))
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, nil, trace.NotFound("user %q not found", user)
 	}
-	var uitems userItems
+
+	u, err := services.UnmarshalUser(
+		item.Value, services.WithResourceID(item.ID), services.WithExpires(item.Expires))
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	if !withSecrets {
+		u.SetLocalAuth(nil)
+	}
+	return u, &userItems{params: item}, nil
+}
+
+func (s *IdentityService) getUserWithSecrets(ctx context.Context, user string) (types.User, *userItems, error) {
+	startKey := backend.Key(webPrefix, usersPrefix, user)
+	result, err := s.GetRange(ctx, startKey, backend.RangeEnd(startKey), backend.NoLimit)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+
+	var items userItems
 	for _, item := range result.Items {
 		suffix := bytes.TrimPrefix(item.Key, append(startKey, byte(backend.Separator)))
-		uitems.Set(string(suffix), item) // Result of Set i
+		items.Set(string(suffix), item) // Result of Set i
 	}
-	u, err := userFromUserItems(user, uitems)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return u, nil
+
+	u, err := userFromUserItems(user, items)
+	return u, &items, trace.Wrap(err)
 }
 
 func (s *IdentityService) upsertLocalAuthSecrets(user string, auth types.LocalAuthSecrets) error {

--- a/lib/services/local/users_test.go
+++ b/lib/services/local/users_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"testing"
 	"time"
 
@@ -30,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/types"
@@ -937,4 +939,151 @@ func TestIdentityService_GetKeyAttestationDataV11Fingerprint(t *testing.T) {
 	retrievedAttestationData, err := identity.GetKeyAttestationData(ctx, key.Public())
 	require.NoError(t, err)
 	require.Equal(t, attestationData, retrievedAttestationData)
+}
+
+func TestIdentityService_UpdateAndSwapUser(t *testing.T) {
+	t.Parallel()
+	identity := newIdentityService(t, clockwork.NewFakeClock())
+	ctx := context.Background()
+
+	type updateParams struct {
+		user        string
+		withSecrets bool
+		fn          func(u types.User) (changed bool, err error)
+	}
+
+	tests := []struct {
+		name     string
+		makeUser func() (types.User, error) // if not nil, the user is created
+		updateParams
+		wantErr  string
+		wantNoop bool
+	}{
+		{
+			name: "update without secrets",
+			makeUser: func() (types.User, error) {
+				return types.NewUser("updateNoSecrets1")
+			},
+			updateParams: updateParams{
+				fn: func(u types.User) (bool, error) {
+					u.SetLogins([]string{"llama", "alpaca"})
+					return true, nil
+				},
+			},
+		},
+		{
+			name: "update without secrets can't write secrets",
+			makeUser: func() (types.User, error) {
+				return types.NewUser("updateNoSecrets2")
+			},
+			updateParams: updateParams{
+				fn: func(u types.User) (bool, error) {
+					u.SetLogins([]string{"llama", "alpaca"})
+					u.SetLocalAuth(&types.LocalAuthSecrets{
+						Webauthn: &types.WebauthnLocalAuth{
+							UserID: []byte("superwebllama"),
+						},
+					})
+					return true, nil
+				},
+			},
+		},
+		{
+			name: "update with secrets",
+			makeUser: func() (types.User, error) {
+				return types.NewUser("updateWithSecrets")
+			},
+			updateParams: updateParams{
+				withSecrets: true,
+				fn: func(u types.User) (bool, error) {
+					u.SetLogins([]string{"llama", "alpaca"})
+					u.SetLocalAuth(&types.LocalAuthSecrets{
+						Webauthn: &types.WebauthnLocalAuth{
+							UserID: []byte("superwebllama"),
+						},
+					})
+					return true, nil
+				},
+			},
+		},
+		{
+			name: "noop fn",
+			makeUser: func() (types.User, error) {
+				return types.NewUser("noop1")
+			},
+			updateParams: updateParams{
+				fn: func(u types.User) (changed bool, err error) {
+					u.SetLogins([]string{"llama"}) // not written to storage!
+					return false, nil
+				},
+			},
+			wantNoop: true,
+		},
+		{
+			name: "user not found",
+			updateParams: updateParams{
+				user: "unknown",
+				fn:   func(u types.User) (changed bool, err error) { return false, nil },
+			},
+			wantErr: "not found",
+		},
+		{
+			name: "fn error surfaced",
+			makeUser: func() (types.User, error) {
+				return types.NewUser("fnErr")
+			},
+			updateParams: updateParams{
+				fn: func(u types.User) (changed bool, err error) {
+					return false, errors.New("something really terrible happened")
+				},
+			},
+			wantErr: "something really terrible",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var before types.User
+
+			// Create user?
+			if test.makeUser != nil {
+				var err error
+				before, err = test.makeUser()
+				require.NoError(t, err, "makeUser failed")
+				require.NoError(t, identity.CreateUser(before), "CreateUser failed")
+
+				if test.user == "" {
+					test.user = before.GetName()
+				} else if test.user != before.GetName() {
+					t.Fatal("Test has both makeUser and updateParams.user, but they don't match")
+				}
+			}
+
+			updated, err := identity.UpdateAndSwapUser(ctx, test.user, test.withSecrets, test.fn)
+			if test.wantErr != "" {
+				assert.ErrorContains(t, err, test.wantErr, "UpdateAndSwapUser didn't error")
+				return
+			}
+
+			// Determine wanted user based on `before` and params.
+			want := before
+			if !test.wantNoop {
+				test.fn(want)
+			}
+			if !test.withSecrets {
+				want = want.WithoutSecrets().(types.User)
+			}
+
+			// Assert update response.
+			if diff := cmp.Diff(want, updated); diff != "" {
+				t.Errorf("UpdateAndSwapUser return mismatch (-want +got)\n%s", diff)
+			}
+
+			// Assert stored.
+			stored, err := identity.GetUser(test.user, test.withSecrets)
+			require.NoError(t, err, "GetUser failed")
+			if diff := cmp.Diff(want, stored); diff != "" {
+				t.Errorf("UpdateAndSwapUser storage mismatch (-want +got)\n%s", diff)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Backport #29414 to branch/v11.

Add a single function to IdentityService - `UpdateAndSwapUser` - that combines
`GetUser`, `CompareAndSwapUser` and the necessary glue code in a single
operation.