### PR TITLE
update shield alert icon name

### DIFF
--- a/web/packages/design/src/SVGIcon/ShieldAlert.tsx
+++ b/web/packages/design/src/SVGIcon/ShieldAlert.tsx
@@ -20,7 +20,7 @@ import { SVGIcon } from './SVGIcon';
 
 import type { SVGIconProps } from './common';
 
-export function ShieldAlert({ size = 16, fill }: SVGIconProps) {
+export function ShieldAlertIcon({ size = 16, fill }: SVGIconProps) {
   return (
     <SVGIcon viewBox="0 0 24 24" size={size} fill={fill}>
       <path d="M12 8.25C12.4142 8.25 12.75 8.58579 12.75 9V12.75C12.75 13.1642 12.4142 13.5 12 13.5C11.5858 13.5 11.25 13.1642 11.25 12.75V9C11.25 8.58579 11.5858 8.25 12 8.25Z" />

--- a/web/packages/design/src/SVGIcon/index.ts
+++ b/web/packages/design/src/SVGIcon/index.ts
@@ -61,7 +61,7 @@ export { ServerIcon } from './Server';
 export { ServersIcon } from './Servers';
 export { SessionRecordingsIcon } from './SessionRecordings';
 export { SettingsIcon } from './Settings';
-export { ShieldAlert } from './ShieldAlert';
+export { ShieldAlertIcon } from './ShieldAlert';
 export { SidebarIcon } from './Sidebar';
 export { SupportIcon } from './Support';
 export { TerminalIcon } from './Terminal';


### PR DESCRIPTION
I noticed missing word "Icon" in `ShiledAlert` svg I added in https://github.com/gravitational/teleport/pull/29528 (somehow I completely overlooked the name!). This PR updates that name for consistency. 