### PR TITLE
Tests: run `lib/integration` and `lib/auth/integration`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -706,7 +706,7 @@ test-go-prepare: ensure-webassets bpf-bytecode rdpclient $(TEST_LOG_DIR) ensure-
 # Runs base unit tests
 .PHONY: test-go-unit
 test-go-unit: FLAGS ?= -race -shuffle on
-test-go-unit: SUBJECT ?= $(shell go list ./... | grep -v -e integration -e tool/tsh -e integrations/operator -e integrations/access -e integrations/lib )
+test-go-unit: SUBJECT ?= $(shell go list ./... | grep -v -e teleport/integration -e tool/tsh -e integrations/operator -e integrations/access -e integrations/lib)
 test-go-unit:
 	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(RDPCLIENT_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \

--- a/Makefile
+++ b/Makefile
@@ -706,7 +706,7 @@ test-go-prepare: ensure-webassets bpf-bytecode rdpclient $(TEST_LOG_DIR) ensure-
 # Runs base unit tests
 .PHONY: test-go-unit
 test-go-unit: FLAGS ?= -race -shuffle on
-test-go-unit: SUBJECT ?= $(shell go list ./... | grep -v -e teleport/integration -e tool/tsh -e integrations/operator -e integrations/access -e integrations/lib)
+test-go-unit: SUBJECT ?= $(shell go list ./... | grep -v -E 'teleport/(integration|tool/tsh|integrations/operator|integrations/access|integrations/lib)')
 test-go-unit:
 	$(CGOFLAG) go test -cover -json -tags "$(PAM_TAG) $(FIPS_TAG) $(BPF_TAG) $(RDPCLIENT_TAG) $(TOUCHID_TAG) $(PIV_TEST_TAG)" $(PACKAGES) $(SUBJECT) $(FLAGS) $(ADDFLAGS) \
 		| tee $(TEST_LOG_DIR)/unit.json \


### PR DESCRIPTION
We exclude integration tests from the Unit Tests github action. However, we were also excluding some unit tests.

The following tests were not running:
- `github.com/gravitational/teleport/lib/auth/integration/integrationv1`
- `github.com/gravitational/teleport/lib/integrations/awsoidc`

This PR adds those tests to the Unit Tests github action by changing the exclusion pattern in `test-go-unit` target (Makefile).