### PR TITLE
Prevent VS Code from showing errors in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -57,7 +57,8 @@
       "gen-proto-js/*": [
         "gen/proto/js/*"
       ]
-    }
+    },
+    "outDir": "dist"
   },
   "include": [
     "e/web/**/*.ts",


### PR DESCRIPTION
If tsconfig doesn't have an `outDir` option set, VS Code shows multitude of errors of the following kind:

> Cannot write file '/Users/bartosz/code/teleport/e/web/teleport/babel.config.js' because it would overwrite input file.