### PR TITLE
propagate tctl verbose flag

### DIFF
--- a/tool/tctl/common/app_command.go
+++ b/tool/tctl/common/app_command.go
@@ -104,11 +104,11 @@ func (c *AppsCommand) ListApps(ctx context.Context, clt auth.ClientI) error {
 		}
 	}
 
-	coll := &appServerCollection{servers: servers, verbose: c.verbose}
+	coll := &appServerCollection{servers: servers}
 
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/auth_command.go
+++ b/tool/tctl/common/auth_command.go
@@ -414,11 +414,13 @@ func (a *AuthCommand) ListAuthServers(ctx context.Context, clusterAPI auth.Clien
 		return trace.Wrap(err)
 	}
 
-	sc := &serverCollection{servers, false}
+	sc := &serverCollection{servers}
 
 	switch a.format {
 	case teleport.Text:
-		return sc.writeText(os.Stdout)
+		// auth servers don't have labels.
+		verbose := false
+		return sc.writeText(os.Stdout, verbose)
 	case teleport.YAML:
 		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -41,13 +41,12 @@ import (
 )
 
 type ResourceCollection interface {
-	writeText(w io.Writer) error
+	writeText(w io.Writer, verbose bool) error
 	resources() []types.Resource
 }
 
 type roleCollection struct {
-	roles   []types.Role
-	verbose bool
+	roles []types.Role
 }
 
 func (r *roleCollection) resources() (res []types.Resource) {
@@ -57,7 +56,7 @@ func (r *roleCollection) resources() (res []types.Resource) {
 	return res
 }
 
-func (r *roleCollection) writeText(w io.Writer) error {
+func (r *roleCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, r := range r.roles {
 		if r.GetName() == constants.DefaultImplicitRole {
@@ -73,7 +72,7 @@ func (r *roleCollection) writeText(w io.Writer) error {
 
 	headers := []string{"Role", "Allowed to login as", "Node Labels", "Access to resources"}
 	var t asciitable.Table
-	if r.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Access to resources")
@@ -94,7 +93,7 @@ func (n *namespaceCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (n *namespaceCollection) writeText(w io.Writer) error {
+func (n *namespaceCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, n := range n.namespaces {
 		t.AddRow([]string{n.Metadata.Name})
@@ -132,7 +131,6 @@ func printNodeLabels(labels types.Labels) string {
 
 type serverCollection struct {
 	servers []types.Server
-	verbose bool
 }
 
 func (s *serverCollection) resources() (r []types.Resource) {
@@ -142,17 +140,17 @@ func (s *serverCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (s *serverCollection) writeText(w io.Writer) error {
+func (s *serverCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, se := range s.servers {
-		labels := stripInternalTeleportLabels(s.verbose, se.GetAllLabels())
+		labels := stripInternalTeleportLabels(verbose, se.GetAllLabels())
 		rows = append(rows, []string{
 			se.GetHostname(), se.GetName(), se.GetAddr(), labels, se.GetTeleportVersion(),
 		})
 	}
 	headers := []string{"Host", "UUID", "Public Address", "Labels", "Version"}
 	var t asciitable.Table
-	if s.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -181,7 +179,7 @@ func (u *userCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (u *userCollection) writeText(w io.Writer) error {
+func (u *userCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"User"})
 	for _, user := range u.users {
 		t.AddRow([]string{user.GetName()})
@@ -201,7 +199,7 @@ func (a *authorityCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (a *authorityCollection) writeText(w io.Writer) error {
+func (a *authorityCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Cluster Name", "CA Type", "Fingerprint", "Role Map"})
 	for _, a := range a.cas {
 		for _, key := range a.GetTrustedSSHKeyPairs() {
@@ -238,7 +236,7 @@ func (r *reverseTunnelCollection) resources() (res []types.Resource) {
 	return res
 }
 
-func (r *reverseTunnelCollection) writeText(w io.Writer) error {
+func (r *reverseTunnelCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Cluster Name", "Dial Addresses"})
 	for _, tunnel := range r.tunnels {
 		t.AddRow([]string{
@@ -260,7 +258,7 @@ func (c *oidcCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *oidcCollection) writeText(w io.Writer) error {
+func (c *oidcCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Issuer URL", "Additional Scope"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{
@@ -282,7 +280,7 @@ func (c *samlCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *samlCollection) writeText(w io.Writer) error {
+func (c *samlCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "SSO URL"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), conn.GetSSO()})
@@ -310,14 +308,14 @@ func (c *connectorsCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *connectorsCollection) writeText(w io.Writer) error {
+func (c *connectorsCollection) writeText(w io.Writer, verbose bool) error {
 	if len(c.oidc) > 0 {
 		_, err := io.WriteString(w, "\nOIDC:\n")
 		if err != nil {
 			return trace.Wrap(err)
 		}
 		oc := &oidcCollection{connectors: c.oidc}
-		err = oc.writeText(w)
+		err = oc.writeText(w, verbose)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -329,7 +327,7 @@ func (c *connectorsCollection) writeText(w io.Writer) error {
 			return trace.Wrap(err)
 		}
 		sc := &samlCollection{connectors: c.saml}
-		err = sc.writeText(w)
+		err = sc.writeText(w, verbose)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -341,7 +339,7 @@ func (c *connectorsCollection) writeText(w io.Writer) error {
 			return trace.Wrap(err)
 		}
 		gc := &githubCollection{connectors: c.github}
-		err = gc.writeText(w)
+		err = gc.writeText(w, verbose)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -361,7 +359,7 @@ func (c *trustedClusterCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *trustedClusterCollection) writeText(w io.Writer) error {
+func (c *trustedClusterCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{
 		"Name", "Enabled", "Token", "Proxy Address", "Reverse Tunnel Address", "Role Map",
 	})
@@ -390,7 +388,7 @@ func (c *githubCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *githubCollection) writeText(w io.Writer) error {
+func (c *githubCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Teams To Logins"})
 	for _, conn := range c.connectors {
 		t.AddRow([]string{conn.GetName(), formatTeamsToLogins(
@@ -420,7 +418,7 @@ func (c *remoteClusterCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *remoteClusterCollection) writeText(w io.Writer) error {
+func (c *remoteClusterCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Status", "Last Heartbeat"})
 	for _, cluster := range c.remoteClusters {
 		lastHeartbeat := cluster.GetLastHeartbeat()
@@ -456,7 +454,7 @@ func (c *semaphoreCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *semaphoreCollection) writeText(w io.Writer) error {
+func (c *semaphoreCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Kind", "Name", "LeaseID", "Holder", "Expires"})
 	for _, sem := range c.sems {
 		for _, ref := range sem.LeaseRefs() {
@@ -471,7 +469,6 @@ func (c *semaphoreCollection) writeText(w io.Writer) error {
 
 type appServerCollection struct {
 	servers []types.AppServer
-	verbose bool
 }
 
 func (a *appServerCollection) resources() (r []types.Resource) {
@@ -481,18 +478,18 @@ func (a *appServerCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (a *appServerCollection) writeText(w io.Writer) error {
+func (a *appServerCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range a.servers {
 		app := server.GetApp()
-		labels := stripInternalTeleportLabels(a.verbose, app.GetAllLabels())
+		labels := stripInternalTeleportLabels(verbose, app.GetAllLabels())
 		rows = append(rows, []string{
 			server.GetHostname(), app.GetName(), app.GetProtocol(), app.GetPublicAddr(), app.GetURI(), labels, server.GetTeleportVersion(),
 		})
 	}
 	var t asciitable.Table
 	headers := []string{"Host", "Name", "Type", "Public Address", "URI", "Labels", "Version"}
-	if a.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -511,8 +508,7 @@ func (a *appServerCollection) writeYAML(w io.Writer) error {
 }
 
 type appCollection struct {
-	apps    []types.Application
-	verbose bool
+	apps []types.Application
 }
 
 func (c *appCollection) resources() (r []types.Resource) {
@@ -522,17 +518,17 @@ func (c *appCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *appCollection) writeText(w io.Writer) error {
+func (c *appCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, app := range c.apps {
-		labels := stripInternalTeleportLabels(c.verbose, app.GetAllLabels())
+		labels := stripInternalTeleportLabels(verbose, app.GetAllLabels())
 		rows = append(rows, []string{
 			app.GetName(), app.GetDescription(), app.GetURI(), app.GetPublicAddr(), labels, app.GetVersion(),
 		})
 	}
 	headers := []string{"Name", "Description", "URI", "Public Address", "Labels", "Version"}
 	var t asciitable.Table
-	if c.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -549,7 +545,7 @@ func (c *authPrefCollection) resources() (r []types.Resource) {
 	return []types.Resource{c.authPref}
 }
 
-func (c *authPrefCollection) writeText(w io.Writer) error {
+func (c *authPrefCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Type", "Second Factor"})
 	t.AddRow([]string{c.authPref.GetType(), string(c.authPref.GetSecondFactor())})
 	_, err := t.AsBuffer().WriteTo(w)
@@ -564,7 +560,7 @@ func (c *uiConfigCollection) resources() (r []types.Resource) {
 	return []types.Resource{c.uiconfig}
 }
 
-func (c *uiConfigCollection) writeText(w io.Writer) error {
+func (c *uiConfigCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Scrollback Lines"})
 	t.AddRow([]string{string(c.uiconfig.GetScrollbackLines())})
 	_, err := t.AsBuffer().WriteTo(w)
@@ -579,7 +575,7 @@ func (c *netConfigCollection) resources() (r []types.Resource) {
 	return []types.Resource{c.netConfig}
 }
 
-func (c *netConfigCollection) writeText(w io.Writer) error {
+func (c *netConfigCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Client Idle Timeout", "Keep Alive Interval", "Keep Alive Count Max", "Session Control Timeout"})
 	t.AddRow([]string{
 		c.netConfig.GetClientIdleTimeout().String(),
@@ -602,7 +598,7 @@ func (c *maintenanceWindowCollection) resources() (r []types.Resource) {
 	return []types.Resource{c.cmc}
 }
 
-func (c *maintenanceWindowCollection) writeText(w io.Writer) error {
+func (c *maintenanceWindowCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Type", "Params"})
 
 	agentUpgradeParams := "none"
@@ -630,7 +626,7 @@ func (c *recConfigCollection) resources() (r []types.Resource) {
 	return []types.Resource{c.recConfig}
 }
 
-func (c *recConfigCollection) writeText(w io.Writer) error {
+func (c *recConfigCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Mode", "Proxy Checks Host Keys"})
 	t.AddRow([]string{c.recConfig.GetMode(), strconv.FormatBool(c.recConfig.GetProxyChecksHostKeys())})
 	_, err := t.AsBuffer().WriteTo(w)
@@ -664,7 +660,7 @@ func (c *netRestrictionsCollection) writeList(as []types.AddressCondition, w *wr
 	}
 }
 
-func (c *netRestrictionsCollection) writeText(w io.Writer) error {
+func (c *netRestrictionsCollection) writeText(w io.Writer, verbose bool) error {
 	out := &writer{w: w}
 	out.write("ALLOW\n")
 	c.writeList(c.netRestricts.GetAllow(), out)
@@ -676,7 +672,6 @@ func (c *netRestrictionsCollection) writeText(w io.Writer) error {
 
 type databaseServerCollection struct {
 	servers []types.DatabaseServer
-	verbose bool
 }
 
 func (c *databaseServerCollection) resources() (r []types.Resource) {
@@ -686,10 +681,10 @@ func (c *databaseServerCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *databaseServerCollection) writeText(w io.Writer) error {
+func (c *databaseServerCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range c.servers {
-		labels := stripInternalTeleportLabels(c.verbose, server.GetDatabase().GetAllLabels())
+		labels := stripInternalTeleportLabels(verbose, server.GetDatabase().GetAllLabels())
 		rows = append(rows, []string{
 			server.GetHostname(),
 			server.GetDatabase().GetName(),
@@ -701,7 +696,7 @@ func (c *databaseServerCollection) writeText(w io.Writer) error {
 	}
 	headers := []string{"Host", "Name", "Protocol", "URI", "Labels", "Version"}
 	var t asciitable.Table
-	if c.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -720,7 +715,6 @@ func (c *databaseServerCollection) writeYAML(w io.Writer) error {
 
 type databaseCollection struct {
 	databases []types.Database
-	verbose   bool
 }
 
 func (c *databaseCollection) resources() (r []types.Resource) {
@@ -730,17 +724,17 @@ func (c *databaseCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *databaseCollection) writeText(w io.Writer) error {
+func (c *databaseCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, database := range c.databases {
-		labels := stripInternalTeleportLabels(c.verbose, database.GetAllLabels())
+		labels := stripInternalTeleportLabels(verbose, database.GetAllLabels())
 		rows = append(rows, []string{
 			database.GetName(), database.GetProtocol(), database.GetURI(), labels,
 		})
 	}
 	headers := []string{"Name", "Protocol", "URI", "Labels"}
 	var t asciitable.Table
-	if c.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -760,7 +754,7 @@ func (c *lockCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *lockCollection) writeText(w io.Writer) error {
+func (c *lockCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"ID", "Target", "Message", "Expires"})
 	for _, lock := range c.locks {
 		target := lock.Target()
@@ -785,7 +779,7 @@ func (c *windowsDesktopServiceCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *windowsDesktopServiceCollection) writeText(w io.Writer) error {
+func (c *windowsDesktopServiceCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Address", "Version"})
 	for _, service := range c.services {
 		addr := service.GetAddr()
@@ -800,7 +794,6 @@ func (c *windowsDesktopServiceCollection) writeText(w io.Writer) error {
 
 type windowsDesktopCollection struct {
 	desktops []types.WindowsDesktop
-	verbose  bool
 }
 
 func (c *windowsDesktopCollection) resources() (r []types.Resource) {
@@ -810,15 +803,15 @@ func (c *windowsDesktopCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *windowsDesktopCollection) writeText(w io.Writer) error {
+func (c *windowsDesktopCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, d := range c.desktops {
-		labels := stripInternalTeleportLabels(c.verbose, d.GetAllLabels())
+		labels := stripInternalTeleportLabels(verbose, d.GetAllLabels())
 		rows = append(rows, []string{d.GetName(), d.GetAddr(), d.GetDomain(), labels})
 	}
 	headers := []string{"Name", "Address", "AD Domain", "Labels"}
 	var t asciitable.Table
-	if c.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -858,7 +851,7 @@ func (c *tokenCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *tokenCollection) writeText(w io.Writer) error {
+func (c *tokenCollection) writeText(w io.Writer, verbose bool) error {
 	for _, token := range c.tokens {
 		_, err := w.Write([]byte(token.String()))
 		if err != nil {
@@ -870,7 +863,6 @@ func (c *tokenCollection) writeText(w io.Writer) error {
 
 type kubeServerCollection struct {
 	servers []types.KubeServer
-	verbose bool
 }
 
 func (c *kubeServerCollection) resources() (r []types.Resource) {
@@ -880,14 +872,14 @@ func (c *kubeServerCollection) resources() (r []types.Resource) {
 	return r
 }
 
-func (c *kubeServerCollection) writeText(w io.Writer) error {
+func (c *kubeServerCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range c.servers {
 		kube := server.GetCluster()
 		if kube == nil {
 			continue
 		}
-		labels := stripInternalTeleportLabels(c.verbose,
+		labels := stripInternalTeleportLabels(verbose,
 			types.CombineLabels(kube.GetStaticLabels(), types.LabelsToV2(kube.GetDynamicLabels())))
 		rows = append(rows, []string{
 			kube.GetName(),
@@ -898,7 +890,7 @@ func (c *kubeServerCollection) writeText(w io.Writer) error {
 	}
 	headers := []string{"Cluster", "Labels", "Version"}
 	var t asciitable.Table
-	if c.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -918,7 +910,6 @@ func (c *kubeServerCollection) writeJSON(w io.Writer) error {
 
 type kubeClusterCollection struct {
 	clusters []types.KubeCluster
-	verbose  bool
 }
 
 func (c *kubeClusterCollection) resources() (r []types.Resource) {
@@ -936,18 +927,18 @@ func (c *kubeClusterCollection) resources() (r []types.Resource) {
 // cluster3      region=northcentralus,resource-group=cluster3,subscription-id=subID
 // cluster4      owner=cluster4,region=southcentralus,resource-group=cluster4,subscription-id=subID
 // If verbose is disabled, labels column can be truncated to fit into the console.
-func (c *kubeClusterCollection) writeText(w io.Writer) error {
+func (c *kubeClusterCollection) writeText(w io.Writer, verbose bool) error {
 	sort.Sort(types.KubeClusters(c.clusters))
 	var rows [][]string
 	for _, cluster := range c.clusters {
-		labels := stripInternalTeleportLabels(c.verbose, cluster.GetAllLabels())
+		labels := stripInternalTeleportLabels(verbose, cluster.GetAllLabels())
 		rows = append(rows, []string{
 			cluster.GetName(), labels,
 		})
 	}
 	headers := []string{"Name", "Labels"}
 	var t asciitable.Table
-	if c.verbose {
+	if verbose {
 		t = asciitable.MakeTable(headers, rows...)
 	} else {
 		t = asciitable.MakeTableWithTruncatedColumn(headers, rows, "Labels")
@@ -968,7 +959,7 @@ func (c *installerCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *installerCollection) writeText(w io.Writer) error {
+func (c *installerCollection) writeText(w io.Writer, verbose bool) error {
 	for _, inst := range c.installers {
 		if _, err := fmt.Fprintf(w, "Script: %s\n----------\n", inst.GetName()); err != nil {
 			return trace.Wrap(err)
@@ -993,7 +984,7 @@ func (c *integrationCollection) resources() (r []types.Resource) {
 	}
 	return r
 }
-func (c *integrationCollection) writeText(w io.Writer) error {
+func (c *integrationCollection) writeText(w io.Writer, verbose bool) error {
 	sort.Sort(types.Integrations(c.integrations))
 	var rows [][]string
 	for _, ig := range c.integrations {
@@ -1053,7 +1044,7 @@ func databaseResourceMatchersToString(in []*types.DatabaseResourceMatcher) strin
 // ------------------------------------ --------------------------------------
 // a6065ee9-d5ee-4555-8d47-94a78625277b (Labels: <all databases>)
 // d4e13f2b-0a55-4e0a-b363-bacfb1a11294 (Labels: env=[prod],aws-tag=[xyz abc])
-func (c *databaseServiceCollection) writeText(w io.Writer) error {
+func (c *databaseServiceCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Resource Matchers"})
 
 	for _, dbService := range c.databaseServices {
@@ -1070,7 +1061,7 @@ type loginRuleCollection struct {
 	rules []*loginrulepb.LoginRule
 }
 
-func (l *loginRuleCollection) writeText(w io.Writer) error {
+func (l *loginRuleCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Priority"})
 	for _, rule := range l.rules {
 		t.AddRow([]string{rule.Metadata.Name, strconv.FormatInt(int64(rule.Priority), 10)})
@@ -1100,7 +1091,7 @@ func (c *samlIdPServiceProviderCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *samlIdPServiceProviderCollection) writeText(w io.Writer) error {
+func (c *samlIdPServiceProviderCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, serviceProvider := range c.serviceProviders {
 		t.AddRow([]string{serviceProvider.GetName()})
@@ -1121,7 +1112,7 @@ func (c *deviceCollection) resources() []types.Resource {
 	return resources
 }
 
-func (c *deviceCollection) writeText(w io.Writer) error {
+func (c *deviceCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"ID", "OS Type", "Asset Tag", "Enrollment Status", "Creation Time", "Last Updated"})
 	for _, device := range c.devices {
 		t.AddRow([]string{
@@ -1149,7 +1140,7 @@ func (c *oktaImportRuleCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *oktaImportRuleCollection) writeText(w io.Writer) error {
+func (c *oktaImportRuleCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, importRule := range c.importRules {
 		t.AddRow([]string{importRule.GetName()})
@@ -1170,7 +1161,7 @@ func (c *oktaAssignmentCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *oktaAssignmentCollection) writeText(w io.Writer) error {
+func (c *oktaAssignmentCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name"})
 	for _, assignment := range c.assignments {
 		t.AddRow([]string{assignment.GetName()})
@@ -1191,7 +1182,7 @@ func (c *userGroupCollection) resources() []types.Resource {
 	return r
 }
 
-func (c *userGroupCollection) writeText(w io.Writer) error {
+func (c *userGroupCollection) writeText(w io.Writer, verbose bool) error {
 	t := asciitable.MakeTable([]string{"Name", "Origin"})
 	for _, userGroup := range c.userGroups {
 		t.AddRow([]string{

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -100,10 +100,9 @@ func Test_kubeClusterCollection_writeText(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := &kubeClusterCollection{
 				clusters: kubeClusters,
-				verbose:  tt.fields.verbose,
 			}
 			w := &bytes.Buffer{}
-			err := c.writeText(w)
+			err := c.writeText(w, tt.fields.verbose)
 			require.NoError(t, err)
 			require.Contains(t, w.String(), tt.wantTable())
 		})

--- a/tool/tctl/common/db_command.go
+++ b/tool/tctl/common/db_command.go
@@ -104,10 +104,10 @@ func (c *DBCommand) ListDatabases(ctx context.Context, clt auth.ClientI) error {
 		}
 	}
 
-	coll := &databaseServerCollection{servers: servers, verbose: c.verbose}
+	coll := &databaseServerCollection{servers: servers}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/desktop_command.go
+++ b/tool/tctl/common/desktop_command.go
@@ -74,11 +74,10 @@ func (c *DesktopCommand) ListDesktop(ctx context.Context, client auth.ClientI) e
 	}
 	coll := windowsDesktopCollection{
 		desktops: desktops,
-		verbose:  c.verbose,
 	}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -72,10 +72,11 @@ func (c *KubeCommand) ListKube(ctx context.Context, client auth.ClientI) error {
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	coll := &kubeServerCollection{servers: kubes, verbose: c.verbose}
+
+	coll := &kubeServerCollection{servers: kubes}
 	switch c.format {
 	case teleport.Text:
-		return trace.Wrap(coll.writeText(os.Stdout))
+		return trace.Wrap(coll.writeText(os.Stdout, c.verbose))
 	case teleport.JSON:
 		return trace.Wrap(coll.writeJSON(os.Stdout))
 	case teleport.YAML:

--- a/tool/tctl/common/node_command.go
+++ b/tool/tctl/common/node_command.go
@@ -248,10 +248,10 @@ func (c *NodeCommand) ListActive(ctx context.Context, clt auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 
-	coll := &serverCollection{servers: nodes, verbose: c.verbose}
+	coll := &serverCollection{servers: nodes}
 	switch c.lsFormat {
 	case teleport.Text:
-		if err := coll.writeText(os.Stdout); err != nil {
+		if err := coll.writeText(os.Stdout, c.verbose); err != nil {
 			return trace.Wrap(err)
 		}
 	case teleport.YAML:

--- a/tool/tctl/common/proxy_command.go
+++ b/tool/tctl/common/proxy_command.go
@@ -51,11 +51,13 @@ func (p *ProxyCommand) ListProxies(ctx context.Context, clusterAPI auth.ClientI)
 		return trace.Wrap(err)
 	}
 
-	sc := &serverCollection{proxies, false}
+	sc := &serverCollection{proxies}
 
 	switch p.format {
 	case teleport.Text:
-		return sc.writeText(os.Stdout)
+		// proxies don't have labels.
+		verbose := false
+		return sc.writeText(os.Stdout, verbose)
 	case teleport.YAML:
 		return writeYAML(sc, os.Stdout)
 	case teleport.JSON:

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -220,7 +220,7 @@ func (rc *ResourceCommand) Get(ctx context.Context, client auth.ClientI) error {
 	// is experimental.
 	switch rc.format {
 	case teleport.Text:
-		return collection.writeText(rc.stdout)
+		return collection.writeText(rc.stdout, rc.verbose)
 	case teleport.YAML:
 		return writeYAML(collection, rc.stdout)
 	case teleport.JSON:
@@ -1503,13 +1503,13 @@ func (rc *ResourceCommand) getCollection(ctx context.Context, client auth.Client
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
-			return &roleCollection{roles: roles, verbose: rc.verbose}, nil
+			return &roleCollection{roles: roles}, nil
 		}
 		role, err := client.GetRole(ctx, rc.ref.Name)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
-		return &roleCollection{roles: []types.Role{role}, verbose: rc.verbose}, nil
+		return &roleCollection{roles: []types.Role{role}}, nil
 	case types.KindNamespace:
 		if rc.ref.Name == "" {
 			namespaces, err := client.GetNamespaces()


### PR DESCRIPTION
This PR ensures that the `--verbose` flag in `tctl` is used for formatting text tables.

Prior behavior: `tctl get --format text --verbose` did not respect the verbose flag.

I changed the interface for collections `writeText` func to take the verbose flag as an argument, to avoid scattering it across each collection type and ensure that all callers of `writeText` provide a value for text verbosity.