### PR TITLE
Ensure http.Server has idle and read timeouts configured

### DIFF
--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -152,7 +152,8 @@ func (rd *Redirector) Start() error {
 			Config: &http.Server{
 				Handler:           rd.mux,
 				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
-				IdleTimeout:       apidefaults.DefaultIdleTimeout},
+				IdleTimeout:       apidefaults.DefaultIdleTimeout,
+			},
 		}
 		rd.server.Start()
 	} else {

--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -27,6 +27,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/utils"
@@ -148,7 +149,10 @@ func (rd *Redirector) Start() error {
 		}
 		rd.server = &httptest.Server{
 			Listener: listener,
-			Config:   &http.Server{Handler: rd.mux},
+			Config: &http.Server{
+				Handler:           rd.mux,
+				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+				IdleTimeout:       apidefaults.DefaultIdleTimeout},
 		}
 		rd.server.Start()
 	} else {

--- a/lib/observability/tracing/collector.go
+++ b/lib/observability/tracing/collector.go
@@ -31,6 +31,8 @@ import (
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/protobuf/proto"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 )
 
 // Collector is a simple in memory implementation of an OpenTelemetry Collector
@@ -80,7 +82,12 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 		exportedC:  make(chan struct{}, 1),
 	}
 
-	c.httpServer = &http.Server{Handler: c, TLSConfig: tlsConfig.Clone()}
+	c.httpServer = &http.Server{
+		Handler:           c,
+		ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+		TLSConfig:         tlsConfig.Clone(),
+	}
 
 	coltracepb.RegisterTraceServiceServer(c.grpcServer, c)
 

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
@@ -185,8 +186,10 @@ func (b *Bot) Run(ctx context.Context) error {
 				_, _ = w.Write([]byte(msg))
 			}))
 			srv := http.Server{
-				Addr:    b.cfg.DiagAddr,
-				Handler: mux,
+				Addr:              b.cfg.DiagAddr,
+				Handler:           mux,
+				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 			}
 			go func() {
 				<-egCtx.Done()


### PR DESCRIPTION
Configures the `ReadHeaderTimeout` and `IdleTimeout` for instances of `http.Server` highlighted by `gosec`.   Similar to the PR here: https://github.com/gravitational/teleport.e/pull/1948