### PR TITLE
Introduce structured and persistent migrations

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -46,6 +46,7 @@ import (
 	"github.com/gravitational/teleport/lib/ai"
 	"github.com/gravitational/teleport/lib/ai/embedding"
 	"github.com/gravitational/teleport/lib/auth/keystore"
+	"github.com/gravitational/teleport/lib/auth/migration"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/events"
@@ -447,10 +448,9 @@ func initCluster(ctx context.Context, cfg InitConfig, asrv *Server) error {
 	// Override user passed in cluster name with what is in the backend.
 	cfg.ClusterName = cn
 
-	// Migrate Host CA as Database CA before certificates generation. Otherwise, the Database CA will be
-	// generated which we don't want for existing installations.
-	if err := migrateDBAuthority(ctx, asrv); err != nil {
-		return trace.Wrap(err, "failed to migrate database CA")
+	// Apply any outstanding migrations.
+	if err := migration.Apply(ctx, cfg.Backend); err != nil {
+		return trace.Wrap(err, "applying migrations")
 	}
 
 	// generate certificate authorities if they don't exist
@@ -1317,90 +1317,6 @@ func migrateRemoteClusters(ctx context.Context, asrv *Server) error {
 			}
 		}
 		log.Infof("Migrations: added remote cluster resource for cert authority %q.", certAuthority.GetName())
-	}
-
-	return nil
-}
-
-// migrateDBAuthority copies Host CA as Database CA. Before v9.0 database access was using host CA to sign all
-// DB certificates. In order to support existing installations Teleport copies Host CA as Database CA on
-// the first run after update to v9.0+.
-// Function does nothing for databases created with Teleport v9.0+.
-// https://github.com/gravitational/teleport/issues/5029
-//
-// DELETE IN 11.0
-func migrateDBAuthority(ctx context.Context, asrv *Server) error {
-	migrationStart(ctx, "db_authority")
-	defer migrationEnd(ctx, "db_authority")
-
-	localClusterName, err := asrv.Services.GetClusterName()
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	trustedClusters, err := asrv.Services.GetTrustedClusters(ctx)
-	if err != nil {
-		return trace.Wrap(err)
-	}
-
-	allClusters := []string{
-		localClusterName.GetClusterName(),
-	}
-
-	for _, tr := range trustedClusters {
-		allClusters = append(allClusters, tr.GetName())
-	}
-
-	for _, clusterName := range allClusters {
-		dbCaID := types.CertAuthID{Type: types.DatabaseCA, DomainName: clusterName}
-		_, err = asrv.Services.GetCertAuthority(ctx, dbCaID, false)
-		if err == nil {
-			continue // no migration needed. DB cert already exists.
-		}
-		if err != nil && !trace.IsNotFound(err) {
-			return trace.Wrap(err)
-		}
-		// Database CA doesn't exist, check for Host.
-		hostCaID := types.CertAuthID{Type: types.HostCA, DomainName: clusterName}
-		hostCA, err := asrv.Services.GetCertAuthority(ctx, hostCaID, true)
-		if trace.IsNotFound(err) {
-			// DB CA and Host CA are missing. Looks like the first start. No migration needed.
-			continue
-		}
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		// Database CA is missing, but Host CA has been found. Database was created with pre v9.
-		// Copy the Host CA as Database CA.
-		log.Infof("Migrating Database CA cluster: %s", clusterName)
-
-		cav2, ok := hostCA.(*types.CertAuthorityV2)
-		if !ok {
-			return trace.BadParameter("expected host CA to be of *types.CertAuthorityV2 type, got: %T", hostCA)
-		}
-
-		dbCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
-			Type:        types.DatabaseCA,
-			ClusterName: clusterName,
-			ActiveKeys: types.CAKeySet{
-				// Copy only TLS keys as SSH are not needed.
-				TLS: cav2.Spec.ActiveKeys.TLS,
-			},
-		})
-		if err != nil {
-			return trace.Wrap(err)
-		}
-
-		err = asrv.CreateCertAuthority(ctx, dbCA)
-		switch {
-		case trace.IsAlreadyExists(err):
-			// Probably another auth server have created the DB CA since we last check.
-			// This shouldn't be a problem, but let's log it to know when it happens.
-			log.Warn("DB CA has already been created by a different Auth server instance")
-		case err != nil:
-			return trace.Wrap(err)
-		}
 	}
 
 	return nil

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -47,7 +47,6 @@ import (
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/services"
-	"github.com/gravitational/teleport/lib/services/suite"
 	"github.com/gravitational/teleport/lib/sshutils"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/proxy"
@@ -1591,29 +1590,4 @@ func TestInitCreatesCertsIfMissing(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, cert, 1)
 	}
