### PR TITLE
[v13] Fix GCP joining for Machine ID 

### DIFF
--- a/lib/tbot/renew.go
+++ b/lib/tbot/renew.go
@@ -534,6 +534,7 @@ func (b *Bot) renewIdentityViaAuth(
 	// renewing using existing credentials.
 	case types.JoinMethodAzure,
 		types.JoinMethodCircleCI,
+		types.JoinMethodGCP,
 		types.JoinMethodGitHub,
 		types.JoinMethodGitLab,
 		types.JoinMethodIAM:


### PR DESCRIPTION
Fix issue reported with GCP joining for Machine ID. This issue was introduced during backporting as the structure of `master` varies significantly from `branch/v13` - this sort of mistake isn't actually even possible in the `master` codebase now as this exhaustive list has been inverted.

This resulted in `ssh: handshake failed: ssh: no authorities for hostname:` when the bot attempted to create a client with the new identity returned by the `GenerateUserCert` RPC.