### PR TITLE
ci: Pass secrets from post-release to update-ami-ids

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -47,5 +47,6 @@ jobs:
     needs: release
     if: needs.release.outputs.type == 'latest'
     uses: gravitational/teleport/.github/workflows/update-ami-ids.yaml@master
+    secrets: inherit
     with:
       version: ${{ needs.release.outputs.version }}


### PR DESCRIPTION
Add a `secrets: inherit` field to `post-release.yaml` so that when
calling `update-ami-ids.yaml` it can see the secrets. It is currently
failing with:

    Error: Input required and not supplied: private_key

as the repo secrets are not available.