### PR TITLE
docs: Minor cosmetic tweaks to tsh puttyconfig

### DIFF
--- a/docs/pages/connect-your-client/putty.mdx
+++ b/docs/pages/connect-your-client/putty.mdx
@@ -119,7 +119,7 @@ and appears in the list of "Active Sessions" within Teleport.
 You can run `teleport status` inside the session to verify that it is connected through
 the Teleport proxy and to output the session's UUID for tracking purposes.
 If session recording is enabled for your cluster, you can also view a
-recording of the session after you stop the session and disconnect from the host..
+recording of the session after you stop the session and disconnect from the host.
 
 
 ## Leaf clusters
@@ -141,7 +141,7 @@ you can add a PuTTY session for the login `ec2-user` using the following command
 
 ```bash
 C:\Users\gus>tsh puttyconfig --leaf example.teleport.sh ec2-user@ip-172-31-34-128.us-east-2.compute.internal
-Added PuTTY session for ec2-user@ip-172-31-34-128.us-east-2.compute.internal [leaf:webby.teleport.sh,proxy:teleport.example.com]
+Added PuTTY session for ec2-user@ip-172-31-34-128.us-east-2.compute.internal [leaf:example.teleport.sh,proxy:teleport.example.com]
 ```
 
 


### PR DESCRIPTION
Fixes an extra full stop and tenant name which was included accidentally.

Sorry for the extra noise, I didn't spot these in the first pass.