### PR TITLE
[v13] dronegen: Build Teleport Connect for amd64 push build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-amd64-centos7" '
+    -input "build-connect=true" -input "release-target=release-amd64-centos7" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -154,7 +154,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-386" '
+    -input "build-connect=false" -input "release-target=release-386" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -227,7 +227,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-amd64-centos7-fips" '
+    -input "build-connect=false" -input "release-target=release-amd64-centos7-fips" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -300,7 +300,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-windows-unsigned" '
+    -input "build-connect=false" -input "release-target=release-windows-unsigned" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -987,7 +987,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-arm" '
+    -input "build-connect=false" -input "release-target=release-arm" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -17092,6 +17092,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: ea74260b48fa18dcde03b7c64f6976a92708b3d84b932221a99a527cbfccd4e8
+hmac: e7372f0fdccfd97567c50162eba67f3ba00ea05e6192370e0e6dfc04cc13ae2a
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -153,6 +153,7 @@ type buildType struct {
 	fips            bool
 	centos7         bool
 	windowsUnsigned bool
+	buildConnect    bool
 }
 
 // Description provides a human-facing description of the artifact, e.g.:

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -40,7 +41,7 @@ func pushCheckoutCommandsWithPath(b buildType, checkoutPath string) []string {
 func pushPipelines() []pipeline {
 	var ps []pipeline
 
-	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: false}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: false, buildConnect: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "386", fips: false}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm", fips: false}))
@@ -95,7 +96,10 @@ func ghaLinuxPushPipeline(b buildType) pipeline {
 		srcRefVar:         "DRONE_COMMIT",
 		ref:               "${DRONE_BRANCH}",
 		shouldTagWorkflow: true,
-		inputs:            map[string]string{"release-target": releaseMakefileTarget(b)},
+		inputs: map[string]string{
+			"release-target": releaseMakefileTarget(b),
+			"build-connect":  strconv.FormatBool(b.buildConnect),
+		},
 	}
 	bt := ghaBuildType{
 		buildType:    buildType{os: b.os, arch: b.arch},


### PR DESCRIPTION
Add an input parameter when calling the release-linux workflow to build
Teleport Connect for the AMD64 build. This was previously done when
Drone was doing the build but got accidentally dropped when moving to
GitHub actions.

This will also be used for the tag builds when they migrate to GHA as we
do a release build of Teleport Connect for each architecture.

Update .drone.yml with `make dronegen` to add the `build-connect`
parameter to the call of the `release-linux` workflow.

Backport: https://github.com/gravitational/teleport/pull/29622
Depends-on: https://github.com/gravitational/teleport.e/pull/1926
Changelog: none