### PR TITLE
Fix `tool.tsh.common.TestKube/list_kube` flaky test

### DIFF
--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -673,7 +673,7 @@ func TestTSHProxyTemplate(t *testing.T) {
 	require.NoError(t, err)
 
 	s := newTestSuite(t)
-	tshHome := mustLoginSetEnv(t, s)
+	tshHome, _ := mustLoginSetEnv(t, s)
 
 	// Create proxy template configuration.
 	tshConfigFile := filepath.Join(tshHome, tshConfigPath)
@@ -974,9 +974,9 @@ func setMockSSOLogin(t *testing.T, s *suite) CliOption {
 	}
 }
 
-func mustLogin(t *testing.T, s *suite, args ...string) (string, string) {
-	tshHome := t.TempDir()
-	kubeConfig := filepath.Join(t.TempDir(), teleport.KubeConfigFile)
+func mustLogin(t *testing.T, s *suite, args ...string) (tshHome, kubeConfig string) {
+	tshHome = t.TempDir()
+	kubeConfig = filepath.Join(t.TempDir(), teleport.KubeConfigFile)
 	args = append([]string{
 		"login",
 		"--insecure",
@@ -989,24 +989,15 @@ func mustLogin(t *testing.T, s *suite, args ...string) (string, string) {
 		setKubeConfigPath(kubeConfig),
 	)
 	require.NoError(t, err)
-	return tshHome, kubeConfig
+	return
 }
 
 // login with new temp tshHome and set it in Env. This is useful
 // when running "ssh" commands with a tsh "ProxyCommand".
-func mustLoginSetEnv(t *testing.T, s *suite, args ...string) string {
-	tshHome := t.TempDir()
+func mustLoginSetEnv(t *testing.T, s *suite, args ...string) (tshHome, kubeConfig string) {
+	tshHome, kubeConfig = mustLogin(t, s, args...)
 	t.Setenv(types.HomeEnvVar, tshHome)
-
-	args = append([]string{
-		"login",
-		"--insecure",
-		"--debug",
-		"--proxy", s.root.Config.Proxy.WebAddr.String(),
-	}, args...)
-	err := Run(context.Background(), args, setMockSSOLogin(t, s), setHomePath(tshHome))
-	require.NoError(t, err)
-	return tshHome
+	return
 }
 
 func mustLoginIdentity(t *testing.T, s *suite, opts ...CliOption) string {


### PR DESCRIPTION
Tests under `tool.tsh.common.TestKube/list_kube` were picking the leftovers of another test which defined the `$HONE/.kube/config` file. This caused the test to be flaky because depending on the tests runnning order, some kube clusters appeared as selected when running `tsh kube ls`.