### PR TITLE
Added Prometheus metric for created access requests

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -36,6 +36,7 @@ import (
 	insecurerand "math/rand"
 	"os"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -530,11 +531,21 @@ var (
 		[]string{teleport.TagUpgrader},
 	)
 
+	accessRequestsCreatedMetric = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: teleport.MetricNamespace,
+			Name:      teleport.MetricAccessRequestsCreated,
+			Help:      "Tracks the number of created access requests",
+		},
+		[]string{teleport.TagRoles, teleport.TagResources},
+	)
+
 	prometheusCollectors = []prometheus.Collector{
 		generateRequestsCount, generateThrottledRequestsCount,
 		generateRequestsCurrent, generateRequestsLatencies, UserLoginCount, heartbeatsMissedByAuth,
 		registeredAgents, migrations,
 		totalInstancesMetric, enrolledInUpgradesMetric, upgraderCountsMetric,
+		accessRequestsCreatedMetric,
 	}
 )
 
@@ -4013,6 +4024,10 @@ func (a *Server) CreateAccessRequestV2(ctx context.Context, req types.AccessRequ
 	if err != nil {
 		log.WithError(err).Warn("Failed to emit access request create event.")
 	}
+
+	accessRequestsCreatedMetric.WithLabelValues(
+		strconv.Itoa(len(req.GetRoles())),
+		strconv.Itoa(len(req.GetRequestedResourceIDs()))).Inc()
 	return req, nil
 }
 

--- a/metrics.go
+++ b/metrics.go
@@ -105,6 +105,13 @@ const (
 
 	// TagUpgrader is a metric tag for upgraders.
 	TagUpgrader = "upgrader"
+
+	// MetricsAccessRequestsCreated provides total number of created access requests.
+	MetricAccessRequestsCreated = "access_requests_created"
+	// TagRoles is a number of roles requested as a part of access request.
+	TagRoles = "roles"
+	// TagResources is a number of resources requested as a part of access request.
+	TagResources = "resources"
 )
 
 const (


### PR DESCRIPTION
This is needed for some product analytics. Tested this locally, example reported metrics after submitting a few access requests:

```
➜  ~ curl -s http://root.gravitational.io:3000/metrics | grep access_requests_created
# HELP teleport_access_requests_created Tracks the number of created access requests
# TYPE teleport_access_requests_created counter
teleport_access_requests_created{resources="0",roles="1"} 1
teleport_access_requests_created{resources="1",roles="1"} 1
teleport_access_requests_created{resources="3",roles="1"} 1
```