### PR TITLE
[v13] web: Ignore .swc directory when computing web SHA

### DIFF
--- a/build.assets/build-webassets-if-changed.sh
+++ b/build.assets/build-webassets-if-changed.sh
@@ -52,8 +52,12 @@ for i in "${!SRC_DIRECTORIES[@]}"; do
 done
 
 function calculate_sha() {
-  #shellcheck disable=SC2005,SC2086
-  echo "$(find "${SRC_DIRECTORIES[@]}" "$ROOT_PATH/package.json" "$ROOT_PATH/yarn.lock" -not \( -type d -name node_modules -prune \) -type f -print0 | LC_ALL=C sort -z | xargs -0 $SHASUM | awk '{print $1}' | $SHASUM | tr -d ' -')"  
+  #shellcheck disable=SC2086
+  #We want to split $SHASUM on spaces so we dont want it quoted.
+  find "${SRC_DIRECTORIES[@]}" "$ROOT_PATH/package.json" "$ROOT_PATH/yarn.lock" \
+	  -not \( -type d \( -name node_modules -o -name .swc \) -prune \) \
+	  -type f -print0 | \
+	  LC_ALL=C sort -z | xargs -0 $SHASUM | awk '{print $1}' | $SHASUM | tr -d ' -'
 }
 
 # Calculate the current hash-of-hashes of the given source directories. Adds in package.json as well.
@@ -79,7 +83,7 @@ if [ "$BUILD" = "true" ]; then \
   # updated by the build process.
   mkdir -p "$(dirname "$LAST_SHA_FILE")"
   # Save SHA with yarn.lock before yarn install
-  echo $CURRENT_SHA > "$LAST_SHA_FILE"
+  echo "$CURRENT_SHA" > "$LAST_SHA_FILE"
   echo "$TYPE webassets successfully updated."
 else
   echo "$TYPE webassets up to date."


### PR DESCRIPTION
Ignore any `.swc` directories when computing the SHA of SHAs to
determine if `make ensure-webassets` should rebuild the web UI. The
`.swc` directories are in the `.gitignore` file, so should also be
ignored when computing the SHA of the web files.

On a fresh checkout of `teleport`, running `make ensure-webassets`
causes a plugin to be build or downloaded into
`web/packages/teleport/.swc/plugins/v4`. As this is inside the directory
over which the SHA of SHAs is computed, if you re-run
`make ensure-webassets`, it ends up rebuilding the web UI for the same
result. It should not rebuild the web UI if it hasn't changed. The SHA
of SHAs generated from a fresh checkout of teleport should match another
fresh checkout. This fails as generating the enterprise webassets after
generating the OSS webassets includes the plugin as part of the SHA, and
that is not there on a fresh checkin.

This will make a difference if we want to build the web assets as a
separate step on CI so that the `webassets` directory can be copied into
other builds. This will allow a later version of node.js to be used to
build the web UI that what may be available on the OS we're building
Teleport on (I'm looking at you, Centos 7).

Fix a shellcheck-reported issue of quoting while we're here.

Issue: https://github.com/gravitational/teleport/issues/21724
Backport: https://github.com/gravitational/teleport/pull/29892
Changelog: none