### PR TITLE
Re-add ServerInfo reconciler with better backend performance

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -47,6 +47,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/pkg/sftp"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -188,6 +189,7 @@ func TestIntegrations(t *testing.T) {
 	t.Run("AuthLocalNodeControlStream", suite.bind(testAuthLocalNodeControlStream))
 	t.Run("AgentlessConnection", suite.bind(testAgentlessConnection))
 	t.Run("LeafAgentlessConnection", suite.bind(testTrustedClusterAgentless))
+	t.Run("ReconcileLabels", suite.bind(testReconcileLabels))
 }
 
 // testDifferentPinnedIP tests connection is rejected when source IP doesn't match the pinned one
@@ -7805,6 +7807,84 @@ func testAgentlessConnection(t *testing.T, suite *integrationTestSuite) {
 	require.NoError(t, err)
 
 	testAgentlessConn(t, tc, node)
+}
+
+// testReconcileLabels verifies that an SSH server's labels can be updated by
+// upserting a corresponding ServerInfo to the auth server.
+func testReconcileLabels(t *testing.T, suite *integrationTestSuite) {
+	// Create Teleport cluster.
+	cfg := suite.defaultServiceConfig()
+	cfg.CachePolicy.Enabled = false
+	cfg.Proxy.DisableWebService = true
+	cfg.Proxy.DisableWebInterface = true
+	cfg.SSH.Labels = map[string]string{"foo": "bar"}
+	clock := clockwork.NewFakeClock()
+	cfg.Clock = clock
+	teleInst := suite.NewTeleportWithConfig(t, nil, nil, cfg)
+
+	t.Cleanup(func() { require.NoError(t, teleInst.StopAll()) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	require.NoError(t, helpers.WaitForNodeCount(ctx, teleInst, helpers.Site, 1))
+
+	authServer := teleInst.Process.GetAuthServer()
+	servers, err := authServer.GetNodes(ctx, defaults.Namespace)
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+
+	server := servers[0]
+	serverName := server.GetName()
+	require.Equal(t, map[string]string{"foo": "bar"}, server.GetStaticLabels())
+	server.SetCloudMetadata(&types.CloudMetadata{
+		AWS: &types.AWSInfo{
+			AccountID:  "my-account",
+			InstanceID: "my-instance",
+		},
+	})
+	_, err = authServer.UpsertNode(ctx, server)
+	require.NoError(t, err)
+
+	// Update the server's labels.
+	labels := map[string]string{"a": "1", "b": "2"}
+	serverInfo, err := types.NewServerInfo(types.Metadata{
+		Name:   "aws-my-account-my-instance",
+		Labels: labels,
+	}, types.ServerInfoSpecV1{})
+	require.NoError(t, err)
+	serverInfo.SetSubKind(types.SubKindCloudInfo)
+	require.NoError(t, authServer.UpsertServerInfo(ctx, serverInfo))
+
+	watcher, err := authServer.NewWatcher(ctx, types.Watch{
+		Kinds: []types.WatchKind{
+			{
+				Kind: types.KindNode,
+			},
+		},
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, watcher.Close()) })
+
+	timeout := time.After(5 * time.Second)
+	// Wait for server to receive updated labels.
+	for {
+		clock.Advance(15 * time.Minute)
+		select {
+		case <-timeout:
+			require.Fail(t, "Timed out waiting for server update")
+		case event := <-watcher.Events():
+			if event.Type != types.OpPut || event.Resource.GetName() != serverName {
+				continue
+			}
+			if utils.StringMapsEqual(
+				map[string]string{"foo": "bar", "a": "1", "b": "2"},
+				event.Resource.GetMetadata().Labels,
+			) {
+				return
+			}
+		}
+	}
 }
 
 func createAgentlessNode(t *testing.T, authServer *auth.Server, clusterName, nodeHostname string) *types.ServerV2 {

--- a/lib/ai/embeddingprocessor_test.go
+++ b/lib/ai/embeddingprocessor_test.go
@@ -21,6 +21,7 @@ import (
 	"crypto/sha256"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -57,6 +58,26 @@ func (m MockEmbedder) ComputeEmbeddings(_ context.Context, input []string) ([]em
 	return result, nil
 }
 
+type mockNodeStreamer struct {
+	mu    sync.Mutex
+	nodes []types.Server
+}
+
+func (m *mockNodeStreamer) UpsertNode(_ context.Context, node types.Server) (*types.KeepAlive, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.nodes = append(m.nodes, node)
+	return nil, nil
+}
+
+func (m *mockNodeStreamer) GetNodeStream(_ context.Context, _ string) stream.Stream[types.Server] {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	nodes := make([]types.Server, 0, len(m.nodes))
+	nodes = append(nodes, m.nodes...)
+	return stream.Slice(nodes)
+}
+
 func TestNodeEmbeddingGeneration(t *testing.T) {
 	t.Parallel()
 
@@ -74,7 +95,7 @@ func TestNodeEmbeddingGeneration(t *testing.T) {
 	require.NoError(t, err)
 
 	embedder := MockEmbedder{}
-	presence := local.NewPresenceService(bk)
+	presence := &mockNodeStreamer{}
 	embeddings := local.NewEmbeddingsService(bk)
 
 	processor := ai.NewEmbeddingProcessor(&ai.EmbeddingProcessorConfig{

--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -5551,6 +5551,31 @@ func (a *Server) getProxyPublicAddr() string {
 	return ""
 }
 
+// GetNodeStream streams a list of registered servers.
+func (a *Server) GetNodeStream(ctx context.Context, namespace string) stream.Stream[types.Server] {
+	var done bool
+	startKey := ""
+	return stream.PageFunc(func() ([]types.Server, error) {
+		if done {
+			return nil, io.EOF
+		}
+		resp, err := a.ListResources(ctx, proto.ListResourcesRequest{
+			ResourceType: types.KindNode,
+			Namespace:    namespace,
+			Limit:        apidefaults.DefaultChunkSize,
+			StartKey:     startKey,
+		})
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		startKey = resp.NextKey
+		done = startKey == ""
+		resources := types.ResourcesWithLabels(resp.Resources)
+		servers, err := resources.AsServers()
+		return servers, trace.Wrap(err)
+	})
+}
+
 // authKeepAliver is a keep aliver using auth server directly
 type authKeepAliver struct {
 	sync.RWMutex

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -1805,10 +1805,6 @@ func (a *ServerWithRoles) GetNodes(ctx context.Context, namespace string) ([]typ
 	return filteredNodes, nil
 }
 
-func (a *ServerWithRoles) StreamNodes(ctx context.Context, namespace string) stream.Stream[types.Server] {
-	return stream.Fail[types.Server](trace.NotImplemented(notImplementedMessage))
-}
-
 // authContextForSearch returns an extended authz.Context which should be used
 // when searching for resources that a user may be able to request access to,
 // but does not already have access to.

--- a/lib/auth/clt.go
+++ b/lib/auth/clt.go
@@ -34,7 +34,6 @@ import (
 	pluginspb "github.com/gravitational/teleport/api/gen/proto/go/teleport/plugins/v1"
 	samlidppb "github.com/gravitational/teleport/api/gen/proto/go/teleport/samlidp/v1"
 	userpreferencesv1 "github.com/gravitational/teleport/api/gen/proto/go/userpreferences/v1"
-	"github.com/gravitational/teleport/api/internalutils/stream"
 	"github.com/gravitational/teleport/api/types"
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
@@ -250,11 +249,6 @@ func (c *Client) CompareAndSwapUser(ctx context.Context, new, expected types.Use
 	return trace.NotImplemented(notImplementedMessage)
 }
 
-// GetNodeStream not implemented: can only be called locally
-func (c *Client) GetNodeStream(_ context.Context, _ string) stream.Stream[types.Server] {
-	return stream.Fail[types.Server](trace.NotImplemented(notImplementedMessage))
-}
-
 // StreamSessionEvents streams all events from a given session recording. An error is returned on the first
 // channel if one is encountered. Otherwise the event channel is closed when the stream ends.
 // The event channel is not closed on error to prevent race conditions in downstream select statements.
@@ -427,10 +421,6 @@ func (c *Client) DeleteAllLocks(context.Context) error {
 
 func (c *Client) UpdatePresence(ctx context.Context, sessionID, user string) error {
 	return trace.NotImplemented(notImplementedMessage)
-}
-
-func (c *Client) StreamNodes(ctx context.Context, namespace string) stream.Stream[types.Server] {
-	return stream.Fail[types.Server](trace.NotImplemented(notImplementedMessage))
 }
 
 func (c *Client) GetLicense(ctx context.Context) (string, error) {

--- a/lib/auth/server_info.go
+++ b/lib/auth/server_info.go
@@ -1,0 +1,101 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/client/proto"
+	"github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/internalutils/stream"
+	"github.com/gravitational/teleport/api/types"
+)
+
+// ReconcileServerInfos periodically reconciles the labels of ServerInfo
+// resources with their corresponding Teleport SSH servers.
+func (s *Server) ReconcileServerInfos(ctx context.Context) error {
+	const batchSize = 100
+	const timeBetweenBatches = 10 * time.Second
+	const timeBetweenReconciliationLoops = 10 * time.Minute
+	clock := s.GetClock()
+
+	for {
+		var failedUpdates int
+		// Iterate over nodes in batches.
+		nodeStream := s.GetNodeStream(ctx, defaults.Namespace)
+		var nodes []types.Server
+
+		for moreNodes := true; moreNodes; {
+			nodes, moreNodes = stream.Take(nodeStream, batchSize)
+			updates, err := s.setCloudLabelsOnNodes(ctx, nodes)
+			if err != nil {
+				return trace.Wrap(err)
+			}
+			failedUpdates += updates
+
+			select {
+			case <-clock.After(timeBetweenBatches):
+			case <-ctx.Done():
+				return trace.Wrap(ctx.Err())
+			}
+		}
+
+		// Log number of nodes that we couldn't find a control stream for.
+		if failedUpdates > 0 {
+			log.Debugf("unable to update labels on %v node(s) due to missing control stream", failedUpdates)
+		}
+
+		select {
+		case <-clock.After(timeBetweenReconciliationLoops):
+		case <-ctx.Done():
+			return trace.Wrap(ctx.Err())
+		}
+	}
+}
+
+func (s *Server) setCloudLabelsOnNodes(ctx context.Context, nodes []types.Server) (failedUpdates int, err error) {
+	for _, node := range nodes {
+		meta := node.GetCloudMetadata()
+		if meta != nil && meta.AWS != nil {
+			si, err := s.GetServerInfo(ctx, meta.AWS.GetServerInfoName())
+			if err == nil {
+				err := s.updateLabelsOnNode(ctx, node, si)
+				// Didn't find control stream for node, save count for logging.
+				if trace.IsNotFound(err) {
+					failedUpdates++
+				} else if err != nil {
+					return failedUpdates, trace.Wrap(err)
+				}
+			} else if !trace.IsNotFound(err) {
+				return failedUpdates, trace.Wrap(err)
+			}
+		}
+	}
+	return failedUpdates, nil
+}
+
+func (s *Server) updateLabelsOnNode(ctx context.Context, node types.Server, si types.ServerInfo) error {
+	err := s.UpdateLabels(ctx, proto.InventoryUpdateLabelsRequest{
+		ServerID: node.GetName(),
+		Kind:     proto.LabelUpdateKind_SSHServerCloudLabels,
+		Labels:   si.GetStaticLabels(),
+	})
+	return trace.Wrap(err)
+}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2001,6 +2001,10 @@ func (process *TeleportProcess) initAuthService() error {
 		return trace.Wrap(err)
 	}
 	process.RegisterFunc("auth.heartbeat", heartbeat.Run)
+
+	process.RegisterFunc("auth.server_info", func() error {
+		return trace.Wrap(authServer.ReconcileServerInfos(process.GracefulExitContext()))
+	})
 	// execute this when process is asked to exit:
 	process.OnExit("auth.shutdown", func(payload any) {
 		// The listeners have to be closed here, because if shutdown

--- a/lib/services/local/presence.go
+++ b/lib/services/local/presence.go
@@ -326,20 +326,6 @@ func (s *PresenceService) GetNodes(ctx context.Context, namespace string) ([]typ
 	return servers, nil
 }
 
-// GetNodeStream returns a stream of nodes in a namespace.
-func (s *PresenceService) GetNodeStream(ctx context.Context, namespace string) stream.Stream[types.Server] {
-	startKey := backend.ExactKey(nodesPrefix, namespace)
-	items := backend.StreamRange(ctx, s, startKey, backend.RangeEnd(startKey), 50)
-	return stream.FilterMap(items, func(item backend.Item) (types.Server, bool) {
-		embedding, err := services.UnmarshalServer(item.Value, types.KindNode)
-		if err != nil {
-			s.log.Warnf("Skipping node at %s, failed to unmarshal: %v", item.Key, err)
-			return nil, false
-		}
-		return embedding, true
-	})
-}
-
 // UpsertNode registers node presence, permanently if TTL is 0 or for the
 // specified duration with second resolution if it's >= 1 second.
 func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (*types.KeepAlive, error) {
@@ -371,26 +357,6 @@ func (s *PresenceService) UpsertNode(ctx context.Context, server types.Server) (
 		LeaseID: lease.ID,
 		Name:    server.GetName(),
 	}, nil
-}
-
-// StreamNodes streams a list of registered servers.
-func (s *PresenceService) StreamNodes(ctx context.Context, namespace string) stream.Stream[types.Server] {
-	startKey := backend.Key(nodesPrefix, namespace)
-	endKey := backend.RangeEnd(startKey)
-	items := backend.StreamRange(ctx, s, startKey, endKey, apidefaults.DefaultChunkSize)
-	return stream.FilterMap(items, func(item backend.Item) (types.Server, bool) {
-		server, err := services.UnmarshalServer(
-			item.Value,
-			types.KindNode,
-			services.WithResourceID(item.ID),
-			services.WithExpires(item.Expires),
-		)
-		if err != nil {
-			s.log.Warnf("Skipping server at %s, failed to unmarshal: %v", item.Key, err)
-			return nil, false
-		}
-		return server, true
-	})
 }
 
 // GetAuthServers returns a list of registered servers

--- a/lib/services/presence.go
+++ b/lib/services/presence.go
@@ -68,9 +68,6 @@ type Presence interface {
 	// NodesGetter gets nodes
 	NodesGetter
 
-	// NodesStreamGetter gets nodes as a stream
-	NodesStreamGetter
-
 	// DeleteAllNodes deletes all nodes in a namespace.
 	DeleteAllNodes(ctx context.Context, namespace string) error
 
@@ -80,9 +77,6 @@ type Presence interface {
 	// UpsertNode registers node presence, permanently if TTL is 0 or for the
 	// specified duration with second resolution if it's >= 1 second.
 	UpsertNode(ctx context.Context, server types.Server) (*types.KeepAlive, error)
-
-	// StreamNodes streams a list of registered servers.
-	StreamNodes(ctx context.Context, namespace string) stream.Stream[types.Server]
 
 	// GetAuthServers returns a list of registered servers
 	GetAuthServers() ([]types.Server, error)


### PR DESCRIPTION
This PR re-adds the ServerInfo reconciler that was removed in #30190 due to an unexpected increase in backend usage. This version decreases the load on the backend by:
- Streaming nodes from the cache instead of the backend
- Increasing the time between batches
- Adding an additional wait between reconciliation loops