### PR TITLE
Add a table of contents entry for Machine ID v14 migration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1301,7 +1301,11 @@
             {
               "title": "Telemetry",
               "slug": "/machine-id/reference/telemetry/"
-            }
+            },
+	    {
+	    	"title": "Upgrading to v14",
+	    	"slug": "/machine-id/reference/v14-upgrade-guide/"
+	    }
           ]
         },
         {


### PR DESCRIPTION
The Machine ID upgrade guide is missing a table of contents entry. Add one for it.