### PR TITLE
kube: Full namespace jail for custom resources

### DIFF
--- a/integration/helpers/kube.go
+++ b/integration/helpers/kube.go
@@ -16,26 +16,22 @@ package helpers
 
 import (
 	"context"
-	"crypto/x509/pkix"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	apiclient "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
-	"github.com/gravitational/teleport/lib/auth/testauthority"
-	"github.com/gravitational/teleport/lib/client"
-	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/service"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
-	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -49,24 +45,40 @@ func EnableKube(t *testing.T, config *servicecfg.Config, clusterName string) err
 	if kubeConfigPath == "" {
 		return trace.BadParameter("missing kubeconfig path")
 	}
-	key, err := genUserKey()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-	err = kubeconfig.Update(kubeConfigPath, kubeconfig.Values{
-		// By default this needs to be an arbitrary address guaranteed not to
-		// be in use, so we're using port 0 for now.
-		ClusterAddr: "https://localhost:0",
 
-		TeleportClusterName: clusterName,
-		Credentials:         key,
-	}, false)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	genKubeConfig(t, kubeConfigPath, clusterName)
 	config.Kube.Enabled = true
 	config.Kube.ListenAddr = utils.MustParseAddr(NewListener(t, service.ListenerKube, &config.FileDescriptors))
 	return nil
+}
+
+// genKubeConfig generates a kubeconfig file for a given cluster based on the
+// kubeMock server.
+func genKubeConfig(t *testing.T, kubeconfigPath, clusterName string) {
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, kubeMock.Close())
+	})
+	cfg := clientcmdapi.Config{
+		Clusters: map[string]*clientcmdapi.Cluster{
+			clusterName: {
+				Server:                kubeMock.URL,
+				InsecureSkipTLSVerify: true,
+			},
+		},
+		AuthInfos: map[string]*clientcmdapi.AuthInfo{
+			clusterName: {},
+		},
+		Contexts: map[string]*clientcmdapi.Context{
+			clusterName: {
+				Cluster:  clusterName,
+				AuthInfo: clusterName,
+			},
+		},
+	}
+	err = kubeconfig.Save(kubeconfigPath, cfg)
+	require.NoError(t, err)
 }
 
 // GetKubeClusters gets all kubernetes clusters accessible from a given auth server.
@@ -84,45 +96,4 @@ func GetKubeClusters(t *testing.T, as *auth.Server) []types.KubeCluster {
 		clusters = append(clusters, ks.GetCluster())
 	}
 	return clusters
-}
-
-func genUserKey() (*client.Key, error) {
-	caKey, caCert, err := tlsca.GenerateSelfSignedCA(pkix.Name{
-		CommonName:   "localhost",
-		Organization: []string{"localhost"},
-	}, nil, defaults.CATTL)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	ca, err := tlsca.FromKeys(caCert, caKey)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	keygen := testauthority.New()
-	priv, err := keygen.GeneratePrivateKey()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	clock := clockwork.NewRealClock()
-	tlsCert, err := ca.GenerateCertificate(tlsca.CertificateRequest{
-		Clock:     clock,
-		PublicKey: priv.Public(),
-		Subject: pkix.Name{
-			CommonName: "teleport-user",
-		},
-		NotAfter: clock.Now().UTC().Add(time.Minute),
-	})
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	return &client.Key{
-		PrivateKey: priv,
-		TLSCert:    tlsCert,
-		TrustedCerts: []auth.TrustedCerts{{
-			ClusterName:     "localhost",
-			TLSCertificates: [][]byte{caCert},
-		}},
-	}, nil
 }

--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -20,12 +20,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"path/filepath"
 	"strings"
@@ -41,7 +39,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/exp/maps"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -59,11 +56,11 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
+	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
-	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/db/mysql"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
@@ -452,9 +449,10 @@ func mustClosePostgresClient(t *testing.T, client *pgconn.PgConn) {
 }
 
 const (
-	kubeClusterName             = "gke_project_europecentral2a_cluster1"
-	kubeClusterDefaultNamespace = "default"
-	kubePodName                 = "firstcontainer-66b6c48dd-bqmwk"
+	// kubeClusterName is the name of the cluster in Teleport.
+	// It it's not a real cluster name, but a cluster that uses
+	// kube mock server.
+	kubeClusterName = "gke_project_europecentral2a_cluster1"
 )
 
 func k8ClientConfig(serverAddr, sni string) clientcmdapi.Config {
@@ -476,38 +474,11 @@ func k8ClientConfig(serverAddr, sni string) clientcmdapi.Config {
 	}
 }
 
