### PR TITLE
Error if users attempt to do `tsh login --headless`

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -183,6 +183,12 @@ const (
 	OktaAssignmentTargetUnknown = "unknown"
 )
 
+// LocalConnectors are the system connectors that use local auth.
+var LocalConnectors = []string{
+	LocalConnector,
+	PasswordlessConnector,
+}
+
 // SystemConnectors lists the names of the system-reserved connectors.
 var SystemConnectors = []string{
 	LocalConnector,

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3531,8 +3531,9 @@ func (tc *TeleportClient) getSSHLoginFunc(pr *webclient.PingResponse) (SSHLoginF
 					return tc.headlessLogin(ctx, priv)
 				}, nil
 			}
-			log.Debug("Headless login is disabled for this command. Only 'tsh ls', 'tsh ssh', and 'tsh scp' are supported. Defaulting to local authentication methods.")
-			fallthrough
+			return nil, trace.BadParameter("" +
+				"Headless login is disabled for this command. " +
+				"Only 'tsh ls', 'tsh ssh', and 'tsh scp' are supported.")
 		case constants.LocalConnector, "":
 			// if passwordless is enabled and there are passwordless credentials
 			// registered, we can try to go with passwordless login even though

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3532,7 +3532,7 @@ func (tc *TeleportClient) getSSHLoginFunc(pr *webclient.PingResponse) (SSHLoginF
 				}, nil
 			}
 			return nil, trace.BadParameter("" +
-				"Headless login is disabled for this command. " +
+				"Headless login is not supported for this command. " +
 				"Only 'tsh ls', 'tsh ssh', and 'tsh scp' are supported.")
 		case constants.LocalConnector, "":
 			// if passwordless is enabled and there are passwordless credentials

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1838,23 +1838,14 @@ func onLogin(cf *CLIConf) error {
 		}
 	}
 
-	// If the cluster is using single-sign on, providing the user name
-	// with --user is likely a mistake, so display a warning.
-	if cf.Username != "" {
-		displayIgnoreUserWarning := false
-		if cf.AuthConnector != "" && cf.AuthConnector != constants.LocalConnector && cf.AuthConnector != constants.PasswordlessConnector {
-			displayIgnoreUserWarning = true
-		} else if cf.AuthConnector == "" {
-			// Get the Ping so we check if the default Auth type is SSO
-			pr, err := tc.Ping(cf.Context)
-			if err != nil {
-				return trace.Wrap(err, "Teleport proxy not available at %s.", tc.WebProxyAddr)
-			}
-			if pr.Auth.Type != constants.LocalConnector && pr.Auth.Type != constants.PasswordlessConnector {
-				displayIgnoreUserWarning = true
-			}
+	// If the cluster is using single-sign on, providing the user name with --user
+	// is likely a mistake, so display a warning.
+	if cf.Username != "" && !slices.Contains(constants.LocalConnectors, cf.AuthConnector) {
+		pr, err := tc.Ping(cf.Context)
+		if err != nil {
+			return trace.Wrap(err, "Teleport proxy not available at %s.", tc.WebProxyAddr)
 		}
-		if displayIgnoreUserWarning {
+		if !slices.Contains(constants.LocalConnectors, pr.Auth.Type) {
 			fmt.Fprintf(os.Stderr, "WARNING: Ignoring Teleport user (%v) for Single Sign-On (SSO) login.\nProvide the user name during the SSO flow instead. Use --auth=local if you did not intend to login with SSO.\n", cf.Username)
 		}
 	}


### PR DESCRIPTION
Instead of silently defaulting to local login, which can run into other errors and potentially confuse the user (it did confuse us), we now error if the user attempts to do `tsh login --headless`.

I've snuck in a fix for the "SSO login warning" logic, as it was showing for me on a local cluster.

#28045