### PR TITLE
integrations/operator: Fix a bug that caused ProvisionToken.spec.github.allow rules to be ignored

### DIFF
--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_provisiontokens.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_provisiontokens.yaml
@@ -78,27 +78,12 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
+                        resource_groups:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        subscription:
                           type: string
                       type: object
                     nullable: true
@@ -118,27 +103,9 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        context_id:
+                          type: string
+                        project_id:
                           type: string
                       type: object
                     nullable: true
@@ -156,28 +123,21 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
+                        locations:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        resources:
-                          description: Resources is a list of resources
+                        project_ids:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        verbs:
-                          description: Verbs is a list of verbs
+                        service_accounts:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        where:
-                          description: Where specifies optional advanced matcher
-                          type: string
                       type: object
                     nullable: true
                     type: array
@@ -192,27 +152,21 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        actor:
+                          type: string
+                        environment:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        repository:
+                          type: string
+                        repository_owner:
+                          type: string
+                        sub:
+                          type: string
+                        workflow:
                           type: string
                       type: object
                     nullable: true
@@ -238,27 +192,19 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        environment:
+                          type: string
+                        namespace_path:
+                          type: string
+                        pipeline_source:
+                          type: string
+                        project_path:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        sub:
                           type: string
                       type: object
                     nullable: true
@@ -284,27 +230,7 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        service_account:
                           type: string
                       type: object
                     nullable: true

--- a/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/config/crd/bases/resources.teleport.dev_provisiontokens.yaml
@@ -78,27 +78,12 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
+                        resource_groups:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        subscription:
                           type: string
                       type: object
                     nullable: true
@@ -118,27 +103,9 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        context_id:
+                          type: string
+                        project_id:
                           type: string
                       type: object
                     nullable: true
@@ -156,28 +123,21 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
+                        locations:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        resources:
-                          description: Resources is a list of resources
+                        project_ids:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        verbs:
-                          description: Verbs is a list of verbs
+                        service_accounts:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        where:
-                          description: Where specifies optional advanced matcher
-                          type: string
                       type: object
                     nullable: true
                     type: array
@@ -192,27 +152,21 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        actor:
+                          type: string
+                        environment:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        repository:
+                          type: string
+                        repository_owner:
+                          type: string
+                        sub:
+                          type: string
+                        workflow:
                           type: string
                       type: object
                     nullable: true
@@ -238,27 +192,19 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        environment:
+                          type: string
+                        namespace_path:
+                          type: string
+                        pipeline_source:
+                          type: string
+                        project_path:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        sub:
                           type: string
                       type: object
                     nullable: true
@@ -284,27 +230,7 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        service_account:
                           type: string
                       type: object
                     nullable: true

--- a/integrations/operator/crdgen/DEBUG.md
+++ b/integrations/operator/crdgen/DEBUG.md
@@ -1,0 +1,46 @@
+## Debugging tips for `crdgen`
+
+The `protoc` request can be saved to a file and loaded by a debug build of
+the plugin. This allows easier and more reproductible tests and is especially
+helpful if you want to attach a debugger.
+
+### 1. Dumping `protoc` request
+
+`protoc` request can be dumped with the dummy `protoc-gen-dump` plugin in
+`./hack`. The `make debug-dump-request` target generates a file for each source
+proto file:
+
+```shell
+$ make debug-dump-request
+
+for proto in teleport/loginrule/v1/loginrule.proto teleport/legacy/types/types.proto; do \
+        protoc \
+                -I=testdata/protofiles \
+                -I=/Users/shaka/go/pkg/mod/github.com/gravitational/protobuf@v1.3.2-teleport.1 \
+                --plugin=./hack/protoc-gen-dump \
+                --dump_out="." \
+                "${proto}"; \
+done
+Output written to /var/folders/vz/qfyzlg092_dgktzq3nzp5s040000gn/T/tmp.q6KOY07KwO
+Output written to /var/folders/vz/qfyzlg092_dgktzq3nzp5s040000gn/T/tmp.WQWM1TXWku
+```
+
+### 2. Building a debug `crdgen`
+
+Configure your IDE to set the tag `debug` on build, or manually build the plugin
+`go build -o protoc-gen-crd-debug -tags debug`.
+
+This debug build won't load requests from stdin, but from a dump file.
+
+### 3. Run the debug build and load instructions from the file
+
+You must instruct the debug build to load instructions from a dump file by
+setting the `TELEPORT_PROTOC_READ_FILE` environment variable.
+
+```shell
+export TELEPORT_PROTOC_READ_FILE="/var/folders/vz/qfyzlg092_dgktzq3nzp5s040000gn/T/tmp.WQWM1TXWku"
+./protoc-gen-crd-debug
+```
+
+From there you can invoke the plugin from `delve`, or configure your favorite
+IDE to set the environment variable when debugging the binary.

