### PR TITLE
Link to example Login Rules from Login Rules guide

### DIFF
--- a/docs/pages/access-controls/login-rules.mdx
+++ b/docs/pages/access-controls/login-rules.mdx
@@ -49,7 +49,8 @@ traits_map:
 
 Check out the [Login Rules guide](./login-rules/guide.mdx) for a quick walkthrough
 that will show you how to write, test, and add the first Login Rule to your
-cluster.
+cluster. See [example Login Rules](./login-rules/guide.mdx#example-login-rules) to
+learn how to adress common use cases.
 
 When you're ready to take full advantage of Login Rules in your cluster, see the
 [Login Rules Reference](./login-rules/reference.mdx) for details on the expression

--- a/docs/pages/access-controls/login-rules.mdx
+++ b/docs/pages/access-controls/login-rules.mdx
@@ -50,7 +50,7 @@ traits_map:
 Check out the [Login Rules guide](./login-rules/guide.mdx) for a quick walkthrough
 that will show you how to write, test, and add the first Login Rule to your
 cluster. See [example Login Rules](./login-rules/guide.mdx#example-login-rules) to
-learn how to adress common use cases.
+learn how to address common use cases.
 
 When you're ready to take full advantage of Login Rules in your cluster, see the
 [Login Rules Reference](./login-rules/reference.mdx) for details on the expression


### PR DESCRIPTION
A customer asked how to use Login Rules to trim down traits. I looked at the docs but I couldn't find examples on how to use Login Roles to achieve the use cases listed on [the main page](https://goteleport.com/docs/access-controls/login-rules/).

I completely overlooked that at the end of [the guide](http://localhost:3000/docs/access-controls/login-rules/guide/) there's a separate section with examples – I didn't expect the guide to have some extra content beyond the steps.

This PR adds a link to that section to the main Login Rules page.

Relevant Zendesk ticket: https://gravitational.zendesk.com/agent/tickets/7726