### PR TITLE
`tsh request search` displays discovered resource name

### DIFF
--- a/tool/common/common.go
+++ b/tool/common/common.go
@@ -171,3 +171,19 @@ func FormatLabels(labels map[string]string, verbose bool) string {
 	namespaced = append(namespaced, teleportNamespaced...)
 	return strings.Join(append(result, namespaced...), ",")
 }
+
+// FormatResourceName returns the resource's name or its name as originally
+// discovered in the cloud by the Teleport Discovery Service.
+// In verbose mode, it always returns the resource name.
+// In non-verbose mode, if the resource came from discovery and has the
+// discovered name label, it returns the discovered name.
+func FormatResourceName(r types.ResourceWithLabels, verbose bool) string {
+	if !verbose {
+		// return the (shorter) discovered name in non-verbose mode.
+		discoveredName, ok := r.GetAllLabels()[types.DiscoveredNameLabel]
+		if ok && discoveredName != "" {
+			return discoveredName
+		}
+	}
+	return r.GetName()
+}

--- a/tool/tctl/common/collection.go
+++ b/tool/tctl/common/collection.go
@@ -688,7 +688,7 @@ func (c *databaseServerCollection) writeText(w io.Writer, verbose bool) error {
 		labels := common.FormatLabels(server.GetDatabase().GetAllLabels(), verbose)
 		rows = append(rows, []string{
 			server.GetHostname(),
-			nameOrDiscoveredName(server.GetDatabase(), verbose),
+			common.FormatResourceName(server.GetDatabase(), verbose),
 			server.GetDatabase().GetProtocol(),
 			server.GetDatabase().GetURI(),
 			labels,
@@ -732,7 +732,7 @@ func (c *databaseCollection) writeText(w io.Writer, verbose bool) error {
 	for _, database := range c.databases {
 		labels := common.FormatLabels(database.GetAllLabels(), verbose)
 		rows = append(rows, []string{
-			nameOrDiscoveredName(database, verbose),
+			common.FormatResourceName(database, verbose),
 			database.GetProtocol(),
 			database.GetURI(),
 			labels,
@@ -877,7 +877,7 @@ func (c *kubeServerCollection) writeText(w io.Writer, verbose bool) error {
 		}
 		labels := common.FormatLabels(kube.GetAllLabels(), verbose)
 		rows = append(rows, []string{
-			nameOrDiscoveredName(kube, verbose),
+			common.FormatResourceName(kube, verbose),
 			labels,
 			server.GetTeleportVersion(),
 		})
@@ -929,7 +929,7 @@ func (c *kubeClusterCollection) writeText(w io.Writer, verbose bool) error {
 	for _, cluster := range c.clusters {
 		labels := common.FormatLabels(cluster.GetAllLabels(), verbose)
 		rows = append(rows, []string{
-			nameOrDiscoveredName(cluster, verbose),
+			common.FormatResourceName(cluster, verbose),
 			labels,
 		})
 	}
@@ -1191,19 +1191,4 @@ func (c *userGroupCollection) writeText(w io.Writer, verbose bool) error {
 	}
 	_, err := t.AsBuffer().WriteTo(w)
 	return trace.Wrap(err)
-}
-
-// nameOrDiscoveredName returns the resource's name or its name as originally
-// discovered in the cloud by the Teleport Discovery Service.
-// In verbose mode, it always returns the resource name.
-// In non-verbose mode, if the resource came from discovery and has the
-// discovered name label, it returns the discovered name.
-func nameOrDiscoveredName(r types.ResourceWithLabels, verbose bool) string {
-	if !verbose {
-		originalName, ok := r.GetAllLabels()[types.DiscoveredNameLabel]
-		if ok && originalName != "" {
-			return originalName
-		}
-	}
-	return r.GetName()
 }

--- a/tool/tsh/common/access_request.go
+++ b/tool/tsh/common/access_request.go
@@ -473,7 +473,7 @@ func onRequestSearch(cf *CLIConf) error {
 			resourceIDs = append(resourceIDs, resourceID)
 
 			row = []string{
-				resource.GetName(),
+				common.FormatResourceName(resource, cf.Verbose),
 				r.Spec.Namespace,
 				common.FormatLabels(resource.GetAllLabels(), cf.Verbose),
 				resourceID,
@@ -495,7 +495,7 @@ func onRequestSearch(cf *CLIConf) error {
 				hostName = r.GetHostname()
 			}
 			row = []string{
-				resource.GetName(),
+				common.FormatResourceName(resource, cf.Verbose),
 				hostName,
 				common.FormatLabels(resource.GetAllLabels(), cf.Verbose),
 				resourceID,

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1008,13 +1008,9 @@ func getKubeClusterTextRow(kc types.KubeCluster, selectedCluster string, verbose
 	if selectedCluster != "" && kc.GetName() == selectedCluster {
 		selectedMark = "*"
 	}
-	printName := kc.GetName()
-	if d, ok := getDiscoveredName(kc); ok && !verbose {
-		// print the (shorter) discovered name in non-verbose mode.
-		printName = d
-	}
+	displayName := common.FormatResourceName(kc, verbose)
 	labels := common.FormatLabels(kc.GetAllLabels(), verbose)
-	row = append(row, printName, labels, selectedMark)
+	row = append(row, displayName, labels, selectedMark)
 	return row
 }
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -2831,23 +2831,15 @@ func formatUsersForDB(database types.Database, accessChecker services.AccessChec
 	return fmt.Sprintf("%v, except: %v", dbUsers.Allowed, dbUsers.Denied)
 }
 
-func getDiscoveredName(r types.ResourceWithLabels) (string, bool) {
-	name, ok := r.GetAllLabels()[types.DiscoveredNameLabel]
-	return name, ok
-}
-
 func getDatabaseRow(proxy, cluster, clusterFlag string, database types.Database, active []tlsca.RouteToDatabase, accessChecker services.AccessChecker, verbose bool) []string {
 	name := database.GetName()
-	printName := name
-	if d, ok := getDiscoveredName(database); ok && !verbose && d != name {
-		printName = d
-	}
+	displayName := common.FormatResourceName(database, verbose)
 	var connect string
 	for _, a := range active {
 		if a.ServiceName == name {
-			a.ServiceName = printName
-			// format the db name with the print name
-			printName = formatActiveDB(a)
+			a.ServiceName = displayName
+			// format the db name with the display name
+			displayName = formatActiveDB(a)
 			// then revert it for connect string
 			a.ServiceName = name
 			switch a.Protocol {
@@ -2869,7 +2861,7 @@ func getDatabaseRow(proxy, cluster, clusterFlag string, database types.Database,
 	labels := common.FormatLabels(database.GetAllLabels(), verbose)
 	if verbose {
 		row = append(row,
-			printName,
+			displayName,
 			database.GetDescription(),
 			database.GetProtocol(),
 			database.GetType(),
@@ -2880,7 +2872,7 @@ func getDatabaseRow(proxy, cluster, clusterFlag string, database types.Database,
 		)
 	} else {
 		row = append(row,
-			printName,
+			displayName,
 			database.GetDescription(),
 			formatUsersForDB(database, accessChecker),
 			labels,


### PR DESCRIPTION
This PR makes `tsh request search` display an auto-discovered resource by its original discovered name instead of the full name as it was renamed by discovery service (in non-verbose mode). In verbose mode it shows the full name.

I also factored out discovered name func from tsh and tctl into tool/common

stacked on https://github.com/gravitational/teleport/pull/30149

Part of the implementation for [RFD 129](https://github.com/gravitational/teleport/blob/master/rfd/0129-discovery-name-templating.md).

Related issue:
- https://github.com/gravitational/teleport/issues/22438

Changelog: `tsh request search` in non-verbose mode will display auto-discovered resources with original resource names instead of the more detailed names generated by the v14+ Teleport Discovery service.