--- a/integrations/operator/crdgen/Makefile
+++ b/integrations/operator/crdgen/Makefile
@@ -51,3 +51,16 @@ update-snapshot: build
 	rm -rf testdata/golden
 	cp -r $(CRD_OUT_PATH) testdata/golden
 	rm -rf $(CRD_OUT_PATH)
+
+.PHONY: debug-dump-request
+debug-dump-request:
+	$(eval PROTOBUF_MOD_PATH := $(shell go mod download --json github.com/gogo/protobuf | awk -F: '/"Dir"/ { print $$2 }' | tr -d ' ",'))
+	for proto in $(PROTOS); do \
+		protoc \
+			-I=testdata/protofiles \
+			-I=$(PROTOBUF_MOD_PATH) \
+			--plugin=./hack/protoc-gen-dump \
+			--dump_out="." \
+			"$${proto}"; \
+	done
+

--- a/integrations/operator/crdgen/debug.go
+++ b/integrations/operator/crdgen/debug.go
@@ -1,0 +1,79 @@
+//go:build debug
+
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// This is an alternative main package that gets included when the `debug` tag
+// is set. When built with this debug tag, the protoc plugin reads its input
+// from a file instead of stdin. This allows to easily attach a debugger and
+// inspect what is happening inside the plugin.
+
+import (
+	"io"
+	"os"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
+	plugin "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	"github.com/gravitational/trace"
+	log "github.com/sirupsen/logrus"
+)
+
+const pluginInputPathEnvironment = "TELEPORT_PROTOC_READ_FILE"
+
+func main() {
+	log.SetLevel(log.DebugLevel)
+	log.SetOutput(os.Stderr)
+	inputPath := os.Getenv(pluginInputPathEnvironment)
+	if inputPath == "" {
+		log.Error(trace.BadParameter("When built with the 'debug' tag, the input path must be set through the environment variable: %s", pluginInputPathEnvironment))
+		os.Exit(-1)
+	}
+	log.Infof("This is a debug build, the protoc request is read from the file: '%s'", inputPath)
+
+	req, err := readRequestFromFile(inputPath)
+	if err != nil {
+		log.WithError(err).Error("error reading request from file")
+		os.Exit(-1)
+	}
+	if err := handleRequest(req); err != nil {
+		log.WithError(err).Error("Failed to generate schema")
+		os.Exit(-1)
+	}
+}
+
+func readRequestFromFile(inputPath string) (*plugin.CodeGeneratorRequest, error) {
+	g := generator.New()
+	inputFile, err := os.Open(inputPath)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	data, err := io.ReadAll(inputFile)
+	if err != nil {
+		return nil, trace.WrapWithMessage(err, "failed to read input")
+	}
+
+	if err := proto.Unmarshal(data, g.Request); err != nil {
+		return nil, trace.WrapWithMessage(err, "failed to parse input proto")
+	}
+
+	if len(g.Request.FileToGenerate) == 0 {
+		return nil, trace.BadParameter("no files to generate")
+	}
+	return g.Request, nil
+}

--- a/integrations/operator/crdgen/hack/protoc-gen-dump
+++ b/integrations/operator/crdgen/hack/protoc-gen-dump
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This is a dummy protoc plugin that dumps all requests to a file.
+# This file can then be replayed `cat file.dump | my-real-protoc-plugin`
+# Or loaded by a debug protoc plugin (see ../DEBUG.md).
+
+DEST="$(mktemp)"
+>&2 echo "Output written to $DEST" 
+
+cat /dev/stdin > "$DEST"

