### PR TITLE
tsh kube ls ux

### DIFF
--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -979,49 +979,73 @@ func (c *kubeLSCommand) run(cf *CLIConf) error {
 	}
 
 	selectedCluster := selectedKubeCluster(currentTeleportCluster, getKubeConfigPath(cf, ""))
+	err = c.showKubeClusters(cf.Stdout(), kubeClusters, selectedCluster)
+	return trace.Wrap(err)
+}
+
+func (c *kubeLSCommand) showKubeClusters(w io.Writer, kubeClusters types.KubeClusters, selectedCluster string) error {
 	format := strings.ToLower(c.format)
 	switch format {
 	case teleport.Text, "":
-		var (
-			t       asciitable.Table
-			columns = []string{"Kube Cluster Name", "Labels", "Selected"}
-			rows    [][]string
-		)
-
-		for _, cluster := range kubeClusters {
-			var selectedMark string
-			if cluster.GetName() == selectedCluster {
-				selectedMark = "*"
-			}
-			rows = append(rows, []string{
-				cluster.GetName(),
-				common.FormatLabels(cluster.GetAllLabels(), c.verbose),
-				selectedMark,
-			})
-		}
-
-		if c.quiet {
-			t = asciitable.MakeHeadlessTable(2)
-			for _, row := range rows {
-				t.AddRow(row[:2])
-			}
-		} else if c.verbose {
-			t = asciitable.MakeTable(columns, rows...)
-		} else {
-			t = asciitable.MakeTableWithTruncatedColumn(columns, rows, "Labels")
-		}
-		fmt.Fprintln(cf.Stdout(), t.AsBuffer().String())
+		out := formatKubeClustersAsText(kubeClusters, selectedCluster, c.quiet, c.verbose)
+		fmt.Fprintln(w, out)
 	case teleport.JSON, teleport.YAML:
+		sort.Sort(kubeClusters)
 		out, err := serializeKubeClusters(kubeClusters, selectedCluster, format)
 		if err != nil {
 			return trace.Wrap(err)
 		}
-		fmt.Fprintln(cf.Stdout(), out)
+		fmt.Fprintln(w, out)
 	default:
-		return trace.BadParameter("unsupported format %q", cf.Format)
+		return trace.BadParameter("unsupported format %q", c.format)
+	}
+	return nil
+}
+
+func getKubeClusterTextRow(kc types.KubeCluster, selectedCluster string, verbose bool) []string {
+	var selectedMark string
+	var row []string
+	if selectedCluster != "" && kc.GetName() == selectedCluster {
+		selectedMark = "*"
+	}
+	printName := kc.GetName()
+	if d, ok := getDiscoveredName(kc); ok && !verbose {
+		// print the (shorter) discovered name in non-verbose mode.
+		printName = d
+	}
+	labels := common.FormatLabels(kc.GetAllLabels(), verbose)
+	row = append(row, printName, labels, selectedMark)
+	return row
+}
+
+func formatKubeClustersAsText(kubeClusters types.KubeClusters, selectedCluster string, quiet, verbose bool) string {
+	var (
+		columns = []string{"Kube Cluster Name", "Labels", "Selected"}
+		t       asciitable.Table
+		rows    [][]string
+	)
+
+	for _, cluster := range kubeClusters {
+		r := getKubeClusterTextRow(cluster, selectedCluster, verbose)
+		rows = append(rows, r)
 	}
 
-	return nil
+	switch {
+	case quiet:
+		// no column headers and only include the cluster name and labels.
+		t = asciitable.MakeHeadlessTable(2)
+		for _, row := range rows {
+			t.AddRow(row)
+		}
+	case verbose:
+		t = asciitable.MakeTable(columns, rows...)
+	default:
+		t = asciitable.MakeTableWithTruncatedColumn(columns, rows, "Labels")
+	}
+
+	// stable sort by kube cluster name.
+	t.SortRowsBy([]int{0}, true)
+	return t.AsBuffer().String()
 }
 
 func serializeKubeClusters(kubeClusters []types.KubeCluster, selectedCluster, format string) (string, error) {
@@ -1081,27 +1105,13 @@ func (c *kubeLSCommand) runAllClusters(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	sort.Sort(listings)
-
 	format := strings.ToLower(c.format)
 	switch format {
 	case teleport.Text, "":
-		var t asciitable.Table
-		if cf.Quiet {
-			t = asciitable.MakeHeadlessTable(3)
-		} else {
-			t = asciitable.MakeTable([]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"})
-		}
-		for _, listing := range listings {
-			t.AddRow([]string{
-				listing.Proxy,
-				listing.Cluster,
-				listing.KubeCluster.GetName(),
-				common.FormatLabels(listing.KubeCluster.GetAllLabels(), c.verbose),
-			})
-		}
-		fmt.Fprintln(cf.Stdout(), t.AsBuffer().String())
+		out := formatKubeListingsAsText(listings, c.quiet, c.verbose)
+		fmt.Fprintln(cf.Stdout(), out)
 	case teleport.JSON, teleport.YAML:
+		sort.Sort(listings)
 		out, err := serializeKubeListings(listings, format)
 		if err != nil {
 			return trace.Wrap(err)
@@ -1112,6 +1122,37 @@ func (c *kubeLSCommand) runAllClusters(cf *CLIConf) error {
 	}
 
 	return nil
+}
+
+func formatKubeListingsAsText(listings kubeListings, quiet, verbose bool) string {
+	var (
+		columns = []string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"}
+		t       asciitable.Table
+		rows    [][]string
+	)
+	for _, listing := range listings {
+		r := append([]string{
+			listing.Proxy,
+			listing.Cluster,
+		}, getKubeClusterTextRow(listing.KubeCluster, "", verbose)...)
+		rows = append(rows, r)
+	}
+
+	switch {
+	case quiet:
+		// quiet, so no column headers.
+		t = asciitable.MakeHeadlessTable(4)
+		for _, row := range rows {
+			t.AddRow(row)
+		}
+	case verbose:
+		t = asciitable.MakeTable(columns, rows...)
+	default:
+		t = asciitable.MakeTableWithTruncatedColumn(columns, rows, "Labels")
+	}
+	// stable sort by proxy, then cluster, then kube cluster name.
+	t.SortRowsBy([]int{0, 1, 2}, true)
+	return t.AsBuffer().String()
 }
 
 func serializeKubeListings(kubeListings []kubeListing, format string) (string, error) {

--- a/tool/tsh/common/kube_test.go
+++ b/tool/tsh/common/kube_test.go
@@ -19,14 +19,13 @@ package common
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"path/filepath"
 	"reflect"
-	"sort"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -40,6 +39,7 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/tool/common"
 )
 
 func TestKube(t *testing.T) {
@@ -59,8 +59,6 @@ type kubeTestPack struct {
 	rootKubeCluster1 string
 	rootKubeCluster2 string
 	leafKubeCluster  string
-	serviceLabels    map[string]string
-	formatedLabels   string
 }
 
 func setupKubeTestPack(t *testing.T) *kubeTestPack {
@@ -69,12 +67,18 @@ func setupKubeTestPack(t *testing.T) *kubeTestPack {
 	ctx := context.Background()
 	rootKubeCluster1 := "root-cluster"
 	rootKubeCluster2 := "first-cluster"
-	leafKubeCluster := "leaf-cluster"
-	serviceLabels := map[string]string{
+	// mock a discovered kube cluster name in the leaf Teleport cluster.
+	leafKubeCluster := "leaf-cluster-some-suffix-added-by-discovery-service"
+	rootLabels := map[string]string{
 		"label1": "val1",
 		"ultra_long_label_for_teleport_kubernetes_service_list_kube_clusters_method": "ultra_long_label_value_for_teleport_kubernetes_service_list_kube_clusters_method",
 	}
-	formatedLabels := formatServiceLabels(serviceLabels)
+	leafLabels := map[string]string{
+		"label1": "val1",
+		"ultra_long_label_for_teleport_kubernetes_service_list_kube_clusters_method": "ultra_long_label_value_for_teleport_kubernetes_service_list_kube_clusters_method",
+		// mock a discovered kube cluster in the leaf Teleport cluster.
+		types.DiscoveredNameLabel: "leaf-cluster",
+	}
 
 	s := newTestSuite(t,
 		withRootConfigFunc(func(cfg *servicecfg.Config) {
@@ -82,7 +86,7 @@ func setupKubeTestPack(t *testing.T) *kubeTestPack {
 			cfg.Kube.Enabled = true
 			cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
 			cfg.Kube.KubeconfigPath = newKubeConfigFile(t, rootKubeCluster1, rootKubeCluster2)
-			cfg.Kube.StaticLabels = serviceLabels
+			cfg.Kube.StaticLabels = rootLabels
 		}),
 		withLeafCluster(),
 		withLeafConfigFunc(
@@ -91,6 +95,7 @@ func setupKubeTestPack(t *testing.T) *kubeTestPack {
 				cfg.Kube.Enabled = true
 				cfg.Kube.ListenAddr = utils.MustParseAddr(localListenerAddr())
 				cfg.Kube.KubeconfigPath = newKubeConfigFile(t, leafKubeCluster)
+				cfg.Kube.StaticLabels = leafLabels
 			},
 		),
 		withValidationFunc(func(s *suite) bool {
@@ -110,12 +115,18 @@ func setupKubeTestPack(t *testing.T) *kubeTestPack {
 		rootKubeCluster1: rootKubeCluster1,
 		rootKubeCluster2: rootKubeCluster2,
 		leafKubeCluster:  leafKubeCluster,
-		serviceLabels:    serviceLabels,
-		formatedLabels:   formatedLabels,
 	}
 }
 
 func (p *kubeTestPack) testListKube(t *testing.T) {
+	staticRootLabels := p.suite.root.Config.Kube.StaticLabels
+	formattedRootLabels := common.FormatLabels(staticRootLabels, false)
+	formattedRootLabelsVerbose := common.FormatLabels(staticRootLabels, true)
+
+	staticLeafLabels := p.suite.leaf.Config.Kube.StaticLabels
+	formattedLeafLabels := common.FormatLabels(staticLeafLabels, false)
+	formattedLeafLabelsVerbose := common.FormatLabels(staticLeafLabels, true)
+
 	tests := []struct {
 		name      string
 		args      []string
@@ -129,7 +140,10 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 				// p.rootKubeCluster1 ("root-cluster") after sorting.
 				table := asciitable.MakeTableWithTruncatedColumn(
 					[]string{"Kube Cluster Name", "Labels", "Selected"},
-					[][]string{{p.rootKubeCluster2, p.formatedLabels, ""}, {p.rootKubeCluster1, p.formatedLabels, ""}},
+					[][]string{
+						{p.rootKubeCluster2, formattedRootLabels, ""},
+						{p.rootKubeCluster1, formattedRootLabels, ""},
+					},
 					"Labels")
 				return table.AsBuffer().String()
 			},
@@ -140,8 +154,8 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			wantTable: func() string {
 				table := asciitable.MakeTable(
 					[]string{"Kube Cluster Name", "Labels", "Selected"},
-					[]string{p.rootKubeCluster2, p.formatedLabels, ""},
-					[]string{p.rootKubeCluster1, p.formatedLabels, ""})
+					[]string{p.rootKubeCluster2, formattedRootLabelsVerbose, ""},
+					[]string{p.rootKubeCluster1, formattedRootLabelsVerbose, ""})
 				return table.AsBuffer().String()
 			},
 		},
@@ -150,8 +164,8 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			args: []string{"--quiet"},
 			wantTable: func() string {
 				table := asciitable.MakeHeadlessTable(2)
-				table.AddRow([]string{p.rootKubeCluster2, p.formatedLabels, ""})
-				table.AddRow([]string{p.rootKubeCluster1, p.formatedLabels, ""})
+				table.AddRow([]string{p.rootKubeCluster2, formattedRootLabels, ""})
+				table.AddRow([]string{p.rootKubeCluster1, formattedRootLabels, ""})
 
 				return table.AsBuffer().String()
 			},
@@ -160,13 +174,43 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 			name: "list all clusters including leaf clusters",
 			args: []string{"--all"},
 			wantTable: func() string {
+				table := asciitable.MakeTableWithTruncatedColumn(
+					[]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"},
+					[][]string{
+						// "leaf-cluster" should be displayed instead of the
+						// full leaf cluster name, since it is mocked as a
+						// discovered resource and the discovered resource name
+						// is displayed in non-verbose mode.
+						{p.root.Config.Proxy.WebAddr.String(), "leaf1", "leaf-cluster", formattedLeafLabels},
+						{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabels},
+						{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabels},
+					},
+					"Labels",
+				)
+				return table.AsBuffer().String()
+			},
+		},
+		{
+			name: "list all clusters including leaf clusters with complete list of labels",
+			args: []string{"--all", "--verbose"},
+			wantTable: func() string {
 				table := asciitable.MakeTable(
 					[]string{"Proxy", "Cluster", "Kube Cluster Name", "Labels"},
-
-					[]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", p.leafKubeCluster, ""},
-					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, p.formatedLabels},
-					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, p.formatedLabels},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", p.leafKubeCluster, formattedLeafLabelsVerbose},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabelsVerbose},
+					[]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabelsVerbose},
 				)
+				return table.AsBuffer().String()
+			},
+		},
+		{
+			name: "list all clusters including leaf clusters in headless table",
+			args: []string{"--all", "--quiet"},
+			wantTable: func() string {
+				table := asciitable.MakeHeadlessTable(4)
+				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "leaf1", "leaf-cluster", formattedLeafLabels})
+				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster2, formattedRootLabels})
+				table.AddRow([]string{p.root.Config.Proxy.WebAddr.String(), "root", p.rootKubeCluster1, formattedRootLabels})
 				return table.AsBuffer().String()
 			},
 		},
@@ -195,7 +239,10 @@ func (p *kubeTestPack) testListKube(t *testing.T) {
 				setKubeConfigPath(filepath.Join(t.TempDir(), "kubeconfig")),
 			)
 			require.NoError(t, err)
-			require.Contains(t, captureStdout.String(), tc.wantTable())
+			got := strings.TrimSpace(captureStdout.String())
+			want := strings.TrimSpace(tc.wantTable())
+			diff := cmp.Diff(want, got)
+			require.Empty(t, diff)
 		})
 	}
 }
