### PR TITLE
[v11] lib/teleterm TestStart: Increase timeout, improve error handling

### DIFF
--- a/lib/teleterm/teleterm_test.go
+++ b/lib/teleterm/teleterm_test.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	// timeout used for most operations in tests.
-	timeout = 5 * time.Second
+	timeout = 10 * time.Second
 )
 
 type createClientTLSConfigFunc func(t *testing.T, certsDir string) *tls.Config
@@ -128,13 +128,15 @@ func TestStart(t *testing.T) {
 				// Verify that the server accepts connections on the advertised address.
 				blockUntilServerAcceptsConnections(t, addr, certsDir,
 					test.createClientTLSConfigFunc, test.connReadExpectationFunc)
+
+				// Stop the server.
+				cancel()
+				require.NoError(t, <-serveErr)
 			case <-time.After(timeout):
 				t.Fatal("listeningC didn't advertise the address within the timeout")
+			case err := <-serveErr:
+				t.Fatalf("teleterm.Serve returned sooner than expected, err: %#v", err)
 			}
-
-			// Stop the server.
-			cancel()
-			require.NoError(t, <-serveErr)
 		})
 	}
 


### PR DESCRIPTION
Backport #29809 to branch/v11