### PR TITLE
Adds `GoArc`

### DIFF
--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -126,7 +126,7 @@ type Client struct {
 	handle cgo.Handle
 
 	// RDP client on the Rust side.
-	rustClient *C.Client
+	rustClient C.GoArc_Client
 
 	// Synchronization point to prevent input messages from being forwarded
 	// until the connection is established.

--- a/lib/srv/desktop/rdp/rdpclient/src/ga.rs
+++ b/lib/srv/desktop/rdp/rdpclient/src/ga.rs
@@ -1,0 +1,164 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! This module provides a wrapper around Arc built such that the underlying
+//! allocation can be passed to and from Go safely without violating Rust
+//! compiler guarantees.
+//!
+//! The [`GoArc`] (created by [`GoArc_new`]) is a raw pointer that is
+//! expected to be passed into Go and held on to for later use; in a sense
+//! it's like an [`Arc`] that's owned by Go. The only way for Rust to safely make use of
+//! the [`GoArc`] is to clone it into a [`Arc`], which is done by calling
+//! [`GoArc_clone`]. Finally, when Go is done with the [`GoArc`], it must drop it
+//! explicitly with [`GoArc_drop`].
+//!
+//! # Memory Management
+//!
+//! While being used in Rust as an [`Arc`], the underlying memory is managed
+//! by standard Rust [`Arc`] semantics.
+//!
+//! On the other hand, the [`GoArc`] itself is owned by Go, and Go doesn't have
+//! any understanding of Rust's ownership semantics, which means that it Go's
+//! responsibility to explicitly drop the [`GoArc`] using [`GoArc_drop`] when it's
+//! no longer needed.
+//!
+//! ## Memory Safety
+//!
+//! It's important that [`GoArc_drop`] is only called once per [`GoArc`]. Calling
+//! it multiple times will result in a double free.
+//!
+//! Once the [`GoArc`] is dropped, it's no longer safe to call [`GoArc_clone`] on
+//! it. Doing so could result in a use-after-free.
+//!
+//! # Thread Safety: [`Send`] + [`Sync`]
+//!
+//! [`GoArc_new`] enforces that the underlying type T is [`Send`] + [`Sync`].
+//!
+//! This constraint is enforced because the underlying memory is expected to
+//! be passed back into Rust from Go via FFI compatible functions, which might
+//! be called from any arbitrary thread selected by Go's runtime. By enforcing
+//! [`Send`] + [`Sync`], we can guarantee that the underlying memory is always
+//! safe to send to and access from any thread.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use ga::{GoArc_new, GoArc_clone, GoArc_drop};
+//!
+//! /// Imagine [`create_go_arc`] being called by CGO via the FFI.
+//! /// Go holds on to the [`GoArc`] returned to it by that call,
+//! /// uses it in any arbitrary goroutine(s) via [`use_go_arc`],
+//! /// and then drops it when it's done with it via [`drop_go_arc`].
+//!
+//! /// Creates a new [`GoArc`] containing the value 42.
+//! #[no_mangle]
+//! pub unsafe extern "C" fn create_go_arc() -> GoArc<u32> {
+//!     GoArc_new(42)
+//! }
+//!
+//! /// Uses the given [`GoArc`] by cloning it into a [`Arc`].
+//! ///
+//! /// This can be called from any arbitrary goroutine(s) in Go,
+//! /// so long as [`drop_go_arc`] hasn't been called yet.
+//! #[no_mangle]
+//! pub unsafe extern "C" fn use_go_arc(go_arc: GoArc<u32>) -> GoArc<u32> {
+//!     // Clone the [`GoArc`] into a [`Arc`] so that we can
+//!     // safely access the value inside.
+//!     let rust_arc = GoArc_clone(go_arc);
+//!
+//!     // We can use the [`Arc`] just like a normal [`Arc`] here.
+//!     // For example, we can directly call any non-mutating methods on
+//!     // the underlying u32 via the [`Deref`] trait.
+//!     let is_lt = rust_arc.lt(32);
+//!     if is_lt {
+//!        println!("{} is less than {}", 32, rust_arc);
+//!     } else {
+//!         println!("{} is not less than {}", 32, rust_arc);
+//!     }
+//!
+//!     // We can even clone it again if we want to, pass it around
+//!     // to other threads, etc.
+//!     let rust_arc_clone = rust_arc.clone();
+//!     std::thread::spawn(move || {
+//!        println!("Hello from another thread! {}", rust_arc_clone);
+//!     });
+//! }
+//!
+//! /// Drops the given [`GoArc`].
+//! ///
+//! /// This must be called once and only once by Go when it's done
+//! /// with the [`GoArc`]. After this is called, [`use_go_arc`] can
+//! /// no longer be called.
+//! #[no_mangle]
+//! pub unsafe extern "C" fn drop_go_arc(go_arc: GoArc<u32>) {
+//!     // Drop the [`GoArc`] explicitly.
+//!     GoArc_drop(go_arc);
+//! }
+//!
+//!
+//! let go_arc = GoArc_new(42);
+//! ```
+use std::sync::Arc;
+
+/// A raw pointer to an [`Arc`] that is owned by Go.
+/// See the module level documentation for more details.
+pub type GoArc<T> = *mut Arc<T>;
+
+/// Creates a new [`GoArc`] containing the given value.
+#[allow(non_snake_case)]
+pub fn GoArc_new<T>(inner: T) -> GoArc<T>
+where
+    T: Send + Sync,
+{
+    // Create a new Send + Sync Arc
+    let arc = Arc::new(inner);
+    // Move it to the heap
+    let boxed_arc = Box::new(arc);
+    // Convert it to a raw pointer, preventing it from being dropped.
+    // The Arc's count is now at 1, and will remain at at least 1
+    // until GoArc_drop is called on the returned pointer.
+    Box::into_raw(boxed_arc)
+}
+
+/// Clones the given [`GoArc`] into a [`Arc`].
+///
+/// # Safety
+///
+/// The given [`GoArc`] must not have been dropped yet
+/// (i.e. [`GoArc_drop`] must not have been called on it).
+#[allow(non_snake_case)]
+pub unsafe fn GoArc_clone<T>(raw: GoArc<T>) -> Arc<T>
+where
+    T: Send + Sync,
+{
+    // Take a reference to the Arc
+    let arc = &*raw;
+    // Return a clone of the Arc
+    arc.clone()
+}
+
+/// Drops the given [`GoArc`].
+///
+/// # Safety
+///
+/// This must be called once and only once per [`GoArc`].
+/// Calling it multiple times will result in a double free.
+#[allow(non_snake_case)]
+pub unsafe fn GoArc_drop<T: Send + Sync>(raw: GoArc<T>) {
+    // The raw pointer was created via Box::into_raw in GoArc_new,
+    // so we can reconstruct it here with Box::from_raw.
+    let boxed_arc = Box::from_raw(raw);
+    // Drop the Box, which will drop the Arc.
+    drop(boxed_arc);
+}


### PR DESCRIPTION
The impetus for this change was realizing that in the current iteration of the `ironrdp` branch, in order to get the compiler to shut up, I devised a way to get myself a `&mut Client` at the top of every `pub unsafe extern "C" fn` (Rust functions called by Go). This allowed me to call whatever functions I needed to on the `Client`, with the one massive oversight that it is in effect letting me break one of [the most foundational guarantees of the Rust compiler](https://doc.rust-lang.org/book/ch04-02-references-and-borrowing.html#mutable-references):

> [I]f you have a mutable reference to a value, you can have no other references to that value.

Because the pointer this `&mut Client` was being created from was being passed to/from Go, there was no way for the Rust compiler to notice this. The reality is that all of these `pub unsafe extern "C" fn`s can be called at any time, concurrently, from any thread ([selected by Go's runtime scheduler](https://stackoverflow.com/questions/28354141/c-code-and-goroutine-scheduling/28354879#28354879)).

With that in mind, I decided that what I should really be aiming for is passing around a Rust type which is built for such usage, namely an `Arc<T: Send + Sync>`. This is the type one would use in a pure Rust program where you need to create a single object and then use it in parallel amongst multiple threads.

`GoArc` is the solution I came up with as an FFI compatible API for creating, using, and cleaning up such an object. The idea here is to create "an Arc which is owned by Go", and then clone it every time you need to use it in Rust. Finally, when you're done with it in Go, you explicitly drop it (necessary because Go has no understanding of Rust ownership semantics). See the module level documentation in `ga.rs` for more detail.

**Note**: the `Sync` requirement on `Client` meant that I needed to add a `Mutex` around `IronRDPClient`, which as of this commit results in a deadlock. This will be addressed in a future couple of commits experimenting breaking this deadlock with both async vs sync. This `GoArc` is necessary for either direction we decide to go there.

