### PR TITLE
dronegen: Convert some linux tag pipelines to GitHub Actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1260,15 +1260,12 @@ volumes:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64-centos7
-environment:
-  BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -1283,185 +1280,50 @@ workspace:
   path: /go
 clone:
   disable: true
-depends_on:
-- clean-up-previous-build
 steps:
 - name: Check out code
   image: docker:git
   pull: if-not-exists
   commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
   - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
   - git submodule update --init e
+  - mkdir -pv /go/cache
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "build-connect=false" -input "build-deb=false" -input "build-rpm=true" -input
+    "release-artifacts=true" -input "release-target=release-amd64-centos7" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-amd64-centos7
-  environment:
-    ARCH: amd64
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Copy artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - export VERSION=$(cat /go/.version.txt)
-  - mv /go/artifacts/teleport-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-v$${VERSION}-linux-amd64-centos7-bin.tar.gz
-  - mv /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz /go/artifacts/teleport-ent-v$${VERSION}-linux-amd64-centos7-bin.tar.gz
-  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
-    done && ls -l
-- name: Assume AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux 64-bit (RHEL/CentOS 7.x compatible)"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="amd64" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -1677,15 +1539,12 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: build-linux-amd64
-environment:
-  BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -1700,191 +1559,50 @@ workspace:
   path: /go
 clone:
   disable: true
-depends_on:
-- clean-up-previous-build
 steps:
 - name: Check out code
   image: docker:git
   pull: if-not-exists
   commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
   - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
   - git submodule update --init e
+  - mkdir -pv /go/cache
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "build-connect=true" -input "build-deb=true" -input "build-rpm=false" -input "release-artifacts=true"
+    -input "release-target=release-amd64" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - make -C build.assets release-amd64-centos7
-  - make -C build.assets teleterm
-  environment:
-    ARCH: amd64
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Copy artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - find /go/src/github.com/gravitational/teleport/web/packages/teleterm/build/release
-    -maxdepth 1 \( -iname "teleport-connect*.tar.gz" -o -iname "teleport-connect*.rpm"
-    -o -iname "teleport-connect*.deb" \) -print -exec cp {} /go/artifacts/ \;
-  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
-    done && ls -l
-  - |-
-    cd /go/artifacts && for FILE in teleport-connect*.deb teleport-connect*.rpm; do
-      sha256sum $FILE > $FILE.sha256;
-    done && ls -l
-- name: Assume AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux 64-bit"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="amd64" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -2091,288 +1809,6 @@ volumes:
   temp: {}
 - name: dockerconfig
   temp: {}
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPackagePipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: build-linux-amd64-centos7-rpm
-trigger:
-  event:
-    include:
-    - tag
-  ref:
-    include:
-    - refs/tags/v*
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-depends_on:
-- build-linux-amd64-centos7
-- clean-up-previous-build
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
-  pull: if-not-exists
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Assume Download AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Download artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - export VERSION=$(cat /go/.version.txt)
-  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else
-    export S3_PATH="tag/"; fi
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-centos7-bin.tar.gz
-    /go/artifacts/
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-centos7-bin.tar.gz
-    /go/artifacts/
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Build AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
-    AWS_ROLE:
-      from_secret: TELEPORT_BUILD_READ_ONLY_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache bash curl gzip make tar go
-  - apk add --no-cache aws-cli
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - mkdir -m0700 $GNUPG_DIR
-  - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
-  - chown -R root:root $GNUPG_DIR
-  - make rpm
-  - rm -rf $GNUPG_DIR
-  environment:
-    ARCH: amd64
-    ENT_TARBALL_PATH: /go/artifacts
-    GNUPG_DIR: /tmpfs/gnupg
-    GPG_RPM_SIGNING_ARCHIVE:
-      from_secret: GPG_RPM_SIGNING_ARCHIVE
-    OSS_TARBALL_PATH: /go/artifacts
-    TMPDIR: /go
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-  - name: awsconfig
-    path: /root/.aws
-  - name: tmpfs
-    path: /tmpfs
-- name: Copy artifacts
-  image: docker
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts
-    \;
-  - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts
-    \;
-- name: Assume Upload AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux 64-bit RPM (RHEL/CentOS 7.x compatible)"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="amd64" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
-- name: tmpfs
-  temp:
-    medium: memory
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -2664,274 +2100,6 @@ image_pull_secrets:
 
 kind: pipeline
 type: kubernetes
