### PR TITLE
Docs: OIDC spelling hotfix

### DIFF
--- a/docs/pages/access-controls/sso/oidc.mdx
+++ b/docs/pages/access-controls/sso/oidc.mdx
@@ -57,7 +57,7 @@ with your Teleport Cloud tenant or Proxy Service address.
 ## OIDC connector configuration
 
 The next step is to add an OIDC connector to Teleport. The connectors are
-created, test, and added or removed using `tctl` [resource commands](../../reference/resources.mdx)
+created, tested, and added or removed using `tctl` [resource commands](../../reference/resources.mdx)
 or the Teleport Web UI.
 
 To create a new connector, use `tctl sso configure`. The following example creates a


### PR DESCRIPTION
Fixes a typo introduced in #29087 and caught in the backports. Will update the backports for 29087 so this one need not be backported.