### PR TITLE
tctl: improve error message when no profile exists on Windows

### DIFF
--- a/tool/tctl/common/tctl.go
+++ b/tool/tctl/common/tctl.go
@@ -23,6 +23,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/gravitational/trace"
@@ -290,6 +291,12 @@ func ApplyConfig(ccf *GlobalCLIFlags, cfg *servicecfg.Config) (*authclient.Confi
 		}
 		if !trace.IsNotFound(err) {
 			return nil, trace.Wrap(err)
+		} else if runtime.GOOS == constants.WindowsOS {
+			// On macOS/Linux, a not found error here is okay, as we can attempt
+			// to use the local auth identity. The auth server itself doesn't run
+			// on Windows though, so exit early with a clear error.
+			return nil, trace.BadParameter("tctl requires a tsh profile on Windows. " +
+				"Try logging in with tsh first.")
 		}
 	}
 


### PR DESCRIPTION
Fallback to local auth server will fail since teleport doesn't run on Windows, so break out early with a clear error message rather than letting things fail in unexpected ways.

Before (tctl tries to read `/var/lib/teleport`, which translates to `C:\var\lib\teleport` on Windows, which doesn't exist):

```
C:\Users\Administrator>tctl status
ERROR: CreateFile C:\var: The system cannot find the file specified.
```

After:

```
C:\Users\Administrator>tctl status
ERROR: tctl requires a tsh profile on Windows. Try logging in with tsh first.
```