### PR TITLE
changelog: Update distroless debug image name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -241,7 +241,7 @@ image: "public.ecr.aws/gravitational/teleport"
 
 For debugging purposes, a "debug" image is available and contains BusyBox,
 which includes a shell and most common POSIX executables:
-`public.ecr.aws/gravitational/teleport-distroless`.
+`public.ecr.aws/gravitational/teleport-distroless-debug`.
 
 ## 12.3.0 (05/01/23)
 


### PR DESCRIPTION
The distroless images which include a shell for debugging are `public.ecr.aws/gravitational/teleport-distroless-debug` rather than `public.ecr.aws/gravitational/teleport-distroless`.