### PR TITLE
`tsh --ttl` takes an integer

### DIFF
--- a/docs/pages/includes/plugins/identity-export.mdx
+++ b/docs/pages/includes/plugins/identity-export.mdx
@@ -33,11 +33,11 @@ You will refer to this file later when configuring the plugin.
   Note that you cannot issue certificates that are valid longer than your existing credentials.
   For example, to issue certificates with a 1000-hour TTL, you must be logged in with a session that is
   valid for at least 1000 hours. This means your user must have a role allowing
-  a `max_session_ttl` of at least 1000 hours, and you must specify a `--ttl`
+  a `max_session_ttl` of at least 1000 hours (60000 minutes), and you must specify a `--ttl`
   when logging in:
 
   ```code
-  $ tsh login --proxy=teleport.example.com --ttl=1001h
+  $ tsh login --proxy=teleport.example.com --ttl=60060
   ```
 
 </Admonition>


### PR DESCRIPTION
unlike `tctl auth sign ... --ttl` that can take a golang duration formatted string, the `--ttl` argument for tsh is an integer in the number of minutes.