### PR TITLE
Fix headless watcher goroutine leak in tests

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -373,7 +373,7 @@ func NewTestAuthServer(cfg TestAuthServerConfig) (*TestAuthServer, error) {
 	}
 	srv.AuthServer.SetLockWatcher(srv.LockWatcher)
 
-	headlessAuthenticationWatcher, err := local.NewHeadlessAuthenticationWatcher(ctx, local.HeadlessAuthenticationWatcherConfig{
+	headlessAuthenticationWatcher, err := local.NewHeadlessAuthenticationWatcher(srv.AuthServer.CloseContext(), local.HeadlessAuthenticationWatcherConfig{
 		Backend: b,
 	})
 	if err != nil {


### PR DESCRIPTION
The headless authentication watcher used in `auth/helpers.go` did not properly close when the test completed leading to goroutine leaks like seen [here](https://github.com/gravitational/teleport/actions/runs/5783105835/job/15671255353?pr=30120).