### PR TITLE
[v12] dronegen: Build Teleport Connect for amd64 push build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -81,7 +81,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-amd64-centos7" '
+    -input "build-connect=true" -input "release-target=release-amd64-centos7" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -154,7 +154,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-386" '
+    -input "build-connect=false" -input "release-target=release-386" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -227,7 +227,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-amd64-centos7-fips" '
+    -input "build-connect=false" -input "release-target=release-amd64-centos7-fips" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -300,7 +300,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-windows-unsigned" '
+    -input "build-connect=false" -input "release-target=release-windows-unsigned" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -987,7 +987,7 @@ steps:
   - 'go run ./cmd/gh-trigger-workflow -owner ${DRONE_REPO_OWNER} -repo teleport.e
     -tag-workflow -timeout 2h30m0s -workflow release-linux.yaml -workflow-ref=${DRONE_BRANCH}
     -input oss-teleport-repo=${DRONE_REPO} -input oss-teleport-ref=${DRONE_COMMIT}
-    -input "release-target=release-arm" '
+    -input "build-connect=false" -input "release-target=release-arm" '
   environment:
     GHA_APP_KEY:
       from_secret: GITHUB_WORKFLOW_APP_PRIVATE_KEY
@@ -19668,6 +19668,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: e03345880d61b343f38a618d32d3eb67d871b62fd3a085d39665a24f837f8795
+hmac: c5966c65b10662e9490ef7658074b8021d7e5d5aab67ccaaa2303a6348d53706
 
 ...

--- a/dronegen/common.go
+++ b/dronegen/common.go
@@ -157,6 +157,7 @@ type buildType struct {
 	fips            bool
 	centos7         bool
 	windowsUnsigned bool
+	buildConnect    bool
 }
 
 // Description provides a human-facing description of the artifact, e.g.:

--- a/dronegen/push.go
+++ b/dronegen/push.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 )
 
@@ -40,7 +41,7 @@ func pushCheckoutCommandsWithPath(b buildType, checkoutPath string) []string {
 func pushPipelines() []pipeline {
 	var ps []pipeline
 
-	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: false}))
+	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: false, buildConnect: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "amd64", fips: true}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "386", fips: false}))
 	ps = append(ps, ghaLinuxPushPipeline(buildType{os: "linux", arch: "arm", fips: false}))
@@ -95,7 +96,10 @@ func ghaLinuxPushPipeline(b buildType) pipeline {
 		srcRefVar:         "DRONE_COMMIT",
 		ref:               "${DRONE_BRANCH}",
 		shouldTagWorkflow: true,
-		inputs:            map[string]string{"release-target": releaseMakefileTarget(b)},
+		inputs: map[string]string{
+			"release-target": releaseMakefileTarget(b),
+			"build-connect":  strconv.FormatBool(b.buildConnect),
+		},
 	}
 	bt := ghaBuildType{
 		buildType:    buildType{os: b.os, arch: b.arch},


### PR DESCRIPTION
Add an input parameter when calling the release-linux workflow to build
Teleport Connect for the AMD64 build. This was previously done when
Drone was doing the build but got accidentally dropped when moving to
GitHub actions.

This will also be used for the tag builds when they migrate to GHA as we
do a release build of Teleport Connect for each architecture.

Update .drone.yml with `make dronegen` to add the `build-connect`
parameter to the call of the `release-linux` workflow.

Update `e` ref for the updated `release-linux.yaml` workflow with the
`build-connect` parameter.

Backport: https://github.com/gravitational/teleport/pull/29622
Depends-on: https://github.com/gravitational/teleport.e/pull/1925
Changelog: none