### PR TITLE
[v11] Update SQL Server guides to mention `sqlcmd` as default CLI (#29543)

### DIFF
--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -175,10 +175,7 @@ $ tsh db connect --db-user=sqlserver-identity --db-name=master sqlserver
 
 Where `--db-user` is the managed identity name.
 
-<Admonition type="note">
-  The `mssql-cli` command-line client should be available in `PATH` of the machine
-  you're running `tsh db connect` from.
-</Admonition>
+(!docs/pages/includes/database-access/sql-server-connect-note.mdx!)
 
 ## Troubleshooting
 

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -360,20 +360,7 @@ To retrieve credentials for a database and connect to it:
 $ tsh db connect --db-user=teleport sqlserver
 ```
 
-<Admonition type="note">
-When you run the `tsh db connect` command above, `tsh` attempts to execute
-the `mssql-cli` command-line client, which must be available in the user's
-`PATH`. If you do not have `mssql-cli` available on your system, you can run the
-following command to start a local proxy server that you can connect
-to with your SQL Server client:
-
-```code
-$ tsh proxy db --db-user=teleport --tunnel sqlserver
-```
-
-Read the [Database Access GUI Clients](../../connect-your-client/gui-clients.mdx#sql-server-with-azure-data-studio) 
-guide for how to connect your DB GUI client to the local proxy.
-</Admonition>
+(!docs/pages/includes/database-access/sql-server-connect-note.mdx!)
 
 To log out of the database and remove credentials:
 

--- a/docs/pages/includes/database-access/sql-server-connect-note.mdx
+++ b/docs/pages/includes/database-access/sql-server-connect-note.mdx
@@ -1,0 +1,16 @@
+<Admonition type="note">
+Either the `sqlcmd` or `mssql-cli` command-line clients should be available in
+`PATH` in order to be able to connect. `tsh` attempts to run `sqlcmd` first and,
+if it's not present on the `PATH`, runs `mssql-cli`.
+
+If you have neither command-line clients available on your system, you can run
+the following command to start a local proxy server that you can connect to with
+your SQL Server client:
+
+```code
+$ tsh proxy db --db-user=teleport --tunnel sqlserver
+```
+
+Read the [Database Access GUI Clients](../../connect-your-client/gui-clients.mdx#sql-server-with-azure-data-studio) 
+guide for how to connect your DB GUI client to the local proxy.
+</Admonition>


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/29543 to branch/v11