### PR TITLE
Add a link to Teleport Labs in the landing page

### DIFF
--- a/docs/pages/index.mdx
+++ b/docs/pages/index.mdx
@@ -41,14 +41,14 @@ We will run the following Teleport services:
 
 ### Prerequisites
 
-<Notice type="tip">
-
 You will need the following to deploy a demo Teleport cluster. If your
 environment doesn't meet the prerequisites above, you can get started with
 Teleport by signing up for a [free trial of Teleport
 Team](https://goteleport.com/signup/).
 
-</Notice>
+If you want to get a feel for Teleport commands and capabilities without setting
+up any infrastructure, take a look at the browser-based [Teleport
+Labs](https://goteleport.com/labs).
 
 - A Linux host with only port `443` open to ingress traffic. You must be able
   to install and run software on the host. Either configure access to the host
@@ -59,15 +59,11 @@ Team](https://goteleport.com/signup/).
   script](https://cloud.google.com/compute/docs/instances/startup-scripts),
   or similar.
 
-  <Admonition type="tip" title="Quick demo environments">
-
   For a quick demo environment you can use to follow this guide, consider
   installing our DigitalOcean 1-Click droplet. View the installation page on
   [DigitalOcean
   Marketplace](https://marketplace.digitalocean.com/apps/teleport). Once your
   droplet is ready, SSH into the droplet and follow the configuration wizard.
-
-  </Admonition>
 
 - A two-factor authenticator app such as [Authy](https://authy.com/download/),
   [Google Authenticator](https://www.google.com/landing/2step/), or


### PR DESCRIPTION
Fixes #29955

Adds this link in the Prerequisites section after the link to the Teleport Team docs. This is a natural place for this information, since the Teleport Team link is for users whose environments do not meet the requirements of the Prerequisites of the Getting Started tutorial.

This change means that the `Notice` that includes the Teleport Team link is now two paragraphs long, which is too long for a `Notice`. An `Admonition`, however, would clash with the `Admonition` telling the reader about our DigitalOcean 1-click droplet. I have removed the colored boxes from the Prerequisites section to reduce noise.