### PR TITLE
Add Teleport and Kube Cluster name tags to Kube Prom metrics

### DIFF
--- a/lib/kube/proxy/watcher.go
+++ b/lib/kube/proxy/watcher.go
@@ -187,6 +187,7 @@ func (s *TLSServer) buildClusterDetailsConfigForCluster(cluster types.KubeCluste
 		resourceMatchers: s.ResourceMatchers,
 		clock:            s.Clock,
 		component:        s.KubeServiceType,
+		teleportCluster:  s.ClusterName,
 	}
 }
 

--- a/lib/observability/metrics/prometheus_test.go
+++ b/lib/observability/metrics/prometheus_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2021 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_labelGetter(t *testing.T) {
+	ctxWithLabels := context.WithValue(context.Background(), promLabelsKey{}, prometheus.Labels{
+		"foo": "bar",
+	})
+	type args struct {
+		ctx   context.Context
+		label string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "label exists",
+			args: args{
+				label: "foo",
+				ctx:   ctxWithLabels,
+			},
+			want: "bar",
+		},
+		{
+			name: "label doesn't exist",
+			args: args{
+				label: "not_found",
+				ctx:   ctxWithLabels,
+			},
+			want: "unknown",
+		},
+		{
+			name: "labels not set in ctx",
+			args: args{
+				label: "not_found",
+				ctx:   context.Background(),
+			},
+			want: "unknown",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := labelGetter(tt.args.label)
+			require.Equal(t, tt.want, got(tt.args.ctx))
+		})
+	}
+}

--- a/metrics.go
+++ b/metrics.go
@@ -94,6 +94,12 @@ const (
 	// TagCluster is a metric tag for a cluster
 	TagCluster = "cluster"
 
+	// TagKubernetesCluster is a metric tag for a kubernetes cluster
+	TagKubernetesCluster = "kube_cluster"
+
+	// TagValueRemoteProxy is a metric tag value used when dialing a remote proxy
+	TagValueRemoteProxy = "remote_proxy"
+
 	// MetricTotalInstances provides an instance count
 	MetricTotalInstances = "total_instances"
 


### PR DESCRIPTION
This PR adds `kube_cluster` and `cluster` tags to Kubernetes Access Prometheus metrics. 

These labels are unknown at the handler so we inserted a `prometheus.Labels` map in the request's `context` and we append the label values in the real handler execution. 

Metrics are collected after the request is handled by the downstream handlers, so we leverage that to fill those labels into the map and retrieve them in the metric's middleware after the request processing finishes.