### PR TITLE
Fix goroutine leak for `token` based renewal on Machine ID

### DIFF
--- a/lib/tbot/bot_identity.go
+++ b/lib/tbot/bot_identity.go
@@ -124,6 +124,7 @@ func (b *Bot) renewBotIdentity(
 		if err != nil {
 			return trace.Wrap(err)
 		}
+		defer authClient.Close()
 		newIdentity, err = botIdentityFromAuth(
 			ctx, b.log, currentIdentity, authClient, b.cfg.CertificateTTL,
 		)


### PR DESCRIPTION
This only affects the upcoming v14 release - noticed it earlier today when setting up a testbed environment. This client is only used once for the following function, and needed closing.

![image](https://github.com/gravitational/teleport/assets/16336790/d0ca36fc-a9cd-4c69-89a3-e57a60f1c7a2)
