### PR TITLE
Make SSH node listener to use multiplexer to leverage parsing of signed PROXY headers

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2623,7 +2623,7 @@ func (process *TeleportProcess) initSSH() error {
 
 			go func() {
 				if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
-					mux.Entry.WithError(err).Error("mux encountered err serving")
+					mux.Entry.WithError(err).Error("node ssh multiplexer terminated unexpectedly")
 				}
 			}()
 			defer mux.Close()

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -2554,10 +2554,6 @@ func (process *TeleportProcess) initSSH() error {
 			return trace.Wrap(err)
 		}
 
-		caGetter := func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error) {
-			return authClient.GetCertAuthority(ctx, id, loadKeys)
-		}
-
 		s, err := regular.New(
 			process.ExitContext(),
 			cfg.SSH.Addr,
@@ -2594,7 +2590,7 @@ func (process *TeleportProcess) initSSH() error {
 			regular.SetInventoryControlHandle(process.inventoryHandle),
 			regular.SetTracerProvider(process.TracingProvider),
 			regular.SetSessionController(sessionController),
-			regular.SetCAGetter(caGetter),
+			regular.SetCAGetter(authClient.GetCertAuthority),
 			regular.SetPublicAddrs(cfg.SSH.PublicAddrs),
 		)
 		if err != nil {
@@ -2613,7 +2609,26 @@ func (process *TeleportProcess) initSSH() error {
 
 			log.Infof("Service %s:%s is starting on %v %v.", teleport.Version, teleport.Gitref, cfg.SSH.Addr.Addr, process.Config.CachePolicy)
 
-			go s.Serve(limiter.WrapListener(listener))
+			// Use multiplexer to leverage support for signed PROXY protocol headers.
+			mux, err := multiplexer.New(multiplexer.Config{
+				Context:             process.ExitContext(),
+				Listener:            listener,
+				ID:                  teleport.Component(teleport.ComponentNode, process.id),
+				CertAuthorityGetter: authClient.GetCertAuthority,
+				LocalClusterName:    conn.ServerIdentity.ClusterName,
+			})
+			if err != nil {
+				return trace.Wrap(err)
+			}
+
+			go func() {
+				if err := mux.Serve(); err != nil && !utils.IsOKNetworkError(err) {
+					mux.Entry.WithError(err).Error("mux encountered err serving")
+				}
+			}()
+			defer mux.Close()
+
+			go s.Serve(limiter.WrapListener(mux.SSH()))
 		} else {
 			// Start the SSH server. This kicks off updating labels and starting the
 			// heartbeat.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -855,7 +855,6 @@ func New(
 		sshutils.SetFIPS(s.fips),
 		sshutils.SetClock(s.clock),
 		sshutils.SetIngressReporter(s.ingressService, s.ingressReporter),
-		sshutils.SetCAGetter(s.caGetter),
 		sshutils.SetClusterName(clusterName.GetClusterName()),
 	)
 	if err != nil {

--- a/lib/sshutils/server.go
+++ b/lib/sshutils/server.go
@@ -19,14 +19,11 @@ limitations under the License.
 package sshutils
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -42,11 +39,9 @@ import (
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/observability/tracing"
 	tracessh "github.com/gravitational/teleport/api/observability/tracing/ssh"
-	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/sshutils"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/limiter"
-	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/observability/metrics"
 	"github.com/gravitational/teleport/lib/srv/ingress"
 	"github.com/gravitational/teleport/lib/utils"
@@ -105,8 +100,6 @@ type Server struct {
 	// clock is used to control time.
 	clock clockwork.Clock
 
-	caGetter CertAuthorityGetter
-
 	clusterName string
 
 	// ingressReporter reports new and active connections.
@@ -125,10 +118,6 @@ const (
 	// SSH version string
 	// https://tools.ietf.org/html/rfc4253
 	MaxVersionStringBytes = 255
-
-	// caGetterTimeout is the timeout on getting host cert authority, that is used in
-	// signed PROXY headers verification.
-	caGetterTimeout = 5 * time.Second
 )
 
 // ServerOption is a functional argument for server
@@ -187,14 +176,6 @@ func SetTracerProvider(provider oteltrace.TracerProvider) ServerOption {
 func SetClock(clock clockwork.Clock) ServerOption {
 	return func(s *Server) error {
 		s.clock = clock
-		return nil
-	}
-}
-
-// SetCAGetter sets the cert authority getter
-func SetCAGetter(caGetter CertAuthorityGetter) ServerOption {
-	return func(s *Server) error {
-		s.caGetter = caGetter
 		return nil
 	}
 }
@@ -480,11 +461,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	// transmitted and received over the connection.
 	wconn := utils.NewTrackingConn(conn)
 
-	// create a new SSH server which handles the handshake (and pass the custom
-	// payload structure which will be populated only when/if this connection
-	// comes from another Teleport proxy):
-	wrappedConn := wrapConnection(wconn, s.caGetter, s.clusterName, s.clock, s.log)
-	sconn, chans, reqs, err := ssh.NewServerConn(wrappedConn, &s.cfg)
+	sconn, chans, reqs, err := ssh.NewServerConn(wconn, &s.cfg)
 	if err != nil {
 		// Ignore EOF as these are triggered by loadbalancer health checks
 		if !errors.Is(err, io.EOF) {
@@ -501,7 +478,6 @@ func (s *Server) HandleConnection(conn net.Conn) {
 		s.ingressReporter.ConnectionAuthenticated(s.ingressService, conn)
 		defer s.ingressReporter.AuthenticatedConnectionClosed(s.ingressService, conn)
 	}
-	ctx := tracing.WithPropagationContext(context.Background(), wrappedConn.traceContext)
 
 	certType := "unknown"
 	if sconn.Permissions != nil {
@@ -539,7 +515,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 	// closeContext field is used to trigger starvation on cancellation by halting
 	// the acceptance of new connections; it is not intended to halt in-progress
 	// connection handling, and is therefore orthogonal to the role of ConnectionContext.
-	ctx, ccx := NewConnectionContext(ctx, wconn, sconn, SetConnectionContextClock(s.clock))
+	ctx, ccx := NewConnectionContext(context.Background(), wconn, sconn, SetConnectionContextClock(s.clock))
 	defer ccx.Close()
 
 	if s.newConnHandler != nil {
@@ -769,118 +745,4 @@ type (
 type ClusterDetails struct {
 	RecordingProxy bool
 	FIPSEnabled    bool
-}
-
-// connectionWrapper allows the SSH server to perform custom handshake which
-// lets teleport proxy servers to relay a true remote client IP address
-// to the SSH server.
-//
-// (otherwise connection.RemoteAddr (client IP) will always point to a proxy IP
-// instead of a true client IP)
-type connectionWrapper struct {
-	net.Conn
-	logger logrus.FieldLogger
-
-	// upstreamReader reads from the underlying (wrapped) connection
-	upstreamReader io.Reader
-
-	// clientAddr points to the true client address (client is behind
-	// a proxy). Keeping this address is the entire point of the
-	// connection wrapper.
-	clientAddr net.Addr
-
-	// traceContext is the tracing context that was passed across the
-	// connection, used to correlate spans.
-	traceContext tracing.PropagationContext
-
-	caGetter    CertAuthorityGetter
-	clusterName string
-	clock       clockwork.Clock
-}
-
-// RemoteAddr returns the behind-the-proxy client address
-func (c *connectionWrapper) RemoteAddr() net.Addr {
-	return c.clientAddr
-}
-
-// Read implements io.Read() part of net.Connection which allows us
-// peek at the beginning of SSH handshake (that's why we're wrapping the connection)
-// DELETE IN 14.0: we need to keep it for compatibility purposes, but in 14.0 we can remove this
-// connection wrapper and instead use multiplexer listener for SSH node.
-func (c *connectionWrapper) Read(b []byte) (int, error) {
-	// handshake already took place, forward upstream:
-	if c.upstreamReader != nil {
-		return c.upstreamReader.Read(b)
-	}
-	// inspect the client's hello message and see if it's a teleport
-	// proxy connecting?
-	buff := make([]byte, MaxVersionStringBytes)
-	n, err := c.Conn.Read(buff)
-	if err != nil {
-		// EOF happens quite often, don't pollute the logs with it
-		if !errors.Is(err, io.EOF) {
-			c.logger.Error(err)
-		}
-		return n, err
-	}
-	// chop off extra unused bytes at the end of the buffer:
-	buff = buff[:n]
-	skip := 0
-
-	if bytes.HasPrefix(buff, multiplexer.ProxyV2Prefix) {
-		reader := bufio.NewReader(io.MultiReader(bytes.NewBuffer(buff), c.Conn))
-
-		proxyLine, err := multiplexer.ReadProxyLineV2(reader)
-		if err != nil {
-			return 0, trace.Wrap(err)
-		}
-		if c.caGetter != nil && proxyLine != nil && proxyLine.IsSigned() {
-			ctx, cancel := context.WithTimeout(context.Background(), caGetterTimeout)
-			defer cancel()
-
-			err = proxyLine.VerifySignature(ctx, c.caGetter, c.clusterName, c.clock)
-			// NOTE(anton): Temporarily using string comparison here to not create circular references.
-			// Will be refactored after #21835 is resolved.
-			if err != nil {
-				if strings.Contains(err.Error(), "could not get specified host CA to verify signed PROXY header") {
-					c.logger.WithFields(logrus.Fields{
-						"src_addr": c.Conn.RemoteAddr(),
-						"dst_addr": c.Conn.LocalAddr(),
-					}).Warn("Could not verify PROXY signature for connection - could not get host CA")
-				} else if strings.Contains(err.Error(), "signing certificate is not signed by local cluster CA") {
-					c.logger.WithFields(logrus.Fields{
-						"src_addr": c.Conn.RemoteAddr(),
-						"dst_addr": c.Conn.LocalAddr(),
-					}).Warn("Could not verify PROXY signature for connection - signed by non local cluster")
-				} else {
-					return 0, trace.Wrap(err)
-				}
-			}
-			if proxyLine.IsVerified {
-				c.clientAddr = &proxyLine.Source
-			}
-		}
-
-		c.upstreamReader = reader
-	}
-
-	if c.upstreamReader == nil {
-		c.upstreamReader = io.MultiReader(bytes.NewBuffer(buff[skip:]), c.Conn)
-	}
-	return c.upstreamReader.Read(b)
-}
-
-type CertAuthorityGetter = func(ctx context.Context, id types.CertAuthID, loadKeys bool) (types.CertAuthority, error)
-
-// wrapConnection takes a network connection, wraps it into connectionWrapper
-// object (which overrides Read method) and returns the wrapper.
-func wrapConnection(conn net.Conn, caGetter CertAuthorityGetter, localClusterName string, clock clockwork.Clock, logger logrus.FieldLogger) *connectionWrapper {
-	return &connectionWrapper{
-		Conn:        conn,
-		clientAddr:  conn.RemoteAddr(),
-		caGetter:    caGetter,
-		clusterName: localClusterName,
-		clock:       clock,
-		logger:      logger,
-	}
 }

--- a/lib/sshutils/server_test.go
+++ b/lib/sshutils/server_test.go
@@ -17,24 +17,17 @@ limitations under the License.
 package sshutils
 
 import (
-	"bytes"
 	"context"
-	"crypto/x509"
-	"encoding/pem"
 	"fmt"
-	"net"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/gravitational/trace"
-	"github.com/jonboulle/clockwork"
-	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ssh"
 
-	"github.com/gravitational/teleport/lib/fixtures"
 	"github.com/gravitational/teleport/lib/utils"
 	"github.com/gravitational/teleport/lib/utils/cert"
 )
@@ -257,104 +250,6 @@ func TestHostSignerFIPS(t *testing.T) {
 		)
 		tt.assert(t, err)
 	}
-}
-
-// TestConnectionWrapper_Read makes sure connectionWrapper can correctly process PROXY protocol
-// on the wire.
-func TestConnectionWrapper_Read(t *testing.T) {
-	testCases := []struct {
-		desc     string
-		sendData []byte
-	}{
-		{
-			desc:     "Plain connection without any special headers",
-			sendData: nil,
-		},
-		{
-			desc:     "Sending PROXY header",
-			sendData: getPROXYProtocolPayload(),
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.desc, func(t *testing.T) {
-			listener, err := net.Listen("tcp", "127.0.0.1:0")
-			require.NoError(t, err)
-			t.Cleanup(func() { listener.Close() })
-
-			go startSSHServer(t, listener)
-
-			conn, err := net.Dial("tcp", listener.Addr().String())
-			require.NoError(t, err)
-
-			_, err = conn.Write(tc.sendData)
-			require.NoError(t, err)
-
-			sconn, nc, r, err := ssh.NewClientConn(conn, "", &ssh.ClientConfig{
-				HostKeyCallback: ssh.InsecureIgnoreHostKey(),
-				Timeout:         time.Second,
-			})
-			require.NoError(t, err)
-			require.Equal(t, "SSH-2.0-Go", string(sconn.ServerVersion()))
-
-			client := ssh.NewClient(sconn, nc, r)
-			require.NoError(t, err)
-
-			// Make sure SSH connection works correctly
-			ok, response, err := client.SendRequest("echo", true, []byte("beep"))
-			require.NoError(t, err)
-			require.True(t, ok)
-			require.Equal(t, "beep", string(response))
-		})
-	}
-}
-
-func getPROXYProtocolPayload() []byte {
-	proxyV2Prefix := []byte{0x0D, 0x0A, 0x0D, 0x0A, 0x00, 0x0D, 0x0A, 0x51, 0x55, 0x49, 0x54, 0x0A}
-	// source=127.0.0.1:12345 destination=127.0.0.2:42
-	sampleIPv4Addresses := []byte{0x7F, 0x00, 0x00, 0x01, 0x7F, 0x00, 0x00, 0x02, 0x30, 0x39, 0x00, 0x2A}
-	// {0x21, 0x11, 0x00, 0x0C} - 4 bits version, 4 bits command, 4 bits address family, 4 bits protocol, 16 bits length
-	sampleProxyV2Line := bytes.Join([][]byte{proxyV2Prefix, {0x21, 0x11, 0x00, 0x0C}, sampleIPv4Addresses}, nil)
-
-	return sampleProxyV2Line
-}
-
-func startSSHServer(t *testing.T, listener net.Listener) {
-	nConn, err := listener.Accept()
-	assert.NoError(t, err)
-
-	t.Cleanup(func() { nConn.Close() })
-
-	wConn := wrapConnection(nConn, nil, "", clockwork.NewRealClock(), logrus.New())
-
-	block, _ := pem.Decode(fixtures.LocalhostKey)
-	pkey, err := x509.ParsePKCS1PrivateKey(block.Bytes)
-	assert.NoError(t, err)
-
-	signer, err := ssh.NewSignerFromKey(pkey)
-	assert.NoError(t, err)
-
-	config := &ssh.ServerConfig{NoClientAuth: true}
-	config.AddHostKey(signer)
-
-	conn, _, reqs, err := ssh.NewServerConn(wConn, config)
-	assert.NoError(t, err)
-	if err != nil {
-		return
-	}
-	t.Cleanup(func() { conn.Close() })
-
-	go func() {
-		for newReq := range reqs {
-			if newReq.Type == "echo" {
-				err := newReq.Reply(true, newReq.Payload)
-				assert.NoError(t, err)
-				continue
-			}
-			err := newReq.Reply(false, nil)
-			assert.NoError(t, err)
-		}
-	}()
 }
 
 func pass(need string) PasswordFunc {


### PR DESCRIPTION
For backward compatibility reason we used regular listener for SSH nodes and later we wrapped connection into handler that could parse signed PROXY header or proxyHelloSignature for getting correct user IP. But after removal of proxyHelloSignature we don't need the wrapper anymore, and we can just use multiplexer.