### PR TITLE
Set network restrictions static fields upon update

### DIFF
--- a/api/types/restrictions.go
+++ b/api/types/restrictions.go
@@ -46,20 +46,27 @@ func NewNetworkRestrictions() NetworkRestrictions {
 	}
 }
 
+func (r *NetworkRestrictionsV4) setStaticFields() {
+	if r.Version == "" {
+		r.Version = V4
+	}
+	if r.Kind == "" {
+		r.Kind = KindNetworkRestrictions
+	}
+	if r.Metadata.Name == "" {
+		r.Metadata.Name = MetaNameNetworkRestrictions
+	}
+}
+
 // CheckAndSetDefaults validates NetworkRestrictions fields and populates empty fields
 // with default values.
 func (r *NetworkRestrictionsV4) CheckAndSetDefaults() error {
-	r.Metadata.Name = MetaNameNetworkRestrictions
+	r.setStaticFields()
 
 	if err := r.Metadata.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}
-	if r.Kind == "" {
-		return trace.BadParameter("NetworkRestrictions missing Kind field")
-	}
-	if r.Version == "" {
-		r.Version = V1
-	}
+
 	return nil
 }
 

--- a/lib/services/local/restrictions.go
+++ b/lib/services/local/restrictions.go
@@ -38,6 +38,9 @@ func NewRestrictionsService(backend backend.Backend) *RestrictionsService {
 
 // SetNetworkRestrictions upserts NetworkRestrictions
 func (s *RestrictionsService) SetNetworkRestrictions(ctx context.Context, nr types.NetworkRestrictions) error {
+	if err := nr.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
 	value, err := services.MarshalNetworkRestrictions(nr)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This is required for #22261 as otherwise the terraform resource is required to specify the kind and version of the resource.