### PR TITLE
:bug: issue #30400 fixing missing `billing_mode` param in `teleport-cluster` helm chart fo dynamodb autoscaling 

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
+++ b/examples/chart/teleport-cluster/templates/auth/_config.aws.tpl
@@ -13,6 +13,7 @@
     continuous_backups: {{ required "aws.backups is required in chart values" .Values.aws.backups }}
     {{- if .Values.aws.dynamoAutoScaling }}
     auto_scaling: true
+    billing_mode: provisioned
     read_min_capacity: {{ required "aws.readMinCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.readMinCapacity }}
     read_max_capacity: {{ required "aws.readMaxCapacity is required when aws.dynamoAutoScaling is true" .Values.aws.readMaxCapacity }}
     read_target_value: {{ required "aws.readTargetValue is required when aws.dynamoAutoScaling is true" .Values.aws.readTargetValue }}
@@ -21,5 +22,6 @@
     write_target_value: {{ required "aws.writeTargetValue is required when aws.dynamoAutoScaling is true" .Values.aws.writeTargetValue }}
     {{- else }}
     auto_scaling: false
+    billing_mode: pay_per_request
     {{- end }}
 {{- end -}}


### PR DESCRIPTION
this PR fixes https://github.com/gravitational/teleport/issues/30400

In [Change log 13.2.5 (07/27/23)](https://goteleport.com/docs/changelog/#1325-072723) introduced below change

* DynamoDB backend tables are now created with PayPerRequest mode. [#29351](https://github.com/gravitational/teleport/pull/29351)

looking up documentation https://goteleport.com/docs/reference/backends/#dynamodb-autoscaling

seems billing_mode defaults to `pay_per_request`
```
    # Enables either Pay-Per-Request or Provisioned billing for the DynamoDB table. Set when Teleport creates the table.
    # If billing_mode is set to "pay_per_request", read/write capacity and auto_scaling settings will be ignored.
    # Possible values: "pay_per_request" and "provisioned"
    # default: "pay_per_request"
    billing_mode: ["pay_per_request"|"provisioned"]
```

when dynamodb autoscaling is enabled, `billing_mode` is required to be `provisioned`, it seems current helm chart **doesn't** support this parameter, hence getting below error
```
2023-08-13T15:45:51Z INFO             Starting Teleport v13.3.2 with a config file located at "/etc/teleport/teleport.yaml" common/teleport.go:5592023-08-13T15:45:51Z INFO [PROC:1]    Service diag is creating new listener on 0.0.0.0:3000. pid:7.1 service/signals.go:2152023-08-13T15:45:51Z INFO [DIAG:1]    Starting diagnostic service on 0.0.0.0:3000. pid:7.1 service/service.go:30002023-08-13T15:45:51Z INFO [DYNAMODB]  Initializing backend. Table: "teleport.ops.p0xlabs.systems-backend", poll streams every 1s. dynamo/dynamodbbk.go:2252023-08-13T15:45:51Z WARN [CLOUDLABE] Could not fetch EC2 instance's tags, please ensure 'allow instance tags in metadata' is enabled on the instance. labels/cloud.go:1402023-08-13T15:45:51Z INFO [DYNAMODB]  Ignoring auto_scaling setting as table is in on-demand mode. dynamo/dynamodbbk.go:287ERROR: initialization failedValidationException: Validation failed for scalable target. Reason: PAY_PER_REQUEST table mode is not scalable.
```

this change adds `billing_mode` to `examples/chart/teleport-cluster/templates/auth/_config.aws.tpl` to fix above error when `aws.dynamoAutoScaling` is true (enabled)