### PR TITLE
[v13] [Mattermost] Lax requiring recipients and set raw recipients on cfg init 

### DIFF
--- a/api/types/plugin.go
+++ b/api/types/plugin.go
@@ -396,11 +396,15 @@ func (s *PluginMattermostSettings) CheckAndSetDefaults() error {
 	if s.ServerUrl == "" {
 		return trace.BadParameter("server url is required")
 	}
-	if s.Team == "" {
-		return trace.BadParameter("team is required")
-	}
-	if s.Channel == "" {
-		return trace.BadParameter("channel is required")
+
+	// If one field is defined, both should be required.
+	if len(s.Channel) > 0 || len(s.Team) > 0 {
+		if len(s.Team) == 0 {
+			return trace.BadParameter("team is required")
+		}
+		if len(s.Channel) == 0 {
+			return trace.BadParameter("channel is required")
+		}
 	}
 	return nil
 }

--- a/api/types/plugin_test.go
+++ b/api/types/plugin_test.go
@@ -469,6 +469,7 @@ func TestPluginMattermostValidation(t *testing.T) {
 			settings: &PluginSpecV1_Mattermost{
 				Mattermost: &PluginMattermostSettings{
 					ServerUrl: "https://test.mattermost.com",
+					Channel:   "some-channel",
 				},
 			},
 			creds: nil,
@@ -527,8 +528,28 @@ func TestPluginMattermostValidation(t *testing.T) {
 			},
 		},
 		{
-			name:     "valid settings",
+			name:     "valid settings with team/channel",
 			settings: defaultSettings,
+			creds: &PluginCredentialsV1{
+				Credentials: &PluginCredentialsV1_StaticCredentialsRef{
+					&PluginStaticCredentialsRef{
+						Labels: map[string]string{
+							"label1": "value1",
+						},
+					},
+				},
+			},
+			assertErr: func(t require.TestingT, err error, args ...any) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "valid settings with no team/channel",
+			settings: &PluginSpecV1_Mattermost{
+				Mattermost: &PluginMattermostSettings{
+					ServerUrl: "https://test.mattermost.com",
+				},
+			},
 			creds: &PluginCredentialsV1{
 				Credentials: &PluginCredentialsV1_StaticCredentialsRef{
 					&PluginStaticCredentialsRef{

--- a/integrations/access/common/config.go
+++ b/integrations/access/common/config.go
@@ -40,9 +40,9 @@ type PluginConfiguration interface {
 }
 
 type BaseConfig struct {
-	Teleport   lib.TeleportConfig
-	Recipients RawRecipientsMap `toml:"role_to_recipients"`
-	Log        logger.Config
+	Teleport   lib.TeleportConfig `toml:"teleport"`
+	Recipients RawRecipientsMap   `toml:"role_to_recipients"`
+	Log        logger.Config      `toml:"log"`
 	PluginType types.PluginType
 }
 

--- a/integrations/access/mattermost/bot.go
+++ b/integrations/access/mattermost/bot.go
@@ -471,11 +471,13 @@ func (b Bot) tryLookupChannel(ctx context.Context, team, name string) string {
 // FetchRecipient returns the recipient for the given raw recipient.
 func (b Bot) FetchRecipient(ctx context.Context, recipient string) (*common.Recipient, error) {
 	var channel string
+	kind := "Channel"
 
 	// Recipients from config file could contain either email or team and
 	// channel names separated by '/' symbol. It's up to user what format to use.
 	if lib.IsEmail(recipient) {
 		channel = b.tryLookupDirectChannel(ctx, recipient)
+		kind = "Email"
 	} else {
 		parts := strings.Split(recipient, "/")
 		if len(parts) == 2 {
@@ -488,7 +490,7 @@ func (b Bot) FetchRecipient(ctx context.Context, recipient string) (*common.Reci
 	return &common.Recipient{
 		Name: recipient,
 		ID:   channel,
-		Kind: "Channel",
+		Kind: kind,
 		Data: nil,
 	}, nil
 }

--- a/integrations/access/mattermost/config.go
+++ b/integrations/access/mattermost/config.go
@@ -35,7 +35,7 @@ type Config struct {
 
 type MattermostConfig struct {
 	URL        string   `toml:"url"`
-	Recipients []string `toml:"recipients"`
+	Recipients []string `toml:"recipients"` // optional
 	Token      string   `toml:"token"`
 }
 
@@ -70,11 +70,12 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Mattermost.URL == "" {
 		return trace.BadParameter("missing required value mattermost.url")
 	}
-	if len(c.Mattermost.Recipients) == 0 {
-		return trace.BadParameter("missing required value mattermost.recipients")
-	}
-	c.Recipients = common.RawRecipientsMap{
-		"*": c.Mattermost.Recipients,
+
+	// Optional field.
+	if len(c.Mattermost.Recipients) > 0 {
+		c.Recipients = common.RawRecipientsMap{
+			"*": c.Mattermost.Recipients,
+		}
 	}
 
 	if c.Log.Output == "" {

--- a/integrations/access/mattermost/config.go
+++ b/integrations/access/mattermost/config.go
@@ -29,7 +29,7 @@ import (
 
 type Config struct {
 	common.BaseConfig
-	Mattermost MattermostConfig
+	Mattermost MattermostConfig `toml:"mattermost"`
 	StatusSink common.StatusSink
 }
 
@@ -70,15 +70,18 @@ func (c *Config) CheckAndSetDefaults() error {
 	if c.Mattermost.URL == "" {
 		return trace.BadParameter("missing required value mattermost.url")
 	}
+	if len(c.Mattermost.Recipients) == 0 {
+		return trace.BadParameter("missing required value mattermost.recipients")
+	}
+	c.Recipients = common.RawRecipientsMap{
+		"*": c.Mattermost.Recipients,
+	}
+
 	if c.Log.Output == "" {
 		c.Log.Output = "stderr"
 	}
 	if c.Log.Severity == "" {
 		c.Log.Severity = "info"
-	}
-
-	if len(c.Recipients) == 0 {
-		return trace.BadParameter("missing required value mattermost.recipients")
 	}
 
 	c.PluginType = types.PluginTypeMattermost


### PR DESCRIPTION
Backport #29889 to branch/v13

Changelog: Removed requiring inputs for team/channel for mattermost plugin