### PR TITLE
Fix Kubernetes Legacy Proxy heartbeats

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -875,3 +875,9 @@ const (
 	// to invite to the session.
 	KubeSessionInvitedQueryParam = "invite"
 )
+
+const (
+	// KubeLegacyProxySuffix is the suffix used for legacy proxy services when
+	// generating their names Server names.
+	KubeLegacyProxySuffix = "-proxy_service"
+)

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1333,8 +1333,9 @@ func (a *ServerWithRoles) KeepAliveServer(ctx context.Context, handle types.Keep
 		} else if serverName != handle.HostID {
 			return trace.AccessDenied("access denied")
 		}
-
-		if !a.hasBuiltinRole(types.RoleKube) {
+		// Legacy kube proxy can heartbeat kube servers from the proxy itself so
+		// we need to check if the host has the Kube or Proxy role.
+		if !a.hasBuiltinRole(types.RoleKube, types.RoleProxy) {
 			return trace.AccessDenied("access denied")
 		}
 		if err := a.action(apidefaults.Namespace, types.KindKubeServer, types.VerbUpdate); err != nil {

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -423,7 +423,7 @@ func (t *TLSServer) getServerInfo(name string) (types.Resource, error) {
 	// Note: we *don't* want to add suffix for kubernetes_service!
 	// This breaks reverse tunnel routing, which uses server.Name.
 	if t.KubeServiceType != KubeService {
-		name += "-proxy_service"
+		name += teleport.KubeLegacyProxySuffix
 	}
 
 	srv, err := types.NewKubernetesServerV3(


### PR DESCRIPTION
When a Teleport Kubernetes Proxy runs in legacy mode - i.e. - spec enables `proxy_service.kubernetes.enabled`, the proxy is capable of proxy requests to a target Kubernetes cluster instead of forwarding them to a Teleport Kubernetes Service.

The following config enables the legacy proxy mode in proxy:

```yaml
proxy_service:
    enabled: yes
    web_listen_addr: 0.0.0.0:3080
    public_addr: tele.local:3080
    kubernetes:
      enabled: yes
      listen_addr: 0.0.0.0:3026
      kubeconfig_file: path # optional
```

Because the proxy forwards and heartbeat the configured Kube clusters, it needs permissions to upsert the kube cluster in auth's backend and to extend its expiration date.

This PR fixes a problem introduced in Teleport 8 where the proxy is allowed to upsert the kube server, but it's not allowed to extend the expiration time.

When the request fails, the proxy becomes degraded and the performance is affected.