-}
-
-func TestMigrateDatabaseCA(t *testing.T) {
-	ctx := context.Background()
-	conf := setupConfig(t)
-
-	// Create only HostCA and UserCA. DatabaseCA should be created on Init().
-	hostCA := suite.NewTestCA(types.HostCA, "me.localhost")
-	userCA := suite.NewTestCA(types.UserCA, "me.localhost")
-
-	conf.Authorities = []types.CertAuthority{hostCA, userCA}
-
-	// Here is where migration happens.
-	auth, err := Init(ctx, conf)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		err = auth.Close()
-		require.NoError(t, err)
-	})
-
-	dbCAs, err := auth.GetCertAuthorities(ctx, types.DatabaseCA, true)
-	require.NoError(t, err)
-	require.Len(t, dbCAs, 1)
-	require.Equal(t, hostCA.Spec.ActiveKeys.TLS[0].Cert, dbCAs[0].GetActiveKeys().TLS[0].Cert)
-	require.Equal(t, hostCA.Spec.ActiveKeys.TLS[0].Key, dbCAs[0].GetActiveKeys().TLS[0].Key)
 }

--- a/lib/auth/migration/0001_db_ca.go
+++ b/lib/auth/migration/0001_db_ca.go
@@ -1,0 +1,170 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/api/observability/tracing"
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+)
+
+// createDBAuthority performs a migration which creates a
+// Database CA for all existing clusters that do not already
+// have one. Introduced in v10.
+type createDBAuthority struct {
+	trustServiceFn    func(b backend.Backend) services.Trust
+	configServiceFn   func(b backend.Backend) (services.ClusterConfiguration, error)
+	presenceServiceFn func(b backend.Backend) services.Presence
+}
+
+func (d createDBAuthority) Version() int64 {
+	return 1
+}
+
+func (d createDBAuthority) Name() string {
+	return "create_db_cas"
+}
+
+// Up creates a Database CA for all known clusters. If a Database CA
+// already exist for a cluster, it is skipped. If no Host or Database CA
+// exist for a cluster, it is also skipped.
+func (d createDBAuthority) Up(ctx context.Context, b backend.Backend) error {
+	ctx, span := tracer.Start(ctx, "createDBAuthority/Up")
+	defer span.End()
+
+	if d.trustServiceFn == nil {
+		d.trustServiceFn = func(b backend.Backend) services.Trust {
+			return local.NewCAService(b)
+		}
+	}
+
+	if d.configServiceFn == nil {
+		d.configServiceFn = func(b backend.Backend) (services.ClusterConfiguration, error) {
+			s, err := local.NewClusterConfigurationService(b)
+			return s, trace.Wrap(err)
+		}
+	}
+
+	if d.presenceServiceFn == nil {
+		d.presenceServiceFn = func(b backend.Backend) services.Presence {
+			return local.NewPresenceService(b)
+		}
+	}
+
+	trustSvc := d.trustServiceFn(b)
+	configSvc, err := d.configServiceFn(b)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	presenceSvc := d.presenceServiceFn(b)
+
+	return trace.Wrap(d.up(ctx, configSvc, trustSvc, presenceSvc))
+}
+
+func (d createDBAuthority) up(ctx context.Context, configSvc services.ClusterConfiguration, trustSvc services.Trust, presenceSvc services.Presence) error {
+	localClusterName, err := configSvc.GetClusterName()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	trustedClusters, err := presenceSvc.GetTrustedClusters(ctx)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	allClusters := []string{localClusterName.GetClusterName()}
+
+	for _, tc := range trustedClusters {
+		allClusters = append(allClusters, tc.GetName())
+	}
+
+	for _, cluster := range allClusters {
+		_, err := trustSvc.GetCertAuthority(ctx, types.CertAuthID{Type: types.DatabaseCA, DomainName: cluster}, false)
+		// The migration for this cluster can be skipped since
+		// a Database CA already exists.
+		if err == nil {
+			continue
+		}
+
+		if err != nil && !trace.IsNotFound(err) {
+			return trace.Wrap(err)
+		}
+
+		// The Database CA does not exists, so we must check to
+		// see if the Host CA exists before proceeding with the migration.
+		// If both the Database and Host CA do not exist, then this cluster
+		// is brand new and the migration can be avoided because they will
+		// both automatically be created. If the Host CA does exist, then
+		// a new Database CA should be constructed from it.
+		hostCA, err := trustSvc.GetCertAuthority(ctx, types.CertAuthID{Type: types.HostCA, DomainName: cluster}, false)
+		if trace.IsNotFound(err) {
+			continue
+		}
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		logrus.Infof("Migrating Database CA cluster: %s", cluster)
+
+		ca, ok := hostCA.(*types.CertAuthorityV2)
+		if !ok {
+			return trace.BadParameter("expected host CA to be *types.CertAuthorityV2, got %T", hostCA)
+		}
+
+		dbCA, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+			Type:        types.DatabaseCA,
+			ClusterName: cluster,
+			ActiveKeys: types.CAKeySet{
+				TLS: ca.Spec.ActiveKeys.TLS,
+			},
+		})
+		if err != nil {
+			return trace.Wrap(err)
+		}
+
+		err = trustSvc.CreateCertAuthority(ctx, dbCA)
+		if trace.IsAlreadyExists(err) {
+			logrus.Warn("Database CA has already been created by a different Auth instance")
+			continue
+		} else if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+
+	return nil
+}
+
+// Down deletes existing Database CAs for all clusters.
+func (d createDBAuthority) Down(ctx context.Context, b backend.Backend) error {
+	tracer := tracing.NewTracer("migrations")
+	_, span := tracer.Start(ctx, "migrations/CreateDBAuthorityDown")
+	defer span.End()
+
+	if d.trustServiceFn == nil {
+		d.trustServiceFn = func(b backend.Backend) services.Trust {
+			return local.NewCAService(b)
+		}
+	}
+
+	trustSvc := d.trustServiceFn(b)
+	return trace.Wrap(trustSvc.DeleteAllCertAuthorities(types.DatabaseCA))
+}

