### PR TITLE
Machine ID: Kubernetes Secret Destination

### DIFF
--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -358,3 +358,34 @@ Configuration:
 # will always be `memory`.
 type: memory
 ```
+
+#### `kubernetes_secret`
+
+The `kubernetes_secret` destination type stores artifacts in a Kubernetes
+Secret. This allows them to be mounted into other containers deployed in
+Kubernetes.
+
+Prerequisites:
+
+- `tbot` must be running in Kubernetes, with at most one replica or multiple
+  instances of `tbot` will write to the same secret. If using a `deployment`,
+  then the `Recreate` strategy must be used.
+- The `tbot` pod must be configured with a Service Account that allows it to
+  read and write from the secret you configure.
+- The `KUBERNETES_POD` environment variable must be configured with the
+  name of the namespace that `tbot` is running in.
+
+Configuration:
+
+```yaml
+# type specifies the type of the destination. For the kubernetes_secret
+# destination, this will always be `kubernetes_secret`.
+type: kubernetes_secret
+# name specifies the name of the Kubernetes Secret to write the artifacts to.
+# This must be in the same namespace that `tbot` is running in.
+name: my-secret
+```
+
+There is no requirement that the secret already exists, one will be created
+if it does not exist. If a secret already exists, `tbot` may overwrite any
+other keys within the secret.

--- a/docs/pages/machine-id/reference/configuration.mdx
+++ b/docs/pages/machine-id/reference/configuration.mdx
@@ -362,18 +362,25 @@ type: memory
 #### `kubernetes_secret`
 
 The `kubernetes_secret` destination type stores artifacts in a Kubernetes
-Secret. This allows them to be mounted into other containers deployed in
+secret. This allows them to be mounted into other containers deployed in
 Kubernetes.
 
 Prerequisites:
 
-- `tbot` must be running in Kubernetes, with at most one replica or multiple
-  instances of `tbot` will write to the same secret. If using a `deployment`,
-  then the `Recreate` strategy must be used.
-- The `tbot` pod must be configured with a Service Account that allows it to
-  read and write from the secret you configure.
-- The `KUBERNETES_POD` environment variable must be configured with the
-  name of the namespace that `tbot` is running in.
+- `tbot` must be running in Kubernetes with at most one replica. If using a
+  `deployment`, then the `Recreate` strategy must be used to ensure only one
+  instance exists at any time. This is because multiple `tbot` agents configured
+  with the same secret will compete to write to the secret and it may be left
+  in an inconsistent state or the `tbot` agents may fail to write.
+- The `tbot` pod must be configured with a service account that allows it to
+  read and write from the configured secret.
+- The `POD_NAMESPACE` environment variable must be configured with the
+  name of the namespace that `tbot` is running in. This is best achieved with
+  the [Downward API](https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/).
+
+There is no requirement that the secret already exists, one will be created
+if it does not exist. If a secret already exists, `tbot` will overwrite any
+other keys within the secret.
 
 Configuration:
 
@@ -385,7 +392,3 @@ type: kubernetes_secret
 # This must be in the same namespace that `tbot` is running in.
 name: my-secret
 ```
-
-There is no requirement that the secret already exists, one will be created
-if it does not exist. If a secret already exists, `tbot` may overwrite any
-other keys within the secret.

