### PR TITLE
Add RDS Postgres end-to-end tests

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -27,11 +27,17 @@ on:
 
 env:
   TEST_KUBE: true
+  TEST_AWS_DB: true
   AWS_REGION: us-west-2
   GHA_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-aws-e2e-gha-role
   KUBERNETES_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-kubernetes-service-access-role
-  DISCOVERY_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-discovery-service-access-role
-  DISCOVERED_CLUSTER_NAME: gha-discovery-ci-eks-us-west-2-307493967395
+  KUBE_DISCOVERY_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-discovery-service-access-role
+  EKS_CLUSTER_NAME: gha-discovery-ci-eks-us-west-2-307493967395
+  DATABASE_USER: teleport-ci-e2e-test
+  DATABASE_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-database-svc
+  DATABASE_DISCOVERY_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-discovery-svc
+  RDS_POSTGRES_INSTANCE_NAME: ci-database-e2e-tests-rds-postgres-instance-us-west-2-307493967395
+  DISCOVERY_MATCHER_LABELS: "*=*"
 jobs:
   test:
     name: AWS E2E Tests (Non-root)

--- a/.github/workflows/flaky-tests.yaml
+++ b/.github/workflows/flaky-tests.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Run base difftest
         uses: ./.github/actions/difftest
         with:
-          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" -e "integrations/operator/**/*" -e "tool/tsh/**/*" -e "integration/**/*" -e "build.assets/**/*" -e "lib/auth/webauthncli/**/*" -e "lib/auth/touchid/**/*" -e "api/**/*" -e "integrations/kube-agent-updater/**/*" -e "examples/teleport-usage/**/*" -e "integrations/access/**" -e "integrations/lib/**" -e "integrations/lib/backoff/backoff_test.go"
+          flags: --skip="${{ steps.find_excluded.outputs.FLAKE_SKIP }}" -e "integrations/operator/**/*" -e "tool/tsh/**/*" -e "integration/**/*" -e "build.assets/**/*" -e "lib/auth/webauthncli/**/*" -e "lib/auth/touchid/**/*" -e "api/**/*" -e "integrations/kube-agent-updater/**/*" -e "examples/teleport-usage/**/*" -e "integrations/access/**" -e "integrations/lib/**" -e "integrations/lib/backoff/backoff_test.go" -e "e2e/**/*"
           target: test-go-unit
 
       - name: Run libfido2 difftest

--- a/Makefile
+++ b/Makefile
@@ -706,7 +706,7 @@ test-go-prepare: ensure-webassets bpf-bytecode rdpclient $(TEST_LOG_DIR) ensure-
 # Runs base unit tests
 .PHONY: test-go-unit
 test-go-unit: FLAGS ?= -race -shuffle on
