### PR TITLE
MFA for admin actions: Add MFA prompt to API client (`tctl` and `tsh`)

### DIFF
--- a/api/client/mfa.go
+++ b/api/client/mfa.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+)
+
+// performMFACeremony retrieves an MFA challenge from the server, prompts the
+// user to answer the challenge, and returns the resulting MFA response.
+func (c *Client) performMFACeremony(ctx context.Context) (*proto.MFAAuthenticateResponse, error) {
+	if c.c.PromptAdminRequestMFA == nil {
+		return nil, trace.BadParameter("missing PromptAdminRequestMFA field, client cannot perform MFA ceremony")
+	}
+
+	chal, err := c.CreateAuthenticateChallenge(ctx, &proto.CreateAuthenticateChallengeRequest{
+		Request: &proto.CreateAuthenticateChallengeRequest_ContextUser{},
+	})
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := c.c.PromptAdminRequestMFA(ctx, chal)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return resp, nil
+}

--- a/api/client/mfa_test.go
+++ b/api/client/mfa_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/client/proto"
+)
+
+const (
+	proxyAddr   = "test-proxy"
+	otpTestCode = "otp-test-code"
+)
+
+type mfaService struct {
+	*proto.UnimplementedAuthServiceServer
+}
+
+func (s *mfaService) Ping(ctx context.Context, req *proto.PingRequest) (*proto.PingResponse, error) {
+	return &proto.PingResponse{
+		ProxyPublicAddr: proxyAddr,
+	}, nil
+}
+
+func (s *mfaService) CreateAuthenticateChallenge(ctx context.Context, req *proto.CreateAuthenticateChallengeRequest) (*proto.MFAAuthenticateChallenge, error) {
+	return &proto.MFAAuthenticateChallenge{
+		TOTP: &proto.TOTPChallenge{},
+	}, nil
+}
+
+func TestPerformMFACeremony(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+
+	server := startMockServer(t, &mfaService{})
+
+	mfaTestResp := &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_TOTP{
+			TOTP: &proto.TOTPResponse{
+				Code: otpTestCode,
+			},
+		},
+	}
+
+	cfg := server.clientCfg()
+	cfg.PromptAdminRequestMFA = func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
+		if chal.TOTP != nil {
+			return mfaTestResp, nil
+		}
+		return nil, trace.BadParameter("expected TOTP challenge")
+	}
+
+	clt, err := New(ctx, cfg)
+	require.NoError(t, err)
+
+	resp, err := clt.performMFACeremony(ctx)
+	require.NoError(t, err)
+	require.Equal(t, mfaTestResp.Response, resp.Response)
+}