--- a/integrations/operator/sidecar/tbot.go
+++ b/integrations/operator/sidecar/tbot.go
@@ -104,10 +104,10 @@ func (b *Bot) GetClient(ctx context.Context) (*client.Client, error) {
 	// If the bot has not joined the cluster yet or not generated client certs we bail out
 	// This is either temporary or the bot is dead and the manager will shut down everything.
 	storageDestination := b.cfg.Storage.Destination
-	if botCert, err := storageDestination.Read(identity.TLSCertKey); err != nil || len(botCert) == 0 {
+	if botCert, err := storageDestination.Read(ctx, identity.TLSCertKey); err != nil || len(botCert) == 0 {
 		return nil, trace.Retry(err, "bot cert not yet present")
 	}
-	if cert, err := b.cfg.Outputs[0].GetDestination().Read(identity.TLSCertKey); err != nil || len(cert) == 0 {
+	if cert, err := b.cfg.Outputs[0].GetDestination().Read(ctx, identity.TLSCertKey); err != nil || len(cert) == 0 {
 		return nil, trace.Retry(err, "cert not yet present")
 	}
 
@@ -116,18 +116,18 @@ func (b *Bot) GetClient(ctx context.Context) (*client.Client, error) {
 	// We loop over missing artifacts and are loading them from the bot storage to the destination
 	for _, artifact := range identity.GetArtifacts() {
 		if artifact.Kind == identity.KindBotInternal {
-			value, err := storageDestination.Read(artifact.Key)
+			value, err := storageDestination.Read(ctx, artifact.Key)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			if err := b.cfg.Outputs[0].GetDestination().Write(nil, artifact.Key, value); err != nil {
+			if err := b.cfg.Outputs[0].GetDestination().Write(ctx, artifact.Key, value); err != nil {
 				return nil, trace.Wrap(err)
 			}
 
 		}
 	}
 
-	id, err := identity.LoadIdentity(b.cfg.Outputs[0].GetDestination(), identity.BotKinds()...)
+	id, err := identity.LoadIdentity(ctx, b.cfg.Outputs[0].GetDestination(), identity.BotKinds()...)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/integrations/operator/sidecar/tbot.go
+++ b/integrations/operator/sidecar/tbot.go
@@ -57,7 +57,7 @@ type Bot struct {
 	opts       Options
 }
 
-func (b *Bot) initializeConfig() {
+func (b *Bot) initializeConfig(ctx context.Context) {
 	// Initialize the memory stores. They contain identities renewed by the bot
 	// We're reading certs directly from them
 	rootMemoryStore := &config.DestinationMemory{}
@@ -91,8 +91,8 @@ func (b *Bot) initializeConfig() {
 	destMemoryStore.CheckAndSetDefaults()
 
 	for _, artifact := range identity.GetArtifacts() {
-		_ = destMemoryStore.Write(artifact.Key, []byte{})
-		_ = rootMemoryStore.Write(artifact.Key, []byte{})
+		_ = destMemoryStore.Write(ctx, artifact.Key, []byte{})
+		_ = rootMemoryStore.Write(ctx, artifact.Key, []byte{})
 	}
 
 }
@@ -120,7 +120,7 @@ func (b *Bot) GetClient(ctx context.Context) (*client.Client, error) {
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			if err := b.cfg.Outputs[0].GetDestination().Write(artifact.Key, value); err != nil {
+			if err := b.cfg.Outputs[0].GetDestination().Write(nil, artifact.Key, value); err != nil {
 				return nil, trace.Wrap(err)
 			}
 
@@ -228,7 +228,7 @@ func CreateAndBootstrapBot(ctx context.Context, opts Options) (*Bot, *proto.Feat
 		opts:       opts,
 	}
 
-	bot.initializeConfig()
+	bot.initializeConfig(ctx)
 	return bot, ping.ServerFeatures, nil
 }
 

--- a/lib/backend/kubernetes/kubernetes_test.go
+++ b/lib/backend/kubernetes/kubernetes_test.go
@@ -350,7 +350,7 @@ func TestBackend_Put(t *testing.T) {
 				func(action k8stesting.Action) (bool, runtime.Object, error) {
 					secretResourceVersion := corev1.SchemeGroupVersion.WithResource("secrets")
 					applyAction := action.(k8stesting.PatchActionImpl)
-
+					
 					var secret *corev1.Secret
 
 					// FIXME(tigrato): in the future merge  applyAction.Patch into the data

--- a/lib/backend/kubernetes/kubernetes_test.go
+++ b/lib/backend/kubernetes/kubernetes_test.go
@@ -350,7 +350,7 @@ func TestBackend_Put(t *testing.T) {
 				func(action k8stesting.Action) (bool, runtime.Object, error) {
 					secretResourceVersion := corev1.SchemeGroupVersion.WithResource("secrets")
 					applyAction := action.(k8stesting.PatchActionImpl)
-					
+
 					var secret *corev1.Secret
 
 					// FIXME(tigrato): in the future merge  applyAction.Patch into the data

--- a/lib/tbot/bot/destination.go
+++ b/lib/tbot/bot/destination.go
@@ -35,7 +35,7 @@ type Destination interface {
 	Write(ctx context.Context, name string, data []byte) error
 
 	// Read fetches data from the destination with a given name.
-	Read(name string) ([]byte, error)
+	Read(ctx context.Context, name string) ([]byte, error)
 
 	// TryLock attempts to lock a destination. This is non-blocking, and will
 	// return an error if it is not possible to lock the destination.

--- a/lib/tbot/bot/destination.go
+++ b/lib/tbot/bot/destination.go
@@ -16,12 +16,15 @@ limitations under the License.
 
 package bot
 
+import "context"
+
 // Destination can persist renewable certificates.
 type Destination interface {
-	// Init attempts to initialize this destination for writing. Init should be
+	// Init attempts to initialize this destination for use. Init should be
 	// idempotent and may write informational log messages if resources are
 	// created.
-	Init(subdirs []string) error
+	// This must be called before Read or Write.
+	Init(ctx context.Context, subdirs []string) error
 
 	// Verify is run before renewals to check for any potential problems with
 	// the destination. These errors may be informational (logged warnings) or

--- a/lib/tbot/bot/destination.go
+++ b/lib/tbot/bot/destination.go
@@ -32,7 +32,7 @@ type Destination interface {
 	Verify(keys []string) error
 
 	// Write stores data to the destination with the given name.
-	Write(name string, data []byte) error
+	Write(ctx context.Context, name string, data []byte) error
 
 	// Read fetches data from the destination with a given name.
 	Read(name string) ([]byte, error)

--- a/lib/tbot/bot_identity.go
+++ b/lib/tbot/bot_identity.go
@@ -111,7 +111,7 @@ func (b *Bot) renewBotIdentity(
 ) error {
 	currentIdentity := b.ident()
 	// Make sure we can still write to the bot's destination.
-	if err := identity.VerifyWrite(botDestination); err != nil {
+	if err := identity.VerifyWrite(ctx, botDestination); err != nil {
 		return trace.Wrap(err, "Cannot write to destination %s, aborting.", botDestination)
 	}
 
@@ -142,7 +142,7 @@ func (b *Bot) renewBotIdentity(
 	b.log.WithField("identity", describeTLSIdentity(b.log, newIdentity)).Info("Fetched new bot identity.")
 	b.setIdent(newIdentity)
 
-	if err := identity.SaveIdentity(newIdentity, botDestination, identity.BotKinds()...); err != nil {
+	if err := identity.SaveIdentity(ctx, newIdentity, botDestination, identity.BotKinds()...); err != nil {
 		return trace.Wrap(err)
 	}
 	b.log.WithField("identity", describeTLSIdentity(b.log, newIdentity)).Debug("Bot identity persisted.")

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -425,6 +425,12 @@ func unmarshalDestination(node *yaml.Node) (bot.Destination, error) {
 			return nil, trace.Wrap(err)
 		}
 		return v, nil
+	case DestinationKubernetesSecretType:
+		v := &DestinationKubernetesSecret{}
+		if err := node.Decode(v); err != nil {
+			return nil, trace.Wrap(err)
+		}
+		return v, nil
 	default:
 		return nil, trace.BadParameter("unrecognized destination type (%s)", header.Type)
 	}

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -292,27 +292,30 @@ func (conf *BotConfig) CheckAndSetDefaults() error {
 	}
 
 	destinationPaths := map[string]int{}
+	addDestinationToKnownPaths := func(d bot.Destination) {
+		switch d := d.(type) {
+		case *DestinationDirectory:
+			destinationPaths[fmt.Sprintf("file://%s", d.Path)]++
+		case *DestinationKubernetesSecret:
+			destinationPaths[fmt.Sprintf("kubernetes-secret://%s", d.Name)]++
+		}
+	}
 	for _, output := range conf.Outputs {
 		if err := output.CheckAndSetDefaults(); err != nil {
 			return trace.Wrap(err)
 		}
-
-		// This check currently only handles directory destinations, but we'll
-		// need to create a more polymorphic way of doing this when we introduce
-		// more destination types.
-		directoryDestination, ok := output.GetDestination().(*DestinationDirectory)
-		if ok {
-			destinationPaths[directoryDestination.Path]++
-		}
+		addDestinationToKnownPaths(output.GetDestination())
 	}
-	// Check for outputs reusing the same destination. This is a deeply
+
+	// Check for identical destinations being used. This is a deeply
 	// uncharted/unknown behavior area. For now we'll emit a heavy warning,
 	// in 15+ this will be an explicit area as outputs writing over one another
 	// is too complex to support.
+	addDestinationToKnownPaths(conf.Storage.Destination)
 	for path, count := range destinationPaths {
 		if count > 1 {
 			log.WithField("path", path).Error(
-				"Multiple outputs reusing the same destination path. This can produce unusable results. In Teleport 15.0, this will be a fatal error.",
+				"Identical destinations used within config. This can produce unusable results. In Teleport 15.0, this will be a fatal error.",
 			)
 		}
 	}

--- a/lib/tbot/config/config_test.go
+++ b/lib/tbot/config/config_test.go
@@ -242,6 +242,11 @@ func TestBotConfig_YAML(t *testing.T) {
 					&IdentityOutput{
 						Destination: &DestinationMemory{},
 					},
+					&IdentityOutput{
+						Destination: &DestinationKubernetesSecret{
+							Name: "my-secret",
+						},
+					},
 				},
 			},
 		},

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -145,7 +146,7 @@ func mkdir(p string) error {
 	return nil
 }
 
-func (dd *DestinationDirectory) Init(subdirs []string) error {
+func (dd *DestinationDirectory) Init(_ context.Context, subdirs []string) error {
 	// Create the directory if needed.
 	if err := mkdir(dd.Path); err != nil {
 		return trace.Wrap(err)

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -219,7 +219,7 @@ func (dd *DestinationDirectory) Write(_ context.Context, name string, data []byt
 	return trace.Wrap(botfs.Write(filepath.Join(dd.Path, name), data, dd.Symlinks))
 }
 
-func (dd *DestinationDirectory) Read(ctx context.Context, name string) ([]byte, error) {
+func (dd *DestinationDirectory) Read(_ context.Context, name string) ([]byte, error) {
 	data, err := botfs.Read(filepath.Join(dd.Path, name), dd.Symlinks)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -215,11 +215,11 @@ func (dd *DestinationDirectory) Verify(keys []string) error {
 	return nil
 }
 
-func (dd *DestinationDirectory) Write(ctx context.Context, name string, data []byte) error {
+func (dd *DestinationDirectory) Write(_ context.Context, name string, data []byte) error {
 	return trace.Wrap(botfs.Write(filepath.Join(dd.Path, name), data, dd.Symlinks))
 }
 
-func (dd *DestinationDirectory) Read(name string) ([]byte, error) {
+func (dd *DestinationDirectory) Read(ctx context.Context, name string) ([]byte, error) {
 	data, err := botfs.Read(filepath.Join(dd.Path, name), dd.Symlinks)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/tbot/config/destination_directory.go
+++ b/lib/tbot/config/destination_directory.go
@@ -215,7 +215,7 @@ func (dd *DestinationDirectory) Verify(keys []string) error {
 	return nil
 }
 
-func (dd *DestinationDirectory) Write(name string, data []byte) error {
+func (dd *DestinationDirectory) Write(ctx context.Context, name string, data []byte) error {
 	return trace.Wrap(botfs.Write(filepath.Join(dd.Path, name), data, dd.Symlinks))
 }
 

--- a/lib/tbot/config/destination_kubernetes_secret.go
+++ b/lib/tbot/config/destination_kubernetes_secret.go
@@ -156,11 +156,10 @@ func (dks *DestinationKubernetesSecret) Write(ctx context.Context, name string, 
 	return trace.Wrap(err)
 }
 
-func (dks *DestinationKubernetesSecret) Read(name string) ([]byte, error) {
+func (dks *DestinationKubernetesSecret) Read(ctx context.Context, name string) ([]byte, error) {
 	dks.mu.Lock()
 	defer dks.mu.Unlock()
 
-	ctx := context.TODO()
 	secret, err := dks.getSecret(ctx)
 	if err != nil {
 		if kubeerrors.IsNotFound(err) {

--- a/lib/tbot/config/destination_kubernetes_secret.go
+++ b/lib/tbot/config/destination_kubernetes_secret.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package config
 
 import (

--- a/lib/tbot/config/destination_kubernetes_secret.go
+++ b/lib/tbot/config/destination_kubernetes_secret.go
@@ -19,11 +19,11 @@ package config
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"os"
 	"sync"
 
 	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/lib/tbot/config/destination_kubernetes_secret.go
+++ b/lib/tbot/config/destination_kubernetes_secret.go
@@ -1,0 +1,185 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"github.com/gravitational/trace"
+	corev1 "k8s.io/api/core/v1"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	applyconfigv1 "k8s.io/client-go/applyconfigurations/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+	"os"
+	"sync"
+)
+
+const DestinationKubernetesSecretType = "kubernetes_secret"
+const kubernetesNamespaceEnv = "POD_NAMESPACE"
+
+type DestinationKubernetesSecret struct {
+	Name string `yaml:"name"`
+
+	mu        sync.Mutex
+	namespace string
+	k8s       kubernetes.Interface
+}
+
+func (dks *DestinationKubernetesSecret) fieldManager() string {
+	return "tbot"
+}
+
+func (dks *DestinationKubernetesSecret) getSecret(ctx context.Context) (*corev1.Secret, error) {
+	secret, err := dks.k8s.CoreV1().Secrets(dks.namespace).Get(ctx, dks.Name, v1.GetOptions{})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	// This will be nil out of Kubernetes if it hasn't had any values provided.
+	// Replace with an initialized map so code using this function does not
+	// need to worry about writing/reading from a nil map.
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
+	return secret, nil
+}
+
+func (dks *DestinationKubernetesSecret) secretTemplate() *corev1.Secret {
+	return &corev1.Secret{
+		Type: corev1.SecretTypeOpaque,
+		ObjectMeta: v1.ObjectMeta{
+			Name:      dks.Name,
+			Namespace: dks.namespace,
+		},
+		Data: map[string][]byte{},
+	}
+}
+
+func (dks *DestinationKubernetesSecret) upsertSecret(ctx context.Context, secret *corev1.Secret) error {
+	apply := applyconfigv1.Secret(dks.Name, dks.namespace).
+		WithData(secret.Data).
+		WithResourceVersion(secret.ResourceVersion).
+		WithType(secret.Type)
+
+	_, err := dks.k8s.CoreV1().Secrets(dks.namespace).Apply(ctx, apply, v1.ApplyOptions{
+		FieldManager: dks.fieldManager(),
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (dks *DestinationKubernetesSecret) Verify(_ []string) error {
+	return nil
+}
+
+func (dks *DestinationKubernetesSecret) TryLock() (func() error, error) {
+	return func() error { return nil }, nil
+}
+
+func (dks *DestinationKubernetesSecret) CheckAndSetDefaults() error {
+	if dks.Name == "" {
+		return trace.BadParameter("name must not be empty")
+	}
+
+	return nil
+}
+
+func (dks *DestinationKubernetesSecret) Init(subdirs []string) error {
+	dks.mu.Lock()
+	defer dks.mu.Unlock()
+
+	ctx := context.TODO()
+	if dks.namespace == "" {
+		dks.namespace = os.Getenv(kubernetesNamespaceEnv)
+		if dks.namespace == "" {
+			return trace.BadParameter("unable to detect namespace from %s environment variable", kubernetesNamespaceEnv)
+		}
+	}
+
+	if len(subdirs) > 0 {
+		return trace.BadParameter("kubernetes_secret destination does not support subdirectories")
+	}
+
+	// If no k8s client is injected, we attempt to create one from the
+	// environment.
+	if dks.k8s == nil {
+		// BuildConfigFromFlags falls back to InClusterConfig if both params
+		// are empty. This means KUBECONFIG takes precedence.
+		clientCfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		dks.k8s, err = kubernetes.NewForConfig(clientCfg)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	// Try and read the secret and then write to it. This lets us fail early
+	// and clearly if the appropriate permissions are missing
+	secret, err := dks.getSecret(ctx)
+	if err != nil {
+		if !kubeerrors.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+		secret = dks.secretTemplate()
+	}
+	if err := dks.upsertSecret(ctx, secret); err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func (dks *DestinationKubernetesSecret) Write(name string, data []byte) error {
+	dks.mu.Lock()
+	defer dks.mu.Unlock()
+
+	ctx := context.TODO()
+	secret, err := dks.getSecret(ctx)
+	if err != nil {
+		if !kubeerrors.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+		log.Warn("Kubernetes secret missing on attempt to write data- will create.")
+		// If the secret doesn't exist, we create it on write - this is ensures
+		// that we can recover if the secret is deleted between renewal loops.
+		secret = dks.secretTemplate()
+	}
+
+	secret.Data[name] = data
+
+	err = dks.upsertSecret(ctx, secret)
+	return trace.Wrap(err)
+}
+
+func (dks *DestinationKubernetesSecret) Read(name string) ([]byte, error) {
+	dks.mu.Lock()
+	defer dks.mu.Unlock()
+
+	ctx := context.TODO()
+	secret, err := dks.getSecret(ctx)
+	if err != nil {
+		if kubeerrors.IsNotFound(err) {
+			return nil, trace.NotFound("secret could not be found")
+		}
+		return nil, trace.Wrap(err)
+	}
+
+	data, ok := secret.Data[name]
+	if !ok {
+		return nil, trace.NotFound("key %q cannot be found in secret data", name)
+	}
+
+	return data, nil
+}
+
+func (dks *DestinationKubernetesSecret) String() string {
+	return fmt.Sprintf("%s: %s", DestinationKubernetesSecretType, dks.Name)
+}
+
+func (dks DestinationKubernetesSecret) MarshalYAML() (interface{}, error) {
+	type raw DestinationKubernetesSecret
+	return withTypeHeader(raw(dks), DestinationKubernetesSecretType)
+}

--- a/lib/tbot/config/destination_kubernetes_secret.go
+++ b/lib/tbot/config/destination_kubernetes_secret.go
@@ -216,7 +216,7 @@ func (dks *DestinationKubernetesSecret) String() string {
 	return fmt.Sprintf("%s: %s", DestinationKubernetesSecretType, dks.Name)
 }
 
-func (dks DestinationKubernetesSecret) MarshalYAML() (interface{}, error) {
+func (dks *DestinationKubernetesSecret) MarshalYAML() (interface{}, error) {
 	type raw DestinationKubernetesSecret
-	return withTypeHeader(raw(dks), DestinationKubernetesSecretType)
+	return withTypeHeader((*raw)(dks), DestinationKubernetesSecretType)
 }

--- a/lib/tbot/config/destination_kubernetes_secret.go
+++ b/lib/tbot/config/destination_kubernetes_secret.go
@@ -85,11 +85,10 @@ func (dks *DestinationKubernetesSecret) CheckAndSetDefaults() error {
 	return nil
 }
 
-func (dks *DestinationKubernetesSecret) Init(subdirs []string) error {
+func (dks *DestinationKubernetesSecret) Init(ctx context.Context, subdirs []string) error {
 	dks.mu.Lock()
 	defer dks.mu.Unlock()
 
-	ctx := context.TODO()
 	if dks.namespace == "" {
 		dks.namespace = os.Getenv(kubernetesNamespaceEnv)
 		if dks.namespace == "" {

--- a/lib/tbot/config/destination_kubernetes_secret.go
+++ b/lib/tbot/config/destination_kubernetes_secret.go
@@ -18,6 +18,8 @@ const DestinationKubernetesSecretType = "kubernetes_secret"
 const kubernetesNamespaceEnv = "POD_NAMESPACE"
 
 type DestinationKubernetesSecret struct {
+	// Name is the name the Kubernetes Secret that should be created and written
+	// to.
 	Name string `yaml:"name"`
 
 	mu        sync.Mutex
@@ -74,6 +76,8 @@ func (dks *DestinationKubernetesSecret) Verify(_ []string) error {
 }
 
 func (dks *DestinationKubernetesSecret) TryLock() (func() error, error) {
+	// No locking support currently implemented. Users will need to be cautious
+	// to not point two tbots to the same secret.
 	return func() error { return nil }, nil
 }
 
@@ -131,11 +135,10 @@ func (dks *DestinationKubernetesSecret) Init(ctx context.Context, subdirs []stri
 	return nil
 }
 
-func (dks *DestinationKubernetesSecret) Write(name string, data []byte) error {
+func (dks *DestinationKubernetesSecret) Write(ctx context.Context, name string, data []byte) error {
 	dks.mu.Lock()
 	defer dks.mu.Unlock()
 
-	ctx := context.TODO()
 	secret, err := dks.getSecret(ctx)
 	if err != nil {
 		if !kubeerrors.IsNotFound(err) {

--- a/lib/tbot/config/destination_kubernetes_secret_test.go
+++ b/lib/tbot/config/destination_kubernetes_secret_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"testing"
+)
+
+func TestDestinationKubernetesSecret_CheckAndSetDefaults(t *testing.T) {
+	tests := []testCheckAndSetDefaultsCase[*DestinationKubernetesSecret]{
+		{
+			name: "valid",
+			in: func() *DestinationKubernetesSecret {
+				return &DestinationKubernetesSecret{
+					Name: "my-secret",
+				}
+			},
+		},
+		{
+			name: "missing name",
+			in: func() *DestinationKubernetesSecret {
+				return &DestinationKubernetesSecret{
+					Name: "",
+				}
+			},
+			wantErr: "name must not be empty",
+		},
+	}
+	testCheckAndSetDefaults(t, tests)
+}
+
+func TestDestinationKubernetesSecret_YAML(t *testing.T) {
+	tests := []testYAMLCase[DestinationKubernetesSecret]{
+		{
+			name: "full",
+			in: DestinationKubernetesSecret{
+				Name: "my-secret",
+			},
+		},
+	}
+	testYAML(t, tests)
+}

--- a/lib/tbot/config/destination_kubernetes_secret_test.go
+++ b/lib/tbot/config/destination_kubernetes_secret_test.go
@@ -17,8 +17,96 @@ limitations under the License.
 package config
 
 import (
+	"context"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/fake"
+	core "k8s.io/client-go/testing"
 	"testing"
 )
+
+func TestDestinationKubernetesSecret(t *testing.T) {
+	t.Setenv("POD_NAMESPACE", "test-namespace")
+
+	// Hack a reactor into the Kubernetes client-go fake client set as it
+	// doesn't currently support Apply :)
+	// https://github.com/kubernetes/kubernetes/issues/99953
+	fakeClientSet := func(objects ...runtime.Object) *fake.Clientset {
+		f := fake.NewSimpleClientset(objects...)
+		f.PrependReactor("patch", "secrets", func(action core.Action) (handled bool, ret runtime.Object, err error) {
+			pa := action.(core.PatchAction)
+			if pa.GetPatchType() == types.ApplyPatchType {
+				react := core.ObjectReaction(f.Tracker())
+				_, _, err := react(
+					core.NewGetAction(pa.GetResource(), pa.GetNamespace(), pa.GetName()),
+				)
+				if kubeerrors.IsNotFound(err) {
+					_, _, err = react(
+						core.NewCreateAction(pa.GetResource(), pa.GetNamespace(), &corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      pa.GetName(),
+								Namespace: pa.GetNamespace(),
+							},
+						}),
+					)
+					if err != nil {
+						return false, nil, err
+					}
+				}
+				return react(action)
+			}
+			return false, nil, nil
+		})
+		return f
+	}
+
+	tests := []struct {
+		name string
+		dest *DestinationKubernetesSecret
+
+		wantErr string
+	}{
+		{
+			name: "no existing secret",
+			dest: &DestinationKubernetesSecret{
+				Name: "my-secret",
+				k8s:  fakeClientSet(),
+			},
+		},
+		{
+			name: "existing secret",
+			dest: &DestinationKubernetesSecret{
+				Name: "my-secret",
+				k8s: fakeClientSet(&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-secret",
+						Namespace: "test-namespace",
+					},
+				}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			require.NoError(t, tt.dest.Init(ctx, []string{}))
+			require.NoError(t, tt.dest.Write(ctx, "artifact-a", []byte("data-a")))
+			require.NoError(t, tt.dest.Write(ctx, "artifact-b", []byte("data-b")))
+			aData, err := tt.dest.Read(ctx, "artifact-a")
+			require.NoError(t, err)
+			require.Equal(t, []byte("data-a"), aData)
+			bData, err := tt.dest.Read(ctx, "artifact-b")
+			require.NoError(t, err)
+			require.Equal(t, []byte("data-b"), bData)
+		})
+	}
+}
 
 func TestDestinationKubernetesSecret_CheckAndSetDefaults(t *testing.T) {
 	tests := []testCheckAndSetDefaultsCase[*DestinationKubernetesSecret]{
@@ -53,4 +141,8 @@ func TestDestinationKubernetesSecret_YAML(t *testing.T) {
 		},
 	}
 	testYAML(t, tests)
+}
+
+func TestDestinationKubernetesSecret_String(t *testing.T) {
+	require.Equal(t, "kubernetes_secret: my-secret", (&DestinationKubernetesSecret{Name: "my-secret"}).String())
 }

--- a/lib/tbot/config/destination_kubernetes_secret_test.go
+++ b/lib/tbot/config/destination_kubernetes_secret_test.go
@@ -133,10 +133,10 @@ func TestDestinationKubernetesSecret_CheckAndSetDefaults(t *testing.T) {
 }
 
 func TestDestinationKubernetesSecret_YAML(t *testing.T) {
-	tests := []testYAMLCase[DestinationKubernetesSecret]{
+	tests := []testYAMLCase[*DestinationKubernetesSecret]{
 		{
 			name: "full",
-			in: DestinationKubernetesSecret{
+			in: &DestinationKubernetesSecret{
 				Name: "my-secret",
 			},
 		},

--- a/lib/tbot/config/destination_kubernetes_secret_test.go
+++ b/lib/tbot/config/destination_kubernetes_secret_test.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,7 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	core "k8s.io/client-go/testing"
-	"testing"
 )
 
 func TestDestinationKubernetesSecret(t *testing.T) {

--- a/lib/tbot/config/destination_memory.go
+++ b/lib/tbot/config/destination_memory.go
@@ -63,13 +63,13 @@ func (dm *DestinationMemory) Verify(keys []string) error {
 	return nil
 }
 
-func (dm *DestinationMemory) Write(ctx context.Context, name string, data []byte) error {
+func (dm *DestinationMemory) Write(_ context.Context, name string, data []byte) error {
 	dm.store[name] = data
 
 	return nil
 }
 
-func (dm *DestinationMemory) Read(name string) ([]byte, error) {
+func (dm *DestinationMemory) Read(ctx context.Context, name string) ([]byte, error) {
 	b, ok := dm.store[name]
 	if !ok {
 		return nil, trace.NotFound("not found: %s", name)

--- a/lib/tbot/config/destination_memory.go
+++ b/lib/tbot/config/destination_memory.go
@@ -63,7 +63,7 @@ func (dm *DestinationMemory) Verify(keys []string) error {
 	return nil
 }
 
-func (dm *DestinationMemory) Write(name string, data []byte) error {
+func (dm *DestinationMemory) Write(ctx context.Context, name string, data []byte) error {
 	dm.store[name] = data
 
 	return nil

--- a/lib/tbot/config/destination_memory.go
+++ b/lib/tbot/config/destination_memory.go
@@ -17,6 +17,7 @@ limitations under the License.
 package config
 
 import (
+	"context"
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 )
@@ -52,7 +53,7 @@ func (dm *DestinationMemory) CheckAndSetDefaults() error {
 	return nil
 }
 
-func (dm *DestinationMemory) Init(subdirs []string) error {
+func (dm *DestinationMemory) Init(_ context.Context, subdirs []string) error {
 	// Nothing to do.
 	return nil
 }

--- a/lib/tbot/config/destination_memory.go
+++ b/lib/tbot/config/destination_memory.go
@@ -69,7 +69,7 @@ func (dm *DestinationMemory) Write(_ context.Context, name string, data []byte) 
 	return nil
 }
 
-func (dm *DestinationMemory) Read(ctx context.Context, name string) ([]byte, error) {
+func (dm *DestinationMemory) Read(_ context.Context, name string) ([]byte, error) {
 	b, ok := dm.store[name]
 	if !ok {
 		return nil, trace.NotFound("not found: %s", name)

--- a/lib/tbot/config/destination_memory.go
+++ b/lib/tbot/config/destination_memory.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"context"
+
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v3"
 )

--- a/lib/tbot/config/output.go
+++ b/lib/tbot/config/output.go
@@ -54,7 +54,7 @@ type Output interface {
 	// initializing in-memory maps.
 	//
 	// This must be called before Render.
-	Init() error
+	Init(ctx context.Context) error
 	// MarshalYAML enables the yaml package to correctly marshal the Output as
 	// YAML.
 	MarshalYAML() (interface{}, error)

--- a/lib/tbot/config/output_application.go
+++ b/lib/tbot/config/output_application.go
@@ -72,13 +72,13 @@ func (o *ApplicationOutput) Render(ctx context.Context, p provider, ident *ident
 	return nil
 }
 
-func (o *ApplicationOutput) Init() error {
+func (o *ApplicationOutput) Init(ctx context.Context) error {
 	subDirs, err := listSubdirectories(o.templates())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(o.Destination.Init(subDirs))
+	return trace.Wrap(o.Destination.Init(ctx, subDirs))
 }
 
 func (o *ApplicationOutput) CheckAndSetDefaults() error {

--- a/lib/tbot/config/output_application.go
+++ b/lib/tbot/config/output_application.go
@@ -59,7 +59,7 @@ func (o *ApplicationOutput) templates() []template {
 }
 
 func (o *ApplicationOutput) Render(ctx context.Context, p provider, ident *identity.Identity) error {
-	if err := identity.SaveIdentity(ident, o.Destination, identity.DestinationKinds()...); err != nil {
+	if err := identity.SaveIdentity(ctx, ident, o.Destination, identity.DestinationKinds()...); err != nil {
 		return trace.Wrap(err, "persisting identity")
 	}
 

--- a/lib/tbot/config/output_database.go
+++ b/lib/tbot/config/output_database.go
@@ -105,7 +105,7 @@ func (o *DatabaseOutput) templates() []template {
 }
 
 func (o *DatabaseOutput) Render(ctx context.Context, p provider, ident *identity.Identity) error {
-	if err := identity.SaveIdentity(ident, o.Destination, identity.DestinationKinds()...); err != nil {
+	if err := identity.SaveIdentity(ctx, ident, o.Destination, identity.DestinationKinds()...); err != nil {
 		return trace.Wrap(err, "persisting identity")
 	}
 

--- a/lib/tbot/config/output_database.go
+++ b/lib/tbot/config/output_database.go
@@ -118,13 +118,13 @@ func (o *DatabaseOutput) Render(ctx context.Context, p provider, ident *identity
 	return nil
 }
 
-func (o *DatabaseOutput) Init() error {
+func (o *DatabaseOutput) Init(ctx context.Context) error {
 	subDirs, err := listSubdirectories(o.templates())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(o.Destination.Init(subDirs))
+	return trace.Wrap(o.Destination.Init(ctx, subDirs))
 }
 
 func (o *DatabaseOutput) CheckAndSetDefaults() error {

--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -69,7 +69,7 @@ func (o *IdentityOutput) templates() []template {
 
 func (o *IdentityOutput) Render(ctx context.Context, p provider, ident *identity.Identity) error {
 	dest := o.GetDestination()
-	if err := identity.SaveIdentity(ident, dest, identity.DestinationKinds()...); err != nil {
+	if err := identity.SaveIdentity(ctx, ident, dest, identity.DestinationKinds()...); err != nil {
 		return trace.Wrap(err, "persisting identity")
 	}
 

--- a/lib/tbot/config/output_identity.go
+++ b/lib/tbot/config/output_identity.go
@@ -82,13 +82,13 @@ func (o *IdentityOutput) Render(ctx context.Context, p provider, ident *identity
 	return nil
 }
 
-func (o *IdentityOutput) Init() error {
+func (o *IdentityOutput) Init(ctx context.Context) error {
 	subDirs, err := listSubdirectories(o.templates())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(o.Destination.Init(subDirs))
+	return trace.Wrap(o.Destination.Init(ctx, subDirs))
 }
 
 func (o *IdentityOutput) GetDestination() bot.Destination {

--- a/lib/tbot/config/output_kubernetes.go
+++ b/lib/tbot/config/output_kubernetes.go
@@ -58,7 +58,7 @@ func (o *KubernetesOutput) templates() []template {
 
 func (o *KubernetesOutput) Render(ctx context.Context, p provider, ident *identity.Identity) error {
 	dest := o.GetDestination()
-	if err := identity.SaveIdentity(ident, dest, identity.DestinationKinds()...); err != nil {
+	if err := identity.SaveIdentity(ctx, ident, dest, identity.DestinationKinds()...); err != nil {
 		return trace.Wrap(err, "persisting identity")
 	}
 

--- a/lib/tbot/config/output_kubernetes.go
+++ b/lib/tbot/config/output_kubernetes.go
@@ -71,13 +71,13 @@ func (o *KubernetesOutput) Render(ctx context.Context, p provider, ident *identi
 	return nil
 }
 
-func (o *KubernetesOutput) Init() error {
+func (o *KubernetesOutput) Init(ctx context.Context) error {
 	subDirs, err := listSubdirectories(o.templates())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(o.Destination.Init(subDirs))
+	return trace.Wrap(o.Destination.Init(ctx, subDirs))
 }
 
 func (o *KubernetesOutput) CheckAndSetDefaults() error {

--- a/lib/tbot/config/output_ssh_host.go
+++ b/lib/tbot/config/output_ssh_host.go
@@ -60,13 +60,13 @@ func (o *SSHHostOutput) Render(ctx context.Context, p provider, ident *identity.
 	return nil
 }
 
-func (o *SSHHostOutput) Init() error {
+func (o *SSHHostOutput) Init(ctx context.Context) error {
 	subDirs, err := listSubdirectories(o.templates())
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(o.Destination.Init(subDirs))
+	return trace.Wrap(o.Destination.Init(ctx, subDirs))
 }
 
 func (o *SSHHostOutput) GetDestination() bot.Destination {

--- a/lib/tbot/config/output_test.go
+++ b/lib/tbot/config/output_test.go
@@ -24,14 +24,18 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 )
 
-type testCheckAndSetDefaultsCase[T Output] struct {
+type checkAndSetDefaulter interface {
+	CheckAndSetDefaults() error
+}
+
+type testCheckAndSetDefaultsCase[T checkAndSetDefaulter] struct {
 	name string
 	in   func() T
 
-	// want specifies the desired state of the Output after check and set
-	// defaults has been run. If want is nil, the Output is compared to its
-	// initial state.
-	want    Output
+	// want specifies the desired state of the checkAndSetDefaulter after
+	// check and set defaults has been run. If want is nil, the Output is
+	// compared to its initial state.
+	want    checkAndSetDefaulter
 	wantErr string
 }
 
@@ -39,7 +43,7 @@ func memoryDestForTest() bot.Destination {
 	return &DestinationMemory{store: map[string][]byte{}}
 }
 
-func testCheckAndSetDefaults[T Output](t *testing.T, tests []testCheckAndSetDefaultsCase[T]) {
+func testCheckAndSetDefaults[T checkAndSetDefaulter](t *testing.T, tests []testCheckAndSetDefaultsCase[T]) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := tt.in()

--- a/lib/tbot/config/template.go
+++ b/lib/tbot/config/template.go
@@ -98,6 +98,8 @@ type template interface {
 // BotConfigWriter is a trivial adapter to use the identityfile package with
 // bot destinations.
 type BotConfigWriter struct {
+	ctx context.Context
+
 	// dest is the Destination that will handle writing of files.
 	dest bot.Destination
 
@@ -114,7 +116,7 @@ func (b *BotConfigWriter) WriteFile(name string, data []byte, _ os.FileMode) err
 		p = path.Join(b.subpath, p)
 	}
 
-	return trace.Wrap(b.dest.Write(p, data))
+	return trace.Wrap(b.dest.Write(b.ctx, p, data))
 }
 
 // Remove removes files. This is a dummy implementation that always returns not found.

--- a/lib/tbot/config/template_cockroach.go
+++ b/lib/tbot/config/template_cockroach.go
@@ -66,6 +66,7 @@ func (t *templateCockroach) render(
 	cfg := identityfile.WriteConfig{
 		OutputPath: defaultCockroachDirName,
 		Writer: &BotConfigWriter{
+			ctx:     ctx,
 			dest:    destination,
 			subpath: defaultCockroachDirName,
 		},

--- a/lib/tbot/config/template_identity.go
+++ b/lib/tbot/config/template_identity.go
@@ -64,6 +64,7 @@ func (t *templateIdentity) render(
 	cfg := identityfile.WriteConfig{
 		OutputPath: IdentityFilePath,
 		Writer: &BotConfigWriter{
+			ctx:  ctx,
 			dest: destination,
 		},
 		Key:    key,

--- a/lib/tbot/config/template_kubernetes.go
+++ b/lib/tbot/config/template_kubernetes.go
@@ -224,5 +224,5 @@ func (t *templateKubernetes) render(
 		return trace.Wrap(err)
 	}
 
-	return trace.Wrap(destination.Write(defaultKubeconfigPath, yamlCfg))
+	return trace.Wrap(destination.Write(ctx, defaultKubeconfigPath, yamlCfg))
 }

--- a/lib/tbot/config/template_mongo.go
+++ b/lib/tbot/config/template_mongo.go
@@ -68,6 +68,7 @@ func (t *templateMongo) render(
 	cfg := identityfile.WriteConfig{
 		OutputPath: defaultMongoPrefix,
 		Writer: &BotConfigWriter{
+			ctx:  ctx,
 			dest: destination,
 		},
 		Key:    key,

--- a/lib/tbot/config/template_ssh_client.go
+++ b/lib/tbot/config/template_ssh_client.go
@@ -122,7 +122,7 @@ func (c *templateSSHClient) render(
 		return trace.Wrap(err)
 	}
 
-	if err := destination.Write(knownHostsName, []byte(knownHosts)); err != nil {
+	if err := destination.Write(ctx, knownHostsName, []byte(knownHosts)); err != nil {
 		return trace.Wrap(err)
 	}
 
@@ -165,7 +165,7 @@ func (c *templateSSHClient) render(
 		return trace.Wrap(err)
 	}
 
-	if err := destination.Write(sshConfigName, []byte(sshConfigBuilder.String())); err != nil {
+	if err := destination.Write(ctx, sshConfigName, []byte(sshConfigBuilder.String())); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/tbot/config/template_ssh_host_cert.go
+++ b/lib/tbot/config/template_ssh_host_cert.go
@@ -139,6 +139,7 @@ func (c *templateSSHHostCert) render(
 	cfg := identityfile.WriteConfig{
 		OutputPath: defaultSSHHostCertPrefix,
 		Writer: &BotConfigWriter{
+			ctx:  ctx,
 			dest: destination,
 		},
 		Key:    key,
@@ -164,7 +165,7 @@ func (c *templateSSHHostCert) render(
 	}
 
 	userCAPath := defaultSSHHostCertPrefix + sshHostUserCASuffix
-	if err := destination.Write(userCAPath, []byte(exportedCAs)); err != nil {
+	if err := destination.Write(ctx, userCAPath, []byte(exportedCAs)); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/tbot/config/template_ssh_host_cert_test.go
+++ b/lib/tbot/config/template_ssh_host_cert_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestTemplateSSHHostCertRender(t *testing.T) {
+	ctx := context.Background()
 	cfg, err := newTestConfig("example.com")
 	require.NoError(t, err)
 
@@ -40,17 +41,17 @@ func TestTemplateSSHHostCertRender(t *testing.T) {
 	require.NoError(t, dest.CheckAndSetDefaults())
 
 	ident := getTestIdent(t, "bot-test")
-	err = tmpl.render(context.Background(), mockBot, ident, dest)
+	err = tmpl.render(ctx, mockBot, ident, dest)
 	require.NoError(t, err)
 
 	// Make sure a cert is written. We just use a dummy cert (the CA fixture)
-	certBytes, err := dest.Read(defaultSSHHostCertPrefix + sshHostCertSuffix)
+	certBytes, err := dest.Read(ctx, defaultSSHHostCertPrefix+sshHostCertSuffix)
 	require.NoError(t, err)
 
 	require.Equal(t, fixtures.SSHCAPublicKey, string(certBytes))
 
 	// Make sure a CA is written.
-	caBytes, err := dest.Read(defaultSSHHostCertPrefix + sshHostUserCASuffix)
+	caBytes, err := dest.Read(ctx, defaultSSHHostCertPrefix+sshHostUserCASuffix)
 	require.NoError(t, err)
 
 	require.True(t, strings.HasPrefix(string(caBytes), fixtures.SSHCAPublicKey))

--- a/lib/tbot/config/template_tls.go
+++ b/lib/tbot/config/template_tls.go
@@ -75,6 +75,7 @@ func (t *templateTLS) render(
 	cfg := identityfile.WriteConfig{
 		OutputPath: defaultTLSPrefix,
 		Writer: &BotConfigWriter{
+			ctx:  ctx,
 			dest: destination,
 		},
 		Key:    key,

--- a/lib/tbot/config/template_tls_cas.go
+++ b/lib/tbot/config/template_tls_cas.go
@@ -100,15 +100,15 @@ func (t *templateTLSCAs) render(
 	// that mariadb at least does not seem to like being passed more than one
 	// CA so there may be some compat issues to address in the future for the
 	// rare case where a CA rotation is in progress.
-	if err := destination.Write(HostCAPath, concatCACerts(hostCAs)); err != nil {
+	if err := destination.Write(ctx, HostCAPath, concatCACerts(hostCAs)); err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := destination.Write(UserCAPath, concatCACerts(userCAs)); err != nil {
+	if err := destination.Write(ctx, UserCAPath, concatCACerts(userCAs)); err != nil {
 		return trace.Wrap(err)
 	}
 
-	if err := destination.Write(DatabaseCAPath, concatCACerts(databaseCAs)); err != nil {
+	if err := destination.Write(ctx, DatabaseCAPath, concatCACerts(databaseCAs)); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
+++ b/lib/tbot/config/testdata/TestBotConfig_YAML/standard_config.golden
@@ -15,6 +15,10 @@ outputs:
   - type: identity
     destination:
       type: memory
+  - type: identity
+    destination:
+      type: kubernetes_secret
+      name: my-secret
 debug: true
 auth_server: example.teleport.sh:443
 certificate_ttl: 1m0s

--- a/lib/tbot/config/testdata/TestDestinationKubernetesSecret_YAML/full.golden
+++ b/lib/tbot/config/testdata/TestDestinationKubernetesSecret_YAML/full.golden
@@ -1,0 +1,2 @@
+type: kubernetes_secret
+name: my-secret

--- a/lib/tbot/identity/identity.go
+++ b/lib/tbot/identity/identity.go
@@ -17,6 +17,7 @@ limitations under the License.
 package identity
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -394,8 +395,8 @@ func ReadSSHIdentityFromKeyPair(identity *Identity, keyBytes, publicKeyBytes, ce
 // VerifyWrite attempts to write to the .write-test artifact inside the given
 // destination. It should be called before attempting a renewal to help ensure
 // we won't then fail to save the identity.
-func VerifyWrite(dest bot.Destination) error {
-	return trace.Wrap(dest.Write(WriteTestKey, []byte{}))
+func VerifyWrite(ctx context.Context, dest bot.Destination) error {
+	return trace.Wrap(dest.Write(ctx, WriteTestKey, []byte{}))
 }
 
 // ListKeys returns a list of artifact keys that will be written given a list
@@ -414,7 +415,7 @@ func ListKeys(kinds ...ArtifactKind) []string {
 }
 
 // SaveIdentity saves a bot identity to a destination.
-func SaveIdentity(id *Identity, d bot.Destination, kinds ...ArtifactKind) error {
+func SaveIdentity(ctx context.Context, id *Identity, d bot.Destination, kinds ...ArtifactKind) error {
 	for _, artifact := range GetArtifacts() {
 		// Only store artifacts matching one of the set kinds.
 		if !artifact.Matches(kinds...) {
@@ -424,7 +425,7 @@ func SaveIdentity(id *Identity, d bot.Destination, kinds ...ArtifactKind) error 
 		data := artifact.ToBytes(id)
 
 		log.Debugf("Writing %s", artifact.Key)
-		if err := d.Write(artifact.Key, data); err != nil {
+		if err := d.Write(ctx, artifact.Key, data); err != nil {
 			return trace.Wrap(err, "could not write to %v", artifact.Key)
 		}
 	}

--- a/lib/tbot/identity/identity.go
+++ b/lib/tbot/identity/identity.go
@@ -434,7 +434,7 @@ func SaveIdentity(ctx context.Context, id *Identity, d bot.Destination, kinds ..
 }
 
 // LoadIdentity loads a bot identity from a destination.
-func LoadIdentity(d bot.Destination, kinds ...ArtifactKind) (*Identity, error) {
+func LoadIdentity(ctx context.Context, d bot.Destination, kinds ...ArtifactKind) (*Identity, error) {
 	var certs proto.Certs
 	var params LoadIdentityParams
 
@@ -444,7 +444,7 @@ func LoadIdentity(d bot.Destination, kinds ...ArtifactKind) (*Identity, error) {
 			continue
 		}
 
-		data, err := d.Read(artifact.Key)
+		data, err := d.Read(ctx, artifact.Key)
 		if err != nil {
 			return nil, trace.Wrap(err, "could not read artifact %q from destination %s", artifact.Key, d)
 		}
@@ -459,7 +459,7 @@ func LoadIdentity(d bot.Destination, kinds ...ArtifactKind) (*Identity, error) {
 				artifact.Key,
 				artifact.OldKey,
 			)
-			data, err = d.Read(artifact.OldKey)
+			data, err = d.Read(ctx, artifact.OldKey)
 			if err != nil {
 				return nil, trace.Wrap(
 					err,

--- a/lib/tbot/identity_test.go
+++ b/lib/tbot/identity_test.go
@@ -20,6 +20,7 @@ limitations under the License.
 package tbot
 
 import (
+	"context"
 	"testing"
 
 	"github.com/gravitational/trace"
@@ -32,13 +33,14 @@ import (
 func TestLoadEmptyIdentity(t *testing.T) {
 	t.Parallel()
 
+	ctx := context.Background()
 	dir := t.TempDir()
 	dest := config.DestinationDirectory{
 		Path: dir,
 	}
 	require.NoError(t, dest.CheckAndSetDefaults())
 
-	_, err := identity.LoadIdentity(&dest, identity.BotKinds()...)
+	_, err := identity.LoadIdentity(ctx, &dest, identity.BotKinds()...)
 	require.Error(t, err)
 
 	require.True(t, trace.IsNotFound(err))

--- a/lib/tbot/impersonated_identity.go
+++ b/lib/tbot/impersonated_identity.go
@@ -539,7 +539,7 @@ func (b *Bot) renewOutputs(
 		// ACLs are misconfigured, regardless of configuration.
 		// TODO: consider not making these a hard error? e.g. write other
 		// destinations even if this one is broken?
-		if err := identity.VerifyWrite(dest); err != nil {
+		if err := identity.VerifyWrite(ctx, dest); err != nil {
 			return trace.Wrap(err, "testing output destination: %s", output)
 		}
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -231,7 +231,7 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 
 	// Start by loading the bot's primary storage.
 	store := b.cfg.Storage.Destination
-	if err := identity.VerifyWrite(store); err != nil {
+	if err := identity.VerifyWrite(ctx, store); err != nil {
 		return nil, trace.Wrap(
 			err, "Could not write to destination %s, aborting.", store,
 		)
@@ -290,7 +290,7 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 	}
 
 	b.log.WithField("identity", describeTLSIdentity(b.log, newIdentity)).Info("Fetched new bot identity.")
-	if err := identity.SaveIdentity(newIdentity, store, identity.BotKinds()...); err != nil {
+	if err := identity.SaveIdentity(ctx, newIdentity, store, identity.BotKinds()...); err != nil {
 		return unlock, trace.Wrap(err)
 	}
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -250,7 +250,7 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 	if b.cfg.Onboarding.RenewableJoinMethod() {
 		// Nil, nil will be returned if no identity can be found in store or
 		// the identity in the store is no longer relevant.
-		loadedIdent, err = b.loadIdentityFromStore(store)
+		loadedIdent, err = b.loadIdentityFromStore(ctx, store)
 		if err != nil {
 			return unlock, trace.Wrap(err)
 		}
@@ -315,9 +315,9 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 // loadIdentityFromStore attempts to load a persisted identity from a store.
 // It checks this loaded identity against the configured onboarding profile
 // and ignores the loaded identity if there has been a configuration change.
-func (b *Bot) loadIdentityFromStore(store bot.Destination) (*identity.Identity, error) {
+func (b *Bot) loadIdentityFromStore(ctx context.Context, store bot.Destination) (*identity.Identity, error) {
 	b.log.WithField("store", store).Info("Loading existing bot identity from store.")
-	loadedIdent, err := identity.LoadIdentity(store, identity.BotKinds()...)
+	loadedIdent, err := identity.LoadIdentity(ctx, store, identity.BotKinds()...)
 	if err != nil {
 		if trace.IsNotFound(err) {
 			b.log.Info("No existing bot identity found in store. Bot will join using configured token.")

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -225,7 +225,7 @@ func (b *Bot) initialize(ctx context.Context) (func() error, error) {
 	}
 
 	// First, try to make sure all destinations are usable.
-	if err := checkDestinations(b.cfg); err != nil {
+	if err := checkDestinations(ctx, b.cfg); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -363,7 +363,7 @@ func hasTokenChanged(configTokenBytes, identityBytes []byte) bool {
 
 // checkDestinations checks all destinations and tries to create any that
 // don't already exist.
-func checkDestinations(cfg *config.BotConfig) error {
+func checkDestinations(ctx context.Context, cfg *config.BotConfig) error {
 	// Note: This is vaguely problematic as we don't recommend that users
 	// store renewable certs under the same user as end-user certs. That said,
 	//  - if the destination was properly created via tbot init this is a no-op
@@ -372,13 +372,13 @@ func checkDestinations(cfg *config.BotConfig) error {
 	storageDest := cfg.Storage.Destination
 
 	// Note: no subdirs to init for bot's internal storage.
-	if err := storageDest.Init([]string{}); err != nil {
+	if err := storageDest.Init(ctx, []string{}); err != nil {
 		return trace.Wrap(err)
 	}
 
 	// TODO: consider warning if ownership of all destintions is not expected.
 	for _, output := range cfg.Outputs {
-		if err := output.Init(); err != nil {
+		if err := output.Init(ctx); err != nil {
 			return trace.Wrap(err)
 		}
 	}

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -275,7 +275,7 @@ func TestBot(t *testing.T) {
 		dest := sshHostOutput.GetDestination()
 
 		// Validate ssh_host
-		hostKeyBytes, err := dest.Read("ssh_host")
+		hostKeyBytes, err := dest.Read(ctx, "ssh_host")
 		require.NoError(t, err)
 		hostKey, err := ssh.ParsePrivateKey(hostKeyBytes)
 		require.NoError(t, err)
@@ -284,7 +284,7 @@ func TestBot(t *testing.T) {
 		require.NoError(t, err)
 
 		// Validate ssh_host-cert.pub
-		hostCertBytes, err := dest.Read("ssh_host-cert.pub")
+		hostCertBytes, err := dest.Read(ctx, "ssh_host-cert.pub")
 		require.NoError(t, err)
 		hostCert, err := sshutils.ParseCertificate(hostCertBytes)
 		require.NoError(t, err)
@@ -305,7 +305,7 @@ func TestBot(t *testing.T) {
 		require.NoError(t, hostCert.Key.Verify(testData, signedTestData), "signature by host key does not verify with public key in host certificate")
 
 		// Validate ssh_host-user-ca.pub
-		userCABytes, err := dest.Read("ssh_host-user-ca.pub")
+		userCABytes, err := dest.Read(ctx, "ssh_host-user-ca.pub")
 		require.NoError(t, err)
 		userCAKey, _, _, _, err := ssh.ParseAuthorizedKey(userCABytes)
 		require.NoError(t, err)
@@ -333,13 +333,13 @@ func requireValidOutputTLSIdent(t *testing.T, ident *tlsca.Identity, wantRoles [
 	require.Equal(t, wantRoles, ident.Groups)
 }
 
-func tlsIdentFromDest(t *testing.T, dest bot.Destination) *tlsca.Identity {
+func tlsIdentFromDest(ctx context.Context, t *testing.T, dest bot.Destination) *tlsca.Identity {
 	t.Helper()
-	keyBytes, err := dest.Read(identity.PrivateKeyKey)
+	keyBytes, err := dest.Read(ctx, identity.PrivateKeyKey)
 	require.NoError(t, err)
-	certBytes, err := dest.Read(identity.TLSCertKey)
+	certBytes, err := dest.Read(ctx, identity.TLSCertKey)
 	require.NoError(t, err)
-	hostCABytes, err := dest.Read(config.HostCAPath)
+	hostCABytes, err := dest.Read(ctx, config.HostCAPath)
 	require.NoError(t, err)
 	ident := &identity.Identity{}
 	err = identity.ReadTLSIdentityFromKeyPair(ident, keyBytes, certBytes, [][]byte{hostCABytes})

--- a/lib/tbot/tbot_test.go
+++ b/lib/tbot/tbot_test.go
@@ -235,17 +235,17 @@ func TestBot(t *testing.T) {
 	})
 
 	t.Run("output: identity", func(t *testing.T) {
-		tlsIdent := tlsIdentFromDest(t, identityOutput.GetDestination())
+		tlsIdent := tlsIdentFromDest(ctx, t, identityOutput.GetDestination())
 		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
 	})
 
 	t.Run("output: identity with role specified", func(t *testing.T) {
-		tlsIdent := tlsIdentFromDest(t, identityOutputWithRoles.GetDestination())
+		tlsIdent := tlsIdentFromDest(ctx, t, identityOutputWithRoles.GetDestination())
 		requireValidOutputTLSIdent(t, tlsIdent, []string{mainRole}, botParams.UserName)
 	})
 
 	t.Run("output: kubernetes", func(t *testing.T) {
-		tlsIdent := tlsIdentFromDest(t, kubeOutput.GetDestination())
+		tlsIdent := tlsIdentFromDest(ctx, t, kubeOutput.GetDestination())
 		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
 		require.Equal(t, kubeClusterName, tlsIdent.KubernetesCluster)
 		require.Equal(t, kubeGroups, tlsIdent.KubernetesGroups)
@@ -253,7 +253,7 @@ func TestBot(t *testing.T) {
 	})
 
 	t.Run("output: application", func(t *testing.T) {
-		tlsIdent := tlsIdentFromDest(t, appOutput.GetDestination())
+		tlsIdent := tlsIdentFromDest(ctx, t, appOutput.GetDestination())
 		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
 		route := tlsIdent.RouteToApp
 		require.Equal(t, appName, route.Name)
@@ -262,7 +262,7 @@ func TestBot(t *testing.T) {
 	})
 
 	t.Run("output: database", func(t *testing.T) {
-		tlsIdent := tlsIdentFromDest(t, dbOutput.GetDestination())
+		tlsIdent := tlsIdentFromDest(ctx, t, dbOutput.GetDestination())
 		requireValidOutputTLSIdent(t, tlsIdent, defaultRoles, botParams.UserName)
 		route := tlsIdent.RouteToDatabase
 		require.Equal(t, databaseServiceName, route.ServiceName)

--- a/tool/tbot/init.go
+++ b/tool/tbot/init.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/user"
@@ -379,6 +380,9 @@ func getAndTestACLOptions(cf *config.CLIConf, destDir string) (*user.User, *user
 }
 
 func onInit(botConfig *config.BotConfig, cf *config.CLIConf) error {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	var output config.Output
 	var err error
 	// First, resolve the correct output. If using a config file with only
@@ -416,7 +420,7 @@ func onInit(botConfig *config.BotConfig, cf *config.CLIConf) error {
 
 	// Create the directory if needed. We haven't checked directory ownership,
 	// but it will fail when the ACLs are created if anything is misconfigured.
-	if err := output.Init(); err != nil {
+	if err := output.Init(ctx); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/tool/tbot/kube.go
+++ b/tool/tbot/kube.go
@@ -18,6 +18,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"time"
 
@@ -63,12 +64,14 @@ func getCredentialData(idFile *identityfile.IdentityFile, currentTime time.Time)
 }
 
 func onKubeCredentialsCommand(cfg *config.BotConfig) error {
+	ctx := context.Background()
+
 	destination, err := tshwrap.GetDestinationDirectory(cfg)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 
-	idData, err := destination.Read(config.IdentityFilePath)
+	idData, err := destination.Read(ctx, config.IdentityFilePath)
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/14421

Adds support for configuring `tbot` to write generated artefacts to a Kubernetes Secret.

See documentation for explanation of pre-requisites.

Configuration

```yaml
# type specifies the type of the destination. For the kubernetes_secret
# destination, this will always be `kubernetes_secret`.
type: kubernetes_secret
# name specifies the name of the Kubernetes Secret to write the artifacts to.
# This must be in the same namespace that `tbot` is running in.
name: my-secret
```