### PR TITLE
Adjust max session duration in web sessions

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3274,20 +3274,20 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 func (a *Server) getWebSessionTTL(accessRequest types.AccessRequest) time.Time {
 	webSessionTTL := accessRequest.GetAccessExpiry()
 	sessionTTL := accessRequest.GetSessionTLL()
-
-	// If the sessionTTL is not set, use the session duration.
-	if !sessionTTL.IsZero() {
-		// Session TTL contains the time when the session should end.
-		// We need to subtract it from the creation time to get the
-		// session duration.
-		sessionDuration := sessionTTL.Sub(accessRequest.GetCreationTime())
-		// Calculate the adjusted session TTL.
-		adjustedSessionTTL := a.clock.Now().UTC().Add(sessionDuration)
-		if webSessionTTL.After(adjustedSessionTTL) {
-			webSessionTTL = adjustedSessionTTL
-		}
+	if sessionTTL.IsZero() {
+		return webSessionTTL
 	}
 
+	// Session TTL contains the time when the session should end.
+	// We need to subtract it from the creation time to get the
+	// session duration.
+	sessionDuration := sessionTTL.Sub(accessRequest.GetCreationTime())
+	// Calculate the adjusted session TTL.
+	adjustedSessionTTL := a.clock.Now().UTC().Add(sessionDuration)
+	// Adjusted TTL can't exceed webSessionTTL.
+	if adjustedSessionTTL.Before(webSessionTTL) {
+		return adjustedSessionTTL
+	}
 	return webSessionTTL
 }
 

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3210,15 +3210,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 			allowedResourceIDs = accessRequest.GetRequestedResourceIDs()
 		}
 
-		webSessionTTL := accessRequest.GetAccessExpiry()
-		sessionTTL := accessRequest.GetSessionTLL()
-		if !sessionTTL.IsZero() {
-			sessionDuration := sessionTTL.Sub(accessRequest.GetCreationTime())
-			adjustedSessionTTL := a.clock.Now().UTC().Add(sessionDuration)
-			if webSessionTTL.After(adjustedSessionTTL) {
-				webSessionTTL = adjustedSessionTTL
-			}
-		}
+		webSessionTTL := a.getWebSessionTTL(accessRequest)
 
 		// Let the session expire with the shortest expiry time.
 		if expiresAt.After(webSessionTTL) {
@@ -3276,6 +3268,27 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 	}
 
 	return sess, nil
