### PR TITLE
chore: Remove devbox comments from `build.assets/versions.mk`

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -30,9 +30,9 @@ RUNTIME_ARCH_aarch64 := arm64
 RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
 
 # BUILDBOX_VERSION, BUILDBOX and BUILDBOX_variant variables are included
-include images.mk
-include grpcbox.mk
 include versions.mk
+include images.mk
+include grpcbox.mk # Requires images.mk
 
 # These variables are used to dynamically change the name of the buildbox Docker image used by the 'release'
 # target. The other solution was to remove the 'buildbox' dependency from the 'release' target, but this would

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -1,22 +1,20 @@
 # Keep all tool versions in one place.
 # This file can be included in other Makefiles to avoid duplication.
+# Keep versions in sync with devbox.json, when applicable.
 
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.20.7
 
-# Sync with devbox.json.
 NODE_VERSION ?= 16.18.1
 
-# Sync any version changes below with devbox.json.
-# run lint-rust check locally before merging code after you bump this
+# Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.71.1
 LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
-# Sync any version changes below with devbox.json.
 # Protogen related versions.
 BUF_VERSION ?= 1.26.1
-# Keep in sync with api/proto/buf.yaml (and buf.lock)
+# Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4
 NODE_PROTOC_TS_VERSION ?= 5.0.1


### PR DESCRIPTION
Makes backports much simpler by avoiding silly conflicts on comments.