--- a/api/mfa/mfa.go
+++ b/api/mfa/mfa.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mfa
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/metadata"
+
+	"github.com/gravitational/teleport/api/client/proto"
+)
+
+const mfaResponseToken = "mfa_challenge_response"
+
+// ErrAdminActionMFARequired is an error indicating that an admin-level
+// API request failed due to missing MFA verification.
+var ErrAdminActionMFARequired = trace.AccessDeniedError{Message: "admin-level API request requires MFA verification"}
+
+// WithCredentials can be called on a GRPC client request to attach
+// MFA credentials to the GRPC metadata for requests that require MFA,
+// like admin-level requests.
+func WithCredentials(resp *proto.MFAAuthenticateResponse) grpc.CallOption {
+	return grpc.PerRPCCredentials(&perRPCCredentials{MFAChallengeResponse: resp})
+}
+
+// CredentialsFromContext can be called from a GRPC server method to return
+// MFA credentials added to the GRPC metadata for requests that require MFA,
+// like admin-level requests. If no MFA credentials are found, an
+// ErrAdminActionMFARequired will be returned, aggregated with any other errors
+// encountered.
+func CredentialsFromContext(ctx context.Context) (*proto.MFAAuthenticateResponse, error) {
+	resp, err := getMFACredentialsFromContext(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return resp, nil
+}
+
+func getMFACredentialsFromContext(ctx context.Context) (*proto.MFAAuthenticateResponse, error) {
+	values := metadata.ValueFromIncomingContext(ctx, mfaResponseToken)
+	if len(values) == 0 {
+		return nil, trace.BadParameter("request metadata missing MFA credentials")
+	}
+	mfaChallengeResponseEnc := values[0]
+
+	mfaChallengeResponseJSON, err := base64.StdEncoding.DecodeString(mfaChallengeResponseEnc)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	var mfaChallengeResponse proto.MFAAuthenticateResponse
+	if err := jsonpb.Unmarshal(bytes.NewReader(mfaChallengeResponseJSON), &mfaChallengeResponse); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &mfaChallengeResponse, nil
+}
+
+// perRPCCredentials supplies perRPCCredentials from an MFA challenge response.
+type perRPCCredentials struct {
+	MFAChallengeResponse *proto.MFAAuthenticateResponse
+}
+
+// GetRequestMetadata gets the request metadata as a map from a TokenSource.
+func (mc *perRPCCredentials) GetRequestMetadata(ctx context.Context, _ ...string) (map[string]string, error) {
+	ri, _ := credentials.RequestInfoFromContext(ctx)
+	if err := credentials.CheckSecurityLevel(ri.AuthInfo, credentials.PrivacyAndIntegrity); err != nil {
+		return nil, trace.BadParameter("unable to transfer MFA PerRPCCredentials: %v", err)
+	}
+
+	challengeJSON, err := (&jsonpb.Marshaler{}).MarshalToString(mc.MFAChallengeResponse)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	enc := base64.StdEncoding.EncodeToString([]byte(challengeJSON))
+	return map[string]string{
+		mfaResponseToken: enc,
+	}, nil
+}
+
+// RequireTransportSecurity indicates whether the credentials requires transport security.
+func (mc *perRPCCredentials) RequireTransportSecurity() bool {
+	return true
+}

--- a/api/mfa/mfa_test.go
+++ b/api/mfa/mfa_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mfa_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/mfa"
+	"github.com/gravitational/teleport/api/testhelpers/mtls"
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+)
+
+const otpTestCode = "otp-test-code"
+
+type mfaService struct {
+	proto.UnimplementedAuthServiceServer
+}
+
+func (s *mfaService) Ping(ctx context.Context, req *proto.PingRequest) (*proto.PingResponse, error) {
+	if err := verifyMFAFromContext(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &proto.PingResponse{}, nil
+}
+
+func verifyMFAFromContext(ctx context.Context) error {
+	mfaResp, err := mfa.CredentialsFromContext(ctx)
+	if err != nil {
+		// (In production consider logging err, so we don't swallow it silently.)
+		return trace.Wrap(&mfa.ErrAdminActionMFARequired)
+	}
+
+	switch r := mfaResp.Response.(type) {
+	case *proto.MFAAuthenticateResponse_TOTP:
+		if r.TOTP.Code != otpTestCode {
+			return trace.AccessDenied("failed MFA verification")
+		}
+	default:
+		return trace.BadParameter("unexpected mfa response type %T", r)
+	}
+
+	return nil
+}
+
+// TestMFAPerRPCCredentials tests the MFA verification process between a client and server.
+func TestMFAPerRPCCredentials(t *testing.T) {
+	t.Parallel()
+
+	mtlsConfig := mtls.NewConfig(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer(
+		grpc.ChainUnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
+		grpc.Creds(credentials.NewTLS(mtlsConfig.ServerTLS)),
+	)
+	proto.RegisterAuthServiceServer(server, &mfaService{})
+	go func() {
+		server.Serve(listener)
+	}()
+	defer server.Stop()
+
+	conn, err := grpc.Dial(
+		listener.Addr().String(),
+		grpc.WithTransportCredentials(credentials.NewTLS(mtlsConfig.ClientTLS)),
+		grpc.WithUnaryInterceptor(interceptors.GRPCClientUnaryErrorInterceptor),
+	)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	client := proto.NewAuthServiceClient(conn)
+	_, err = client.Ping(context.Background(), &proto.PingRequest{})
+	assert.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired, "Ping error mismatch")
+
+	mfaTestResp := &proto.MFAAuthenticateResponse{
+		Response: &proto.MFAAuthenticateResponse_TOTP{
+			TOTP: &proto.TOTPResponse{
+				Code: otpTestCode,
+			},
+		},
+	}
+
+	_, err = client.Ping(context.Background(), &proto.PingRequest{}, mfa.WithCredentials(mfaTestResp))
+	assert.NoError(t, err)
+}

--- a/api/utils/grpc/interceptors/mfa.go
+++ b/api/utils/grpc/interceptors/mfa.go
@@ -1,0 +1,45 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptors
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gravitational/trace"
+	"github.com/gravitational/trace/trail"
+	"google.golang.org/grpc"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/mfa"
+)
+
+// RetryWithMFAUnaryInterceptor intercepts a GRPC client unary call to check if the
+// error indicates that the client should retry with MFA verification.
+func RetryWithMFAUnaryInterceptor(mfaCeremony func(ctx context.Context) (*proto.MFAAuthenticateResponse, error)) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		err := invoker(ctx, method, req, reply, cc, opts...)
+		if !errors.Is(trail.FromGRPC(err), &mfa.ErrAdminActionMFARequired) {
+			return err
+		}
+
+		mfaResp, ceremonyErr := mfaCeremony(ctx)
+		if ceremonyErr != nil {
+			return trace.NewAggregate(trail.FromGRPC(err), ceremonyErr)
+		}
+
+		return invoker(ctx, method, req, reply, cc, append(opts, mfa.WithCredentials(mfaResp))...)
+	}
+}

