### PR TITLE
[v13] chore: Bump Go to v1.21.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1341,7 +1341,7 @@ type: kubernetes
 name: build-linux-amd64-centos7
 environment:
   BUILDBOX_VERSION: teleport13
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -1550,7 +1550,7 @@ type: kubernetes
 name: build-linux-amd64-centos7-fips
 environment:
   BUILDBOX_VERSION: teleport13
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -1758,7 +1758,7 @@ type: kubernetes
 name: build-linux-amd64
 environment:
   BUILDBOX_VERSION: teleport13
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -1973,7 +1973,7 @@ type: kubernetes
 name: build-linux-amd64-fips
 environment:
   BUILDBOX_VERSION: teleport13
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -3273,7 +3273,7 @@ type: kubernetes
 name: build-linux-386
 environment:
   BUILDBOX_VERSION: teleport13
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -4099,7 +4099,7 @@ type: kubernetes
 name: build-linux-arm
 environment:
   BUILDBOX_VERSION: teleport13
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -5428,7 +5428,7 @@ type: kubernetes
 name: build-windows-amd64
 environment:
   BUILDBOX_VERSION: teleport13
-  RUNTIME: go1.20.7
+  RUNTIME: go1.21.0
 trigger:
   event:
     include:
@@ -17092,6 +17092,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: e7372f0fdccfd97567c50162eba67f3ba00ea05e6192370e0e6dfc04cc13ae2a
+hmac: 384f5c1febc0d1c98c82a281c1b4e1c2d3be4554671bfbaab5abd2313cd7fa8f
 
 ...

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -19,7 +19,7 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.20.7
+GOLANG_VERSION ?= go1.21.0
 
 NODE_VERSION ?= 16.18.1
 


### PR DESCRIPTION
Update Go toolchain to the latest release.

* https://go.dev/doc/go1.21