### PR TITLE
improve reporter key formatting

### DIFF
--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -365,7 +365,7 @@ func (s *Reporter) trackRequest(opType types.OpType, key []byte, endKey []byte) 
 	if len(key) == 0 {
 		return
 	}
-	keyLabel := buildKeyLabel(string(key), sensitiveBackendPrefixes)
+	keyLabel := buildKeyLabel(string(key), sensitiveBackendPrefixes, singletonBackendPrefixes, len(endKey) != 0)
 	rangeSuffix := teleport.TagFalse
 	if len(endKey) != 0 {
 		// Range denotes range queries in stat entry
@@ -399,20 +399,42 @@ func (s *Reporter) trackRequest(opType types.OpType, key []byte, endKey []byte) 
 
 // buildKeyLabel builds the key label for storing to the backend. The key's name
 // is masked if it is determined to be sensitive based on sensitivePrefixes.
-func buildKeyLabel(key string, sensitivePrefixes []string) string {
+func buildKeyLabel(key string, sensitivePrefixes, singletonPrefixes []string, isRange bool) string {
 	parts := strings.Split(key, string(Separator))
-	if len(parts) > 3 {
-		// Cut the key down to 3 parts, otherwise too many
-		// distinct requests can end up in the key label map.
-		parts = parts[:3]
+
+	finalLen := len(parts)
+	var realStart int
+
+	// skip leading space if one exists so that we can consistently access path segments by
+	// index regardless of wether or not the specific path has a leading separator.
+	if finalLen-realStart > 1 && parts[realStart] == "" {
+		realStart = 1
 	}
 
-	// If the key matches "/sensitiveprefix/keyname", mask the key.
-	if len(parts) == 3 && len(parts[0]) == 0 && slices.Contains(sensitivePrefixes, parts[1]) {
-		parts[2] = string(MaskKeyName(parts[2]))
+	// trim trailing space for consistency
+	if finalLen-realStart > 1 && parts[finalLen-1] == "" {
+		finalLen -= 1
 	}
 
-	return strings.Join(parts, string(Separator))
+	// we typically always want to trim the final element from any multipart path to avoid tracking individual
+	// resources. the two exceptions are if the path originates from a range request, or if the first element
+	// in the path is a known singleton range.
+	if finalLen-realStart > 1 && !isRange && !slices.Contains(singletonPrefixes, parts[realStart]) {
+		finalLen -= 1
+	}
+
+	// paths may contain at most two segments excluding leading blank
+	if finalLen-realStart > 2 {
+		finalLen = realStart + 2
+	}
+
+	// if the first non-empty segment is a secret range and there are at least two non-empty
+	// segments, then the second non-empty segment should be masked.
+	if finalLen-realStart > 1 && slices.Contains(sensitivePrefixes, parts[realStart]) {
+		parts[realStart+1] = string(MaskKeyName(parts[realStart+1]))
+	}
+
+	return strings.Join(parts[:finalLen], string(Separator))
 }
 
 // sensitiveBackendPrefixes is a list of backend request prefixes preceding
@@ -424,6 +446,12 @@ var sensitiveBackendPrefixes = []string{
 	// https://github.com/gravitational/teleport/blob/01775b73f138ff124ff0351209d629bb01836869/lib/services/local/users.go#L1510.
 	"sessionData",
 	"access_requests",
+}
+
+// singletonBackendPrefixes is a list of prefixes where its not necessary to trim the trailing
+// path component automatically since the range only contains singleton values.
+var singletonBackendPrefixes = []string{
+	"cluster_configuration",
 }
 
 // ReporterWatcher is a wrapper around backend

--- a/lib/backend/report.go
+++ b/lib/backend/report.go
@@ -406,7 +406,7 @@ func buildKeyLabel(key string, sensitivePrefixes, singletonPrefixes []string, is
 	var realStart int
 
 	// skip leading space if one exists so that we can consistently access path segments by
-	// index regardless of wether or not the specific path has a leading separator.
+	// index regardless of whether or not the specific path has a leading separator.
 	if finalLen-realStart > 1 && parts[realStart] == "" {
 		realStart = 1
 	}


### PR DESCRIPTION
Attempts to reduce clutter in backend key range stats.  Aggregating stats about backend key ranges is tricky, because our key ranges aren't very consistent about the meaning of path segments.  Some resources are stored at `/<kind>/<id>`, while others are stored at `/<api>/<kind>/<id>` or even `/<kind>/<namespace>/<id>/<sub-kind>`.  This has lead to cluttered an inconsistent stats.  On one hand we trac stats for the number of backend operations on each `kubeServer` or `instance` resource individually, while at the same time we track a single aggregate for all nodes.

The changes made here try to push us toward always tracking by "kind" of resource rather than individual resource, though an exception is made for ranges that are all singleton resources since those tend to have totally separate access patterns that should be tracked individually.  This is the fifth or sixth iteration and seems to work best given the spread of key layouts currently in use, but I think the key takeaway is that we should be trying to come up with some kind of standardized key layout (e.g. `/<kind>/<version>/<sub-kind>/<id>`), that can meet the needs of all or most existing resources.