### PR TITLE
Add support for Kubernetes discovery into kube agent helm chart

### DIFF
--- a/examples/chart/teleport-kube-agent/.lint/app-discovery.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/app-discovery.yaml
@@ -1,0 +1,4 @@
+authToken: auth-token
+proxyAddr: proxy.example.com:3080
+roles: kube,app,discovery
+kubeClusterName: test-kube-cluster

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -5,6 +5,7 @@ with an existing Teleport cluster:
 - Teleport Kubernetes access
 - Teleport Application access
 - Teleport Database access
+- Teleport Kubernetes Discovery
 
 To use it, you will need:
 - an existing Teleport cluster (at least proxy and auth services)
@@ -22,7 +23,7 @@ To use it, you will need:
 
 ## Combining roles
 
-You can combine multiple roles as a comma-separated list: `--set roles=kube\,db\,app`
+You can combine multiple roles as a comma-separated list: `--set roles=kube\,db\,app\,discovery`
 
 Note that commas must be escaped if the values are provided on the command line. This is due to the way that
 Helm parses arguments.
@@ -231,6 +232,28 @@ You can add multiple databases using `databases[1].name`, `databases[1].uri`, `d
 `databases[2].name`, `databases[2].uri`, `databases[2].protocol` etc.
 
 After installing, the new database should show up in `tsh db ls` after a few minutes.
+
+## Kubernetes discovery
+
+Teleport can be used to automatically discover apps based on services found in the Kubernetes cluster.
+To run Teleport discovery you will need to enabled roles `discovery` and `app` and also provide token that allows access for these roles.
+
+To install the agent, run:
+
+```sh
+$ helm install teleport-kube-agent . \
+  --create-namespace \
+  --namespace teleport \
+  --set roles=kube,app,discovery \
+  --set proxyAddr=${PROXY_ENDPOINT?} \
+  --set authToken=${JOIN_TOKEN?}
+```
+
+With default settings Teleport will try to discovery all apps available in the cluster. To control what namespaces and what service labels
+to use for discovery you can use `kubernetesDiscovery` property of the chart.
+
+When discovery is running, `kubeClusterName` should be set in values, since it is used as a name for discovery field and as a target label
+for the app service, so it can expose discovered apps.
 
 ## Troubleshooting
 

--- a/examples/chart/teleport-kube-agent/README.md
+++ b/examples/chart/teleport-kube-agent/README.md
@@ -5,7 +5,7 @@ with an existing Teleport cluster:
 - Teleport Kubernetes access
 - Teleport Application access
 - Teleport Database access
-- Teleport Kubernetes Discovery
+- Teleport Kubernetes App Discovery
 
 To use it, you will need:
 - an existing Teleport cluster (at least proxy and auth services)
@@ -233,7 +233,7 @@ You can add multiple databases using `databases[1].name`, `databases[1].uri`, `d
 
 After installing, the new database should show up in `tsh db ls` after a few minutes.
 
-## Kubernetes discovery
+## Kubernetes App Discovery
 
 Teleport can be used to automatically discover apps based on services found in the Kubernetes cluster.
 To run Teleport discovery you will need to enabled roles `discovery` and `app` and also provide token that allows access for these roles.

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -123,7 +123,7 @@ discovery_service:
 {{- if $discoveryEnabled }}
   enabled: true
   discovery_group: {{ required "kubeClusterName is required in chart values when kube or discovery role is enabled, see README" .Values.kubeClusterName }}
