### PR TITLE
Attempt to deflake TestLockInForce

### DIFF
--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -574,7 +574,7 @@ func TestLockInForce(t *testing.T) {
 			return false
 		}
 	}
-	require.Eventually(t, sessionHasFinished, 1*time.Second, 100*time.Millisecond,
+	require.Eventually(t, sessionHasFinished, 3*time.Second, 100*time.Millisecond,
 		"Timed out waiting for session to finish")
 
 	// Expect the lock-in-force message to have been delivered via stderr.


### PR DESCRIPTION
Increases the session termination timeout from 1s to 3s to attempt to reduce the flakiness of the test.

Closes #13770