### PR TITLE
Add PostgresSQL and MySQL benchmark commands

### DIFF
--- a/api/types/database.go
+++ b/api/types/database.go
@@ -961,6 +961,8 @@ const (
 	DatabaseProtocolClickHouseHTTP = "clickhouse-http"
 	// DatabaseProtocolClickHouse is the ClickHouse database native write protocol.
 	DatabaseProtocolClickHouse = "clickhouse"
+	// DatabaseProtocolMySQL is the MySQL database protocol.
+	DatabaseProtocolMySQL = "mysql"
 
 	// DatabaseTypeSelfHosted is the self-hosted type of database.
 	DatabaseTypeSelfHosted = "self-hosted"

--- a/lib/benchmark/db/db.go
+++ b/lib/benchmark/db/db.go
@@ -1,0 +1,110 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/srv/alpnproxy"
+)
+
+// retrieveDatabaseCertificates issues user database certificates. Same flow as
+// `tsh db login`.
+func retrieveDatabaseCertificates(ctx context.Context, tc *client.TeleportClient, db types.Database, dbUser, dbName string) (tls.Certificate, error) {
+	profile, err := tc.ProfileStatus()
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+
+	key, err := tc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
+		RouteToCluster: tc.SiteName,
+		RouteToDatabase: proto.RouteToDatabase{
+			ServiceName: db.GetName(),
+			Protocol:    db.GetProtocol(),
+			Username:    dbUser,
+			Database:    dbName,
+		},
+		AccessRequests: profile.ActiveRequests.AccessRequests,
+	}, nil)
+	if err != nil {
+		return tls.Certificate{}, trace.Wrap(err)
+	}
+
+	rawCert, ok := key.DBTLSCerts[db.GetName()]
+	if !ok {
+		return tls.Certificate{}, trace.AccessDenied("failed to retrieve database certificates")
+	}
+
+	tlsCert, err := key.TLSCertificate(rawCert)
+	return tlsCert, trace.Wrap(err)
+}
+
+// getDatabase loads the database which the name matches.
+func getDatabase(ctx context.Context, tc *client.TeleportClient, serviceName string, protocol string) (types.Database, error) {
+	databases, err := tc.ListDatabases(ctx, &proto.ListResourcesRequest{
+		Namespace:           tc.Namespace,
+		ResourceType:        types.KindDatabaseServer,
+		PredicateExpression: fmt.Sprintf(`name == "%s" && resource.spec.protocol == "%s"`, serviceName, protocol),
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(databases) != 1 {
+		return nil, trace.NotFound("no database with name %q found", serviceName)
+	}
+
+	return databases[0], nil
+}
+
+// startLocalProxy starts a local proxy (tunneled) which will be used to
+// establish a new database connection.
+func startLocalProxy(ctx context.Context, insecureSkipVerify bool, tc *client.TeleportClient, dbProtocol string, dbCert tls.Certificate) (*alpnproxy.LocalProxy, error) {
+	listener, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	opts := []alpnproxy.LocalProxyConfigOpt{
+		alpnproxy.WithDatabaseProtocol(dbProtocol),
+		alpnproxy.WithClusterCAsIfConnUpgrade(ctx, tc.RootClusterCACertPool),
+		alpnproxy.WithClientCerts(dbCert),
+	}
+
+	lp, err := alpnproxy.NewLocalProxy(alpnproxy.LocalProxyConfig{
+		RemoteProxyAddr:         tc.WebProxyAddr,
+		InsecureSkipVerify:      insecureSkipVerify,
+		ParentContext:           ctx,
+		Listener:                listener,
+		ALPNConnUpgradeRequired: tc.TLSRoutingConnUpgradeRequired,
+	}, opts...)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	go func() {
+		defer listener.Close()
+		_ = lp.Start(ctx)
+	}()
+	return lp, nil
+}

--- a/lib/benchmark/db/mysql.go
+++ b/lib/benchmark/db/mysql.go
@@ -1,0 +1,148 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"context"
+	"net/url"
+	"strings"
+
+	mysqlclient "github.com/go-mysql-org/go-mysql/client"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/benchmark"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+const (
+	// mysqlProtocolScheme is the URL scheme for MySQL databases.
+	mysqlProtocolScheme = "mysql"
+)
+
+// MySQLBenchmark is a benchmark suite that connects to a MySQL database
+// (directly or through Teleport) and issues a ping command.
+type MySQLBenchmark struct {
+	// DBService database service name of the target database. Can be a Teleport
+	// database or a direct URI.
+	DBService string
+	// DBUser database user used to connect to the target database.
+	DBUser string
+	// DBName database name where the benchmark queries are going to be
+	// executed.
+	DBName string
+	// InsecureSkipVerify bypasses verification of TLS certificate.
+	InsecureSkipVerify bool
+	// connOptions are the MySQL connection options.
+	connOptions *mysqlConnOptions
+}
+
+func (p *MySQLBenchmark) CheckAndSetDefaults() error {
+	if p.DBService == "" {
+		return trace.BadParameter("database or direct database URI must be provided")
+	}
+
+	if strings.Contains(p.DBService, "://") {
+		var err error
+		p.connOptions, err = parseMySQLConnString(p.DBService)
+		return trace.Wrap(err)
+	}
+
+	if p.DBUser == "" || p.DBName == "" {
+		return trace.BadParameter("must provide and database name and user")
+	}
+
+	return nil
+}
+
+func (p *MySQLBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (benchmark.WorkloadFunc, error) {
+	if err := p.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config, err := p.buildConnectionConfig(ctx, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return func(ctx context.Context) error {
+		conn, err := mysqlclient.Connect(config.host, config.username, config.password, config.database)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		return trace.Wrap(conn.Ping())
+	}, nil
+}
+
+// mysqlConnOptions defines connection configuration for MySQL database.
+type mysqlConnOptions struct {
+	host     string
+	username string
+	password string
+	database string
+}
+
+// buildConnectionConfig generates a connect configuration for the database.
+func (p *MySQLBenchmark) buildConnectionConfig(ctx context.Context, tc *client.TeleportClient) (*mysqlConnOptions, error) {
+	if p.connOptions != nil {
+		return p.connOptions, nil
+	}
+
+	database, err := getDatabase(ctx, tc, p.DBService, types.DatabaseProtocolMySQL)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	dbCert, err := retrieveDatabaseCertificates(ctx, tc, database, p.DBUser, p.DBName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	lp, err := startLocalProxy(ctx, p.InsecureSkipVerify, tc, database.GetProtocol(), dbCert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &mysqlConnOptions{
+		host:     lp.GetAddr(),
+		username: p.DBUser,
+		database: p.DBName,
+	}, nil
+}
+
+// parseMySQLConnString parses a MySQL URI into connection options.
+// URI Format:
+// [scheme://][user[:[password]]@]host[:port][/schema][?attribute1=value1&attribute2=value2...
+//
+// Reference: https://dev.mysql.com/doc/refman/8.0/en/connecting-using-uri-or-key-value-pairs.html
+func parseMySQLConnString(connString string) (*mysqlConnOptions, error) {
+	parsed, err := url.Parse(connString)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if parsed.Scheme != mysqlProtocolScheme {
+		return nil, trace.BadParameter("scheme %q not supported. Please use %q", parsed.Scheme, mysqlProtocolScheme)
+	}
+
+	password, _ := parsed.User.Password()
+	return &mysqlConnOptions{
+		host:     parsed.Host,
+		username: parsed.User.Username(),
+		password: password,
+		database: strings.TrimPrefix(parsed.Path, "/"),
+	}, nil
+}

--- a/lib/benchmark/db/mysql.go
+++ b/lib/benchmark/db/mysql.go
@@ -60,13 +60,14 @@ func (p *MySQLBenchmark) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 
-	if p.DBUser == "" || p.DBName == "" {
-		return trace.BadParameter("must provide and database name and user")
+	if p.DBUser == "" {
+		return trace.BadParameter("must provide database user")
 	}
 
 	return nil
 }
 
+// BenchBuilder returns a WorkloadFunc for the given benchmark suite.
 func (p *MySQLBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (benchmark.WorkloadFunc, error) {
 	if err := p.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/benchmark/db/mysql_test.go
+++ b/lib/benchmark/db/mysql_test.go
@@ -1,0 +1,68 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMySQLConnString(t *testing.T) {
+	for name, tc := range map[string]struct {
+		connString string
+		expectErr  bool
+		host       string
+		username   string
+		password   string
+		database   string
+	}{
+		"valid": {
+			connString: "mysql://user_name:123123@localhost:3333/db?get-server-public-key=true",
+			host:       "localhost:3333",
+			username:   "user_name",
+			password:   "123123",
+			database:   "db",
+		},
+		"valid without database": {
+			connString: "mysql://user@localhost:3306?get-server-public-key=true",
+			host:       "localhost:3306",
+			username:   "user",
+		},
+		"valid with escaped char": {
+			connString: "mysql://user_name@198.51.100.2:33060/world%5Fx",
+			host:       "198.51.100.2:33060",
+			username:   "user_name",
+			database:   "world_x",
+		},
+		"unsupported scheme": {
+			connString: "mysqlx://user_name@localhost:33065",
+			expectErr:  true,
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			config, err := parseMySQLConnString(tc.connString)
+			if tc.expectErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.Equal(t, tc.host, config.host)
+			require.Equal(t, tc.username, config.username)
+			require.Equal(t, tc.password, config.password)
+			require.Equal(t, tc.database, config.database)
+		})
+	}
+}

--- a/lib/benchmark/db/postgres.go
+++ b/lib/benchmark/db/postgres.go
@@ -1,0 +1,120 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gravitational/trace"
+	"github.com/jackc/pgconn"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/benchmark"
+	"github.com/gravitational/teleport/lib/client"
+)
+
+const (
+	// postgresPingQuery is a noop query used to verify the connection is
+	// working.
+	postgresPingQuery = "SELECT 1;"
+)
+
+// PostgresBenchmark is a benchmark suite that connects to a PostgreSQL database
+// (directly or through Teleport) and issues a ping query.
+type PostgresBenchmark struct {
+	// DBService database service name of the target database. Can be a Teleport
+	// database or a direct URI.
+	DBService string
+	// DBUser database user used to connect to the target database.
+	DBUser string
+	// DBName database name where the benchmark queries are going to be
+	// executed.
+	DBName string
+	// InsecureSkipVerify bypasses verification of TLS certificate.
+	InsecureSkipVerify bool
+	// connConfig is a configuration to directly connect to a PostgreSQL
+	// database (without Teleport).
+	connConfig *pgconn.Config
+}
+
+func (p *PostgresBenchmark) CheckAndSetDefaults() error {
+	if p.DBService == "" {
+		return trace.BadParameter("database or direct database URI must be provided")
+	}
+
+	if directConfig, err := pgconn.ParseConfig(p.DBService); err == nil {
+		p.connConfig = directConfig
+	}
+
+	if p.connConfig == nil && (p.DBUser == "" || p.DBName == "") {
+		return trace.BadParameter("must provide and database name and user")
+	}
+
+	return nil
+}
+
+func (p *PostgresBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (benchmark.WorkloadFunc, error) {
+	if err := p.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config, err := p.buildConnectionConfig(ctx, tc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return func(ctx context.Context) error {
+		conn, err := pgconn.ConnectConfig(ctx, config)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		defer conn.Close(ctx)
+
+		_, err = conn.Exec(ctx, postgresPingQuery).ReadAll()
+		return trace.Wrap(err)
+	}, nil
+}
+
+// buildConnectionConfig generates a connect configuration for the database.
+func (p *PostgresBenchmark) buildConnectionConfig(ctx context.Context, tc *client.TeleportClient) (*pgconn.Config, error) {
+	if p.connConfig != nil {
+		return p.connConfig, nil
+	}
+
+	database, err := getDatabase(ctx, tc, p.DBService, types.DatabaseProtocolPostgreSQL)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	dbCert, err := retrieveDatabaseCertificates(ctx, tc, database, p.DBUser, p.DBName)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	lp, err := startLocalProxy(ctx, p.InsecureSkipVerify, tc, database.GetProtocol(), dbCert)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config, err := pgconn.ParseConfig(fmt.Sprintf("postgres://%v/?sslmode=verify-full", lp.GetAddr()))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	config.User = p.DBUser
+	config.Database = p.DBName
+	return config, nil
+}

--- a/lib/benchmark/db/postgres.go
+++ b/lib/benchmark/db/postgres.go
@@ -66,6 +66,7 @@ func (p *PostgresBenchmark) CheckAndSetDefaults() error {
 	return nil
 }
 
+// BenchBuilder returns a WorkloadFunc for the given benchmark suite.
 func (p *PostgresBenchmark) BenchBuilder(ctx context.Context, tc *client.TeleportClient) (benchmark.WorkloadFunc, error) {
 	if err := p.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Closes #27534 and #27533.

Implements [RFD 141](https://github.com/gravitational/teleport/pull/28727/files).

This PR adds two benchmark commands for PostgreSQL and MySQL: `tsh bench postgres` and `tsh bench mysql`. With two execution options: Direct access (without using Teleport) and through Teleport. When connecting through Teleport, the command uses a local tunneled proxy (same as `tsh proxy db --tunnel`).

<details>
<summary>Examples</summary>

Command execution:
```
// For Teleport-proxied databases.
$ tsh bench postgres --db-name=postgres --db-user=postgres postgresinstance
$ tsh bench mysql --db-name=mysql --db-user=root mysqlinstance

// For direct connection (without Teleport).
$ tsh bench postgres postgres://postgres@localhost:5432/postgres
$ tsh bench mysql mysql://root@localhost:3306/mysql
```

Output example:
```
$ tsh bench mysql --insecure mysql://root@localhost:3306/mysql

* Requests originated: 10
* Requests failed: 0

Histogram

Percentile Response Duration
---------- -----------------
25         8 ms
50         8 ms
75         15 ms
90         21 ms
95         25 ms
99         25 ms
100        25 ms
```

</details>