-func mkPodList() *v1.PodList {
-	return &v1.PodList{
-		TypeMeta: metav1.TypeMeta{
-			Kind:       "PodList",
-			APIVersion: "v1",
-		},
-		Items: []v1.Pod{
-			{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      kubePodName,
-					Namespace: kubeClusterDefaultNamespace,
-				},
-			},
-		},
-	}
-}
-
-func startKubeAPIMock(t *testing.T) *httptest.Server {
-	mux := http.NewServeMux()
-	mux.HandleFunc("/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", func(rw http.ResponseWriter, request *http.Request) {
-	})
-	mux.HandleFunc("/api/v1/namespaces/default/pods", func(rw http.ResponseWriter, request *http.Request) {
-		rw.Header().Add("Content-Type", "application/json")
-		err := json.NewEncoder(rw).Encode(mkPodList())
-		require.NoError(t, err)
-	})
-
-	svr := httptest.NewTLSServer(mux)
-	t.Cleanup(func() {
-		svr.Close()
-	})
-	return svr
+func startKubeAPIMock(t *testing.T) *testingkubemock.KubeMockServer {
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+	return kubeMock
 }
 
 func mustCreateKubeConfigFile(t *testing.T, config clientcmdapi.Config) string {
@@ -713,13 +684,12 @@ func mustFindKubePod(t *testing.T, tc *client.TeleportClient) {
 	response, err := serviceClient.ListKubernetesResources(context.Background(), &kubeproto.ListKubernetesResourcesRequest{
 		ResourceType:        types.KindKubePod,
 		KubernetesCluster:   kubeClusterName,
-		KubernetesNamespace: kubeClusterDefaultNamespace,
+		KubernetesNamespace: metav1.NamespaceDefault,
 		TeleportCluster:     tc.SiteName,
 	})
 	require.NoError(t, err)
-	require.Len(t, response.Resources, 1)
+	require.Len(t, response.Resources, 3)
 	require.Equal(t, types.KindKubePod, response.Resources[0].Kind)
-	require.Equal(t, kubePodName, response.Resources[0].GetName())
 }
 
 func mustConnectDatabaseGateway(t *testing.T, gw gateway.Gateway) {
@@ -758,7 +728,7 @@ func kubeClientForLocalProxy(t *testing.T, kubeconfigPath, teleportCluster, kube
 		CAData:     config.Clusters[contextName].CertificateAuthorityData,
 		CertData:   config.AuthInfos[contextName].ClientCertificateData,
 		KeyData:    config.AuthInfos[contextName].ClientKeyData,
-		ServerName: common.KubeLocalProxySNI(teleportCluster, kubeCluster),
+		ServerName: alpncommon.KubeLocalProxySNI(teleportCluster, kubeCluster),
 	}
 	client, err := kubernetes.NewForConfig(&rest.Config{
 		Host:            "https://" + teleportCluster,
@@ -769,13 +739,12 @@ func kubeClientForLocalProxy(t *testing.T, kubeconfigPath, teleportCluster, kube
 	return client
 }
 
-func mustGetKubePod(t *testing.T, client *kubernetes.Clientset, wantPodName string) {
+func mustGetKubePod(t *testing.T, client *kubernetes.Clientset) {
 	t.Helper()
 
-	resp, err := client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
+	resp, err := client.CoreV1().Pods(metav1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Equal(t, len(resp.Items), 1)
-	require.Equal(t, wantPodName, resp.Items[0].GetName())
+	require.Equal(t, len(resp.Items), 3)
 }
 
 func mustGetProfileName(t *testing.T, webProxyAddr string) string {

--- a/integration/proxy/proxy_test.go
+++ b/integration/proxy/proxy_test.go
@@ -390,7 +390,7 @@ func TestALPNSNIProxyKube(t *testing.T) {
 
 	resp, err := k8Client.CoreV1().Pods("default").List(context.Background(), metav1.ListOptions{})
 	require.NoError(t, err)
-	require.Equal(t, 1, len(resp.Items), "pods item length mismatch")
+	require.Equal(t, 3, len(resp.Items), "pods item length mismatch")
 
 	// Simulate how tsh uses a kube local proxy to send kube requests to
 	// Teleport Proxy with a L7 LB in front.
@@ -434,7 +434,7 @@ func TestALPNSNIProxyKube(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		mustGetKubePod(t, k8Client, kubePodName)
+		mustGetKubePod(t, k8Client)
 	})
 }
 
@@ -505,7 +505,7 @@ func TestALPNSNIProxyKubeV2Leaf(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	mustGetKubePod(t, k8Client, kubePodName)
+	mustGetKubePod(t, k8Client)
 }
 
 func TestKubeIPPinning(t *testing.T) {
@@ -628,7 +628,7 @@ func TestKubeIPPinning(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			require.Equal(t, 1, len(resp.Items), "pods item length mismatch")
+			require.Equal(t, 3, len(resp.Items), "pods item length mismatch")
 		})
 	}
 }

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -349,7 +349,7 @@ func testKubeGatewayCertRenewal(t *testing.T, suite *Suite, albAddr string, kube
 			client = kubeClientForLocalProxy(t, kubeconfigPath, teleportCluster, kubeCluster)
 		})
 
-		mustGetKubePod(t, client, kubePodName)
+		mustGetKubePod(t, client)
 	}
 
 	testGatewayCertRenewal(
@@ -362,7 +362,6 @@ func testKubeGatewayCertRenewal(t *testing.T, suite *Suite, albAddr string, kube
 		},
 		testKubeConnection,
 	)
-
 }
 
 func checkKubeconfigPathInCommandEnv(t *testing.T, gw gateway.Gateway, wantKubeconfigPath string) {

--- a/lib/kube/grpc/grpc_test.go
+++ b/lib/kube/grpc/grpc_test.go
@@ -77,6 +77,13 @@ func TestListKubernetesResources(t *testing.T) {
 			Name:       usernameWithFullAccess,
 			KubeUsers:  kubeUsers,
 			KubeGroups: kubeGroups,
+			SetupRoleFunc: func(r types.Role) {
+				// override the role to allow access to all kube resources.
+				r.SetKubeResources(
+					types.Allow,
+					[]types.KubernetesResource{{Kind: types.Wildcard, Name: types.Wildcard, Namespace: types.Wildcard, Verbs: []string{types.Wildcard}}},
+				)
+			},
 		},
 	)
 

--- a/lib/kube/proxy/auth_test.go
+++ b/lib/kube/proxy/auth_test.go
@@ -18,6 +18,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"net/http"
 	"os"
@@ -25,7 +26,10 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 	authzapi "k8s.io/api/authorization/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -34,6 +38,7 @@ import (
 	"k8s.io/client-go/transport"
 
 	"github.com/gravitational/teleport/api/types"
+	testingkubemock "github.com/gravitational/teleport/lib/kube/proxy/testing/kube_server"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -122,6 +127,16 @@ func failsForCluster(clusterName string) servicecfg.ImpersonationPermissionsChec
 
 func TestGetKubeCreds(t *testing.T) {
 	t.Parallel()
+	// kubeMock is a Kubernetes API mock for the session tests.
+	kubeMock, err := testingkubemock.NewKubeAPIMock()
+	require.NoError(t, err)
+	t.Cleanup(func() { kubeMock.Close() })
+	targetAddr := kubeMock.Address
+
+	rbacSupportedTypes := maps.Clone(defaultRBACResources)
+	rbacSupportedTypes[allowedResourcesKey{apiGroup: "resources.teleport.dev", resourceKind: "teleportroles"}] = utils.KubeCustomResource
+	rbacSupportedTypes[allowedResourcesKey{apiGroup: "resources.teleport.dev", resourceKind: "teleportroles/status"}] = utils.KubeCustomResource
+
 	logger := utils.NewLoggerForTests()
 	ctx := context.TODO()
 	const teleClusterName = "teleport-cluster"
@@ -132,7 +147,8 @@ apiVersion: v1
 kind: Config
 clusters:
 - cluster:
-    server: https://example.com:3026
+    server: ` + kubeMock.URL + `
+    insecure-skip-tls-verify: true
   name: example
 contexts:
 - context:
@@ -151,7 +167,7 @@ users:
 - name: creds
 current-context: foo
 `)
-	err := os.WriteFile(kubeconfigPath, data, 0o600)
+	err = os.WriteFile(kubeconfigPath, data, 0o600)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -189,30 +205,33 @@ current-context: foo
 			want: map[string]*kubeDetails{
 				"foo": {
 					kubeCreds: &staticKubeCreds{
-						targetAddr:      "example.com:3026",
+						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster: mustCreateKubernetesClusterV3(t, "foo"),
+					kubeCluster:        mustCreateKubernetesClusterV3(t, "foo"),
+					rbacSupportedTypes: rbacSupportedTypes,
 				},
 				"bar": {
 					kubeCreds: &staticKubeCreds{
-						targetAddr:      "example.com:3026",
+						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster: mustCreateKubernetesClusterV3(t, "bar"),
+					kubeCluster:        mustCreateKubernetesClusterV3(t, "bar"),
+					rbacSupportedTypes: rbacSupportedTypes,
 				},
 				"baz": {
 					kubeCreds: &staticKubeCreds{
-						targetAddr:      "example.com:3026",
+						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster: mustCreateKubernetesClusterV3(t, "baz"),
+					kubeCluster:        mustCreateKubernetesClusterV3(t, "baz"),
+					rbacSupportedTypes: rbacSupportedTypes,
 				},
 			},
 			assertErr: require.NoError,
@@ -231,12 +250,13 @@ current-context: foo
 			want: map[string]*kubeDetails{
 				teleClusterName: {
 					kubeCreds: &staticKubeCreds{
-						targetAddr:      "example.com:3026",
+						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster: mustCreateKubernetesClusterV3(t, teleClusterName),
+					kubeCluster:        mustCreateKubernetesClusterV3(t, teleClusterName),
+					rbacSupportedTypes: rbacSupportedTypes,
 				},
 			},
 			assertErr: require.NoError,
@@ -248,30 +268,33 @@ current-context: foo
 			want: map[string]*kubeDetails{
 				"foo": {
 					kubeCreds: &staticKubeCreds{
-						targetAddr:      "example.com:3026",
+						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster: mustCreateKubernetesClusterV3(t, "foo"),
+					kubeCluster:        mustCreateKubernetesClusterV3(t, "foo"),
+					rbacSupportedTypes: rbacSupportedTypes,
 				},
 				"bar": {
 					kubeCreds: &staticKubeCreds{
-						targetAddr:      "example.com:3026",
+						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster: mustCreateKubernetesClusterV3(t, "bar"),
+					kubeCluster:        mustCreateKubernetesClusterV3(t, "bar"),
+					rbacSupportedTypes: rbacSupportedTypes,
 				},
 				"baz": {
 					kubeCreds: &staticKubeCreds{
-						targetAddr:      "example.com:3026",
+						targetAddr:      targetAddr,
 						transportConfig: &transport.Config{},
 						kubeClient:      &kubernetes.Clientset{},
 						clientRestCfg:   &rest.Config{},
 					},
-					kubeCluster: mustCreateKubernetesClusterV3(t, "baz"),
+					kubeCluster:        mustCreateKubernetesClusterV3(t, "baz"),
+					rbacSupportedTypes: rbacSupportedTypes,
 				},
 			},
 			assertErr: require.NoError,
@@ -281,15 +304,28 @@ current-context: foo
 		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
-			got, err := getKubeDetails(ctx, logger, teleClusterName, "", tt.kubeconfigPath, tt.serviceType, tt.impersonationCheck)
+			fwd := &Forwarder{
+				clusterDetails: map[string]*kubeDetails{},
+				cfg: ForwarderConfig{
+					ClusterName:                   teleClusterName,
+					KubeServiceType:               tt.serviceType,
+					KubeconfigPath:                tt.kubeconfigPath,
+					CheckImpersonationPermissions: tt.impersonationCheck,
+					Clock:                         clockwork.NewFakeClock(),
+				},
+				log: logger,
+			}
+			err := fwd.getKubeDetails(ctx)
 			tt.assertErr(t, err)
 			if err != nil {
 				return
 			}
-			require.Empty(t, cmp.Diff(got, tt.want,
+			require.Empty(t, cmp.Diff(fwd.clusterDetails, tt.want,
 				cmp.AllowUnexported(staticKubeCreds{}),
 				cmp.AllowUnexported(kubeDetails{}),
+				cmpopts.IgnoreFields(kubeDetails{}, "rwMu", "kubeCodecs", "wg", "cancelFunc"),
 				cmp.Comparer(func(a, b *transport.Config) bool { return (a == nil) == (b == nil) }),
+				cmp.Comparer(func(a, b *tls.Config) bool { return true }),
 				cmp.Comparer(func(a, b *kubernetes.Clientset) bool { return (a == nil) == (b == nil) }),
 				cmp.Comparer(func(a, b *rest.Config) bool { return (a == nil) == (b == nil) }),
 				cmp.Comparer(func(a, b http.RoundTripper) bool { return true }),

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -17,6 +17,7 @@ package proxy
 import (
 	"context"
 	"encoding/base64"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -26,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 
@@ -45,12 +47,30 @@ type kubeDetails struct {
 	dynamicLabels *labels.Dynamic
 	// kubeCluster is the dynamic kube_cluster or a static generated from kubeconfig and that only has the name populated.
 	kubeCluster types.KubeCluster
+
+	// rwMu is the mutex to protect the kubeCodecs and rbacSupportedTypes.
+	rwMu sync.RWMutex
+	// kubeCodecs is the codec factory for the cluster resources.
+	// The codec factory includes the default resources and the namespaced resources
+	// that are supported by the cluster.
+	// The codec factory is updated periodically to include the latest custom resources
+	// that are added to the cluster.
+	kubeCodecs serializer.CodecFactory
+	// rbacSupportedTypes is the list of supported types for RBAC for the cluster.
+	// The list is updated periodically to include the latest custom resources
+	// that are added to the cluster.
+	rbacSupportedTypes rbacSupportedResources
+
+	cancelFunc context.CancelFunc
+	wg         sync.WaitGroup
 }
 
 // clusterDetailsConfig contains the configuration for creating a proxied cluster.
 type clusterDetailsConfig struct {
 	// cloudClients is the cloud clients to use for dynamic clusters.
 	cloudClients cloud.Clients
+	// kubeCreds is the credentials to use for the cluster.
+	kubeCreds kubeCreds
 	// cluster is the cluster to create a proxied cluster for.
 	cluster types.KubeCluster
 	// log is the logger to use.
@@ -67,14 +87,16 @@ type clusterDetailsConfig struct {
 }
 
 // newClusterDetails creates a proxied kubeDetails structure given a dynamic cluster.
-func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (*kubeDetails, error) {
-	var dynLabels *labels.Dynamic
-
-	creds, err := getKubeClusterCredentials(ctx, cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
+func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDetails, err error) {
+	creds := cfg.kubeCreds
+	if creds == nil {
+		creds, err = getKubeClusterCredentials(ctx, cfg)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
 	}
 
+	var dynLabels *labels.Dynamic
 	if len(cfg.cluster.GetDynamicLabels()) > 0 {
 		dynLabels, err = labels.NewDynamic(
 			ctx,
@@ -89,19 +111,65 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (*kubeDeta
 		go dynLabels.Start()
 	}
 
-	return &kubeDetails{
-		kubeCreds:     creds,
-		dynamicLabels: dynLabels,
-		kubeCluster:   cfg.cluster,
-	}, nil
+	// Create the codec factory and the list of supported types for RBAC.
+	codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(creds.getKubeClient())
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	k := &kubeDetails{
+		kubeCreds:          creds,
+		dynamicLabels:      dynLabels,
+		kubeCluster:        cfg.cluster,
+		kubeCodecs:         codecFactory,
+		rbacSupportedTypes: rbacSupportedTypes,
+		cancelFunc:         cancel,
+	}
+
+	k.wg.Add(1)
+	// Start the periodic update of the codec factory and the list of supported types for RBAC.
+	go func() {
+		defer k.wg.Done()
+		ticker := cfg.clock.NewTicker(5 * time.Minute)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.Chan():
+				codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(creds.getKubeClient())
+				if err != nil {
+					cfg.log.WithError(err).Error("Failed to update cluster schema")
+					continue
+				}
+
+				k.rwMu.Lock()
+				k.kubeCodecs = codecFactory
+				k.rbacSupportedTypes = rbacSupportedTypes
+				k.rwMu.Unlock()
+			}
+		}
+	}()
+	return k, nil
 }
 
 func (k *kubeDetails) Close() {
+	// send a close signal and wait for the close to finish.
+	k.cancelFunc()
+	k.wg.Wait()
 	if k.dynamicLabels != nil {
 		k.dynamicLabels.Close()
 	}
 	// it is safe to call close even for static creds.
 	k.kubeCreds.close()
+}
+
+// getClusterSupportedResources returns the codec factory and the list of supported types for RBAC.
+func (k *kubeDetails) getClusterSupportedResources() (*serializer.CodecFactory, rbacSupportedResources) {
+	k.rwMu.RLock()
+	defer k.rwMu.RUnlock()
+	return &(k.kubeCodecs), k.rbacSupportedTypes
 }
 
 // getKubeClusterCredentials generates kube credentials for dynamic clusters.

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -28,7 +28,6 @@ import (
 	"io"
 	"net"
 	"net/http"
-	"path"
 	"strconv"
 	"strings"
 	"sync"
@@ -48,6 +47,7 @@ import (
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apiserver/pkg/util/wsstream"
 	"k8s.io/client-go/tools/remotecommand"
@@ -312,31 +312,6 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 
 	router.POST("/apis/authorization.k8s.io/:ver/selfsubjectaccessreviews", fwd.withAuth(fwd.selfSubjectAccessReviews))
 
-	for k, v := range allowedResources {
-		prefix := "/api"
-		if k.apiGroup != "core" {
-			prefix = path.Join("/apis", k.apiGroup)
-		}
-		prefix = path.Join(prefix, ":ver")
-
-		switch namespace := ""; {
-		case !slices.Contains(types.KubernetesClusterWideResourceKinds, v):
-			router.GET(path.Join(prefix, k.resourceKind), fwd.withAuth(fwd.listResources))
-			namespace = "namespaces/:podNamespace"
-			fallthrough
-		default:
-			endpoint := path.Join(prefix, namespace, k.resourceKind)
-			router.GET(endpoint, fwd.withAuth(fwd.listResources))
-			router.DELETE(endpoint, fwd.withAuth(fwd.deleteResourcesCollection))
-			router.POST(endpoint, fwd.withAuth(
-				func(ctx *authContext, w http.ResponseWriter, r *http.Request, _ httprouter.Params) (any, error) {
-					// Forward pod creation to default handler.
-					return fwd.catchAll(ctx, w, r)
-				},
-			))
-		}
-	}
-
 	router.GET("/api/:ver/teleport/join/:session", fwd.withAuthPassthrough(fwd.join))
 
 	router.NotFound = fwd.withAuthStd(fwd.catchAll)
@@ -347,8 +322,7 @@ func NewForwarder(cfg ForwarderConfig) (*Forwarder, error) {
 		fwd.log.Debugf("Cluster override is set, forwarder will send all requests to remote cluster %v.", cfg.ClusterOverride)
 	}
 	if len(cfg.KubeClusterName) > 0 || len(cfg.KubeconfigPath) > 0 || cfg.KubeServiceType != KubeService {
-		fwd.clusterDetails, err = getKubeDetails(cfg.Context, fwd.log, cfg.ClusterName, cfg.KubeClusterName, cfg.KubeconfigPath, cfg.KubeServiceType, cfg.CheckImpersonationPermissions)
-		if err != nil {
+		if err := fwd.getKubeDetails(cfg.Context); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}
@@ -555,27 +529,10 @@ func (f *Forwarder) authenticate(req *http.Request) (*authContext, error) {
 		return nil, authz.ConvertAuthorizerError(ctx, f.log, err)
 	}
 
-	// kubeResource is the Kubernetes Resource the request is targeted at.
-	// Currently only supports Pods and it includes the pod name and namespace.
-	kubeResource, apiResource, err := getResourceFromRequest(req)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	authContext, err := f.setupContext(ctx, *userContext, req, isRemoteUser, apiResource, kubeResource)
+	authContext, err := f.setupContext(ctx, *userContext, req, isRemoteUser)
 	if err != nil {
 		f.log.WithError(err).Warn("Unable to setup context.")
 		if trace.IsAccessDenied(err) {
-			if kubeResource != nil {
-				return nil, trace.AccessDenied(
-					kubeResourceDeniedAccessMsg(
-						// return the unmapped username to the client, otherwise for leaf
-						// clusters the client will see the "remote-username".
-						userContext.UnmappedIdentity.GetIdentity().Username,
-						req.Method,
-						kubeResource,
-					),
-				)
-			}
 			return nil, trace.AccessDenied(accessDeniedMsg)
 		}
 		return nil, trace.Wrap(err)
@@ -735,7 +692,7 @@ func (f *Forwarder) formatStatusResponseError(rw http.ResponseWriter, respErr er
 		Code:    int32(code),
 		Reason:  errorToKubeStatusReason(respErr, code),
 	}
-	data, err := runtime.Encode(kubeCodecs.LegacyCodec(), status)
+	data, err := runtime.Encode(globalKubeCodecs.LegacyCodec(), status)
 	if err != nil {
 		f.log.Warningf("Failed encoding error into kube Status object: %v", err)
 		trace.WriteError(rw, respErr)
@@ -757,8 +714,6 @@ func (f *Forwarder) setupContext(
 	authCtx authz.Context,
 	req *http.Request,
 	isRemoteUser bool,
-	apiResource apiResource,
-	kubeResource *types.KubernetesResource,
 ) (*authContext, error) {
 	ctx, span := f.cfg.tracer.Start(
 		ctx,
@@ -807,8 +762,10 @@ func (f *Forwarder) setupContext(
 	}
 
 	var (
-		kubeServers []types.KubeServer
-		err         error
+		kubeServers  []types.KubeServer
+		kubeResource *types.KubernetesResource
+		apiResource  apiResource
+		err          error
 	)
 	// Only check k8s principals for local clusters.
 	//
@@ -818,6 +775,12 @@ func (f *Forwarder) setupContext(
 		kubeServers, err = f.getKubernetesServersForKubeCluster(ctx, kubeCluster)
 		if err != nil || len(kubeServers) == 0 {
 			return nil, trace.NotFound("cluster %q not found", kubeCluster)
+		}
+	}
+	if f.isLocalKubeCluster(isRemoteCluster, kubeCluster) {
+		kubeResource, apiResource, err = f.parseResourceFromRequest(req, kubeCluster)
+		if err != nil {
+			return nil, trace.Wrap(err)
 		}
 	}
 
@@ -841,7 +804,6 @@ func (f *Forwarder) setupContext(
 		Context:               authCtx,
 		recordingConfig:       recordingConfig,
 		kubeClusterName:       kubeCluster,
-		kubeResource:          kubeResource,
 		certExpires:           identity.Expires,
 		disconnectExpiredCert: srv.GetDisconnectExpiredCertFromIdentity(roles, authPref, &identity),
 		teleportCluster: teleportClusterClient{
@@ -849,15 +811,51 @@ func (f *Forwarder) setupContext(
 			remoteAddr: utils.NetAddr{AddrNetwork: "tcp", Addr: req.RemoteAddr},
 			isRemote:   isRemoteCluster,
 		},
-		requestVerb: apiResource.getVerb(req),
-		kubeServers: kubeServers,
-		apiResource: apiResource,
+		kubeServers:  kubeServers,
+		requestVerb:  apiResource.getVerb(req),
+		apiResource:  apiResource,
+		kubeResource: kubeResource,
 	}, nil
+}
+
+func (f *Forwarder) parseResourceFromRequest(req *http.Request, kubeClusterName string) (*types.KubernetesResource, apiResource, error) {
+	switch f.cfg.KubeServiceType {
+	case LegacyProxyService:
+		if details, err := f.findKubeDetailsByClusterName(kubeClusterName); err == nil {
+			resource, apiRes, err := getResourceFromRequest(req, details)
+			return resource, apiRes, trace.Wrap(err)
+		}
+		// When the cluster is not being served by the local service, the LegacyProxy
+		// is working as a normal proxy and will forward the request to the remote
+		// service. When this happens, proxy won't enforce any Kubernetes RBAC rules
+		// and will forward the request as is to the remote service. The remote
+		// service will enforce RBAC rules and will return an error if the user is
+		// not authorized.
+		fallthrough
+	case ProxyService:
+		// When the service is acting as a proxy (ProxyService or LegacyProxyService
+		// if the local cluster wasn't found), the proxy will forward the request
+		// to the remote service without enforcing any RBAC rules - we send the
+		// details = nil to indicate that we don't want to extract the kube resource
+		// from the request.
+		resource, apiRes, err := getResourceFromRequest(req, nil /*details*/)
+		return resource, apiRes, trace.Wrap(err)
+	case KubeService:
+		details, err := f.findKubeDetailsByClusterName(kubeClusterName)
+		if err != nil {
+			return nil, apiResource{}, trace.Wrap(err)
+		}
+		resource, apiRes, err := getResourceFromRequest(req, details)
+		return resource, apiRes, trace.Wrap(err)
+
+	default:
+		return nil, apiResource{}, trace.BadParameter("unsupported kube service type: %q", f.cfg.KubeServiceType)
+	}
 }
 
 // emitAuditEvent emits the audit event for a `kube.request` event if the session
 // requires audit events.
-func (f *Forwarder) emitAuditEvent(ctx *authContext, req *http.Request, sess *clusterSession, status int) {
+func (f *Forwarder) emitAuditEvent(req *http.Request, sess *clusterSession, status int) {
 	_, span := f.cfg.tracer.Start(
 		req.Context(),
 		"kube.Forwarder/emitAuditEvent",
@@ -872,7 +870,7 @@ func (f *Forwarder) emitAuditEvent(ctx *authContext, req *http.Request, sess *cl
 	if sess.noAuditEvents {
 		return
 	}
-	r := ctx.apiResource
+	r := sess.apiResource
 	if r.skipEvent {
 		return
 	}
@@ -882,7 +880,7 @@ func (f *Forwarder) emitAuditEvent(ctx *authContext, req *http.Request, sess *cl
 			Type: events.KubeRequestEvent,
 			Code: events.KubeRequestCode,
 		},
-		UserMetadata: ctx.eventUserMeta(),
+		UserMetadata: sess.eventUserMeta(),
 		ConnectionMetadata: apievents.ConnectionMetadata{
 			RemoteAddr: req.RemoteAddr,
 			LocalAddr:  sess.kubeAddress,
@@ -895,7 +893,7 @@ func (f *Forwarder) emitAuditEvent(ctx *authContext, req *http.Request, sess *cl
 		RequestPath:               req.URL.Path,
 		Verb:                      req.Method,
 		ResponseCode:              int32(status),
-		KubernetesClusterMetadata: ctx.eventClusterMeta(req),
+		KubernetesClusterMetadata: sess.eventClusterMeta(req),
 	}
 
 	r.populateEvent(event)
@@ -1034,10 +1032,10 @@ func (f *Forwarder) authorize(ctx context.Context, actx *authContext) error {
 	notFoundMessage := fmt.Sprintf("kubernetes cluster %q not found", actx.kubeClusterName)
 	var roleMatchers services.RoleMatchers
 	if actx.kubeResource != nil {
-		notFoundMessage = kubeResourceDeniedAccessMsg(
+		notFoundMessage = f.kubeResourceDeniedAccessMsg(
 			actx.User.GetName(),
 			actx.requestVerb,
-			actx.kubeResource,
+			actx.apiResource,
 		)
 		roleMatchers = services.RoleMatchers{
 			// Append a matcher that validates if the Kubernetes resource is allowed
@@ -1165,7 +1163,7 @@ func (f *Forwarder) join(ctx *authContext, w http.ResponseWriter, req *http.Requ
 		return nil, trace.Wrap(err)
 	}
 
-	if !f.isLocalKubeCluster(sess) {
+	if !f.isLocalKubeCluster(ctx.teleportCluster.isRemote, ctx.kubeClusterName) {
 		return f.remoteJoin(ctx, w, req, p, sess)
 	}
 
@@ -1883,7 +1881,10 @@ func setupImpersonationHeaders(log logrus.FieldLogger, ctx authContext, headers 
 	if err != nil {
 		return trace.Wrap(err)
 	}
+	return replaceImpersonationHeaders(headers, impersonateUser, impersonateGroups)
+}
 
+func replaceImpersonationHeaders(headers http.Header, impersonateUser string, impersonateGroups []string) error {
 	headers.Set(ImpersonateUserHeader, impersonateUser)
 
 	// Make sure to overwrite the exiting headers, instead of appending to
@@ -2040,12 +2041,28 @@ func (f *Forwarder) catchAll(authCtx *authContext, w http.ResponseWriter, req *h
 		f.log.Errorf("Failed to set up forwarding headers: %v.", err)
 		return nil, trace.Wrap(err)
 	}
-	rw := httplib.NewResponseStatusRecorder(w)
-	sess.forwarder.ServeHTTP(rw, req)
 
-	f.emitAuditEvent(authCtx, req, sess, rw.Status())
+	isLocalKubeCluster := f.isLocalKubeCluster(sess.teleportCluster.isRemote, sess.kubeClusterName)
+	isListRequest := authCtx.requestVerb == types.KubeVerbList
+	// Watch requests can be send to a single resource or to a collection of resources.
+	// isWatchingCollectionRequest is true when the request is a watch request and
+	// the resource is a collection of resources, e.g. /api/v1/pods?watch=true.
+	// authCtx.kubeResource is only set when the request targets a single resource.
+	isWatchingCollectionRequest := authCtx.requestVerb == types.KubeVerbWatch && authCtx.kubeResource == nil
 
-	return nil, nil
+	switch {
+	case isListRequest || isWatchingCollectionRequest:
+		return f.listResources(sess, w, req)
+	case authCtx.requestVerb == types.KubeVerbDeleteCollection && isLocalKubeCluster:
+		return f.deleteResourcesCollection(sess, w, req)
+	default:
+		rw := httplib.NewResponseStatusRecorder(w)
+		sess.forwarder.ServeHTTP(rw, req)
+
+		f.emitAuditEvent(req, sess, rw.Status())
+
+		return nil, nil
+	}
 }
 
 func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http.Request) (remotecommand.Executor, error) {
@@ -2132,6 +2149,12 @@ type clusterSession struct {
 	monitorCancel context.CancelFunc
 	// requestContext is the context of the original request.
 	requestContext context.Context
+	// codecFactory is the codec factory used to create the serializer
+	// for unmarshalling the payload.
+	codecFactory *serializer.CodecFactory
+	// rbacSupportedResources is the list of resources that support RBAC for the
+	// current cluster.
+	rbacSupportedResources rbacSupportedResources
 }
 
 // close cancels the connection monitor context if available.
@@ -2258,13 +2281,16 @@ func (f *Forwarder) newClusterSessionLocal(ctx context.Context, authCtx authCont
 		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
 
+	codecFactory, rbacSupportedResources := details.getClusterSupportedResources()
 	f.log.Debugf("Handling kubernetes session for %v using local credentials.", authCtx)
 	return &clusterSession{
-		parent:         f,
-		authContext:    authCtx,
-		kubeAPICreds:   details.kubeCreds,
-		targetAddr:     details.getTargetAddr(),
-		requestContext: ctx,
+		parent:                 f,
+		authContext:            authCtx,
+		kubeAPICreds:           details.kubeCreds,
+		targetAddr:             details.getTargetAddr(),
+		requestContext:         ctx,
+		codecFactory:           codecFactory,
+		rbacSupportedResources: rbacSupportedResources,
 	}, nil
 }
 
@@ -2483,19 +2509,19 @@ func (f *Forwarder) removeKubeDetails(name string) {
 // if it's of Type KubeService.
 // KubeProxy services or remote clusters are automatically forwarded to
 // the final destination.
-func (f *Forwarder) isLocalKubeCluster(sess *clusterSession) bool {
+func (f *Forwarder) isLocalKubeCluster(isRemoteTeleportCluster bool, kubeClusterName string) bool {
 	switch f.cfg.KubeServiceType {
 	case KubeService:
 		// Kubernetes service is always local.
 		return true
 	case LegacyProxyService:
 		// remote clusters are always forwarded to the final destination.
-		if sess.authContext.teleportCluster.isRemote {
+		if isRemoteTeleportCluster {
 			return false
 		}
 		// Legacy proxy service is local only if the kube cluster name matches
 		// with clusters served by this agent.
-		_, err := f.findKubeDetailsByClusterName(sess.authContext.kubeClusterName)
+		_, err := f.findKubeDetailsByClusterName(kubeClusterName)
 		return err == nil
 	default:
 		return false
@@ -2505,27 +2531,49 @@ func (f *Forwarder) isLocalKubeCluster(sess *clusterSession) bool {
 // kubeResourceDeniedAccessMsg creates a Kubernetes API like forbidden response.
 // Logic from:
 // https://github.com/kubernetes/kubernetes/blob/ea0764452222146c47ec826977f49d7001b0ea8c/staging/src/k8s.io/apiserver/pkg/endpoints/handlers/responsewriters/errors.go#L51
-func kubeResourceDeniedAccessMsg(user, verb string, kubeResource *types.KubernetesResource) string {
-	resource, apiGroup := getKubeResourceAndAPIGroupFromType(kubeResource.Kind)
-	// <resource> "<pod_name>" is forbidden: User "<user>" cannot create resource "<resource>" in API group "" in the namespace "<namespace>"
-	return fmt.Sprintf(
-		"%s %q is forbidden: User %q cannot %s resource %q in API group %q in the namespace %q\n"+
-			"Ask your Teleport admin to ensure that your Teleport role includes access to the %s in %q field.\n"+
-			"Check by running: kubectl auth can-i %s %s/%s --namespace %s ",
-		resource,
-		kubeResource.Name,
-		user,
-		verb,
-		resource,
-		apiGroup,
-		kubeResource.Namespace,
-		kubeResource.Kind,
-		kubernetesResourcesKey,
-		verb,
-		resource,
-		kubeResource.Name,
-		kubeResource.Namespace,
-	)
+func (f *Forwarder) kubeResourceDeniedAccessMsg(user, verb string, resource apiResource) string {
+	kind := strings.Split(resource.resourceKind, "/")[0]
+	apiGroup := resource.apiGroup
+	if apiGroup == "core" {
+		apiGroup = ""
+	}
+	teleportType, ok := defaultRBACResources.getTeleportResourceKindFromAPIResource(resource)
+	// If the resource is not in the default resources list, it is a custom resource
+	// controlled by a CRD. In this case, we use the namespace to restrict access to.
+	if !ok {
+		teleportType = types.KindKubeNamespace
+	}
+
+	switch {
+	case resource.namespace != "":
+		// <resource> "<pod_name>" is forbidden: User "<user>" cannot create resource "<resource>" in API group "" in the namespace "<namespace>"
+		return fmt.Sprintf(
+			"%[1]s %[2]q is forbidden: User %[3]q cannot %[4]s resource %[1]q in API group %[5]q in the namespace %[6]q\n"+
+				"Ask your Teleport admin to ensure that your Teleport role includes access to the %[7]s in %[8]q field.\n"+
+				"Check by running: kubectl auth can-i %[4]s %[1]s/%[2]s --namespace %[6]s ",
+			kind,                   // 1
+			resource.resourceName,  // 2
+			user,                   // 3
+			verb,                   // 4
+			apiGroup,               // 5
+			resource.namespace,     // 6
+			teleportType,           // 7
+			kubernetesResourcesKey, // 8
+		)
+	default:
+		return fmt.Sprintf(
+			"%[1]s %[2]q is forbidden: User %[3]q cannot %[4]s resource %[1]q in API group %[5]q at the cluster scope\n"+
+				"Ask your Teleport admin to ensure that your Teleport role includes access to the %[6]s in %[7]q field.\n"+
+				"Check by running: kubectl auth can-i %[4]s %[1]s/%[2]s",
+			kind,                   // 1
+			resource.resourceName,  // 2
+			user,                   // 3
+			verb,                   // 4
+			apiGroup,               // 5
+			teleportType,           // 6
+			kubernetesResourcesKey, // 7
+		)
+	}
 }
 
 // errorToKubeStatusReason returns an appropriate StatusReason based on the

--- a/lib/kube/proxy/forwarder_test.go
+++ b/lib/kube/proxy/forwarder_test.go
@@ -174,6 +174,7 @@ func TestAuthenticate(t *testing.T) {
 			TracerProvider:    otel.GetTracerProvider(),
 			tracer:            otel.Tracer(teleport.ComponentKube),
 			ClusterFeatures:   fakeClusterFeatures,
+			KubeServiceType:   ProxyService,
 		},
 		getKubernetesServersForKubeCluster: func(ctx context.Context, name string) ([]types.KubeServer, error) {
 			servers, err := ap.GetKubernetesServers(ctx)
@@ -782,6 +783,7 @@ func TestAuthenticate(t *testing.T) {
 				require.Equal(t, trace.IsAccessDenied(err), tt.wantAuthErr)
 				return
 			}
+			require.NoError(t, err)
 			err = f.authorize(context.Background(), gotCtx)
 			require.NoError(t, err)
 

--- a/lib/kube/proxy/resource_filters.go
+++ b/lib/kube/proxy/resource_filters.go
@@ -29,10 +29,13 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	authv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/kube/proxy/responsewriters"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 // newResourceFilterer creates a wrapper function that once executed creates
@@ -41,14 +44,14 @@ import (
 // - deniedResources: excluded if (namespace,name) matches an entry even if it matches
 // the allowedResources's list.
 // - allowedResources: excluded if (namespace,name) not match a single entry.
-func newResourceFilterer(kind, verb string, allowedResources, deniedResources []types.KubernetesResource, log logrus.FieldLogger) responsewriters.FilterWrapper {
+func newResourceFilterer(kind, verb string, codecs *serializer.CodecFactory, allowedResources, deniedResources []types.KubernetesResource, log logrus.FieldLogger) responsewriters.FilterWrapper {
 	// If the list of allowed resources contains a wildcard and no deniedResources, then we
 	// don't need to filter anything.
 	if containsWildcard(allowedResources) && len(deniedResources) == 0 {
 		return nil
 	}
 	return func(contentType string, responseCode int) (responsewriters.Filter, error) {
-		negotiator := newClientNegotiator()
+		negotiator := newClientNegotiator(codecs)
 		encoder, decoder, err := newEncoderAndDecoderForContentType(contentType, negotiator)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -70,9 +73,10 @@ func newResourceFilterer(kind, verb string, allowedResources, deniedResources []
 
 // wildcardFilter is a filter that matches all pods.
 var wildcardFilter = types.KubernetesResource{
-	Kind:      types.KindKubePod,
+	Kind:      types.Wildcard,
 	Namespace: types.Wildcard,
 	Name:      types.Wildcard,
+	Verbs:     []string{types.Wildcard},
 }
 
 // containsWildcard returns true if the list of resources contains a wildcard filter.
@@ -80,7 +84,8 @@ func containsWildcard(resources []types.KubernetesResource) bool {
 	for _, r := range resources {
 		if r.Kind == wildcardFilter.Kind &&
 			r.Name == wildcardFilter.Name &&
-			r.Namespace == wildcardFilter.Namespace {
+			r.Namespace == wildcardFilter.Namespace &&
+			len(r.Verbs) == 1 && r.Verbs[0] == wildcardFilter.Verbs[0] {
 			return true
 		}
 	}
@@ -173,10 +178,10 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 	case *corev1.Pod:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
 		if err != nil {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.PodList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -186,11 +191,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.Secret:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.SecretList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -200,11 +205,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.ConfigMap:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.ConfigMapList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -214,11 +219,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.Namespace:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.NamespaceList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -228,12 +233,26 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.Service:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.ServiceList:
+		o.Items = pointerArrayToArray(
+			filterResourceList(
+				d.kind, d.verb,
+				arrayToPointerArray(o.Items), d.allowedResources, d.deniedResources, d.log),
+		)
+		return len(o.Items) > 0, true, nil
+	case *corev1.Endpoints:
+		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
+		}
+		// if err is not nil or result is false, we should not include it.
+		return result, false, nil
+	case *corev1.EndpointsList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
 				d.kind, d.verb,
@@ -242,11 +261,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.ServiceAccount:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.ServiceAccountList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -256,11 +275,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.Node:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.NodeList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -270,11 +289,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.PersistentVolume:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.PersistentVolumeList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -284,11 +303,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *corev1.PersistentVolumeClaim:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *corev1.PersistentVolumeClaimList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -299,11 +318,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *appsv1.Deployment:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *appsv1.DeploymentList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -314,11 +333,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *appsv1.ReplicaSet:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *appsv1.ReplicaSetList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -328,11 +347,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *appsv1.StatefulSet:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *appsv1.StatefulSetList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -343,11 +362,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *appsv1.DaemonSet:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *appsv1.DaemonSetList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -357,11 +376,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *authv1.ClusterRole:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *authv1.ClusterRoleList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -371,11 +390,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *authv1.Role:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *authv1.RoleList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -386,11 +405,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *authv1.ClusterRoleBinding:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *authv1.ClusterRoleBindingList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -401,11 +420,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *authv1.RoleBinding:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *authv1.RoleBindingList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -416,11 +435,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *batchv1.CronJob:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *batchv1.CronJobList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -431,11 +450,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *batchv1.Job:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *batchv1.JobList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -446,11 +465,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 
 	case *certificatesv1.CertificateSigningRequest:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *certificatesv1.CertificateSigningRequestList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -460,11 +479,11 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 		return len(o.Items) > 0, true, nil
 	case *networkingv1.Ingress:
 		result, err := filterResource(d.kind, d.verb, o, d.allowedResources, d.deniedResources)
-		if err != nil && !trace.IsAccessDenied(err) {
-			d.log.WithError(err).Warn("Unable to compile role kubernetes_resources.")
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
 		}
 		// if err is not nil or result is false, we should not include it.
-		return err == nil && result, false, nil
+		return result, false, nil
 	case *networkingv1.IngressList:
 		o.Items = pointerArrayToArray(
 			filterResourceList(
@@ -472,6 +491,22 @@ func (d *resourceFilterer) FilterObj(obj runtime.Object) (isAllowed bool, isList
 				arrayToPointerArray(o.Items), d.allowedResources, d.deniedResources, d.log),
 		)
 		return len(o.Items) > 0, true, nil
+	case *unstructured.Unstructured:
+		if o.IsList() {
+			hasElemts := filterUnstructuredList(d.verb, o, d.allowedResources, d.deniedResources, d.log)
+			return hasElemts, true, nil
+		}
+
+		r := getKubeResource(utils.KubeCustomResource, d.verb, o)
+		result, err := matchKubernetesResource(
+			r,
+			d.allowedResources, d.deniedResources,
+		)
+		if err != nil {
+			d.log.WithError(err).Warn("Unable to compile regex expressions within kubernetes_resources.")
+		}
+		// if err is not nil or result is false, we should not include it.
+		return result, false, nil
 
 	case *metav1.Table:
 		_, err := d.filterMetaV1Table(o, d.allowedResources, d.deniedResources)
@@ -534,7 +569,7 @@ func filterResourceList[T kubeObjectInterface](kind, verb string, originalList [
 		if result, err := filterResource(kind, verb, resource, allowed, denied); err == nil && result {
 			filteredList = append(filteredList, resource)
 		} else if err != nil {
-			log.WithError(err).Warnf("Unable to compile role kubernetes_resources.")
+			log.WithError(err).Warnf("Unable to compile regex expressions within kubernetes_resources.")
 		}
 	}
 	return filteredList
@@ -675,4 +710,37 @@ func filterBuffer(filterWrapper responsewriters.FilterWrapper, src *responsewrit
 	// into the sync.Pool.
 	defer comp.Close()
 	return trace.Wrap(filter.FilterBuffer(b.Bytes(), comp))
+}
+
+// filterUnstructuredList filters the unstructured list object to exclude resources
+// that the user must not have access to.
+// The filtered list is re-assigned to `obj.Object["items"]`.
+func filterUnstructuredList(verb string, obj *unstructured.Unstructured, allowed, denied []types.KubernetesResource, log logrus.FieldLogger) (hasElems bool) {
+	const (
+		itemsKey = "items"
+	)
+	if obj == nil || obj.Object == nil {
+		return false
+	}
+	objList, err := obj.ToList()
+	if err != nil {
+		// This should never happen, but if it does, we should log it.
+		log.WithError(err).Warnf("Unable to convert unstructured object to list.")
+		return false
+	}
+
+	filteredList := make([]any, 0, len(objList.Items))
+	for _, resource := range objList.Items {
+		r := getKubeResource(utils.KubeCustomResource, verb, &resource)
+		if result, err := matchKubernetesResource(
+			r,
+			allowed, denied,
+		); result {
+			filteredList = append(filteredList, resource.Object)
+		} else if err != nil {
+			log.WithError(err).Warnf("Unable to compile regex expressions within kubernetes_resources.")
+		}
+	}
+	obj.Object[itemsKey] = filteredList
+	return len(filteredList) > 0
 }

--- a/lib/kube/proxy/resource_filters_test.go
+++ b/lib/kube/proxy/resource_filters_test.go
@@ -63,7 +63,7 @@ func Test_filterBuffer(t *testing.T) {
 		types.KindKubeIngress:               {obj: "Ingress", api: "networking.k8s.io/v1"},
 	}
 
-	_, decoder, err := newEncoderAndDecoderForContentType(responsewriters.DefaultContentType, newClientNegotiator())
+	_, decoder, err := newEncoderAndDecoderForContentType(responsewriters.DefaultContentType, newClientNegotiator(&globalKubeCodecs))
 	require.NoError(t, err)
 
 	type args struct {
@@ -150,7 +150,7 @@ func Test_filterBuffer(t *testing.T) {
 
 				buf, decompress := newMemoryResponseWriter(t, data.Bytes(), tt.args.contentEncoding)
 
-				err = filterBuffer(newResourceFilterer(r, types.KubeVerbList, allowedResources, nil, log), buf)
+				err = filterBuffer(newResourceFilterer(r, types.KubeVerbList, &globalKubeCodecs, allowedResources, nil, log), buf)
 				require.NoError(t, err)
 
 				// Decompress the buffer to compare the result.

--- a/lib/kube/proxy/scheme.go
+++ b/lib/kube/proxy/scheme.go
@@ -17,23 +17,38 @@ limitations under the License.
 package proxy
 
 import (
+	"strings"
+
+	"github.com/gravitational/trace"
+	"golang.org/x/exp/maps"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	metav1beta1 "k8s.io/apimachinery/pkg/apis/meta/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const (
+	// listSuffix is the suffix added to the name of the type to create the name
+	// of the list type.
+	// For example: "Role" -> "RoleList"
+	listSuffix = "List"
 )
 
 var (
-	// kubeScheme is the runtime Scheme that holds information about supported
+	// globalKubeScheme is the runtime Scheme that holds information about supported
 	// message types.
-	kubeScheme = runtime.NewScheme()
-	// kubeCodecs creates a serializer/deserizalier for the different codecs
+	globalKubeScheme = runtime.NewScheme()
+	// globalKubeCodecs creates a serializer/deserizalier for the different codecs
 	// supported by the Kubernetes API.
-	kubeCodecs = serializer.NewCodecFactory(kubeScheme)
+	globalKubeCodecs = serializer.NewCodecFactory(globalKubeScheme)
 )
 
 // Register all groups in the schema's registry.
@@ -41,11 +56,25 @@ var (
 // support it but `kubectl` calls require support for it.
 func init() {
 	// Register external types for Scheme
-	metav1.AddToGroupVersion(kubeScheme, schema.GroupVersion{Version: "v1"})
-	utilruntime.Must(metav1.AddMetaToScheme(kubeScheme))
-	utilruntime.Must(metav1beta1.AddMetaToScheme(kubeScheme))
-	utilruntime.Must(scheme.AddToScheme(kubeScheme))
-	utilruntime.Must(kubeScheme.SetVersionPriority(corev1.SchemeGroupVersion))
+	utilruntime.Must(registerDefaultKubeTypes(globalKubeScheme))
+}
+
+// registerDefaultKubeTypes registers the default types for the Kubernetes API into
+// the given scheme.
+func registerDefaultKubeTypes(s *runtime.Scheme) error {
+	// Register external types for Scheme
+	metav1.AddToGroupVersion(s, schema.GroupVersion{Version: "v1"})
+	if err := metav1.AddMetaToScheme(s); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := metav1beta1.AddMetaToScheme(s); err != nil {
+		return trace.Wrap(err)
+	}
+	if err := scheme.AddToScheme(s); err != nil {
+		return trace.Wrap(err)
+	}
+	err := s.SetVersionPriority(corev1.SchemeGroupVersion)
+	return trace.Wrap(err)
 }
 
 // newClientNegotiator creates a negotiator that based on `Content-Type` header
@@ -54,12 +83,121 @@ func init() {
 // - "application/json"
 // - "application/yaml"
 // - "application/vnd.kubernetes.protobuf"
-func newClientNegotiator() runtime.ClientNegotiator {
+func newClientNegotiator(codecFactory *serializer.CodecFactory) runtime.ClientNegotiator {
 	return runtime.NewClientNegotiator(
-		kubeCodecs.WithoutConversion(),
+		codecFactory.WithoutConversion(),
 		schema.GroupVersion{
 			// create a serializer for Kube API v1
 			Version: "v1",
 		},
 	)
+}
+
+// newClusterSchemaBuilder creates a new schema builder for the given cluster.
+// This schema includes all well-known Kubernetes types and all namespaced
+// custom resources.
+// It also returns a map of resources that we support RBAC restrictions for.
+func newClusterSchemaBuilder(client *kubernetes.Clientset) (serializer.CodecFactory, rbacSupportedResources, error) {
+	kubeScheme := runtime.NewScheme()
+	kubeCodecs := serializer.NewCodecFactory(kubeScheme)
+	supportedResources := maps.Clone(defaultRBACResources)
+
+	if err := registerDefaultKubeTypes(kubeScheme); err != nil {
+		return serializer.CodecFactory{}, nil, trace.Wrap(err)
+	}
+
+	// register all namespaced custom resources
+	_, apiGroups, err := client.DiscoveryClient.ServerGroupsAndResources()
+	if err != nil {
+		return serializer.CodecFactory{}, nil, trace.Wrap(err)
+	}
+
+	for _, apiGroup := range apiGroups {
+		group, version := getKubeAPIGroupAndVersion(apiGroup.GroupVersion)
+		// Skip well-known Kubernetes API groups because they are already registered
+		// in the scheme.
+		if _, ok := knownKubernetesGroups[group]; ok {
+			continue
+		}
+
+		groupVersion := schema.GroupVersion{Group: group, Version: version}
+		for _, apiResource := range apiGroup.APIResources {
+			// Skip cluster-scoped resources because we don't support RBAC restrictions
+			// for them.
+			if !apiResource.Namespaced {
+				continue
+			}
+			// build the resource key to be able to look it up later and check if
+			// if we support RBAC restrictions for it.
+			resourceKey := allowedResourcesKey{
+				apiGroup:     group,
+				resourceKind: apiResource.Name,
+			}
+			// Namespaced custom resources are allowed if the user has access to
+			// the namespace where the resource is located.
+			// This means that we need to map the resource to the namespace kind.
+			supportedResources[resourceKey] = utils.KubeCustomResource
+
+			// register the resource with the scheme to be able to decode it
+			// into an unstructured object
+			kubeScheme.AddKnownTypeWithName(
+				groupVersion.WithKind(apiResource.Kind),
+				&unstructured.Unstructured{},
+			)
+			// register the resource list with the scheme to be able to decode it
+			// into an unstructured object.
+			// Resource lists follow the naming convention: <resource-kind>List
+			kubeScheme.AddKnownTypeWithName(
+				groupVersion.WithKind(apiResource.Kind+listSuffix),
+				&unstructured.Unstructured{},
+			)
+		}
+	}
+
+	return kubeCodecs, supportedResources, nil
+}
+
+// getKubeAPIGroupAndVersion returns the API group and version from the given
+// groupVersion string.
+// The groupVersion string can be in the following formats:
+// - "v1" -> group: "", version: "v1"
+// - "<group>/<version>" -> group: "<group>", version: "<version>"
+func getKubeAPIGroupAndVersion(groupVersion string) (group string, version string) {
+	splits := strings.Split(groupVersion, "/")
+	switch {
+	case len(splits) == 1:
+		return "", splits[0]
+	case len(splits) >= 2:
+		return splits[0], splits[1]
+	default:
+		return "", ""
+	}
+}
+
+// knownKubernetesGroups is a map of well-known Kubernetes API groups that
+// are already registered in the scheme and we don't need to register them
+// again.
+var knownKubernetesGroups = map[string]struct{}{
+	// core group
+	"":                             {},
+	"apiregistration.k8s.io":       {},
+	"apps":                         {},
+	"events.k8s.io":                {},
+	"authentication.k8s.io":        {},
+	"authorization.k8s.io":         {},
+	"autoscaling":                  {},
+	"batch":                        {},
+	"certificates.k8s.io":          {},
+	"networking.k8s.io":            {},
+	"policy":                       {},
+	"rbac.authorization.k8s.io":    {},
+	"storage.k8s.io":               {},
+	"admissionregistration.k8s.io": {},
+	"apiextensions.k8s.io":         {},
+	"scheduling.k8s.io":            {},
+	"coordination.k8s.io":          {},
+	"node.k8s.io":                  {},
+	"discovery.k8s.io":             {},
+	"flowcontrol.apiserver.k8s.io": {},
+	"metrics.k8s.io":               {},
 }

--- a/lib/kube/proxy/self_subject_reviews.go
+++ b/lib/kube/proxy/self_subject_reviews.go
@@ -26,6 +26,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/exp/slices"
 	authv1 "k8s.io/api/authorization/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -54,15 +55,6 @@ func (f *Forwarder) selfSubjectAccessReviews(authCtx *authContext, w http.Respon
 	req = req.WithContext(ctx)
 	defer span.End()
 
-	// only allow self subject access reviews for the local teleport cluster
-	// and not for remote clusters
-	if !authCtx.teleportCluster.isRemote {
-		if err := f.validateSelfSubjectAccessReview(authCtx, w, req); trace.IsAccessDenied(err) {
-			return nil, nil
-		} else if err != nil {
-			return nil, trace.Wrap(err)
-		}
-	}
 	sess, err := f.newClusterSession(req.Context(), *authCtx)
 	if err != nil {
 		// This error goes to kubernetes client and is not visible in the logs
@@ -82,6 +74,16 @@ func (f *Forwarder) selfSubjectAccessReviews(authCtx *authContext, w http.Respon
 		return nil, trace.Wrap(err)
 	}
 
+	// only allow self subject access reviews for the service that proxies the
+	// request to the kubernetes API server.
+	if f.isLocalKubeCluster(sess.teleportCluster.isRemote, sess.kubeClusterName) {
+		if err := f.validateSelfSubjectAccessReview(sess, w, req); trace.IsAccessDenied(err) {
+			return nil, nil
+		} else if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	}
+
 	if err := f.setupForwardingHeaders(sess, req, true /* withImpersonationHeaders */); err != nil {
 		// This error goes to kubernetes client and is not visible in the logs
 		// of the teleport server if not logged here.
@@ -91,15 +93,15 @@ func (f *Forwarder) selfSubjectAccessReviews(authCtx *authContext, w http.Respon
 	rw := httplib.NewResponseStatusRecorder(w)
 	sess.forwarder.ServeHTTP(rw, req)
 
-	f.emitAuditEvent(authCtx, req, sess, rw.Status())
+	f.emitAuditEvent(req, sess, rw.Status())
 
 	return nil, nil
 }
 
 // validateSelfSubjectAccessReview validates the self subject access review
 // request by applying the kubernetes resources RBAC rules to the request.
-func (f *Forwarder) validateSelfSubjectAccessReview(actx *authContext, w http.ResponseWriter, req *http.Request) error {
-	negotiator := newClientNegotiator()
+func (f *Forwarder) validateSelfSubjectAccessReview(sess *clusterSession, w http.ResponseWriter, req *http.Request) error {
+	negotiator := newClientNegotiator(sess.codecFactory)
 	encoder, decoder, err := newEncoderAndDecoderForContentType(responsewriters.GetContentTypeHeader(req.Header), negotiator)
 	if err != nil {
 		return trace.Wrap(err)
@@ -114,7 +116,7 @@ func (f *Forwarder) validateSelfSubjectAccessReview(actx *authContext, w http.Re
 	}
 
 	namespace := accessReview.Spec.ResourceAttributes.Namespace
-	resource := getResourceWithKey(
+	resource := sess.rbacSupportedResources.getResourceWithKey(
 		allowedResourcesKey{
 			apiGroup:     accessReview.Spec.ResourceAttributes.Group,
 			resourceKind: accessReview.Spec.ResourceAttributes.Resource,
@@ -132,7 +134,9 @@ func (f *Forwarder) validateSelfSubjectAccessReview(actx *authContext, w http.Re
 		return trace.Wrap(err)
 	}
 
+	actx := sess.authContext
 	state := actx.GetAccessState(authPref)
+
 	switch err := actx.Checker.CheckAccess(
 		actx.kubeCluster,
 		state,
@@ -150,7 +154,9 @@ func (f *Forwarder) validateSelfSubjectAccessReview(actx *authContext, w http.Re
 		}...); {
 	case errors.Is(err, services.ErrTrustedDeviceRequired):
 		return trace.Wrap(err)
-	case err != nil:
+	case err != nil &&
+		!slices.Contains(types.KubernetesClusterWideResourceKinds, resource) &&
+		resource != utils.KubeCustomResource:
 		namespaceNameToString := func(namespace, name string) string {
 			switch {
 			case namespace == "" && name == "":
@@ -173,15 +179,42 @@ func (f *Forwarder) validateSelfSubjectAccessReview(actx *authContext, w http.Re
 					"- kind: %s\n"+
 					"  name: %s\n"+
 					"  namespace: %s\n"+
-					"  verbs: [%s]\n", accessReview.Spec.ResourceAttributes.Resource, namespaceNameToString(namespace, name), kubernetesResourcesKey, resource, emptyOrWildcard(name), emptyOrWildcard(namespace), types.Wildcard),
+					"  verbs: [%s]\n", accessReview.Spec.ResourceAttributes.Resource, namespaceNameToString(namespace, name), kubernetesResourcesKey, resource, emptyOrWildcard(name), emptyOrWildcard(namespace), emptyOrWildcard("")),
 		}
 
 		responsewriters.SetContentTypeHeader(w, req.Header)
-		if err := encoder.Encode(accessReview, w); err != nil {
-			return trace.Wrap(err)
+		if encodeErr := encoder.Encode(accessReview, w); encodeErr != nil {
+			return trace.Wrap(encodeErr)
+		}
+		return trace.Wrap(err)
+	case err != nil && resource == utils.KubeCustomResource:
+		// If the request is for a custom resource, we need grant access to the
+		// the namespace that the custom resource is in.
+		resource = types.KindKubeNamespace
+		name = namespace
+		fallthrough
+	case err != nil:
+		// If the request is for a cluster-wide resource, we need to grant access
+		// to it.
+		accessReview.Status = authv1.SubjectAccessReviewStatus{
+			Allowed: false,
+			Denied:  true,
+			Reason: fmt.Sprintf(
+				"access to %s %s denied by Teleport: please ensure that %q field in your Teleport role defines access to the desired resource.\n\n"+
+					"Valid example:\n"+
+					"kubernetes_resources:\n"+
+					"- kind: %s\n"+
+					"  name: %s\n"+
+					"  verbs: [%s]\n", accessReview.Spec.ResourceAttributes.Resource, name, kubernetesResourcesKey, resource, emptyOrWildcard(name), emptyOrWildcard("")),
+		}
+
+		responsewriters.SetContentTypeHeader(w, req.Header)
+		if encodeErr := encoder.Encode(accessReview, w); encodeErr != nil {
+			return trace.Wrap(encodeErr)
 		}
 		return trace.Wrap(err)
 	}
+
 	return nil
 }
 
@@ -238,10 +271,23 @@ func (m *kubernetesResourceMatcher) Match(role types.Role, condition types.RoleC
 	if len(resources) == 0 {
 		return false, nil
 	}
+	kind := m.resource.Kind
+	name := m.resource.Name
+	namespace := m.resource.Namespace
+
+	if kind == utils.KubeCustomResource {
+		kind = types.KindKubeNamespace
+		name = m.resource.Namespace
+		namespace = ""
+	}
+
 	for _, resource := range resources {
-		// TODO(tigrato): evaluate if we should support wildcards as well
-		// for future compatibility.
-		if m.resource.Kind != resource.Kind {
+		isResourceTheSameKind := kind == resource.Kind || resource.Kind == types.Wildcard
+		namespaceScopeMatch := resource.Kind == types.KindKubeNamespace && !slices.Contains(types.KubernetesClusterWideResourceKinds, kind)
+		if !isResourceTheSameKind && !namespaceScopeMatch {
+			continue
+		}
+		if len(m.resource.Verbs) == 1 && !isVerbAllowed(resource.Verbs, m.resource.Verbs[0]) {
 			continue
 		}
 		// If the resource name and namespace are empty, it means that the
@@ -249,26 +295,35 @@ func (m *kubernetesResourceMatcher) Match(role types.Role, condition types.RoleC
 		// We can return true immediately because the user is allowed to get resources
 		// of the specified kind but might not be able to see any if the matchers do not
 		// match with any resource.
-		if m.resource.Name == "" && m.resource.Namespace == "" {
+		if name == "" && namespace == "" {
 			return true, nil
 		}
-		if m.resource.Name != "" {
-			switch ok, err := utils.SliceMatchesRegex(m.resource.Name, []string{resource.Name}); {
+		if name != "" {
+			switch ok, err := utils.SliceMatchesRegex(name, []string{resource.Name}); {
 			case err != nil:
 				return false, trace.Wrap(err)
 			case !ok:
 				continue
 			}
 		}
-		if ok, err := utils.SliceMatchesRegex(m.resource.Namespace, []string{resource.Namespace}); err != nil || ok || m.resource.Namespace == "" {
-			return ok || m.resource.Namespace == "", trace.Wrap(err)
+		if resource.Kind == types.KindKubeNamespace && namespace != "" {
+			if ok, err := utils.SliceMatchesRegex(namespace, []string{resource.Name}); err != nil || ok {
+				return ok, trace.Wrap(err)
+			}
+		} else {
+			if ok, err := utils.SliceMatchesRegex(namespace, []string{resource.Namespace}); err != nil || ok || namespace == "" {
+				return ok || namespace == "", trace.Wrap(err)
+			}
 		}
+
 	}
 
 	return false, nil
 }
 
-// String returns the matcher's string representation.
-func (m *kubernetesResourceMatcher) String() string {
-	return fmt.Sprintf("kubernetesResourceMatcher(Resource=%v)", m.resource)
+// isVerbAllowed returns true if the verb is allowed in the resource.
+// If the resource has a wildcard verb, it matches all verbs, otherwise
+// the resource must have the verb we're looking for.
+func isVerbAllowed(allowedVerbs []string, verb string) bool {
+	return len(allowedVerbs) != 0 && (allowedVerbs[0] == types.Wildcard || slices.Contains(allowedVerbs, verb))
 }

--- a/lib/kube/proxy/testing/kube_server/kube_mock.go
+++ b/lib/kube/proxy/testing/kube_server/kube_mock.go
@@ -24,9 +24,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"time"
 
@@ -98,8 +98,8 @@ type KubeMockServer struct {
 	log              *log.Entry
 	server           *httptest.Server
 	TLS              *tls.Config
-	Addr             net.Addr
 	URL              string
+	Address          string
 	CA               []byte
 	deletedResources map[deletedResource][]string
 	mu               sync.Mutex
@@ -124,7 +124,7 @@ func NewKubeAPIMock() (*KubeMockServer, error) {
 	}
 	s.server.StartTLS()
 	s.TLS = s.server.TLS
-	s.Addr = s.server.Listener.Addr()
+	s.Address = strings.TrimPrefix(s.server.URL, "https://")
 	s.URL = s.server.URL
 	return s, nil
 }
@@ -152,10 +152,10 @@ func (s *KubeMockServer) setup() {
 
 	s.router.POST("/apis/authorization.k8s.io/v1/selfsubjectaccessreviews", s.withWriter(s.selfSubjectAccessReviews))
 
-	s.router.GET("/resources.teleport.dev/v6/namespaces/:namespace/teleportroles", s.withWriter(s.listTeleportRoles))
-	s.router.GET("/resources.teleport.dev/v6/teleportroles", s.withWriter(s.listTeleportRoles))
-	s.router.GET("/resources.teleport.dev/v6/namespaces/:namespace/teleportroles/:name", s.withWriter(s.getTeleportRole))
-	s.router.DELETE("/resources.teleport.dev/v6/namespaces/:namespace/teleportroles/:name", s.withWriter(s.deleteTeleportRole))
+	s.router.GET("/apis/resources.teleport.dev/v6/namespaces/:namespace/teleportroles", s.withWriter(s.listTeleportRoles))
+	s.router.GET("/apis/resources.teleport.dev/v6/teleportroles", s.withWriter(s.listTeleportRoles))
+	s.router.GET("/apis/resources.teleport.dev/v6/namespaces/:namespace/teleportroles/:name", s.withWriter(s.getTeleportRole))
+	s.router.DELETE("/apis/resources.teleport.dev/v6/namespaces/:namespace/teleportroles/:name", s.withWriter(s.deleteTeleportRole))
 
 	for _, endpoint := range []string{"/api", "/api/:ver", "/apis", "/apis/resources.teleport.dev/v6"} {
 		s.router.GET(endpoint, s.withWriter(s.discoveryEndpoint))

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	"github.com/gravitational/trace"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
 
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
@@ -160,14 +161,32 @@ type allowedResourcesKey struct {
 	resourceKind string
 }
 
-// allowedResources is a map of supported resources and their corresponding
+type rbacSupportedResources map[allowedResourcesKey]string
+
+// getResourceWithKey returns the teleport resource kind for a given resource key if
+// it exists, otherwise returns an empty string.
+func (r rbacSupportedResources) getResourceWithKey(k allowedResourcesKey) string {
+	if k.apiGroup == "" {
+		k.apiGroup = "core"
+	}
+	return r[k]
+}
+
+func (r rbacSupportedResources) getTeleportResourceKindFromAPIResource(api apiResource) (string, bool) {
+	resource := getResourceFromAPIResource(api.resourceKind)
+	resourceType, ok := r[allowedResourcesKey{apiGroup: api.apiGroup, resourceKind: resource}]
+	return resourceType, ok
+}
+
+// defaultRBACResources is a map of supported resources and their corresponding
 // teleport resource kind for the purpose of resource rbac.
-var allowedResources = map[allowedResourcesKey]string{
+var defaultRBACResources = rbacSupportedResources{
 	{apiGroup: "core", resourceKind: "pods"}:                                      types.KindKubePod,
 	{apiGroup: "core", resourceKind: "secrets"}:                                   types.KindKubeSecret,
 	{apiGroup: "core", resourceKind: "configmaps"}:                                types.KindKubeConfigmap,
 	{apiGroup: "core", resourceKind: "namespaces"}:                                types.KindKubeNamespace,
 	{apiGroup: "core", resourceKind: "services"}:                                  types.KindKubeService,
+	{apiGroup: "core", resourceKind: "endpoints"}:                                 types.KindKubeService,
 	{apiGroup: "core", resourceKind: "serviceaccounts"}:                           types.KindKubeServiceAccount,
 	{apiGroup: "core", resourceKind: "nodes"}:                                     types.KindKubeNode,
 	{apiGroup: "core", resourceKind: "persistentvolumes"}:                         types.KindKubePersistentVolume,
@@ -186,38 +205,17 @@ var allowedResources = map[allowedResourcesKey]string{
 	{apiGroup: "networking.k8s.io", resourceKind: "ingresses"}:                    types.KindKubeIngress,
 }
 
-// getKubeResourceAndAPIGroupFromType returns the Kubernetes resource kind and
-// API group for a given Teleport resource kind. If the Teleport resource kind
-// is not supported, it returns the Teleport resource kind as the Kubernetes
-// resource kind and an empty string as the API group.
-func getKubeResourceAndAPIGroupFromType(s string) (kind string, apiGroup string) {
-	for k, v := range allowedResources {
-		if v == s {
-			apiGroup := ""
-			if k.apiGroup != "core" {
-				apiGroup = k.apiGroup
-			}
-			return k.resourceKind, apiGroup
-		}
-	}
-	return s + "s", ""
-}
-
-// getResourceWithKey returns the teleport resource kind for a given resource key if
-// it exists, otherwise returns an empty string.
-func getResourceWithKey(k allowedResourcesKey) string {
-	if k.apiGroup == "" {
-		k.apiGroup = "core"
-	}
-	return allowedResources[k]
-}
-
 // getResourceFromRequest returns a KubernetesResource if the user tried to access
 // a specific endpoint that Teleport support resource filtering. Otherwise, returns nil.
-func getResourceFromRequest(req *http.Request) (*types.KubernetesResource, apiResource, error) {
+func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (*types.KubernetesResource, apiResource, error) {
 	apiResource := parseResourcePath(req.URL.Path)
 	verb := apiResource.getVerb(req)
-	resourceType, ok := getTeleportResourceKindFromAPIResource(apiResource)
+	if kubeDetails == nil {
+		return nil, apiResource, nil
+	}
+	codecFactory, rbacSupportedTypes := kubeDetails.getClusterSupportedResources()
+
+	resourceType, ok := rbacSupportedTypes.getTeleportResourceKindFromAPIResource(apiResource)
 	switch {
 	case !ok:
 		// if the resource is not supported, return nil.
@@ -230,7 +228,7 @@ func getResourceFromRequest(req *http.Request) (*types.KubernetesResource, apiRe
 	case apiResource.resourceName == "" && verb == types.KubeVerbCreate:
 		// If the request is a create request, extract the resource name from the request body.
 		var err error
-		if apiResource.resourceName, err = extractResourceNameFromPostRequest(req); err != nil {
+		if apiResource.resourceName, err = extractResourceNameFromPostRequest(req, codecFactory); err != nil {
 			return nil, apiResource, trace.Wrap(err)
 		}
 	}
@@ -248,20 +246,25 @@ func getResourceFromRequest(req *http.Request) (*types.KubernetesResource, apiRe
 // and decodes it into a Kubernetes object. It then extracts the resource name
 // from the object.
 // The body is then reset to the original request body using a new buffer.
-func extractResourceNameFromPostRequest(req *http.Request) (string, error) {
+func extractResourceNameFromPostRequest(req *http.Request, codecs *serializer.CodecFactory) (string, error) {
 	if req.Body == nil {
 		return "", trace.BadParameter("request body is empty")
 	}
-	negotiator := newClientNegotiator()
-	_, decoder, err := newEncoderAndDecoderForContentType(responsewriters.GetContentTypeHeader(req.Header), negotiator)
+
+	negotiator := newClientNegotiator(codecs)
+	_, decoder, err := newEncoderAndDecoderForContentType(
+		responsewriters.GetContentTypeHeader(req.Header),
+		negotiator,
+	)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
+
 	newBody := bytes.NewBuffer(make([]byte, 0, 2048))
-	if io.Copy(newBody, req.Body); err != nil {
+	if _, err := io.Copy(newBody, req.Body); err != nil {
 		return "", trace.Wrap(err)
 	}
-	if req.Body.Close(); err != nil {
+	if err := req.Body.Close(); err != nil {
 		return "", trace.Wrap(err)
 	}
 	req.Body = io.NopCloser(newBody)
@@ -275,12 +278,6 @@ func extractResourceNameFromPostRequest(req *http.Request) (string, error) {
 		return "", trace.BadParameter("object %T does not implement kubeObjectInterface", obj)
 	}
 	return namer.GetName(), nil
-}
-
-func getTeleportResourceKindFromAPIResource(r apiResource) (string, bool) {
-	resource := getResourceFromAPIResource(r.resourceKind)
-	resourceType, ok := allowedResources[allowedResourcesKey{apiGroup: r.apiGroup, resourceKind: resource}]
-	return resourceType, ok
 }
 
 // getResourceFromAPIResource returns the resource kind from the api resource.

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -211,7 +211,10 @@ func Test_getResourceFromRequest(t *testing.T) {
 			if tt.body != nil {
 				verb = http.MethodPost
 			}
-			got, _, err := getResourceFromRequest(&http.Request{Method: verb, URL: &url.URL{Path: tt.path}, Body: tt.body})
+			got, _, err := getResourceFromRequest(&http.Request{Method: verb, URL: &url.URL{Path: tt.path}, Body: tt.body}, &kubeDetails{
+				kubeCodecs:         globalKubeCodecs,
+				rbacSupportedTypes: defaultRBACResources,
+			})
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got, "parsing path %q", tt.path)
 		})

--- a/lib/kube/proxy/watcher_test.go
+++ b/lib/kube/proxy/watcher_test.go
@@ -19,6 +19,7 @@ package proxy
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -144,7 +145,7 @@ func TestWatcher(t *testing.T) {
 
 	// Update kube2 expiry so it gets re-registered.
 	kube2.SetExpiry(time.Now().Add(1 * time.Hour))
-	kube2.SetKubeconfig(newKubeConfig(t, "random", "https://api.cluster.com"))
+	kube2.SetKubeconfig(newKubeConfig(t, "random", kubeMock.URL))
 	err = testCtx.AuthServer.UpdateKubernetesCluster(ctx, kube2)
 	require.NoError(t, err)
 
@@ -156,7 +157,7 @@ func TestWatcher(t *testing.T) {
 			cmpopts.IgnoreFields(types.Metadata{}, "ID"),
 		))
 		// make sure credentials were updated as well.
-		require.Equal(t, "api.cluster.com:443", testCtx.KubeServer.fwd.clusterDetails["kube2"].kubeCreds.getTargetAddr())
+		require.Equal(t, strings.TrimPrefix(kubeMock.URL, "https://"), testCtx.KubeServer.fwd.clusterDetails["kube2"].kubeCreds.getTargetAddr())
 	case <-time.After(time.Second):
 		t.Fatal("Didn't receive reconcile event after 1s.")
 	}


### PR DESCRIPTION
This PR implements a feature where it's possible to restrict access to
namespace scoped `CustomResources`.

To be able to deserialize unknown Kubernetes objects, we keep a
`serializer.CodecFactory` per cluster where we register not only the default
types - such as `Pods`, `Statefulsets`... -, but also all the
`CustomResourceDefinitions` that are namespaced.

With the list of RBAC-supported resources and the serializer, Kube
access identifies if we support Kubernetes per-Resource RBAC for that
type - the match happens based on resource `kind` and `apiGroup` -
and enforces the RBAC rules.

Namespace controls access to `CustomResources`. When a user has an allow
rule for a namespace - similar to the rule below -, he has access to
all resources within that namespace including the custom resources.

```yaml
kubernetes_resources:
- kind: namespace
  name: "someNamespace"
  verbs: ['*']
```

The list of `CustomResources` is constantly updated and monitored in
intervals of `5m`. If a new CRD is created between two iteration cycles,
Teleport will only enforce RBAC after the resource and codecs are
updated.