-name: build-linux-amd64-deb
-trigger:
-  event:
-    include:
-    - tag
-  ref:
-    include:
-    - refs/tags/v*
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-depends_on:
-- build-linux-amd64
-- clean-up-previous-build
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
-  pull: if-not-exists
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Assume Download AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Download artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - export VERSION=$(cat /go/.version.txt)
-  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else
-    export S3_PATH="tag/"; fi
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-amd64-bin.tar.gz
-    /go/artifacts/
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-amd64-bin.tar.gz
-    /go/artifacts/
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Build AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
-    AWS_ROLE:
-      from_secret: TELEPORT_BUILD_READ_ONLY_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache bash curl gzip make tar
-  - apk add --no-cache aws-cli
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - make deb
-  environment:
-    ARCH: amd64
-    ENT_TARBALL_PATH: /go/artifacts
-    OSS_TARBALL_PATH: /go/artifacts
-    TMPDIR: /go
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-  - name: awsconfig
-    path: /root/.aws
-- name: Copy artifacts
-  image: docker
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts
-    \;
-  - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts
-    \;
-- name: Assume Upload AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux 64-bit DEB"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="amd64" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPackagePipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
 name: build-linux-amd64-fips-deb
 trigger:
   event:
@@ -3192,15 +2360,12 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: build-linux-386
-environment:
-  BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -3215,732 +2380,50 @@ workspace:
   path: /go
 clone:
   disable: true
-depends_on:
-- clean-up-previous-build
 steps:
 - name: Check out code
   image: docker:git
   pull: if-not-exists
   commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
   - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
   - git submodule update --init e
+  - mkdir -pv /go/cache
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "build-connect=false" -input "build-deb=true" -input "build-rpm=true" -input "release-artifacts=true"
+    -input "release-target=release-386" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-386
-  environment:
-    ARCH: "386"
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Copy artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
-    done && ls -l
-- name: Assume AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux 32-bit"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="386" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPackagePipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: build-linux-386-rpm
-trigger:
-  event:
-    include:
-    - tag
-  ref:
-    include:
-    - refs/tags/v*
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-depends_on:
-- build-linux-386
-- clean-up-previous-build
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
-  pull: if-not-exists
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Assume Download AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Download artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - export VERSION=$(cat /go/.version.txt)
-  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else
-    export S3_PATH="tag/"; fi
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz
-    /go/artifacts/
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz
-    /go/artifacts/
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Build AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
-    AWS_ROLE:
-      from_secret: TELEPORT_BUILD_READ_ONLY_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache bash curl gzip make tar go
-  - apk add --no-cache aws-cli
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - mkdir -m0700 $GNUPG_DIR
-  - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
-  - chown -R root:root $GNUPG_DIR
-  - make rpm
-  - rm -rf $GNUPG_DIR
-  environment:
-    ARCH: "386"
-    ENT_TARBALL_PATH: /go/artifacts
-    GNUPG_DIR: /tmpfs/gnupg
-    GPG_RPM_SIGNING_ARCHIVE:
-      from_secret: GPG_RPM_SIGNING_ARCHIVE
-    OSS_TARBALL_PATH: /go/artifacts
-    TMPDIR: /go
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-  - name: awsconfig
-    path: /root/.aws
-  - name: tmpfs
-    path: /tmpfs
-- name: Copy artifacts
-  image: docker
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts
-    \;
-  - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts
-    \;
-- name: Assume Upload AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux 32-bit RPM"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="386" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
-- name: tmpfs
-  temp:
-    medium: memory
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPackagePipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: build-linux-386-deb
-trigger:
-  event:
-    include:
-    - tag
-  ref:
-    include:
-    - refs/tags/v*
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-depends_on:
-- build-linux-386
-- clean-up-previous-build
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
-  pull: if-not-exists
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Assume Download AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Download artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - export VERSION=$(cat /go/.version.txt)
-  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else
-    export S3_PATH="tag/"; fi
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-386-bin.tar.gz
-    /go/artifacts/
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-386-bin.tar.gz
-    /go/artifacts/
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Build AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
-    AWS_ROLE:
-      from_secret: TELEPORT_BUILD_READ_ONLY_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache bash curl gzip make tar
-  - apk add --no-cache aws-cli
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - make deb
-  environment:
-    ARCH: "386"
-    ENT_TARBALL_PATH: /go/artifacts
-    OSS_TARBALL_PATH: /go/artifacts
-    TMPDIR: /go
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-  - name: awsconfig
-    path: /root/.aws
-- name: Copy artifacts
-  image: docker
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts
-    \;
-  - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts
-    \;
-- name: Assume Upload AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux 32-bit DEB"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="386" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -4018,15 +2501,12 @@ image_pull_secrets:
 ################################################
 # Generated using dronegen, do not edit by hand!
 # Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPipeline)
