### PR TITLE
[v11] fix: Do not show SSO warning for local auth

### DIFF
--- a/api/constants/constants.go
+++ b/api/constants/constants.go
@@ -153,6 +153,12 @@ const (
 	SSHRSAType = "ssh-rsa"
 )
 
+// LocalConnectors are the system connectors that use local auth.
+var LocalConnectors = []string{
+	LocalConnector,
+	PasswordlessConnector,
+}
+
 // SystemConnectors lists the names of the system-reserved connectors.
 var SystemConnectors = []string{
 	LocalConnector,

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -48,6 +48,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
@@ -1545,23 +1546,14 @@ func onLogin(cf *CLIConf) error {
 		}
 	}
 
-	// If the cluster is using single-sign on, providing the user name
-	// with --user is likely a mistake, so display a warning.
-	if cf.Username != "" {
-		var displayIgnoreUserWarning = false
-		if cf.AuthConnector != "" && cf.AuthConnector != constants.LocalConnector && cf.AuthConnector != constants.PasswordlessConnector {
-			displayIgnoreUserWarning = true
-		} else if cf.AuthConnector == "" {
-			// Get the Ping so we check if the default Auth type is SSO
-			pr, err := tc.Ping(cf.Context)
-			if err != nil {
-				return trace.Wrap(err, "Teleport proxy not available at %s.", tc.WebProxyAddr)
-			}
-			if pr.Auth.Type != constants.LocalConnector && pr.Auth.Type != constants.PasswordlessConnector {
-				displayIgnoreUserWarning = true
-			}
+	// If the cluster is using single-sign on, providing the user name with --user
+	// is likely a mistake, so display a warning.
+	if cf.Username != "" && !slices.Contains(constants.LocalConnectors, cf.AuthConnector) {
+		pr, err := tc.Ping(cf.Context)
+		if err != nil {
+			return trace.Wrap(err, "Teleport proxy not available at %s.", tc.WebProxyAddr)
 		}
-		if displayIgnoreUserWarning {
+		if !slices.Contains(constants.LocalConnectors, pr.Auth.Type) {
 			fmt.Fprintf(os.Stderr, "WARNING: Ignoring Teleport user (%v) for Single Sign-On (SSO) login.\nProvide the user name during the SSO flow instead. Use --auth=local if you did not intend to login with SSO.\n", cf.Username)
 		}
 	}


### PR DESCRIPTION
Partial backport of #30298 to branch/v11.

Fix "SSO login warning" showing for local users.