### PR TITLE
docs: include gke in Kube Discovery config list

### DIFF
--- a/docs/pages/kubernetes-access/discovery.mdx
+++ b/docs/pages/kubernetes-access/discovery.mdx
@@ -101,6 +101,21 @@ discovery_service:
       # Optional section: Defaults to "*":"*"
       tags:
         "env": "prod"
+    # Matchers for discovering GCP-hosted resources.
+    gcp:
+      # GCP resource types. Valid options are:
+      # 'gke' - discovers and registers GCP GKE Kubernetes Clusters.
+    - types: ["gke"]
+      # GCP location to search for resources from. Valid options are:
+      # '*' - discovers resources in all locations (default).
+      # Any valid GCP region or zone name.
+      locations: ["*"]
+      # GCP project ID
+      project_ids: ["myproject"]
+      # GCP resource tag filters used to match resources.
+      # Optional section: Defaults to "*":"*"
+      tags:
+        "*" : "*"
 ```
 
 ### Forwarding requests to the Kubernetes Cluster


### PR DESCRIPTION
ONly AWS and Azure were included.