### PR TITLE
Extend IngressReporter with service metadata

### DIFF
--- a/lib/srv/db/common/reporting.go
+++ b/lib/srv/db/common/reporting.go
@@ -16,6 +16,7 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"net"
 	"time"
 
@@ -233,4 +234,15 @@ func GetMessagesFromClientMetric(db types.Database) prometheus.Counter {
 // GetMessagesFromServerMetric increments the messages from server metric.
 func GetMessagesFromServerMetric(db types.Database) prometheus.Counter {
 	return messagesFromServer.WithLabelValues(teleport.ComponentDatabase, db.GetProtocol(), db.GetType())
+}
+
+// ReporterMetadataFromProxyCtx returns string suitable for passing as a value for "service_metadata" label in
+// metrics "authenticated_active_connections" and "authenticated_accepted_connections_total"
+// declared by ingress.Reporter.
+func ReporterMetadataFromProxyCtx(proxyCtx *ProxyContext) string {
+	if len(proxyCtx.Servers) > 0 {
+		db := proxyCtx.Servers[0].GetDatabase()
+		return fmt.Sprintf("%v;%v", db.GetProtocol(), db.GetType())
+	}
+	return fmt.Sprintf("%v;%v", proxyCtx.Identity.RouteToDatabase.Protocol, "unknown")
 }

--- a/lib/srv/db/common/reporting_test.go
+++ b/lib/srv/db/common/reporting_test.go
@@ -1,0 +1,57 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestReporterMetadataFromProxyCtx(t *testing.T) {
+	tests := []struct {
+		name     string
+		proxyCtx *ProxyContext
+		want     string
+	}{
+		{
+			name:     "no servers, metadata from identity",
+			proxyCtx: &ProxyContext{Identity: tlsca.Identity{RouteToDatabase: tlsca.RouteToDatabase{Protocol: "foobar"}}},
+			want:     "foobar;unknown",
+		},
+		{
+			name: "servers, metadata from db info",
+			proxyCtx: &ProxyContext{Servers: []types.DatabaseServer{&types.DatabaseServerV3{
+				Spec: types.DatabaseServerSpecV3{
+					Database: &types.DatabaseV3{
+						Spec: types.DatabaseSpecV3{
+							Protocol: types.DatabaseProtocolPostgreSQL,
+							URI:      "postgres.example.com:5432",
+						},
+					},
+				},
+			}}},
+			want: "postgres;self-hosted",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, ReporterMetadataFromProxyCtx(tt.proxyCtx))
+		})
+	}
+}

--- a/lib/srv/db/postgres/proxy.go
+++ b/lib/srv/db/postgres/proxy.go
@@ -95,8 +95,9 @@ func (p *Proxy) handleConnection(ctx context.Context, clientConn utils.TLSConn, 
 	}
 
 	if p.IngressReporter != nil {
-		p.IngressReporter.ConnectionAuthenticated(ingress.Postgres, clientConn)
-		defer p.IngressReporter.AuthenticatedConnectionClosed(ingress.Postgres, clientConn)
+		metadata := common.ReporterMetadataFromProxyCtx(proxyCtx)
+		p.IngressReporter.ConnectionAuthenticated(ingress.Postgres, metadata, clientConn)
+		defer p.IngressReporter.AuthenticatedConnectionClosed(ingress.Postgres, metadata, clientConn)
 	}
 
 	serviceConn, err := p.Service.Connect(ctx, proxyCtx, clientConn.RemoteAddr(), clientConn.LocalAddr())

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -337,10 +337,11 @@ func (s *ProxyServer) handleConnection(conn net.Conn) error {
 	}
 
 	if s.cfg.IngressReporter != nil {
-		s.cfg.IngressReporter.ConnectionAuthenticated(ingress.DatabaseTLS, conn)
-		defer s.cfg.IngressReporter.AuthenticatedConnectionClosed(ingress.DatabaseTLS, conn)
+		metadata := common.ReporterMetadataFromProxyCtx(proxyCtx)
+		s.cfg.IngressReporter.ConnectionAuthenticated(ingress.DatabaseTLS, metadata, conn)
+		defer s.cfg.IngressReporter.AuthenticatedConnectionClosed(ingress.DatabaseTLS, metadata, conn)
 	}
