### PR TITLE
[v11] chore: Bump Buf to v1.26.1

### DIFF
--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -18,23 +18,6 @@ TEST_KUBE ?=
 OS ?= linux
 ARCH ?= amd64
 
-GOLANG_VERSION ?= go1.20.7
-
-NODE_VERSION ?= 16.18.1
-
-# run lint-rust check locally before merging code after you bump this
-RUST_VERSION ?= 1.68.0
-LIBBPF_VERSION ?= 0.7.0-teleport
-LIBPCSCLITE_VERSION ?= 1.9.9-teleport
-
-# Protogen related versions.
-BUF_VERSION ?= 1.25.1
-# Keep in sync with api/proto/buf.yaml (and buf.lock)
-GOGO_PROTO_TAG ?= v1.3.2
-NODE_GRPC_TOOLS_VERSION ?= 1.12.4
-NODE_PROTOC_TS_VERSION ?= 5.0.1
-PROTOC_VER ?= 3.20.3
-
 UID := $$(id -u)
 GID := $$(id -g)
 
@@ -46,8 +29,9 @@ RUNTIME_ARCH_aarch64 := arm64
 RUNTIME_ARCH := $(RUNTIME_ARCH_$(HOST_ARCH))
 
 # BUILDBOX_VERSION, BUILDBOX and BUILDBOX_variant variables are included
+include versions.mk
 include images.mk
-include grpcbox.mk
+include grpcbox.mk # Requires images.mk
 
 # These variables are used to dynamically change the name of the buildbox Docker image used by the 'release'
 # target. The other solution was to remove the 'buildbox' dependency from the 'release' target, but this would

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -11,7 +11,7 @@ LIBBPF_VERSION ?= 0.7.0-teleport
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Protogen related versions.
-BUF_VERSION ?= 1.25.1
+BUF_VERSION ?= 1.26.1
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -1,0 +1,19 @@
+# Keep all tool versions in one place.
+# This file can be included in other Makefiles to avoid duplication.
+
+GOLANG_VERSION ?= go1.20.7
+
+NODE_VERSION ?= 16.18.1
+
+# Run lint-rust check locally before merging code after you bump this.
+RUST_VERSION ?= 1.68.0
+LIBBPF_VERSION ?= 0.7.0-teleport
+LIBPCSCLITE_VERSION ?= 1.9.9-teleport
+
+# Protogen related versions.
+BUF_VERSION ?= 1.25.1
+# Keep in sync with api/proto/buf.yaml (and buf.lock).
+GOGO_PROTO_TAG ?= v1.3.2
+NODE_GRPC_TOOLS_VERSION ?= 1.12.4
+NODE_PROTOC_TS_VERSION ?= 5.0.1
+PROTOC_VER ?= 3.20.3


### PR DESCRIPTION
Backport #30313 to branch/v11.

Update to latest release.

* https://github.com/bufbuild/buf/releases/tag/v1.26.1
* https://github.com/bufbuild/buf/releases/tag/v1.26.0