### PR TITLE
ci: Add missing dot to `gh -q` arg

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Determine release latest flag and version
         id: artifacts
         run: |
-          LATEST_RELEASE_ID=$(gh release view --json id -q id)
+          LATEST_RELEASE_ID=$(gh release view --json id -q .id)
           CURRENT_RELEASE_ID=${{ github.event.release.node_id }}
 
           if [ "$LATEST_RELEASE_ID" == "$CURRENT_RELEASE_ID" ]; then


### PR DESCRIPTION
I missed a dot in bc491d73b11aa31c88b59e5ed9805f433e8102dd in the `-q`
arg to `gh`. `--json` takes a field without the dot, `-q` needs the dot
(it's a `jq` expression).

Fixes: bc491d73b11aa31c88b59e5ed9805f433e8102dd