### PR TITLE
personalize discover with user preferences

### DIFF
--- a/web/packages/teleport/src/Apps/Apps.tsx
+++ b/web/packages/teleport/src/Apps/Apps.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { Indicator, Box } from 'design';
+import { Box, Indicator } from 'design';
 
 import useTeleport from 'teleport/useTeleport';
 import {
@@ -28,8 +28,10 @@ import ErrorMessage from 'teleport/components/AgentErrorMessage';
 
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 
+import { SearchResource } from 'teleport/Discover/SelectResource';
+
 import AppList from './AppList';
-import { useApps, State } from './useApps';
+import { State, useApps } from './useApps';
 
 export default function Container() {
   const ctx = useTeleport();
@@ -69,7 +71,7 @@ export function Apps(props: State) {
         <FeatureHeaderTitle>Applications</FeatureHeaderTitle>
         {attempt.status === 'success' && !hasNoApps && (
           <AgentButtonAdd
-            agent="application"
+            agent={SearchResource.APPLICATION}
             beginsWithVowel={true}
             isLeafCluster={isLeafCluster}
             canCreate={canCreate}
@@ -116,7 +118,7 @@ const emptyStateInfo: EmptyStateInfo = {
   byline:
     'Teleport Application Access provides secure access to internal applications.',
   docsURL: 'https://goteleport.com/docs/application-access/getting-started/',
-  resourceType: 'application',
+  resourceType: SearchResource.APPLICATION,
   readOnly: {
     title: 'No Applications Found',
     resource: 'applications',

--- a/web/packages/teleport/src/Databases/Databases.tsx
+++ b/web/packages/teleport/src/Databases/Databases.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Indicator, Box } from 'design';
+import { Box, Indicator } from 'design';
 
 import useTeleport from 'teleport/useTeleport';
 import {
@@ -28,8 +28,10 @@ import ErrorMessage from 'teleport/components/AgentErrorMessage';
 
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 
+import { SearchResource } from 'teleport/Discover/SelectResource';
+
 import DatabaseList from './DatabaseList';
-import { useDatabases, State } from './useDatabases';
+import { State, useDatabases } from './useDatabases';
 
 export default function Container() {
   const ctx = useTeleport();
@@ -72,7 +74,7 @@ export function Databases(props: State) {
         <FeatureHeaderTitle>Databases</FeatureHeaderTitle>
         {attempt.status === 'success' && !hasNoDatabases && (
           <AgentButtonAdd
-            agent="database"
+            agent={SearchResource.DATABASE}
             beginsWithVowel={false}
             isLeafCluster={isLeafCluster}
             canCreate={canCreate}
@@ -123,7 +125,7 @@ const emptyStateInfo: EmptyStateInfo = {
   byline:
     'Teleport Database Access provides secure access to PostgreSQL, MySQL, MariaDB, MongoDB, Redis, and Microsoft SQL Server.',
   docsURL: 'https://goteleport.com/docs/database-access/guides/',
-  resourceType: 'database',
+  resourceType: SearchResource.DATABASE,
   readOnly: {
     title: 'No Databases Found',
     resource: 'databases',

--- a/web/packages/teleport/src/Desktops/Desktops.tsx
+++ b/web/packages/teleport/src/Desktops/Desktops.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Indicator, Box } from 'design';
+import { Box, Indicator } from 'design';
 
 import useTeleport from 'teleport/useTeleport';
 import {
@@ -28,8 +28,10 @@ import ErrorMessage from 'teleport/components/AgentErrorMessage';
 
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 
+import { SearchResource } from 'teleport/Discover/SelectResource';
+
 import DesktopList from './DesktopList';
-import { useDesktops, State } from './useDesktops';
+import { State, useDesktops } from './useDesktops';
 
 const DOC_URL = 'https://goteleport.com/docs/desktop-access/getting-started/';
 
@@ -74,7 +76,7 @@ export function Desktops(props: State) {
         <FeatureHeaderTitle>Desktops</FeatureHeaderTitle>
         {attempt.status === 'success' && !hasNoDesktops && (
           <AgentButtonAdd
-            agent="desktop"
+            agent={SearchResource.DESKTOP}
             beginsWithVowel={false}
             isLeafCluster={isLeafCluster}
             canCreate={canCreate}
@@ -125,7 +127,7 @@ const emptyStateInfo: EmptyStateInfo = {
   byline:
     'Teleport Desktop Access provides graphical desktop access to remote Windows hosts.',
   docsURL: DOC_URL,
-  resourceType: 'desktop',
+  resourceType: SearchResource.DESKTOP,
   readOnly: {
     title: 'No Desktops Found',
     resource: 'desktops',

--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -20,17 +20,16 @@ import { MemoryRouter } from 'react-router';
 
 import { render, screen } from 'design/utils/testing';
 
-import { Acl } from 'teleport/services/user';
 import TeleportContextProvider from 'teleport/TeleportContextProvider';
 import { Discover } from 'teleport/Discover/Discover';
 import { FeaturesContextProvider } from 'teleport/FeaturesContext';
-import { getAcl, createTeleportContext } from 'teleport/mocks/contexts';
+import { createTeleportContext, getAcl } from 'teleport/mocks/contexts';
 import { getOSSFeatures } from 'teleport/features';
 import cfg from 'teleport/config';
 import {
-  SERVERS,
   APPLICATIONS,
   KUBERNETES,
+  SERVERS,
   WINDOWS_DESKTOPS,
 } from 'teleport/Discover/SelectResource/resources';
 import {
@@ -41,15 +40,15 @@ import {
 
 import { ResourceKind } from './Shared';
 
-describe('discover', () => {
-  function create(initialEntry: string, userAcl: Acl) {
-    const ctx = createTeleportContext({ customAcl: userAcl });
+const create = (initialEntry: string) => {
+  const userAcl = getAcl()
+  const ctx = createTeleportContext({ customAcl: userAcl });
 
-    return render(
+  return render(
       <MemoryRouter
-        initialEntries={[
-          { pathname: cfg.routes.discover, state: { entity: initialEntry } },
-        ]}
+          initialEntries={[
+            { pathname: cfg.routes.discover, state: { entity: initialEntry } },
+          ]}
       >
         <TeleportContextProvider ctx={ctx}>
           <FeaturesContextProvider value={getOSSFeatures()}>
@@ -57,58 +56,96 @@ describe('discover', () => {
           </FeaturesContextProvider>
         </TeleportContextProvider>
       </MemoryRouter>
+  );
+}
+
+test('displays all resources by default', () => {
+  create('')
+
+  expect(screen.getAllByTestId(ResourceKind.Server)).toHaveLength(
+    SERVERS.length
+  );
+  expect(screen.getAllByTestId(ResourceKind.Desktop)).toHaveLength(
+    WINDOWS_DESKTOPS.length
+  );
+  expect(screen.getAllByTestId(ResourceKind.Database)).toHaveLength(
+    DATABASES.length + DATABASES_UNGUIDED.length + DATABASES_UNGUIDED_DOC.length
+  );
+  expect(screen.getAllByTestId(ResourceKind.Application)).toHaveLength(
+    APPLICATIONS.length
+  );
+  expect(screen.getAllByTestId(ResourceKind.Kubernetes)).toHaveLength(
+    KUBERNETES.length
+  );
+});
+
+describe('location state', () => {
+  test('displays servers when the location state is server', () => {
+    create('server');
+
+    expect(screen.getAllByTestId(ResourceKind.Server)).toHaveLength(
+      SERVERS.length
     );
-  }
 
-  describe('server', () => {
-    test('shows all the servers when location state is server', () => {
-      create('server', getAcl());
+    // we assert three databases for servers because the naming convention includes "server"
+    expect(screen.queryAllByTestId(ResourceKind.Database)).toHaveLength(3);
 
-      expect(screen.getAllByTestId(ResourceKind.Server)).toHaveLength(
-        SERVERS.length
-      );
-    });
+    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Application)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Kubernetes)).not.toBeInTheDocument();
   });
 
-  describe('desktop', () => {
-    test('shows the desktops when the location state is desktop', () => {
-      create('desktop', getAcl());
+  test('displays desktops when the location state is desktop', () => {
+    create('desktop');
 
-      expect(screen.getAllByTestId(ResourceKind.Desktop)).toHaveLength(
-        WINDOWS_DESKTOPS.length
-      );
-    });
+    expect(screen.getAllByTestId(ResourceKind.Desktop)).toHaveLength(
+      WINDOWS_DESKTOPS.length
+    );
+
+    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Application)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Kubernetes)).not.toBeInTheDocument();
   });
 
-  describe('application', () => {
-    test('shows the apps when the location state is application', () => {
-      create('application', getAcl());
+  test('displays apps when the location state is application', () => {
+    create('application');
 
-      expect(screen.getAllByTestId(ResourceKind.Application)).toHaveLength(
-        APPLICATIONS.length
-      );
-    });
+    expect(screen.getAllByTestId(ResourceKind.Application)).toHaveLength(
+      APPLICATIONS.length
+    );
+
+    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Kubernetes)).not.toBeInTheDocument();
   });
 
-  describe('database', () => {
-    test('shows the database when the location state is database', () => {
-      create('database', getAcl());
+  test('displays databases when the location state is database', () => {
+    create('database');
 
-      expect(screen.getAllByTestId(ResourceKind.Database)).toHaveLength(
-        DATABASES.length +
-          DATABASES_UNGUIDED.length +
-          DATABASES_UNGUIDED_DOC.length
-      );
-    });
+    expect(screen.getAllByTestId(ResourceKind.Database)).toHaveLength(
+      DATABASES.length +
+        DATABASES_UNGUIDED.length +
+        DATABASES_UNGUIDED_DOC.length
+    );
+
+    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Application)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Kubernetes)).not.toBeInTheDocument();
   });
 
-  describe('kube', () => {
-    test('shows the kubes when the location state is kubernetes', () => {
-      create('kubernetes', getAcl());
+  test('displays kube resources when the location state is kubernetes', () => {
+    create('kubernetes');
 
-      expect(screen.getAllByTestId(ResourceKind.Kubernetes)).toHaveLength(
-        KUBERNETES.length
-      );
-    });
+    expect(screen.getAllByTestId(ResourceKind.Kubernetes)).toHaveLength(
+      KUBERNETES.length
+    );
+
+    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(ResourceKind.Application)).not.toBeInTheDocument();
   });
 });

--- a/web/packages/teleport/src/Discover/Discover.test.tsx
+++ b/web/packages/teleport/src/Discover/Discover.test.tsx
@@ -103,7 +103,7 @@ test('displays all resources by default', () => {
   );
 });
 
-test('location state overrides preferred resource state', () => {
+test('location state applies filter/search', () => {
   create({
     initialEntry: 'desktop',
     preferredResource: ClusterResource.RESOURCE_WEB_APPLICATIONS,
@@ -194,93 +194,6 @@ describe('location state', () => {
 
   test('displays kube resources when the location state is kubernetes', () => {
     create({ initialEntry: 'kubernetes' });
-
-    expect(screen.getAllByTestId(ResourceKind.Kubernetes)).toHaveLength(
-      KUBERNETES.length
-    );
-
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Application)
-    ).not.toBeInTheDocument();
-  });
-});
-
-describe('preferred resources', () => {
-  test('displays servers when the preferred resource is server', () => {
-    create({ preferredResource: ClusterResource.RESOURCE_SERVER_SSH });
-
-    expect(screen.getAllByTestId(ResourceKind.Server)).toHaveLength(
-      SERVERS.length
-    );
-
-    // we assert three databases for servers because the naming convention includes "server"
-    expect(screen.queryAllByTestId(ResourceKind.Database)).toHaveLength(3);
-
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Application)
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
-    ).not.toBeInTheDocument();
-  });
-
-  test('displays desktops when the preferred resource is desktop', () => {
-    create({ preferredResource: ClusterResource.RESOURCE_WINDOWS_DESKTOPS });
-
-    expect(screen.getAllByTestId(ResourceKind.Desktop)).toHaveLength(
-      WINDOWS_DESKTOPS.length
-    );
-
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Application)
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
-    ).not.toBeInTheDocument();
-  });
-
-  test('displays apps when the preferred resource is application', () => {
-    create({ preferredResource: ClusterResource.RESOURCE_WEB_APPLICATIONS });
-
-    expect(screen.getAllByTestId(ResourceKind.Application)).toHaveLength(
-      APPLICATIONS.length
-    );
-
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Database)).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
-    ).not.toBeInTheDocument();
-  });
-
-  test('displays databases when the preferred resource is database', () => {
-    create({ preferredResource: ClusterResource.RESOURCE_DATABASES });
-
-    expect(screen.getAllByTestId(ResourceKind.Database)).toHaveLength(
-      DATABASES.length +
-        DATABASES_UNGUIDED.length +
-        DATABASES_UNGUIDED_DOC.length
-    );
-
-    expect(screen.queryByTestId(ResourceKind.Server)).not.toBeInTheDocument();
-    expect(screen.queryByTestId(ResourceKind.Desktop)).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Application)
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByTestId(ResourceKind.Kubernetes)
-    ).not.toBeInTheDocument();
-  });
-
-  test('displays kube resources when the preferred resource is kubernetes', () => {
-    create({ preferredResource: ClusterResource.RESOURCE_KUBERNETES });
 
     expect(screen.getAllByTestId(ResourceKind.Kubernetes)).toHaveLength(
       KUBERNETES.length

--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.story.test.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.story.test.tsx
@@ -17,6 +17,9 @@
 import React from 'react';
 import { render } from 'design/utils/testing';
 
+import { mockUserContextProviderWith } from 'teleport/User/testHelpers/mockUserContextWith';
+import { makeTestUserContext } from 'teleport/User/testHelpers/makeTestUserContext';
+
 import {
   AllAccess,
   NoAccess,
@@ -25,21 +28,25 @@ import {
 } from './SelectResource.story';
 
 test('render with all access', async () => {
+  mockUserContextProviderWith(makeTestUserContext());
   const { container } = render(<AllAccess />);
   expect(container.firstChild).toMatchSnapshot();
 });
 
 test('render with no access', async () => {
+  mockUserContextProviderWith(makeTestUserContext());
   const { container } = render(<NoAccess />);
   expect(container.firstChild).toMatchSnapshot();
 });
 
 test('render with partial access', async () => {
+  mockUserContextProviderWith(makeTestUserContext());
   const { container } = render(<PartialAccess />);
   expect(container.firstChild).toMatchSnapshot();
 });
 
 test('render with URL loc state set to "server"', async () => {
+  mockUserContextProviderWith(makeTestUserContext());
   const { container } = render(<InitRouteEntryServer />);
   expect(container.firstChild).toMatchSnapshot();
 });

--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.story.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.story.tsx
@@ -24,17 +24,29 @@ import {
 } from 'teleport/mocks/contexts';
 import { ContextProvider } from 'teleport';
 
+import { UserContext } from 'teleport/User/UserContext';
+
+import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
+
+import {
+  ClusterResource,
+  UserPreferences,
+} from 'teleport/services/userPreferences/types';
+import { Acl } from 'teleport/services/user';
+
 import { SelectResource } from './SelectResource';
 
 export default {
   title: 'Teleport/Discover/SelectResource',
 };
 
-export const AllAccess = () => (
-  <Provider>
-    <SelectResource onSelect={() => null} />
-  </Provider>
-);
+export const AllAccess = () => {
+  return (
+    <Provider>
+      <SelectResource onSelect={() => null} />
+    </Provider>
+  );
+};
 
 export const NoAccess = () => {
   const customAcl = getAcl({ noAccess: true });
@@ -55,20 +67,45 @@ export const PartialAccess = () => {
   );
 };
 
+export const PreferredDBAccess = () => {
+  return (
+    <Provider resources={[3]}>
+      <SelectResource onSelect={() => null} />
+    </Provider>
+  );
+};
+
 export const InitRouteEntryServer = () => (
   <Provider entity="server">
     <SelectResource onSelect={() => null} />
   </Provider>
 );
 
-const Provider = props => {
-  const ctx = createTeleportContext({ customAcl: props.customAcl });
+type ProviderProps = {
+  customAcl?: Acl;
+  entity?: string;
+  resources?: ClusterResource[];
+  children?: React.ReactNode;
+};
+
+const Provider = ({
+  customAcl,
+  entity,
+  resources,
+  children,
+}: ProviderProps) => {
+  const ctx = createTeleportContext({ customAcl: customAcl });
+  const updatePreferences = () => Promise.resolve();
+  const preferences: UserPreferences = makeDefaultUserPreferences();
+  preferences.onboard = { preferredResources: resources };
 
   return (
     <MemoryRouter
-      initialEntries={[{ pathname: '/test', state: { entity: props.entity } }]}
+      initialEntries={[{ pathname: '/test', state: { entity: entity } }]}
     >
-      <ContextProvider ctx={ctx}>{props.children}</ContextProvider>
+      <UserContext.Provider value={{ preferences, updatePreferences }}>
+        <ContextProvider ctx={ctx}>{children}</ContextProvider>
+      </UserContext.Provider>
     </MemoryRouter>
   );
 };

--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.test.tsx
@@ -14,140 +14,224 @@
  * limitations under the License.
  */
 
+import { makeDefaultUserPreferences } from 'teleport/services/userPreferences/userPreferences';
+
+import {
+  ClusterResource,
+  OnboardUserPreferences,
+} from 'teleport/services/userPreferences/types';
+
 import { ResourceKind } from '../Shared';
 
 import { sortResources } from './SelectResource';
 import { ResourceSpec } from './types';
 
-test('sortResources sorts resources alphabetically with guided resources first', () => {
-  const sorted = sortResources(mockUnsorted);
+const makeResourceSpec = (
+  overrides: Partial<ResourceSpec> = {}
+): ResourceSpec => {
+  return Object.assign(
+    {
+      name: '',
+      kind: ResourceKind.Application,
+      icon: '',
+      event: null,
+      keywords: '',
+      hasAccess: true,
+    },
+    overrides
+  );
+};
 
-  expect(sorted).toMatchObject(mockSorted);
+test('sortResources without preferred resources, sorts resources alphabetically with guided resources first', () => {
+  const mockIn: ResourceSpec[] = [
+    // unguided
+    makeResourceSpec({ name: 'jenkins', unguidedLink: 'test.com' }),
+    makeResourceSpec({ name: 'grafana', unguidedLink: 'test.com' }),
+    makeResourceSpec({ name: 'linux', unguidedLink: 'test.com' }),
+    makeResourceSpec({ name: 'apple', unguidedLink: 'test.com' }),
+    // guided
+    makeResourceSpec({ name: 'zapier' }),
+    makeResourceSpec({ name: 'amazon' }),
+    makeResourceSpec({ name: 'costco' }),
+  ];
+
+  const actual = sortResources(mockIn, makeDefaultUserPreferences());
+
+  expect(actual).toMatchObject([
+    // guided and alpha
+    makeResourceSpec({ name: 'amazon' }),
+    makeResourceSpec({ name: 'costco' }),
+    makeResourceSpec({ name: 'zapier' }),
+    // unguided and alpha
+    makeResourceSpec({ name: 'apple', unguidedLink: 'test.com' }),
+    makeResourceSpec({ name: 'grafana', unguidedLink: 'test.com' }),
+    makeResourceSpec({ name: 'jenkins', unguidedLink: 'test.com' }),
+    makeResourceSpec({ name: 'linux', unguidedLink: 'test.com' }),
+  ]);
 });
 
-const mockUnsorted: ResourceSpec[] = [
-  {
-    name: 'jenkins',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
+const kindBasedList: ResourceSpec[] = [
+  makeResourceSpec({ name: 'charlie', kind: ResourceKind.Application }),
+  makeResourceSpec({ name: 'alpha', kind: ResourceKind.Database }),
+  makeResourceSpec({ name: 'linux', kind: ResourceKind.Desktop }),
+  makeResourceSpec({
+    name: 'echo',
+    kind: ResourceKind.Kubernetes,
     unguidedLink: 'test.com',
-  },
-  {
-    name: 'grafana',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-    unguidedLink: 'test.com',
-  },
-  {
-    name: 'linux',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-    unguidedLink: 'test.com',
-  },
-  {
-    name: 'apple',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-    unguidedLink: 'test.com',
-  },
-  // Guided
-  {
-    name: 'zapier',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-  },
-  {
-    name: 'amazon',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-  },
-  {
-    name: 'costco',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-  },
+  }),
+  makeResourceSpec({ name: 'foxtrot', kind: ResourceKind.Server }),
+  makeResourceSpec({ name: 'delta', kind: ResourceKind.SamlApplication }),
+  makeResourceSpec({ name: 'golf', kind: ResourceKind.Application }),
+  makeResourceSpec({ name: 'kilo', kind: ResourceKind.Database }),
+  makeResourceSpec({ name: 'india', kind: ResourceKind.Desktop }),
+  makeResourceSpec({ name: 'juliette', kind: ResourceKind.Kubernetes }),
+  makeResourceSpec({ name: 'hotel', kind: ResourceKind.Server }),
+  makeResourceSpec({ name: 'lima', kind: ResourceKind.SamlApplication }),
 ];
 
-const mockSorted: ResourceSpec[] = [
-  {
-    name: 'amazon',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-  },
-  {
-    name: 'costco',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-  },
-  {
-    name: 'zapier',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-  },
-  {
-    name: 'apple',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-    unguidedLink: 'test.com',
-  },
-  {
-    name: 'grafana',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-    unguidedLink: 'test.com',
-  },
-  {
-    name: 'jenkins',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-    unguidedLink: 'test.com',
-  },
-  {
-    name: 'linux',
-    kind: ResourceKind.Application,
-    icon: 'Apple',
-    event: null,
-    keywords: 'test',
-    hasAccess: true,
-    unguidedLink: 'test.com',
-  },
-];
+describe('preferred resources', () => {
+  const testCases: {
+    name: string;
+    preferred: OnboardUserPreferences;
+    expected: ResourceSpec[];
+  }[] = [
+    {
+      name: 'preferred server/ssh',
+      preferred: {
+        preferredResources: [ClusterResource.RESOURCE_SERVER_SSH],
+      },
+      expected: [
+        // preferred first
+        makeResourceSpec({ name: 'foxtrot', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'hotel', kind: ResourceKind.Server }),
+        // alpha; guided before unguided
+        makeResourceSpec({ name: 'alpha', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'charlie', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'delta', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'golf', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'india', kind: ResourceKind.Desktop }),
+        makeResourceSpec({ name: 'juliette', kind: ResourceKind.Kubernetes }),
+        makeResourceSpec({ name: 'kilo', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'lima', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'linux', kind: ResourceKind.Desktop }),
+        makeResourceSpec({
+          name: 'echo',
+          kind: ResourceKind.Kubernetes,
+          unguidedLink: 'test.com',
+        }),
+      ],
+    },
+    {
+      name: 'preferred databases',
+      preferred: {
+        preferredResources: [ClusterResource.RESOURCE_DATABASES],
+      },
+      expected: [
+        // preferred first
+        makeResourceSpec({ name: 'alpha', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'kilo', kind: ResourceKind.Database }),
+        // alpha; guided before unguided
+        makeResourceSpec({ name: 'charlie', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'delta', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'foxtrot', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'golf', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'hotel', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'india', kind: ResourceKind.Desktop }),
+        makeResourceSpec({ name: 'juliette', kind: ResourceKind.Kubernetes }),
+        makeResourceSpec({ name: 'lima', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'linux', kind: ResourceKind.Desktop }),
+        makeResourceSpec({
+          name: 'echo',
+          kind: ResourceKind.Kubernetes,
+          unguidedLink: 'test.com',
+        }),
+      ],
+    },
+    {
+      name: 'preferred windows',
+      preferred: {
+        preferredResources: [ClusterResource.RESOURCE_WINDOWS_DESKTOPS],
+      },
+      expected: [
+        // preferred first
+        makeResourceSpec({ name: 'india', kind: ResourceKind.Desktop }),
+        makeResourceSpec({ name: 'linux', kind: ResourceKind.Desktop }),
+        // alpha; guided before unguided
+        makeResourceSpec({ name: 'alpha', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'charlie', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'delta', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'foxtrot', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'golf', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'hotel', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'juliette', kind: ResourceKind.Kubernetes }),
+        makeResourceSpec({ name: 'kilo', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'lima', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({
+          name: 'echo',
+          kind: ResourceKind.Kubernetes,
+          unguidedLink: 'test.com',
+        }),
+      ],
+    },
+    {
+      name: 'preferred applications',
+      preferred: {
+        preferredResources: [ClusterResource.RESOURCE_WEB_APPLICATIONS],
+      },
+      expected: [
+        // preferred first
+        makeResourceSpec({ name: 'charlie', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'golf', kind: ResourceKind.Application }),
+        // alpha; guided before unguided
+        makeResourceSpec({ name: 'alpha', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'delta', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'foxtrot', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'hotel', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'india', kind: ResourceKind.Desktop }),
+        makeResourceSpec({ name: 'juliette', kind: ResourceKind.Kubernetes }),
+        makeResourceSpec({ name: 'kilo', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'lima', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'linux', kind: ResourceKind.Desktop }),
+        makeResourceSpec({
+          name: 'echo',
+          kind: ResourceKind.Kubernetes,
+          unguidedLink: 'test.com',
+        }),
+      ],
+    },
+    {
+      name: 'preferred kubernetes',
+      preferred: {
+        preferredResources: [ClusterResource.RESOURCE_KUBERNETES],
+      },
+      expected: [
+        // preferred first; guided before unguided
+        makeResourceSpec({ name: 'juliette', kind: ResourceKind.Kubernetes }),
+        makeResourceSpec({
+          name: 'echo',
+          kind: ResourceKind.Kubernetes,
+          unguidedLink: 'test.com',
+        }),
+        // alpha
+        makeResourceSpec({ name: 'alpha', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'charlie', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'delta', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'foxtrot', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'golf', kind: ResourceKind.Application }),
+        makeResourceSpec({ name: 'hotel', kind: ResourceKind.Server }),
+        makeResourceSpec({ name: 'india', kind: ResourceKind.Desktop }),
+        makeResourceSpec({ name: 'kilo', kind: ResourceKind.Database }),
+        makeResourceSpec({ name: 'lima', kind: ResourceKind.SamlApplication }),
+        makeResourceSpec({ name: 'linux', kind: ResourceKind.Desktop }),
+      ],
+    },
+  ];
+
+  test.each(testCases)('$name', testCase => {
+    const preferences = makeDefaultUserPreferences();
+    preferences.onboard = testCase.preferred;
+    const actual = sortResources(kindBasedList, preferences);
+
+    expect(actual).toMatchObject(testCase.expected);
+  });
+});

--- a/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
+++ b/web/packages/teleport/src/Discover/SelectResource/__snapshots__/SelectResource.story.test.tsx.snap
@@ -1,12 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`render with URL loc state set to "server" 1`] = `
-.c8 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .c0 {
   box-sizing: border-box;
   margin-top: 24px;
@@ -74,6 +68,12 @@ exports[`render with URL loc state set to "server" 1`] = `
   font-size: 12px;
   margin: 0px;
   margin-top: 40px;
+}
+
+.c8 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .c19 {

--- a/web/packages/teleport/src/Discover/SelectResource/constants.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/constants.ts
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ClusterResource } from 'teleport/services/userPreferences/types';
+import { SearchResource } from 'teleport/Discover/SelectResource/types';
+
+export const resourceMapping: { [key in ClusterResource]: SearchResource } = {
+  [ClusterResource.RESOURCE_UNSPECIFIED]: SearchResource.UNSPECIFIED,
+  [ClusterResource.RESOURCE_DATABASES]: SearchResource.DATABASE,
+  [ClusterResource.RESOURCE_KUBERNETES]: SearchResource.KUBERNETES,
+  [ClusterResource.RESOURCE_SERVER_SSH]: SearchResource.SERVER,
+  [ClusterResource.RESOURCE_WEB_APPLICATIONS]: SearchResource.APPLICATION,
+  [ClusterResource.RESOURCE_WINDOWS_DESKTOPS]: SearchResource.DESKTOP,
+};

--- a/web/packages/teleport/src/Discover/SelectResource/types.ts
+++ b/web/packages/teleport/src/Discover/SelectResource/types.ts
@@ -65,11 +65,20 @@ export interface ResourceSpec {
   // It is used as a flag, that when defined, means that
   // this resource is not "guided" (has no UI interactive flow).
   unguidedLink?: string;
-  // isDialog is whether or not the flow for this resource is a popover dialog as opposed to a Discover flow.
+  // isDialog indicates whether the flow for this resource is a popover dialog as opposed to a Discover flow.
   // This is the case for the 'Application' resource.
   isDialog?: boolean;
   // event is the expected backend enum event name that describes
-  // the type of this resource (eg. server v. kubernetes),
+  // the type of this resource (e.g. server v. kubernetes),
   // used for usage reporting.
   event: DiscoverEventResource;
+}
+
+export enum SearchResource {
+  UNSPECIFIED = '',
+  APPLICATION = 'application',
+  DATABASE = 'database',
+  DESKTOP = 'desktop',
+  KUBERNETES = 'kubernetes',
+  SERVER = 'server',
 }

--- a/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
+++ b/web/packages/teleport/src/Discover/Server/DownloadScript/DownloadScript.story.tsx
@@ -24,6 +24,8 @@ import { PingTeleportProvider } from 'teleport/Discover/Shared/PingTeleportConte
 import { userContext } from 'teleport/Main/fixtures';
 import { ResourceKind } from 'teleport/Discover/Shared';
 
+import { UserContextProvider } from 'teleport/User';
+
 import DownloadScript from './DownloadScript';
 
 const { worker, rest } = window.msw;
@@ -120,14 +122,16 @@ const Provider = props => {
         { pathname: cfg.routes.discover, state: { entity: 'database' } },
       ]}
     >
-      <ContextProvider ctx={ctx}>
-        <PingTeleportProvider
-          interval={props.interval || 100000}
-          resourceKind={ResourceKind.Server}
-        >
-          {props.children}
-        </PingTeleportProvider>
-      </ContextProvider>
+      <UserContextProvider>
+        <ContextProvider ctx={ctx}>
+          <PingTeleportProvider
+            interval={props.interval || 100000}
+            resourceKind={ResourceKind.Server}
+          >
+            {props.children}
+          </PingTeleportProvider>
+        </ContextProvider>
+      </UserContextProvider>
     </MemoryRouter>
   );
 };

--- a/web/packages/teleport/src/Discover/Shared/ResourceKind.ts
+++ b/web/packages/teleport/src/Discover/Shared/ResourceKind.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { ClusterResource } from 'teleport/services/userPreferences/types';
+
 import type { JoinRole } from 'teleport/services/joinToken';
 
 export enum ResourceKind {
@@ -37,5 +39,22 @@ export function resourceKindToJoinRole(kind: ResourceKind): JoinRole {
       return 'Kube';
     case ResourceKind.Server:
       return 'Node';
+  }
+}
+
+export function resourceKindToPreferredResource(
+  kind: ResourceKind
+): ClusterResource {
+  switch (kind) {
+    case ResourceKind.Application:
+      return ClusterResource.RESOURCE_WEB_APPLICATIONS;
+    case ResourceKind.Database:
+      return ClusterResource.RESOURCE_DATABASES;
+    case ResourceKind.Desktop:
+      return ClusterResource.RESOURCE_WINDOWS_DESKTOPS;
+    case ResourceKind.Kubernetes:
+      return ClusterResource.RESOURCE_KUBERNETES;
+    case ResourceKind.Server:
+      return ClusterResource.RESOURCE_SERVER_SSH;
   }
 }

--- a/web/packages/teleport/src/Kubes/Kubes.tsx
+++ b/web/packages/teleport/src/Kubes/Kubes.tsx
@@ -29,7 +29,9 @@ import useTeleport from 'teleport/useTeleport';
 
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 
-import { useKubes, State } from './useKubes';
+import { SearchResource } from 'teleport/Discover/SelectResource';
+
+import { State, useKubes } from './useKubes';
 
 export default function Container() {
   const ctx = useTeleport();
@@ -74,7 +76,7 @@ export function Kubes(props: State) {
         <FeatureHeaderTitle>Kubernetes</FeatureHeaderTitle>
         {attempt.status === 'success' && !hasNoKubes && (
           <AgentButtonAdd
-            agent="kubernetes"
+            agent={SearchResource.KUBERNETES}
             beginsWithVowel={false}
             isLeafCluster={isLeafCluster}
             canCreate={canCreate}
@@ -125,7 +127,7 @@ const emptyStateInfo: EmptyStateInfo = {
   byline:
     'Teleport Kubernetes Access provides secure access to Kubernetes clusters.',
   docsURL: DOC_URL,
-  resourceType: 'kubernetes',
+  resourceType: SearchResource.KUBERNETES,
   readOnly: {
     title: 'No Kubernetes Clusters Found',
     resource: 'kubernetes clusters',

--- a/web/packages/teleport/src/Nodes/Nodes.tsx
+++ b/web/packages/teleport/src/Nodes/Nodes.tsx
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 import React from 'react';
-import { Indicator, Box, Flex } from 'design';
+import { Box, Flex, Indicator } from 'design';
 
 import {
   FeatureBox,
@@ -29,7 +29,9 @@ import ErrorMessage from 'teleport/components/AgentErrorMessage';
 import useTeleport from 'teleport/useTeleport';
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 
-import { useNodes, State } from './useNodes';
+import { SearchResource } from 'teleport/Discover/SelectResource';
+
+import { State, useNodes } from './useNodes';
 
 export default function Container() {
   const teleCtx = useTeleport();
@@ -82,7 +84,7 @@ export function Nodes(props: State) {
           <Flex alignItems="center">
             <QuickLaunch width="280px" onPress={onSshEnter} mr={3} />
             <AgentButtonAdd
-              agent="server"
+              agent={SearchResource.SERVER}
               beginsWithVowel={false}
               isLeafCluster={isLeafCluster}
               canCreate={canCreate}
@@ -132,7 +134,7 @@ const emptyStateInfo: EmptyStateInfo = {
   byline:
     'Teleport Server Access consolidates SSH access across all environments.',
   docsURL: 'https://goteleport.com/docs/server-access/getting-started/',
-  resourceType: 'server',
+  resourceType: SearchResource.SERVER,
   readOnly: {
     title: 'No Servers Found',
     resource: 'servers',

--- a/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.story.tsx
+++ b/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.story.tsx
@@ -17,7 +17,9 @@ limitations under the License.
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 
-import AgentButtocnAdd, { Props } from './AgentButtonAdd';
+import { SearchResource } from 'teleport/Discover/SelectResource';
+
+import AgentButtonAdd, { Props } from './AgentButtonAdd';
 
 export default {
   title: 'Teleport/AgentButtonAdd',
@@ -25,21 +27,21 @@ export default {
 
 export const CanCreate = () => (
   <MemoryRouter>
-    <AgentButtocnAdd {...props} />
+    <AgentButtonAdd {...props} />
   </MemoryRouter>
 );
 
 export const CannotCreate = () => (
   <MemoryRouter>
-    <AgentButtocnAdd {...props} canCreate={false} />
+    <AgentButtonAdd {...props} canCreate={false} />
   </MemoryRouter>
 );
 
 export const CannotCreateVowel = () => (
   <MemoryRouter>
-    <AgentButtocnAdd
+    <AgentButtonAdd
       {...props}
-      agent="application"
+      agent={SearchResource.APPLICATION}
       beginsWithVowel={true}
       canCreate={false}
     />
@@ -48,18 +50,18 @@ export const CannotCreateVowel = () => (
 
 export const OnLeaf = () => (
   <MemoryRouter>
-    <AgentButtocnAdd {...props} isLeafCluster={true} />
+    <AgentButtonAdd {...props} isLeafCluster={true} />
   </MemoryRouter>
 );
 
 export const OnLeafVowel = () => (
   <MemoryRouter>
-    <AgentButtocnAdd {...props} isLeafCluster={true} beginsWithVowel={true} />
+    <AgentButtonAdd {...props} isLeafCluster={true} beginsWithVowel={true} />
   </MemoryRouter>
 );
 
 const props: Props = {
-  agent: 'server',
+  agent: SearchResource.SERVER,
   beginsWithVowel: false,
   canCreate: true,
   isLeafCluster: false,

--- a/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
+++ b/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
@@ -20,6 +20,7 @@ import { Link } from 'react-router-dom';
 import { ButtonPrimary } from 'design';
 
 import cfg from 'teleport/config';
+import { SearchResource } from 'teleport/Discover/SelectResource';
 
 export default function AgentButtonAdd(props: Props) {
   const { canCreate, isLeafCluster, onClick, agent, beginsWithVowel } = props;
@@ -58,17 +59,10 @@ export default function AgentButtonAdd(props: Props) {
   );
 }
 
-export type AddButtonResourceKind =
-  | 'server'
-  | 'application'
-  | 'desktop'
-  | 'kubernetes'
-  | 'database';
-
 export type Props = {
   isLeafCluster: boolean;
   canCreate: boolean;
   onClick?: () => void;
-  agent: AddButtonResourceKind;
+  agent: SearchResource;
   beginsWithVowel: boolean;
 };

--- a/web/packages/teleport/src/components/Empty/Empty.test.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.test.tsx
@@ -18,6 +18,8 @@ import React from 'react';
 import { render, screen } from 'design/utils/testing';
 import { MemoryRouter } from 'react-router';
 
+import { SearchResource } from 'teleport/Discover/SelectResource';
+
 import Empty, { Props } from './Empty';
 
 test('empty state for enterprise or oss, with create perms', async () => {
@@ -52,7 +54,7 @@ const props: Props = {
     byline:
       'Teleport Server Access consolidates SSH access across all environments.',
     docsURL: 'https://goteleport.com/docs/server-access/getting-started/',
-    resourceType: 'server',
+    resourceType: SearchResource.SERVER,
     readOnly: {
       title: 'No Servers Found',
       resource: 'servers',


### PR DESCRIPTION
This PR adds the ability to automatically sort the discover page based on preferred resources added to the user preferences cluster state after answering the onboarding questionnaire.

supports https://github.com/gravitational/cloud/issues/5050