### PR TITLE
Disable MongoDB fuzzing in oss-fuzz

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -101,9 +101,6 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/srv/db/sqlserver/protocol \
     FuzzMSSQLRPCClientPartialLength fuzz_mssql_rpc_client_partial_length
 
-  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/srv/db/mongodb/protocol \
-    FuzzMongoRead fuzz_mongo_read
-
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/srv/db/opensearch \
     FuzzPathToMatcher fuzz_opensearch_path_to_matcher
 


### PR DESCRIPTION
I recently had re-enabled the MongoDB fuzzing in #29656.  Since then we got a false positive failure in oss-fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=61087

This out of memory error is not reproducible using go fuzzing.  Though notable memory is still used, it's within defined limits.

I don't think `oss-fuzz` in the foreseeable future will be able to provide us good signal around failures.  So instead of commenting out I am suggesting we just remove this test from our oss-fuzz test suite.