### PR TITLE
[v13] chore: Bump Buf to v1.25.0

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -29,7 +29,7 @@ LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Protogen related versions.
-BUF_VERSION ?= 1.24.0
+BUF_VERSION ?= 1.25.0
 # Keep in sync with api/proto/buf.yaml (and buf.lock)
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
Backport #29643 to branch/v13

Update to latest release.

* https://github.com/bufbuild/buf/releases/tag/v1.25.0