--- a/integrations/operator/crdgen/handlerequest.go
+++ b/integrations/operator/crdgen/handlerequest.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2022 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+
+	gogodesc "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
+	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
+	gogoplugin "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
+	"github.com/gogo/protobuf/vanity/command"
+	"github.com/gravitational/trace"
+	"sigs.k8s.io/yaml"
+
+	"github.com/gravitational/teleport/api/types"
+)
+
+func handleRequest(req *gogoplugin.CodeGeneratorRequest) error {
+	if len(req.FileToGenerate) == 0 {
+		return trace.Errorf("no input file provided")
+	}
+	if len(req.FileToGenerate) > 1 {
+		return trace.Errorf("too many input files")
+	}
+
+	gen, err := newGenerator(req)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	rootFileName := req.FileToGenerate[0]
+	gen.SetFile(rootFileName)
+	for _, fileDesc := range gen.AllFiles().File {
+		file := gen.addFile(fileDesc)
+		if fileDesc.GetName() == rootFileName {
+			if err := generateSchema(file, "resources.teleport.dev", gen.Response); err != nil {
+				return trace.Wrap(err)
+			}
+		}
+	}
+
+	command.Write(gen.Response)
+
+	return nil
+}
+
+func newGenerator(req *gogoplugin.CodeGeneratorRequest) (*Forest, error) {
+	gen := generator.New()
+
+	gen.Request = req
+	gen.CommandLineParameters(gen.Request.GetParameter())
+	gen.WrapTypes()
+	gen.SetPackageNames()
+	gen.BuildTypeNameMap()
+
+	return &Forest{
+		Generator:  gen,
+		messageMap: make(map[*gogodesc.DescriptorProto]*Message),
+	}, nil
+}
+
+type resource struct {
+	name string
+	opts []resourceSchemaOption
+}
+
+func generateSchema(file *File, groupName string, resp *gogoplugin.CodeGeneratorResponse) error {
+	generator := NewSchemaGenerator(groupName)
+
+	resources := []resource{
+		{name: "UserV2"},
+		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V5)}},
+		{name: "RoleV6"},
+		{name: "SAMLConnectorV2"},
+		{name: "OIDCConnectorV3"},
+		{name: "GithubConnectorV3"},
+		{
+			name: "LoginRule",
+			opts: []resourceSchemaOption{
+				// Overriding the version because it is not in the type name.
+				withVersionOverride(types.V1),
+				// The LoginRule proto does not have a "spec" field, so force
+				// the CRD spec to include these fields from the root.
+				withCustomSpecFields([]string{"priority", "traits_expression", "traits_map"}),
+			},
+		},
+		{name: "ProvisionTokenV2"},
+		{name: "OktaImportRuleV1"},
+	}
+
+	for _, resource := range resources {
+		_, ok := file.messageByName[resource.name]
+		if !ok {
+			continue
+		}
+		err := generator.addResource(file, resource.name, resource.opts...)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	for _, root := range generator.roots {
+		crd := root.CustomResourceDefinition()
+		data, err := yaml.Marshal(crd)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		name := fmt.Sprintf("%s_%s.yaml", groupName, root.pluralName)
+		content := string(data)
+		resp.File = append(resp.File, &gogoplugin.CodeGeneratorResponse_File{Name: &name, Content: &content})
+	}
+
+	return nil
+}

