### PR TITLE
collections.go: Fix Memory Aliasing in `getAll`

### DIFF
--- a/lib/cache/collections.go
+++ b/lib/cache/collections.go
@@ -890,8 +890,9 @@ func (namespaceExecutor) getAll(ctx context.Context, cache *Cache, loadSecrets b
 	}
 
 	derefNamespaces := make([]*types.Namespace, len(namespaces))
-	for i, namespace := range namespaces {
-		derefNamespaces[i] = &namespace
+	for i := range namespaces {
+		ns := namespaces[i]
+		derefNamespaces[i] = &ns
 	}
 	return derefNamespaces, nil
 }


### PR DESCRIPTION
Resolved a memory aliasing issue flagged by gosec in the getAll function.  The issue being reuse of the loop variable's memory address.

This PR fixes the issue by creating a unique variable per loop iteration, avoiding the aliasing.