### PR TITLE
Refactor terminateWithTimeout to avoid dangling promises

### DIFF
--- a/web/packages/teleterm/src/mainProcess/terminateWithTimeout/terminateWithTimeout.test.ts
+++ b/web/packages/teleterm/src/mainProcess/terminateWithTimeout/terminateWithTimeout.test.ts
@@ -48,7 +48,7 @@ test('kills a process using SIGKILL when a graceful kill did not work', async ()
   // wait for the process to start and register callbacks
   await new Promise(resolve => process.stdout.once('data', resolve));
 
-  await terminateWithTimeout(process, 1_000);
+  await terminateWithTimeout(process, 50);
 
   expect(process.killed).toBeTruthy();
   expect(process.signalCode).toBe('SIGKILL');


### PR DESCRIPTION
Running tests for `web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.test.ts` was returning the following warning:

> Jest did not exit one second after the test run has completed.
>
> This usually means that there are asynchronous operations that weren't stopped in your tests. Consider running Jest with `--detectOpenHandles` to troubleshoot this issue.

Running the tests again with `--detectOpenHandles` didn't return anything. I suspected that the problem is with async stuff in `finally`:

https://github.com/gravitational/teleport/blob/6d3abeee87af9d6d1b47651e802cd5f7e0821408/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.test.ts#L52-L54

However, after reading MDN on `finally`, it didn't seem like it's some kind of a forbidden thing to do, so I kept digging.

`agentRunner.killAll` uses `terminateWithTimeout` underneath. It turned out that running the tests of `terminateWithTimeout` returned the same warning. This time `--detectOpenHandles` did report something:

```
Jest has detected the following 1 open handle potentially keeping Jest from exiting:

  ●  Timeout

      45 |     gracefullyKill(process);
      46 |
    > 47 |     await setTimeout(timeout);
         |                     ^
      48 |
      49 |     if (isProcessRunning(process)) {
      50 |       const timeoutInSeconds = timeout / 1_000;
```

We can see that we await the timeout inside this closure. However, the surrounding async function was not awaited:

https://github.com/gravitational/teleport/blob/6d3abeee87af9d6d1b47651e802cd5f7e0821408/web/packages/teleterm/src/mainProcess/terminateWithTimeout/terminateWithTimeout.ts#L42-L60

Thus, if the process did manage to get gracefully killed, `processExit` would resolve before the timeout and we were left with a dangling promise.

This PR refactors `terminateWithTimeout` so that there's no dangling promises. Instead of starting two separate promises, we use `Promise.race` to timeout the `processExit` promise. Using an abort signal takes care of clearing the timeout if the function returns early.