### PR TITLE
Consistent `http.Server` timeout configurations

### DIFF
--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -189,7 +189,9 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		cfg: cfg,
 		httpServer: &http.Server{
 			Handler:           tracingHandler,
-			ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+			ReadTimeout:       apidefaults.DefaultIOTimeout,
+			ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+			WriteTimeout:      apidefaults.DefaultIOTimeout,
 			IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		},
 		log: logrus.WithFields(logrus.Fields{

--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -29,6 +29,7 @@ import (
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/lib/auth"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/secret"
 	"github.com/gravitational/teleport/lib/utils"
 )
@@ -151,7 +152,9 @@ func (rd *Redirector) Start() error {
 			Listener: listener,
 			Config: &http.Server{
 				Handler:           rd.mux,
-				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+				ReadTimeout:       apidefaults.DefaultIOTimeout,
+				ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+				WriteTimeout:      apidefaults.DefaultIOTimeout,
 				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 			},
 		}

--- a/lib/defaults/defaults.go
+++ b/lib/defaults/defaults.go
@@ -135,7 +135,7 @@ const (
 
 	// ReadHeadersTimeout is a default TCP timeout when we wait
 	// for the response headers to arrive
-	ReadHeadersTimeout = time.Second
+	ReadHeadersTimeout = 10 * time.Second
 
 	// DatabaseConnectTimeout is a timeout for connecting to a database via
 	// database access.

--- a/lib/kube/proxy/server.go
+++ b/lib/kube/proxy/server.go
@@ -239,6 +239,8 @@ func NewTLSServer(cfg TLSServerConfig) (*TLSServer, error) {
 		Server: &http.Server{
 			Handler:           httplib.MakeTracingHandler(limiter, teleport.ComponentKube),
 			ReadHeaderTimeout: apidefaults.DefaultIOTimeout * 2,
+			ReadTimeout:       apidefaults.DefaultIOTimeout,
+			WriteTimeout:      apidefaults.DefaultIOTimeout,
 			IdleTimeout:       apidefaults.DefaultIdleTimeout,
 			TLSConfig:         cfg.TLS,
 			ConnState:         ingress.HTTPConnStateReporter(ingress.Kube, cfg.IngressReporter),

--- a/lib/observability/tracing/collector.go
+++ b/lib/observability/tracing/collector.go
@@ -33,6 +33,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/lib/defaults"
 )
 
 // Collector is a simple in memory implementation of an OpenTelemetry Collector
@@ -84,7 +85,9 @@ func NewCollector(cfg CollectorConfig) (*Collector, error) {
 
 	c.httpServer = &http.Server{
 		Handler:           c,
-		ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
 		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		TLSConfig:         tlsConfig.Clone(),
 	}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2875,7 +2875,9 @@ func (process *TeleportProcess) initMetricsService() error {
 
 	server := &http.Server{
 		Handler:           mux,
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
 		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
 		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentMetrics),
 		TLSConfig:         tlsConfig,
@@ -2996,7 +2998,9 @@ func (process *TeleportProcess) initDiagnosticService() error {
 
 	server := &http.Server{
 		Handler:           mux,
-		ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
 		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentDiagnostic),
 	}
@@ -3926,7 +3930,9 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 					limiter.MakeMiddleware(proxyLimiter),
 					httplib.MakeTracingMiddleware(teleport.ComponentProxy),
 				),
-				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+				ReadTimeout:       apidefaults.DefaultIOTimeout,
+				ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+				WriteTimeout:      apidefaults.DefaultIOTimeout,
 				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 				ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentProxy),
 				ConnState:         ingress.HTTPConnStateReporter(ingress.Web, ingressReporter),
@@ -4625,7 +4631,9 @@ func (process *TeleportProcess) initMinimalReverseTunnel(listeners *proxyListene
 	minimalWebServer, err := web.NewServer(web.ServerConfig{
 		Server: &http.Server{
 			Handler:           httplib.MakeTracingHandler(minimalProxyLimiter, teleport.ComponentProxy),
-			ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+			ReadTimeout:       apidefaults.DefaultIOTimeout,
+			ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+			WriteTimeout:      apidefaults.DefaultIOTimeout,
 			IdleTimeout:       apidefaults.DefaultIdleTimeout,
 			ErrorLog:          utils.NewStdlogger(log.Error, teleport.ComponentReverseTunnelServer),
 		},

--- a/lib/srv/alpnproxy/forward_proxy.go
+++ b/lib/srv/alpnproxy/forward_proxy.go
@@ -28,10 +28,12 @@ import (
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/http/httpproxy"
 
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
 	"github.com/gravitational/teleport/api/utils/azure"
 	"github.com/gravitational/teleport/api/utils/gcp"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/utils"
 )
 
@@ -91,7 +93,14 @@ func NewForwardProxy(cfg ForwardProxyConfig) (*ForwardProxy, error) {
 
 // Start starts serving on the listener.
 func (p *ForwardProxy) Start() error {
-	err := http.Serve(p.cfg.Listener, p)
+	server := &http.Server{
+		Handler:           p,
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+	}
+	err := server.Serve(p.cfg.Listener)
 	if err != nil && !utils.IsUseOfClosedNetworkError(err) {
 		return trace.Wrap(err)
 	}

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -320,6 +320,10 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 	defaultProxy := l.makeHTTPReverseProxy(l.getCerts())
 
 	server := &http.Server{
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 			if l.cfg.HTTPMiddleware.HandleRequest(rw, req) {
 				return
@@ -340,10 +344,6 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 
 			proxy.ServeHTTP(rw, req)
 		}),
-		ReadTimeout:       apidefaults.DefaultIOTimeout,
-		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
-		WriteTimeout:      apidefaults.DefaultIOTimeout,
-		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 	}
 
 	// Shut down the server when the context is done

--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -35,7 +35,9 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/gravitational/teleport/api/client"
+	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils/pingconn"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	commonApp "github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -316,27 +318,43 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 	l.cfg.Log.Info("Starting HTTP access proxy")
 	defer l.cfg.Log.Info("HTTP access proxy stopped")
 	defaultProxy := l.makeHTTPReverseProxy(l.getCerts())
-	err := http.Serve(l.cfg.Listener, http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-		if l.cfg.HTTPMiddleware.HandleRequest(rw, req) {
-			return
-		}
 
-		// Requests from forward proxy have original hostnames instead of
-		// localhost. Set appropriate header to keep this information.
-		if addr, err := utils.ParseAddr(req.Host); err == nil && !addr.IsLocal() {
-			req.Header.Set("X-Forwarded-Host", req.Host)
-		}
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			if l.cfg.HTTPMiddleware.HandleRequest(rw, req) {
+				return
+			}
 
-		proxy, err := l.getHTTPReverseProxyForReq(req, defaultProxy)
-		if err != nil {
-			l.cfg.Log.Warnf("Failed to get reverse proxy: %v.", err)
-			trace.WriteError(rw, trace.Wrap(err))
-			return
-		}
+			// Requests from forward proxy have original hostnames instead of
+			// localhost. Set appropriate header to keep this information.
+			if addr, err := utils.ParseAddr(req.Host); err == nil && !addr.IsLocal() {
+				req.Header.Set("X-Forwarded-Host", req.Host)
+			}
 
-		proxy.ServeHTTP(rw, req)
-	}))
-	if err != nil && !utils.IsUseOfClosedNetworkError(err) {
+			proxy, err := l.getHTTPReverseProxyForReq(req, defaultProxy)
+			if err != nil {
+				l.cfg.Log.Warnf("Failed to get reverse proxy: %v.", err)
+				trace.WriteError(rw, trace.Wrap(err))
+				return
+			}
+
+			proxy.ServeHTTP(rw, req)
+		}),
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
+		IdleTimeout:       apidefaults.DefaultIdleTimeout,
+	}
+
+	// Shut down the server when the context is done
+	go func() {
+		<-ctx.Done()
+		server.Shutdown(context.Background())
+	}()
+
+	// Use the custom server to listen and serve
+	err := server.Serve(l.cfg.Listener)
+	if err != nil && err != http.ErrServerClosed && !utils.IsUseOfClosedNetworkError(err) {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -1050,7 +1050,9 @@ func (s *Server) newHTTPServer(clusterName string) *http.Server {
 
 	return &http.Server{
 		Handler:           httplib.MakeTracingHandler(s.authMiddleware, teleport.ComponentApp),
-		ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+		ReadTimeout:       apidefaults.DefaultIOTimeout,
+		ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+		WriteTimeout:      apidefaults.DefaultIOTimeout,
 		IdleTimeout:       apidefaults.DefaultIdleTimeout,
 		ErrorLog:          utils.NewStdlogger(s.log.Error, teleport.ComponentApp),
 		ConnContext: func(ctx context.Context, c net.Conn) context.Context {

--- a/lib/tbot/tbot.go
+++ b/lib/tbot/tbot.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/auth/authclient"
+	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tbot/config"
@@ -188,7 +189,9 @@ func (b *Bot) Run(ctx context.Context) error {
 			srv := http.Server{
 				Addr:              b.cfg.DiagAddr,
 				Handler:           mux,
-				ReadHeaderTimeout: apidefaults.DefaultIOTimeout,
+				ReadTimeout:       apidefaults.DefaultIOTimeout,
+				ReadHeaderTimeout: defaults.ReadHeadersTimeout,
+				WriteTimeout:      apidefaults.DefaultIOTimeout,
 				IdleTimeout:       apidefaults.DefaultIdleTimeout,
 			}
 			go func() {


### PR DESCRIPTION
This PR builds on the work from https://github.com/gravitational/teleport/pull/30151 in the following ways:
* A couple additional server configuartions that were missing timeouts are now covered
* Timeouts are now configured in a consistent way.  This means:
  - Configuring the `ReadTimeout` which was not covered by only setting `ReadHeaderTimeout`
  - Set `ReadHeaderTimeout` to be the more aggressive (1 second) `defaults.ReadHeadersTimeout`
  - Set a `WriteTimeout` in cases of potential large responses