### PR TITLE
feat(helm/teleport-kube-agent): custom annotations in the Secret

### DIFF
--- a/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/teleport-kube-agent.mdx
@@ -1635,6 +1635,24 @@ Kubernetes annotations which should be applied to each `Pod` created by the char
       kubernetes.io/annotation: value
   ```
 
+## `annotations.secret`
+
+| Type     | Default value |
+|----------|---------------|
+| `object` | `{}`          |
+
+[Kubernetes reference](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
+
+Kubernetes annotations which should be applied to the `Secret` created by the chart.
+
+`values.yaml` example:
+
+  ```yaml
+  annotations:
+    secret:
+      kubernetes.io/annotation: value
+  ```
+
 ## `annotations.serviceAccount`
 
 | Type     | Default value |

--- a/examples/chart/teleport-kube-agent/.lint/annotations.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/annotations.yaml
@@ -12,6 +12,9 @@ annotations:
   pod:
     kubernetes.io/pod: "test-annotation"
     kubernetes.io/pod-different: 4
+  secret:
+    kubernetes.io/secret: "test-annotation"
+    kubernetes.io/secret-different: 6
   serviceAccount:
     kubernetes.io/serviceaccount: "test-annotation"
     kubernetes.io/serviceaccount-different: 5

--- a/examples/chart/teleport-kube-agent/templates/secret.yaml
+++ b/examples/chart/teleport-kube-agent/templates/secret.yaml
@@ -8,6 +8,10 @@ metadata:
   labels:
   {{- toYaml .Values.extraLabels.secret | nindent 4 }}
 {{- end }}
+{{- if .Values.annotations.secret }}
+  annotations:
+  {{- toYaml .Values.annotations.secret | nindent 4 }}
+{{- end }}
 type: Opaque
 stringData:
   auth-token: |

--- a/examples/chart/teleport-kube-agent/tests/secret_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/secret_test.yaml
@@ -87,3 +87,15 @@ tests:
           path: metadata.labels.resource
           value: secret
       - matchSnapshot: {}
+
+  - it: sets Secret annotations when specified
+    values:
+      - ../.lint/annotations.yaml
+    asserts:
+      - equal:
+          path: metadata.annotations.kubernetes\.io/secret
+          value: test-annotation
+      - equal:
+          path: metadata.annotations.kubernetes\.io/secret-different
+          value: 6
+      - matchSnapshot: {}

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -504,6 +504,7 @@
                 "config",
                 "deployment",
                 "pod",
+                "secret",
                 "serviceAccount"
             ],
             "properties": {
@@ -519,6 +520,11 @@
                 },
                 "pod": {
                     "$id": "#/properties/annotations/properties/pod",
+                    "type": "object",
+                    "default": {}
+                },
+                "secret": {
+                    "$id": "#/properties/annotations/properties/secret",
                     "type": "object",
                     "default": {}
                 },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -354,6 +354,8 @@ annotations:
   deployment: {}
   # Annotations for each Pod in the Deployment
   pod: {}
+  # Annotations for the Secret (has no effect when `joinTokenSecret.create` is false)
+  secret: {}
   # Annotations for the ServiceAccount object
   serviceAccount: {}
 


### PR DESCRIPTION
Adding support for custom annodations in the kube agent Secret.
This makes it easier to work with e.g. [ArgoCD Vault Plugin](https://argocd-vault-plugin.readthedocs.io/en/stable/howitworks/).

Signed-off-by: danmx <daniel.iziourov@elastic.co>