### PR TITLE
Fix an issue sometimes MachineID does not work behind L7 LB

### DIFF
--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
-	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/webclient"
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/defaults"
@@ -43,11 +42,6 @@ func (c *Cluster) SyncAuthPreference(ctx context.Context) (*webclient.WebConfigA
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-
-	// Do the ALPN handshake test to decide if connection upgrades are required
-	// for TLS Routing. Only do the test once Ping verifies the cluster is
-	// reachable.
-	c.clusterClient.TLSRoutingConnUpgradeRequired = apiclient.IsALPNConnUpgradeRequired(ctx, c.clusterClient.WebProxyAddr, c.clusterClient.InsecureSkipVerify)
 
 	if err := c.clusterClient.SaveProfile(false); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/teleterm/clusters/storage.go
+++ b/lib/teleterm/clusters/storage.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/gravitational/trace"
 
-	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/profile"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
@@ -170,11 +169,6 @@ func (s *Storage) addCluster(ctx context.Context, dir, webProxyAddress string) (
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-
-	// Do the ALPN handshake test to decide if connection upgrades are required
-	// for TLS Routing. Only do the test once Ping verifies the cluster is
-	// reachable.
-	clusterClient.TLSRoutingConnUpgradeRequired = apiclient.IsALPNConnUpgradeRequired(ctx, webProxyAddress, s.InsecureSkipVerify)
 
 	if err := clusterClient.SaveProfile(false); err != nil {
 		return nil, nil, trace.Wrap(err)


### PR DESCRIPTION
Fixes #28486
- #28486

When `tbot` wraps `tsh`, it passes `--identity` instead of using a saved profile:
https://github.com/gravitational/teleport/blob/cf23101efbad671d6f65bd502f5025997e446be9/tool/tsh/common/tsh.go#L3325-L3338

The ALPN handshake test (to decide if ALPN conn upgrade is required) was missing in this case.