### PR TITLE
Remove usage of TELEPORT_CLIENT_ADDR env var

### DIFF
--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -1437,14 +1437,6 @@ func (proxy *ProxyClient) ConnectToNode(ctx context.Context, nodeAddress NodeDet
 		return nil, trace.Wrap(err)
 	}
 
-	// pass the true client IP (if specified) to the proxy so it could pass it into the
-	// SSH session for proper audit
-	if len(proxy.clientAddr) > 0 {
-		if err = proxySession.Setenv(ctx, sshutils.TrueClientAddrVar, proxy.clientAddr); err != nil {
-			log.Error(err)
-		}
-	}
-
 	// the client only tries to forward an agent when the proxy is in recording
 	// mode. we always try and forward an agent here because each new session
 	// creates a new context which holds the agent. if ForwardToAgent returns an error

--- a/lib/srv/regular/proxy.go
+++ b/lib/srv/regular/proxy.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gravitational/teleport/lib/agentless"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/srv"
-	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -215,16 +214,6 @@ func (t *proxySubsys) Start(ctx context.Context, sconn *ssh.ServerConn, ch ssh.C
 	t.log.Debugf("Starting subsystem")
 
 	clientAddr := sconn.RemoteAddr()
-
-	// did the client pass us a true client IP ahead of time via an environment variable?
-	// (usually the web client would do that)
-	trueClientIP, ok := serverContext.GetEnv(sshutils.TrueClientAddrVar)
-	if ok {
-		a, err := utils.ParseAddr(trueClientIP)
-		if err == nil {
-			clientAddr = a
-		}
-	}
 
 	// connect to a site's auth server
 	if t.host == "" {

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -126,10 +126,6 @@ const (
 	// https://tools.ietf.org/html/rfc4253
 	MaxVersionStringBytes = 255
 
-	// TrueClientAddrVar environment variable is used by the web UI to pass
-	// the remote IP (user's IP) from the browser/HTTP session into an SSH session
-	TrueClientAddrVar = "TELEPORT_CLIENT_ADDR"
-
 	// caGetterTimeout is the timeout on getting host cert authority, that is used in
 	// signed PROXY headers verification.
 	caGetterTimeout = 5 * time.Second


### PR DESCRIPTION
Removes usage of `TELEPORT_CLIENT_ADDR` environment variable, that was used to pass client IP from web UI, but now it's not needed, since it was superseded by signed PROXY headers.

Closes #29608 