### PR TITLE
AWS MySQL end-to-end test

### DIFF
--- a/.github/workflows/aws-e2e-tests-non-root.yaml
+++ b/.github/workflows/aws-e2e-tests-non-root.yaml
@@ -37,6 +37,7 @@ env:
   DATABASE_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-database-svc
   DATABASE_DISCOVERY_SERVICE_ASSUME_ROLE: arn:aws:iam::307493967395:role/ci-database-e2e-tests-discovery-svc
   RDS_POSTGRES_INSTANCE_NAME: ci-database-e2e-tests-rds-postgres-instance-us-west-2-307493967395
+  RDS_MYSQL_INSTANCE_NAME: ci-database-e2e-tests-rds-mysql-instance-us-west-2-307493967395
   DISCOVERY_MATCHER_LABELS: "*=*"
 jobs:
   test:

--- a/e2e/aws/main_test.go
+++ b/e2e/aws/main_test.go
@@ -45,6 +45,10 @@ const (
 	// name of the RDS Postgres DB instance that will be created by the Teleport
 	// Discovery Service.
 	rdsPostgresInstanceNameEnv = "RDS_POSTGRES_INSTANCE_NAME"
+	// rdsMySQLInstanceNameEnv is the environment variable that specifies the
+	// name of the RDS MySQL DB instance that will be created by the Teleport
+	// Discovery Service.
+	rdsMySQLInstanceNameEnv = "RDS_MYSQL_INSTANCE_NAME"
 	// kubeSvcRoleARNEnv is the environment variable that specifies
 	// the IAM role that Teleport Kubernetes Service will assume to access the EKS cluster.
 	// This role needs to have the following permissions:


### PR DESCRIPTION
This PR adds end-to-end tests for AWS RDS MySQL instance.

implements https://github.com/gravitational/teleport/pull/27156 for MySQL db.

stacked on https://github.com/gravitational/teleport/pull/29755

~~Leaving in draft pending merge of the terraform resources that the test requires in https://github.com/gravitational/cloud-terraform/pull/3066~~

issue: https://github.com/gravitational/teleport/issues/27325