+}
+
+// getWebSessionTTL returns the earliest expiration time of allowed in the access request.
+func (a *Server) getWebSessionTTL(accessRequest types.AccessRequest) time.Time {
+	webSessionTTL := accessRequest.GetAccessExpiry()
+	sessionTTL := accessRequest.GetSessionTLL()
+
+	// If the sessionTTL is not set, use the session duration.
+	if !sessionTTL.IsZero() {
+		// Session TTL contains the time when the session should end.
+		// We need to subtract it from the creation time to get the
+		// session duration.
+		sessionDuration := sessionTTL.Sub(accessRequest.GetCreationTime())
+		// Calculate the adjusted session TTL.
+		adjustedSessionTTL := a.clock.Now().UTC().Add(sessionDuration)
+		if webSessionTTL.After(adjustedSessionTTL) {
+			webSessionTTL = adjustedSessionTTL
+		}
+	}
+
+	return webSessionTTL
 }
 
 func (a *Server) getValidatedAccessRequest(ctx context.Context, identity tlsca.Identity, user string, accessRequestID string) (types.AccessRequest, error) {

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -3182,7 +3182,7 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 
 	if req.ReloadUser {
 		// We don't call from the cache layer because we want to
-		// retrieve the recently updated user. Otherwise the cache
+		// retrieve the recently updated user. Otherwise, the cache
 		// returns stale data.
 		user, err := a.Identity.GetUser(req.User, false)
 		if err != nil {
@@ -3210,9 +3210,19 @@ func (a *Server) ExtendWebSession(ctx context.Context, req WebSessionReq, identi
 			allowedResourceIDs = accessRequest.GetRequestedResourceIDs()
 		}
 
-		// Let session expire with the shortest expiry time.
-		if expiresAt.After(accessRequest.GetAccessExpiry()) {
-			expiresAt = accessRequest.GetAccessExpiry()
+		webSessionTTL := accessRequest.GetAccessExpiry()
+		sessionTTL := accessRequest.GetSessionTLL()
+		if !sessionTTL.IsZero() {
+			sessionDuration := sessionTTL.Sub(accessRequest.GetCreationTime())
+			adjustedSessionTTL := a.clock.Now().UTC().Add(sessionDuration)
+			if webSessionTTL.After(adjustedSessionTTL) {
+				webSessionTTL = adjustedSessionTTL
+			}
+		}
+
+		// Let the session expire with the shortest expiry time.
+		if expiresAt.After(webSessionTTL) {
+			expiresAt = webSessionTTL
 		}
 	} else if req.Switchback {
 		if prevSession.GetLoginTime().IsZero() {

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1825,16 +1825,6 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, newUser.GetRoles(), 1)
 
-	requestableRole, err := clt.GetRole(ctx, newUser.GetRoles()[0])
-	require.NoError(t, err)
-
-	requestableRole.SetAccessRequestConditions(types.Allow, types.AccessRequestConditions{
-		Roles:       []string{testRequestRole},
-		MaxDuration: types.Duration(5 * time.Hour),
-	})
-	err = clt.UpsertRole(ctx, requestableRole)
-	require.NoError(t, err)
-
 	require.Len(t, newUser.GetRoles(), 1)
 	require.Empty(t, cmp.Diff(newUser.GetRoles(), []string{"user:user2"}))
 
@@ -1858,26 +1848,64 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 	web, err := testSrv.NewClientFromWebSession(ws)
 	require.NoError(t, err)
 
-	// Create an approved access request.
-	accessReq, err := services.NewAccessRequest(user, []string{"test-request-role"}...)
-	require.NoError(t, err)
+	testCases := []struct {
+		desc            string
+		maxDurationRole time.Duration
+		expectedExpiry  time.Duration
+	}{
+		{
+			desc:            "default",
+			maxDurationRole: 0,
+			expectedExpiry:  12 * time.Hour, // default certificate TTL
+		},
+		{
+			desc:            "max duration is set",
+			maxDurationRole: 5 * time.Hour,
+			expectedExpiry:  5 * time.Hour,
+		},
+		{
+			desc:            "max duration greater than default",
+			maxDurationRole: 24 * time.Hour,
+			expectedExpiry:  12 * time.Hour,
+		},
+	}
 
-	// Set a lesser expiry date, to test switching back to default expiration later.
-	//accessReq.SetAccessExpiry(clock.Now().Add(time.Minute * 10))
-	accessReq.SetMaxDuration(clock.Now().Add(5 * time.Hour))
-	accessReq.SetState(types.RequestState_APPROVED)
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			requestableRole, err := clt.GetRole(ctx, newUser.GetRoles()[0])
+			require.NoError(t, err)
 
-	err = clt.CreateAccessRequest(ctx, accessReq)
-	require.NoError(t, err)
+			// Set max duration on the role.
+			requestableRole.SetAccessRequestConditions(types.Allow, types.AccessRequestConditions{
+				Roles:       []string{testRequestRole},
+				MaxDuration: types.Duration(tc.maxDurationRole),
+			})
+			err = clt.UpsertRole(ctx, requestableRole)
+			require.NoError(t, err)
 
-	sess1, err := web.ExtendWebSession(ctx, WebSessionReq{
-		User:            user,
-		PrevSessionID:   ws.GetName(),
-		AccessRequestID: accessReq.GetMetadata().Name,
-	})
-	require.NoError(t, err)
+			// Create an approved access request.
+			accessReq, err := services.NewAccessRequest(user, []string{testRequestRole}...)
+			require.NoError(t, err)
 
-	require.WithinDuration(t, clock.Now().Add(5*time.Hour), sess1.Expiry(), time.Second)
+			// Set max duration higher than the role max duration. It will be capped.
+			accessReq.SetMaxDuration(clock.Now().Add(48 * time.Hour))
+			err = accessReq.SetState(types.RequestState_APPROVED)
+			require.NoError(t, err)
+
+			err = clt.CreateAccessRequest(ctx, accessReq)
+			require.NoError(t, err)
+
+			sess1, err := web.ExtendWebSession(ctx, WebSessionReq{
+				User:            user,
+				PrevSessionID:   ws.GetName(),
+				AccessRequestID: accessReq.GetMetadata().Name,
+			})
+			require.NoError(t, err)
+
+			// Check the expiry is capped to the max allowed duration.
+			require.WithinDuration(t, clock.Now().Add(tc.expectedExpiry), sess1.Expiry(), time.Second)
+		})
+	}
 }
 
 // TestGetCertAuthority tests certificate authority permissions

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1807,6 +1807,79 @@ func TestExtendWebSessionWithReloadUser(t *testing.T) {
 	require.Equal(t, traits[constants.TraitDBUsers], []string{"llama", "alpaca"})
 }
 
