### PR TITLE
Add PIV support for Kube Access with `tsh proxy kube` and Teleport Connect

### DIFF
--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -41,12 +41,12 @@ like `tctl edit`. With touch required, hardware key support provides better secu
     - Standard Teleport API requests such as `tsh ls`, `tctl create`, and so on.
     - Server access.
     - Database access with `tsh proxy db` instead of `tsh db connect`.
+    - Kubernetes access with `tsh proxy kube` instead of `tsh kube login`.
   
   Not yet supported:
 
     - Teleport Web UI (except for user registration and reset password).
     - Agent forwarding functionality such as `tsh ssh -A`, Proxy Recording mode, and OpenSSH integration.
-    - Kubernetes access.
     - Desktop access.
     - Application access.
 
@@ -238,7 +238,7 @@ Yubikey for Hardware Key support, you might get an error on rare occasions.
 Depending on your settings, you might be asked to tap your Yubikey many times.
 Each tap is necessary to safely authenticate you.
 
-For example, if you have `second_factor: webauthn` set in your `cluster_auth_preference, 
+For example, if you have `second_factor: webauthn` set in your `cluster_auth_preference`, 
 and `require_session_mfa: hardware_key_touch` set on your role,
 you'll see the following output when you first sign in:
 

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -419,11 +419,7 @@ func (k *Key) KubeTLSCert(kubeClusterName string) (tls.Certificate, error) {
 	if !ok {
 		return tls.Certificate{}, trace.NotFound("TLS certificate for kubernetes cluster %q not found", kubeClusterName)
 	}
-	keyPem, err := k.PrivateKey.RSAPrivateKeyPEM()
-	if err != nil {
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-	tlsCert, err := keys.X509KeyPair(certPem, keyPem)
+	tlsCert, err := k.PrivateKey.TLSCertificate(certPem)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/api/utils/keys"
 	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
+	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy"
@@ -57,9 +58,9 @@ func makeKubeGateway(cfg Config) (Kube, error) {
 
 	k := &kube{base}
 
-	// A key is required here for generating local CAs. It can be any key.
-	// Reading the provided key path to avoid generating a new one.
-	key, err := keys.LoadPrivateKey(k.cfg.KeyPath)
+	// Generate a new private key for the proxy. The client's existing private key may be
+	// a hardware-backed private key, which cannot be added to the local proxy kube config.
+	key, err := native.GeneratePrivateKey()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}


### PR DESCRIPTION
Use a plain RSA key for the local kube proxy to fix Hardware Key support for `tsh proxy kube` and Teleport Connect.