### PR TITLE
Fix Memory Aliasing in for loops

### DIFF
--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -407,8 +407,8 @@ func UnmarshalServers(bytes []byte) ([]types.Server, error) {
 	}
 
 	out := make([]types.Server, len(servers))
-	for i, v := range servers {
-		out[i] = types.Server(&v)
+	for i := range servers {
+		out[i] = types.Server(&servers[i])
 	}
 	return out, nil
 }

--- a/lib/services/server_info.go
+++ b/lib/services/server_info.go
@@ -92,8 +92,8 @@ func UnmarshalServerInfos(bytes []byte) ([]types.ServerInfo, error) {
 	}
 
 	out := make([]types.ServerInfo, len(serverInfos))
-	for i, v := range serverInfos {
-		out[i] = types.ServerInfo(&v)
+	for i := range serverInfos {
+		out[i] = types.ServerInfo(&serverInfos[i])
 	}
 
 	return out, nil

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -87,8 +87,8 @@ type namespaceCollection struct {
 }
 
 func (n *namespaceCollection) resources() (r []types.Resource) {
-	for _, resource := range n.namespaces {
-		r = append(r, &resource)
+	for i := range n.namespaces {
+		r = append(r, &n.namespaces[i])
 	}
 	return r
 }


### PR DESCRIPTION
This commit is a similar fix to 1022fe926c16629214177eafc412b32145a63b52 / #30127

This fixes other discovered cases of referencing a for loop variable pointer.  Since the value is updated without the location changing it can result in only the last value being seen. This is typically fixed by referencing the slice offset directly, or using a new variable.