### PR TITLE
[v12] Added IP pinning support for TLS routing behind ALB mode

### DIFF
--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -1071,7 +1071,7 @@ func applyProxyConfig(fc *FileConfig, cfg *service.Config) error {
 		return trace.Wrap(err)
 	}
 	cfg.Proxy.ACME = *acme
-
+	cfg.Proxy.TrustXForwardedFor = fc.Proxy.TrustXForwardedFor.Value()
 	return nil
 }
 

--- a/lib/config/configuration_test.go
+++ b/lib/config/configuration_test.go
@@ -219,8 +219,8 @@ func TestSampleConfig(t *testing.T) {
 	}
 }
 
-// TestBooleanParsing tests that boolean options
-// are parsed properly
+// TestBooleanParsing tests that types.Bool and *types.BoolOption are parsed
+// properly
 func TestBooleanParsing(t *testing.T) {
 	testCases := []struct {
 		s string
@@ -240,11 +240,15 @@ func TestBooleanParsing(t *testing.T) {
 		conf, err := ReadFromString(base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf(`
 teleport:
   advertise_ip: 10.10.10.1
+proxy_service:
+  enabled: yes
+  trust_x_forwarded_for: %v
 auth_service:
   enabled: yes
   disconnect_expired_cert: %v
-`, tc.s))))
+`, tc.s, tc.s))))
 		require.NoError(t, err, msg)
+		require.Equal(t, tc.b, conf.Proxy.TrustXForwardedFor.Value(), msg)
 		require.Equal(t, tc.b, conf.Auth.DisconnectExpiredCert.Value, msg)
 	}
 }

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -2024,6 +2024,11 @@ type Proxy struct {
 
 	// Assist is a set of options related to the Teleport Assist feature.
 	Assist *AssistOptions `yaml:"assist,omitempty"`
+
+	// TrustXForwardedFor enables the service to take client source IPs from
+	// the "X-Forwarded-For" headers for web APIs received from layer 7 load
+	// balancers or reverse proxies.
+	TrustXForwardedFor types.Bool `yaml:"trust_x_forwarded_for,omitempty"`
 }
 
 // UIConfig provides config options for the web UI served by the proxy service.

--- a/lib/httplib/httplib.go
+++ b/lib/httplib/httplib.go
@@ -97,6 +97,14 @@ func MakeTracingHandler(h http.Handler, component string) http.Handler {
 	return otelhttp.NewHandler(http.HandlerFunc(handler), component, otelhttp.WithSpanNameFormatter(tracehttp.HandlerFormatter))
 }
 
+// MakeTracingMiddleware returns an HTTP middleware that makes tracing
+// handlers.
+func MakeTracingMiddleware(component string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return MakeTracingHandler(next, component)
+	}
+}
+
 // MakeHandlerWithErrorWriter returns a httprouter.Handle from the HandlerFunc,
 // and sends all errors to ErrorWriter.
 func MakeHandlerWithErrorWriter(fn HandlerFunc, errWriter ErrorWriter) httprouter.Handle {

--- a/lib/limiter/limiter.go
+++ b/lib/limiter/limiter.go
@@ -181,3 +181,16 @@ func (l *Limiter) StreamServerInterceptor(srv interface{}, serverStream grpc.Ser
 func (l *Limiter) WrapListener(ln net.Listener) *Listener {
 	return NewListener(ln, l.ConnectionsLimiter)
 }
+
+type handlerWrapper interface {
+	http.Handler
+	WrapHandle(http.Handler)
+}
+
+// MakeMiddleware creates an HTTP middleware that wraps provided handle.
+func MakeMiddleware(limiter handlerWrapper) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		limiter.WrapHandle(next)
+		return limiter
+	}
+}

--- a/lib/reversetunnel/transport.go
+++ b/lib/reversetunnel/transport.go
@@ -274,7 +274,7 @@ func (p *transport) start() {
 			var clientConn net.Conn = sshutils.NewChConn(p.sconn, p.channel)
 			src, err := utils.ParseAddr(dreq.ClientSrcAddr)
 			if err == nil {
-				clientConn = newConnectionWithSrcAddr(clientConn, src)
+				clientConn = utils.NewConnWithSrcAddr(clientConn, getTCPAddr(src))
 			}
 			p.server.HandleConnection(clientConn)
 			return
@@ -317,7 +317,7 @@ func (p *transport) start() {
 			var clientConn net.Conn = sshutils.NewChConn(p.sconn, p.channel)
 			src, err := utils.ParseAddr(dreq.ClientSrcAddr)
 			if err == nil {
-				clientConn = newConnectionWithSrcAddr(clientConn, src)
+				clientConn = utils.NewConnWithSrcAddr(clientConn, getTCPAddr(src))
 			}
 			p.server.HandleConnection(clientConn)
 			return
@@ -530,37 +530,9 @@ func (p *transport) directDial(addr string) (net.Conn, error) {
 	return conn, nil
 }
 
-// connectionWithSrcAddr is a net.Conn wrapper that allows us to specify remote client address
-type connectionWithSrcAddr struct {
-	net.Conn
-	clientSrcAddr net.Addr
-}
-
-// RemoteAddr returns specified client source address
-func (c *connectionWithSrcAddr) RemoteAddr() net.Addr {
-	return c.clientSrcAddr
-}
-
-// NetConn returns the underlying net.Conn.
-func (c *connectionWithSrcAddr) NetConn() net.Conn {
-	return c.Conn
-}
-
-// newConnectionWithSrcAddr wraps provided connection and overrides client remote address
-func newConnectionWithSrcAddr(conn net.Conn, clientSrcAddr net.Addr) *connectionWithSrcAddr {
-	var addr net.Addr
-	if clientSrcAddr != nil {
-		addr = getTCPAddr(clientSrcAddr) // SSH package requires net.TCPAddr for source-address check
-	}
-	if addr == nil {
-		addr = conn.RemoteAddr()
-	}
-	return &connectionWithSrcAddr{
-		Conn:          conn,
-		clientSrcAddr: addr,
-	}
-}
-
+// getTCPAddr converts net.Addr to *net.TCPAddr.
+//
+// SSH package requires net.TCPAddr for source-address check.
 func getTCPAddr(addr net.Addr) *net.TCPAddr {
 	ap, err := netip.ParseAddrPort(addr.String())
 	if err != nil {

--- a/lib/service/cfg.go
+++ b/lib/service/cfg.go
@@ -552,6 +552,11 @@ type ProxyConfig struct {
 	// AssistAPIKey is the OpenAI API key.
 	// TODO: This key will be moved to a plugin once support for plugins is implemented.
 	AssistAPIKey string
+
+	// TrustXForwardedFor enables the service to take client source IPs from
+	// the "X-Forwarded-For" headers for web APIs recevied from layer 7 load
+	// balancers or reverse proxies.
+	TrustXForwardedFor bool
 }
 
 // ACME configures ACME automatic certificate renewal

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -3709,7 +3709,6 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		proxyLimiter.WrapHandle(webHandler)
 		if !cfg.Proxy.DisableTLS && cfg.Proxy.DisableALPNSNIListener {
 			listeners.tls, err = multiplexer.NewWebListener(multiplexer.WebListenerConfig{
 				Listener: tls.NewListener(listeners.web, tlsConfigWeb),
@@ -3732,7 +3731,12 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 
 		webServer, err = web.NewServer(web.ServerConfig{
 			Server: &http.Server{
-				Handler:           httplib.MakeTracingHandler(proxyLimiter, teleport.ComponentProxy),
+				Handler: utils.ChainHTTPMiddlewares(
+					webHandler,
+					makeXForwardedForMiddleware(cfg),
+					limiter.MakeMiddleware(proxyLimiter),
+					httplib.MakeTracingMiddleware(teleport.ComponentProxy),
+				),
 				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
 				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
@@ -5480,4 +5484,11 @@ func copyAndConfigureTLS(config *tls.Config, log logrus.FieldLogger, accessPoint
 	tlsConfig.GetConfigForClient = auth.WithClusterCAs(tlsConfig.Clone(), accessPoint, clusterName, log)
 
 	return tlsConfig
+}
+
+func makeXForwardedForMiddleware(cfg *Config) utils.HTTPMiddleware {
+	if cfg.Proxy.TrustXForwardedFor {
+		return web.NewXForwardedForMiddleware
+	}
+	return utils.NoopHTTPMiddleware
 }

--- a/lib/utils/conn.go
+++ b/lib/utils/conn.go
@@ -197,3 +197,30 @@ func (w *TrackingWriter) Write(b []byte) (int, error) {
 	atomic.AddUint64(&w.count, uint64(n))
 	return n, trace.Wrap(err)
 }
+
+// ConnWithSrcAddr is a net.Conn wrapper that allows us to specify remote client address
+type ConnWithSrcAddr struct {
+	net.Conn
+	clientSrcAddr net.Addr
+}
+
+// RemoteAddr returns specified client source address
+func (c *ConnWithSrcAddr) RemoteAddr() net.Addr {
+	if c.clientSrcAddr == nil {
+		return c.Conn.RemoteAddr()
+	}
+	return c.clientSrcAddr
+}
+
+// NetConn returns the underlying net.Conn.
+func (c *ConnWithSrcAddr) NetConn() net.Conn {
+	return c.Conn
+}
+
+// NewConnWithSrcAddr wraps provided connection and overrides client remote address
+func NewConnWithSrcAddr(conn net.Conn, clientSrcAddr net.Addr) *ConnWithSrcAddr {
+	return &ConnWithSrcAddr{
+		Conn:          conn,
+		clientSrcAddr: clientSrcAddr,
+	}
+}

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -116,3 +116,26 @@ func GetAnyHeader(header http.Header, keys ...string) string {
 	}
 	return ""
 }
+
+// HTTPMiddleware defines a HTTP middleware.
+type HTTPMiddleware func(next http.Handler) http.Handler
+
+// ChainHTTPMiddlewares wraps an http.Handler with a list of middlewares. Inner
+// middlewares should be provided before outer middlewares.
+func ChainHTTPMiddlewares(handler http.Handler, middlewares ...HTTPMiddleware) http.Handler {
+	if len(middlewares) == 0 {
+		return handler
+	}
+	apply := middlewares[0]
+	middlewares = middlewares[1:]
+	if apply != nil {
+		handler = apply(handler)
+	}
+	return ChainHTTPMiddlewares(handler, middlewares...)
+}
+
+// NoopHTTPMiddleware is a no-operation HTTPMiddleware that returns the
+// original handler.
+func NoopHTTPMiddleware(next http.Handler) http.Handler {
+	return next
+}

--- a/lib/utils/http_test.go
+++ b/lib/utils/http_test.go
@@ -17,7 +17,9 @@ limitations under the License.
 package utils
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -50,4 +52,43 @@ func TestGetAnyHeader(t *testing.T) {
 	require.Equal(t, "a1", GetAnyHeader(header, "aaa"))
 	require.Equal(t, "a1", GetAnyHeader(header, "ccc", "aaa"))
 	require.Equal(t, "b1", GetAnyHeader(header, "bbb", "aaa"))
+}
+
+func TestChainHTTPMiddlewares(t *testing.T) {
+	baseHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("baseHandler"))
+	})
+
+	middleware2 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("middleware2->"))
+			next.ServeHTTP(w, r)
+		})
+	}
+	middleware4 := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("middleware4->"))
+			next.ServeHTTP(w, r)
+		})
+	}
+
+	handler := ChainHTTPMiddlewares(
+		baseHandler,
+		nil,
+		middleware2,
+		NoopHTTPMiddleware,
+		middleware4,
+	)
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("", "/", nil)
+	handler.ServeHTTP(w, r)
+
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.Equal(t, "middleware4->middleware2->baseHandler", string(body))
 }

--- a/lib/utils/net.go
+++ b/lib/utils/net.go
@@ -41,6 +41,11 @@ func ClientAddrContext(ctx context.Context, src net.Addr, dst net.Addr) context.
 	return context.WithValue(ctx, ClientDstAddrContextKey, dst)
 }
 
+// ClientSrcAddrContext sets client source address.
+func ClientSrcAddrContext(ctx context.Context, src net.Addr) context.Context {
+	return context.WithValue(ctx, ClientSrcAddrContextKey, src)
+}
+
 // ClientAddrFromContext gets client source address and destination addresses from the context. If an address is
 // not present, nil will be returned
 func ClientAddrFromContext(ctx context.Context) (src net.Addr, dst net.Addr) {

--- a/lib/web/addr.go
+++ b/lib/web/addr.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"bufio"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+const xForwardedForHeader = "X-Forwarded-For"
+
+// NewXForwardedForMiddleware is an HTTP middleware that overwrites client
+// source address if X-Forwarded-For is set.
+//
+// Both hijacked conn and request context are updated. The hijacked conn can be
+// used for ALPN connection upgrades or Websocket connections.
+func NewXForwardedForMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		clientSrcAddr, err := parseXForwardedForHeaders(r.RemoteAddr, r.Header.Values(xForwardedForHeader))
+		switch {
+		// Skip updating client source address if no X-Forwarded-For is
+		// present. For example, the request may come from an internal
+		// network or the load balancer itself.
+		case trace.IsNotFound(err):
+			next.ServeHTTP(w, r)
+
+		// Reject the request on error.
+		case err != nil:
+			trace.WriteError(w, err)
+
+		// Serve with updated client source address.
+		default:
+			next.ServeHTTP(
+				responseWriterWithClientSrcAddr(w, clientSrcAddr),
+				requestWithClientSrcAddr(r, clientSrcAddr),
+			)
+		}
+	})
+}
+
+// parseXForwardedForHeaders returns a net.Addr from provided values of X-Forwarded-For.
+//
+// MDN reference:
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For
+//
+// AWS ALB reference:
+// https://docs.aws.amazon.com/elasticloadbalancing/latest/application/x-forwarded-headers.html
+func parseXForwardedForHeaders(observedAddr string, xForwardedForHeaders []string) (net.Addr, error) {
+	switch len(xForwardedForHeaders) {
+	case 0:
+		return nil, trace.NotFound("no X-Forwarded-For headers")
+
+	case 1:
+		// Reject multiple IPs.
+		if strings.Contains(xForwardedForHeaders[0], ",") {
+			return nil, trace.BadParameter("expect a single IP from X-Forwarded-For but got %v", xForwardedForHeaders)
+		}
+
+	default:
+		// Reject multiple IPs.
+		return nil, trace.BadParameter("expect a single IP from X-Forwarded-For but got %v", xForwardedForHeaders)
+	}
+
+	// If forwardedAddr has a port, use that.
+	forwardedAddr := strings.TrimSpace(xForwardedForHeaders[0])
+	if ipAddrPort, err := netip.ParseAddrPort(forwardedAddr); err == nil {
+		return net.TCPAddrFromAddrPort(ipAddrPort), nil
+	}
+
+	// If forwardedAddr does not have a port, use port from observedAddr.
+	ipAddr, err := netip.ParseAddr(forwardedAddr)
+	if err != nil {
+		return nil, trace.BadParameter("invalid X-Forwarded-For %v: %v", xForwardedForHeaders, err)
+	}
+
+	var port int
+	if parsed, err := utils.ParseAddr(observedAddr); err == nil {
+		port = parsed.Port(port)
+	}
+
+	return net.TCPAddrFromAddrPort(netip.AddrPortFrom(ipAddr, uint16(port))), nil
+}
+
+func requestWithClientSrcAddr(r *http.Request, clientSrcAddr net.Addr) *http.Request {
+	ctx := utils.ClientSrcAddrContext(r.Context(), clientSrcAddr)
+	r = r.WithContext(ctx)
+	r.RemoteAddr = clientSrcAddr.String()
+	return r
+}
+
+func responseWriterWithClientSrcAddr(w http.ResponseWriter, clientSrcAddr net.Addr) http.ResponseWriter {
+	// Returns the original ResponseWriter if not a http.Hijacker.
+	_, ok := w.(http.Hijacker)
+	if !ok {
+		logrus.Debug("Provided ResponseWriter is not a hijacker.")
+		return w
+	}
+
+	return &responseWriterWithRemoteAddr{
+		ResponseWriter: w,
+		remoteAddr:     clientSrcAddr,
+	}
+}
+
+// responseWriterWithRemoteAddr is a wrapper of provided http.ResponseWriter
+// and overwrites Hijacker interface to return a net.Conn with provided
+// remoteAddr.
+type responseWriterWithRemoteAddr struct {
+	http.ResponseWriter
+	remoteAddr net.Addr
+}
+
+// Hijack returns a net.Conn with provided remoteAddr.
+func (r *responseWriterWithRemoteAddr) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := r.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, trace.BadParameter("provided ResponseWriter is not a hijacker")
+	}
+	conn, buffer, err := hijacker.Hijack()
+	if err != nil {
+		return conn, buffer, trace.Wrap(err)
+	}
+
+	return utils.NewConnWithSrcAddr(conn, r.remoteAddr), buffer, nil
+}

--- a/lib/web/addr_test.go
+++ b/lib/web/addr_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package web
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/utils"
+)
+
+func TestNewXForwardedForMiddleware(t *testing.T) {
+	t.Parallel()
+
+	observeredAddr := utils.MustParseAddr("11.22.33.44:1234")
+	xForwardedAddr := utils.MustParseAddr("55.66.77.88:5678")
+
+	// Setup response writer with observeredAddr.
+	fakeConn, _ := net.Pipe()
+
+	// Setup request with observeredAddr.
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req = req.WithContext(utils.ClientSrcAddrContext(req.Context(), observeredAddr))
+	req.RemoteAddr = observeredAddr.String()
+
+	// Setup other requests for testing.
+	reqWithXFF := req.Clone(req.Context())
+	reqWithXFF.Header.Set("X-Forwarded-For", xForwardedAddr.String())
+
+	reqWithMultipleXFF := req.Clone(req.Context())
+	reqWithMultipleXFF.Header.Add("X-Forwarded-For", xForwardedAddr.String())
+	reqWithMultipleXFF.Header.Add("X-Forwarded-For", "88.77.66.55:8765")
+
+	tests := []struct {
+		name           string
+		inputReq       *http.Request
+		wantRemoteAddr string
+		wantError      bool
+	}{
+		{
+			name:           "no X-Forwarded-For header",
+			inputReq:       req,
+			wantRemoteAddr: observeredAddr.String(),
+		},
+		{
+			name:      "multiple X-Forwarded-For values",
+			inputReq:  reqWithMultipleXFF,
+			wantError: true,
+		},
+		{
+			name:           "using X-Forwarded-For header",
+			inputReq:       reqWithXFF,
+			wantRemoteAddr: xForwardedAddr.String(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			checkRemoteAddr := http.HandlerFunc(func(outputRW http.ResponseWriter, outputReq *http.Request) {
+				// Verify hijacked conn.
+				hj, ok := outputRW.(http.Hijacker)
+				require.True(t, ok)
+				outputConn, _, err := hj.Hijack()
+				require.NoError(t, err)
+				require.Equal(t, test.wantRemoteAddr, outputConn.RemoteAddr().String())
+
+				// Verify request.
+				require.Equal(t, test.wantRemoteAddr, outputReq.RemoteAddr)
+
+				// Verify request context.
+				clientSrcAddr, _ := utils.ClientAddrFromContext(outputReq.Context())
+				require.Equal(t, test.wantRemoteAddr, clientSrcAddr.String())
+
+				outputRW.WriteHeader(http.StatusAccepted)
+			})
+
+			recorder := httptest.NewRecorder()
+			inputResponseWriter := &responseWriterWithRemoteAddr{
+				ResponseWriter: newResponseWriterHijacker(recorder, fakeConn),
+				remoteAddr:     observeredAddr,
+			}
+			handler := NewXForwardedForMiddleware(checkRemoteAddr)
+			handler.ServeHTTP(inputResponseWriter, test.inputReq)
+
+			response := recorder.Result()
+			defer response.Body.Close()
+			if test.wantError {
+				require.Equal(t, http.StatusBadRequest, response.StatusCode)
+			} else {
+				require.Equal(t, http.StatusAccepted, response.StatusCode)
+			}
+		})
+	}
+
+}
+
+func TestParseXForwardedForHeaders(t *testing.T) {
+	t.Parallel()
+
+	inputObserveredAddr := "1.2.3.4:12345"
+	tests := []struct {
+		name                      string
+		inputXForwardedForHeaders []string
+		wantAddr                  string
+		wantError                 func(error) bool
+	}{
+		{
+			name:                      "empty",
+			inputXForwardedForHeaders: []string{},
+			wantError:                 trace.IsNotFound,
+		},
+		{
+			name:                      "invalid X-Forwarded-For",
+			inputXForwardedForHeaders: []string{"not-an-ip"},
+			wantError:                 trace.IsBadParameter,
+		},
+		{
+			name:                      "ipv4",
+			inputXForwardedForHeaders: []string{"3.4.5.6"},
+			wantAddr:                  "3.4.5.6:12345",
+		},
+		{
+			name:                      "ipv4 with port",
+			inputXForwardedForHeaders: []string{"3.4.5.6:22222"},
+			wantAddr:                  "3.4.5.6:22222",
+		},
+		{
+			name:                      "ipv6",
+			inputXForwardedForHeaders: []string{"2001:db8::21f:5bff:febf:ce22:8a2e"},
+			wantAddr:                  "[2001:db8:0:21f:5bff:febf:ce22:8a2e]:12345",
+		},
+		{
+			name:                      "ipv6 with port",
+			inputXForwardedForHeaders: []string{"[2001:db8::21f:5bff:febf:ce22:8a2e]:22222"},
+			wantAddr:                  "[2001:db8:0:21f:5bff:febf:ce22:8a2e]:22222",
+		},
+		{
+			name:                      "multiple IPs",
+			inputXForwardedForHeaders: []string{"3.4.5.6, 7.8.9.10, 11.12.13.14"},
+			wantError:                 trace.IsBadParameter,
+		},
+		{
+			name:                      "multiple headers",
+			inputXForwardedForHeaders: []string{"3.4.5.6", "7.8.9.10", "11.12.13.14"},
+			wantError:                 trace.IsBadParameter,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actualAddr, err := parseXForwardedForHeaders(inputObserveredAddr, test.inputXForwardedForHeaders)
+			if test.wantError != nil {
+				require.True(t, test.wantError(err))
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, test.wantAddr, actualAddr.String())
+			}
+		})
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -277,7 +277,6 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// request has a session cookie or a client cert, forward to
 	// application handlers. If the request is requesting a
 	// FQDN that is not of the proxy, redirect to application launcher.
-
 	if h.appHandler != nil && (app.HasFragment(r) || app.HasSession(r) || app.HasClientCert(r)) {
 		h.appHandler.ServeHTTP(w, r)
 		return
@@ -1950,8 +1949,6 @@ func (h *Handler) createWebSession(w http.ResponseWriter, r *http.Request, p htt
 }
 
 func clientMetaFromReq(r *http.Request) *auth.ForwardedClientMetadata {
-	// multiplexer handles extracting real client IP using PROXY protocol where
-	// available, so we can omit checking X-Forwarded-For.
 	return &auth.ForwardedClientMetadata{
 		UserAgent:  r.UserAgent(),
 		RemoteAddr: r.RemoteAddr,

--- a/lib/web/conn_upgrade_test.go
+++ b/lib/web/conn_upgrade_test.go
@@ -98,7 +98,7 @@ func TestHandlerConnectionUpgrade(t *testing.T) {
 		r, err := http.NewRequest("GET", "http://localhost/webapi/connectionupgrade", nil)
 		require.NoError(t, err)
 		r.Header.Add("Upgrade", "alpn")
-		r.Header.Add("X-Forwarded-For", xForwardedFor)
+		r.Header.Add("X-Forwarded-For", expectedIP)
 
 		go func() {
 			// serverConn will be hijacked.


### PR DESCRIPTION
backport #26623 to branch/v12

aka `proxy_service.trust_x_forwarded_for` support. Requested by customer for v12.

Note that this is for `proxy_listener_mode` set to `separate`, where the web port is served behind L7 LB but the rest of the ports are served by L4 LBs. In this case, TLS routing is only relevant for the web port, and requires `proxy_service.trust_x_forwarded_for`. PROXY protocol must also be enabled for other ports.

Tested with an ALB+NLB setup.