### PR TITLE
Refactor `utils/tls.go` to `utilstls/tls.go`

### DIFF
--- a/integrations/operator/sidecar/tbot.go
+++ b/integrations/operator/sidecar/tbot.go
@@ -35,7 +35,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/config"
 	"github.com/gravitational/teleport/lib/tbot/identity"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 const (
@@ -148,7 +148,7 @@ func (c clientCredentials) Dialer(client.Config) (client.ContextDialer, error) {
 }
 
 func (c clientCredentials) TLSConfig() (*tls.Config, error) {
-	return c.id.TLSConfig(utils.DefaultCipherSuites())
+	return c.id.TLSConfig(utilstls.DefaultCipherSuites())
 }
 
 func (c clientCredentials) SSHClientConfig() (*ssh.ClientConfig, error) {

--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -51,7 +51,7 @@ import (
 	"github.com/gravitational/teleport/lib/services/local"
 	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // TestAuthServerConfig is auth server test config
@@ -94,7 +94,7 @@ func (cfg *TestAuthServerConfig) CheckAndSetDefaults() error {
 		cfg.Clock = clockwork.NewFakeClock()
 	}
 	if len(cfg.CipherSuites) == 0 {
-		cfg.CipherSuites = utils.DefaultCipherSuites()
+		cfg.CipherSuites = utilstls.DefaultCipherSuites()
 	}
 	if cfg.AuthPreferenceSpec == nil {
 		cfg.AuthPreferenceSpec = &types.AuthPreferenceSpecV2{
@@ -622,7 +622,7 @@ func (a *TestAuthServer) NewTestTLSServer() (*TestTLSServer, error) {
 // NewRemoteClient creates new client to the remote server using identity
 // generated for this certificate authority
 func (a *TestAuthServer) NewRemoteClient(identity TestIdentity, addr net.Addr, pool *x509.CertPool) (*Client, error) {
-	tlsConfig := utils.TLSConfig(a.CipherSuites)
+	tlsConfig := utilstls.TLSConfig(a.CipherSuites)
 	cert, err := a.NewCertificate(identity)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -55,6 +55,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 var log = logrus.WithFields(logrus.Fields{
@@ -1038,7 +1039,7 @@ func (i *Identity) HasDNSNames(dnsNames []string) bool {
 // TLSConfig returns TLS config for mutual TLS authentication
 // can return NotFound error if there are no TLS credentials setup for identity
 func (i *Identity) TLSConfig(cipherSuites []uint16) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(cipherSuites)
+	tlsConfig := utilstls.TLSConfig(cipherSuites)
 	if !i.HasTLSConfig() {
 		return nil, trace.NotFound("no TLS credentials setup for this identity")
 	}
@@ -1174,7 +1175,7 @@ func ReadTLSIdentityFromKeyPair(keyBytes, certBytes []byte, caCertsBytes [][]byt
 	}
 	// The passed in ciphersuites don't appear to matter here since the returned
 	// *tls.Config is never actually used?
-	_, err = identity.TLSConfig(utils.DefaultCipherSuites())
+	_, err = identity.TLSConfig(utilstls.DefaultCipherSuites())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/auth/middleware.go
+++ b/lib/auth/middleware.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 const (
@@ -698,7 +699,7 @@ func (a *Middleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // WrapContextWithUser enriches the provided context with the identity information
 // extracted from the provided TLS connection.
-func (a *Middleware) WrapContextWithUser(ctx context.Context, conn utils.TLSConn) (context.Context, error) {
+func (a *Middleware) WrapContextWithUser(ctx context.Context, conn utilstls.TLSConn) (context.Context, error) {
 	// Perform the handshake if it hasn't been already. Before the handshake we
 	// won't have client certs available.
 	if !conn.ConnectionState().HandshakeComplete {

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // UpsertTrustedCluster creates or toggles a Trusted Cluster relationship.
@@ -629,7 +630,7 @@ func (a *Server) sendValidateRequestToProxy(host string, validateRequest *Valida
 		// Clone the transport to not modify the global instance.
 		tr := defaultTransport.Clone()
 		// Disable certificate checking while in debug mode.
-		tlsConfig := utils.TLSConfig(a.cipherSuites)
+		tlsConfig := utilstls.TLSConfig(a.cipherSuites)
 		tlsConfig.InsecureSkipVerify = true
 		tr.TLSClientConfig = tlsConfig
 

--- a/lib/backend/etcdbk/etcd.go
+++ b/lib/backend/etcdbk/etcd.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	cq "github.com/gravitational/teleport/lib/utils/concurrentqueue"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 const (
@@ -385,7 +386,7 @@ func (b *EtcdBackend) reconnect(ctx context.Context) error {
 	}
 	b.clients.items = nil
 
-	tlsConfig := utils.TLSConfig(nil)
+	tlsConfig := utilstls.TLSConfig(nil)
 
 	if b.cfg.TLSCertFile != "" {
 		clientCertPEM, err := os.ReadFile(b.cfg.TLSCertFile)

--- a/lib/client/https_client.go
+++ b/lib/client/https_client.go
@@ -31,7 +31,7 @@ import (
 	tracehttp "github.com/gravitational/teleport/api/observability/tracing/http"
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 func NewInsecureWebClient() *http.Client {
@@ -47,7 +47,7 @@ func newClient(insecure bool, pool *x509.CertPool, extraHeaders map[string]strin
 func httpTransport(insecure bool, pool *x509.CertPool) *http.Transport {
 	// Because Teleport clients can't be configured (yet), they take the default
 	// list of cipher suites from Go.
-	tlsConfig := utils.TLSConfig(nil)
+	tlsConfig := utilstls.TLSConfig(nil)
 	tlsConfig.InsecureSkipVerify = insecure
 	tlsConfig.RootCAs = pool
 

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -41,7 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // KeyIndex helps to identify a key in the store.
@@ -237,7 +237,7 @@ func (k *Key) clientTLSConfig(cipherSuites []uint16, tlsCertRaw []byte, clusters
 		return nil, trace.Wrap(err)
 	}
 
-	tlsConfig := utils.TLSConfig(cipherSuites)
+	tlsConfig := utilstls.TLSConfig(cipherSuites)
 	tlsConfig.RootCAs = pool
 	tlsConfig.Certificates = append(tlsConfig.Certificates, tlsCert)
 	// Use Issuer CN from the certificate to populate the correct SNI in

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // CommandLineFlags stores command line flag values, it's a much simplified subset
@@ -370,7 +371,7 @@ func ApplyFileConfig(fc *FileConfig, cfg *servicecfg.Config) error {
 	// Apply (TLS) cipher suites and (SSH) ciphers, KEX algorithms, and MAC
 	// algorithms.
 	if len(fc.CipherSuites) > 0 {
-		cipherSuites, err := utils.CipherSuiteMapping(fc.CipherSuites)
+		cipherSuites, err := utilstls.CipherSuiteMapping(fc.CipherSuites)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -133,6 +133,7 @@ import (
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 	uw "github.com/gravitational/teleport/lib/versioncontrol/upgradewindow"
 	"github.com/gravitational/teleport/lib/web"
 )
@@ -4699,7 +4700,7 @@ func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv revers
 				acme.ALPNProto, // enable tls-alpn ACME challenges
 			},
 		}
-		utils.SetupTLSConfig(tlsConfig, cfg.CipherSuites)
+		utilstls.SetupTLSConfig(tlsConfig, cfg.CipherSuites)
 	} else {
 		certReloader := NewCertReloader(CertReloaderConfig{
 			KeyPairs:               process.Config.Proxy.KeyPairs,
@@ -4709,7 +4710,7 @@ func (process *TeleportProcess) setupProxyTLSConfig(conn *Connector, tsrv revers
 			return nil, trace.Wrap(err)
 		}
 
-		tlsConfig = utils.TLSConfig(cfg.CipherSuites)
+		tlsConfig = utilstls.TLSConfig(cfg.CipherSuites)
 		tlsConfig.GetCertificate = certReloader.GetCertificate
 	}
 
@@ -4753,7 +4754,7 @@ func setupTLSConfigClientCAsForCluster(tlsConfig *tls.Config, accessPoint auth.R
 }
 
 func (process *TeleportProcess) setupALPNTLSConfigForWeb(serverTLSConfig *tls.Config, accessPoint auth.ReadProxyAccessPoint, clusterName string) *tls.Config {
-	tlsConfig := utils.TLSConfig(process.Config.CipherSuites)
+	tlsConfig := utilstls.TLSConfig(process.Config.CipherSuites)
 	tlsConfig.Certificates = serverTLSConfig.Certificates
 
 	setupTLSConfigALPNProtocols(tlsConfig)

--- a/lib/service/servicecfg/config.go
+++ b/lib/service/servicecfg/config.go
@@ -44,6 +44,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshca"
 	usagereporter "github.com/gravitational/teleport/lib/usagereporter/teleport"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // Config contains the configuration for all services that Teleport can run.
@@ -495,7 +496,7 @@ func ApplyDefaults(cfg *Config) {
 	cfg.Hostname = hostname
 	cfg.DataDir = defaults.DataDir
 	cfg.Console = os.Stdout
-	cfg.CipherSuites = utils.DefaultCipherSuites()
+	cfg.CipherSuites = utilstls.DefaultCipherSuites()
 	cfg.Ciphers = sc.Ciphers
 	cfg.KEXAlgorithms = kex
 	cfg.MACAlgorithms = macs

--- a/lib/service/servicecfg/config_test.go
+++ b/lib/service/servicecfg/config_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -50,7 +51,7 @@ func TestDefaultConfig(t *testing.T) {
 	}
 
 	// crypto settings
-	require.Equal(t, config.CipherSuites, utils.DefaultCipherSuites())
+	require.Equal(t, config.CipherSuites, utilstls.DefaultCipherSuites())
 	// Unfortunately, the below algos don't have exported constants in
 	// golang.org/x/crypto/ssh for us to use.
 	require.ElementsMatch(t, config.Ciphers, []string{

--- a/lib/srv/alpnproxy/proxy.go
+++ b/lib/srv/alpnproxy/proxy.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/dbutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // ProxyConfig  is the configuration for an ALPN proxy server.
@@ -443,7 +444,7 @@ func checkCertIPPinning(tlsConn *tls.Conn) error {
 }
 
 // handlePingConnection starts the server ping routine and returns `pingConn`.
-func (p *Proxy) handlePingConnection(ctx context.Context, conn *tls.Conn) utils.TLSConn {
+func (p *Proxy) handlePingConnection(ctx context.Context, conn *tls.Conn) utilstls.TLSConn {
 	pingConn := pingconn.NewTLS(conn)
 
 	// Start ping routine. It will continuously send pings in a defined

--- a/lib/srv/app/server_test.go
+++ b/lib/srv/app/server_test.go
@@ -60,6 +60,7 @@ import (
 	"github.com/gravitational/teleport/lib/session"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 func TestMain(m *testing.M) {
@@ -333,7 +334,7 @@ func SetUpSuiteWithConfig(t *testing.T, config suiteConfig) *Suite {
 		AccessPoint:       s.authClient,
 		AuthClient:        s.authClient,
 		TLSConfig:         tlsConfig,
-		CipherSuites:      utils.DefaultCipherSuites(),
+		CipherSuites:      utilstls.DefaultCipherSuites(),
 		HostID:            s.hostUUID,
 		Hostname:          "test",
 		Authorizer:        authorizer,

--- a/lib/srv/app/transport.go
+++ b/lib/srv/app/transport.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/srv/app/common"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // transportConfig is configuration for a rewriting transport.
@@ -271,7 +272,7 @@ func (t *transport) rewriteRedirect(resp *http.Response) error {
 // configureTLS creates and configures a *tls.Config that will be used for
 // mutual authentication.
 func configureTLS(c *transportConfig) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(c.cipherSuites)
+	tlsConfig := utilstls.TLSConfig(c.cipherSuites)
 
 	// Don't verify the server's certificate if Teleport was started with
 	// the --insecure flag, or 'insecure_skip_verify' was specifically requested in

--- a/lib/srv/db/access_test.go
+++ b/lib/srv/db/access_test.go
@@ -86,6 +86,7 @@ import (
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 func TestMain(m *testing.M) {
@@ -1996,7 +1997,7 @@ func (c *testContext) makeTLSConfig(t *testing.T) *tls.Config {
 	require.NoError(t, err)
 	cert, err := tls.X509KeyPair(creds.Cert, creds.PrivateKey)
 	require.NoError(t, err)
-	conf := utils.TLSConfig(nil)
+	conf := utilstls.TLSConfig(nil)
 	conf.Certificates = append(conf.Certificates, cert)
 	conf.ClientAuth = tls.VerifyClientCertIfGiven
 	conf.ClientCAs, _, err = auth.DefaultClientCertPool(c.authServer, c.clusterName)

--- a/lib/srv/db/common/interfaces.go
+++ b/lib/srv/db/common/interfaces.go
@@ -24,7 +24,7 @@ import (
 	"github.com/gravitational/teleport/lib/authz"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // Proxy defines an interface a database proxy should implement.
@@ -47,7 +47,7 @@ type ConnectParams struct {
 // Service defines an interface for connecting to a remote database service.
 type Service interface {
 	// Authorize authorizes the provided client TLS connection.
-	Authorize(ctx context.Context, tlsConn utils.TLSConn, params ConnectParams) (*ProxyContext, error)
+	Authorize(ctx context.Context, tlsConn utilstls.TLSConn, params ConnectParams) (*ProxyContext, error)
 	// Connect is used to connect to remote database server over reverse tunnel.
 	Connect(ctx context.Context, proxyCtx *ProxyContext, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error)
 	// Proxy starts proxying between client and service connections.

--- a/lib/srv/db/mysql/proxy.go
+++ b/lib/srv/db/mysql/proxy.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/db/mysql/protocol"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // Proxy proxies connections from MySQL clients to database services
@@ -187,7 +188,7 @@ func (p *Proxy) makeServer(clientConn net.Conn, serverVersion string) *server.Co
 // performHandshake performs the initial handshake between MySQL client and
 // this server, up to the point where the client sends us a certificate for
 // authentication, and returns the upgraded connection.
-func (p *Proxy) performHandshake(conn *multiplexer.Conn, server *server.Conn) (utils.TLSConn, error) {
+func (p *Proxy) performHandshake(conn *multiplexer.Conn, server *server.Conn) (utilstls.TLSConn, error) {
 	// MySQL protocol is server-initiated which means the client will expect
 	// server to send initial handshake message.
 	err := server.WriteInitialHandshake()
@@ -212,7 +213,7 @@ func (p *Proxy) performHandshake(conn *multiplexer.Conn, server *server.Conn) (u
 	case *tls.Conn:
 		return c, nil
 	case *multiplexer.Conn:
-		tlsConn, ok := c.Conn.(utils.TLSConn)
+		tlsConn, ok := c.Conn.(utilstls.TLSConn)
 		if !ok {
 			return nil, trace.BadParameter("expected TLS connection, got: %T", c.Conn)
 		}

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -54,6 +54,7 @@ import (
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // ProxyServer runs inside Teleport proxy and is responsible to accepting
@@ -315,7 +316,7 @@ func (s *ProxyServer) handleConnection(conn net.Conn) error {
 	}
 
 	s.log.Debugf("Accepted TLS database connection from %v.", conn.RemoteAddr())
-	tlsConn, ok := conn.(utils.TLSConn)
+	tlsConn, ok := conn.(utilstls.TLSConn)
 	if !ok {
 		return trace.BadParameter("expected utils.TLSConn, got %T", conn)
 	}
@@ -520,7 +521,7 @@ func (s *ProxyServer) Proxy(ctx context.Context, proxyCtx *common.ProxyContext, 
 }
 
 // Authorize authorizes the provided client TLS connection.
-func (s *ProxyServer) Authorize(ctx context.Context, tlsConn utils.TLSConn, params common.ConnectParams) (*common.ProxyContext, error) {
+func (s *ProxyServer) Authorize(ctx context.Context, tlsConn utilstls.TLSConn, params common.ConnectParams) (*common.ProxyContext, error) {
 	ctx, err := s.middleware.WrapContextWithUser(ctx, tlsConn)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -36,6 +36,7 @@ import (
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 const (
@@ -275,7 +276,7 @@ func (conf *BotConfig) CipherSuites() []uint16 {
 	if conf.FIPS {
 		return defaults.FIPSCipherSuites
 	}
-	return utils.DefaultCipherSuites()
+	return utilstls.DefaultCipherSuites()
 }
 
 func (conf *BotConfig) CheckAndSetDefaults() error {

--- a/lib/tbot/identity/identity.go
+++ b/lib/tbot/identity/identity.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/tbot/bot"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 const (
@@ -197,7 +198,7 @@ func (i *Identity) HasDNSNames(dnsNames []string) bool {
 // TLSConfig returns TLS config for mutual TLS authentication
 // can return NotFound error if there are no TLS credentials setup for identity
 func (i *Identity) TLSConfig(cipherSuites []uint16) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(cipherSuites)
+	tlsConfig := utilstls.TLSConfig(cipherSuites)
 	if !i.HasTLSConfig() {
 		return nil, trace.NotFound("no TLS credentials setup for this identity")
 	}
@@ -330,7 +331,7 @@ func ReadTLSIdentityFromKeyPair(identity *Identity, keyBytes, certBytes []byte, 
 
 	// The passed in ciphersuites don't appear to matter here since the returned
 	// *tls.Config is never actually used?
-	_, err = identity.TLSConfig(utils.DefaultCipherSuites())
+	_, err = identity.TLSConfig(utilstls.DefaultCipherSuites())
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/utils/tls_alias.go
+++ b/lib/utils/tls_alias.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"github.com/gravitational/teleport/lib/utils/utilstls"
+)
+
+// TODO(jent): Remove after `e` has been updated to no longer reference this
+var TLSConfig = utilstls.TLSConfig

--- a/lib/utils/utilstls/tls.go
+++ b/lib/utils/utilstls/tls.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package utilstls
 
 import (
 	"context"

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -129,6 +129,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 	websession "github.com/gravitational/teleport/lib/web/session"
 	"github.com/gravitational/teleport/lib/web/ui"
 )
@@ -453,7 +454,7 @@ func newWebSuiteWithConfig(t *testing.T, cfg webSuiteConfig) *WebSuite {
 		AuthServers:                     utils.FromAddr(s.server.TLS.Addr()),
 		DomainName:                      s.server.ClusterName(),
 		ProxyClient:                     s.proxyClient,
-		CipherSuites:                    utils.DefaultCipherSuites(),
+		CipherSuites:                    utilstls.DefaultCipherSuites(),
 		AccessPoint:                     s.proxyClient,
 		Context:                         s.ctx,
 		HostUUID:                        proxyID,
@@ -7800,7 +7801,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 	})
 	require.NoError(t, err)
 
-	tlscfg, err := authServer.Identity.TLSConfig(utils.DefaultCipherSuites())
+	tlscfg, err := authServer.Identity.TLSConfig(utilstls.DefaultCipherSuites())
 	require.NoError(t, err)
 	tlscfg.ClientAuth = tls.RequireAndVerifyClientCert
 	if lib.IsInsecureDevMode() {
@@ -7905,7 +7906,7 @@ func createProxy(ctx context.Context, t *testing.T, proxyID string, node *regula
 		DomainName:       authServer.ClusterName(),
 		ProxyClient:      client,
 		ProxyPublicAddrs: utils.MustParseAddrList("proxy-1.example.com", "proxy-2.example.com"),
-		CipherSuites:     utils.DefaultCipherSuites(),
+		CipherSuites:     utilstls.DefaultCipherSuites(),
 		AccessPoint:      client,
 		Context:          ctx,
 		HostUUID:         proxyID,

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -41,6 +41,7 @@ import (
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // HandlerConfig is the configuration for an application handler.
@@ -143,7 +144,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // HandleConnection handles connections from plain TCP applications.
 func (h *Handler) HandleConnection(ctx context.Context, clientConn net.Conn) error {
-	tlsConn, ok := clientConn.(utils.TLSConn)
+	tlsConn, ok := clientConn.(utilstls.TLSConn)
 	if !ok {
 		return trace.BadParameter("expected *tls.Conn, got: %T", clientConn)
 	}

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 type eventCheckFn func(t *testing.T, events []apievents.AuditEvent)
@@ -485,7 +486,7 @@ func TestHealthCheckAppServer(t *testing.T) {
 				AuthClient:   authClient,
 				AccessPoint:  authClient,
 				ProxyClient:  tunnel,
-				CipherSuites: utils.DefaultCipherSuites(),
+				CipherSuites: utilstls.DefaultCipherSuites(),
 			})
 			require.NoError(t, err)
 
@@ -506,7 +507,7 @@ func setup(t *testing.T, clock clockwork.FakeClock, authClient auth.ClientI, pro
 		AuthClient:       authClient,
 		AccessPoint:      authClient,
 		ProxyClient:      proxyClient,
-		CipherSuites:     utils.DefaultCipherSuites(),
+		CipherSuites:     utilstls.DefaultCipherSuites(),
 		ProxyPublicAddrs: proxyPublicAddrs,
 	})
 	require.NoError(t, err)

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -38,6 +38,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // transportConfig is configuration for a rewriting transport.
@@ -311,7 +312,7 @@ func dialAppServer(ctx context.Context, proxyClient reversetunnelclient.Tunnel, 
 // configureTLS creates and configures a *tls.Config that will be used for
 // mutual authentication.
 func configureTLS(c *transportConfig) (*tls.Config, error) {
-	tlsConfig := utils.TLSConfig(c.cipherSuites)
+	tlsConfig := utilstls.TLSConfig(c.cipherSuites)
 
 	// Configure the pool of certificates that will be used to verify the
 	// identity of the server. This allows the client to verify the identity of

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -27,7 +27,7 @@ import (
 	apiutils "github.com/gravitational/teleport/api/utils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/tlsca"
-	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 func Test_transport_rewriteRedirect(t *testing.T) {
@@ -64,7 +64,7 @@ func Test_transport_rewriteRedirect(t *testing.T) {
 			identity:    identity,
 			servers:     []types.AppServer{server},
 
-			cipherSuites: utils.DefaultCipherSuites(),
+			cipherSuites: utilstls.DefaultCipherSuites(),
 			proxyClient:  &mockProxyClient{},
 			accessPoint: &mockAuthClient{
 				caKey:       caKey,

--- a/lib/web/sessions.go
+++ b/lib/web/sessions.go
@@ -56,6 +56,7 @@ import (
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 )
 
 // SessionContext is a context associated with a user's
@@ -374,7 +375,7 @@ func (c *SessionContext) ClientTLSConfig(ctx context.Context, clusterName ...str
 		}
 	}
 
-	tlsConfig := utils.TLSConfig(c.cfg.Parent.cipherSuites)
+	tlsConfig := utilstls.TLSConfig(c.cfg.Parent.cipherSuites)
 	tlsCert, err := tls.X509KeyPair(c.cfg.Session.GetTLSCert(), c.cfg.Session.GetPriv())
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to parse TLS cert and key")
@@ -1008,7 +1009,7 @@ func (s *sessionCache) tlsConfig(ctx context.Context, cert, privKey []byte) (*tl
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	tlsConfig := utils.TLSConfig(s.cipherSuites)
+	tlsConfig := utilstls.TLSConfig(s.cipherSuites)
 	tlsCert, err := tls.X509KeyPair(cert, privKey)
 	if err != nil {
 		return nil, trace.Wrap(err, "failed to parse TLS certificate and key")

--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -68,6 +68,7 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
+	"github.com/gravitational/teleport/lib/utils/utilstls"
 	"github.com/gravitational/teleport/tool/common"
 )
 
@@ -197,7 +198,7 @@ func (c *kubeJoinCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 
-	ciphers := utils.DefaultCipherSuites()
+	ciphers := utilstls.DefaultCipherSuites()
 	tlsConfig, err := k.KubeClientTLSConfig(ciphers, kubeCluster)
 	if err != nil {
 		return trace.Wrap(err)


### PR DESCRIPTION
This PR is presented as an alternative option to PR #30193 as a means to solve the cyclic import issue that needs addressed for the default to be moved in PR #30184.

PR #30193 is a fairly large change set due to the broad usage of `NetAddr`.  It also has consistent integration test timeouts that are not obvious how they were introduced by the rename. Although that change may be ideal, this is a possibly simpler solution.