### PR TITLE
docs: Content fixes regarding SOC 2

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1558,9 +1558,6 @@
       },
       "ca_pin": "sha256:abdc1245efgh5678abdc1245efgh5678abdc1245efgh5678abdc1245efgh5678"
     },
-    "soc2": {
-      "last_report": "August 9th, 2022"
-    },
     "teleport": {
       "major_version": "14",
       "version": "14.0.0-dev",

--- a/docs/pages/access-controls/compliance-frameworks/soc2.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/soc2.mdx
@@ -35,7 +35,7 @@ Teleport helps audit and monitor access.
 - Monitor, share and join interactive sessions in real-time from the CLI or browser.
 
 ### CC8 Change Management
-Teleport helps users elevate their permissions during incidents, RBAC helps limit the need for approvals. The Teleport slack integration allows for managers to quickly approve temporary SSH Access Requests.
+Teleport helps users elevate their permissions during incidents, RBAC helps limit the need for approvals. The Teleport Slack integration allows for managers to quickly approve temporary SSH Access Requests.
 
 - Let engineers request elevated permissions on the fly without ever leaving the terminal
 - Approve or deny permission requests with ChatOps workflow via Slack or other supported platforms.
@@ -43,9 +43,9 @@ Teleport helps users elevate their permissions during incidents, RBAC helps limi
 
 ## What Specific Criteria does Teleport Help Satisfy? 
 
-Below is a table of principles and common points of focus listed by [AICPA’s official “trust Service Criteria” Document](https://www.aicpa.org/content/dam/aicpa/interestareas/frc/assuranceadvisoryservices/downloadabledocuments/trust-services-criteria.pdf) and how Teleport helps satisfy them.
+Below is a table of principles and common points of focus listed by [AICPA's official "Trust Services Criteria" reference document](https://us.aicpa.org/content/dam/aicpa/interestareas/frc/assuranceadvisoryservices/downloadabledocuments/trust-services-criteria-2020.pdf) and how Teleport helps satisfy them.
 
-Each principle has many “Points of Focus” which will apply differently to different products and organizations, talk to an auditor to understand exactly which points of focus apply to your organization.
+Each principle has many "Points of Focus" which will apply differently to different products and organizations, talk to an auditor to understand exactly which points of focus apply to your organization.
 
 | Principle Criteria | Point of Focus | Teleport Features |
 | --- | --- | --- |

--- a/docs/pages/includes/soc2.mdx
+++ b/docs/pages/includes/soc2.mdx
@@ -1,6 +1,6 @@
-We completed our most current SOC 2 Type II audit on (=soc2.last_report=).
+We undergo an annual SOC 2 Type II audit of the Teleport Access Platform.
 
-The report covers:
+The audit report covers:
 
 - Teleport Open Source
 - Teleport Enterprise, self-hosted


### PR DESCRIPTION
Our SOC 2 report is maintained our trust portal, so no need to have the date be listed in docs.

Also, some minor content fixes on SOC 2 compliance framework guide.