### PR TITLE
Update roles for kube-agent chart in guides/documentation to be 'kube,app,discovery'

### DIFF
--- a/docs/pages/agents/join-services-to-your-cluster/kubernetes.mdx
+++ b/docs/pages/agents/join-services-to-your-cluster/kubernetes.mdx
@@ -206,7 +206,7 @@ following content:
 proxyAddr: "teleport.example.com:443"
 
 # Comma-separated list of services the `teleport-kube-agent` chart must run
-# (supported values are: kube,db,app)
+# (supported values are: kube,db,app,discovery)
 # In this guide we only deploy app access.
 # Adding more services here also requires to add role to the provision token created in step 1.
 roles: app

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -323,7 +323,7 @@ Request a token that the Kubernetes Service will use to join your Teleport
 cluster:
 
 ```code
-$ tctl tokens add --type=kube --ttl=10000h --format=json
+$ tctl tokens add --type=kube,app,discovery --ttl=10000h --format=json
 ```
 
 Copy this token so you can use it when running the Teleport Kubernetes Service.
@@ -344,6 +344,7 @@ requested earlier:
 ```code
 $ helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=minikube \
+  --set roles="kube\,app\,discovery"
   --set proxyAddr=<Var name="proxy-address" /> \
   --set authToken=<Var name="token" /> \
   --create-namespace \

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -344,7 +344,7 @@ requested earlier:
 ```code
 $ helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=minikube \
-  --set roles="kube\,app\,discovery"
+  --set roles="kube\,app\,discovery" \
   --set proxyAddr=<Var name="proxy-address" /> \
   --set authToken=<Var name="token" /> \
   --create-namespace \

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -61,7 +61,7 @@ join token from the Teleport Auth Service:
 
 ```code
 # Create a join token for the Teleport Kubernetes Service to authenticate
-$ TOKEN=$(tctl tokens add --type=kube --ttl=1h --format=text)
+$ TOKEN=$(tctl tokens add --type=kube,app,discovery --ttl=1h --format=text)
 $ echo $TOKEN
 ```
 
@@ -90,7 +90,7 @@ $ CLUSTER=cookie
 $ cat > values.yaml << EOF
 authToken: "${TOKEN}"
 proxyAddr: "${PROXY_ADDR}"
-roles: "kube"
+roles: "kube,app,discovery"
 joinParams:
   method: "token"
   tokenName: "${TOKEN}"
@@ -118,7 +118,7 @@ $ CLUSTER=cookie
 $ cat > values.yaml << EOF
 authToken: "${TOKEN}"
 proxyAddr: "${PROXY_ADDR}"
-roles: "kube"
+roles: "kube,app,discovery"
 joinParams:
   method: "token"
   tokenName: "${TOKEN}"
@@ -148,7 +148,7 @@ $ CLUSTER=cookie
 $ cat > values.yaml << EOF
 authToken: "${TOKEN}"
 proxyAddr: "${PROXY_ADDR}"
-roles: "kube"
+roles: "kube,app,discovery"
 joinParams:
   method: "token"
   tokenName: "${TOKEN}"

--- a/docs/pages/kubernetes-access/manage-access/rbac.mdx
+++ b/docs/pages/kubernetes-access/manage-access/rbac.mdx
@@ -213,7 +213,7 @@ Request a token that the Kubernetes Service will use to join your Teleport
 cluster:
 
 ```code
-$ tctl tokens add --type=kube --ttl=1h --format=text
+$ tctl tokens add --type=kube,app,discovery --ttl=1h --format=text
 ```
 
 Copy this token so you can use it when running the Teleport Kubernetes Service.
@@ -226,6 +226,7 @@ requested earlier:
 ```code
 $ helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=minikube \
+  --set roles="kube\,app\,discovery"
   --set proxyAddr=<Var name="proxy-address" /> \
   --set authToken=<Var name="token" /> \
   --set labels.region=local --set labels.platform=minikube \

--- a/docs/pages/kubernetes-access/manage-access/rbac.mdx
+++ b/docs/pages/kubernetes-access/manage-access/rbac.mdx
@@ -226,7 +226,7 @@ requested earlier:
 ```code
 $ helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=minikube \
-  --set roles="kube\,app\,discovery"
+  --set roles="kube\,app\,discovery" \
   --set proxyAddr=<Var name="proxy-address" /> \
   --set authToken=<Var name="token" /> \
   --set labels.region=local --set labels.platform=minikube \

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -249,7 +249,7 @@ $ CLUSTER=iam-cluster
 $ PROXY=tele.example.com:443
 $ helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=${CLUSTER?} \
-  --set roles="kube\,app\,discovery"
+  --set roles="kube\,app\,discovery" \
   --set proxyAddr=${PROXY?} \
   --set joinParams.method=iam \
   --set joinParams.tokenName=<Var name="kube-iam-token"/> \

--- a/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/iam-joining.mdx
@@ -249,6 +249,7 @@ $ CLUSTER=iam-cluster
 $ PROXY=tele.example.com:443
 $ helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=${CLUSTER?} \
+  --set roles="kube\,app\,discovery"
   --set proxyAddr=${PROXY?} \
   --set joinParams.method=iam \
   --set joinParams.tokenName=<Var name="kube-iam-token"/> \

--- a/docs/pages/kubernetes-access/troubleshooting.mdx
+++ b/docs/pages/kubernetes-access/troubleshooting.mdx
@@ -170,7 +170,7 @@ $ CLUSTER=cookie
 $ cat > values.yaml << EOF
 authToken: "${TOKEN}"
 proxyAddr: "${PROXY_ADDR}"
