### PR TITLE
Version ID check on Amazon Linux 2023/rhel installs

### DIFF
--- a/docs/pages/includes/cloud/install-linux-cloud.mdx
+++ b/docs/pages/includes/cloud/install-linux-cloud.mdx
@@ -42,6 +42,9 @@
   # Source variables about OS version
   $ source /etc/os-release
   # Add the Teleport yum repository for cloud.
+  # First, get the major version from $VERSION_ID so this fetches the correct
+  # package version.
+  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   # Use the dnf config manager plugin to add the teleport RPM repo
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/cloud/teleport.repo")"
   

--- a/docs/pages/includes/install-linux-enterprise.mdx
+++ b/docs/pages/includes/install-linux-enterprise.mdx
@@ -59,6 +59,9 @@ Use the appropriate commands for your environment to install your package:
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
+  # First, get the major version from $VERSION_ID so this fetches the correct
+  # package version.
+  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   # Use the dnf config manager plugin to add the teleport RPM repo
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -83,6 +83,9 @@ Use the appropriate commands for your environment to install your package:
   $ source /etc/os-release
   # Add the Teleport YUM repository for v(=teleport.major_version=). You'll need to update this
   # file for each major release of Teleport.
+  # First, get the major version from $VERSION_ID so this fetches the correct
+  # package version.
+  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   # Use the dnf config manager plugin to add the teleport RPM repo
   $ sudo dnf config-manager --add-repo "$(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")"
   


### PR DESCRIPTION
The VERSION_ID was not being updated for Amazon Linux 2023/rhel8+ installs.  This would lead to unfound repos since some like RHEL have VERSION_ID=8.8, not 8. This is already done for Amazon Linux 2, RHEL 7+.