### PR TITLE
Fix error when dynamodb table summary has an unspecified billing mode from an already existing table

### DIFF
--- a/lib/backend/dynamo/dynamodbbk.go
+++ b/lib/backend/dynamo/dynamodbbk.go
@@ -661,6 +661,13 @@ func (b *Backend) getTableStatus(ctx context.Context, tableName string) (tableSt
 			return tableStatusNeedsMigration, "", nil
 		}
 	}
+	// the billing mode can be empty unless it was specified on the
+	// initial create table request, and the default billing mode is
+	// PROVISIONED, if unspecified.
+	// https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BillingModeSummary.html
+	if td.Table.BillingModeSummary == nil {
+		return tableStatusOK, dynamodb.BillingModeProvisioned, nil
+	}
 	return tableStatusOK, aws.StringValue(td.Table.BillingModeSummary.BillingMode), nil
 }
 


### PR DESCRIPTION
When fetching the DynamoDB table summary the `BillingModeSummary` is not necessarily in the response if the table was created without specifying the billing mode initially

Tables that are created without specifying the billing mode will default to using provisioned 

fixes #29600