### PR TITLE
ci: Fix post-release calling update-ami-ids

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -22,23 +22,23 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
         with:
-          ref: ${{ vars.GITHUB_REF }}
+          ref: ${{ github.ref }}
 
       # Release event metadata doesn't include "is latest" flag so we have
       # to determine it another way.
       - name: Determine release latest flag and version
         id: artifacts
         run: |
-          LATEST_RELEASE_ID=$(gh release view --json id | jq '.id' | tr -d \")
+          LATEST_RELEASE_ID=$(gh release view --json id -q id)
           CURRENT_RELEASE_ID=${{ github.event.release.node_id }}
 
-          if [ $LATEST_RELEASE_ID == $CURRENT_RELEASE_ID ]; then
-            echo "type=latest" >> $GITHUB_OUTPUT
+          if [ "$LATEST_RELEASE_ID" == "$CURRENT_RELEASE_ID" ]; then
+            echo "type=latest" >> "$GITHUB_OUTPUT"
           else
-            echo "type=other" >> $GITHUB_OUTPUT
+            echo "type=other" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "version=$(make --no-print-directory print-version)" >> $GITHUB_OUTPUT
+          echo "version=$(make --no-print-directory print-version)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -46,6 +46,6 @@ jobs:
     name: Update AMI IDs
     needs: release
     if: needs.release.outputs.type == 'latest'
-    uses: ./.github/workflows/update-ami-ids.yml
+    uses: gravitational/teleport/.github/workflows/update-ami-ids.yaml@master
     with:
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Fix the `post-release` workflow when calling the `update-ami-ids`
workflow. Two problems fixed:
1) The file extension is `.yaml` not `.yml`
2) You can't call a workflow in the current repo unless you check out
   the repo or you qualify the workflow with an owner/repository and a
   ref.

I've chosen to use the qualified form so we don't need to check out the
teleport repo just to call the `update-ami-ids` workflow as the previous
job already checked it out and `update-ami-ids` will also check it out,
so I feel a third checkout of the same repo is a bit excessive. Since
the workflow always runs of `master`, using the qualified form that
requires a ref works ok.

While we're here, fix up a couple of other things:

* `${{ vars.GITHUB_REF }}` is not correct. It was probably meant to be
  `${{ env.GITHUB_REF}}` (vars are from GitHub environments, not
  environment variables - different things), but I went with
  `${{ github.ref }}` as that is simpler.
* Quote a bunch of var expansions in the shell fragment, as actionlint
  and shellcheck complained about them.
* Use `gh`'s `-q` flag to remove the `jq | tr` pipeline.

This is hard to test since it triggers off the latest GitHub release.
Currently this workflow is not working so no harm if this is still not
right - we'll continue to tweak it.