+func TestExtendWebSessionWithMaxDuration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testSrv := newTestTLSServer(t)
+	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
+
+	clt, err := testSrv.NewClient(TestAdmin())
+	require.NoError(t, err)
+
+	const user = "user2"
+	const testRequestRole = "test-request-role"
+	pass := []byte("abc123")
+
+	newUser, err := CreateUserRoleAndRequestable(clt, user, testRequestRole)
+	require.NoError(t, err)
+	require.Len(t, newUser.GetRoles(), 1)
+
+	requestableRole, err := clt.GetRole(ctx, newUser.GetRoles()[0])
+	require.NoError(t, err)
+
+	requestableRole.SetAccessRequestConditions(types.Allow, types.AccessRequestConditions{
+		Roles:       []string{testRequestRole},
+		MaxDuration: types.Duration(5 * time.Hour),
+	})
+	err = clt.UpsertRole(ctx, requestableRole)
+	require.NoError(t, err)
+
+	require.Len(t, newUser.GetRoles(), 1)
+	require.Empty(t, cmp.Diff(newUser.GetRoles(), []string{"user:user2"}))
+
+	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	require.NoError(t, err)
+
+	// Create a user to create a web session for.
+	req := AuthenticateUserRequest{
+		Username: user,
+		Pass: &PassCreds{
+			Password: pass,
+		},
+	}
+
+	err = testSrv.Auth().UpsertPassword(user, pass)
+	require.NoError(t, err)
+
+	ws, err := proxy.AuthenticateWebUser(ctx, req)
+	require.NoError(t, err)
+
+	web, err := testSrv.NewClientFromWebSession(ws)
+	require.NoError(t, err)
+
+	// Create an approved access request.
+	accessReq, err := services.NewAccessRequest(user, []string{"test-request-role"}...)
+	require.NoError(t, err)
+
+	// Set a lesser expiry date, to test switching back to default expiration later.
+	//accessReq.SetAccessExpiry(clock.Now().Add(time.Minute * 10))
+	accessReq.SetMaxDuration(clock.Now().Add(5 * time.Hour))
+	accessReq.SetState(types.RequestState_APPROVED)
+
+	err = clt.CreateAccessRequest(ctx, accessReq)
+	require.NoError(t, err)
+
+	sess1, err := web.ExtendWebSession(ctx, WebSessionReq{
+		User:            user,
+		PrevSessionID:   ws.GetName(),
+		AccessRequestID: accessReq.GetMetadata().Name,
+	})
+	require.NoError(t, err)
+
+	require.WithinDuration(t, clock.Now().Add(5*time.Hour), sess1.Expiry(), time.Second)
+}
+
 // TestGetCertAuthority tests certificate authority permissions
 func TestGetCertAuthority(t *testing.T) {
 	t.Parallel()

--- a/lib/auth/tls_test.go
+++ b/lib/auth/tls_test.go
@@ -1814,21 +1814,21 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 	testSrv := newTestTLSServer(t)
 	clock := testSrv.AuthServer.TestAuthServerConfig.Clock
 
-	clt, err := testSrv.NewClient(TestAdmin())
+	adminClient, err := testSrv.NewClient(TestAdmin())
 	require.NoError(t, err)
 
 	const user = "user2"
 	const testRequestRole = "test-request-role"
 	pass := []byte("abc123")
 
-	newUser, err := CreateUserRoleAndRequestable(clt, user, testRequestRole)
+	newUser, err := CreateUserRoleAndRequestable(adminClient, user, testRequestRole)
 	require.NoError(t, err)
 	require.Len(t, newUser.GetRoles(), 1)
 
 	require.Len(t, newUser.GetRoles(), 1)
 	require.Empty(t, cmp.Diff(newUser.GetRoles(), []string{"user:user2"}))
 
-	proxy, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
+	proxyRoleClient, err := testSrv.NewClient(TestBuiltin(types.RoleProxy))
 	require.NoError(t, err)
 
 	// Create a user to create a web session for.
@@ -1842,10 +1842,10 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 	err = testSrv.Auth().UpsertPassword(user, pass)
 	require.NoError(t, err)
 
-	ws, err := proxy.AuthenticateWebUser(ctx, req)
+	webSession, err := proxyRoleClient.AuthenticateWebUser(ctx, req)
 	require.NoError(t, err)
 
-	web, err := testSrv.NewClientFromWebSession(ws)
+	userClient, err := testSrv.NewClientFromWebSession(webSession)
 	require.NoError(t, err)
 
 	testCases := []struct {
@@ -1856,7 +1856,7 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 		{
 			desc:            "default",
 			maxDurationRole: 0,
-			expectedExpiry:  12 * time.Hour, // default certificate TTL
+			expectedExpiry:  apidefaults.CertDuration,
 		},
 		{
 			desc:            "max duration is set",
@@ -1866,13 +1866,13 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 		{
 			desc:            "max duration greater than default",
 			maxDurationRole: 24 * time.Hour,
-			expectedExpiry:  12 * time.Hour,
+			expectedExpiry:  apidefaults.CertDuration,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			requestableRole, err := clt.GetRole(ctx, newUser.GetRoles()[0])
+			requestableRole, err := adminClient.GetRole(ctx, newUser.GetRoles()[0])
 			require.NoError(t, err)
 
 			// Set max duration on the role.
@@ -1880,7 +1880,7 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 				Roles:       []string{testRequestRole},
 				MaxDuration: types.Duration(tc.maxDurationRole),
 			})
-			err = clt.UpsertRole(ctx, requestableRole)
+			err = adminClient.UpsertRole(ctx, requestableRole)
 			require.NoError(t, err)
 
 			// Create an approved access request.
@@ -1892,12 +1892,12 @@ func TestExtendWebSessionWithMaxDuration(t *testing.T) {
 			err = accessReq.SetState(types.RequestState_APPROVED)
 			require.NoError(t, err)
 
-			err = clt.CreateAccessRequest(ctx, accessReq)
+			err = adminClient.CreateAccessRequest(ctx, accessReq)
 			require.NoError(t, err)
 
-			sess1, err := web.ExtendWebSession(ctx, WebSessionReq{
+			sess1, err := userClient.ExtendWebSession(ctx, WebSessionReq{
 				User:            user,
-				PrevSessionID:   ws.GetName(),
+				PrevSessionID:   webSession.GetName(),
 				AccessRequestID: accessReq.GetMetadata().Name,
 			})
 			require.NoError(t, err)


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/29042 introduced `max_duration` parameter that allows to set the maximum access request duration up to 7 days. When generating the certificate by `tsh` the session is capped to `min(max_duration, sessionTTL)`. Currently, web sessions do not respect `max_duration` in all cases.

This PR adjusts the web session behavior to behave the same.