--- a/lib/auth/migration/0001_db_ca_test.go
+++ b/lib/auth/migration/0001_db_ca_test.go
@@ -1,0 +1,334 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"crypto/x509/pkix"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/auth/testauthority"
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/services/local"
+	"github.com/gravitational/teleport/lib/tlsca"
+)
+
+func TestDBAuthorityDown(t *testing.T) {
+	b, err := memory.New(memory.Config{EventsOff: true})
+	require.NoError(t, err)
+	svc := local.NewCAService(b)
+
+	migration := createDBAuthority{}
+
+	ctx := context.Background()
+
+	// create a CA for all types except DB
+	for _, caType := range types.CertAuthTypes {
+		if caType == types.DatabaseCA {
+			continue
+		}
+		require.NoError(t, svc.CreateCertAuthority(ctx, newCertAuthority(t, uuid.NewString(), caType)))
+	}
+
+	t.Run("down succeeds when no db cas exists", func(t *testing.T) {
+		require.NoError(t, migration.Down(ctx, b))
+
+		// validate all other CA types still exist
+		for _, caType := range types.CertAuthTypes {
+			if caType == types.DatabaseCA {
+				continue
+			}
+
+			cas, err := svc.GetCertAuthorities(ctx, caType, false)
+			require.NoError(t, err)
+			require.Len(t, cas, 1)
+		}
+	})
+
+	t.Run("down removes db cas", func(t *testing.T) {
+		require.NoError(t, svc.CreateCertAuthority(ctx, newCertAuthority(t, uuid.NewString(), types.DatabaseCA)))
+
+		require.NoError(t, migration.Down(ctx, b))
+
+		// validate all other CA types still exist
+		for _, caType := range types.CertAuthTypes {
+			cas, err := svc.GetCertAuthorities(ctx, caType, false)
+			require.NoError(t, err)
+			if caType == types.DatabaseCA {
+				require.Empty(t, cas)
+			} else {
+				require.Len(t, cas, 1)
+			}
+		}
+	})
+}
+
+func newCertAuthority(t *testing.T, name string, caType types.CertAuthType) types.CertAuthority {
+	ta := testauthority.New()
+	priv, pub, err := ta.GenerateKeyPair()
+	require.NoError(t, err)
+
+	// CA for cluster1 with 1 key pair.
+	key, cert, err := tlsca.GenerateSelfSignedCA(pkix.Name{CommonName: name}, nil, time.Minute)
+	require.NoError(t, err)
+
+	jwtPub, jwtPriv, err := ta.GenerateJWT()
+	require.NoError(t, err)
+
+	ca, err := types.NewCertAuthority(types.CertAuthoritySpecV2{
+		Type:        caType,
+		ClusterName: name,
+		ActiveKeys: types.CAKeySet{
+			SSH: []*types.SSHKeyPair{{
+				PrivateKey:     priv,
+				PrivateKeyType: types.PrivateKeyType_RAW,
+				PublicKey:      pub,
+			}},
+			TLS: []*types.TLSKeyPair{{
+				Cert: cert,
+				Key:  key,
+			}},
+			JWT: []*types.JWTKeyPair{{
+				PublicKey:  jwtPub,
+				PrivateKey: jwtPriv,
+			}},
+		},
+	})
+	require.NoError(t, err)
+	return ca
+}
+
+func TestDBAuthorityUp(t *testing.T) {
+	fakeCA := &types.CertAuthorityV2{
+		Kind: types.KindCertAuthority,
+		Spec: types.CertAuthoritySpecV2{
+			ActiveKeys: types.CAKeySet{
+				TLS: []*types.TLSKeyPair{
+					{
+						Cert: []byte{0, 1, 2},
+						Key:  []byte{3, 4, 5},
+					},
+				},
+			},
+		},
+	}
+
+	rootDB := types.CertAuthID{
+		Type:       types.DatabaseCA,
+		DomainName: "root",
+	}
+
+	rootHost := types.CertAuthID{
+		Type:       types.HostCA,
+		DomainName: "root",
+	}
+
+	leaf1DB := types.CertAuthID{
+		Type:       types.DatabaseCA,
+		DomainName: "leaf1",
+	}
+
+	leaf1Host := types.CertAuthID{
+		Type:       types.HostCA,
+		DomainName: "leaf1",
+	}
+
+	leaf2DB := types.CertAuthID{
+		Type:       types.DatabaseCA,
+		DomainName: "leaf2",
+	}
+
+	leaf2Host := types.CertAuthID{
+		Type:       types.HostCA,
+		DomainName: "leaf2",
+	}
+
+	clusterName := func(name string) types.ClusterName {
+		return &types.ClusterNameV2{
+			Kind: types.KindClusterName,
+			Spec: types.ClusterNameSpecV2{
+				ClusterName: name,
+				ClusterID:   "test",
+			},
+		}
+	}
+
+	cases := []struct {
+		name         string
+		fakeTrust    *fakeTrust
+		fakePresence fakePresence
+		assertion    require.ErrorAssertionFunc
+		validateFunc func(t *testing.T, created []types.CertAuthority)
+	}{
+		{
+			name: "db cas created from host cas",
+			fakeTrust: &fakeTrust{
+				authorities: map[types.CertAuthID]types.CertAuthority{
+					rootHost:  fakeCA,
+					leaf1Host: fakeCA,
+					leaf1DB:   fakeCA,
+					leaf2Host: fakeCA,
+				},
+			},
+			fakePresence: fakePresence{
+				clusters: []types.TrustedCluster{
+					&types.TrustedClusterV2{
+						Kind:     types.KindTrustedCluster,
+						Metadata: types.Metadata{Name: "leaf1"},
+						Spec: types.TrustedClusterSpecV2{
+							Enabled: true,
+						},
+					}, &types.TrustedClusterV2{
+						Kind:     types.KindTrustedCluster,
+						Metadata: types.Metadata{Name: "leaf2"},
+						Spec:     types.TrustedClusterSpecV2{},
+					},
+				},
+			},
+			assertion: require.NoError,
+			validateFunc: func(t *testing.T, created []types.CertAuthority) {
+				require.Len(t, created, 2)
+				require.Equal(t, types.DatabaseCA, created[0].GetType())
+				require.Equal(t, "root", created[0].GetClusterName())
+				require.Equal(t, types.DatabaseCA, created[1].GetType())
+				require.Equal(t, "leaf2", created[1].GetClusterName())
+			},
+		},
+		{
+			name: "db certs already exists",
+			fakeTrust: &fakeTrust{
+				authorities: map[types.CertAuthID]types.CertAuthority{
+					rootDB:  fakeCA,
+					leaf2DB: fakeCA,
+					leaf1DB: fakeCA,
+				},
+			},
+			fakePresence: fakePresence{
+				clusters: []types.TrustedCluster{
+					&types.TrustedClusterV2{
+						Kind:     types.KindTrustedCluster,
+						Metadata: types.Metadata{Name: "leaf1"},
+						Spec: types.TrustedClusterSpecV2{
+							Enabled: true,
+						},
+					}, &types.TrustedClusterV2{
+						Kind:     types.KindTrustedCluster,
+						Metadata: types.Metadata{Name: "leaf2"},
+						Spec:     types.TrustedClusterSpecV2{},
+					},
+				},
+			},
+			assertion: require.NoError,
+			validateFunc: func(t *testing.T, created []types.CertAuthority) {
+				require.Empty(t, created)
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := memory.New(memory.Config{EventsOff: true})
+			require.NoError(t, err)
+
+			test.fakePresence.Presence = local.NewPresenceService(b)
+			test.fakeTrust.Trust = local.NewCAService(b)
+
+			migration := createDBAuthority{
+				trustServiceFn: func(b backend.Backend) services.Trust {
+					return test.fakeTrust
+				},
+				configServiceFn: func(b backend.Backend) (services.ClusterConfiguration, error) {
+					svc, err := local.NewClusterConfigurationService(b)
+					if err != nil {
+						return nil, trace.Wrap(err)
+					}
+					return fakeConfig{
+						ClusterConfiguration: svc,
+						clusterName:          clusterName("root"),
+					}, nil
+				},
+				presenceServiceFn: func(b backend.Backend) services.Presence {
+					return test.fakePresence
+				},
+			}
+
+			test.assertion(t, migration.Up(context.Background(), b))
+			test.validateFunc(t, test.fakeTrust.casCreated())
+		})
+	}
+}
+
+type fakeConfig struct {
+	services.ClusterConfiguration
+	clusterName types.ClusterName
+}
+
+func (f fakeConfig) GetClusterName(opts ...services.MarshalOption) (types.ClusterName, error) {
+	return f.clusterName, nil
+}
+
+type fakePresence struct {
+	services.Presence
+	clusters []types.TrustedCluster
+}
+
+func (f fakePresence) GetTrustedClusters(ctx context.Context) ([]types.TrustedCluster, error) {
+	return f.clusters, nil
+}
+
+type fakeTrust struct {
+	services.Trust
+
+	authorities map[types.CertAuthID]types.CertAuthority
+
+	mu      sync.Mutex
+	created []types.CertAuthority
+}
+
+func (f *fakeTrust) casCreated() []types.CertAuthority {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	cas := make([]types.CertAuthority, len(f.created))
+	copy(cas, f.created)
+
+	return cas
+}
+
+func (f *fakeTrust) CreateCertAuthority(ctx context.Context, ca types.CertAuthority) error {
+	f.mu.Lock()
+	f.created = append(f.created, ca)
+	f.mu.Unlock()
+
+	return nil
+}
+
+func (f *fakeTrust) GetCertAuthority(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
+	ca, ok := f.authorities[id]
+	if !ok {
+		return nil, trace.NotFound("no authority matching %s present", id)
+	}
+
+	return ca, nil
+}

