### PR TITLE
events emitter: improve logging on failed emits

### DIFF
--- a/lib/events/emitter.go
+++ b/lib/events/emitter.go
@@ -169,7 +169,7 @@ func (r *CheckingEmitter) EmitAuditEvent(ctx context.Context, event apievents.Au
 	}
 	if err := r.Inner.EmitAuditEvent(ctx, event); err != nil {
 		AuditFailedEmit.Inc()
-		log.WithError(err).Errorf("Failed to emit audit event.")
+		log.WithError(err).Errorf("Failed to emit audit event of type: %s.", event.GetType())
 		return trace.Wrap(err)
 	}
 	return nil


### PR DESCRIPTION
This PR adds `eventType` that will be logged during events emitting error.

Currently it's almost impossible to track down what's causing following error:
```
"RequestCanceled: request context canceled\ncaused by: context canceled","level":"error","message":"Failed to emit audit event."
```
It can be either asyncEmitter error (which is acceptable) or auth internal ctx cancelled that we should take care of.