### PR TITLE
Remove exported Webauthn functions

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8603,18 +8603,15 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 			panic("this should not be called")
 		})
 
-	oldStdin, oldWebauthn := prompt.Stdin(), *client.PromptWebauthn
+	oldStdin := prompt.Stdin()
 	t.Cleanup(func() {
 		prompt.SetStdin(oldStdin)
-		*client.PromptWebauthn = oldWebauthn
 	})
 
 	device, err := mocku2f.Create()
 	require.NoError(t, err)
 	device.SetPasswordless()
-
-	prompt.SetStdin(inputReader)
-	*client.PromptWebauthn = func(ctx context.Context, realOrigin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, _ *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
+	customWebauthnLogin := func(ctx context.Context, realOrigin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, _ *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error) {
 		car, err := device.SignAssertion("https://127.0.0.1", assertion) // use the fake origin to prevent a mismatch
 		if err != nil {
 			return nil, "", err
@@ -8625,6 +8622,8 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 			},
 		}, "", nil
 	}
+
+	prompt.SetStdin(inputReader)
 
 	// Enable web service.
 	cfg := suite.defaultServiceConfig()
@@ -8731,6 +8730,7 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 			return
 		}
 
+		cl.WebauthnLogin = customWebauthnLogin
 		cl.Stdout = peerTerminal
 		cl.Stdin = peerTerminal
 		if err := cl.SSH(ctx, []string{}, false); err != nil {
@@ -8761,6 +8761,7 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 			return
 		}
 
+		cl.WebauthnLogin = customWebauthnLogin
 		cl.Stdout = moderatorTerminal
 		cl.Stdin = moderatorTerminal
 		if err := cl.Join(ctx, types.SessionModeratorMode, defaults.Namespace, session.ID(sessionID), moderatorTerminal); err != nil {

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -8604,6 +8604,7 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 		})
 
 	oldStdin := prompt.Stdin()
+	prompt.SetStdin(inputReader)
 	t.Cleanup(func() {
 		prompt.SetStdin(oldStdin)
 	})
@@ -8622,8 +8623,6 @@ func testModeratedSessions(t *testing.T, suite *integrationTestSuite) {
 			},
 		}, "", nil
 	}
-
-	prompt.SetStdin(inputReader)
 
 	// Enable web service.
 	cfg := suite.defaultServiceConfig()

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -459,6 +459,10 @@ type Config struct {
 	// PromptMFAFunc allows tests to override the default MFA prompt function.
 	// Defaults to [mfa.NewPrompt().Run].
 	PromptMFAFunc PromptMFAFunc
+
+	// WebauthnLogin allows tests to override the Webauthn Login func.
+	// Defaults to [wancli.Login].
+	WebauthnLogin WebauthnLoginFunc
 }
 
 // CachePolicy defines cache policy for local clients

--- a/lib/client/api.go
+++ b/lib/client/api.go
@@ -3624,6 +3624,7 @@ func (tc *TeleportClient) pwdlessLoginWeb(ctx context.Context, priv *keys.Privat
 		User:                    user,
 		AuthenticatorAttachment: tc.AuthenticatorAttachment,
 		StderrOverride:          tc.Stderr,
+		WebauthnLogin:           tc.WebauthnLogin,
 	})
 	return clt, session, trace.Wrap(err)
 }
