### PR TITLE
[v11] chore: Bump gci to v0.11.0

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -276,7 +276,7 @@ RUN go install "github.com/gogo/protobuf/protoc-gen-gogofast@$GOGO_PROTO_TAG"
 RUN go install github.com/google/addlicense@v1.0.0
 
 # Install GCI.
-RUN go install github.com/daixiang0/gci@v0.9.1
+RUN go install github.com/daixiang0/gci@v0.11.0
 
 # Install golangci-lint.
 RUN TAG='v1.53.3' && \

--- a/examples/service-discovery-api-client/main.go
+++ b/examples/service-discovery-api-client/main.go
@@ -29,11 +29,12 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/strslice"
 	docker "github.com/docker/docker/client"
+	"github.com/gravitational/trace"
+	"google.golang.org/grpc"
+
 	teleport "github.com/gravitational/teleport/api/client"
 	"github.com/gravitational/teleport/api/client/proto"
 	"github.com/gravitational/teleport/api/types"
-	"github.com/gravitational/trace"
-	"google.golang.org/grpc"
 )
 
 const (


### PR DESCRIPTION
Backport #30228 to branch/v11.

Update to latest release.

* https://github.com/daixiang0/gci/releases/tag/v0.11.0
