### PR TITLE
Remove note about canceled requests not being supported

### DIFF
--- a/docs/pages/database-access/faq.mdx
+++ b/docs/pages/database-access/faq.mdx
@@ -29,9 +29,6 @@ See the available [guides](./guides.mdx) for all supported configurations.
 
 The following PostgreSQL protocol features aren't currently supported:
 
-- [Canceling requests in progress](https://www.postgresql.org/docs/current/protocol-flow.html#id-1.10.5.7.9).
-  Cancel requests issued by the PostgreSQL clients connected to the Teleport
-  Proxy Service won't be passed to the database server.
 - Any [authentication methods](https://www.postgresql.org/docs/current/auth-methods.html)
   except for client certificate authentication and IAM authentication for cloud
   databases.


### PR DESCRIPTION
Support for canceling requests was added in https://github.com/gravitational/teleport/pull/22173