### PR TITLE
Fix AWS EKS E2E tests

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -31,7 +31,7 @@ env:
   GHA_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-aws-e2e-gha-role
   KUBERNETES_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-kubernetes-service-access-role
   DISCOVERY_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/tf-eks-discovery-ci-cluster-discovery-service-access-role
-  DISCOVERED_CLUSTER_NAME: gha-discovery-ci
+  DISCOVERED_CLUSTER_NAME: gha-discovery-ci-eks-us-west-2-307493967395
 jobs:
   test:
     name: AWS E2E Tests (Non-root)


### PR DESCRIPTION
After merging #28845, the cluster name is different and the test failed. 
Since the AWS E2E tests are not required, the merge happened and broke all tests.