### PR TITLE
Add support for Amazon Linux 2023 to installer script and Discover UI

### DIFF
--- a/lib/web/scripts/node-join/install.sh
+++ b/lib/web/scripts/node-join/install.sh
@@ -933,7 +933,7 @@ is_repo_available() {
         debian-9* | debian-10* | debian-11* | \
         rhel-7* | rhel-8* | rhel-9* | \
         centos-7* | centos-8* | centos-9* | \
-        amzn-2)
+        amzn-2 | amzn-2023)
             return 0;;
     esac
 

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -295,7 +295,7 @@ exports[`render with URL loc state set to "server" 1`] = `
           <div
             class="c18"
           >
-            Amazon Linux 2
+            Amazon Linux 2/2023
           </div>
         </div>
       </div>
@@ -884,7 +884,7 @@ exports[`render with all access 1`] = `
           <div
             class="c14"
           >
-            Amazon Linux 2
+            Amazon Linux 2/2023
           </div>
         </div>
       </div>
@@ -2599,7 +2599,7 @@ exports[`render with no access 1`] = `
           <div
             class="c14"
           >
-            Amazon Linux 2
+            Amazon Linux 2/2023
           </div>
         </div>
       </div>
@@ -4469,7 +4469,7 @@ exports[`render with partial access 1`] = `
           <div
             class="c14"
           >
-            Amazon Linux 2
+            Amazon Linux 2/2023
           </div>
         </div>
       </div>

--- a/web/packages/teleport/src/Discover/SelectResource/resources.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/resources.tsx
@@ -51,7 +51,7 @@ export const SERVERS: ResourceSpec[] = [
     event: DiscoverEventResource.Server,
   },
   {
-    name: 'Amazon Linux 2',
+    name: 'Amazon Linux 2/2023',
     kind: ResourceKind.Server,
     keywords: baseServerKeywords + 'amazon linux',
     icon: 'Aws',


### PR DESCRIPTION
The installer script was hardcoded to only allow `amzn` version `2`. We have a repo for `amzn` version `2023` which works fine, so we should use that instead.