### PR TITLE
[v11] docs: include mfa session option for ssh access control

### DIFF
--- a/docs/pages/server-access/rbac.mdx
+++ b/docs/pages/server-access/rbac.mdx
@@ -169,6 +169,9 @@ spec:
       # Optional: Session recording mode for SSH sessions. 
       # If not set, the value set on default will be used.
       ssh: best_effort|strict
+    # Require an additional MFA tap to start new sessions.
+    # Optional: the default is false.
+    require_session_mfa: true
     # Enterprise-only: when enabled, the source IP that was used to log in is embedded in the SSH
     # certificate, preventing a compromised certificate from being used on other
     # devices. The default is false.

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4844,7 +4844,26 @@ func initSelfSignedHTTPSCert(cfg *Config) (err error) {
 	}
 	cfg.Log.Warningf("Generating self-signed key and cert to %v %v.", keyPath, certPath)
 
-	creds, err := cert.GenerateSelfSignedCert([]string{cfg.Hostname, "localhost"})
+	hosts := []string{cfg.Hostname, "localhost"}
+	var ips []string
+
+	// add web public address hosts to self-signed cert
+	for _, addr := range cfg.Proxy.PublicAddrs {
+		proxyHost, _, err := net.SplitHostPort(addr.String())
+		if err != nil {
+			// log and skip error since this is a nice to have
+			cfg.Log.Warnf("Error parsing proxy.public_address %v, skipping adding to self-signed cert: %v", addr.String(), err)
+			continue
+		}
+		// If the address is a IP have it added as IP SAN
+		if ip := net.ParseIP(proxyHost); ip != nil {
+			ips = append(ips, proxyHost)
+		} else {
+			hosts = append(hosts, proxyHost)
+		}
+	}
+
+	creds, err := cert.GenerateSelfSignedCert(hosts, ips)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -1832,7 +1832,7 @@ func (c *testContext) createUserAndRole(ctx context.Context, t *testing.T, userN
 
 // makeTLSConfig returns tls configuration for the test's tls listener.
 func (c *testContext) makeTLSConfig(t *testing.T) *tls.Config {
-	creds, err := cert.GenerateSelfSignedCert([]string{"localhost"})
+	creds, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil)
 	require.NoError(t, err)
 	cert, err := tls.X509KeyPair(creds.Cert, creds.PrivateKey)
 	require.NoError(t, err)

--- a/lib/teleterm/gateway/local_proxy_middleware_test.go
+++ b/lib/teleterm/gateway/local_proxy_middleware_test.go
@@ -35,7 +35,7 @@ import (
 )
 
 func TestLocalProxyMiddleware_OnNewConnection(t *testing.T) {
-	testCert, err := cert.GenerateSelfSignedCert([]string{"localhost"})
+	testCert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil)
 	require.NoError(t, err)
 	tlsCert, err := keys.X509KeyPair(testCert.Cert, testCert.PrivateKey)
 	require.NoError(t, err)

--- a/lib/teleterm/grpccredentials.go
+++ b/lib/teleterm/grpccredentials.go
@@ -108,7 +108,7 @@ func generateAndSaveCert(targetPath string) (tls.Certificate, error) {
 	}
 	defer os.Remove(tempFile.Name())
 
-	cert, err := cert.GenerateSelfSignedCert([]string{"localhost"})
+	cert, err := cert.GenerateSelfSignedCert([]string{"localhost"}, nil)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err, "failed to generate the certificate")
 	}

--- a/lib/utils/cert/selfsigned.go
+++ b/lib/utils/cert/selfsigned.go
@@ -50,7 +50,7 @@ type Credentials struct {
 
 // GenerateSelfSignedCert generates a self-signed certificate that
 // is valid for given domain names and ips, returns PEM-encoded bytes with key and cert
-func GenerateSelfSignedCert(hostNames []string) (*Credentials, error) {
+func GenerateSelfSignedCert(hostNames []string, ipAddresses []string) (*Credentials, error) {
 	priv, err := native.GenerateRSAPrivateKey()
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -86,6 +86,13 @@ func GenerateSelfSignedCert(hostNames []string) (*Credentials, error) {
 	ips, _ := net.LookupIP("localhost")
 	if ips != nil {
 		template.IPAddresses = append(ips, net.ParseIP("::1"))
+	}
+	for _, ip := range ipAddresses {
+		ipParsed := net.ParseIP(ip)
+		if ipParsed == nil {
+			return nil, trace.Errorf("Unable to parse IP address for self-signed certificate (%v)", ip)
+		}
+		template.IPAddresses = append(template.IPAddresses, ipParsed)
 	}
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
 	if err != nil {

--- a/lib/utils/utils_test.go
+++ b/lib/utils/utils_test.go
@@ -91,7 +91,7 @@ func TestHostUUIDRegenerateEmpty(t *testing.T) {
 func TestSelfSignedCert(t *testing.T) {
 	t.Parallel()
 
-	creds, err := cert.GenerateSelfSignedCert([]string{"example.com"})
+	creds, err := cert.GenerateSelfSignedCert([]string{"example.com"}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, creds)
 	require.Equal(t, 4, len(creds.PublicKey)/100)


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/29011 to branch/v11