### PR TITLE
Add gotestsum to devbox

### DIFF
--- a/.github/workflows/check-devbox.yaml
+++ b/.github/workflows/check-devbox.yaml
@@ -30,5 +30,5 @@ jobs:
         uses: jetpack-io/devbox-install-action@v0.4.0
         with:
           enable-cache: true
-          devbox-version: 0.5.7
+          devbox-version: 0.5.10
           sha256-sum: a4f66cacf6091530f3d51148df83a08353906496c8ada001b0edd7ac29226dc5

--- a/devbox.json
+++ b/devbox.json
@@ -7,6 +7,7 @@
     "gci@0.9.1",
     "go@1.20.5",
     "golangci-lint@1.53.3",
+    "gotestsum@1.10.1",
     "libiconvReal@1.16",
     "libfido2@1.13.0",
     "nodejs@16.18.1",

--- a/devbox.lock
+++ b/devbox.lock
@@ -14,11 +14,6 @@
       "resolved": "github:NixOS/nixpkgs/6cc260cfd60f094500b79e279069b499806bf6d8#bats",
       "version": "1.3.0"
     },
-    "clang@11.1.0": {
-      "last_modified": "2023-05-01T16:53:22Z",
-      "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#clang",
-      "version": "11.1.0"
-    },
     "gci@0.9.1": {
       "last_modified": "2023-02-28T22:11:13Z",
       "resolved": "github:NixOS/nixpkgs/995edc972ad3a1e291ac22d74b9610821357175f#gci",
@@ -39,6 +34,12 @@
       "source": "devbox-search",
       "version": "1.53.3"
     },
+    "gotestsum@1.10.1": {
+      "last_modified": "2023-07-23T03:35:12Z",
+      "resolved": "github:NixOS/nixpkgs/af8cd5ded7735ca1df1a1174864daab75feeb64a#gotestsum",
+      "source": "devbox-search",
+      "version": "1.10.1"
+    },
     "libfido2@1.13.0": {
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#libfido2",
@@ -48,6 +49,12 @@
       "last_modified": "2023-05-01T16:53:22Z",
       "resolved": "github:NixOS/nixpkgs/8670e496ffd093b60e74e7fa53526aa5920d09eb#libiconvReal",
       "version": "1.16"
+    },
+    "llvmPackages_14.clangUseLLVM@14.0.6": {
+      "last_modified": "2023-07-23T03:35:12Z",
+      "resolved": "github:NixOS/nixpkgs/af8cd5ded7735ca1df1a1174864daab75feeb64a#llvmPackages_14.clangUseLLVM",
+      "source": "devbox-search",
+      "version": "14.0.6"
     },
     "nodejs@16.18.1": {
       "last_modified": "2023-01-02T04:31:48Z",


### PR DESCRIPTION
gotestsum has been added to the Docker image in https://github.com/gravitational/teleport/pull/29862 Unfortunately, devbox failed to rebuild the image due to a bug in devbox that has been fixed in 0.5.8. This PR re-adds the gotestsum to devbox and upgrades the version used in the CI.