### PR TITLE
helm: add azure support

### DIFF
--- a/examples/chart/teleport-cluster/.lint/azure.yaml
+++ b/examples/chart/teleport-cluster/.lint/azure.yaml
@@ -1,0 +1,11 @@
+clusterName: test-azure-cluster
+chartMode: azure
+azure:
+  databaseHost: "mypostgresinstance.postgres.database.azure.com"
+  databaseUser: "teleport"
+  backendDatabase: "teleport_backend"
+  auditLogDatabase: "teleport_audit"
+  auditLogMirrorOnStdout: true
+  sessionRecordingStorageAccount: "mystorageaccount.blob.core.windows.net"
+  clientID: "1234"
+  databasePoolMaxConnections: 100

--- a/examples/chart/teleport-cluster/templates/auth/_config.azure.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.azure.tpl
@@ -1,0 +1,38 @@
+{{/* Helper to build the database connection string, adds paraneters if needed */}}
+{{- define "teleport-cluster.auth.config.azure.conn_string.query" }}
+  {{- if .Values.azure.databasePoolMaxConnections -}}
+    {{- printf "sslmode=verify-full&pool_max_conns=%v" .Values.azure.databasePoolMaxConnections -}}
+  {{- else -}}
+    sslmode=verify-full
+  {{- end -}}
+{{- end -}}
+
+{{- define "teleport-cluster.auth.config.azure" -}}
+{{ include "teleport-cluster.auth.config.common" . }}
+  storage:
+    type: postgresql
+    auth_mode: azure
+    conn_string: {{ urlJoin (dict
+      "scheme" "postgresql"
+      "userinfo" .Values.azure.databaseUser
+      "host" .Values.azure.databaseHost
+      "path" .Values.azure.backendDatabase
+      "query" (include "teleport-cluster.auth.config.azure.conn_string.query" .)
+    ) | toYaml }}
+    audit_sessions_uri: {{ urlJoin (dict
+      "scheme" "azblob"
+      "host" .Values.azure.sessionRecordingStorageAccount
+    ) | toYaml }}
+    audit_events_uri:
+      - {{ urlJoin (dict
+          "scheme" "postgresql"
+          "userinfo" .Values.azure.databaseUser
+          "host" .Values.azure.databaseHost
+          "path" .Values.azure.auditLogDatabase
+          "query" "sslmode=verify-full"
+          "fragment" "auth_mode=azure"
+        ) | toYaml }}
+{{- if .Values.azure.auditLogMirrorOnStdout }}
+      - "stdout://"
+{{- end }}
+{{- end -}}

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -43,6 +43,9 @@ spec:
       labels:
         {{- include "teleport-cluster.auth.labels" . | nindent 8 }}
         app: {{ .Release.Name }}
+{{- if eq $auth.chartMode "azure"}}
+        azure.workload.identity/use: "true"
+{{- end }}
     spec:
 {{- if $auth.nodeSelector }}
       nodeSelector: {{- toYaml $auth.nodeSelector | nindent 8 }}
@@ -302,7 +305,7 @@ spec:
         configMap:
           name: {{ .Release.Name }}-auth
       - name: "data"
-        {{- if and ($auth.persistence.enabled) ( and (not (eq $auth.chartMode "gcp")) (not (eq $auth.chartMode "aws"))) }}
+        {{- if and ($auth.persistence.enabled) ( and (not (eq $auth.chartMode "gcp")) (not (eq $auth.chartMode "aws")) (not (eq $auth.chartMode "azure"))) }}
         persistentVolumeClaim:
           claimName: {{ if $auth.persistence.existingClaimName }}{{ $auth.persistence.existingClaimName }}{{ else }}{{ .Release.Name }}{{ end }}
         {{- else }}

--- a/examples/chart/teleport-cluster/templates/auth/pvc.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/pvc.yaml
@@ -1,7 +1,7 @@
 {{- $auth := mustMergeOverwrite (mustDeepCopy .Values) .Values.auth -}}
 {{- if $auth.persistence.enabled }}
