### PR TITLE
refactor label string formatting

### DIFF
--- a/api/types/app.go
+++ b/api/types/app.go
@@ -42,8 +42,6 @@ type Application interface {
 	GetDynamicLabels() map[string]CommandLabel
 	// SetDynamicLabels sets the app dynamic labels.
 	SetDynamicLabels(map[string]CommandLabel)
-	// LabelsString returns all labels as a string.
-	LabelsString() string
 	// String returns string representation of the app.
 	String() string
 	// GetDescription returns the app description.
@@ -199,11 +197,6 @@ func (a *AppV3) GetLabel(key string) (value string, ok bool) {
 // GetAllLabels returns the app combined static and dynamic labels.
 func (a *AppV3) GetAllLabels() map[string]string {
 	return CombineLabels(a.Metadata.Labels, a.Spec.DynamicLabels)
-}
-
-// LabelsString returns all app labels as a string.
-func (a *AppV3) LabelsString() string {
-	return LabelsAsString(a.Metadata.Labels, a.Spec.DynamicLabels)
 }
 
 // GetDescription returns the app description.

--- a/api/types/database.go
+++ b/api/types/database.go
@@ -46,8 +46,6 @@ type Database interface {
 	GetDynamicLabels() map[string]CommandLabel
 	// SetDynamicLabels sets the database dynamic labels.
 	SetDynamicLabels(map[string]CommandLabel)
-	// LabelsString returns all labels as a string.
-	LabelsString() string
 	// String returns string representation of the database.
 	String() string
 	// GetDescription returns the database description.
@@ -253,11 +251,6 @@ func (d *DatabaseV3) GetLabel(key string) (value string, ok bool) {
 // GetAllLabels returns the database combined static and dynamic labels.
 func (d *DatabaseV3) GetAllLabels() map[string]string {
 	return CombineLabels(d.Metadata.Labels, d.Spec.DynamicLabels)
-}
-
-// LabelsString returns all database labels as a string.
-func (d *DatabaseV3) LabelsString() string {
-	return LabelsAsString(d.Metadata.Labels, d.Spec.DynamicLabels)
 }
 
 // GetDescription returns the database description.

--- a/api/types/desktop.go
+++ b/api/types/desktop.go
@@ -124,8 +124,6 @@ type WindowsDesktop interface {
 	ResourceWithLabels
 	// GetAddr returns the network address of this host.
 	GetAddr() string
-	// LabelsString returns all labels as a string.
-	LabelsString() string
 	// GetDomain returns the ActiveDirectory domain of this host.
 	GetDomain() string
 	// GetHostID returns the ID of the Windows Desktop Service reporting the desktop.
@@ -185,11 +183,6 @@ func (d *WindowsDesktopV3) GetAddr() string {
 // GetHostID returns the HostID for the associated desktop service.
 func (d *WindowsDesktopV3) GetHostID() string {
 	return d.Spec.HostID
-}
-
-// LabelsString returns all desktop labels as a string.
-func (d *WindowsDesktopV3) LabelsString() string {
-	return LabelsAsString(d.Metadata.Labels, nil)
 }
 
 // GetDomain returns the Active Directory domain of this host.

--- a/api/types/kubernetes.go
+++ b/api/types/kubernetes.go
@@ -46,8 +46,6 @@ type KubeCluster interface {
 	GetKubeconfig() []byte
 	// SetKubeconfig sets the kubeconfig.
 	SetKubeconfig([]byte)
-	// LabelsString returns all labels as a string.
-	LabelsString() string
 	// String returns string representation of the kube cluster.
 	String() string
 	// GetDescription returns the kube cluster description.
@@ -242,11 +240,6 @@ func (k *KubernetesClusterV3) SetDynamicLabels(dl map[string]CommandLabel) {
 // GetAllLabels returns the combined static and dynamic labels.
 func (k *KubernetesClusterV3) GetAllLabels() map[string]string {
 	return CombineLabels(k.Metadata.Labels, k.Spec.DynamicLabels)
-}
-
-// LabelsString returns all labels as a string.
-func (k *KubernetesClusterV3) LabelsString() string {
-	return LabelsAsString(k.Metadata.Labels, k.Spec.DynamicLabels)
 }
 
 // GetDescription returns the description.

--- a/api/types/server.go
+++ b/api/types/server.go
@@ -80,13 +80,6 @@ type Server interface {
 	SetPeerAddr(string)
 	// ProxiedService provides common methods for a proxied service.
 	ProxiedService
-	// MatchAgainst takes a map of labels and returns True if this server
-	// has ALL of them
-	//
-	// Any server matches against an empty label set
-	MatchAgainst(labels map[string]string) bool
-	// LabelsString returns a comma separated string with all node's labels
-	LabelsString() string
 
 	// DeepCopy creates a clone of this server value
 	DeepCopy() Server
@@ -384,33 +377,6 @@ func (s *ServerV2) GetPeerAddr() string {
 // SetPeerAddr sets the peer address of the server.
 func (s *ServerV2) SetPeerAddr(addr string) {
 	s.Spec.PeerAddr = addr
-}
-
-// MatchAgainst takes a map of labels and returns True if this server
-// has ALL of them
-//
-// Any server matches against an empty label set
-func (s *ServerV2) MatchAgainst(labels map[string]string) bool {
-	return MatchLabels(s, labels)
-}
-
-// LabelsString returns a comma separated string of all labels.
-func (s *ServerV2) LabelsString() string {
-	return LabelsAsString(s.Metadata.Labels, s.Spec.CmdLabels)
-}
-
-// LabelsAsString combines static and dynamic labels and returns a comma
-// separated string.
-func LabelsAsString(static map[string]string, dynamic map[string]CommandLabelV2) string {
-	labels := []string{}
-	for key, val := range static {
-		labels = append(labels, fmt.Sprintf("%s=%s", key, val))
-	}
-	for key, val := range dynamic {
-		labels = append(labels, fmt.Sprintf("%s=%s", key, val.Result))
-	}
-	sort.Strings(labels)
-	return strings.Join(labels, ",")
 }
 
 // setStaticFields sets static resource header and metadata fields.

--- a/lib/services/suite/presence_test.go
+++ b/lib/services/suite/presence_test.go
@@ -31,9 +31,9 @@ func TestServerLabels(t *testing.T) {
 	// empty
 	server := &types.ServerV2{}
 	require.Empty(t, cmp.Diff(server.GetAllLabels(), emptyLabels))
-	require.Equal(t, server.LabelsString(), "")
-	require.Equal(t, server.MatchAgainst(emptyLabels), true)
-	require.Equal(t, server.MatchAgainst(map[string]string{"a": "b"}), false)
+	require.Empty(t, server.GetAllLabels())
+	require.Equal(t, types.MatchLabels(server, emptyLabels), true)
+	require.Equal(t, types.MatchLabels(server, map[string]string{"a": "b"}), false)
 
 	// more complex
 	server = &types.ServerV2{
@@ -58,10 +58,9 @@ func TestServerLabels(t *testing.T) {
 		"time": "now",
 	}))
 
-	require.Equal(t, server.LabelsString(), "role=database,time=now")
-	require.Equal(t, server.MatchAgainst(emptyLabels), true)
-	require.Equal(t, server.MatchAgainst(map[string]string{"a": "b"}), false)
-	require.Equal(t, server.MatchAgainst(map[string]string{"role": "database"}), true)
-	require.Equal(t, server.MatchAgainst(map[string]string{"time": "now"}), true)
-	require.Equal(t, server.MatchAgainst(map[string]string{"time": "now", "role": "database"}), true)
+	require.Equal(t, types.MatchLabels(server, emptyLabels), true)
+	require.Equal(t, types.MatchLabels(server, map[string]string{"a": "b"}), false)
+	require.Equal(t, types.MatchLabels(server, map[string]string{"role": "database"}), true)
+	require.Equal(t, types.MatchLabels(server, map[string]string{"time": "now"}), true)
+	require.Equal(t, types.MatchLabels(server, map[string]string{"time": "now", "role": "database"}), true)
 }

--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 
 	"github.com/gravitational/trace"
@@ -136,4 +137,37 @@ func ShowClusterAlerts(ctx context.Context, client ClusterAlertGetter, w io.Writ
 		fmt.Fprintf(w, "%s\n\n", utils.FormatAlert(alert))
 	}
 	return trace.NewAggregate(errs...)
+}
+
+// FormatLabels filters out Teleport namespaced (teleport.[dev|hidden|internal])
+// labels in non-verbose mode, groups the labels by namespace, sorts each
+// group, then re-combines the groups and returns the result as a comma
+// separated string.
+func FormatLabels(labels map[string]string, verbose bool) string {
+	var (
+		teleportNamespaced []string
+		namespaced         []string
+		result             []string
+	)
+	for key, val := range labels {
+		if strings.HasPrefix(key, types.TeleportNamespace+"/") ||
+			strings.HasPrefix(key, types.TeleportHiddenLabelPrefix) ||
+			strings.HasPrefix(key, types.TeleportInternalLabelPrefix) {
+			// remove teleport.[dev|hidden|internal] labels in non-verbose mode.
+			if verbose {
+				teleportNamespaced = append(teleportNamespaced, fmt.Sprintf("%s=%s", key, val))
+			}
+			continue
+		}
+		if strings.Contains(key, "/") {
+			namespaced = append(namespaced, fmt.Sprintf("%s=%s", key, val))
+			continue
+		}
+		result = append(result, fmt.Sprintf("%s=%s", key, val))
+	}
+	sort.Strings(result)
+	sort.Strings(namespaced)
+	sort.Strings(teleportNamespaced)
+	namespaced = append(namespaced, teleportNamespaced...)
+	return strings.Join(append(result, namespaced...), ",")
 }

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/common"
 	"github.com/gravitational/teleport/tool/tctl/common/loginrule"
 	"github.com/gravitational/teleport/tool/tctl/common/oktaassignment"
 )
@@ -143,7 +144,7 @@ func (s *serverCollection) resources() (r []types.Resource) {
 func (s *serverCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, se := range s.servers {
-		labels := stripInternalTeleportLabels(verbose, se.GetAllLabels())
+		labels := common.FormatLabels(se.GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			se.GetHostname(), se.GetName(), se.GetAddr(), labels, se.GetTeleportVersion(),
 		})
@@ -482,7 +483,7 @@ func (a *appServerCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range a.servers {
 		app := server.GetApp()
-		labels := stripInternalTeleportLabels(verbose, app.GetAllLabels())
+		labels := common.FormatLabels(app.GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			server.GetHostname(), app.GetName(), app.GetProtocol(), app.GetPublicAddr(), app.GetURI(), labels, server.GetTeleportVersion(),
 		})
@@ -521,7 +522,7 @@ func (c *appCollection) resources() (r []types.Resource) {
 func (c *appCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, app := range c.apps {
-		labels := stripInternalTeleportLabels(verbose, app.GetAllLabels())
+		labels := common.FormatLabels(app.GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			app.GetName(), app.GetDescription(), app.GetURI(), app.GetPublicAddr(), labels, app.GetVersion(),
 		})
@@ -684,7 +685,7 @@ func (c *databaseServerCollection) resources() (r []types.Resource) {
 func (c *databaseServerCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, server := range c.servers {
-		labels := stripInternalTeleportLabels(verbose, server.GetDatabase().GetAllLabels())
+		labels := common.FormatLabels(server.GetDatabase().GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			server.GetHostname(),
 			nameOrDiscoveredName(server.GetDatabase(), verbose),
@@ -729,7 +730,7 @@ func (c *databaseCollection) resources() (r []types.Resource) {
 func (c *databaseCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, database := range c.databases {
-		labels := stripInternalTeleportLabels(verbose, database.GetAllLabels())
+		labels := common.FormatLabels(database.GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			nameOrDiscoveredName(database, verbose),
 			database.GetProtocol(),
@@ -813,7 +814,7 @@ func (c *windowsDesktopCollection) resources() (r []types.Resource) {
 func (c *windowsDesktopCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, d := range c.desktops {
-		labels := stripInternalTeleportLabels(verbose, d.GetAllLabels())
+		labels := common.FormatLabels(d.GetAllLabels(), verbose)
 		rows = append(rows, []string{d.GetName(), d.GetAddr(), d.GetDomain(), labels})
 	}
 	headers := []string{"Name", "Address", "AD Domain", "Labels"}
@@ -833,18 +834,6 @@ func (c *windowsDesktopCollection) writeYAML(w io.Writer) error {
 
 func (c *windowsDesktopCollection) writeJSON(w io.Writer) error {
 	return utils.WriteJSON(w, c.desktops)
-}
-
-func stripInternalTeleportLabels(verbose bool, labels map[string]string) string {
-	if verbose { // remove teleport.dev labels unless we're in verbose mode.
-		return types.LabelsAsString(labels, nil)
-	}
-	for key := range labels {
-		if strings.HasPrefix(key, types.TeleportNamespace+"/") {
-			delete(labels, key)
-		}
-	}
-	return types.LabelsAsString(labels, nil)
 }
 
 type tokenCollection struct {
@@ -886,8 +875,7 @@ func (c *kubeServerCollection) writeText(w io.Writer, verbose bool) error {
 		if kube == nil {
 			continue
 		}
-		labels := stripInternalTeleportLabels(verbose,
-			types.CombineLabels(kube.GetStaticLabels(), types.LabelsToV2(kube.GetDynamicLabels())))
+		labels := common.FormatLabels(kube.GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			nameOrDiscoveredName(kube, verbose),
 			labels,
@@ -939,7 +927,7 @@ func (c *kubeClusterCollection) resources() (r []types.Resource) {
 func (c *kubeClusterCollection) writeText(w io.Writer, verbose bool) error {
 	var rows [][]string
 	for _, cluster := range c.clusters {
-		labels := stripInternalTeleportLabels(verbose, cluster.GetAllLabels())
+		labels := common.FormatLabels(cluster.GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			nameOrDiscoveredName(cluster, verbose),
 			labels,

--- a/tool/tctl/common/collection_test.go
+++ b/tool/tctl/common/collection_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/tool/common"
 )
 
 var (
@@ -325,7 +326,7 @@ func formatTestLabels(l1, l2 map[string]string, verbose bool) string {
 	for key, value := range l2 {
 		labels[key] = value
 	}
-	return stripInternalTeleportLabels(verbose, labels)
+	return common.FormatLabels(labels, verbose)
 }
 
 func makeTestLabels(extraStaticLabels map[string]string) map[string]string {

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -503,7 +503,12 @@ func onRequestSearch(cf *CLIConf) error {
 		}
 		rows = append(rows, row)
 	}
-	table := asciitable.MakeTableWithTruncatedColumn(tableColumns, rows, "Labels")
+	var table asciitable.Table
+	if cf.Verbose {
+		table = asciitable.MakeTable(tableColumns, rows...)
+	} else {
+		table = asciitable.MakeTableWithTruncatedColumn(tableColumns, rows, "Labels")
+	}
 	if _, err := table.AsBuffer().WriteTo(cf.Stdout()); err != nil {
 		return trace.Wrap(err)
 	}

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/common"
 )
 
 var requestLoginHint = "use 'tsh login --request-id=<request-id>' to login with an approved request"
@@ -474,7 +475,7 @@ func onRequestSearch(cf *CLIConf) error {
 			row = []string{
 				resource.GetName(),
 				r.Spec.Namespace,
-				sortedLabels(resource.GetAllLabels()),
+				common.FormatLabels(resource.GetAllLabels(), cf.Verbose),
 				resourceID,
 			}
 
@@ -496,7 +497,7 @@ func onRequestSearch(cf *CLIConf) error {
 			row = []string{
 				resource.GetName(),
 				hostName,
-				sortedLabels(resource.GetAllLabels()),
+				common.FormatLabels(resource.GetAllLabels(), cf.Verbose),
 				resourceID,
 			}
 		}

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1032,9 +1032,13 @@ func serializeKubeClusters(kubeClusters []types.KubeCluster, selectedCluster, fo
 	}
 	clusterInfo := make([]cluster, 0, len(kubeClusters))
 	for _, cl := range kubeClusters {
+		labels := cl.GetAllLabels()
+		if len(labels) == 0 {
+			labels = nil
+		}
 		clusterInfo = append(clusterInfo, cluster{
 			KubeClusterName: cl.GetName(),
-			Labels:          cl.GetAllLabels(),
+			Labels:          labels,
 			Selected:        cl.GetName() == selectedCluster,
 		})
 	}

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -68,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/common"
 )
 
 type kubeCommands struct {
@@ -958,18 +959,6 @@ func (l kubeListings) Swap(i, j int) {
 	l[i], l[j] = l[j], l[i]
 }
 
-func formatKubeLabels(cluster types.KubeCluster) string {
-	labels := make([]string, 0, len(cluster.GetStaticLabels())+len(cluster.GetDynamicLabels()))
-	for key, value := range cluster.GetStaticLabels() {
-		labels = append(labels, fmt.Sprintf("%s=%s", key, value))
-	}
-	for key, value := range cluster.GetDynamicLabels() {
-		labels = append(labels, fmt.Sprintf("%s=%s", key, value.GetResult()))
-	}
-	sort.Strings(labels)
-	return strings.Join(labels, " ")
-}
-
 func (c *kubeLSCommand) run(cf *CLIConf) error {
 	cf.SearchKeywords = c.searchKeywords
 	cf.Labels = c.labels
@@ -1004,7 +993,11 @@ func (c *kubeLSCommand) run(cf *CLIConf) error {
 			if cluster.GetName() == selectedCluster {
 				selectedMark = "*"
 			}
-			rows = append(rows, []string{cluster.GetName(), formatKubeLabels(cluster), selectedMark})
+			rows = append(rows, []string{
+				cluster.GetName(),
+				common.FormatLabels(cluster.GetAllLabels(), c.verbose),
+				selectedMark,
+			})
 		}
 
 		if c.quiet {
@@ -1039,14 +1032,9 @@ func serializeKubeClusters(kubeClusters []types.KubeCluster, selectedCluster, fo
 	}
 	clusterInfo := make([]cluster, 0, len(kubeClusters))
 	for _, cl := range kubeClusters {
-		labels := cl.GetStaticLabels()
-		for key, value := range cl.GetDynamicLabels() {
-			labels[key] = value.GetResult()
-		}
-
 		clusterInfo = append(clusterInfo, cluster{
 			KubeClusterName: cl.GetName(),
-			Labels:          labels,
+			Labels:          cl.GetAllLabels(),
 			Selected:        cl.GetName() == selectedCluster,
 		})
 	}
@@ -1101,7 +1089,12 @@ func (c *kubeLSCommand) runAllClusters(cf *CLIConf) error {
 			t = asciitable.MakeTable([]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"})
 		}
 		for _, listing := range listings {
-			t.AddRow([]string{listing.Proxy, listing.Cluster, listing.KubeCluster.GetName(), formatKubeLabels(listing.KubeCluster)})
+			t.AddRow([]string{
+				listing.Proxy,
+				listing.Cluster,
+				listing.KubeCluster.GetName(),
+				common.FormatLabels(listing.KubeCluster.GetAllLabels(), c.verbose),
+			})
 		}
 		fmt.Fprintln(cf.Stdout(), t.AsBuffer().String())
 	case teleport.JSON, teleport.YAML:

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -341,7 +341,7 @@ func formatServiceLabels(labels map[string]string) string {
 	}
 
 	sort.Strings(labelSlice)
-	return strings.Join(labelSlice, " ")
+	return strings.Join(labelSlice, ",")
 }
 
 func newKubeSelfSubjectServer(t *testing.T) string {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2594,10 +2594,11 @@ func getNodeRow(proxy, cluster string, node types.Server, verbose bool) []string
 		row = append(row, proxy, cluster)
 	}
 
+	labels := common.FormatLabels(node.GetAllLabels(), verbose)
 	if verbose {
-		row = append(row, node.GetHostname(), node.GetName(), getAddr(node), node.LabelsString())
+		row = append(row, node.GetHostname(), node.GetName(), getAddr(node), labels)
 	} else {
-		row = append(row, node.GetHostname(), getAddr(node), sortedLabels(node.GetAllLabels()))
+		row = append(row, node.GetHostname(), getAddr(node), labels)
 	}
 	return row
 }
@@ -2623,28 +2624,6 @@ func printNodesAsText(output io.Writer, nodes []types.Server, verbose bool) erro
 	}
 
 	return nil
-}
-
-func sortedLabels(labels map[string]string) string {
-	var teleportNamespaced []string
-	var namespaced []string
-	var result []string
-	for key, val := range labels {
-		if strings.HasPrefix(key, types.TeleportNamespace+"/") {
-			teleportNamespaced = append(teleportNamespaced, key)
-			continue
-		}
-		if strings.Contains(key, "/") {
-			namespaced = append(namespaced, fmt.Sprintf("%s=%s", key, val))
-			continue
-		}
-		result = append(result, fmt.Sprintf("%s=%s", key, val))
-	}
-	sort.Strings(result)
-	sort.Strings(namespaced)
-	sort.Strings(teleportNamespaced)
-	namespaced = append(namespaced, teleportNamespaced...)
-	return strings.Join(append(result, namespaced...), ",")
 }
 
 func showApps(apps []types.Application, active []tlsca.RouteToApp, format string, verbose bool) error {
@@ -2692,10 +2671,11 @@ func getAppRow(proxy, cluster string, app types.Application, active []tlsca.Rout
 		}
 	}
 
+	labels := common.FormatLabels(app.GetAllLabels(), verbose)
 	if verbose {
-		row = append(row, name, app.GetDescription(), app.GetProtocol(), app.GetPublicAddr(), app.GetURI(), sortedLabels(app.GetAllLabels()))
+		row = append(row, name, app.GetDescription(), app.GetProtocol(), app.GetPublicAddr(), app.GetURI(), labels)
 	} else {
-		row = append(row, name, app.GetDescription(), app.GetProtocol(), app.GetPublicAddr(), sortedLabels(app.GetAllLabels()))
+		row = append(row, name, app.GetDescription(), app.GetProtocol(), app.GetPublicAddr(), labels)
 	}
 
 	return row
@@ -2886,6 +2866,7 @@ func getDatabaseRow(proxy, cluster, clusterFlag string, database types.Database,
 		row = append(row, proxy, cluster)
 	}
 
+	labels := common.FormatLabels(database.GetAllLabels(), verbose)
 	if verbose {
 		row = append(row,
 			printName,
@@ -2894,7 +2875,7 @@ func getDatabaseRow(proxy, cluster, clusterFlag string, database types.Database,
 			database.GetType(),
 			database.GetURI(),
 			formatUsersForDB(database, accessChecker),
-			database.LabelsString(),
+			labels,
 			connect,
 		)
 	} else {
@@ -2902,7 +2883,7 @@ func getDatabaseRow(proxy, cluster, clusterFlag string, database types.Database,
 			printName,
 			database.GetDescription(),
 			formatUsersForDB(database, accessChecker),
-			formatDatabaseLabels(database),
+			labels,
 			connect,
 		)
 	}
@@ -2952,14 +2933,6 @@ func printDatabasesWithClusters(clusterFlag string, dbListings []databaseListing
 		)
 	}
 	fmt.Println(t.AsBuffer().String())
-}
-
-func formatDatabaseLabels(database types.Database) string {
-	labels := database.GetAllLabels()
-	// Hide the origin and discovered-name labels unless printing verbose table.
-	delete(labels, types.OriginLabel)
-	delete(labels, types.DiscoveredNameLabel)
-	return sortedLabels(labels)
 }
 
 func formatActiveDB(active tlsca.RouteToDatabase) string {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2989,22 +2989,30 @@ func onListClusters(cf *CLIConf) error {
 	format := strings.ToLower(cf.Format)
 	switch format {
 	case teleport.Text, "":
-		var t asciitable.Table
-		if cf.Quiet {
-			t = asciitable.MakeHeadlessTable(4)
-		} else {
-			t = asciitable.MakeTable([]string{"Cluster Name", "Status", "Cluster Type", "Labels", "Selected"})
+		header := []string{"Cluster Name", "Status", "Cluster Type", "Labels", "Selected"}
+		rows := [][]string{
+			{rootClusterName, teleport.RemoteClusterStatusOnline, "root", "", showSelected(rootClusterName)},
 		}
-
-		t.AddRow([]string{
-			rootClusterName, teleport.RemoteClusterStatusOnline, "root", "", showSelected(rootClusterName),
-		})
 		for _, cluster := range leafClusters {
 			labels := common.FormatLabels(cluster.GetAllLabels(), cf.Verbose)
-			t.AddRow([]string{
+			rows = append(rows, []string{
 				cluster.GetName(), cluster.GetConnectionStatus(), "leaf", labels, showSelected(cluster.GetName()),
 			})
 		}
+
+		var t asciitable.Table
+		switch {
+		case cf.Quiet:
+			t = asciitable.MakeHeadlessTable(4)
+			for _, row := range rows {
+				t.AddRow(row)
+			}
+		case cf.Verbose:
+			t = asciitable.MakeTable(header, rows...)
+		default:
+			t = asciitable.MakeTableWithTruncatedColumn(header, rows, "Labels")
+		}
+
 		fmt.Println(t.AsBuffer().String())
 	case teleport.JSON, teleport.YAML:
 		rootClusterInfo := clusterInfo{

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -3535,6 +3535,7 @@ func setCmdRunner(cmdRunner func(*exec.Cmd) error) CliOption {
 }
 
 func testSerialization(t *testing.T, expected string, serializer func(string) (string, error)) {
+	t.Helper()
 	out, err := serializer(teleport.JSON)
 	require.NoError(t, err)
 	require.JSONEq(t, expected, out)


### PR DESCRIPTION
This PR:
1. refactors label string formatting in tsh and tctl text table output to be consistent
2. removes some dead/useless code in our our resource types
3. adds --verbose flag to `tsh clusters` and `tsh request search`

I did this because we had multiple bespoke helpers all doing similar but inconsistent label->string conversion.

Now labels will always be displayed grouped by namespace, in sorted order within each group, as a comma-separated string. Also, anything that displays labels in a text table will respect a `--verbose` flag - without verbosity, all teleport namespace labels (`teleport.dev teleport.internal teleport.hidden`) get filtered out.

Changelog: `tsh` and `tctl` commands that output a text-formatted table will now consistently output resource labels as a comma-separated string, sorted by label namespace. Labels starting with `teleport.dev/`, `teleport.hidden/`, and `teleport.internal/` are omitted unless the `--verbose` flag is used.