### PR TITLE
Add access request functionality to Assist package

### DIFF
--- a/lib/ai/model/messages.go
+++ b/lib/ai/model/messages.go
@@ -53,7 +53,7 @@ type CompletionCommand struct {
 	Labels  []Label  `json:"labels,omitempty"`
 }
 
-// CompletionRequest represents an access request suggestion returned by OpenAI's completion API.
+// AccessRequest represents an access request suggestion returned by OpenAI's completion API.
 type AccessRequest struct {
 	Roles              []string `json:"roles"`
 	ResourceIDs        []string `json:"resource_ids"`

--- a/lib/assist/assist.go
+++ b/lib/assist/assist.go
@@ -419,7 +419,7 @@ func (c *Chat) ProcessComplete(ctx context.Context, onMessage onMessageFunc, use
 			return nil, trace.Wrap(err)
 		}
 
-		if err := onMessage(MessageKindCommand, payloadJson, c.assist.clock.Now().UTC()); nil != err {
+		if err := onMessage(MessageKindAccessRequest, payloadJson, c.assist.clock.Now().UTC()); nil != err {
 			return nil, trace.Wrap(err)
 		}
 	case *model.AccessRequestsDisplay:
@@ -455,7 +455,7 @@ func (c *Chat) ProcessComplete(ctx context.Context, onMessage onMessageFunc, use
 			return nil, trace.Wrap(err)
 		}
 
-		if err := onMessage(MessageKindCommand, payloadJson, c.assist.clock.Now().UTC()); nil != err {
+		if err := onMessage(MessageKindAccessRequestsDisplay, payloadJson, c.assist.clock.Now().UTC()); nil != err {
 			return nil, trace.Wrap(err)
 		}
 	default:

--- a/web/packages/teleport/src/Assist/Conversation/AccessRequest.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/AccessRequest.tsx
@@ -72,6 +72,9 @@ const SubTitle = styled.div`
 export function AccessRequest(props: AccessRequestProps) {
   const [reason, setReason] = useState(props.reason);
 
+  console.log(props.resources);
+  //TODO: Implement the request access API call
+
   return (
     <Container>
       <InfoText style={{ marginTop: 0 }}>Create an access request</InfoText>

--- a/web/packages/teleport/src/Assist/Conversation/AccessRequests/Resources.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/AccessRequests/Resources.tsx
@@ -75,6 +75,9 @@ const ResourceName = styled.div`
 export function Resources(props: ResourcesProps) {
   const theme = useTheme();
 
+  // TODO: Assist can return empty resources array :\
+  if (!props.resources) return <Container />;
+
   return (
     <Container>
       {props.resources.map((resource, index) => (

--- a/web/packages/teleport/src/Assist/Conversation/Message.tsx
+++ b/web/packages/teleport/src/Assist/Conversation/Message.tsx
@@ -154,7 +154,7 @@ function createComponentForEntry(
           summary={entry.summary}
         />
       );
-
+    // TODO: My IDE says that this is unreachable code
     case ServerMessageType.AccessRequests:
       return (
         <AccessRequests

--- a/web/packages/teleport/src/Assist/context/AssistContext.tsx
+++ b/web/packages/teleport/src/Assist/context/AssistContext.tsx
@@ -32,6 +32,7 @@ import cfg from 'teleport/config';
 import { getAccessToken, getHostName } from 'teleport/services/api';
 
 import {
+  AccessRequestStatus,
   ExecutionEnvelopeType,
   ExecutionTeleportErrorType,
   RawPayload,
@@ -48,6 +49,7 @@ import {
 
 import * as service from '../service';
 import {
+  resolveAccessRequestMessage,
   resolveServerAssistThoughtMessage,
   resolveServerCommandMessage,
   resolveServerMessage,
@@ -207,6 +209,26 @@ export function AssistContextProvider(props: PropsWithChildren<unknown>) {
           dispatch({
             type: AssistStateActionType.SetStreaming,
             streaming: false,
+          });
+
+          break;
+        }
+
+        case ServerMessageType.AccessRequest: {
+          const message = resolveAccessRequestMessage(data);
+
+          dispatch({
+            type: AssistStateActionType.AddAccessRequest,
+            summary: '',
+            suggested_reviewers: [],
+            requested_resources: message.resources.map(
+              r => r as unknown as string // TODO: fix me
+            ),
+            events: [],
+            status: AccessRequestStatus.Pending,
+            username: '???',
+            reason: message.reason,
+            conversationId,
           });
 
           break;

--- a/web/packages/teleport/src/Assist/context/state.ts
+++ b/web/packages/teleport/src/Assist/context/state.ts
@@ -186,12 +186,15 @@ export interface ToggleSidebarAction {
 }
 
 export interface AddAccessRequestAction {
+  suggested_reviewers: string[];
   type: AssistStateActionType.AddAccessRequest;
   conversationId: string;
-  status: AccessRequestStatus;
-  summary: string;
-  username: string;
+  status: AccessRequestStatus; // TODO: I don't fully understand what this field represents. New request are always "pending".
+  summary: string; // TODO: What is summary?
+  requested_resources: string[];
+  username: string; // TODO: ??
   events: AccessRequestEvent[];
+  reason: string;
 }
 
 export type AssistContextAction =
@@ -735,17 +738,21 @@ export function addAccessRequest(
   action: AddAccessRequestAction
 ): AssistState {
   const messages = new Map(state.messages.data);
-
+  console.log('action', action);
   const existingMessages = messages.get(action.conversationId);
 
   messages.set(action.conversationId, [
     ...existingMessages,
     {
-      type: ServerMessageType.AccessRequests,
+      type: ServerMessageType.AccessRequest,
       status: action.status,
       username: action.username,
       events: action.events,
       summary: action.summary,
+      suggested_reviewers: action.suggested_reviewers,
+      requested_resources: action.requested_resources,
+      reason: action.reason,
+      resources: action.summary,
       created: new Date(),
     },
   ]);

--- a/web/packages/teleport/src/Assist/service.ts
+++ b/web/packages/teleport/src/Assist/service.ts
@@ -27,13 +27,8 @@ import { EventType } from 'teleport/lib/term/enums';
 
 import NodeService from 'teleport/services/nodes';
 
-import {
-  ResolvedAssistThoughtServerMessage,
-  ServerMessageType,
-  ThoughtMessagePayload,
-} from './types';
-
 import type {
+  AccessRequestPayload,
   CommandResultPayload,
   CommandResultSummaryPayload,
   Conversation,
@@ -43,12 +38,18 @@ import type {
   GenerateTitleResponse,
   GetConversationMessagesResponse,
   GetConversationsResponse,
+  ResolvedAccessRequestServerMessage,
   ResolvedCommandResultServerMessage,
   ResolvedCommandResultSummaryServerMessage,
   ResolvedCommandServerMessage,
   ResolvedServerMessage,
   ServerMessage,
   SessionEvent,
+} from './types';
+import {
+  ResolvedAssistThoughtServerMessage,
+  ServerMessageType,
+  ThoughtMessagePayload,
 } from './types';
 
 export async function loadConversations(): Promise<Conversation[]> {
@@ -68,6 +69,8 @@ export async function resolveServerMessage(
   clusterId: string
 ): Promise<ResolvedServerMessage> {
   switch (message.type) {
+    case ServerMessageType.AccessRequest:
+      return resolveAccessRequestMessage(message);
     case ServerMessageType.Command:
       return resolveServerCommandMessage(message);
 
@@ -220,6 +223,20 @@ export function resolveServerCommandMessage(
     created: new Date(message.created_time),
     query,
     command: payload.command,
+  };
+}
+
+export function resolveAccessRequestMessage(
+  message: ServerMessage
+): ResolvedAccessRequestServerMessage {
+  const payload: AccessRequestPayload = JSON.parse(message.payload);
+
+  return {
+    type: ServerMessageType.AccessRequest,
+    created: new Date(message.created_time),
+    resources: payload.resource_ids,
+    reason: payload.reason,
+    suggested_reviewers: payload.suggested_reviewers || [],
   };
 }
 

--- a/web/packages/teleport/src/Assist/types.ts
+++ b/web/packages/teleport/src/Assist/types.ts
@@ -142,6 +142,10 @@ export enum AccessRequestStatus {
   Declined,
 }
 
+export interface AccessRequestEvent {
+  // TODO: missing implementation?
+}
+
 export type ResolvedServerMessage =
   | ResolvedCommandServerMessage
   | ResolvedAssistServerMessage
@@ -224,6 +228,14 @@ export interface SessionData {
 
 export interface SessionEndData {
   node_id: string;
+}
+
+export interface AccessRequestPayload {
+  roles: string[];
+  resource_ids: Resource[];
+  reason: string;
+  suggested_reviewers: string[];
+  created_time: Date;
 }
 
 export interface ExecuteRemoteCommandPayload {


### PR DESCRIPTION
Added AccessRequestEvent and AccessRequestPayload interfaces. Refactored AddAccessRequestAction and related functions to include requested resources, suggested reviewers, and reason for request. Modified 'assist.go' to handle access request actions appropriately.

This change allows Assist to handle and create new access requests, which was a previously missing feature. Note that certain components require further implementation (indicated in TODOs), but this commit provides the base for handling access requests.