### PR TITLE
Deflake `TestListKube`

### DIFF
--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -385,7 +385,7 @@ func onRequestSearch(cf *CLIConf) error {
 
 	// If KubeCluster not provided try to read it from kubeconfig.
 	if cf.KubernetesCluster == "" {
-		cf.KubernetesCluster = selectedKubeCluster(tc.SiteName)
+		cf.KubernetesCluster = selectedKubeCluster(tc.SiteName, getKubeConfigPath(cf, ""))
 	}
 	if slices.Contains(types.KubernetesResourcesKinds, cf.ResourceKind) && cf.KubernetesCluster == "" {
 		return trace.BadParameter("when searching for Pods, --kube-cluster cannot be empty")

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -989,7 +989,7 @@ func (c *kubeLSCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	selectedCluster := selectedKubeCluster(currentTeleportCluster)
+	selectedCluster := selectedKubeCluster(currentTeleportCluster, getKubeConfigPath(cf, ""))
 	format := strings.ToLower(c.format)
 	switch format {
 	case teleport.Text, "":
@@ -1128,8 +1128,9 @@ func serializeKubeListings(kubeListings []kubeListing, format string) (string, e
 	return string(out), trace.Wrap(err)
 }
 
-func selectedKubeCluster(currentTeleportCluster string) string {
-	kc, err := kubeconfig.Load("")
+// selectedKubeCluster determines which kube cluster, is any, is selected.
+func selectedKubeCluster(currentTeleportCluster string, kubeconfgPath string) string {
+	kc, err := kubeconfig.Load(kubeconfgPath)
 	if err != nil {
 		log.WithError(err).Warning("Failed parsing existing kubeconfig")
 		return ""

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1128,7 +1128,7 @@ func serializeKubeListings(kubeListings []kubeListing, format string) (string, e
 	return string(out), trace.Wrap(err)
 }
 
-// selectedKubeCluster determines which kube cluster, is any, is selected.
+// selectedKubeCluster determines which kube cluster, if any, is selected.
 func selectedKubeCluster(currentTeleportCluster string, kubeconfgPath string) string {
 	kc, err := kubeconfig.Load(kubeconfgPath)
 	if err != nil {

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -188,6 +188,11 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 					tc.args...,
 				),
 				setCopyStdout(captureStdout),
+
+				// set a custom empty kube config for each test, as we do
+				// not want parallel (or even shuffled sequential) tests
+				// potentially racing on the same config
+				setKubeConfigPath(filepath.Join(t.TempDir(), "kubeconfig")),
 			)
 			require.NoError(t, err)
 			require.Contains(t, captureStdout.String(), tc.wantTable())

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -249,7 +249,7 @@ func TestKubeLoginAccessRequest(t *testing.T) {
 		}),
 	)
 	// login as the user.
-	mustLoginSetEnv(t, s)
+	tshHome, kubeConfig := mustLoginSetEnv(t, s)
 
 	// Run the login command in a goroutine so we can check if the access
 	// request was created and approved.
@@ -266,6 +266,8 @@ func TestKubeLoginAccessRequest(t *testing.T) {
 				"--request-reason",
 				"test",
 			},
+			setHomePath(tshHome),
+			setKubeConfigPath(kubeConfig),
 		)
 		return trace.Wrap(err)
 	})

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -613,7 +613,12 @@ func initLogger(cf *CLIConf) {
 	}
 }
 
-// Run executes TSH client. same as main() but easier to test
+// Run executes TSH client. same as main() but easier to test. Note that this
+// function modifies global state in `tsh` (e.g. the system logger), and WILL
+// ALSO MODIFY EXTERNAL SHARED STATE in its default configuration (e.g. the
+// $HOME/.tsh dir, $KUBECONFIG, etc).
+//
+// DO NOT RUN TESTS that call Run() in parallel (unless you taken precautions).
 func Run(ctx context.Context, args []string, opts ...CliOption) error {
 	cf := CLIConf{
 		Context:         ctx,
@@ -4243,7 +4248,7 @@ func makeProfileInfo(p *client.ProfileStatus, env map[string]string, isActive bo
 		Traits:             p.Traits,
 		Logins:             logins,
 		KubernetesEnabled:  p.KubeEnabled,
-		KubernetesCluster:  selectedKubeCluster(p.Cluster),
+		KubernetesCluster:  selectedKubeCluster(p.Cluster, ""),
 		KubernetesUsers:    p.KubeUsers,
 		KubernetesGroups:   p.KubeGroups,
 		Databases:          p.DatabaseServices(),
@@ -4710,7 +4715,7 @@ func onEnvironment(cf *CLIConf) error {
 			fmt.Printf("unset %v\n", kubeClusterEnvVar)
 			fmt.Printf("unset %v\n", teleport.EnvKubeConfig)
 		case !cf.unsetEnvironment:
-			kubeName := selectedKubeCluster(profile.Cluster)
+			kubeName := selectedKubeCluster(profile.Cluster, "")
 			fmt.Printf("export %v=%v\n", proxyEnvVar, profile.ProxyURL.Host)
 			fmt.Printf("export %v=%v\n", clusterEnvVar, profile.Cluster)
 			if kubeName != "" {
@@ -4735,7 +4740,7 @@ func serializeEnvironment(profile *client.ProfileStatus, format string) (string,
 		proxyEnvVar:   profile.ProxyURL.Host,
 		clusterEnvVar: profile.Cluster,
 	}
-	kubeName := selectedKubeCluster(profile.Cluster)
+	kubeName := selectedKubeCluster(profile.Cluster, "")
 	if kubeName != "" {
 		env[kubeClusterEnvVar] = kubeName
 		env[teleport.EnvKubeConfig] = profile.KubeConfigPath(kubeName)


### PR DESCRIPTION
PR #29993 tried to deflake this test but only fixed it partially during login.
This prevents the kubeconfig in `$HOME/.kube/config` to be used everywhere