+# Generated at dronegen/gha.go (main.ghaMultiBuildPipeline)
 ################################################
 
 kind: pipeline
 type: kubernetes
 name: build-linux-arm
-environment:
-  BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.6
 trigger:
   event:
     include:
@@ -4041,182 +2521,50 @@ workspace:
   path: /go
 clone:
   disable: true
-depends_on:
-- clean-up-previous-build
 steps:
 - name: Check out code
   image: docker:git
   pull: if-not-exists
   commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
+  - mkdir -pv "/go/src/github.com/gravitational/teleport"
+  - cd "/go/src/github.com/gravitational/teleport"
+  - git init
+  - git remote add origin ${DRONE_REMOTE_URL}
+  - git fetch origin --tags
+  - git checkout -qf "${DRONE_COMMIT_SHA}"
+  - mkdir -m 0700 /root/.ssh && echo "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa &&
+    chmod 600 /root/.ssh/id_rsa
   - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
   - git submodule update --init e
+  - mkdir -pv /go/cache
   - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
   environment:
     GITHUB_PRIVATE_KEY:
       from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
+- name: Delegate build to GitHub
+  image: golang:1.18-alpine
   pull: if-not-exists
   commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
+  - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
+  - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
+    -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_TAG}
+    -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_TAG} -input
+    "build-connect=false" -input "build-deb=true" -input "build-rpm=true" -input "release-artifacts=true"
+    -input "release-target=release-arm" '
   environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Build artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - apk add --no-cache make
-  - chown -R $UID:$GID /go
-  - cd /go/src/github.com/gravitational/teleport
-  - make -C build.assets release-arm
-  environment:
-    ARCH: arm
-    GID: "1000"
-    GOCACHE: /go/cache
-    GOPATH: /go
-    OS: linux
-    UID: "1000"
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Copy artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find . -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - find e/ -maxdepth 1 -iname "teleport*.tar.gz" -print -exec cp {} /go/artifacts
-    \;
-  - cd /go/artifacts && for FILE in teleport*.tar.gz; do sha256sum $FILE > $FILE.sha256;
-    done && ls -l
-- name: Assume AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  pull: if-not-exists
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux ARMv7 (32-bit)"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="arm" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
+    GHA_APP_KEY:
+      from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
+- name: Send Slack notification
+  image: plugins/slack:1.4.1
+  settings:
+    template: |-
+      *✘ Failed:* `{{ build.event }}` / `${DRONE_STAGE_NAME}` / <{{ build.link }}|Build: #{{ build.number }}>
+      Author: <https://github.com/{{ build.author }}|{{ build.author }}> Repo: <https://github.com/{{ repo.owner }}/{{ repo.name }}/|{{ repo.owner }}/{{ repo.name }}> Branch: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commits/{{ build.branch }}|{{ build.branch }}> Commit: <https://github.com/{{ repo.owner }}/{{ repo.name }}/commit/{{ build.commit }}|{{ truncate build.commit 8 }}>
+    webhook:
+      from_secret: SLACK_WEBHOOK_DEV_TELEPORT
+  when:
+    status:
+    - failure
 image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 
@@ -4539,274 +2887,6 @@ volumes:
 
 kind: pipeline
 type: kubernetes