-  kubernetes: {{- toYaml .Values.kubernetesDiscovery | nindent 6 }}
+  kubernetes: {{- toYaml .Values.kubernetesDiscovery | nindent 4 }}
 {{- else }}
   enabled: false
 {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -43,7 +43,7 @@ kubernetes_service:
 app_service:
   {{- if $appRolePresent }}
     {{- if not (or (.Values.apps) (.Values.appResources) ($appDiscoveryEnabled)) }}
-      {{- fail "app discovery should be enabled or at least one of 'apps'/'appResources' is required in chart values when app role is enabled, see README" }}
+      {{- fail "app service is enabled, but no application source is enabled. You must either statically define apps through `apps`, dynamically through `appResources`, or enable in-cluster discovery." }}
     {{- end }}
   enabled: true
   {{- if .Values.apps }}

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -119,14 +119,6 @@ discovery_service:
 {{- if $discoveryEnabled }}
   enabled: true
   discovery_group: {{ required "kubeClusterName is required in chart values when kube or discovery role is enabled, see README" .Values.kubeClusterName }}
-  {{- range $matcher := .Values.kubernetesDiscovery }}
-    {{- if not (hasKey $matcher "namespaces") }}
-      {{- fail "'namespaces' is required for all 'kubernetesDiscovery' items in chart values when discovery role is enabled, see README" }}
-    {{- end }}
-    {{- if not (hasKey $matcher "labels") }}
-      {{- fail "'labels' is required for all 'kubernetesDiscovery' items in chart values when discovery role is enabled, see README" }}
-    {{- end }}
-  {{- end }}
   kubernetes: {{- toYaml .Values.kubernetesDiscovery | nindent 6 }}
 {{- else }}
   enabled: false

--- a/examples/chart/teleport-kube-agent/templates/_config.tpl
+++ b/examples/chart/teleport-kube-agent/templates/_config.tpl
@@ -41,7 +41,7 @@ kubernetes_service:
 {{- end }}
 
 app_service:
-  {{- if and ($appRolePresent) }}
+  {{- if $appRolePresent }}
     {{- if not (or (.Values.apps) (.Values.appResources) ($appDiscoveryEnabled)) }}
       {{- fail "app discovery should be enabled or at least one of 'apps'/'appResources' is required in chart values when app role is enabled, see README" }}
     {{- end }}

--- a/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
+++ b/examples/chart/teleport-kube-agent/templates/clusterrole.yaml
@@ -16,6 +16,14 @@ rules:
   - serviceaccounts
   verbs:
   - impersonate
+{{- if contains "discovery" (.Values.roles | toString) }}
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+{{- end}}
 - apiGroups:
   - ""
   resources:

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/admin_clusterrolebinding_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/admin_clusterrolebinding_test.yaml.snap
@@ -1,4 +1,4 @@
-generate a admin cluster role binding when adminClusterRolebinding.create is true:
+generate a admin cluster role binding when adminClusterRoleBinding.create is true:
   1: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding
@@ -12,7 +12,7 @@ generate a admin cluster role binding when adminClusterRolebinding.create is tru
     - apiGroup: rbac.authorization.k8s.io
       kind: Group
       name: cluster-admin
-generate a admin cluster role binding when adminClusterRolebinding.create is true and adminClusterRolebinding.name is set:
+generate a admin cluster role binding when adminClusterRoleBinding.create is true and adminClusterRoleBinding.name is set:
   1: |
     apiVersion: rbac.authorization.k8s.io/v1
     kind: ClusterRoleBinding

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/clusterrole_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/clusterrole_test.yaml.snap
@@ -55,3 +55,63 @@ sets ClusterRole labels when specified:
       - selfsubjectaccessreviews
       verbs:
       - create
+adds services listing permission if discovery is enabled:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: RELEASE-NAME
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - users
+      - groups
+      - serviceaccounts
+      verbs:
+      - impersonate
+    - apiGroups:
+      - ""
+      resources:
+      - services
+      verbs:
+      - list
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - selfsubjectaccessreviews
+      verbs:
+      - create
+does not add services listing permission if discovery is disabled:
+  1: |
+    apiVersion: rbac.authorization.k8s.io/v1
+    kind: ClusterRole
+    metadata:
+      name: RELEASE-NAME
+    rules:
+    - apiGroups:
+      - ""
+      resources:
+      - users
+      - groups
+      - serviceaccounts
+      verbs:
+      - impersonate
+    - apiGroups:
+      - ""
+      resources:
+      - pods
+      verbs:
+      - get
+    - apiGroups:
+      - authorization.k8s.io
+      resources:
+      - selfsubjectaccessreviews
+      verbs:
+      - create

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/config_test.yaml.snap
@@ -9,6 +9,8 @@ does not generate a config for clusterrole.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster
@@ -47,6 +49,8 @@ does not generate a config for pdb.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster-name
@@ -84,6 +88,8 @@ matches snapshot and tests for annotations.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -126,6 +132,8 @@ matches snapshot and tests for extra-labels.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster
@@ -167,6 +175,8 @@ matches snapshot for affinity.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster
@@ -206,6 +216,7 @@ matches snapshot for all-v6.yaml:
             name: grafana
             uri: http://localhost:3000
           enabled: true
+          resources: null
         auth_service:
           enabled: false
         db_service:
@@ -216,6 +227,8 @@ matches snapshot for all-v6.yaml:
             protocol: postgres
             uri: postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432
           enabled: true
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster-name
@@ -272,6 +285,8 @@ matches snapshot for aws-databases.yaml:
             types:
             - rds
           enabled: true
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: false
         proxy_service:
@@ -331,6 +346,8 @@ matches snapshot for azure-databases.yaml:
             types:
             - mysql
           enabled: true
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: false
         proxy_service:
@@ -367,6 +384,8 @@ matches snapshot for backwards-compatibility.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -405,6 +424,8 @@ matches snapshot for ca-pin.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -452,6 +473,8 @@ matches snapshot for db.yaml:
             protocol: postgres
             uri: postgres-aurora-instance-1.xxx.us-east-1.rds.amazonaws.com:5432
           enabled: true
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: false
         proxy_service:
@@ -491,6 +514,8 @@ matches snapshot for dynamic-app.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: false
@@ -532,6 +557,8 @@ matches snapshot for dynamic-db.yaml:
           resources:
           - labels:
               '*': '*'
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: false
         proxy_service:
@@ -568,6 +595,8 @@ matches snapshot for imagepullsecrets.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -607,6 +636,8 @@ matches snapshot for initcontainers.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster
@@ -644,6 +675,8 @@ matches snapshot for join-params-iam.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -683,6 +716,8 @@ matches snapshot for join-params-token.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster-name
@@ -720,6 +755,8 @@ matches snapshot for log-basic.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -759,6 +796,8 @@ matches snapshot for log-extra.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster-name
@@ -796,6 +835,8 @@ matches snapshot for log-legacy.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -835,6 +876,8 @@ matches snapshot for node-selector.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster-name
@@ -872,6 +915,8 @@ matches snapshot for pdb.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -911,6 +956,8 @@ matches snapshot for resources.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster
@@ -948,6 +995,8 @@ matches snapshot for stateful.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -987,6 +1036,8 @@ matches snapshot for tolerations.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster
@@ -1024,6 +1075,8 @@ matches snapshot for v10.yaml:
         auth_service:
           enabled: false
         db_service:
+          enabled: false
+        discovery_service:
           enabled: false
         kubernetes_service:
           enabled: true
@@ -1063,6 +1116,8 @@ matches snapshot for v11.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster-name
@@ -1101,6 +1156,60 @@ matches snapshot for volumes.yaml:
           enabled: false
         db_service:
           enabled: false
+        discovery_service:
+          enabled: false
+        kubernetes_service:
+          enabled: true
+          kube_cluster_name: test-kube-cluster
+        proxy_service:
+          enabled: false
+        ssh_service:
+          enabled: false
+        teleport:
+          join_params:
+            method: token
+            token_name: /etc/teleport-secrets/auth-token
+          log:
+            format:
+              extra_fields:
+              - timestamp
+              - level
+              - component
+              - caller
+              output: text
+            output: stderr
+            severity: INFO
+          proxy_server: proxy.example.com:3080
+        version: v3
+    kind: ConfigMap
+    metadata:
+      name: RELEASE-NAME
+      namespace: NAMESPACE
+matches snapshot when app discovery is enabled:
+  1: |
+    apiVersion: v1
+    data:
+      teleport.yaml: |-
+        app_service:
+          enabled: true
+          resources:
+          - labels:
+              teleport.dev/kubernetes-cluster: test-kube-cluster
+              teleport.dev/origin: discovery-kubernetes
+        auth_service:
+          enabled: false
+        db_service:
+          enabled: false
+        discovery_service:
+          discovery_group: test-kube-cluster
+          enabled: true
+          kubernetes:
+          - labels:
+              '*': '*'
+            namespaces:
+            - '*'
+            types:
+            - app
         kubernetes_service:
           enabled: true
           kube_cluster_name: test-kube-cluster

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -18,7 +18,7 @@ sets Deployment annotations when specified if action is Upgrade:
       template:
         metadata:
           annotations:
-            checksum/config: 80088923d2d7ce4344db0f2174d29d7cfb2d599424adfabf6f6818a9434794ca
+            checksum/config: e2a099e6eeb24c94a395c55fa6cc7ba6cbf4502ab9ed6e9c47233adc40b7927e
             kubernetes.io/pod: test-annotation
             kubernetes.io/pod-different: 4
           labels:
@@ -89,7 +89,7 @@ sets Deployment labels when specified if action is Upgrade:
     template:
       metadata:
         annotations:
-          checksum/config: db49feab9b174f73188febc30d2b01d27b16e5a76b586c6e87e6e62eb43620a2
+          checksum/config: 759fbcfcd1e9750bb5682ac3777c0e6146b5228d7ae9bba03136f7989eafd12d
         labels:
           app: RELEASE-NAME
           app.kubernetes.io/name: teleport-kube-agent

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -154,7 +154,7 @@ sets StatefulSet labels when specified:
       template:
         metadata:
           annotations:
-            checksum/config: db49feab9b174f73188febc30d2b01d27b16e5a76b586c6e87e6e62eb43620a2
+            checksum/config: 759fbcfcd1e9750bb5682ac3777c0e6146b5228d7ae9bba03136f7989eafd12d
           labels:
             app: RELEASE-NAME
             app.kubernetes.io/name: teleport-kube-agent
@@ -408,7 +408,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
       template:
         metadata:
           annotations:
-            checksum/config: 6e010c147e8d81d244e7aafdcee7e652cdb4d5640fb7f14d0e1ebb7832f943a5
+            checksum/config: 98a7bc8bca7ccc7b9b16552b81cfec61134d375b7a6fb3dc897f3f07bd1164e2
           labels:
             app: RELEASE-NAME
         spec:

--- a/examples/chart/teleport-kube-agent/tests/clusterrole_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/clusterrole_test.yaml
@@ -21,3 +21,23 @@ tests:
           path: metadata.labels.resource
           value: clusterrole
       - matchSnapshot: {}
+
+  - it: adds services listing permission if discovery is enabled
+    set:
+      roles: kube,discovery
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - matchSnapshot: {}
+
+  - it: does not add services listing permission if discovery is disabled
+    set:
+      roles: kube
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ClusterRole
+      - matchSnapshot: {}

--- a/examples/chart/teleport-kube-agent/tests/config_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/config_test.yaml
@@ -289,3 +289,13 @@ tests:
       - isKind:
           of: ConfigMap
       - matchSnapshot: {}
+
+  - it: matches snapshot when app discovery is enabled
+    values:
+      - ../.lint/app-discovery.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - matchSnapshot: {}

--- a/examples/chart/teleport-kube-agent/tests/role_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/role_test.yaml
@@ -4,7 +4,7 @@ templates:
 tests:
   - it: Create a Role when upgrading
     release:
-      isupgrade: true
+      upgrade: true
     set:
       unitTestUpgrade: true
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/rolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/rolebinding_test.yaml
@@ -4,7 +4,7 @@ templates:
 tests:
   - it: Create a RoleBinding when upgrading
     release:
-      isupgrade: true
+      upgrade: true
     set:
       unitTestUpgrade: true
     asserts:

--- a/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/statefulset_test.yaml
@@ -7,8 +7,8 @@ tests:
     template: statefulset.yaml
     values:
       - ../.lint/stateful.yaml
-    elease:
-      isupgrade: true
+    release:
+      upgrade: true
     asserts:
       - isKind:
           of: StatefulSet
@@ -372,7 +372,7 @@ tests:
   - it: should not add emptyDir for data when using StatefulSet
     template: statefulset.yaml
     release:
-      isupgrade: true
+      upgrade: true
     set:
       unitTestUpgrade: true
     values:
@@ -408,7 +408,7 @@ tests:
        # https://github.com/helm/helm/issues/8137
        unitTestUpgrade: true
     release:
-      isupgrade: true
+      upgrade: true
     asserts:
       - isNotNull:
           path: spec.volumeClaimTemplates[0].spec
@@ -435,7 +435,7 @@ tests:
     values:
       - ../.lint/stateful.yaml
     release:
-      isupgrade: true
+      upgrade: true
     set:
       # unit test does not support lookup functions, so to test the behavior we use this undoc value 
       # https://github.com/helm/helm/issues/8137
@@ -455,7 +455,7 @@ tests:
     values:
       - ../.lint/stateful.yaml
     release:
-      isupgrade: true
+      upgrade: true
     set:
       storage:
         requests: 256Mi
@@ -624,11 +624,11 @@ tests:
   - it: should generate Statefulset when storage is disabled and mode is a Upgrade
     template: statefulset.yaml
     release:
-      isupgrade: true
+      upgrade: true
     values:
       - ../.lint/stateful.yaml
     set:
-      unitTestUpgrade: false
+      unitTestUpgrade: true
       storage: 
         enabled: false
     asserts:

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -612,6 +612,34 @@
             "$id": "#/properties/probeTimeoutSeconds",
             "type": "integer",
             "default": 1
+        },
+        "kubernetesDiscovery": {
+            "$id": "#/properties/kubernetesDiscovery",
+            "type": "array",
+            "default": [],
+            "properties": {
+                "types": {
+                    "$id": "#/properties/kubernetesDiscovery/types",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "namespaces": {
+                    "$id": "#/properties/kubernetesDiscovery/namespaces",
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "labels": {
+                    "$id": "#/properties/kubernetesDiscovery/labels",
+                    "type": "object"
+                },
+                "additionalProperties": false
+            }
         }
     }
 }

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -50,7 +50,7 @@
         "roles": {
             "$id": "#/properties/roles",
             "type": "string",
-            "default": "kube,app,discovery"
+            "default": "kube"
         },
         "joinParams": {
             "$id": "#/properties/joinParams",

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -50,7 +50,7 @@
         "roles": {
             "$id": "#/properties/roles",
             "type": "string",
-            "default": "kube"
+            "default": "kube,app,discovery"
         },
         "joinParams": {
             "$id": "#/properties/joinParams",

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -8,7 +8,7 @@ authToken: ""
 
 # Address of the teleport proxy with port (usually :3080).
 proxyAddr: ""
-# Comma-separated list of roles to enable (any of: kube,db,app)
+# Comma-separated list of roles to enable (any of: kube,db,app,discovery)
 roles: "kube"
 
 ################################################################
@@ -98,6 +98,19 @@ databases: []
 #  - labels:
 #      "*": "*"
 databaseResources: []
+
+################################################################
+# Values that must be provided for Kubernetes Discovery
+################################################################
+
+# kubernetesDiscovery controls configuration for discovery service if it's enabled.
+# Default value will try to discovery all apps, use needs to override it to limit
+# scope of the discovered apps.
+kubernetesDiscovery:
+  - types: ["app"]
+    namespaces: ["*"]
+    labels:
+      "*": "*"
 
 ################################################################
 # Values that you may need to change.

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -104,6 +104,7 @@ databaseResources: []
 ################################################################
 
 # kubernetesDiscovery controls configuration for discovery service if it's enabled.
+# discovery service is enabled when the agent `roles` contains "discovery".
 # Default value will try to discovery all apps, use needs to override it to limit
 # scope of the discovered apps.
 kubernetesDiscovery:


### PR DESCRIPTION
Add support for Kubernetes discovery into kube agent helm chart. 
Enabling of the discovery is controlled by what roles are provided to the chart - if `discovery` and `app` roles are specified we enable app discovery. We're no changing default roles in the chart to contain `discovery,app` to keep backward compatibility with existing installations, which don't have tokens allowing those new roles. But we will add `roles='kube,app,discovery'` to all docs/wizards so most new users following guides will have it automatically enabled.

Part of https://github.com/gravitational/teleport/issues/25538