### PR TITLE
AgentMetadataEvent: add AWS OIDC Deploy Service install method

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -870,6 +870,12 @@ const (
 	ProxyGroupGenerationLabel = TeleportInternalLabelPrefix + "proxygroup-gen"
 )
 
+const (
+	// InstallMethodAWSOIDCDeployServiceEnvVar is the env var used to detect if the agent was installed
+	// using the DeployService action of the AWS OIDC integration.
+	InstallMethodAWSOIDCDeployServiceEnvVar = "TELEPORT_INSTALL_METHOD_AWSOIDC_DEPLOYSERVICE"
+)
+
 // CloudHostnameTag is the name of the tag in a cloud instance used to override a node's hostname.
 const CloudHostnameTag = "TeleportHostname"
 

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -447,6 +447,10 @@ func upsertTask(ctx context.Context, clt DeployServiceClient, req DeployServiceR
 		TaskRoleArn:      &req.TaskRoleARN,
 		ExecutionRoleArn: &req.TaskRoleARN,
 		ContainerDefinitions: []ecsTypes.ContainerDefinition{{
+			Environment: []ecsTypes.KeyValuePair{{
+				Name:  aws.String(types.InstallMethodAWSOIDCDeployServiceEnvVar),
+				Value: aws.String("true"),
+			}},
 			Command: []string{
 				"start",
 				"--config-string",

--- a/lib/inventory/metadata/metadata.go
+++ b/lib/inventory/metadata/metadata.go
@@ -179,6 +179,9 @@ func (c *fetchConfig) fetchInstallMethods() []string {
 	if c.systemctlInstallMethod() {
 		installMethods = append(installMethods, "systemctl")
 	}
+	if c.awsoidcDeployServiceInstallMethod() {
+		installMethods = append(installMethods, "awsoidc_deployservice")
+	}
 	return installMethods
 }
 
@@ -198,6 +201,13 @@ func (c *fetchConfig) helmKubeAgentInstallMethod() bool {
 // install-node.sh script.
 func (c *fetchConfig) nodeScriptInstallMethod() bool {
 	return c.boolEnvIsTrue("TELEPORT_INSTALL_METHOD_NODE_SCRIPT")
+}
+
+// awsoidcDeployServiceInstallMethod returns true if the instance was installed using
+// the DeployService action of the AWS OIDC integration.
+// This install method uses Amazon ECS with Fargate deployment method.
+func (c *fetchConfig) awsoidcDeployServiceInstallMethod() bool {
+	return c.boolEnvIsTrue(types.InstallMethodAWSOIDCDeployServiceEnvVar)
 }
 
 // systemctlInstallMethod returns true if the instance is running using systemctl.

--- a/lib/inventory/metadata/metadata_test.go
+++ b/lib/inventory/metadata/metadata_test.go
@@ -25,6 +25,8 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
 )
 
 func TestFetchInstallMethods(t *testing.T) {
@@ -79,6 +81,21 @@ func TestFetchInstallMethods(t *testing.T) {
 			},
 			expected: []string{
 				"node_script",
+			},
+		},
+		{
+			desc: "awsoidc_deployservice if env var is present",
+			getenv: func(name string) string {
+				if name == types.InstallMethodAWSOIDCDeployServiceEnvVar {
+					return "true"
+				}
+				return ""
+			},
+			execCommand: func(name string, args ...string) ([]byte, error) {
+				return nil, trace.NotFound("command does not exist")
+			},
+			expected: []string{
+				"awsoidc_deployservice",
 			},
 		},
 		{


### PR DESCRIPTION
This PR adds a new install method (`awsoidc_deployservice`) to agent metadata events that are sent to posthog in tp.agent.metadata event.

The task definition was changed to include a new env var that indicates this installation method.

Example events in PostHog
![image](https://github.com/gravitational/teleport/assets/689271/7ea40100-1d8c-4fbf-b9ea-78146b45b358)

Env var is set in ECS Task
![image](https://github.com/gravitational/teleport/assets/689271/73be4a1a-4e52-4035-9645-666831b6ade6)

Related https://github.com/gravitational/teleport/issues/29988