@@ -3902,6 +3903,7 @@ func (tc *TeleportClient) pwdlessLogin(ctx context.Context, priv *keys.PrivateKe
 		User:                    user,
 		AuthenticatorAttachment: tc.AuthenticatorAttachment,
 		StderrOverride:          tc.Stderr,
+		WebauthnLogin:           tc.WebauthnLogin,
 	})
 
 	return response, trace.Wrap(err)

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -55,6 +55,8 @@ import (
 )
 
 func TestTeleportClient_Login_local(t *testing.T) {
+	t.Parallel()
+
 	silenceLogger(t)
 
 	clock := clockwork.NewFakeClockAt(time.Now())

--- a/lib/client/api_login_test.go
+++ b/lib/client/api_login_test.go
@@ -81,15 +81,10 @@ func TestTeleportClient_Login_local(t *testing.T) {
 
 	// Reset functions after tests.
 	oldStdin := prompt.Stdin()
-	oldHasPlatformSupport := *client.HasPlatformSupport
-	*client.HasPlatformSupport = func() bool {
-		return true
-	}
 	oldHasCredentials := *client.HasTouchIDCredentials
 
 	t.Cleanup(func() {
 		prompt.SetStdin(oldStdin)
-		*client.HasPlatformSupport = oldHasPlatformSupport
 		*client.HasTouchIDCredentials = oldHasCredentials
 	})
 

--- a/lib/client/export.go
+++ b/lib/client/export.go
@@ -15,4 +15,3 @@
 package client
 
 var PromptWebauthn = &promptWebauthn
-var HasPlatformSupport = &hasPlatformSupport

--- a/lib/client/export.go
+++ b/lib/client/export.go
@@ -14,5 +14,5 @@
 
 package client
 
-// TODO (Joerger): Remove this export once /e no longer depends on it.
+// TODO(Joerger): Remove this export once /e no longer depends on it.
 var PromptWebauthn = &promptWebauthn

--- a/lib/client/export.go
+++ b/lib/client/export.go
@@ -14,4 +14,5 @@
 
 package client
 
+// TODO (Joerger): Remove this export once /e no longer depends on it.
 var PromptWebauthn = &promptWebauthn

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -27,13 +27,16 @@ import (
 
 // TODO(Joerger): remove this once the exported PromptWebauthn function is no longer used in tests.
 // promptWebauthn provides indirection for tests.
-var promptWebauthn func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error)
+var promptWebauthn WebauthnLoginFunc
 
 // hasPlatformSupport is used to mock wancli.HasPlatformSupport for tests.
 var hasPlatformSupport = wancli.HasPlatformSupport
 
 // PromptMFAFunc matches the signature of [mfa.Prompt.Run].
 type PromptMFAFunc func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error)
+
+// WebauthnLoginFunc matches the signature of [wancli.Login].
+type WebauthnLoginFunc func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt, opts *wancli.LoginOpts) (*proto.MFAAuthenticateResponse, string, error)
 
 // NewMFAPrompt creates a new MFA prompt from client settings.
 func (tc *TeleportClient) NewMFAPrompt(opts ...mfa.PromptOpt) PromptMFAFunc {
@@ -49,6 +52,11 @@ func (tc *TeleportClient) NewMFAPrompt(opts ...mfa.PromptOpt) PromptMFAFunc {
 	// TODO(Joerger): remove this once the exported PromptWebauthn function is no longer used in tests.
 	if promptWebauthn != nil {
 		prompt.WebauthnLogin = promptWebauthn
+		prompt.WebauthnSupported = true
+	}
+
+	if tc.WebauthnLogin != nil {
+		prompt.WebauthnLogin = tc.WebauthnLogin
 		prompt.WebauthnSupported = true
 	}
 

--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -29,9 +29,6 @@ import (
 // promptWebauthn provides indirection for tests.
 var promptWebauthn WebauthnLoginFunc
 
-// hasPlatformSupport is used to mock wancli.HasPlatformSupport for tests.
-var hasPlatformSupport = wancli.HasPlatformSupport
-
 // PromptMFAFunc matches the signature of [mfa.Prompt.Run].
 type PromptMFAFunc func(ctx context.Context, chal *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error)
 

--- a/lib/client/mfa_test.go
+++ b/lib/client/mfa_test.go
@@ -36,11 +36,9 @@ import (
 // See api_login_test.go and/or TeleportClient tests for more general
 // authentication tests.
 func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
-	oldPromptWebauthn := *client.PromptWebauthn
 	oldHasPlatformSupport := *client.HasPlatformSupport
 	oldStdin := prompt.Stdin()
 	t.Cleanup(func() {
-		*client.PromptWebauthn = oldPromptWebauthn
 		*client.HasPlatformSupport = oldHasPlatformSupport
 		prompt.SetStdin(oldStdin)
 	})
@@ -89,6 +87,9 @@ func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			test := test
+			t.Parallel()
+
 			// Set a timeout so the test won't block forever.
 			// We don't expect to hit the timeout for any of the test cases.
 			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)

--- a/lib/client/mfa_test.go
+++ b/lib/client/mfa_test.go
@@ -26,7 +26,6 @@ import (
 	wanpb "github.com/gravitational/teleport/api/types/webauthn"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
 	wantypes "github.com/gravitational/teleport/lib/auth/webauthntypes"
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/client/mfa"
 	"github.com/gravitational/teleport/lib/utils/prompt"
 )
@@ -36,10 +35,8 @@ import (
 // See api_login_test.go and/or TeleportClient tests for more general
 // authentication tests.
 func TestPromptMFAChallenge_usingNonRegisteredDevice(t *testing.T) {
-	oldHasPlatformSupport := *client.HasPlatformSupport
 	oldStdin := prompt.Stdin()
 	t.Cleanup(func() {
-		*client.HasPlatformSupport = oldHasPlatformSupport
 		prompt.SetStdin(oldStdin)
 	})
 

--- a/lib/client/weblogin.go
+++ b/lib/client/weblogin.go
@@ -279,6 +279,10 @@ type SSHLoginMFA struct {
 type SSHLoginPasswordless struct {
 	SSHLogin
 
+	// WebauthnLogin is a customizable webauthn login function.
+	// Defaults to [wancli.Login]
+	WebauthnLogin WebauthnLoginFunc
+
 	// StderrOverride will override the default os.Stderr if provided.
 	StderrOverride io.Writer
 
@@ -543,13 +547,12 @@ func SSHAgentPasswordlessLogin(ctx context.Context, login SSHLoginPasswordless) 
 		prompt = wancli.NewDefaultPrompt(ctx, stderr)
 	}
 
-	// TODO(Joerger): remove this once the exported PromptWebauthn function is no longer used in tests.
-	webauthnLogin := wancli.Login
-	if promptWebauthn != nil {
-		webauthnLogin = promptWebauthn
+	promptWebauthn := login.WebauthnLogin
+	if promptWebauthn == nil {
+		promptWebauthn = wancli.Login
 	}
 
-	mfaResp, _, err := webauthnLogin(ctx, webURL.String(), challenge.WebauthnChallenge, prompt, &wancli.LoginOpts{
+	mfaResp, _, err := promptWebauthn(ctx, webURL.String(), challenge.WebauthnChallenge, prompt, &wancli.LoginOpts{
 		User:                    login.User,
 		AuthenticatorAttachment: login.AuthenticatorAttachment,
 	})
@@ -882,13 +885,12 @@ func SSHAgentPasswordlessLoginWeb(ctx context.Context, login SSHLoginPasswordles
 		prompt = wancli.NewDefaultPrompt(ctx, stderr)
 	}
 
-	// TODO(Joerger): remove this once the exported PromptWebauthn function is no longer used in tests.
-	webauthnLogin := wancli.Login
-	if promptWebauthn != nil {
-		webauthnLogin = promptWebauthn
+	promptWebauthn := login.WebauthnLogin
+	if promptWebauthn == nil {
+		promptWebauthn = wancli.Login
 	}
 
-	mfaResp, _, err := webauthnLogin(ctx, webURL.String(), challenge.WebauthnChallenge, prompt, &wancli.LoginOpts{
+	mfaResp, _, err := promptWebauthn(ctx, webURL.String(), challenge.WebauthnChallenge, prompt, &wancli.LoginOpts{
 		User:                    login.User,
 		AuthenticatorAttachment: login.AuthenticatorAttachment,
 	})

--- a/lib/client/weblogin_test.go
+++ b/lib/client/weblogin_test.go
@@ -115,6 +115,7 @@ func newServer(handler http.HandlerFunc, loopback bool) (*httptest.Server, error
 }
 
 func TestSSHAgentPasswordlessLogin(t *testing.T) {
+	t.Parallel()
 	silenceLogger(t)
 
 	clock := clockwork.NewFakeClockAt(time.Now())

--- a/lib/client/weblogin_test.go
+++ b/lib/client/weblogin_test.go
@@ -133,12 +133,6 @@ func TestSSHAgentPasswordlessLogin(t *testing.T) {
 	cfg.KeysDir = t.TempDir()
 	cfg.InsecureSkipVerify = true
 
-	// Reset functions after tests.
-	oldWebauthn := *client.PromptWebauthn
-	t.Cleanup(func() {
-		*client.PromptWebauthn = oldWebauthn
-	})
-
 	solvePwdless := func(ctx context.Context, origin string, assertion *wantypes.CredentialAssertion, prompt wancli.LoginPrompt) (*proto.MFAAuthenticateResponse, error) {
 		car, err := device.SignAssertion(origin, assertion)
 		if err != nil {
@@ -225,9 +219,9 @@ func TestSSHAgentPasswordlessLogin(t *testing.T) {
 			},
 			AuthenticatorAttachment: tc.AuthenticatorAttachment,
 			CustomPrompt:            test.customPromptLogin,
+			WebauthnLogin:           test.customPromptWebauthn,
 		}
 
-		*client.PromptWebauthn = test.customPromptWebauthn
 		_, err = client.SSHAgentPasswordlessLogin(ctx, req)
 		require.NoError(t, err)
 		require.True(t, customPromptCalled, "Custom prompt present but not called")

--- a/lib/teleterm/clusters/cluster_auth.go
+++ b/lib/teleterm/clusters/cluster_auth.go
@@ -294,6 +294,7 @@ func (c *Cluster) passwordlessLogin(stream api.TerminalService_LoginPasswordless
 			},
 			AuthenticatorAttachment: c.clusterClient.AuthenticatorAttachment,
 			CustomPrompt:            newPwdlessLoginPrompt(ctx, c.Log, stream),
+			WebauthnLogin:           c.clusterClient.WebauthnLogin,
 		})
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -483,6 +483,10 @@ type CLIConf struct {
 	// Defaults to [dtauthn.NewCeremony().Run].
 	DTAuthnRunCeremony client.DTAuthnRunCeremonyFunc
 
+	// WebauthnLogin allows tests to override the Webauthn Login func.
+	// Defaults to [wancli.Login].
+	WebauthnLogin client.WebauthnLoginFunc
+
 	// LeafClusterName is the optional name of a leaf cluster to connect to instead
 	LeafClusterName string
 }
@@ -3742,6 +3746,7 @@ func loadClientConfigFromCLIConf(cf *CLIConf, proxy string) (*client.Config, err
 	c.MockSSOLogin = cf.MockSSOLogin
 	c.MockHeadlessLogin = cf.MockHeadlessLogin
 	c.DTAuthnRunCeremony = cf.DTAuthnRunCeremony
+	c.WebauthnLogin = cf.WebauthnLogin
 
 	// pass along MySQL/Postgres path overrides (only used in tests).
 	c.OverrideMySQLOptionFilePath = cf.overrideMySQLOptionFilePath

--- a/tool/tsh/common/tsh_test.go
+++ b/tool/tsh/common/tsh_test.go
@@ -1003,10 +1003,9 @@ func approveAllAccessRequests(ctx context.Context, approver accessApprover) erro
 // sessions when set either via role or cluster auth preference.
 // Sessions created via hostname and by matched labels are
 // verified.
-//
-// NOTE: This test must NOT be run in parallel because it updates
-// the global [client.PromptWebauthn] in multiple test cases.
 func TestSSHOnMultipleNodes(t *testing.T) {
+	t.Parallel()
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
Updates tests to pass custom `WebauthnLogin` functions through `tsh.CLIConf.WebauthnLogin` and `teleportClient.Config.WebauthnLogin`.

In a follow up PR I will delete `lib/client/export.go`, after updating `e/tool/tsh/tsh_test.go` to use the CLIConf option added in this PR.

Depends on https://github.com/gravitational/teleport/pull/30379

e PR: https://github.com/gravitational/teleport.e/pull/1983