### PR TITLE
[v12] chore: Bump gci to v0.11.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -291,7 +291,7 @@ RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.9.1
+RUN go install github.com/daixiang0/gci@v0.11.0
 
 # Install golangci-lint.
 RUN TAG='v1.53.3' && \


### PR DESCRIPTION
Backport #30228 to branch/v12.

Update to latest release.

* https://github.com/daixiang0/gci/releases/tag/v0.11.0