@@ -332,16 +379,6 @@ func newKubeConfigFile(t *testing.T, clusterNames ...string) string {
 	err := clientcmd.WriteToFile(*kubeConf, kubeConfigLocation)
 	require.NoError(t, err)
 	return kubeConfigLocation
-}
-
-func formatServiceLabels(labels map[string]string) string {
-	labelSlice := make([]string, 0, len(labels))
-	for key, value := range labels {
-		labelSlice = append(labelSlice, fmt.Sprintf("%s=%s", key, value))
-	}
-
-	sort.Strings(labelSlice)
-	return strings.Join(labelSlice, ",")
 }
 
 func newKubeSelfSubjectServer(t *testing.T) string {

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -179,7 +179,7 @@ type CLIConf struct {
 	ProxyJump string
 	// --local flag for ssh
 	LocalExec bool
-	// SiteName specifies remote site go login to
+	// SiteName specifies remote site to login to.
 	SiteName string
 	// KubernetesCluster specifies the kubernetes cluster to login to.
 	KubernetesCluster string


### PR DESCRIPTION
This PR makes `tsh kube ls` display the original discovered kube cluster name (the name in the cloud, before discovery service added a metadata suffix).

changelog: `tsh kube ls` non-verbose text-formatted output will display auto-discovered kube clusters with the original kube cluster name instead of the more detailed name generated by the v14+ Teleport Discovery service.

With `--verbose`, the full (discovery service suffix included) kube cluster name is displayed

Part of the implementation for [RFD 129](https://github.com/gravitational/teleport/blob/master/rfd/0129-discovery-name-templating.md).

It also fixes:
1. `tsh kube ls --all --quiet` to include the (headless) "Labels" column, consistent with other commands that have a "quiet" mode.
2. `tsh kube ls` to sort the table entries, consistent with other text tables we output, `tsh kube ls --all` was already sorting the listings for example.

PR stacked on https://github.com/gravitational/teleport/pull/30079

## Example UX
```
$ tsh kube ls
Kube Cluster Name Labels                                    Selected 
----------------- ----------------------------------------- -------- 
example1          account-id=123456789012,region=eu-north-1

$ tsh kube ls -v
Kube Cluster Name                    Labels                                                                                                                                                                               Selected 
------------------------------------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ -------- 
example1-eks-eu-north-1-123456789012 account-id=123456789012,region=eu-north-1,teleport.dev/cloud=AWS,teleport.dev/origin=cloud,teleport.internal/discovered-name=example1,teleport.internal/discovery-group-name=aws-dev

$ tsh kube ls --all
Proxy              Cluster       Kube Cluster Name Labels                                    
------------------ ------------- ----------------- ----------------------------------------- 
mars.local.gd:3080 mars.local.gd example1          account-id=123456789012,region=eu-north-1

$ tsh kube ls --all -v
Proxy              Cluster       Kube Cluster Name                    Labels                                                                                                                                                                               
------------------ ------------- ------------------------------------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ 
mars.local.gd:3080 mars.local.gd example1-eks-eu-north-1-123456789012 account-id=123456789012,region=eu-north-1,teleport.dev/cloud=AWS,teleport.dev/origin=cloud,teleport.internal/discovered-name=example1,teleport.internal/discovery-group-name=aws-dev
```

Related issue:
- https://github.com/gravitational/teleport/issues/22438