-test-go-unit: SUBJECT ?= $(shell go list ./... | grep -v -E 'teleport/(integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
+test-go-unit: SUBJECT ?= $(shell go list ./... | grep -v -E 'teleport/(e2e|integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
 test-go-unit:
 	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(RDPCLIENT_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \
@@ -755,13 +755,13 @@ test-go-chaos:
 		| gotestsum --raw-command -- cat
 
 #
-# Runs all Go tests except integration and chaos, called by CI/CD.
+# Runs all Go tests except integration, end-to-end, and chaos, called by CI/CD.
 #
 UNIT_ROOT_REGEX := ^TestRoot
 .PHONY: test-go-root
 test-go-root: ensure-webassets bpf-bytecode rdpclient $(TEST_LOG_DIR) ensure-gotestsum
 test-go-root: FLAGS ?= -race -shuffle on
-test-go-root: PACKAGES = $(shell go list $(ADDFLAGS) ./... | grep -v -e integration -e integrations/operator)
+test-go-root: PACKAGES = $(shell go list $(ADDFLAGS) ./... | grep -v -e e2e -e integration -e integrations/operator)
 test-go-root: $(VERSRC)
 	$(CGOFLAG) go test -json -run "$(UNIT_ROOT_REGEX)" -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(RDPCLIENT_TAG)" $(PACKAGES) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit-root.json \
@@ -829,7 +829,7 @@ FLAKY_TIMEOUT ?= 1h
 FLAKY_TOP_N ?= 20
 FLAKY_SUMMARY_FILE ?= /tmp/flaky-report.txt
 test-go-flaky: FLAGS ?= -race -shuffle on
-test-go-flaky: SUBJECT ?= $(shell go list ./... | grep -v -e integration -e tool/tsh -e integrations/operator -e integrations/access -e integrations/lib )
+test-go-flaky: SUBJECT ?= $(shell go list ./... | grep -v -e e2e -e integration -e tool/tsh -e integrations/operator -e integrations/access -e integrations/lib )
 test-go-flaky: GO_BUILD_TAGS ?= $(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(RDPCLIENT_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG)
 test-go-flaky: RENDER_FLAGS ?= -report-by flakiness -summary-file $(FLAKY_SUMMARY_FILE) -top $(FLAKY_TOP_N)
 test-go-flaky: test-go-prepare $(RENDER_TESTS) $(RERUN)
@@ -915,8 +915,8 @@ integration-root: $(TEST_LOG_DIR) ensure-gotestsum
 e2e-aws: FLAGS ?= -v -race
 e2e-aws: PACKAGES = $(shell go list ./... | grep 'e2e/aws')
 e2e-aws: $(TEST_LOG_DIR) ensure-gotestsum
-	@echo TEST_KUBE: $(TEST_KUBE)
-	$(CGOFLAG) go test -json $(PACKAGES) $(FLAGS) \
+	@echo TEST_KUBE: $(TEST_KUBE) TEST_AWS_DB: $(TEST_AWS_DB)
+	$(CGOFLAG) go test -json $(PACKAGES) $(FLAGS) $(ADDFLAGS)\
 		| tee $(TEST_LOG_DIR)/e2e-aws.json \
 		| gotestsum --raw-command --format=testname -- cat
 

--- a/constants.go
+++ b/constants.go
@@ -349,6 +349,9 @@ const (
 	// AWSRunTests turns on tests executed against AWS directly
 	AWSRunTests = "TEST_AWS"
 
+	// AWSRunDBTests turns on tests executed against AWS databases directly.
+	AWSRunDBTests = "TEST_AWS_DB"
+
 	// Region is AWS region parameter
 	Region = "region"
 

--- a/e2e/aws/fixtures.go
+++ b/e2e/aws/fixtures.go
@@ -1,0 +1,217 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e
+
+import (
+	"os"
+	"os/user"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/service/servicecfg"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+var (
+	// Username used for tests.
+	username string
+)
+
+func init() {
+	me, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	username = me.Username
+}
+
+// mustGetEnv is a test helper that fetches an env variable or fails with an
+// error describing the missing env variable.
+func mustGetEnv(t *testing.T, key string) string {
+	t.Helper()
+	val := os.Getenv(key)
+	require.NotEmpty(t, val, "%s environment variable must be set and not empty", key)
+	return val
+}
+
+func mustGetDiscoveryMatcherLabels(t *testing.T) types.Labels {
+	t.Helper()
+	labelSpec := mustGetEnv(t, discoveryMatcherLabelsEnv)
+	labels, err := client.ParseLabelSpec(labelSpec)
+	require.NoError(t, err)
+	out := make(types.Labels)
+	for k, v := range labels {
+		out[k] = []string{v}
+	}
+	return out
+}
+
+// testOptionsFunc is a test option configuration func.
+type testOptionsFunc func(*testOptions)
+
+// testOptions are options to pass to createTeleportCluster.
+type testOptions struct {
+	// instanceConfigFuncs are a list of functions that configure the
+	// TeleInstance before it is used to create Teleport services.
+	instanceConfigFuncs []func(*helpers.InstanceConfig)
+	// serviceConfigFuncs are a list of functions that configure the Teleport
+	// cluster before it starts.
+	serviceConfigFuncs []func(*servicecfg.Config)
+	// userRoles are roles that will be bootstrapped and added to the Teleport
+	// user under test.
+	userRoles []types.Role
+}
+
+// createTeleportCluster sets up a Teleport cluster for tests.
+func createTeleportCluster(t *testing.T, opts ...testOptionsFunc) *helpers.TeleInstance {
+	t.Helper()
+	var options testOptions
+	for _, opt := range opts {
+		opt(&options)
+	}
+
+	cfg := newInstanceConfig(t)
+	for _, optFn := range options.instanceConfigFuncs {
+		optFn(&cfg)
+	}
+	teleport := helpers.NewInstance(t, cfg)
+
+	// Create a new user with the role created above.
+	teleport.AddUserWithRole(username, options.userRoles...)
+
+	tconf := newTeleportConfig(t)
+	for _, optFn := range options.serviceConfigFuncs {
+		optFn(tconf)
+	}
+	// Create a new teleport instance with the auth server.
+	err := teleport.CreateEx(t, nil, tconf)
+	require.NoError(t, err)
+	// Start the teleport instance and wait for it to be ready.
+	err = teleport.Start()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, teleport.StopAll())
+	})
+	return teleport
+}
+
+func newInstanceConfig(t *testing.T) helpers.InstanceConfig {
+	// Create the CA authority that will be used in Auth.
+	priv, pub, err := testauthority.New().GenerateKeyPair()
+	require.NoError(t, err)
+	const (
+		host   = helpers.Host
+		site   = helpers.Site
+		hostID = helpers.HostID
+	)
+	return helpers.InstanceConfig{
+		ClusterName: site,
+		HostID:      host,
+		NodeName:    host,
+		Priv:        priv,
+		Pub:         pub,
+		Log:         utils.NewLoggerForTests(),
+	}
+}
+
+func newTeleportConfig(t *testing.T) *servicecfg.Config {
+	tconf := servicecfg.MakeDefaultConfig()
+	// Replace the default auth and proxy listeners with the ones so we can
+	// run multiple tests in parallel.
+	tconf.Console = nil
+	tconf.Proxy.DisableWebInterface = true
+	tconf.PollingPeriod = 500 * time.Millisecond
+	tconf.ClientTimeout = time.Second
+	tconf.ShutdownTimeout = 2 * tconf.ClientTimeout
+	return tconf
+}
+
+// withUserRole creates a new role that will be bootstraped and then granted to
+// the Teleport user under test.
+func withUserRole(t *testing.T, name string, spec types.RoleSpecV6) testOptionsFunc {
+	t.Helper()
+	// Create a new role with full access to all databases.
+	role, err := types.NewRole(name, spec)
+	require.NoError(t, err)
+	return func(options *testOptions) {
+		options.userRoles = append(options.userRoles, role)
+	}
+}
+
+// withSingleProxyPort sets up a single proxy port listener config and
+// sets `auth.proxy_listener_mode` to "multiplex".
+func withSingleProxyPort(t *testing.T) testOptionsFunc {
+	t.Helper()
+	// enable proxy single port mode
+	return func(options *testOptions) {
+		options.instanceConfigFuncs = append(options.instanceConfigFuncs, func(cfg *helpers.InstanceConfig) {
+			cfg.Listeners = helpers.SingleProxyPortSetup(t, &cfg.Fds)
+		})
+		options.serviceConfigFuncs = append(options.serviceConfigFuncs, func(cfg *servicecfg.Config) {
+			cfg.Auth.NetworkingConfig.SetProxyListenerMode(types.ProxyListenerMode_Multiplex)
+		})
+	}
+}
+
+// withDiscoveryService sets up the discovery service to watch for resources
+// in the AWS account.
+func withDiscoveryService(t *testing.T, discoveryGroup string, awsMatchers ...types.AWSMatcher) testOptionsFunc {
+	t.Helper()
+	return func(options *testOptions) {
+		options.serviceConfigFuncs = append(options.serviceConfigFuncs, func(cfg *servicecfg.Config) {
+			cfg.Discovery.Enabled = true
+			cfg.Discovery.DiscoveryGroup = discoveryGroup
+			// Reduce the polling interval to speed up the test execution
+			// in the case of a failure of the first attempt.
+			// The default polling interval is 5 minutes.
+			cfg.Discovery.PollInterval = 1 * time.Minute
+			cfg.Discovery.AWSMatchers = append(cfg.Discovery.AWSMatchers, awsMatchers...)
+		})
+	}
+}
+
+// withDatabaseService sets up the databases service to watch for discovered
+// database resources in the AWS account.
+func withDatabaseService(t *testing.T, matchers ...services.ResourceMatcher) testOptionsFunc {
+	t.Helper()
+	return func(options *testOptions) {
+		options.serviceConfigFuncs = append(options.serviceConfigFuncs, func(cfg *servicecfg.Config) {
+			cfg.Databases.Enabled = true
+			cfg.Databases.ResourceMatchers = matchers
+		})
+	}
+}
+
+// withFullDatabaseAccessUserRole creates a Teleport role with full access to
+// databases.
+func withFullDatabaseAccessUserRole(t *testing.T) testOptionsFunc {
+	t.Helper()
+	// Create a new role with full access to all databases.
+	return withUserRole(t, "db-access", types.RoleSpecV6{
+		Allow: types.RoleConditions{
+			DatabaseLabels: types.Labels{types.Wildcard: []string{types.Wildcard}},
+			DatabaseUsers:  []string{types.Wildcard},
+			DatabaseNames:  []string{types.Wildcard},
+		},
+	})
+}

--- a/e2e/aws/main_test.go
+++ b/e2e/aws/main_test.go
@@ -13,16 +13,87 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package integration
+package e2e
 
 import (
 	"testing"
 
 	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib"
+)
+
+const (
+	// awsRegionEnv is the environment variable that specifies the AWS region
+	// where the EKS cluster is running.
+	awsRegionEnv = "AWS_REGION"
+	// discoveryMatcherLabelsEnv is the env variable that specifies the matcher
+	// labels to use in test discovery services.
+	discoveryMatcherLabelsEnv = "DISCOVERY_MATCHER_LABELS"
+	// dbSvcRoleARNEnv is the environment variable that specifies the IAM role
+	// that Teleport Database Service will assume to access databases.
+	// check modules/databases-ci/ from cloud-terraform repo for more details.
+	dbSvcRoleARNEnv = "DATABASE_SERVICE_ASSUME_ROLE"
+	// dbDiscoverySvcRoleARNEnv is the environment variable that specifies the
+	// IAM role that Teleport Discovery Service will assume to discover
+	// databases.
+	// check modules/databases-ci/ from cloud-terraform repo for more details.
+	dbDiscoverySvcRoleARNEnv = "DATABASE_DISCOVERY_SERVICE_ASSUME_ROLE"
+	// dbUserEnv is the database user configured in databases for access via
+	// Teleport.
+	dbUserEnv = "DATABASE_USER"
+	// rdsPostgresInstanceNameEnv is the environment variable that specifies the
+	// name of the RDS Postgres DB instance that will be created by the Teleport
+	// Discovery Service.
+	rdsPostgresInstanceNameEnv = "RDS_POSTGRES_INSTANCE_NAME"
+	// kubeSvcRoleARNEnv is the environment variable that specifies
+	// the IAM role that Teleport Kubernetes Service will assume to access the EKS cluster.
+	// This role needs to have the following permissions:
+	// - eks:DescribeCluster
+	// But it also requires the role to be mapped to a Kubernetes group with the following RBAC permissions:
+	//	apiVersion: rbac.authorization.k8s.io/v1
+	//	kind: ClusterRole
+	//	metadata:
+	//		name: teleport-role
+	//	rules:
+	//	- apiGroups:
+	//		- ""
+	//		resources:
+	//		- users
+	//		- groups
+	//		- serviceaccounts
+	//		verbs:
+	//		- impersonate
+	//	- apiGroups:
+	//		- ""
+	//		resources:
+	//		- pods
+	//		verbs:
+	//		- get
+	//	- apiGroups:
+	//		- "authorization.k8s.io"
+	//		resources:
+	//		- selfsubjectaccessreviews
+	//		- selfsubjectrulesreviews
+	//		verbs:
+	//		- create
+	// check modules/eks-discovery-ci/ from cloud-terraform repo for more details.
+	kubeSvcRoleARNEnv = "KUBERNETES_SERVICE_ASSUME_ROLE"
+	// kubeDiscoverySvcRoleARNEnv is the environment variable that specifies
+	// the IAM role that Teleport Discovery Service will assume to list the EKS clusters.
+	// This role needs to have the following permissions:
+	// - eks:DescribeCluster
+	// - eks:ListClusters
+	// check modules/eks-discovery-ci/ from cloud-terraform repo for more details.
+	kubeDiscoverySvcRoleARNEnv = "KUBE_DISCOVERY_SERVICE_ASSUME_ROLE"
+	// eksClusterNameEnv is the environment variable that specifies the name of
+	// the EKS cluster that will be created by Teleport Discovery Service.
+	eksClusterNameEnv = "EKS_CLUSTER_NAME"
 )
 
 // TestMain will re-execute Teleport to run a command if "exec" is passed to
 // it as an argument. Otherwise, it will run tests as normal.
 func TestMain(m *testing.M) {
+	// agents connect over a reverse tunnel to proxy, so we use insecure mode.
+	lib.SetInsecureDevMode(true)
 	helpers.TestMainImplementation(m)
 }

--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -1,0 +1,325 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package e2e
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgconn"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/integration/helpers"
+	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/service"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
+	"github.com/gravitational/teleport/lib/srv/db/common"
+	"github.com/gravitational/teleport/lib/srv/db/postgres"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestDatabases(t *testing.T) {
+	t.Parallel()
+	testEnabled := os.Getenv(teleport.AWSRunDBTests)
+	if ok, _ := strconv.ParseBool(testEnabled); !ok {
+		t.Skip("Skipping Databases test suite.")
+	}
+	t.Run("AWS DB Discovery - Unmatched database", awsDBDiscoveryUnmatched)
+	t.Run("AWS DB Discovery - Matched database", awsDBDiscoveryMatched)
+}
+
+func awsDBDiscoveryUnmatched(t *testing.T) {
+	t.Parallel()
+	// get test settings
+	awsRegion := mustGetEnv(t, awsRegionEnv)
+	dbDiscoverySvcRoleARN := mustGetEnv(t, dbDiscoverySvcRoleARNEnv)
+	dbSvcRoleARN := mustGetEnv(t, dbSvcRoleARNEnv)
+	cluster := createTeleportCluster(t,
+		withSingleProxyPort(t),
+		withDiscoveryService(t, "db-e2e-test", types.AWSMatcher{
+			Types: []string{services.AWSMatcherRDS},
+			Tags: types.Labels{
+				// This label should not match.
+				"env": {"tag_not_found"},
+			},
+			Regions: []string{awsRegion},
+			AssumeRole: &types.AssumeRole{
+				RoleARN: dbDiscoverySvcRoleARN,
+			},
+		}),
+		withDatabaseService(t, services.ResourceMatcher{
+			Labels: types.Labels{types.Wildcard: {types.Wildcard}},
+			AWS: services.ResourceMatcherAWS{
+				AssumeRoleARN: dbSvcRoleARN,
+			},
+		}),
+		withFullDatabaseAccessUserRole(t),
+	)
+
+	// Get the auth server.
+	authC := cluster.Process.GetAuthServer()
+	// Wait for the discovery service to not create a database resource
+	// because the database does not match the selectors.
+	require.Never(t, func() bool {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		databases, err := authC.GetDatabases(ctx)
+		return err == nil && len(databases) != 0
+	}, 2*time.Minute, 10*time.Second, "discovery service incorrectly created a database")
+}
+
+func awsDBDiscoveryMatched(t *testing.T) {
+	t.Parallel()
+	// get test settings
+	awsRegion := mustGetEnv(t, awsRegionEnv)
+	dbDiscoverySvcRoleARN := mustGetEnv(t, dbDiscoverySvcRoleARNEnv)
+	dbSvcRoleARN := mustGetEnv(t, dbSvcRoleARNEnv)
+	dbUser := mustGetEnv(t, dbUserEnv)
+	rdsPostgresInstanceName := mustGetEnv(t, rdsPostgresInstanceNameEnv)
+
+	cluster := createTeleportCluster(t,
+		withSingleProxyPort(t),
+		withDiscoveryService(t, "db-e2e-test", types.AWSMatcher{
+			Types:   []string{services.AWSMatcherRDS},
+			Tags:    mustGetDiscoveryMatcherLabels(t),
+			Regions: []string{awsRegion},
+			AssumeRole: &types.AssumeRole{
+				RoleARN: dbDiscoverySvcRoleARN,
+			},
+		}),
+		withDatabaseService(t, services.ResourceMatcher{
+			Labels: types.Labels{types.Wildcard: {types.Wildcard}},
+			AWS: services.ResourceMatcherAWS{
+				AssumeRoleARN: dbSvcRoleARN,
+			},
+		}),
+		withFullDatabaseAccessUserRole(t),
+	)
+
+	wantDBNames := []string{
+		rdsPostgresInstanceName,
+	}
+	// wait for the databases to be discovered
+	waitForDatabases(t, cluster.Process, wantDBNames...)
+	// wait for the database heartbeats from database service
+	waitForDatabaseServers(t, cluster.Process, wantDBNames...)
+
+	rdsPostgresInstance := tlsca.RouteToDatabase{
+		ServiceName: rdsPostgresInstanceName,
+		Protocol:    defaults.ProtocolPostgres,
+		Username:    dbUser,
+		Database:    "postgres",
+	}
+	t.Run("connection", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			route            tlsca.RouteToDatabase
+			testDBConnection dbConnectionTestFunc
+		}{
+			{
+				name:             "RDS postgres instance",
+				route:            rdsPostgresInstance,
+				testDBConnection: postgresConnTestFn(cluster),
+			},
+			{
+				name:             "RDS postgres instance via local proxy",
+				route:            rdsPostgresInstance,
+				testDBConnection: postgresLocalProxyConnTestFn(cluster),
+			},
+		}
+		for _, test := range tests {
+			test := test
+			t.Run(test.name, func(t *testing.T) {
+				t.Parallel()
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+				test.testDBConnection(t, ctx, test.route)
+			})
+		}
+	})
+}
+
+type dbConnectionTestFunc func(*testing.T, context.Context, tlsca.RouteToDatabase)
+
+// postgresConnTestFn tests connection to a postgres database via proxy web
+// multiplexer.
+func postgresConnTestFn(cluster *helpers.TeleInstance) dbConnectionTestFunc {
+	return func(t *testing.T, ctx context.Context, route tlsca.RouteToDatabase) {
+		var pgConn *pgconn.PgConn
+		// retry for a while, the database service might need time to give
+		// itself IAM rds:connect permissions.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			pgConn, err = postgres.MakeTestClient(ctx, common.TestClientConfig{
+				AuthClient:      cluster.GetSiteAPI(cluster.Secrets.SiteName),
+				AuthServer:      cluster.Process.GetAuthServer(),
+				Address:         cluster.Web,
+				Cluster:         cluster.Secrets.SiteName,
+				Username:        username,
+				RouteToDatabase: route,
+			})
+			assert.NoError(c, err)
+			assert.NotNil(c, pgConn)
+		}, time.Second*10, time.Second, "connecting to postgres")
+
+		// Execute a query.
+		results, err := pgConn.Exec(ctx, "select 1").ReadAll()
+		require.NoError(t, err)
+		for i, r := range results {
+			require.NoError(t, r.Err, "error in result %v", i)
+		}
+
+		// Disconnect.
+		err = pgConn.Close(ctx)
+		require.NoError(t, err)
+	}
+}
+
+// postgresLocalProxyConnTestFn tests connection to a postgres database via
+// local proxy tunnel.
+func postgresLocalProxyConnTestFn(cluster *helpers.TeleInstance) dbConnectionTestFunc {
+	return func(t *testing.T, ctx context.Context, route tlsca.RouteToDatabase) {
+		lp := startLocalALPNProxy(t, ctx, cluster, route)
+		defer lp.Close()
+
+		connString := fmt.Sprintf("postgres://%s@%v/%s",
+			route.Username, lp.GetAddr(), route.Database)
+		var pgConn *pgconn.PgConn
+		// retry for a while, the database service might need time to give
+		// itself IAM rds:connect permissions.
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			var err error
+			pgConn, err = pgconn.Connect(ctx, connString)
+			assert.NoError(c, err)
+			assert.NotNil(c, pgConn)
+		}, time.Second*10, time.Second, "connecting to postgres")
+
+		// Execute a query.
+		results, err := pgConn.Exec(ctx, "select 1").ReadAll()
+		require.NoError(t, err)
+		for i, r := range results {
+			require.NoError(t, r.Err, "error in result %v", i)
+		}
+
+		// Disconnect.
+		err = pgConn.Close(ctx)
+		require.NoError(t, err)
+	}
+}
+
+// startLocalALPNProxy starts local ALPN proxy for the specified database.
+func startLocalALPNProxy(t *testing.T, ctx context.Context, cluster *helpers.TeleInstance, route tlsca.RouteToDatabase) *alpnproxy.LocalProxy {
+	t.Helper()
+	proto, err := alpncommon.ToALPNProtocol(route.Protocol)
+	require.NoError(t, err)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	proxyNetAddr, err := cluster.Process.ProxyWebAddr()
+	require.NoError(t, err)
+
+	authSrv := cluster.Process.GetAuthServer()
+	tlsCert := generateClientDBCert(t, authSrv, username, route)
+
+	proxy, err := alpnproxy.NewLocalProxy(alpnproxy.LocalProxyConfig{
+		RemoteProxyAddr:    proxyNetAddr.String(),
+		Protocols:          []alpncommon.Protocol{proto},
+		InsecureSkipVerify: true,
+		Listener:           listener,
+		ParentContext:      ctx,
+		Certs:              []tls.Certificate{tlsCert},
+	})
+	require.NoError(t, err)
+
+	go proxy.Start(ctx)
+
+	return proxy
+}
+
+// generateClientDBCert creates a test db cert for the given user and database.
+func generateClientDBCert(t *testing.T, authSrv *auth.Server, user string, route tlsca.RouteToDatabase) tls.Certificate {
+	t.Helper()
+	key, err := client.GenerateRSAKey()
+	require.NoError(t, err)
+
+	clusterName, err := authSrv.GetClusterName()
+	require.NoError(t, err)
+
+	clientCert, err := authSrv.GenerateDatabaseTestCert(
+		auth.DatabaseTestCertRequest{
+			PublicKey:       key.MarshalSSHPublicKey(),
+			Cluster:         clusterName.GetClusterName(),
+			Username:        user,
+			RouteToDatabase: route,
+		})
+	require.NoError(t, err)
+
+	tlsCert, err := key.TLSCertificate(clientCert)
+	require.NoError(t, err)
+	return tlsCert
+}
+
+func waitForDatabases(t *testing.T, auth *service.TeleportProcess, wantNames ...string) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		databases, err := auth.GetAuthServer().GetDatabases(ctx)
+		require.NoError(t, err)
+
+		// map the registered "db" resource names.
+		seen := map[string]struct{}{}
+		for _, db := range databases {
+			seen[db.GetName()] = struct{}{}
+		}
+		for _, name := range wantNames {
+			assert.Contains(t, seen, name)
+		}
+	}, 3*time.Minute, 3*time.Second, "waiting for the discovery service to create databases")
+}
+
+func waitForDatabaseServers(t *testing.T, auth *service.TeleportProcess, wantNames ...string) {
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		servers, err := auth.GetAuthServer().GetDatabaseServers(ctx, apidefaults.Namespace)
+		require.NoError(t, err)
+
+		// map the registered "db_server" resource names.
+		seen := map[string]struct{}{}
+		for _, s := range servers {
+			seen[s.GetName()] = struct{}{}
+		}
+		for _, name := range wantNames {
+			assert.Contains(t, seen, name)
+		}
+	}, 1*time.Minute, time.Second, "waiting for the database service to heartbeat the databases")
+}