-  {{/* Disable persistence for aws and gcp modes */}}
-  {{- if and (not (eq $auth.chartMode "aws")) (not (eq $auth.chartMode "gcp")) }}
+  {{/* Disable persistence for cloud modes */}}
+  {{- if and (not (eq $auth.chartMode "aws")) (not (eq $auth.chartMode "gcp")) (not (eq $auth.chartMode "azure")) }}
     {{/* No need to create a PVC if we reuse an existing claim */}}
     {{- if not $auth.persistence.existingClaimName }}
 apiVersion: v1

--- a/examples/chart/teleport-cluster/templates/auth/serviceaccount.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/serviceaccount.yaml
@@ -5,8 +5,13 @@ kind: ServiceAccount
 metadata:
   name: {{ template "teleport-cluster.auth.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- if $auth.annotations.serviceAccount }}
+  {{- if or $auth.annotations.serviceAccount $auth.azure.clientID }}
   annotations:
-{{- toYaml $auth.annotations.serviceAccount | nindent 4 }}
-{{- end -}}
+    {{- if $auth.annotations.serviceAccount }}
+      {{- toYaml $auth.annotations.serviceAccount | nindent 4 }}
+    {{- end }}
+    {{- if $auth.azure.clientID }}
+    azure.workload.identity/client-id: "{{ $auth.azure.clientID }}"
+    {{- end }}
+  {{- end -}}
 {{- end }}

--- a/examples/chart/teleport-cluster/templates/proxy/_config.azure.tpl
+++ b/examples/chart/teleport-cluster/templates/proxy/_config.azure.tpl
@@ -1,0 +1,3 @@
+{{- define "teleport-cluster.proxy.config.azure" -}}
+{{ include "teleport-cluster.proxy.config.common" . }}
+{{- end -}}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_config_test.yaml.snap
@@ -687,6 +687,92 @@ matches snapshot for aws.yaml:
           table_name: test-dynamodb-backend-table
           type: dynamodb
       version: v3
+matches snapshot for azure.yaml:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factor: "on"
+          type: local
+          webauthn:
+            rp_id: test-azure-cluster
+        cluster_name: test-azure-cluster
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: test-azure-cluster
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+        storage:
+          audit_events_uri:
+          - postgresql://teleport@mypostgresinstance.postgres.database.azure.com/teleport_audit?sslmode=verify-full#auth_mode=azure
+          - stdout://
+          audit_sessions_uri: azblob://mystorageaccount.blob.core.windows.net
+          auth_mode: azure
+          conn_string: postgresql://teleport@mypostgresinstance.postgres.database.azure.com/teleport_backend?sslmode=verify-full&pool_max_conns=100
+          type: postgresql
+      version: v3
+matches snapshot for azure.yaml without pool_max_conn:
+  1: |
+    |-
+      auth_service:
+        authentication:
+          local_auth: true
+          second_factor: "on"
+          type: local
+          webauthn:
+            rp_id: test-azure-cluster
+        cluster_name: test-azure-cluster
+        enabled: true
+        proxy_listener_mode: separate
+      kubernetes_service:
+        enabled: true
+        kube_cluster_name: test-azure-cluster
+        listen_addr: 0.0.0.0:3026
+        public_addr: RELEASE-NAME-auth.NAMESPACE.svc.cluster.local:3026
+      proxy_service:
+        enabled: false
+      ssh_service:
+        enabled: false
+      teleport:
+        auth_server: 127.0.0.1:3025
+        log:
+          format:
+            extra_fields:
+            - timestamp
+            - level
+            - component
+            - caller
+            output: text
+          output: stderr
+          severity: INFO
+        storage:
+          audit_events_uri:
+          - postgresql://teleport@mypostgresinstance.postgres.database.azure.com/teleport_audit?sslmode=verify-full#auth_mode=azure
+          - stdout://
+          audit_sessions_uri: azblob://mystorageaccount.blob.core.windows.net
+          auth_mode: azure
+          conn_string: postgresql://teleport@mypostgresinstance.postgres.database.azure.com/teleport_backend?sslmode=verify-full
+          type: postgresql
+      version: v3
 matches snapshot for existing-tls-secret-with-ca.yaml:
   1: |
     |-

--- a/examples/chart/teleport-cluster/tests/auth_config_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_config_test.yaml
@@ -477,3 +477,28 @@ tests:
           value: null
       - matchSnapshot:
           path: data.apply-on-startup\.yaml
+
+  - it: matches snapshot for azure.yaml
+    values:
+      - ../.lint/azure.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml
+
+  - it: matches snapshot for azure.yaml without pool_max_conn
+    values:
+      - ../.lint/azure.yaml
+    set:
+      azure:
+        databasePoolMaxConnections: 0
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot:
+          path: data.teleport\.yaml

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -1,4 +1,4 @@
-suite: Auth StatefulSet
+suite: Auth Deployment
 templates:
   - auth/deployment.yaml
   - auth/config.yaml
@@ -814,3 +814,13 @@ tests:
             mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             name: auth-serviceaccount-token
             readOnly: true
+
+  - it: should add the azure workload identity label to auth pods in azure mode
+    template: auth/deployment.yaml
+    set:
+      chartMode: azure
+      clusterName: teleport.example.com
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels.azure\.workload\.identity/use
+          value: "true"

--- a/examples/chart/teleport-cluster/tests/auth_pvc_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_pvc_test.yaml
@@ -66,3 +66,10 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: does not create a PersistentVolumeClaim when chartMode=azure
+    set:
+      chartMode: azure
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_serviceaccount_test.yaml
@@ -20,3 +20,13 @@ tests:
       - equal:
           path: metadata.name
           value: "helm-lint"
+
+  - it: sets Azure client ID when set
+    set:
+      chartMode: azure
+      azure:
+        clientID: "1234"
+    asserts:
+      - equal:
+          path: metadata.annotations.azure\.workload\.identity/client-id
+          value: "1234"

--- a/examples/chart/teleport-cluster/values.schema.json
+++ b/examples/chart/teleport-cluster/values.schema.json
@@ -305,6 +305,7 @@
             "enum": [
                 "standalone",
                 "aws",
+                "azure",
                 "gcp",
                 "scratch"
             ],
@@ -460,6 +461,52 @@
                         "$id": "#/properties/aws/properties/writeTargetValue",
                         "type": "null"
                     }
+                }
+            }
+        },
+        "azure": {
+            "$id": "#/properties/azure",
+            "type": "object",
+            "properties": {
+                "databaseHost": {
+                    "$id": "#/properties/azure/properties/databaseHost",
+                    "type": "string",
+                    "default": ""
+                },
+                "databaseUser": {
+                    "$id": "#/properties/azure/properties/databaseUser",
+                    "type": "string",
+                    "default": ""
+                },
+                "backendDatabase": {
+                    "$id": "#/properties/azure/properties/backendDatabase",
+                    "type": "string",
+                    "default": "teleport_backend"
+                },
+                "auditLogDatabase": {
+                    "$id": "#/properties/azure/properties/auditLogDatabase",
+                    "type": "string",
+                    "default": "teleport_audit"
+                },
+                "auditLogMirrorOnStdout": {
+                    "$id": "#/properties/azure/properties/auditLogMirrorOnStdout",
+                    "type": "boolean",
+                    "default": false
+                },
+                "sessionRecordingStorageAccount": {
+                    "$id": "#/properties/azure/properties/sessionRecordingStorageAccount",
+                    "type": "string",
+                    "default": ""
+                },
+                "clientID": {
+                    "$id": "#/properties/azure/properties/clientID",
+                    "type": "string",
+                    "default": ""
+                },
+                "databasePoolMaxConnections": {
+                    "$id": "#/properties/azure/properties/databasePoolMaxConnections",
+                    "type": "integer",
+                    "default": 0
                 }
             }
         },

