### PR TITLE
Register join metrics into prometheus default registry

### DIFF
--- a/lib/kube/proxy/prometheus.go
+++ b/lib/kube/proxy/prometheus.go
@@ -51,6 +51,8 @@ func init() {
 		execSessionsRequestCounter,
 		portforwardSessionsInFlightGauge,
 		portforwardRequestCounter,
+		joinSessionsInFlightGauge,
+		joinSessionsRequestCounter,
 	)
 }
 


### PR DESCRIPTION
When Kube prometheus metrics were originally introduced by #29970, I missed to register the join sessions metrics into the prometheus default registry. The metrics were collected but were unavailable via `/metrics` endpoint.