### PR TITLE
Ensure Helm deployment guides match the sidebar

### DIFF
--- a/docs/pages/deploy-a-cluster/helm-deployments.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments.mdx
@@ -9,11 +9,13 @@ layout: tocless-doc
 These guides show you how to set up a full self-hosted Teleport deployment using
 our `teleport-cluster` Helm chart.
 
-- [Teleport Cluster](./helm-deployments/kubernetes-cluster.mdx): Run a Teleport cluster in a Kubernetes cluster using
+- [Deploy Teleport on Kubernetes](./helm-deployments/kubernetes-cluster.mdx): Run a Teleport cluster in a Kubernetes cluster using
   the default configuration. This deployment is a great starting point to try a self-hosted 
   Teleport with minimal resources. 
 - [HA AWS Teleport Cluster](./helm-deployments/aws.mdx): Running an HA Teleport cluster in Kubernetes using an AWS EKS Cluster
 - [HA GCP Teleport Cluster](./helm-deployments/gcp.mdx): Running an HA Teleport cluster in Kubernetes using a Google Cloud GKE Cluster
+- [DigitalOcean Kubernetes Cluster](./helm-deployments/digitalocean.mdx):
+  Running Teleport on DigitalOcean Kubernetes.
 - [Custom Teleport config](./helm-deployments/custom.mdx): Running a Teleport cluster in Kubernetes with a custom Teleport config
 
 ## Migration Guides


### PR DESCRIPTION
Closes #27406

The DigitalOcean guide is missing in the menu page.