### PR TITLE
[v11] Version ID check on Amazon Linux 2023/rhel installs

### DIFF
--- a/docs/pages/application-access/getting-started.mdx
+++ b/docs/pages/application-access/getting-started.mdx
@@ -133,7 +133,6 @@ for your environment.
 To install on Linux:
 
 1. (!docs/pages/includes/install-linux.mdx!)
-
 1. Create the configuration file for Grafana at `/etc/app_config.yaml`
 with a command similar to the following:
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -50,6 +50,9 @@ Next, use the appropriate commands for your environment to install your package.
   # Note: if using a fork of RHEL/CentOS or Amazon Linux you may need to use '$ID_LIKE'
   # and the codename your distro was forked from instead of '$ID'
   # Supported versions are listed here: https://github.com/gravitational/teleport/blob/master/build.assets/tooling/cmd/build-os-package-repos/runners.go#L133-L153
+  # First, get the major version from $VERSION_ID so this fetches the correct
+  # package version.
+  $ VERSION_ID=$(echo $VERSION_ID | grep -Eo "^[0-9]+")
   $ sudo yum-config-manager --add-repo $(rpm --eval "https://yum.releases.teleport.dev/$ID/$VERSION_ID/Teleport/%{_arch}/stable/v(=teleport.major_version=)/teleport.repo")
   $ sudo yum install teleport
   #


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/30292 to branch/v11