### PR TITLE
chore: Bump golangci-lint to v1.54.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -321,7 +321,7 @@ RUN go install gotest.tools/gotestsum@v1.10.1
 
 # Install golangci-lint.
 # Keep the version below synced with devbox.json
-RUN TAG='v1.53.3' && \
+RUN TAG='v1.54.0' && \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
 


### PR DESCRIPTION
Update to the latest version.

* https://github.com/golangci/golangci-lint/releases/tag/v1.54.0