### PR TITLE
Make `--type` flag required on `tctl auth crl` command

### DIFF
--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -152,7 +152,7 @@ func (a *AuthCommand) Initialize(app *kingpin.Application, config *servicecfg.Co
 	a.authLS.Flag("format", "Output format: 'yaml', 'json' or 'text'").Default(teleport.YAML).StringVar(&a.format)
 
 	a.authCRL = auth.Command("crl", "Export empty certificate revocation list (CRL) for certificate authorities.")
-	a.authCRL.Flag("type", "certificate authority type").EnumVar(&a.caType, allowedCRLCertificateTypes...)
+	a.authCRL.Flag("type", fmt.Sprintf("Certificate authority type, one of: %s", strings.Join(allowedCRLCertificateTypes, ", "))).Required().EnumVar(&a.caType, allowedCRLCertificateTypes...)
 }
 
 // TryRun takes the CLI command as an argument (like "auth gen") and executes it


### PR DESCRIPTION
Closes #28703.

The certificate authority type is always required when generating the CRL. This PR makes the parameter required and add the possible values on its description.

Before:
```bash
$ tctl auth crl
ERROR: "" authority type is not supported
```

After:
```bash
$ tctl auth crl
usage: tctl auth crl --type=TYPE

Export empty certificate revocation list (CRL) for certificate authorities.

Flags:
  -d, --[no-]debug     Enable verbose logging to stderr
  -c, --config         Path to a configuration file [/etc/teleport.yaml]. Can also be set via the TELEPORT_CONFIG_FILE environment variable.
      --auth-server    Attempts to connect to specific auth/proxy address(es) instead of local auth [127.0.0.1:3025]
  -i, --identity       Path to an identity file. Must be provided to make remote connections to auth. An identity file can be exported with 'tctl auth sign'
      --[no-]insecure  When specifying a proxy address in --auth-server, do not verify its TLS certificate. Danger: any data you send can be intercepted or modified by an attacker.
      --type           Certificate authority type, one of: host, db, user

Aliases:

ERROR: required flag --type not provided

```