### PR TITLE
Update Rust version to 1.71.1

### DIFF
--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -9,7 +9,7 @@ NODE_VERSION ?= 16.18.1
 
 # Sync any version changes below with devbox.json.
 # run lint-rust check locally before merging code after you bump this
-RUST_VERSION ?= 1.71.0
+RUST_VERSION ?= 1.71.1
 LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 


### PR DESCRIPTION
The project's Rust version was updated from 1.71.0 to 1.71.1 in the versions.mk file.

Linter didn't complain after the update.