### PR TITLE
Fix flaky test `TestTeleterm/Test_headless_watcher`

### DIFF
--- a/integration/helpers/internal.go
+++ b/integration/helpers/internal.go
@@ -40,7 +40,7 @@ func StartAndWait(process *service.TeleportProcess, expectedEvents []string) ([]
 	// wait for all events to arrive or a timeout. if all the expected events
 	// from above are not received, this instance will not start
 	receivedEvents := make([]service.Event, 0, len(expectedEvents))
-	ctx, cancel := context.WithTimeout(process.ExitContext(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(process.ExitContext(), 30*time.Second)
 	defer cancel()
 	for _, eventName := range expectedEvents {
 		if event, err := process.WaitForEvent(ctx, eventName); err == nil {

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -272,53 +272,40 @@ func testHeadlessWatcher(t *testing.T, pack *dbhelpers.DatabasePack, creds *help
 		daemonService.Stop()
 	})
 
-	// Start the tshd event service and connect the daemon to it. This should also
-	// start a headless watcher for the connected cluster.
-
-	tshdEventsService, addr := newMockTSHDEventsServiceServer(t)
-	err = daemonService.UpdateAndDialTshdEventsServerAddress(addr)
-	require.NoError(t, err)
-
-	// Ensure the watcher catches events and sends them to the Electron App.
-
 	expires := pack.Root.Cluster.Config.Clock.Now().Add(time.Minute)
 	ha, err := types.NewHeadlessAuthentication(pack.Root.User.GetName(), "uuid", expires)
 	require.NoError(t, err)
 	ha.State = types.HeadlessAuthenticationState_HEADLESS_AUTHENTICATION_STATE_PENDING
 
-	eventuallyCatchAndSendHeadlessAuthn := func(t require.TestingT) {
-		tshdEventsService.sendPendingHeadlessAuthenticationCount.Store(0)
+	// Start the tshd event service and connect the daemon to it.
 
-		err = pack.Root.Cluster.Process.GetAuthServer().UpsertHeadlessAuthentication(ctx, ha)
-		require.NoError(t, err)
-
-		assert.Eventually(t, func() bool {
-			return tshdEventsService.sendPendingHeadlessAuthenticationCount.Load() == 1
-		}, 100*time.Millisecond, 20*time.Millisecond, "Expected tshdEventService to receive a SendPendingHeadlessAuthentication message")
-	}
-
-	// The watcher takes some amount of time to set up, so if we immediately upsert a headless
-	// authentication, it may not be caught by the watcher.
-	// require.Eventually(t, upsertAndWaitForEvent, time.Second, 100*time.Millisecond, "Expected tshdEventService to receive a SendPendingHeadlessAuthentication message")
-
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		eventuallyCatchAndSendHeadlessAuthn(collect)
-	}, time.Second, 100*time.Millisecond)
+	tshdEventsService, addr := newMockTSHDEventsServiceServer(t)
+	err = daemonService.UpdateAndDialTshdEventsServerAddress(addr)
+	require.NoError(t, err)
 
 	// Stop and restart the watcher twice to simulate logout + login + relogin. Ensure the watcher catches events.
 
 	err = daemonService.StopHeadlessWatcher(cluster.URI.String())
 	require.NoError(t, err)
-	err = daemonService.StartHeadlessWatcher(cluster.URI.String())
+	err = daemonService.StartHeadlessWatcher(cluster.URI.String(), false /* waitInit */)
 	require.NoError(t, err)
-	err = daemonService.StartHeadlessWatcher(cluster.URI.String())
+	err = daemonService.StartHeadlessWatcher(cluster.URI.String(), true /* waitInit */)
 	require.NoError(t, err)
 
 	// Ensure the watcher catches events and sends them to the Electron App.
 
-	require.EventuallyWithT(t, func(collect *assert.CollectT) {
-		eventuallyCatchAndSendHeadlessAuthn(collect)
-	}, time.Second, 100*time.Millisecond)
+	err = pack.Root.Cluster.Process.GetAuthServer().UpsertHeadlessAuthentication(ctx, ha)
+	assert.NoError(t, err)
+
+	assert.Eventually(t,
+		func() bool {
+			return tshdEventsService.sendPendingHeadlessAuthenticationCount.Load() == 1
+		},
+		10*time.Second,
+		500*time.Millisecond,
+		"Expected tshdEventService to receive 1 SendPendingHeadlessAuthentication message but got %v",
+		tshdEventsService.sendPendingHeadlessAuthenticationCount.Load(),
+	)
 }
 
 func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack) {

--- a/lib/teleterm/apiserver/handler/handler_auth.go
+++ b/lib/teleterm/apiserver/handler/handler_auth.go
@@ -46,7 +46,8 @@ func (s *Handler) Login(ctx context.Context, req *api.LoginRequest) (*api.EmptyR
 		return nil, trace.BadParameter("unsupported login parameters")
 	}
 
-	if err := s.DaemonService.StartHeadlessWatcher(req.ClusterUri); err != nil {
+	// Don't wait for the headless watcher to initialize as this could slow down logins.
+	if err := s.DaemonService.StartHeadlessWatcher(req.ClusterUri, false /* waitInit */); err != nil {
 		return nil, trace.Wrap(err)
 	}
 
@@ -76,7 +77,8 @@ func (s *Handler) LoginPasswordless(stream api.TerminalService_LoginPasswordless
 		return trace.Wrap(err)
 	}
 
-	if err := s.DaemonService.StartHeadlessWatcher(initReq.GetClusterUri()); err != nil {
+	// Don't wait for the headless watcher to initialize as this could slow down logins.
+	if err := s.DaemonService.StartHeadlessWatcher(initReq.GetClusterUri(), false /* waitInit */); err != nil {
 		return trace.Wrap(err)
 	}
 


### PR DESCRIPTION
Fix flaky test by waiting for Teleport Connect headless watcher to finish initializing in tests. 

Generally, we don't want to wait for the watcher to initialize as this could slow down Teleport Connect during startup and login. The headless watcher is not critical enough to warrant this slowdown, IMO.

Closes https://github.com/gravitational/teleport/issues/30044