--- a/examples/chart/teleport-cluster/values.yaml
+++ b/examples/chart/teleport-cluster/values.yaml
@@ -250,10 +250,12 @@ labels: {}
 # - "standalone": will deploy a Teleport container running auth and proxy services with a PersistentVolumeClaim for storage.
 # - "aws": will deploy Teleport using DynamoDB for backend/audit log storage and S3 for session recordings. (1)
 # - "gcp": will deploy Teleport using Firestore for backend/audit log storage and Google Cloud storage for session recordings. (2)
-# - "scratch": will deploy Teleport containers but will not provide default configuration file. You must pass your own configuration. (3)
+# - "azure": will deploy Teleport using Azure Database for PostgreSQL for backend/audit and Azure Blob Storage for session recordings. (3)
+# - "scratch": will deploy Teleport containers but will not provide default configuration file. You must pass your own configuration. (4)
 # (1) To use "aws" mode, you must also configure the "aws" section below.
 # (2) To use "gcp" mode, you must also configure the "gcp" section below.
-# (3) When set to "scratch", you must write the teleport configuration in auth.teleportConfig and proxy.teleportConfig.
+# (3) To use "azure" mode, you must also configure the "azure" section below.
+# (4) When set to "scratch", you must write the teleport configuration in auth.teleportConfig and proxy.teleportConfig.
 # `scratch` usage is strongly discouraged, this is a last resort option and
 # everything should be doable with `standalone` mode + overrides through
 # `auth.teleportConfig` and `proxy.teleportConfig`.
