### PR TITLE
chore: Bump Go to v1.21.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1268,7 +1268,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -1477,7 +1477,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -1685,7 +1685,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -1900,7 +1900,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -3200,7 +3200,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -4026,7 +4026,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -5355,7 +5355,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport14
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -17069,6 +17069,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: a0cd6e281f864553c31bf642861283cdfa54275907721fcbd1949b3ca239a3e1
+hmac: db22e0dbdfaf7b438259c59d1648a2de7dfc266c308fc650ccc1dd496f4dbd11
 
 ...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -72,7 +72,7 @@ output:
   uniq-by-line: false
 
 run:
-  go: '1.20'
+  go: '1.21'
   skip-dirs:
     - (^|/)node_modules/
     - ^api/gen/

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -20,7 +20,7 @@ OS ?= linux
 ARCH ?= amd64
 
 # Sync with devbox.json.
-GOLANG_VERSION ?= go1.20.7
+GOLANG_VERSION ?= go1.21.0
 
 # Sync with devbox.json.
 NODE_VERSION ?= 16.18.1

--- a/docs/config.json
+++ b/docs/config.json
@@ -1577,7 +1577,7 @@
     "teleport": {
       "major_version": "14",
       "version": "14.0.0-dev",
-      "golang": "1.20",
+      "golang": "1.21",
       "plugin": {
         "version": "12.1.1"
       },


### PR DESCRIPTION
Update Go toolchain to the latest release.

* https://go.dev/doc/go1.21

Changelog: Update Go to 1.21.0.