--- a/lib/auth/migration/migration.go
+++ b/lib/auth/migration/migration.go
@@ -1,0 +1,190 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/api/observability/tracing"
+	"github.com/gravitational/teleport/lib/backend"
+)
+
+// applyConfig is a group of options used to
+// customize Apply when running tests.
+type applyConfig struct {
+	// migrations to execute during Apply instead of the
+	// default registered set.
+	migrations []migration
+}
+
+// withMigrations overrides the default set of migrations used by Apply.
+func withMigrations(m []migration) func(c *applyConfig) {
+	return func(c *applyConfig) {
+		c.migrations = m
+	}
+}
+
+var tracer = tracing.NewTracer("migrations")
+
+// migration is an interface responsible for applying data migrations to the backend.
+//
+// Only a single migration should be run at once. Migrations are applied in sequential
+// order based on their Version. No two migrations should have the same Version, and there
+// should be no holes in the Version sequence.
+type migration interface {
+	// Up runs the migration, performing any task needed to convert, alter, or move
+	// resources to new key ranges. A successful migration must return nil, any failed
+	// migrations must return an error.
+	Up(ctx context.Context, b backend.Backend) error
+	// Down rolls back the migration, restoring the backend to the state it was in
+	// prior to performing Up.
+	Down(ctx context.Context, b backend.Backend) error
+	// Version is the sequence identifier of the migration.
+	Version() int64
+	// Name is a friendly identifier used to provide context on what the migration is doing.
+	Name() string
+}
+
+// Apply executes any outstanding registered migrations.
+func Apply(ctx context.Context, b backend.Backend, opts ...func(c *applyConfig)) (err error) {
+	cfg := applyConfig{
+		migrations: []migration{
+			createDBAuthority{},
+		},
+	}
+
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	ctx, span := tracer.Start(ctx, "migrations/Apply")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err)
+		}
+		span.End()
+	}()
+
+	slices.SortFunc(cfg.migrations, func(a, b migration) int {
+		return int(a.Version() - b.Version())
+	})
+
+	current, err := getCurrentMigration(ctx, b)
+	if err != nil {
+		return trace.Wrap(err, "unable to determine current migration version")
+	}
+
+	migrationCount := len(cfg.migrations)
+
+	if migrationCount < current.Version {
+		return trace.BadParameter("unable to apply migrations: the number of registered migrations is less than the current version, this can be caused by downgraded without rolling back migrations")
+	}
+
+	if current.Version > 0 && current.Phase != migrationPhaseComplete {
+		return trace.BadParameter("previous attempt to apply migration %d never completed - the failure must be remedied before further migrations can be applied", current.Version)
+	}
+
+	for i, m := range cfg.migrations {
+		version := i + 1
+		if m.Version() != int64(version) {
+			return trace.BadParameter("missing migration %d", version)
+		}
+
+		if m.Version() <= int64(current.Version) {
+			continue
+		}
+
+		logrus.Infof("Starting migration %d %s", version, m.Name())
+		span.AddEvent("Starting migration", oteltrace.WithAttributes(attribute.Int("migration", version)))
+
+		started := time.Now().UTC()
+		if err := setCurrentMigration(ctx, b, migrationStatus{Version: version, Phase: migrationPhaseInProgress, Started: started}); err != nil {
+			return trace.Wrap(err)
+		}
+
+		if err := m.Up(ctx, b); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err)
+			return trace.NewAggregate(err, setCurrentMigration(ctx, b, migrationStatus{Version: version, Phase: migrationPhaseError, Started: started, Completed: time.Now().UTC()}))
+		}
+
+		if err := setCurrentMigration(ctx, b, migrationStatus{Version: version, Phase: migrationPhaseComplete, Started: started, Completed: time.Now().UTC()}); err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err)
+			return trace.Wrap(err)
+		}
+
+		logrus.Infof("Completed migration %d %s", version, m.Name())
+		span.AddEvent("Completed migration", oteltrace.WithAttributes(attribute.Int("migration", version)))
+	}
+
+	return nil
+}
+
+type migrationPhase int
+
+const (
+	migrationPhasePending migrationPhase = iota
+	migrationPhaseInProgress
+	migrationPhaseComplete
+	migrationPhaseError
+)
+
+type migrationStatus struct {
+	Version   int            `json:"version"`
+	Phase     migrationPhase `json:"phase"`
+	Started   time.Time      `json:"started"`
+	Completed time.Time      `json:"completed"`
+}
+
+var key = backend.Key("migrations", "current")
+
+func setCurrentMigration(ctx context.Context, b backend.Backend, status migrationStatus) error {
+	value, err := json.Marshal(status)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = b.Put(ctx, backend.Item{Key: key, Value: value})
+	return trace.Wrap(err)
+}
+
+func getCurrentMigration(ctx context.Context, b backend.Backend) (*migrationStatus, error) {
+	item, err := b.Get(ctx, key)
+	if err != nil {
+		if !trace.IsNotFound(err) {
+			return nil, trace.Wrap(err, "unable to determine current migration")
+		}
+
+		return &migrationStatus{Version: 0}, nil
+	}
+
+	var status migrationStatus
+	if err := json.Unmarshal(item.Value, &status); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &status, nil
+}

