### PR TITLE
AWS OIDC - ListDatabases: fix aurora engine filter

### DIFF
--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/google/go-cmp/cmp"
 	"github.com/gravitational/trace"
 	"github.com/stretchr/testify/require"
@@ -141,10 +142,10 @@ func TestDeployServiceRequest(t *testing.T) {
 				Region:               "r",
 				SubnetIDs:            []string{"1"},
 				TaskRoleARN:          "arn",
-				ClusterName:          stringPointer("mycluster-teleport"),
-				ServiceName:          stringPointer("mycluster-teleport-database-service"),
-				TaskName:             stringPointer("mycluster-teleport-database-service"),
-				TeleportIAMTokenName: stringPointer("discover-aws-oidc-iam-token"),
+				ClusterName:          aws.String("mycluster-teleport"),
+				ServiceName:          aws.String("mycluster-teleport-database-service"),
+				TaskName:             aws.String("mycluster-teleport-database-service"),
+				TeleportIAMTokenName: aws.String("discover-aws-oidc-iam-token"),
 				IntegrationName:      "teleportdev",
 				ProxyServerHostPort:  "proxy.example.com:3080",
 				ResourceCreationTags: awsTags{

--- a/lib/integrations/awsoidc/listdatabases.go
+++ b/lib/integrations/awsoidc/listdatabases.go
@@ -112,7 +112,7 @@ func ListDatabases(ctx context.Context, clt ListDatabasesClient, req ListDatabas
 		// Related:
 		// https://github.com/gravitational/teleport/pull/18328
 		// https://github.com/aws/aws-toolkit-jetbrains/pull/3644
-		var enginesWithoutAurora []string
+		enginesWithoutAurora := make([]string, 0, len(req.Engines))
 		for _, e := range req.Engines {
 			if e == services.RDSEngineAurora {
 				continue

--- a/lib/integrations/awsoidc/listdatabases.go
+++ b/lib/integrations/awsoidc/listdatabases.go
@@ -139,9 +139,7 @@ func isUnrecognizedAWSEngineNameAuroraError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// AWS Go SDK V1 error message has the first letter in lowercase: unrecognized engine name: aurora
-	// AWS Go SDK V2 error message has the first letter in uppercase: Unrecognized engine name: aurora
-	return strings.Contains(strings.ToLower(err.Error()), "nrecognized engine name: aurora")
+	return strings.Contains(strings.ToLower(err.Error()), "unrecognized engine name: aurora")
 }
 
 func listDBs(ctx context.Context, clt ListDatabasesClient, req ListDatabasesRequest) (*ListDatabasesResponse, error) {

--- a/lib/integrations/awsoidc/listdatabases_test.go
+++ b/lib/integrations/awsoidc/listdatabases_test.go
@@ -166,6 +166,19 @@ func TestListDatabases(t *testing.T) {
 		require.Len(t, resp.Databases, 3)
 	})
 
+	t.Run("aurora is not a valid engine name in the given region but was the only provided engine", func(t *testing.T) {
+		mockListClient := mockListDatabasesClient{}
+
+		_, err := ListDatabases(ctx, mockListClient, ListDatabasesRequest{
+			Region:    "us-east-1",
+			RDSType:   "cluster",
+			Engines:   []string{"aurora"},
+			NextToken: "",
+		})
+		require.Error(t, err)
+		require.ErrorContains(t, err, "Unrecognized engine name: aurora")
+	})
+
 	t.Run("aurora is not a valid engine name in the given region", func(t *testing.T) {
 		mockListClient := mockListDatabasesClient{
 			regionHasAuroraEngine: false,

--- a/lib/integrations/awsoidc/listdatabases_test.go
+++ b/lib/integrations/awsoidc/listdatabases_test.go
@@ -80,6 +80,7 @@ func hasAuroraEngineFilter(filters []rdsTypes.Filter) bool {
 					return true
 				}
 			}
+			return false
 		}
 	}
 	return false

--- a/lib/integrations/awsoidc/listec2_test.go
+++ b/lib/integrations/awsoidc/listec2_test.go
@@ -76,7 +76,7 @@ func (m mockListEC2Client) DescribeInstances(ctx context.Context, params *ec2.De
 
 	if sliceEnd < totalInstances {
 		nextToken := strconv.Itoa(requestedPage + 1)
-		ret.NextToken = stringPointer(nextToken)
+		ret.NextToken = aws.String(nextToken)
 	}
 
 	return ret, nil


### PR DESCRIPTION
Some AWS regions do not accept the aurora engine as a filter. This PR handles that error and re-queries AWS without it.

Demo
Before
![image](https://github.com/gravitational/teleport/assets/689271/e9a9dfc6-2f25-43fb-a2c0-f457eb5c0ef4)

After
![image](https://github.com/gravitational/teleport/assets/689271/81d54e96-b771-423c-bbb2-57e9bd16fc77)

Fixes #29974