### PR TITLE
Redirect directly to Okta apps from proxy.

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -235,7 +235,6 @@ func (h *Handler) HealthCheckAppServer(ctx context.Context, publicAddr string, c
 // handleHttp forwards the request to the application service or redirects
 // to the application directly.
 func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *session) error {
-	needsRedirect := false
 	var redirectURI string
 	session.tr.servers.Range(func(serverID, appServerInterface any) bool {
 		appServer, ok := appServerInterface.(types.AppServer)
@@ -246,7 +245,6 @@ func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *se
 
 		// If encounter an app server that is to be redirected to, stop iterating.
 		if redirectInsteadOfForward(appServer) {
-			needsRedirect = true
 			redirectURI = appServer.GetApp().GetURI()
 			return false
 		}
@@ -254,7 +252,7 @@ func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *se
 		return true
 	})
 
-	if needsRedirect {
+	if redirectURI != "" {
 		http.Redirect(w, r, redirectURI, http.StatusFound)
 		return nil
 	}

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -131,7 +131,7 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 	h.router.POST("/x-teleport-auth", makeRouterHandler(h.withCustomCORS(h.handleAuth)))
 	h.router.OPTIONS("/x-teleport-auth", makeRouterHandler(h.withCustomCORS(nil)))
 	h.router.GET("/teleport-logout", h.withRouterAuth(h.handleLogout))
-	h.router.NotFound = h.withAuth(h.handleForward)
+	h.router.NotFound = h.withAuth(h.handleHttp)
 
 	return h, nil
 }
@@ -232,8 +232,31 @@ func (h *Handler) HealthCheckAppServer(ctx context.Context, publicAddr string, c
 	return nil
 }
 
-// handleForward forwards the request to the application service.
-func (h *Handler) handleForward(w http.ResponseWriter, r *http.Request, session *session) error {
+// handleHttp forwards the request to the application service or redirects
+// to the application directly.
+func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *session) error {
+	redirected := false
+	session.tr.servers.Range(func(serverID, appServerInterface any) bool {
+		appServer, ok := appServerInterface.(types.AppServer)
+		if !ok {
+			h.log.Warnf("Failed to load AppServer, invalid type %T", appServerInterface)
+			return true
+		}
+
+		// If encounter an app server that is to be redirected to, stop iterating.
+		if redirectInsteadOfForward(appServer) {
+			redirected = true
+			http.Redirect(w, r, appServer.GetApp().GetURI(), http.StatusFound)
+			return true
+		}
+
+		return false
+	})
+
+	if redirected {
+		return nil
+	}
+
 	if r.Body != nil {
 		// We replace the request body with a NopCloser so that the request body can
 		// be closed multiple times. This is needed because Go's HTTP RoundTripper
@@ -599,4 +622,10 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, hostname string) strin
 	}
 
 	return u.String()
+}
+
+// redirectInsteadOfForward returns true if an application shouldn't be forwarded, but
+// should be redirected directly to the public address instead.
+func redirectInsteadOfForward(appServer types.AppServer) bool {
+	return appServer.GetApp().Origin() == types.OriginOkta
 }

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -248,10 +248,10 @@ func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *se
 		if redirectInsteadOfForward(appServer) {
 			needsRedirect = true
 			redirectURI = appServer.GetApp().GetURI()
-			return true
+			return false
 		}
 
-		return false
+		return true
 	})
 
 	if needsRedirect {

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -101,6 +101,11 @@ func MatchName(name string) Matcher {
 // doesn't return any error.
 func MatchHealthy(proxyClient reversetunnelclient.Tunnel, clusterName string) Matcher {
 	return func(ctx context.Context, appServer types.AppServer) bool {
+		// Redirected apps don't need to be dialed, as the proxy will redirect to them.
+		if redirectInsteadOfForward(appServer) {
+			return true
+		}
+
 		conn, err := dialAppServer(ctx, proxyClient, clusterName, appServer)
 		if err != nil {
 			return false


### PR DESCRIPTION
The proxy will redirect directly to Okta apps rather than try to dial them through the reverse proxy. This will make the Okta plugin function as expected, as it will no longer require a reverse tunnel to operate properly.