### PR TITLE
[v11] chore: Bump Go to 1.20.7

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1376,7 +1376,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20.6
+  RUNTIME: go1.20.7
 trigger:
   event:
     include:
@@ -1585,7 +1585,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20.6
+  RUNTIME: go1.20.7
 trigger:
   event:
     include:
@@ -1793,7 +1793,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20.6
+  RUNTIME: go1.20.7
 trigger:
   event:
     include:
@@ -2008,7 +2008,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20.6
+  RUNTIME: go1.20.7
 trigger:
   event:
     include:
@@ -3308,7 +3308,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20.6
+  RUNTIME: go1.20.7
 trigger:
   event:
     include:
@@ -4134,7 +4134,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20.6
+  RUNTIME: go1.20.7
 trigger:
   event:
     include:
@@ -5463,7 +5463,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport11
-  RUNTIME: go1.20.6
+  RUNTIME: go1.20.7
 trigger:
   event:
     include:
@@ -18762,6 +18762,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: e62b1074cfe89f559626d790ba3a10f62473aab8ff3506c059b39575a2f7284e
+hmac: 6c70c6837661909dc89c9e819eb10d8e54597ab190e916d42fde428db82739ae
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,7 +18,7 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.20.6
+GOLANG_VERSION ?= go1.20.7
 
 NODE_VERSION ?= 16.18.1
 


### PR DESCRIPTION
Update to the latest patch.

* https://groups.google.com/g/golang-announce/c/X0b6CsSAaYI/m/Efv5DbZ9AwAJ
