### PR TITLE
Wait for `FileUploader` to finish all writes before leaving `Close()`

### DIFF
--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -481,6 +481,9 @@ func TestEC2Hostname(t *testing.T) {
 	proc, err := service.NewTeleport(tconf)
 	require.NoError(t, err)
 	require.NoError(t, proc.Start())
-	t.Cleanup(func() { require.NoError(t, proc.Close()) })
+	t.Cleanup(func() {
+		require.NoError(t, proc.Close())
+		require.NoError(t, proc.Wait())
+	})
 	require.Equal(t, teleportHostname, proc.Config.Hostname)
 }


### PR DESCRIPTION
`FileUploader` doesn't wait for all go-routines handling writes to finish before releasing the close method.
This causes writes after close which makes tests fail while running the rmdir function on non-empty dirs.


Fixes #30212