### PR TITLE
add oss support for partial onboard survey

### DIFF
--- a/web/packages/teleport/src/Main/Main.tsx
+++ b/web/packages/teleport/src/Main/Main.tsx
@@ -184,7 +184,6 @@ export function Main(props: MainProps) {
       {showOnboardSurvey && (
         <Dialog open={showOnboardSurvey}>
           <props.Questionnaire
-            full={true}
             onSubmit={() => setShowOnboardSurvey(false)}
             onboard={false}
           />

--- a/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
+++ b/web/packages/teleport/src/Welcome/NewCredentials/NewCredentials.tsx
@@ -98,11 +98,9 @@ export function NewCredentials(props: NewCredentialsProps) {
     setDisplayOnboardingQuestionnaire &&
     Questionnaire
   ) {
-    // todo (michellescripts) check cluster config to determine if all or partial questions are asked
     return (
       <Card mx="auto" maxWidth="600px" p="4">
         <Questionnaire
-          full={true}
           username={resetToken.user}
           onSubmit={() => setDisplayOnboardingQuestionnaire(false)}
           onboard={true}

--- a/web/packages/teleport/src/Welcome/NewCredentials/types.ts
+++ b/web/packages/teleport/src/Welcome/NewCredentials/types.ts
@@ -43,7 +43,6 @@ export type UseTokenState = {
 
 // Note: QuestionnaireProps is duplicated in Enterprise (e-teleport/Welcome/Questionnaire/Questionnaire)
 export type QuestionnaireProps = {
-  full: boolean;
   onboard: boolean;
   username?: string;
   onSubmit?: () => void;
@@ -57,7 +56,6 @@ export type NewCredentialsProps = UseTokenState & {
   displayOnboardingQuestionnaire?: boolean;
   setDisplayOnboardingQuestionnaire?: (bool: boolean) => void;
   Questionnaire?: ({
-    full,
     onboard,
     username,
     onSubmit,


### PR DESCRIPTION
Removes the "full" prop from onboarding questionnaire components. Was hard-coded to true, but implementation changed to leverage sales center responses in the questionnaire itself: https://github.com/gravitational/teleport.e/pull/1873

supports https://github.com/gravitational/cloud/issues/4802