### PR TITLE
Fix matcher AssumeRoleARN not applied to DiscoveryResourceChecker

### DIFF
--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -2999,14 +2999,16 @@ func withAzureRedis(name string, token string) withDatabaseOption {
 }
 
 type fakeDiscoveryResourceChecker struct {
-	errorsByName map[string]error
+	byName map[string]func(context.Context, types.Database) error
 }
 
-func (f *fakeDiscoveryResourceChecker) Check(_ context.Context, database types.Database) error {
-	if len(f.errorsByName) == 0 {
-		return nil
+func (f *fakeDiscoveryResourceChecker) Check(ctx context.Context, database types.Database) error {
+	if len(f.byName) > 0 {
+		if check := f.byName[database.GetName()]; check != nil {
+			return trace.Wrap(check(ctx, database))
+		}
 	}
-	return trace.Wrap(f.errorsByName[database.GetName()])
+	return nil
 }
 
 var dynamicLabels = types.LabelsToV2(map[string]types.CommandLabel{

--- a/lib/srv/db/watcher.go
+++ b/lib/srv/db/watcher.go
@@ -162,17 +162,19 @@ func (s *Server) onCreate(ctx context.Context, resource types.ResourceWithLabels
 		return trace.BadParameter("expected types.Database, got %T", resource)
 	}
 
-	if s.monitoredDatabases.isDiscoveryResource(database) {
-		if err := s.cfg.discoveryResourceChecker.Check(ctx, database); err != nil {
-			return trace.Wrap(err)
-		}
-	}
-
 	// OnCreate receives a "new" resource from s.monitoredDatabases. Make a
 	// copy here so that any attribute changes to the proxied database will not
 	// affect database objects tracked in s.monitoredDatabases.
 	databaseCopy := database.Copy()
 	applyResourceMatchersToDatabase(databaseCopy, s.cfg.ResourceMatchers)
+
+	// Run DiscoveryResourceChecker after resource matchers are applied to make
+	// sure the correct AssumeRoleARN is used.
+	if s.monitoredDatabases.isDiscoveryResource(database) {
+		if err := s.cfg.discoveryResourceChecker.Check(ctx, databaseCopy); err != nil {
+			return trace.Wrap(err)
+		}
+	}
 	return s.registerDatabase(ctx, databaseCopy)
 }
 


### PR DESCRIPTION
Introduced in #29864

This change makes sure DiscoveryResourceChecker receives the database copy with the updated AssumeRoleARN. UT updated.

Note that the resource matcher AssumeRoleARN feature is not documented yet so not expecting many using it. Also the DiscoveryResourceChecker (crednetialsChecker) only prints warnings. So the bug has no real functional impact. 