--- a/integration/helpers/instance.go
+++ b/integration/helpers/instance.go
@@ -845,6 +845,7 @@ func (i *TeleInstance) StartDatabase(conf *servicecfg.Config) (*service.Teleport
 	})
 	conf.SetToken("token")
 	conf.UploadEventsC = i.UploadEventsC
+	conf.Databases.Enabled = true
 	conf.Auth.Enabled = false
 	conf.Proxy.Enabled = false
 	conf.Apps.Enabled = false


### PR DESCRIPTION
This PR adds end-to-end tests for AWS RDS Postgres instances.
I limited it to just Postgres instance for this PR, for smaller scope and easier review.

It tests that:
- The Teleport Discovery Service discovers RDS Postgres databases and creates them in Teleport
- The Teleport Database Service can connect a user to an RDS Postgres instance via IAM auth as db user `teleport-ci-e2e-test`
  - the database user will have already been provisioned by terraform with IAM auth enabled.

GHA will assume the intermediate role `arn:aws:iam::307493967395:role/tf-aws-e2e-gha-role` as it does for the existing kube e2e tests.

Then the role `arn:aws:iam::307493967395:role/ci-databases-database-svc` can be assumed for database access (connecting users)
and the role `arn:aws:iam::307493967395:role/ci-databases-discovery-svc` can be assumed for discovering databases.

The test can be run manually by deploying the required infra in AWS and setting the appropriate env vars, for example:
```bash
$ export AWS_REGION=us-west-1
$ export DATABASE_USER=teleport-ci-e2e-test
$ export DATABASE_SERVICE_ASSUME_ROLE=arn:aws:iam::278576220453:role/ci-database-e2e-tests-database-svc
$ export DATABASE_DISCOVERY_SERVICE_ASSUME_ROLE=arn:aws:iam::278576220453:role/ci-database-e2e-tests-discovery-svc
$ export DISCOVERY_MATCHER_LABELS="env=ci"
$ export RDS_POSTGRES_INSTANCE_NAME=ci-database-e2e-tests-rds-postgres-instance-us-west-1-278576220453
$ make e2e-aws ADDFLAGS='-run TestDatabases' 
```
Part one of implementing https://github.com/gravitational/teleport/pull/27156 for databases.

TODO Followup PRs: 
- [x] RDS MySQL instance tests

issue: https://github.com/gravitational/teleport/issues/27325