### PR TITLE
Fix `create_host_user_mode` role reference

### DIFF
--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -100,7 +100,7 @@ spec:
     # Controls whether this role supports auto provisioning of SSH users.
     # Options: drop (remove user on session end), keep (keep users at session end)
     #          and off (disable host user creation)
-    create_host_user_mode: drop    create_host_user: true
+    create_host_user_mode: drop
     # Controls whether this role requires automatic database user provisioning.
     create_db_user: true
     # Specifies role specific options for identity provider access.


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/28192 munged the role spec, this PR fixes it

Related: https://github.com/gravitational/teleport-plugins/issues/878