### PR TITLE
Bump Helm version in the buildbox

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -273,7 +273,7 @@ RUN scversion='v0.9.0' && \
 # Install helm.
 # Keep the version below synced with devbox.json
 RUN mkdir -p helm-tarball && \
-    curl -fsSL https://get.helm.sh/helm-v3.5.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \
+    curl -fsSL https://get.helm.sh/helm-v3.12.2-$(go env GOOS)-$(go env GOARCH).tar.gz | tar -C helm-tarball -xz && \
     cp helm-tarball/$(go env GOOS)-$(go env GOARCH)/helm /bin/ && \
     rm -r helm-tarball*
 # TODO(hugoShaka): remove this backward compatible hack with teleportv13 buildbox


### PR DESCRIPTION
Unblocks https://github.com/gravitational/teleport/pull/29581

This PR bumps the Helm versions. We were stuck because of PSPs, but since v13 we can update.

Replaces https://github.com/gravitational/teleport/pull/12760