### PR TITLE
Fix desktop access connecting to direct dial nodes

### DIFF
--- a/lib/service/desktop.go
+++ b/lib/service/desktop.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
+	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnel"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/services"
@@ -248,7 +249,26 @@ func (process *TeleportProcess) initWindowsDesktopServiceRegistered(log *logrus.
 			log.Infof("Starting Windows desktop service on %v.", listener.Addr())
 		}
 		process.BroadcastEvent(Event{Name: WindowsDesktopReady, Payload: nil})
-		err := srv.Serve(listener)
+
+		mux, err := multiplexer.New(multiplexer.Config{
+			Context:                     process.ExitContext(),
+			Listener:                    listener,
+			EnableExternalProxyProtocol: cfg.Proxy.EnableProxyProtocol,
+			ID:                          teleport.Component(teleport.ComponentWindowsDesktop),
+			CertAuthorityGetter:         accessPoint.GetCertAuthority,
+			LocalClusterName:            clusterName,
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		go func() {
+			if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
+				mux.Entry.WithError(err).Error("mux encountered err serving")
+			}
+		}()
+
+		err = srv.Serve(mux.TLS())
 		if err != nil {
 			if err == http.ErrServerClosed {
 				return nil


### PR DESCRIPTION
After removing returning of teleport version of the target when dialling a host we started  PROXY headers to the direct dial windows desktop service. And it highlighted a problem - windows desktop listener didn't support signed PROXY headers. So there was a bug even before removal of teleport version returning, it just went unnoticed, but IP propagation (and by extension IP pinning) wouldn't work for direct dial desktop access nodes. In this PR we're adding multiplexer to the desktop access server listener to leverage PROXY headers parsing.