@@ -363,6 +365,39 @@ gcp:
   # You can override this to a blank value if the worker node running Teleport already has a service account which grants access.
   credentialSecretName: teleport-gcp-credentials
 
+#####################################################
+# Azure-specific settings (only used in "azure" mode)
+#####################################################
+azure:
+  # The fully qualified hostname of the Postgres database cluster hosted in Azure.
+  # It should follow the format "<database name>.postgres.database.azure.com".
+  databaseHost: ""
+  # The Postgres user Teleport must use to connect to the backend and audit
+  # databases.
+  databaseUser: ""
+  # The Postgres database to use for backend storage.
+  backendDatabase: "teleport_backend"
+  # The Postgres database to use for audit log storage.
+  # This MUST NOT be the same database as used for 'backendDatabase'.
+  auditLogDatabase: "teleport_audit"
+  # Whether to mirror audit log entries to stdout in JSON format (useful for external log collectors)
+  auditLogMirrorOnStdout: false
+  # The fully qualified domain name of the Azure Blob Storage account to use for
+  # recorded session storage. This account must already exist.
+  # It should follow the format "<storage account>.blob.core.windows.net"
+  sessionRecordingStorageAccount: ""
+  # Azure client ID is used by the Kubernetes Service Account to know which
+  # Application it should impersonate. This can be unset only if the clientID is
+  # passed through other means (e.g. environment variable)
+  clientID: ""
+  # Controls the `pool_max_conns` setting passed to PostgreSQL. This is the
+  # max amount of connections Teleport can open to the database. This can affect
+  # performance on large clusters and depends on various factors like the
+  # database size, the number of CPU cores available for Teleport, GOMAXPROCS
+  # and the database latency.
+  # This only applies to the core backend connections, not the audit log ones.
+  # 0 means the parameter is not set and the client's default is used (recommended)
+  databasePoolMaxConnections: 0
 
 # `highAvailability` contains settings controlling how Teleport pods are
 # replicated and scheduled. This allows Teleport to run in a highly-available


### PR DESCRIPTION
Implements azure support in the chart based on @espadolini requirements.

Reference documentation is NOT part of this PR. It will be added later in an azure documentation PR by @espadolini.

Tests are failing, this is a Helm bug. Updating the Helm version in the CI will fix this.