--- a/lib/auth/migration/migration_test.go
+++ b/lib/auth/migration/migration_test.go
@@ -1,0 +1,167 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package migration
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib/backend"
+	"github.com/gravitational/teleport/lib/backend/memory"
+)
+
+type testMigration struct {
+	version int64
+	name    string
+	up      func(ctx context.Context, b backend.Backend) error
+	down    func(ctx context.Context, b backend.Backend) error
+}
+
+func (t testMigration) Up(ctx context.Context, b backend.Backend) error {
+	if t.up == nil {
+		return nil
+	}
+	return t.up(ctx, b)
+}
+
+func (t testMigration) Down(ctx context.Context, b backend.Backend) error {
+	if t.down == nil {
+		return nil
+	}
+
+	return t.down(ctx, b)
+}
+
+func (t testMigration) Version() int64 {
+	return t.version
+}
+
+func (t testMigration) Name() string {
+	return t.name
+}
+
+func TestApply(t *testing.T) {
+	cases := []struct {
+		name           string
+		migrations     []migration
+		initialStatus  *migrationStatus
+		expectedStatus migrationStatus
+		errAssertion   require.ErrorAssertionFunc
+	}{
+		{
+			name: "migrations up to date",
+			migrations: []migration{
+				testMigration{version: 1},
+				testMigration{version: 2},
+				testMigration{version: 3},
+			},
+			initialStatus: &migrationStatus{
+				Version: 3,
+				Phase:   migrationPhaseComplete,
+			},
+			expectedStatus: migrationStatus{
+				Version: 3,
+				Phase:   migrationPhaseComplete,
+			},
+			errAssertion: require.NoError,
+		},
+		{
+			name: "deleted migrations",
+			initialStatus: &migrationStatus{
+				Version: 2,
+				Phase:   migrationPhaseComplete,
+			},
+			errAssertion: require.Error,
+			expectedStatus: migrationStatus{
+				Version: 2,
+				Phase:   migrationPhaseComplete,
+			},
+		},
+		{
+			name: "previous migration attempt failed",
+			initialStatus: &migrationStatus{
+				Version: 2,
+				Phase:   migrationPhaseError,
+			},
+			migrations: []migration{
+				testMigration{version: 1},
+				testMigration{version: 2},
+				testMigration{version: 3},
+			},
+			errAssertion: require.Error,
+			expectedStatus: migrationStatus{
+				Version: 2,
+				Phase:   migrationPhaseError,
+			},
+		},
+		{
+			name: "missing migration",
+			initialStatus: &migrationStatus{
+				Version: 0,
+				Phase:   migrationPhaseComplete,
+			},
+			migrations: []migration{
+				testMigration{version: 1},
+				testMigration{version: 3},
+			},
+			errAssertion: require.Error,
+			expectedStatus: migrationStatus{
+				Version: 1,
+				Phase:   migrationPhaseComplete,
+			},
+		},
+		{
+			name: "migration failed",
+			migrations: []migration{
+				testMigration{version: 1},
+				testMigration{version: 2},
+				testMigration{version: 3, up: func(ctx context.Context, b backend.Backend) error {
+					return errors.New("failure")
+				}},
+				testMigration{version: 4},
+				testMigration{version: 5},
+			},
+			errAssertion: require.Error,
+			expectedStatus: migrationStatus{
+				Version: 3,
+				Phase:   migrationPhaseError,
+			},
+		},
+	}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := memory.New(memory.Config{EventsOff: true})
+			require.NoError(t, err)
+
+			ctx := context.Background()
+
+			if test.initialStatus != nil {
+				require.NoError(t, setCurrentMigration(ctx, b, *test.initialStatus))
+			}
+
+			test.errAssertion(t, Apply(ctx, b, withMigrations(test.migrations)))
+
+			current, err := getCurrentMigration(ctx, b)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(&test.expectedStatus, current, cmpopts.IgnoreFields(migrationStatus{}, "Started", "Completed")))
+		})
+	}
+}

