### PR TITLE
[v12] Use distinct prompts during Windows WebAuthn registration

### DIFF
--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -73,7 +73,7 @@ type makeCredentialRequest struct {
 }
 
 // Login implements Login for Windows Webauthn API.
-func Login(ctx context.Context, origin string, assertion *wanlib.CredentialAssertion, loginOpts *LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+func Login(_ context.Context, origin string, assertion *wanlib.CredentialAssertion, loginOpts *LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
 	if origin == "" {
 		return nil, "", trace.BadParameter("origin required")
 	}
@@ -112,10 +112,7 @@ func Login(ctx context.Context, origin string, assertion *wanlib.CredentialAsser
 }
 
 // Register implements Register for Windows Webauthn API.
-func Register(
-	ctx context.Context,
-	origin string, cc *wanlib.CredentialCreation,
-) (*proto.MFARegisterResponse, error) {
+func Register(_ context.Context, origin string, cc *wanlib.CredentialCreation) (*proto.MFARegisterResponse, error) {
 	if origin == "" {
 		return nil, trace.BadParameter("origin required")
 	}
@@ -163,12 +160,20 @@ func Register(
 	}, nil
 }
 
+const defaultPromptMessage = "Using platform authenticator, follow the OS dialogs"
+
 var (
-	// PromptPlatformMessage is the message shown before Touch ID prompts.
-	PromptPlatformMessage = "Using platform authenticator, follow the OS dialogs"
+	// PromptPlatformMessage is the message shown before system prompts.
+	PromptPlatformMessage = defaultPromptMessage
+
 	// PromptWriter is the writer used for prompt messages.
 	PromptWriter io.Writer = os.Stderr
 )
+
+// ResetPromptPlatformMessage resets [PromptPlatformMessage] to its original state.
+func ResetPromptPlatformMessage() {
+	PromptPlatformMessage = defaultPromptMessage
+}
 
 func promptPlatform() {
 	if PromptPlatformMessage != "" {

--- a/lib/auth/webauthnwin/api.go
+++ b/lib/auth/webauthnwin/api.go
@@ -215,7 +215,7 @@ type DiagResult struct {
 
 // Diag runs a few diagnostic commands and returns the result.
 // User interaction is required.
-func Diag(ctx context.Context, promptOut io.Writer) (*DiagResult, error) {
+func Diag(ctx context.Context) (*DiagResult, error) {
 	res := &DiagResult{}
 	if !IsAvailable() {
 		return res, nil

--- a/tool/tsh/winwebauthn.go
+++ b/tool/tsh/winwebauthn.go
@@ -58,7 +58,12 @@ func (w *webauthnwinDiagCommand) run(cf *CLIConf) error {
 	if !diag.IsAvailable {
 		return nil
 	}
-	resp, err := webauthnwin.Diag(cf.Context, os.Stdout)
+
+	promptBefore := webauthnwin.PromptWriter
+	defer func() { webauthnwin.PromptWriter = promptBefore }()
+	webauthnwin.PromptWriter = os.Stderr
+
+	resp, err := webauthnwin.Diag(cf.Context)
 	// Abort if we got a nil diagnostic, otherwise print as much as we can.
 	if resp == nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
Backport #30195 to branch/v12

Clearly distinguish between "registered" and "new" devices on Windows "platform"
prompts. This is relevant for Windows because it uses the system APIs for both
Hello and WebAuthn devices.

I've decided against doing a similar change for Touch ID, as there isn't much to
confuse there (lib/auth/touchid doesn't prompt devices other than Touch ID).

Changing the globals is safe because only one WebAuthn prompt happens at a time.

#17563

Changelog: Explicitly mention *registered* and *new* device when running `tsh mfa add` on Windows