### PR TITLE
Add --silent flag to teleport node configure command

### DIFF
--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -185,6 +185,8 @@ type SampleFlags struct {
 	JoinMethod string
 	// NodeName is the name of the teleport node
 	NodeName string
+	// Silent suppresses user hint printed after config has been generated.
+	Silent bool
 }
 
 // MakeSampleFileConfig returns a sample config to start

--- a/tool/teleport/common/teleport_test.go
+++ b/tool/teleport/common/teleport_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package common
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -186,6 +187,20 @@ func TestConfigure(t *testing.T) {
 		flags := dumpFlags{}
 		err := flags.CheckAndSetDefaults()
 		require.NoError(t, err)
+	})
+
+	t.Run("Suppress output", func(t *testing.T) {
+		tempDir := t.TempDir()
+		var stdout bytes.Buffer
+		err := onConfigDump(dumpFlags{
+			SampleFlags: config.SampleFlags{
+				Silent: true,
+			},
+			output: filepath.Join(tempDir, "teleport.yaml"),
+			stdout: &stdout,
+		})
+		require.NoError(t, err)
+		require.Empty(t, stdout.Bytes())
 	})
 }
 


### PR DESCRIPTION
This is the first part to fixing https://github.com/gravitational/teleport/issues/29518. Adds `--silent` flag to `teleport node configure` that suppresses user hint message that looks confusing when shown in the install script output.

Note that this PR doesn't actually make use of this flag in the install script yet. It will come in a follow up, once there's a published release with this flag and Cloud has updated its /version endpoint to it. Otherwise I'm afraid the script will be downloading the older binary that doesn't support this flag.