### PR TITLE
Fix resources being deleted from Firestore on update

### DIFF
--- a/lib/backend/firestore/firestorebk.go
+++ b/lib/backend/firestore/firestorebk.go
@@ -762,9 +762,20 @@ func (b *Backend) purgeExpiredDocuments() error {
 			return b.clientContext.Err()
 		case <-t.C:
 			expiryTime := b.clock.Now().UTC().Unix()
-			docs, err := b.svc.Collection(b.CollectionName).Where(expiresDocProperty, "<=", expiryTime).Documents(b.clientContext).GetAll()
+			// Find all documents that have expired, but EXCLUDE
+			// any documents that do not have an expiry as indicated
+			// by a value of 0.
+			docs, err := b.svc.Collection(b.CollectionName).
+				Where(expiresDocProperty, "<=", expiryTime).
+				Where(expiresDocProperty, ">", 0).
+				Documents(b.clientContext).
+				GetAll()
 			if err != nil {
 				b.Logger.WithError(trail.FromGRPC(err)).Warn("Failed to get expired documents")
+				continue
+			}
+
+			if len(docs) == 0 {
 				continue
 			}
 


### PR DESCRIPTION
The change to use `Update` in #28473 caused a 0 value to be written to the expires field of the document. When using `Create` or `Set` a zero expiry value would result in an empty expires field for that document. Now that the expires column was containing a 0 value the purgeExpiredDocuments loop was detecting the document as needing to be removed. To prevent removing resources that have no expiry the purge loop now explicitly ignores any resources that have a 0 expiry value.

Fixes #30236