### PR TITLE
[docs] add athena docs

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -357,6 +357,7 @@
     "dylib",
     "dynamicappregexample",
     "dynamicregexample",
+    "dynamoathenamigration",
     "eastus",
     "editbasicsaml",
     "efgh",

--- a/docs/pages/reference/audit.mdx
+++ b/docs/pages/reference/audit.mdx
@@ -46,12 +46,12 @@ used, events are written to the filesystem in JSON format. The `dir` backend rot
 the event file approximately once every 24 hours, but never deletes captured events.
 
 For High Availability configurations, users can refer to our
-[DynamoDB](./backends.mdx#dynamodb) or [Firestore](./backends.mdx#firestore)
-chapters for information on how to configure the SSH events and recorded
-sessions to be stored on network storage. When these backends are in use, audit
-events will eventually expire and be removed from the log. The default retention
-period is 1 year, but this can be overridden using the `audit_retention_period`
-configuration parameter.
+[Athena](./backends.mdx#athena), [DynamoDB](./backends.mdx#dynamodb) or
+[Firestore](./backends.mdx#firestore) chapters for information on how to
+configure the SSH events and recorded sessions to be stored on network storage.
+When these backends are in use, audit events will eventually expire and be
+removed from the log. The default retention period is 1 year, but this can be
+overridden using the `audit_retention_period` configuration parameter.
 
 It is even possible to store audit logs in multiple places at the same time. For
 more information on how to configure the audit log, refer to the `storage`

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -798,6 +798,294 @@ Config option priority is applied in the following order:
   are not supported in certain regions or environments or are only supported in GovCloud.
 </Admonition>
 
+## Athena
+
+If you are running Teleport on AWS, you can use an
+[Athena](https://aws.amazon.com/athena/)-based audit log system that manages
+[Parquet files](https://parquet.apache.org/) stored on
+[S3](https://aws.amazon.com/s3/) as a storage back-end to achieve high
+availability. The Athena back-end supports only one type of Teleport data, audit
+events.
+
+The Athena audit back-end is better at scale and search than DynamoDB.
+
+The Athena audit logs are eventually consistent. It may take up to one minute
+(depending on the `batchMaxInterval` setting and event load) until you can view
+events in the Teleport Web UI.
+
+### Infrastructure setup
+
+The Auth Service uses an SQS queue subscribed to an SNS topic for event
+publishing. A single Auth Service instance reads events in batches from SQS,
+converts them into Parquet format, and sends the resulting data to S3. During
+queries, the Athena engine searches for events on S3, reading metadata from a
+Glue table.
+
+You can set up the required infrastructure to support the Athena backend with
+the following Terraform script:
+
+<Details title="Terraform script" opened={false}>
+```
+(!examples/athena/variables.tf!)
+(!examples/athena/athena.tf!)
+```
+</Details>
+
+### Configuring the Athena audit log backend
+
+To configure Teleport to use Athena:
+
+- Make sure you are using **Teleport version 14.0.0** or newer.
+- Prepare infrastructure
+- Specify an Athena URL inside the `audit_events_uri` array in your Teleport
+  configuration file:
+
+```yaml
+teleport:
+  storage:
+    # This setting configures Teleport to keep a copy of the audit log in Athena
+    # and a copy on a local filesystem, and also to output the events to stdout.
+    audit_events_uri:
+      # More details about the full Athena URL are shown below.
+      - 'athena://database.table?params'
+      - 'file:///var/lib/teleport/audit/events'
+      - 'stdout://'
+```
+
+Here is an example of an Amazon Athena URL within the `audit_events_uri` configuration field:
+
+```
+athena://db.table?topicArn=arn:aws:sns:region:account_id:topic_name&largeEventsS3=s3://transient/large_payloads&locationS3=s3://long-term/events&workgroup=workgroup&queueURL=https://sqs.region.amazonaws.com/account_id/queue_name&queryResultsS3=s3://transient/query_results
+```
+
+The URL hostname consist of `database.table`, which points to the Glue database
+and a table which will be used by the Athena audit logger.
+
+Other parameters are specified as query parameters within the Athena URL.
+
+The following parameters are required:
+
+| Parameter name   | Example value                                            | Description                                            |
+|------------------|----------------------------------------------------------|--------------------------------------------------------|
+| `topicArn`       | `arn:aws:sns:region:account_id:topic_name`               | ARN of SNS topic where events are published            |
+| `locationS3`     | `s3://long-term/events`                                  | S3 bucket used for long-term storage                   |
+| `largeEventsS3`  | `s3://transient/large_payloads`                          | S3 bucket used for transient storage for large events  |
+| `queueURL`       | `https://sqs.region.amazonaws.com/account_id/queue_name` | SQS URL used for a subscription to an SNS topic        |
+| `workgroup`      | `workgroup_name`                                         | Athena workgroup used for queries                      |
+| `queryResultsS3` | `s3://transient/results`                                 | S3 bucket used for transient storage for query results |
+
+
+The following parameters are optional:
+
+| Parameter name     | Example value | Description                                                                                           |
+|--------------------|---------------|-------------------------------------------------------------------------------------------------------|
+| `region`           | `us-east-1`   | AWS region. If empty, defaults to one from the AuditConfig or ambient AWS credentials                 |
+| `batchMaxItems`    | `20000`       | defines the maximum number of events allowed for a single Parquet file (default 20000)                |
+| `batchMaxInterval` | `1m`          | defines the maximum interval used to buffer incoming data before creating a Parquet file (default 1m) |
+
+### Authenticating to AWS
+
+The Teleport Auth Service must be able to read AWS credentials in order to
+authenticate to Athena.
+
+(!docs/pages/includes/aws-credentials.mdx service="the Teleport Auth Service"!)
+
+The IAM role that the Teleport Auth Service authenticates as must have the
+policies specified in the next section.
+
+### IAM policies
+
+Make sure that the IAM role assigned to Teleport is configured with sufficient
+access to Athena. Below you can find the IAM permissions that the Auth Service
+requires to use Athena Audit logs as an audit event backend.
+
+You'll need to replace these values in the policy example below:
+
+| Placeholder value | Replace with                                             |
+|-------------------|----------------------------------------------------------|
+| `eu-central-1`    | AWS region                                               |
+| `1234567890`      | AWS account ID                                           |
+| `audit-long-term` | S3 bucket used for long-term storage                     |
+| `audit-transient` | S3 bucket used for transient storage                     |
+| `audit-sqs`       | SNS topic name                                           |
+| `audit-sns`       | SQS name                                                 |
+| `kms_id`          | KMS key ID used for server-side encryption of SNS/SQS/S3 |
+| `audit_db`        | Glue database used for audit logs                        |
+| `audit_table`     | Glue table used for audit logs                           |
+| `audit_workgroup` | Athena workgroup used for audit logs                     |
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "s3:ListBucketMultipartUploads",
+                "s3:GetBucketLocation",
+                "s3:ListBucketVersions",
+                "s3:ListBucket"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::audit-transient",
+                "arn:aws:s3:::audit-long-term"
+            ],
+            "Sid": "AllowListingMultipartUploads"
+        },
+        {
+            "Action": [
+                "s3:PutObject",
+                "s3:ListMultipartUploadParts",
+                "s3:GetObjectVersion",
+                "s3:GetObject",
+                "s3:DeleteObjectVersion",
+                "s3:DeleteObject",
+                "s3:AbortMultipartUpload"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::audit-transient/results/*",
+                "arn:aws:s3:::audit-transient/large_payloads/*",
+                "arn:aws:s3:::audit-long-term/events/*"
+            ],
+            "Sid": "AllowMultipartAndObjectAccess"
+        },
+        {
+            "Action": "sns:Publish",
+            "Effect": "Allow",
+            "Resource": "arn:aws:sns:eu-central-1:1234567890:audit-sqs",
+            "Sid": "AllowPublishSNS"
+        },
+        {
+            "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:DeleteMessage"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:sqs:eu-central-1:1234567890:audit-sns",
+            "Sid": "AllowReceiveSQS"
+        },
+        {
+            "Action": [
+                "glue:GetTable",
+                "athena:StartQueryExecution",
+                "athena:GetQueryResults",
+                "athena:GetQueryExecution"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:glue:eu-central-1:1234567890:table/audit_db/audit_table",
+                "arn:aws:glue:eu-central-1:1234567890:database/audit_db",
+                "arn:aws:glue:eu-central-1:1234567890:catalog",
+                "arn:aws:athena:eu-central-1:1234567890:workgroup/audit_workgroup"
+            ],
+            "Sid": "AllowAthenaQuery"
+        },
+        {
+            "Action": [
+                "kms:GenerateDataKey",
+                "kms:Decrypt"
+            ],
+            "Effect": "Allow",
+            "Resource": "arn:aws:kms:eu-central-1:1234567890:key/kms_id",
+            "Sid": "AllowAthenaKMSUsage"
+        }
+    ]
+}
+```
+
+### Migration from Dynamo to the Athena audit logs backend
+
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  Migration is only needed if you used Amazon DynamoDB for audit logs and you
+  want to keep old data.
+</Admonition>
+
+Migration consist of following steps:
+
+1. Set up Athena infrastructure
+1. Dual write to both DynamoDB and Athena, and query from DynamoDB
+1. Migrate old data from DynamoDB to Athena
+1. Dual write to both DynamoDB and Athena, and query from Athena
+1. Disable writing to DynamoDB
+
+In the Teleport storage configuration, `audit_events_uri` accepts multiple
+URLs. Those URLs are used to configure connections to the different audit
+loggers. If more than 1 is used, then events are written to each audit system,
+and queries are executed from first one.
+
+<Admonition
+  type="tip"
+  title="Tip"
+>
+  If anything goes wrong during migration steps 1-4, roll back to the Amazon
+  DynamoDB solution by making sure its URL is the first value in the
+  `audit_events_uri` field and removing the Athena URL.
+</Admonition>
+
+Each of these steps is explained in more detail below.
+
+#### Dual write to both DynamoDB and Athena, and query from DynamoDB
+
+The second step of migration requires setting the following configuration:
+
+```yaml
+teleport:
+  storage:
+    audit_events_uri:
+    - 'dynamodb://events_table_name'
+    - 'athena://db.table?otherQueryParams'
+```
+
+When an Auth Service instance is restarted, you should verify that Parquet files
+are stored in the S3 bucket specified using the `locationS3` parameter.
+
+#### Migrate old data from DynamoDB to Athena
+
+This step requires using the client machine to export data from Amazon DynamoDB
+and publish it to the Athena logger. We recommend using, for example, an EC2
+instance with a disk size at least 2x bigger than the table size in Amazon
+DynamoDB.
+
+Instructions for how to use the migration tool can be found
+[on GitHub](https://github.com/gravitational/teleport/blob/master/examples/dynamoathenamigration/README.md).
+
+You should set `exportTime` to the time when dual writing began.
+
+We recommend running your first migration with the `-dry-run` flag because it
+validates the exported data. If no errors are reported, proceed to a real
+migration without the `-dry-run` flag.
+
+#### Dual write to both DynamoDB and Athena, and query from Athena
+
+Change the order of the `audit_events_uri` values in your Teleport
+configuration file:
+
+```yaml
+teleport:
+  storage:
+    audit_events_uri:
+    - 'athena://db.table?otherQueryParams'
+    - 'dynamodb://events_table_name'
+```
+
+When the Auth Service is restarted, you should verify that events are visible
+on the Audit Logs page.
+
+#### Disable writing to DynamoDB
+
+Disabling writing to DynamoDB means that you won't be able to roll back to
+DynamoDB without losing data. Dual writing to both Athena and DynamoDB does not
+have a significant performance impact, and it's recommended to keep dual
+writing for some time, even if your system already executes queries from
+Athena.
+
+To disable writing to DynamoDB, remove the DynamoDB URL from the
+`audit_events_uri` array.
+
 ## GCS
 
 <Admonition


### PR DESCRIPTION
This PR adds docs for using Athena Audit logs by self hosted clients.

Part of https://github.com/gravitational/teleport.e/issues/894
RFD: https://github.com/gravitational/teleport/blob/master/rfd/0118-scalable-audit-logs.md

Depends on https://github.com/gravitational/teleport/pull/29895 for terraform examples.

- [x] https://github.com/gravitational/teleport/pull/29895