--- a/lib/auth/trustedcluster_test.go
+++ b/lib/auth/trustedcluster_test.go
@@ -428,50 +428,6 @@ func newTestAuthServer(ctx context.Context, t *testing.T, name ...string) *Serve
 	return a
 }
 
-func TestRemoteDBCAMigration(t *testing.T) {
-	const (
-		localClusterName  = "localcluster"
-		remoteClusterName = "trustedcluster"
-	)
-	ctx := context.Background()
-
-	testAuth, err := NewTestAuthServer(TestAuthServerConfig{
-		ClusterName: localClusterName,
-		Dir:         t.TempDir(),
-	})
-	require.NoError(t, err)
-	a := testAuth.AuthServer
-
-	trustedCluster, err := types.NewTrustedCluster(remoteClusterName,
-		types.TrustedClusterSpecV2{Roles: []string{"nonempty"}})
-	require.NoError(t, err)
-	// use the UpsertTrustedCluster in Uncached as we just want the resource in
-	// the backend, we don't want to actually connect
-	_, err = a.Services.UpsertTrustedCluster(ctx, trustedCluster)
-	require.NoError(t, err)
-
-	// Generate remote HostCA and remove private key as remote CA should have only public cert.
-	remoteHostCA := suite.NewTestCA(types.HostCA, remoteClusterName)
-	types.RemoveCASecrets(remoteHostCA)
-
-	err = a.UpsertCertAuthority(ctx, remoteHostCA)
-	require.NoError(t, err)
-
-	// Run the migration
-	err = migrateDBAuthority(ctx, a)
-	require.NoError(t, err)
-
-	dbCAs, err := a.GetCertAuthority(context.Background(), types.CertAuthID{
-		Type:       types.DatabaseCA,
-		DomainName: remoteClusterName,
-	}, true)
-	require.NoError(t, err)
-	// Certificate should be copied.
-	require.Equal(t, remoteHostCA.Spec.ActiveKeys.TLS[0].Cert, dbCAs.GetActiveKeys().TLS[0].Cert)
-	// Private key should be empty.
-	require.Nil(t, dbCAs.GetActiveKeys().TLS[0].Key)
-}
-
 func TestUpsertTrustedCluster(t *testing.T) {
 	ctx := context.Background()
 	testAuth, err := NewTestAuthServer(TestAuthServerConfig{


### PR DESCRIPTION
Historically migrations have been ad-hoc functions added and removed from `lib/auth/init.go`. They are introduced for a major version and removed in time for the following major version. The migrations are applied during every boot sequence for the Auth service until the migration is removed. This causes tracking which versions introduced migrations challenging and slows down Auth start up time.

Persisting the migrations status in the backend allows Auth to only execute a migration once. This improves start up time and provides observability into the clusters migration state by inspecting the backend. Migration state is stored in the backend at key `migrations/current`. It's not available from tctl yet but can be added to `tctl get` in a subsequent change.

All new migrations must be added to a new file in `lib/auth/migration`. The file should follow the naming convention `<version>_<friendly_identifer>.go`. For example, the existing migration that created database CAs from host CAs was moved to `lib/auth/0001_db_ca.go` as it is the first migration. The migration package is also the entry point into executing `backend.Migration`s. `migration.Apply` executes any outstanding migrations and persists the status. When adding a new migration it must also be registered within `migration.Apply` by adding to the migrations slice.

The structure added is meant to make migrations more discoverable and make the process of adding a new migration easier. With the new structure there are a few rules that must be adhered to.

1) All migrations must have a version - as dictated by the `backend.Migration` interface.
2) Migration version must be unique and not skip any versions. 
3) Migrations must not be removed or have their version altered after they have been released.