-name: build-linux-arm-deb
-trigger:
-  event:
-    include:
-    - tag
-  ref:
-    include:
-    - refs/tags/v*
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-depends_on:
-- build-linux-arm
-- clean-up-previous-build
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
-  pull: if-not-exists
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Assume Download AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Download artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - export VERSION=$(cat /go/.version.txt)
-  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else
-    export S3_PATH="tag/"; fi
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-arm-bin.tar.gz
-    /go/artifacts/
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-arm-bin.tar.gz
-    /go/artifacts/
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Build AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
-    AWS_ROLE:
-      from_secret: TELEPORT_BUILD_READ_ONLY_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache bash curl gzip make tar
-  - apk add --no-cache aws-cli
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - make deb
-  environment:
-    ARCH: arm
-    ENT_TARBALL_PATH: /go/artifacts
-    OSS_TARBALL_PATH: /go/artifacts
-    TMPDIR: /go
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-  - name: awsconfig
-    path: /root/.aws
-- name: Copy artifacts
-  image: docker
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts
-    \;
-  - find e/build -maxdepth 1 -iname "teleport*.deb*" -print -exec cp {} /go/artifacts
-    \;
-- name: Assume Upload AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux ARMv7 (32-bit) DEB"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="arm" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPackagePipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
 name: build-linux-arm64-rpm
 trigger:
   event:
@@ -5060,288 +3140,6 @@ volumes:
 - name: tmpfs
   temp:
     medium: memory