-roles: "kube"
+roles: "kube,app,discovery"
 joinParams:
   method: "token"
   tokenName: "${TOKEN}"

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -28,7 +28,7 @@
       helm install ${RELEASE_NAME?} teleport/teleport-kube-agent \
         --create-namespace \
         --namespace ${NAMESPACE?} \
-        --set roles="kube\,app\,discovery"
+        --set roles="kube\,app\,discovery" \
         --set proxyAddr=${PROXY_ENDPOINT?} \
         --set authToken=${JOIN_TOKEN?} \
         --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}</pre>

--- a/examples/chart/index.html
+++ b/examples/chart/index.html
@@ -28,6 +28,7 @@
       helm install ${RELEASE_NAME?} teleport/teleport-kube-agent \
         --create-namespace \
         --namespace ${NAMESPACE?} \
+        --set roles="kube\,app\,discovery"
         --set proxyAddr=${PROXY_ENDPOINT?} \
         --set authToken=${JOIN_TOKEN?} \
         --set kubeClusterName=${KUBERNETES_CLUSTER_NAME?}</pre>

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -122,7 +122,7 @@ helm repo update
 
 > helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=cluster ` + "`" + `# Change kubeClusterName variable to your preferred name.` + "`" + ` \
-  --set roles="{{.set_roles}}"
+  --set roles="{{.set_roles}}" \
   --set proxyAddr={{.auth_server}} \
   --set authToken={{.token}} \
   --create-namespace \

--- a/tool/tctl/common/kube_command.go
+++ b/tool/tctl/common/kube_command.go
@@ -122,6 +122,7 @@ helm repo update
 
 > helm install teleport-agent teleport/teleport-kube-agent \
   --set kubeClusterName=cluster ` + "`" + `# Change kubeClusterName variable to your preferred name.` + "`" + ` \
+  --set roles="{{.set_roles}}"
   --set proxyAddr={{.auth_server}} \
   --set authToken={{.token}} \
   --create-namespace \

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -163,6 +163,12 @@ func (c *TokensCommand) Add(ctx context.Context, client auth.ClientI) error {
 		return trace.Wrap(err)
 	}
 
+	// If it's Kube, then enable App and Discovery roles automatically so users
+	// don't have problems with running Kubernetes App Discovery by default.
+	if len(roles) == 1 && roles[0] == types.RoleKube {
+		roles = append(roles, types.RoleApp, types.RoleDiscovery)
+	}
+
 	token := c.value
 	if c.value == "" {
 		token, err = utils.CryptoRandomHex(auth.TokenLenBytes)

--- a/tool/tctl/common/token_command.go
+++ b/tool/tctl/common/token_command.go
@@ -257,11 +257,13 @@ func (c *TokensCommand) Add(ctx context.Context, client auth.ClientI) error {
 		if len(proxies) == 0 {
 			return trace.NotFound("cluster has no proxies")
 		}
+		setRoles := strings.ToLower(strings.Join(roles.StringSlice(), "\\,"))
 		return kubeMessageTemplate.Execute(c.stdout,
 			map[string]interface{}{
 				"auth_server": proxies[0].GetPublicAddr(),
 				"token":       token,
 				"minutes":     c.ttl.Minutes(),
+				"set_roles":   setRoles,
 			})
 	case roles.Include(types.RoleApp):
 		proxies, err := client.GetProxies()

--- a/tool/tctl/common/token_command_test.go
+++ b/tool/tctl/common/token_command_test.go
@@ -103,6 +103,11 @@ func TestTokens(t *testing.T) {
 		require.Len(t, out.Roles, 2)
 		require.Equal(t, types.KindNode, strings.ToLower(out.Roles[0]))
 		require.Equal(t, types.KindApp, strings.ToLower(out.Roles[1]))
+
+		buf, err = runTokensCommand(t, fileConfig, []string{"add", "--type=kube"})
+		require.NoError(t, err)
+		require.Contains(t, buf.String(), `--set roles="kube\,app\,discovery"`,
+			"Command print out should include setting kube, app and discovery roles for helm install.")
 	})
 
 	// Test all output formats of "tokens ls".
@@ -110,23 +115,23 @@ func TestTokens(t *testing.T) {
 		buf, err := runTokensCommand(t, fileConfig, []string{"ls"})
 		require.NoError(t, err)
 		require.True(t, strings.HasPrefix(buf.String(), "Token "))
-		require.Equal(t, strings.Count(buf.String(), "\n"), 6) // account for header lines
+		require.Equal(t, 7, strings.Count(buf.String(), "\n")) // account for header lines
 
 		buf, err = runTokensCommand(t, fileConfig, []string{"ls", "--format", teleport.Text})
 		require.NoError(t, err)
-		require.Equal(t, strings.Count(buf.String(), "\n"), 4)
+		require.Equal(t, 5, strings.Count(buf.String(), "\n"))
 
 		var jsonOut []listedToken
 		buf, err = runTokensCommand(t, fileConfig, []string{"ls", "--format", teleport.JSON})
 		require.NoError(t, err)
 		mustDecodeJSON(t, buf, &jsonOut)
-		require.Len(t, jsonOut, 4)
+		require.Len(t, jsonOut, 5)
 
 		var yamlOut []listedToken
 		buf, err = runTokensCommand(t, fileConfig, []string{"ls", "--format", teleport.YAML})
 		require.NoError(t, err)
 		mustDecodeYAML(t, buf, &yamlOut)
-		require.Len(t, yamlOut, 4)
+		require.Len(t, yamlOut, 5)
 
 		require.Equal(t, jsonOut, yamlOut)
 	})


### PR DESCRIPTION
New feature of Kuberentes app discovery is controlled by roles provided to helm chart (it's automatically enabled if discovery and app roles are present). We want users to not have problems with feature discovery of Kubernetes app discovery, so we're making sure by default appropriate guides/docs tell users to enable it by setting roles to be 'kube,app,discovery'.