### PR TITLE
Dont allow directly dialing to servers not in inventory

### DIFF
--- a/build.assets/tooling/cmd/difftest/main.go
+++ b/build.assets/tooling/cmd/difftest/main.go
@@ -59,7 +59,7 @@ var (
 
 		// TestProxySSH and TestList takes around 10-15s to run, largely due to the 7-10 seconds it takes to create a
 		// tsh test suite. This prevents it from ever completing the 100 runs successfully.
-		"TestProxySSH", "TestList", "TestForwardingTraces", "TestExportingTraces",
+		"TestProxySSH", "TestSSHLoadAllCAs", "TestList", "TestForwardingTraces", "TestExportingTraces",
 
 		// TestDiagnoseSSHConnection takes around 15s to run.
 		// When running 100x it exceeds the 600s defined to run the tests.

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4655,6 +4655,18 @@ func testProxyHostKeyCheck(t *testing.T, suite *integrationTestSuite) {
 				Port:         nodePort,
 				ForwardAgent: true,
 			}
+
+			// Create the node
+			clt := instance.Process.GetAuthServer()
+			server, err := types.NewServer("name", types.KindNode, types.ServerSpecV2{
+				Addr:     net.JoinHostPort(Host, strconv.Itoa(nodePort)),
+				Hostname: "localhost",
+			})
+			require.NoError(t, err)
+			server.SetSubKind(types.SubKindOpenSSHNode)
+			_, err = clt.UpsertNode(context.Background(), server)
+			require.NoError(t, err)
+
 			_, err = runCommand(t, instance, []string{"echo hello"}, clientConfig, 1)
 
 			// check if we were able to exec the command or not

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -7196,24 +7196,26 @@ func TestTraitsPropagation(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run command in root.
-	outputRoot, err := runCommand(t, rc, []string{"echo", "hello root"}, helpers.ClientConfig{
-		Login:   me.Username,
-		Cluster: "root.example.com",
-		Host:    Loopback,
-		Port:    helpers.Port(t, rc.SSH),
-	}, 1)
-	require.NoError(t, err)
-	require.Equal(t, "hello root", strings.TrimSpace(outputRoot))
+	require.Eventually(t, func() bool {
+		outputRoot, err := runCommand(t, rc, []string{"echo", "hello root"}, helpers.ClientConfig{
+			Login:   me.Username,
+			Cluster: "root.example.com",
+			Host:    Loopback,
+			Port:    helpers.Port(t, rc.SSH),
+		}, 1)
+		return err == nil && strings.TrimSpace(outputRoot) == "hello root"
+	}, time.Second*30, time.Millisecond*100)
 
 	// Run command in leaf.
-	outputLeaf, err := runCommand(t, rc, []string{"echo", "hello leaf"}, helpers.ClientConfig{
-		Login:   me.Username,
-		Cluster: "leaf.example.com",
-		Host:    Loopback,
-		Port:    helpers.Port(t, lc.SSH),
-	}, 1)
-	require.NoError(t, err)
-	require.Equal(t, "hello leaf", strings.TrimSpace(outputLeaf))
+	require.Eventually(t, func() bool {
+		outputLeaf, err := runCommand(t, rc, []string{"echo", "hello leaf"}, helpers.ClientConfig{
+			Login:   me.Username,
+			Cluster: "leaf.example.com",
+			Host:    Loopback,
+			Port:    helpers.Port(t, lc.SSH),
+		}, 1)
+		return err == nil && strings.TrimSpace(outputLeaf) == "hello leaf"
+	}, time.Second*30, time.Millisecond*100)
 }
 
 // testSessionStreaming tests streaming events from session recordings.

--- a/lib/proxy/router.go
+++ b/lib/proxy/router.go
@@ -162,13 +162,14 @@ func (c *RouterConfig) CheckAndSetDefaults() error {
 // Router is used by the proxy to establish connections to both
 // nodes and other clusters.
 type Router struct {
-	clusterName           string
-	log                   *logrus.Entry
-	clusterGetter         RemoteClusterGetter
-	localSite             reversetunnelclient.RemoteSite
-	siteGetter            SiteGetter
-	tracer                oteltrace.Tracer
-	serverResolver        serverResolverFn
+	clusterName    string
+	log            *logrus.Entry
+	clusterGetter  RemoteClusterGetter
+	localSite      reversetunnelclient.RemoteSite
+	siteGetter     SiteGetter
+	tracer         oteltrace.Tracer
+	serverResolver serverResolverFn
+	// DELETE IN 15.0.0: necessary for smoothing over v13 to v14 transition only.
 	permitUnlistedDialing bool
 }
 

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -6014,7 +6014,7 @@ func TestDiagnoseSSHConnection(t *testing.T) {
 					Type:    types.ConnectionDiagnosticTrace_CONNECTIVITY,
 					Status:  types.ConnectionDiagnosticTrace_FAILED,
 					Details: `Failed to connect to the Node. Ensure teleport service is running using "systemctl status teleport".`,
-					Error:   "Teleport proxy failed to connect to",
+					Error:   "direct dialing to nodes not found in inventory is not supported",
 				},
 			},
 		},

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -239,6 +239,7 @@ func TestSSHLoadAllCAs(t *testing.T) {
 			err = Run(context.Background(), []string{
 				"ssh", "-d",
 				"-p", strconv.Itoa(s.leaf.Config.SSH.Addr.Port(0)),
+				"--cluster", s.leaf.Config.Auth.ClusterName.GetClusterName(),
 				s.leaf.Config.SSH.Addr.Host(),
 				"echo", "hello",
 			}, setHomePath(tshHome))

--- a/tool/tsh/common/proxy_test.go
+++ b/tool/tsh/common/proxy_test.go
@@ -522,6 +522,12 @@ func TestProxySSH(t *testing.T) {
 				s.root.Config.Auth.ClusterName.GetClusterName(),
 				s.root.Config.SSH.Addr.Port(defaults.SSHServerListenPort))
 
+			require.Eventually(t, func() bool {
+				nodes, err := s.root.GetAuthServer().GetNodes(ctx, "default")
+				require.NoError(t, err)
+				return len(nodes) != 0
+			}, time.Second*30, time.Millisecond*100)
+
 			runProxySSH := func(proxyRequest string, opts ...CliOption) error {
 				return Run(ctx, []string{
 					"--insecure",


### PR DESCRIPTION
Fix for #28984 

This feature is being deprecated and so does not require adding a switch to re-enable this, just that it get removed.