### PR TITLE
ALPN upgrade with custom X-Teleport-Upgrade header

### DIFF
--- a/api/client/alpn_conn_upgrade.go
+++ b/api/client/alpn_conn_upgrade.go
@@ -217,6 +217,7 @@ func upgradeConnThroughWebAPI(conn net.Conn, api url.URL, upgradeType string) (n
 	}
 
 	req.Header.Add(constants.WebAPIConnUpgradeHeader, upgradeType)
+	req.Header.Add(constants.WebAPIConnUpgradeTeleportHeader, upgradeType)
 
 	// Set "Connection" header to meet RFC spec:
 	// https://datatracker.ietf.org/doc/html/rfc2616#section-14.42

--- a/api/client/alpn_conn_upgrade_test.go
+++ b/api/client/alpn_conn_upgrade_test.go
@@ -299,6 +299,7 @@ func mockConnUpgradeHandler(t *testing.T, upgradeType string, write []byte) http
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, constants.WebAPIConnUpgrade, r.URL.Path)
 		require.Equal(t, upgradeType, r.Header.Get(constants.WebAPIConnUpgradeHeader))
+		require.Equal(t, upgradeType, r.Header.Get(constants.WebAPIConnUpgradeTeleportHeader))
 		require.Equal(t, constants.WebAPIConnUpgradeConnectionType, r.Header.Get(constants.WebAPIConnUpgradeConnectionHeader))
 
 		hj, ok := w.(http.Hijacker)

--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -406,6 +406,11 @@ const (
 	// WebAPIConnUpgradeHeader is the header used to indicate the requested
 	// connection upgrade types in the connection upgrade API.
 	WebAPIConnUpgradeHeader = "Upgrade"
+	// WebAPIConnUpgradeTeleportHeader is a Teleport-specific header used to
+	// indicate the requested connection upgrade types in the connection
+	// upgrade API. This header is sent in addition to "Upgrade" header in case
+	// a load balancer/reverse proxy removes "Upgrade".
+	WebAPIConnUpgradeTeleportHeader = "X-Teleport-Upgrade"
 	// WebAPIConnUpgradeTypeALPN is a connection upgrade type that specifies
 	// the upgraded connection should be handled by the ALPN handler.
 	WebAPIConnUpgradeTypeALPN = "alpn"

--- a/lib/web/conn_upgrade.go
+++ b/lib/web/conn_upgrade.go
@@ -35,7 +35,10 @@ import (
 // selectConnectionUpgrade selects the requested upgrade type and returns the
 // corresponding handler.
 func (h *Handler) selectConnectionUpgrade(r *http.Request) (string, ConnectionHandler, error) {
-	upgrades := r.Header.Values(constants.WebAPIConnUpgradeHeader)
+	upgrades := append(
+		r.Header.Values(constants.WebAPIConnUpgradeTeleportHeader),
+		r.Header.Values(constants.WebAPIConnUpgradeHeader)...,
+	)
 	for _, upgradeType := range upgrades {
 		switch upgradeType {
 		case constants.WebAPIConnUpgradeTypeALPNPing:
@@ -130,6 +133,7 @@ func (h *Handler) startPing(ctx context.Context, pingConn *pingconn.PingConn) {
 func writeUpgradeResponse(w io.Writer, upgradeType string) error {
 	header := make(http.Header)
 	header.Add(constants.WebAPIConnUpgradeHeader, upgradeType)
+	header.Add(constants.WebAPIConnUpgradeTeleportHeader, upgradeType)
 	header.Add(constants.WebAPIConnUpgradeConnectionHeader, constants.WebAPIConnUpgradeConnectionType)
 	response := &http.Response{
 		Status:     http.StatusText(http.StatusSwitchingProtocols),

--- a/rfd/0123-tls-routing-behind-layer7-lb.md
+++ b/rfd/0123-tls-routing-behind-layer7-lb.md
@@ -1,6 +1,6 @@
 ---
 authors: STeve Huang (xin.huang@goteleport.com)
-state: draft
+state: implemented
 ---
 
 # RFD 0123 - TLS Routing behind load balancers
@@ -84,6 +84,11 @@ Teleport Proxy:
 ```
 
 This allows the client to tunnel the "original TLS Routing" call through a Layer 7 (HTTP) load balancer.
+
+In addition to the `Upgrade` header, the following headers are also set from the client:
+- `Connection` header is set to `Upgrade` to meet [RFC spec](https://datatracker.ietf.org/doc/html/rfc2616#section-14.42)
+- `X-Teleport-Upgrade` header is set to the same value as the `Upgrade` header as some load balancers have seen
+  dropping values from the `Upgrade` header
 
 ### Teleport Proxy with self-signed certs
 


### PR DESCRIPTION
During ALPN connection upgrade, client now sets `X-Teleport-Upgrade` header to the same value as the `Upgrade` header as some load balancers have seen dropping values from the `Upgrade` header. 

Server side will check both `Upgrade` and `X-Teleport-Upgrade` header values.