--- a/api/utils/grpc/interceptors/mfa_test.go
+++ b/api/utils/grpc/interceptors/mfa_test.go
@@ -1,0 +1,148 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package interceptors_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/mfa"
+	"github.com/gravitational/teleport/api/testhelpers/mtls"
+	"github.com/gravitational/teleport/api/utils/grpc/interceptors"
+)
+
+const otpTestCode = "otp-test-code"
+
+type mfaService struct {
+	proto.UnimplementedAuthServiceServer
+}
+
+func (s *mfaService) Ping(ctx context.Context, req *proto.PingRequest) (*proto.PingResponse, error) {
+	if err := verifyMFAFromContext(ctx); err != nil {
+		return nil, trace.Wrap(err)
+	}
+	return &proto.PingResponse{}, nil
+}
+
+func verifyMFAFromContext(ctx context.Context) error {
+	mfaResp, err := mfa.CredentialsFromContext(ctx)
+	if err != nil {
+		// (In production consider logging err, so we don't swallow it silently.)
+		return trace.Wrap(&mfa.ErrAdminActionMFARequired)
+	}
+
+	switch r := mfaResp.Response.(type) {
+	case *proto.MFAAuthenticateResponse_TOTP:
+		if r.TOTP.Code != otpTestCode {
+			return trace.AccessDenied("failed MFA verification")
+		}
+	default:
+		return trace.BadParameter("unexpected mfa response type %T", r)
+	}
+
+	return nil
+}
+
+// TestGRPCErrorWrapping tests the error wrapping capability of the client
+// and server unary and stream interceptors
+func TestRetryWithMFA(t *testing.T) {
+	t.Parallel()
+
+	mtlsConfig := mtls.NewConfig(t)
+	listener, err := net.Listen("tcp", "localhost:0")
+	require.NoError(t, err)
+
+	server := grpc.NewServer(
+		grpc.Creds(credentials.NewTLS(mtlsConfig.ServerTLS)),
+		grpc.ChainUnaryInterceptor(interceptors.GRPCServerUnaryErrorInterceptor),
+	)
+	proto.RegisterAuthServiceServer(server, &mfaService{})
+	go func() {
+		server.Serve(listener)
+	}()
+	defer server.Stop()
+
+	t.Run("without interceptor", func(t *testing.T) {
+		conn, err := grpc.Dial(
+			listener.Addr().String(),
+			grpc.WithTransportCredentials(credentials.NewTLS(mtlsConfig.ClientTLS)),
+			grpc.WithUnaryInterceptor(interceptors.GRPCClientUnaryErrorInterceptor),
+		)
+		require.NoError(t, err)
+		defer conn.Close()
+
+		client := proto.NewAuthServiceClient(conn)
+		_, err = client.Ping(context.Background(), &proto.PingRequest{})
+		assert.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired, "Ping error mismatch")
+	})
+
+	t.Run("with interceptor", func(t *testing.T) {
+		t.Run("ok mfa ceremony", func(t *testing.T) {
+			okMFACeremony := func(ctx context.Context) (*proto.MFAAuthenticateResponse, error) {
+				return &proto.MFAAuthenticateResponse{
+					Response: &proto.MFAAuthenticateResponse_TOTP{
+						TOTP: &proto.TOTPResponse{
+							Code: otpTestCode,
+						},
+					},
+				}, nil
+			}
+			conn, err := grpc.Dial(
+				listener.Addr().String(),
+				grpc.WithTransportCredentials(credentials.NewTLS(mtlsConfig.ClientTLS)),
+				grpc.WithChainUnaryInterceptor(
+					interceptors.RetryWithMFAUnaryInterceptor(okMFACeremony),
+					interceptors.GRPCClientUnaryErrorInterceptor,
+				),
+			)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			client := proto.NewAuthServiceClient(conn)
+			_, err = client.Ping(context.Background(), &proto.PingRequest{})
+			assert.NoError(t, err)
+		})
+
+		t.Run("nok mfa ceremony", func(t *testing.T) {
+			mfaCeremonyErr := trace.BadParameter("client does not support mfa")
+			nokMFACeremony := func(ctx context.Context) (*proto.MFAAuthenticateResponse, error) {
+				return nil, mfaCeremonyErr
+			}
+			conn, err := grpc.Dial(
+				listener.Addr().String(),
+				grpc.WithTransportCredentials(credentials.NewTLS(mtlsConfig.ClientTLS)),
+				grpc.WithChainUnaryInterceptor(
+					interceptors.RetryWithMFAUnaryInterceptor(nokMFACeremony),
+					interceptors.GRPCClientUnaryErrorInterceptor,
+				),
+			)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			client := proto.NewAuthServiceClient(conn)
+			_, err = client.Ping(context.Background(), &proto.PingRequest{})
+			assert.ErrorIs(t, err, &mfa.ErrAdminActionMFARequired, "Ping error mismatch")
+			assert.ErrorIs(t, err, mfaCeremonyErr, "Ping error mismatch")
+		})
+	})
+}

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -85,6 +85,7 @@ var _ ClientI = &Client{}
 // functionality that hasn't been ported to the new client yet.
 func NewClient(cfg client.Config, params ...roundtrip.ClientParam) (*Client, error) {
 	cfg.DialInBackground = true
+
 	if err := cfg.CheckAndSetDefaults(); err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/client/client.go
+++ b/lib/client/client.go
@@ -52,6 +52,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/api/utils/retryutils"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/client/mfa"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/sshutils"
@@ -1147,6 +1148,7 @@ func (proxy *ProxyClient) ConnectToAuthServiceThroughALPNSNIProxy(ctx context.Co
 		ALPNConnUpgradeRequired:    proxy.teleportClient.IsALPNConnUpgradeRequiredForWebProxy(ctx, proxyAddr),
 		PROXYHeaderGetter:          CreatePROXYHeaderGetter(ctx, proxy.teleportClient.PROXYSigner),
 		InsecureAddressDiscovery:   proxy.teleportClient.InsecureSkipVerify,
+		PromptAdminRequestMFA:      proxy.teleportClient.NewMFAPrompt(mfa.WithHintBeforePrompt(mfa.AdminMFAHintBeforePrompt)),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -1224,7 +1226,8 @@ func (proxy *ProxyClient) ConnectToCluster(ctx context.Context, clusterName stri
 		Credentials: []client.Credentials{
 			client.LoadTLS(tlsConfig),
 		},
-		CircuitBreakerConfig: breaker.NoopBreakerConfig(),
+		CircuitBreakerConfig:  breaker.NoopBreakerConfig(),
+		PromptAdminRequestMFA: proxy.teleportClient.NewMFAPrompt(mfa.WithHintBeforePrompt(mfa.AdminMFAHintBeforePrompt)),
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/cluster_client.go
+++ b/lib/client/cluster_client.go
@@ -86,7 +86,7 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 
 	mfaClt := c
 	if target.Cluster != rootClusterName {
-		aclt, err := auth.NewClient(c.ProxyClient.ClientConfig(ctx, rootClusterName))
+		authClient, err := auth.NewClient(c.ProxyClient.ClientConfig(ctx, rootClusterName))
 		if err != nil {
 			return nil, trace.Wrap(MFARequiredUnknown(err))
 		}
@@ -94,12 +94,12 @@ func (c *ClusterClient) SessionSSHConfig(ctx context.Context, user string, targe
 		mfaClt = &ClusterClient{
 			tc:          c.tc,
 			ProxyClient: c.ProxyClient,
-			AuthClient:  aclt,
+			AuthClient:  authClient,
 			Tracer:      c.Tracer,
 			cluster:     rootClusterName,
 		}
 		// only close the new auth client and not the copied cluster client.
-		defer aclt.Close()
+		defer authClient.Close()
 	}
 
 	log.Debug("Attempting to issue a single-use user certificate with an MFA check.")

--- a/lib/client/mfa/prompt.go
+++ b/lib/client/mfa/prompt.go
@@ -37,6 +37,9 @@ import (
 	"github.com/gravitational/teleport/lib/utils/prompt"
 )
 
+// AdminMFAHintBeforePrompt is a hint used for MFA prompts for admin-level API requests.
+const AdminMFAHintBeforePrompt = "MFA is required for admin-level API request."
+
 var log = logrus.WithFields(logrus.Fields{
 	trace.Component: teleport.ComponentClient,
 })


### PR DESCRIPTION
This PR updates the API client to prompt for MFA for admin actions. This can be done either by passing the call option directly, or retrying after getting the relevant access denied error.

Part of implementing [RFD 131](https://github.com/gravitational/teleport/blob/master/rfd/0131-adminitrative-actions-mfa.md).

In follow up PRs, Admin Action API requests will be updated to
 - Client side:  provide MFA through the call option when we know MFA is required
 - Server side: verify the MFA passed in the request context.
   - MFA will not be required until we flip the switch in Teleport 15, but Teleport 14 clients will be able to pass the requirement with the retry mechanism added in this PR.

This is used in `tctl`, `tsh`, and Teleport Connect, though Teleport Connect does not show a modal yet.

WebSessions do not use this retry mechanism. I follow up this PR with a solution for the WebUI if I find a way to do it.

Depends on https://github.com/gravitational/teleport/pull/30578