### PR TITLE
chore: Bump gci to v0.11.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -313,7 +313,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
 # Keep the version below synced with devbox.json
-RUN go install github.com/daixiang0/gci@v0.9.1
+RUN go install github.com/daixiang0/gci@v0.11.0
 
 # Install gotestsum.
 # Keep the version below synced with devbox.json


### PR DESCRIPTION
Update to latest release.

* https://github.com/daixiang0/gci/releases/tag/v0.11.0

Note: updates to devbox to v0.10.1, which is the latest version on nixpkgs.