--- a/integrations/operator/crdgen/main.go
+++ b/integrations/operator/crdgen/main.go
@@ -1,3 +1,5 @@
+//go:build !debug
+
 /*
 Copyright 2021-2022 Gravitational, Inc.
 
@@ -17,18 +19,10 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
 	"os"
 
-	gogodesc "github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
-	"github.com/gogo/protobuf/protoc-gen-gogo/generator"
-	gogoplugin "github.com/gogo/protobuf/protoc-gen-gogo/plugin"
 	"github.com/gogo/protobuf/vanity/command"
-	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/yaml"
-
-	"github.com/gravitational/teleport/api/types"
 )
 
 func main() {
@@ -39,102 +33,4 @@ func main() {
 		log.WithError(err).Error("Failed to generate schema")
 		os.Exit(-1)
 	}
-}
-
-func handleRequest(req *gogoplugin.CodeGeneratorRequest) error {
-	if len(req.FileToGenerate) == 0 {
-		return trace.Errorf("no input file provided")
-	}
-	if len(req.FileToGenerate) > 1 {
-		return trace.Errorf("too many input files")
-	}
-
-	gen, err := newGenerator(req)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	rootFileName := req.FileToGenerate[0]
-	gen.SetFile(rootFileName)
-	for _, fileDesc := range gen.AllFiles().File {
-		file := gen.addFile(fileDesc)
-		if fileDesc.GetName() == rootFileName {
-			if err := generateSchema(file, "resources.teleport.dev", gen.Response); err != nil {
-				return trace.Wrap(err)
-			}
-		}
-	}
-
-	command.Write(gen.Response)
-
-	return nil
-}
-
-func newGenerator(req *gogoplugin.CodeGeneratorRequest) (*Forest, error) {
-	gen := generator.New()
-
-	gen.Request = req
-	gen.CommandLineParameters(gen.Request.GetParameter())
-	gen.WrapTypes()
-	gen.SetPackageNames()
-	gen.BuildTypeNameMap()
-
-	return &Forest{
-		Generator:  gen,
-		messageMap: make(map[*gogodesc.DescriptorProto]*Message),
-	}, nil
-}
-
-type resource struct {
-	name string
-	opts []resourceSchemaOption
-}
-
-func generateSchema(file *File, groupName string, resp *gogoplugin.CodeGeneratorResponse) error {
-	generator := NewSchemaGenerator(groupName)
-
-	resources := []resource{
-		{name: "UserV2"},
-		{name: "RoleV6", opts: []resourceSchemaOption{withVersionOverride(types.V5)}},
-		{name: "RoleV6"},
-		{name: "SAMLConnectorV2"},
-		{name: "OIDCConnectorV3"},
-		{name: "GithubConnectorV3"},
-		{
-			name: "LoginRule",
-			opts: []resourceSchemaOption{
-				// Overriding the version because it is not in the type name.
-				withVersionOverride(types.V1),
-				// The LoginRule proto does not have a "spec" field, so force
-				// the CRD spec to include these fields from the root.
-				withCustomSpecFields([]string{"priority", "traits_expression", "traits_map"}),
-			},
-		},
-		{name: "ProvisionTokenV2"},
-		{name: "OktaImportRuleV1"},
-	}
-
-	for _, resource := range resources {
-		_, ok := file.messageByName[resource.name]
-		if !ok {
-			continue
-		}
-		err := generator.addResource(file, resource.name, resource.opts...)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
-	for _, root := range generator.roots {
-		crd := root.CustomResourceDefinition()
-		data, err := yaml.Marshal(crd)
-		if err != nil {
-			return trace.Wrap(err)
-		}
-		name := fmt.Sprintf("%s_%s.yaml", groupName, root.pluralName)
-		content := string(data)
-		resp.File = append(resp.File, &gogoplugin.CodeGeneratorResponse_File{Name: &name, Content: &content})
-	}
-
-	return nil
 }

--- a/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_provisiontokens.yaml
+++ b/integrations/operator/crdgen/testdata/golden/resources.teleport.dev_provisiontokens.yaml
@@ -78,27 +78,12 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
+                        resource_groups:
                           items:
                             type: string
                           nullable: true
                           type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        subscription:
                           type: string
                       type: object
                     nullable: true
@@ -118,27 +103,9 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        context_id:
+                          type: string
+                        project_id:
                           type: string
                       type: object
                     nullable: true
@@ -156,27 +123,21 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        actor:
+                          type: string
+                        environment:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        repository:
+                          type: string
+                        repository_owner:
+                          type: string
+                        sub:
+                          type: string
+                        workflow:
                           type: string
                       type: object
                     nullable: true
@@ -202,27 +163,19 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        environment:
+                          type: string
+                        namespace_path:
+                          type: string
+                        pipeline_source:
+                          type: string
+                        project_path:
+                          type: string
+                        ref:
+                          type: string
+                        ref_type:
+                          type: string
+                        sub:
                           type: string
                       type: object
                     nullable: true
@@ -248,27 +201,7 @@ spec:
                       must match one allow rule to use this token.
                     items:
                       properties:
-                        actions:
-                          description: Actions specifies optional actions taken when
-                            this rule matches
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        resources:
-                          description: Resources is a list of resources
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        verbs:
-                          description: Verbs is a list of verbs
-                          items:
-                            type: string
-                          nullable: true
-                          type: array
-                        where:
-                          description: Where specifies optional advanced matcher
+                        service_account:
                           type: string
                       type: object
                     nullable: true

--- a/integrations/operator/crdgen/tree.go
+++ b/integrations/operator/crdgen/tree.go
@@ -144,6 +144,9 @@ func (file File) Package() string {
 }
 
 func (message Message) Name() string {
+	if message.parentMsg != nil {
+		return message.parentMsg.Name() + "/" + message.desc.GetName()
+	}
 	return message.desc.GetName()
 }
 


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/30049

This fixes a `crdgen` bug happening on nested messages.

`Rule` was both a top-level message and also a sub-message of `ProvisionTokenSpecV2GitHub`. Because of the name conflict, the `ProvisionTokenSpecV2GitHub` `allow` field used the wrong spec and caused #30049 . 

The first commit adds an alternative `main()` function that supports loading the protoc request from a file. This allows easier debugging (you can run the binary directly from your debugger and don't have to use `protoc`).

The 2nd commit contains the fix: message names now recursively include the parents, avoiding conflicts.

The 3rd commit contains the CRDs generated with the `crdgen` fix. 

The 4th commit adds a controller test covering reproducing the original issue.

The 5th commit adds documentation on how to dump protoc requests and replay them while debugging the plugin.

Note: The `crdgen` support for nested messages is still imperfect. The location generated for sub-messages is wrong and this causes field descriptions not to load. I will investigate this later, this is a cosmetic issue (`kubectl explain` won't be as helpful as for top-level messages) and doesn't block the release of the fix.