### PR TITLE
Add Teleport agent pod readiness checks to docs

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -183,6 +183,15 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
 - Change `apps[0].name` and `apps[0].uri` if you're configuring access to a different 
 web application.
 
+Make sure that the Teleport agent pod is running. You should see one
+`teleport-kube-agent` pod with a single ready container:
+
+```code
+$ kubectl -n teleport get pods
+NAME                    READY   STATUS    RESTARTS   AGE
+teleport-kube-agent-0   1/1     Running   0          32s
+```
+
 </TabItem>
 </Tabs>
 

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -176,6 +176,15 @@ Install and configure Teleport where you will run the Teleport Database Service:
 
 (!docs/pages/includes/database-access/multiple-instances-tip.mdx !)
 
+Make sure that the Teleport agent pod is running. You should see one Teleport
+agent pod pod with a single ready container:
+
+```code
+$ kubectl -n teleport get pods
+NAME                    READY   STATUS    RESTARTS   AGE
+teleport-kube-agent-0   1/1     Running   0          32s
+```
+
 ## Step 5/5. Connect
 
 Once the Database Service has joined the cluster, log in to see the available

--- a/docs/pages/includes/database-access/db-helm-install.mdx
+++ b/docs/pages/includes/database-access/db-helm-install.mdx
@@ -41,3 +41,13 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
 
 </TabItem>
 </Tabs>
+
+Make sure that the Teleport agent pod is running. You should see one
+`teleport-kube-agent` pod with a single ready container:
+
+```code
+$ kubectl -n teleport get pods
+NAME                    READY   STATUS    RESTARTS   AGE
+teleport-kube-agent-0   1/1     Running   0          32s
+```
+

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -166,6 +166,15 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
 </TabItem>
 </Tabs>
 
+Make sure that the Teleport agent pod is running. You should see one Teleport
+agent pod pod with a single ready container:
+
+```code
+$ kubectl -n teleport get pods
+NAME               READY   STATUS    RESTARTS   AGE
+teleport-agent-0   1/1     Running   0          32s
+```
+
 ## Step 3/3 Access your Kubernetes cluster
 
 (!docs/pages/includes/kubernetes-access/rbac.mdx!)

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -259,6 +259,15 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --version (=teleport.version=)
 ```
 
+Make sure that the Teleport agent pod is running. You should see one Teleport
+agent pod pod with a single ready container:
+
+```code
+$ kubectl -n teleport get pods
+NAME               READY   STATUS    RESTARTS   AGE
+teleport-agent-0   1/1     Running   0          32s
+```
+
 List connected clusters using `tsh kube ls` and switch between
 them using `tsh kube login`:
 

--- a/docs/pages/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/kubernetes-access/troubleshooting.mdx
@@ -186,6 +186,15 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --version (=teleport.version=)
 ```
 
+Make sure that the Teleport agent pod is running. You should see one Teleport
+agent pod pod with a single ready container:
+
+```code
+$ kubectl -n teleport get pods
+NAME               READY   STATUS    RESTARTS   AGE
+teleport-agent-0   1/1     Running   0          32s
+```
+
 Now that the cluster is labeled, you can split the `k8s-admin` role into two
 roles: one that allows access to all non-Autopilot clusters and another that only
 allows access to Autopilot clusters.


### PR DESCRIPTION
Fixes #23449

Ensure that all guides that include instructions for installing the `teleport-kube-agent` chart also show how to check that the Teleport agent pods are up and healthy.