### PR TITLE
Fix data race in TestTeleterm/CreateConnectMyComputerRole

### DIFF
--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -464,7 +464,7 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 					Name: roleName,
 				})
 				existingRole = &role
-				err = authServer.UpsertRole(ctx, &role)
+				err := authServer.UpsertRole(ctx, &role)
 				require.NoError(t, err)
 			}
 


### PR DESCRIPTION
Closes #29771.

The test function of parallel table tests was doing `err =` instead of `err :=`, thus assigning an error to a variable created outside of the function.