### PR TITLE
single auth client per instance

### DIFF
--- a/integration/conntest/database_test.go
+++ b/integration/conntest/database_test.go
@@ -329,5 +329,5 @@ func waitForDatabases(t *testing.T, authServer *auth.Server, dbNames []string) {
 			}
 		}
 		return registered == len(dbNames)
-	}, 10*time.Second, 100*time.Millisecond)
+	}, 30*time.Second, 100*time.Millisecond)
 }

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -417,7 +417,7 @@ func MakeTestServers(t *testing.T) (auth *service.TeleportProcess, proxy *servic
 	})
 
 	// Wait for proxy to become ready.
-	_, err = proxy.WaitForEventTimeout(10*time.Second, service.ProxyWebServerReady)
+	_, err = proxy.WaitForEventTimeout(30*time.Second, service.ProxyWebServerReady)
 	require.NoError(t, err, "proxy web server didn't start after 10s")
 
 	return auth, proxy, provisionToken
@@ -438,6 +438,7 @@ func MakeTestDatabaseServer(t *testing.T, proxyAddr utils.NetAddr, token string,
 	cfg.SetToken(token)
 	cfg.SSH.Enabled = false
 	cfg.Auth.Enabled = false
+	cfg.Proxy.Enabled = false
 	cfg.Databases.Enabled = true
 	cfg.Databases.Databases = dbs
 	cfg.Databases.ResourceMatchers = resMatchers
@@ -452,7 +453,7 @@ func MakeTestDatabaseServer(t *testing.T, proxyAddr utils.NetAddr, token string,
 	})
 
 	// Wait for database agent to start.
-	_, err = db.WaitForEventTimeout(10*time.Second, service.DatabasesReady)
+	_, err = db.WaitForEventTimeout(30*time.Second, service.DatabasesReady)
 	require.NoError(t, err, "database server didn't start after 10s")
 
 	return db

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1047,6 +1047,14 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 // For config v1 and v2, it will attempt to direct dial the auth server, and fallback to trying to tunnel
 // to the Auth Server through the proxy.
 func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client, error) {
+	if identity.ID.Role != types.RoleInstance {
+		clt, ok := process.waitForInstanceClient()
+		if !ok {
+			return nil, trace.Errorf("failed to get instance client for identity %q", identity.ID.Role)
+		}
+		return clt, nil
+	}
+
 	tlsConfig, err := identity.TLSConfig(process.Config.CipherSuites)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -868,7 +868,7 @@ func testVersionCheck(t *testing.T, nodeCfg *servicecfg.Config, skipVersionCheck
 	nodeProc, err := NewTeleport(nodeCfg)
 	require.NoError(t, err)
 
-	c, err := nodeProc.reconnectToAuthService(types.RoleNode)
+	c, err := nodeProc.reconnectToAuthService(types.RoleInstance)
 	if skipVersionCheck {
 		require.NoError(t, err)
 		require.NotNil(t, c)

--- a/lib/service/supervisor.go
+++ b/lib/service/supervisor.go
@@ -454,7 +454,11 @@ func (s *LocalSupervisor) WaitForEvent(ctx context.Context, name string) (Event,
 func (s *LocalSupervisor) WaitForEventTimeout(timeout time.Duration, name string) (Event, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
-	return s.WaitForEvent(ctx, name)
+	event, err := s.WaitForEvent(ctx, name)
+	if err != nil && ctx.Err() != nil {
+		return event, trace.Errorf("timeout waiting for event %q (%s)", name, timeout)
+	}
+	return event, trace.Wrap(err)
 }
 
 func (s *LocalSupervisor) ListenForEvents(ctx context.Context, name string, eventC chan<- Event) {


### PR DESCRIPTION
In v10 we introduced a new certificate type `Instance`, which contained all system roles of the teleport agent rather than having one system role per certificate.  The old single-system role certificates were still necessary at the time for backwards-compatibility, but they can now be phased out.  This is a very minimal implementation of a phase out that changes very little actual code, just injecting the instance client at the point where we would previously allocate per-service clients.  If the upcoming testplan doesn't uncover any issues with dropping the per-instance clients, then a more significant rework of our setup logic is probably warranted since we should be able to cut a decent amount of complexity now that we don't have to juggle multiple auth clients.

The main benefit of phasing out per-service certs/clients is that it will reduce the number of connections to the auth server, but there are various possible future benefits (e.g. establishing a common cache across all services), which might get us additional efficiency gains.

Fixes https://github.com/gravitational/teleport/issues/17023