### PR TITLE
Ensure the Minimum TLS version is consistently set

### DIFF
--- a/api/defaults/defaults.go
+++ b/api/defaults/defaults.go
@@ -18,6 +18,7 @@ limitations under the License.
 package defaults
 
 import (
+	"crypto/tls"
 	"sync"
 	"time"
 
@@ -33,6 +34,9 @@ const (
 
 	// DefaultIdleTimeout is a default idle connection timeout.
 	DefaultIdleTimeout = 30 * time.Second
+
+	// MinTLSVersion is the minimum TLS version the server will accept.
+	MinTLSVersion = tls.VersionTLS12
 
 	// KeepAliveCountMax is the number of keep-alive messages that can be sent
 	// without receiving a response from the client before the client is

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2833,7 +2833,9 @@ func (process *TeleportProcess) initMetricsService() error {
 	}
 	warnOnErr(process.closeImportedDescriptors(teleport.ComponentMetrics), log)
 
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: apidefaults.MinTLSVersion,
+	}
 	if process.Config.Metrics.MTLS {
 		for _, pair := range process.Config.Metrics.KeyPairs {
 			certificate, err := tls.LoadX509KeyPair(pair.Certificate, pair.PrivateKey)

--- a/lib/service/servicecfg/metrics.go
+++ b/lib/service/servicecfg/metrics.go
@@ -23,6 +23,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/gravitational/teleport"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -86,7 +87,9 @@ func (t TracingConfig) Config(attrs ...attribute.KeyValue) (*tracing.Config, err
 		SamplingRate: t.SamplingRate,
 	}
 
-	tlsConfig := &tls.Config{}
+	tlsConfig := &tls.Config{
+		MinVersion: apidefaults.MinTLSVersion,
+	}
 	// if a custom CA is specified, use a custom cert pool
 	if len(t.CACerts) > 0 {
 		pool := x509.NewCertPool()

--- a/lib/srv/alpnproxy/kube.go
+++ b/lib/srv/alpnproxy/kube.go
@@ -38,6 +38,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
@@ -259,6 +260,7 @@ func NewKubeListener(casByTeleportCluster map[string]tls.Certificate) (net.Liste
 			Certificates: []tls.Certificate{ca},
 			ClientAuth:   tls.RequireAndVerifyClientCert,
 			ClientCAs:    clientCAs,
+			MinVersion:   apidefaults.MinTLSVersion,
 		}
 	}
 	listener, err := tls.Listen("tcp", "localhost:0", &tls.Config{
@@ -269,6 +271,7 @@ func NewKubeListener(casByTeleportCluster map[string]tls.Certificate) (net.Liste
 			}
 			return config, nil
 		},
+		MinVersion: apidefaults.MinTLSVersion,
 	})
 	return listener, trace.Wrap(err)
 }

--- a/lib/srv/alpnproxy/listener.go
+++ b/lib/srv/alpnproxy/listener.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -186,6 +187,7 @@ func NewCertGenListener(config CertGenListenerConfig) (*CertGenListener, error) 
 
 	r.Listener, err = tls.Listen("tcp", r.cfg.ListenAddr, &tls.Config{
 		GetCertificate: r.GetCertificate,
+		MinVersion:     apidefaults.MinTLSVersion,
 	})
 	if err != nil {
 		return nil, trace.ConvertSystemError(err)

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/constants"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils/pingconn"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/authz"
@@ -496,6 +497,7 @@ func (p *Proxy) readHelloMessageWithoutTLSTermination(conn net.Conn) (*tls.Clien
 			hello = info
 			return nil, nil
 		},
+		MinVersion: apidefaults.MinTLSVersion,
 	})
 	if err := conn.SetReadDeadline(p.cfg.Clock.Now().Add(p.cfg.ReadDeadline)); err != nil {
 		return nil, nil, trace.Wrap(err)

--- a/lib/teleterm/grpccredentials.go
+++ b/lib/teleterm/grpccredentials.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
@@ -45,6 +46,7 @@ func createServerCredentials(serverKeyPair tls.Certificate, clientCertPath strin
 	config := &tls.Config{
 		ClientAuth:   tls.RequireAndVerifyClientCert,
 		Certificates: []tls.Certificate{serverKeyPair},
+		MinVersion:   apidefaults.MinTLSVersion,
 	}
 
 	config.GetConfigForClient = func(_ *tls.ClientHelloInfo) (*tls.Config, error) {

--- a/lib/utils/tls.go
+++ b/lib/utils/tls.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	"github.com/gravitational/trace"
+
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 )
 
 // TLSConfig returns default TLS configuration strong defaults.
@@ -41,7 +43,7 @@ func SetupTLSConfig(config *tls.Config, cipherSuites []uint16) {
 		config.CipherSuites = cipherSuites
 	}
 
-	config.MinVersion = tls.VersionTLS12
+	config.MinVersion = apidefaults.MinTLSVersion
 	config.SessionTicketsDisabled = false
 	config.ClientSessionCache = tls.NewLRUClientSessionCache(DefaultLRUCapacity)
 }

--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/client/proto"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/client"
@@ -666,6 +667,7 @@ func createLocalProxyListener(addr string, route tlsca.RouteToDatabase, profile 
 		l, err := tls.Listen("tcp", addr, &tls.Config{
 			Certificates: []tls.Certificate{localCert},
 			ServerName:   "localhost",
+			MinVersion:   apidefaults.MinTLSVersion,
 		})
 		return l, trace.Wrap(err)
 	}


### PR DESCRIPTION
We were already configuring the minimum TLS version for the server side in `utils/tls.go`. However this was not being consistently used, and client side TLS version requirements were not set.

With this PR I have introduced a minimum TLS version in `api/defaults/defaults.go`.  Currently 1.2, all server side listeners are designed to reference this value.  This should make future updates simpler. Client side TLS configurations are hard coded to 1.2, since 1.0 and 1.1 are deprecated.

This PR is not currently planned to be backported