-	if enterprise.ProtocolValidation(proxyCtx.Identity.RouteToDatabase.Protocol); err != nil {
+	if err = enterprise.ProtocolValidation(proxyCtx.Identity.RouteToDatabase.Protocol); err != nil {
 		return trace.Wrap(err)
 	}
 

--- a/lib/srv/ingress/reporter_test.go
+++ b/lib/srv/ingress/reporter_test.go
@@ -41,7 +41,7 @@ func TestIngressReporter(t *testing.T) {
 		authenticatedConnectionsActive.Reset()
 	})
 
-	const metadata = "foo;bar;baz"
+	metadata := ServiceMetadata{"foo", "bar", "baz"}
 
 	reporter.ConnectionAccepted(SSH, conn)
 	require.Equal(t, 1, getAcceptedConnections(PathALPN, SSH))
@@ -106,12 +106,12 @@ func getActiveConnections(path, service string) int {
 	return getGaugeValue(activeConnections, path, service)
 }
 
-func getAuthenticatedAcceptedConnections(path, service, metadata string) int {
-	return getCounterValue(authenticatedConnectionsAccepted, path, service, metadata)
+func getAuthenticatedAcceptedConnections(path, service string, metadata ServiceMetadata) int {
+	return getCounterValue(authenticatedConnectionsAccepted, path, service, metadata.Label1, metadata.Label2, metadata.Label3)
 }
 
-func getAuthenticatedActiveConnections(path, service, metadata string) int {
-	return getGaugeValue(authenticatedConnectionsActive, path, service, metadata)
+func getAuthenticatedActiveConnections(path, service string, metadata ServiceMetadata) int {
+	return getGaugeValue(authenticatedConnectionsActive, path, service, metadata.Label1, metadata.Label2, metadata.Label3)
 }
 
 func getCounterValue(metric *prometheus.CounterVec, values ...string) int {
@@ -185,7 +185,7 @@ func TestHTTPConnStateReporter(t *testing.T) {
 				authenticatedConnectionsActive.Reset()
 			}()
 
-			metadata := "unknown"
+			metadata := ServiceMetadata{}
 
 			require.Equal(t, 0, getAcceptedConnections(PathDirect, Web))
 			require.Equal(t, 0, getActiveConnections(PathDirect, Web))

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -510,7 +510,11 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	}
 
 	if s.ingressReporter != nil {
-		metadata := fmt.Sprintf("%v;%v;%v", certType, string(sconn.ClientVersion()), string(sconn.ServerVersion()))
+		metadata := ingress.ServiceMetadata{
+			Label1: certType,
+			Label2: string(sconn.ClientVersion()),
+			Label3: string(sconn.ServerVersion()),
+		}
 
 		s.ingressReporter.ConnectionAuthenticated(s.ingressService, metadata, conn)
 		defer s.ingressReporter.AuthenticatedConnectionClosed(s.ingressService, metadata, conn)


### PR DESCRIPTION
This PR extends the metrics reported by `IngressReported` with service metadata. The primary goal is to extend the metrics dealing with the database connections with the database information, as requested initially in a parallel PR: https://github.com/gravitational/teleport/pull/28150#pullrequestreview-1554790459.

However, since the metrics are shared, I've made a change across the other metrics. This is an area in which I'm especially open to suggestions.

Sample from `http://127.0.0.1:3000/metrics`:

```
# HELP teleport_authenticated_accepted_connections_total 
# TYPE teleport_authenticated_accepted_connections_total counter
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="database_tls",service_metadata="mongodb;self-hosted"} 5
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="mysql",service_metadata="mysql;self-hosted"} 1
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="postgres",service_metadata="cockroachdb;self-hosted"} 1
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="postgres",service_metadata="postgres;self-hosted"} 1
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="ssh",service_metadata="user;SSH-2.0-Go;SSH-2.0-Teleport"} 21
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="tunnel",service_metadata="host;SSH-2.0-Go;SSH-2.0-Teleport"} 9
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="web",service_metadata="boson.tener.io;boson.tener.io;;dumper;"} 5
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="web",service_metadata="boson.tener.io;boson.tener.io;;jaeger;"} 2
teleport_authenticated_accepted_connections_total{ingress_path="alpn",ingress_service="web",service_metadata="boson.tener.io;boson.tener.io;;pihole;"} 2
```

Changelog: Extended Proxy metrics `teleport_authenticated_accepted_connections_total` and  `teleport_authenticated_active_connections` with service metadata.