### PR TITLE
Edit the app access DynamoDB guide

### DIFF
--- a/docs/pages/application-access/guides/dynamodb.mdx
+++ b/docs/pages/application-access/guides/dynamodb.mdx
@@ -3,16 +3,8 @@ title: Amazon DynamoDB using the Teleport Application Service
 description: How to access Amazon DynamoDB through the Teleport Application Service
 ---
 
-Access to Amazon DynamoDB can be provided by [**Teleport Application
-Access**](../../application-access/introduction.mdx) for the AWS Console and
-API. This is an alternative to accessing DynamoDB through the Teleport Database
-service, as described in our [Database Access with AWS
-DynamoDB](../../database-access/guides/aws-dynamodb.mdx) guide.
-
-Note that using the Database Service will allow you to connect with GUI clients,
-whereas the Application Service does not. On the other hand, a single Application
-Service configuration can access DynamoDB across regions, while Database resources
-must be configured for each region with DynamoDB databases.
+You can configure the Teleport Application Service to enable secure access to
+DynamoDB.
 
 This guide will help you to:
 
@@ -29,6 +21,27 @@ This guide will help you to:
 </TabItem>
 
 </Tabs>
+
+<Admonition type="warning" title="Recommendation: Use the Teleport Database
+Service">
+
+The Teleport Application Service enables secure access to DynamoDB via its
+[integration](../cloud-apis/aws-console.mdx) with the AWS management console and
+API. This is an alternative to accessing DynamoDB through the Teleport Database
+service, as described in our [Database Access with AWS
+DynamoDB](../../database-access/guides/aws-dynamodb.mdx) guide.
+
+The Application Service's integration with AWS is not designed specifically for
+DynamoDB, while the Database Service has a purpose-built DynamoDB integration.
+As a result, we recommend using the Database Service to enable secure access to
+DynamoDB.
+
+It is worth noting that the Database Service will allow you to connect with GUI
+clients, whereas the Application Service does not. On the other hand, a single
+Application Service configuration can access DynamoDB across regions, while
+database resources must be configured for each region with DynamoDB databases.
+
+</Admonition>
 
 ## Prerequisites
 

--- a/docs/pages/application-access/guides/dynamodb.mdx
+++ b/docs/pages/application-access/guides/dynamodb.mdx
@@ -4,7 +4,7 @@ description: How to access Amazon DynamoDB through the Teleport Application Serv
 ---
 
 You can configure the Teleport Application Service to enable secure access to
-DynamoDB.
+Amazon DynamoDB.
 
 This guide will help you to:
 


### PR DESCRIPTION
Closes #21774

Add an explicit recommendation to use the Database Service to proxy DynamoDB. There is already language in the guide to compare the App Service and Database Service approaches, so this change moves this text into an Admonition and includes the recommendation there.