-
----
-################################################
-# Generated using dronegen, do not edit by hand!
-# Use 'make dronegen' to update.
-# Generated at dronegen/tag.go (main.tagPackagePipeline)
-################################################
-
-kind: pipeline
-type: kubernetes
-name: build-linux-arm-rpm
-trigger:
-  event:
-    include:
-    - tag
-  ref:
-    include:
-    - refs/tags/v*
-  repo:
-    include:
-    - gravitational/*
-workspace:
-  path: /go
-clone:
-  disable: true
-depends_on:
-- build-linux-arm
-- clean-up-previous-build
-steps:
-- name: Check out code
-  image: docker:git
-  commands:
-  - mkdir -p /go/src/github.com/gravitational/teleport
-  - cd /go/src/github.com/gravitational/teleport
-  - git clone https://github.com/gravitational/${DRONE_REPO_NAME}.git .
-  - git checkout ${DRONE_TAG:-$DRONE_COMMIT}
-  - mkdir -m 0700 /root/.ssh && echo -n "$GITHUB_PRIVATE_KEY" > /root/.ssh/id_rsa
-    && chmod 600 /root/.ssh/id_rsa
-  - ssh-keyscan -H github.com > /root/.ssh/known_hosts 2>/dev/null && chmod 600 /root/.ssh/known_hosts
-  - git submodule update --init e
-  - rm -f /root/.ssh/id_rsa
-  - mkdir -p /go/cache /go/artifacts
-  - |-
-    VERSION=$(egrep ^VERSION Makefile | cut -d= -f2)
-    if [ "$$VERSION" != "${DRONE_TAG##v}" ]; then
-      echo "Mismatch between Makefile version: $$VERSION and git tag: $DRONE_TAG"
-      exit 1
-    fi
-    echo "$$VERSION" > /go/.version.txt
-  environment:
-    GITHUB_PRIVATE_KEY:
-      from_secret: GITHUB_PRIVATE_KEY
-- name: Wait for docker
-  image: docker
-  pull: if-not-exists
-  commands:
-  - timeout 30s /bin/sh -c 'while [ ! -S /var/run/docker.sock ]; do sleep 1; done'
-  - printenv DOCKERHUB_PASSWORD | docker login -u="$DOCKERHUB_USERNAME" --password-stdin
-  environment:
-    DOCKERHUB_PASSWORD:
-      from_secret: DOCKERHUB_READONLY_TOKEN
-    DOCKERHUB_USERNAME:
-      from_secret: DOCKERHUB_USERNAME
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-- name: Assume Download AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Download artifacts from S3
-  image: amazon/aws-cli
-  commands:
-  - export VERSION=$(cat /go/.version.txt)
-  - if [[ "${DRONE_TAG}" != "" ]]; then export S3_PATH="tag/$${DRONE_TAG##v}/"; else
-    export S3_PATH="tag/"; fi
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-v$${VERSION}-linux-arm-bin.tar.gz
-    /go/artifacts/
-  - aws s3 cp s3://$AWS_S3_BUCKET/teleport/$${S3_PATH}teleport-ent-v$${VERSION}-linux-arm-bin.tar.gz
-    /go/artifacts/
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Assume Build AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_KEY
-    AWS_ROLE:
-      from_secret: TELEPORT_BUILD_READ_ONLY_AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: TELEPORT_BUILD_USER_READ_ONLY_SECRET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Build artifacts
-  image: docker
-  commands:
-  - apk add --no-cache bash curl gzip make tar go
-  - apk add --no-cache aws-cli
-  - cd /go/src/github.com/gravitational/teleport
-  - export VERSION=$(cat /go/.version.txt)
-  - aws ecr-public get-login-password --region us-east-1 | docker login -u="AWS" --password-stdin
-    public.ecr.aws
-  - mkdir -m0700 $GNUPG_DIR
-  - echo "$GPG_RPM_SIGNING_ARCHIVE" | base64 -d | tar -xzf - -C $GNUPG_DIR
-  - chown -R root:root $GNUPG_DIR
-  - make rpm
-  - rm -rf $GNUPG_DIR
-  environment:
-    ARCH: arm
-    ENT_TARBALL_PATH: /go/artifacts
-    GNUPG_DIR: /tmpfs/gnupg
-    GPG_RPM_SIGNING_ARCHIVE:
-      from_secret: GPG_RPM_SIGNING_ARCHIVE
-    OSS_TARBALL_PATH: /go/artifacts
-    TMPDIR: /go
-  volumes:
-  - name: dockersock
-    path: /var/run
-  - name: dockerconfig
-    path: /root/.docker
-  - name: awsconfig
-    path: /root/.aws
-  - name: tmpfs
-    path: /tmpfs
-- name: Copy artifacts
-  image: docker
-  commands:
-  - cd /go/src/github.com/gravitational/teleport
-  - find build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts
-    \;
-  - find e/build -maxdepth 1 -iname "teleport*.rpm*" -print -exec cp {} /go/artifacts
-    \;
-- name: Assume Upload AWS Role
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - aws sts get-caller-identity
-  - |-
-    printf "[default]\naws_access_key_id = %s\naws_secret_access_key = %s\naws_session_token = %s\n" \
-      $(aws sts assume-role \
-        --role-arn "$AWS_ROLE" \
-        --role-session-name $(echo "drone-${DRONE_REPO}-${DRONE_BUILD_NUMBER}" | sed "s|/|-|g") \
-        --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
-        --output text) \
-      > /root/.aws/credentials
-  - unset AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY
-  - aws sts get-caller-identity --profile default
-  environment:
-    AWS_ACCESS_KEY_ID:
-      from_secret: AWS_ACCESS_KEY_ID
-    AWS_ROLE:
-      from_secret: AWS_ROLE
-    AWS_SECRET_ACCESS_KEY:
-      from_secret: AWS_SECRET_ACCESS_KEY
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Upload to S3
-  image: amazon/aws-cli
-  pull: if-not-exists
-  commands:
-  - cd /go/artifacts/
-  - aws s3 sync . s3://$AWS_S3_BUCKET/teleport/tag/${DRONE_TAG##v}
-  environment:
-    AWS_REGION: us-west-2
-    AWS_S3_BUCKET:
-      from_secret: AWS_S3_BUCKET
-  volumes:
-  - name: awsconfig
-    path: /root/.aws
-- name: Register artifacts
-  image: docker
-  commands:
-  - WORKSPACE_DIR=$${WORKSPACE_DIR:-/}
-  - VERSION=$(cat "$WORKSPACE_DIR/go/.version.txt")
-  - RELEASES_HOST='https://releases-prod.platform.teleport.sh'
-  - echo "$RELEASES_CERT" | base64 -d > "$WORKSPACE_DIR/releases.crt"
-  - echo "$RELEASES_KEY" | base64 -d > "$WORKSPACE_DIR/releases.key"
-  - trap "rm -f '$WORKSPACE_DIR/releases.crt' '$WORKSPACE_DIR/releases.key'" EXIT
-  - CREDENTIALS="--cert $WORKSPACE_DIR/releases.crt --key $WORKSPACE_DIR/releases.key"
-  - which curl || apk add --no-cache curl
-  - |-
-    cd "$WORKSPACE_DIR/go/artifacts"
-    find . -type f ! -iname '*.sha256' ! -iname '*-unsigned.zip*' | while read -r file; do
-      # Skip files that are not results of this build
-      # (e.g. tarballs from which OS packages are made)
-      [ -f "$file.sha256" ] || continue
-
-      name="$(basename "$file" | sed -E 's/(-|_)v?[0-9].*$//')" # extract part before -vX.Y.Z
-      description="Linux ARMv7 (32-bit) RPM"
-      products="$name"
-      if [ "$name" = "tsh" ]; then
-        products="teleport teleport-ent"
-      elif [ "$name" = "Teleport Connect" -o "$name" = "teleport-connect" ]; then
-        description="Teleport Connect"
-        products="teleport teleport-ent"
-      fi
-      shasum="$(cat "$file.sha256" | cut -d ' ' -f 1)"
-
-      release_params="" # List of "-F releaseId=XXX" parameters to curl
-
-      for product in $products; do
-        status_code=$(curl $CREDENTIALS -o "$WORKSPACE_DIR/curl_out.txt" -w "%{http_code}" -F "product=$product" -F "version=$VERSION" -F notesMd="# Teleport $VERSION" -F status=draft "$RELEASES_HOST/releases")
-        if [ $status_code -ne 200 ] && [ $status_code -ne 409 ]; then
-          echo "curl HTTP status: $status_code"
-          cat $WORKSPACE_DIR/curl_out.txt
-          exit 1
-        fi
-
-        release_params="$release_params -F releaseId=$product@$VERSION"
-      done
-
-      curl $CREDENTIALS --fail -o /dev/null -F description="$description" -F os="linux" -F arch="arm" -F "file=@$file" -F "sha256=$shasum" $release_params "$RELEASES_HOST/assets";
-    done
-  environment:
-    RELEASES_CERT:
-      from_secret: RELEASES_CERT
-    RELEASES_KEY:
-      from_secret: RELEASES_KEY
-services:
-- name: Start Docker
-  image: docker:dind
-  privileged: true
-  volumes:
-  - name: tmpfs
-    path: /tmpfs
-  - name: dockersock
-    path: /var/run
-volumes:
-- name: awsconfig
-  temp: {}
-- name: dockersock
-  temp: {}
-- name: dockerconfig
-  temp: {}
-- name: tmpfs
-  temp:
-    medium: memory
-image_pull_secrets:
-- DOCKERHUB_CREDENTIALS
 
 ---
 ################################################
@@ -8245,10 +6043,10 @@ clone:
   disable: true
 depends_on:
 - clean-up-previous-build
-- build-linux-amd64-deb
+- build-linux-amd64
 - build-linux-amd64-fips-deb
 - build-linux-arm64-deb
-- build-linux-arm-deb
+- build-linux-arm
 steps:
 - name: Check out code
   image: docker:git
@@ -8309,7 +6107,7 @@ clone:
   disable: true
 depends_on:
 - clean-up-previous-build
-- build-linux-amd64-deb
+- build-linux-amd64
 - build-linux-amd64-fips-deb
 steps:
 - name: Check out code
@@ -16997,6 +14795,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 8ea3e8ce5db0629a9304f3fa1991035711cb7cdf03eec07c555810ef2fdf707d
+hmac: 28c2c7a466aeeafd8ad163b15274034bf274314367fb3dbc0bedd05b9d2207be
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -154,6 +154,8 @@ type buildType struct {
 	centos7         bool
 	windowsUnsigned bool
 	buildConnect    bool
+	buildDeb        bool
+	buildRPM        bool
 }
 
 // Description provides a human-facing description of the artifact, e.g.:
@@ -260,8 +262,9 @@ func dockerRegistryService() service {
 // releaseMakefileTarget gets the correct Makefile target for a given arch/fips/centos combo
 func releaseMakefileTarget(b buildType) string {
 	makefileTarget := fmt.Sprintf("release-%s", b.arch)
-	// All x86_64 binaries are built on CentOS 7 now for better glibc compatibility.
-	if b.centos7 || b.arch == "amd64" {
+	// x86_64 binaries are built on CentOS 7 now for better glibc compatibility,
+	// unless we're building a debian package.
+	if (b.centos7 || b.arch == "amd64") && !b.buildDeb {
 		makefileTarget += "-centos7"
 	}
 	if b.fips {

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -169,25 +169,24 @@ done && ls -l`)
 // tagPipelines builds all applicable tag pipeline combinations
 func tagPipelines() []pipeline {
 	var ps []pipeline
-	// regular tarball builds
-	for _, arch := range []string{"amd64", "386", "arm"} {
-		for _, fips := range []bool{false, true} {
-			if arch != "amd64" && fips {
-				// FIPS mode only supported on linux/amd64
-				continue
-			}
-			ps = append(ps, tagPipeline(buildType{os: "linux", arch: arch, fips: fips}))
 
-			// RPM/DEB package builds
-			for _, packageType := range []string{rpmPackage, debPackage} {
-				bt := buildType{os: "linux", arch: arch, fips: fips}
-				if packageType == "rpm" && arch == "amd64" {
-					bt.centos7 = true
-				}
-				ps = append(ps, tagPackagePipeline(packageType, bt))
-			}
-		}
-	}
+	// amd64 builds
+	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", fips: false}))
+	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "amd64", fips: false, centos7: true}))
+	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "amd64", fips: false}))
+	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", fips: true}))
+	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "amd64", fips: true, centos7: true}))
+	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "amd64", fips: true}))
+
+	// 386 builds
+	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "386", fips: false}))
+	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "386", fips: false}))
+	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "386", fips: false}))
+
+	// arm builds
+	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "arm", fips: false}))
+	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "arm", fips: false}))
+	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "arm", fips: false}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
 		buildType:    buildType{os: "linux", arch: "arm64", fips: false},

--- a/dronegen/tag.go
+++ b/dronegen/tag.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -170,23 +171,16 @@ done && ls -l`)
 func tagPipelines() []pipeline {
 	var ps []pipeline
 
-	// amd64 builds
-	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", fips: false}))
-	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "amd64", fips: false, centos7: true}))
-	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "amd64", fips: false}))
+	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "amd64", fips: false, centos7: false, buildConnect: true, buildDeb: true, buildRPM: false}))
+	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "amd64", fips: false, centos7: true, buildConnect: false, buildDeb: false, buildRPM: true}))
+	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "386", buildDeb: true, buildRPM: true}))
+	ps = append(ps, ghaLinuxTagPipeline(buildType{os: "linux", arch: "arm", buildDeb: true, buildRPM: true}))
+
+	// FIPS builds. Still drone pipelines.
 	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", fips: true}))
+	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos7: true, fips: true}))
 	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "amd64", fips: true, centos7: true}))
 	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "amd64", fips: true}))
-
-	// 386 builds
-	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "386", fips: false}))
-	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "386", fips: false}))
-	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "386", fips: false}))
-
-	// arm builds
-	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "arm", fips: false}))
-	ps = append(ps, tagPackagePipeline(rpmPackage, buildType{os: "linux", arch: "arm", fips: false}))
-	ps = append(ps, tagPackagePipeline(debPackage, buildType{os: "linux", arch: "arm", fips: false}))
 
 	ps = append(ps, ghaBuildPipeline(ghaBuildType{
 		buildType:    buildType{os: "linux", arch: "arm64", fips: false},
@@ -211,10 +205,10 @@ func tagPipelines() []pipeline {
 		pipelineName: "build-teleport-oci-distroless-images",
 		dependsOn: []string{
 			tagCleanupPipelineName,
-			"build-linux-amd64-deb",
+			"build-linux-amd64",
 			"build-linux-amd64-fips-deb",
 			"build-linux-arm64-deb",
-			"build-linux-arm-deb",
+			"build-linux-arm",
 		},
 		workflows: []ghaWorkflow{
 			{
@@ -233,7 +227,7 @@ func tagPipelines() []pipeline {
 		pipelineName: "build-teleport-hardened-amis",
 		dependsOn: []string{
 			tagCleanupPipelineName,
-			"build-linux-amd64-deb",
+			"build-linux-amd64",
 			"build-linux-amd64-fips-deb",
 		},
 		workflows: []ghaWorkflow{
@@ -265,16 +259,56 @@ func tagPipelines() []pipeline {
 	// Only amd64 Windows is supported for now.
 	ps = append(ps, tagPipeline(buildType{os: "windows", arch: "amd64"}))
 
-	// Also add CentOS artifacts
-	// CentOS 6 FIPS builds have been removed in Teleport 7.0. See https://github.com/gravitational/teleport/issues/7207
-	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos7: true}))
-	ps = append(ps, tagPipeline(buildType{os: "linux", arch: "amd64", centos7: true, fips: true}))
-
 	ps = append(ps, darwinTagPipelineGHA())
 	ps = append(ps, windowsTagPipeline())
 
 	ps = append(ps, tagCleanupPipeline())
 	return ps
+}
+
+// ghaLinuxTagPipeline generates a tag pipeline for a given combination of
+// os/arch/FIPS that calls a GitHub Actions workflow to perform the build on a
+// Linux box. This dispatches to the release-linux.yaml workflow in the
+// teleport.e repo, which is a little more generic than the
+// release-linux-arm64.yml workflow used for the arm64 build. The two will be
+// unified shortly.
+func ghaLinuxTagPipeline(b buildType) pipeline {
+	if b.os == "" {
+		panic("b.os must be set")
+	}
+	if b.arch == "" {
+		panic("b.arch must be set")
+	}
+	if b.fips {
+		panic("b.fips cannot yet be used with ghaLinuxTagPipeline()")
+	}
+
+	pipelineName := fmt.Sprintf("build-%s-%s", b.os, b.arch)
+	if b.centos7 {
+		pipelineName += "-centos7"
+	}
+	wf := ghaWorkflow{
+		name:              "release-linux.yaml",
+		timeout:           150 * time.Minute,
+		slackOnError:      true,
+		srcRefVar:         "DRONE_TAG",
+		ref:               "${DRONE_TAG}",
+		shouldTagWorkflow: true,
+		inputs: map[string]string{
+			"release-artifacts": "true",
+			"release-target":    releaseMakefileTarget(b),
+			"build-connect":     strconv.FormatBool(b.buildConnect),
+			"build-deb":         strconv.FormatBool(b.buildDeb),
+			"build-rpm":         strconv.FormatBool(b.buildRPM),
+		},
+	}
+	bt := ghaBuildType{
+		buildType:    buildType{os: b.os, arch: b.arch},
+		trigger:      triggerTag,
+		pipelineName: pipelineName,
+		workflows:    []ghaWorkflow{wf},
+	}
+	return ghaBuildPipeline(bt)
 }
 
 // tagPipeline generates a tag pipeline for a given combination of os/arch/FIPS


### PR DESCRIPTION
Convert some of the linux-based tag build pipelines to run on GitHub 
Actions. The following pipelines have been converted:

    build-linux-amd64
    build-linux-amd64-centos7
    build-linux-386
    build-linux-arm
    build-linux-amd64-deb
    build-linux-amd64-centos7-rpm
    build-linux-386-deb
    build-linux-386-rpm
    build-linux-arm-deb
    build-linux-arm-rpm

The GHA workflows builds tarballs as well as deb/rpm packages in the one 
workflow, so the `-deb` and `-rpm` pipelines will need to be manually 
removed from `.drone.yml`.

Still remaining of the linux-based tag build pipelines are the fips 
pipelines which will need some special handing in the GitHub workflow, the
arm64 pipelines which are already converted using a different workflow and
the non-native windows build.

Issue: https://github.com/gravitational/teleport/issues/20729
Changelog: none

---

Note: This requires that https://github.com/gravitational/teleport.e/pull/1923
be merged first, after which the `e` ref update in this PR will be
updated to master (assuming it is not already done by another PR).

This PR has been split into separate commits for easier reviewing. The
first commit just redoes the pipeline generation to make it easier to
see what the following commit does.

The majority of the changes in the diffstat are the changes to `.drone.yml`.
Some of these were generated by dronegen. Some of the removals were
done manually (as required), See the commit message on that commit
for details.