### PR TITLE
pgbk: ensure TOASTed values in the change feed

### DIFF
--- a/lib/backend/pgbk/pgbk.go
+++ b/lib/backend/pgbk/pgbk.go
@@ -480,9 +480,19 @@ func (b *Backend) DeleteRange(ctx context.Context, startKey []byte, endKey []byt
 func (b *Backend) KeepAlive(ctx context.Context, lease backend.Lease, expires time.Time) error {
 	revision := newRevision()
 	updated, err := pgcommon.Retry(ctx, b.log, func() (bool, error) {
+		// value = value || '' forces a value update; if the value is TOASTed
+		// and doesn't change, it won't appear in the change feed
+		//
+		// TODO(espadolini): figure out if it's better to switch to REPLICA
+		// IDENTITY FULL and fill unchanged columns from the identity data; it's
+		// unclear if the benefits of having a more standard solution outweigh
+		// the penalty of essentially doubling the WAL writes for no good
+		// reason, but it might also become useful in the future to have backend
+		// events include the previous state for the item (i.e. it might become
+		// a good reason)
 		tag, err := b.pool.Exec(ctx,
-			"UPDATE kv SET expires = $1, revision = $2 WHERE key = $3 AND (expires IS NULL OR expires > now())",
-			zeronull.Timestamptz(expires.UTC()), revision, lease.Key)
+			"UPDATE kv SET value = value || $1, expires = $2, revision = $3 WHERE key = $4 AND (expires IS NULL OR expires > now())",
+			[]byte(""), zeronull.Timestamptz(expires.UTC()), revision, lease.Key)
 		if err != nil {
 			return false, trace.Wrap(err)
 		}


### PR DESCRIPTION
This PR makes it so that we forcibly update values during `KeepAlive`, because unchanged [TOASTed](https://www.postgresql.org/docs/current/storage-toast.html) values are not stored in the WAL, even at logical level. This can happen when doing `KeepAlive` on a `node` with a lot of labels, for example.

This relies on the planner not being able to see that we are not going to be actually mutating the value; from my tests it seems to work even with a literal `value = value || ''` but we go the extra mile and actually send an always-empty bytestring to concatenate to.

A more stable solution might be to switch to `REPLICA IDENTITY FULL` on the table, but that requires some smarter parsing of the change feed data and comes with some performance drawbacks (as the WAL essentially doubles in volume).

Fixes #29911.