### PR TITLE
AWS OIDC - DeployService: use debug log level for service

### DIFF
--- a/lib/integrations/awsoidc/deployservice_config.go
+++ b/lib/integrations/awsoidc/deployservice_config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gravitational/trace"
 	"gopkg.in/yaml.v2"
 
+	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/config"
 	"github.com/gravitational/teleport/lib/defaults"
@@ -40,6 +41,8 @@ func generateTeleportConfigString(req DeployServiceRequest) (string, error) {
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
+
+	teleportConfig.Logger.Severity = teleport.DebugLevel
 
 	// Disable default services
 	teleportConfig.Auth.EnabledFlag = "no"

--- a/lib/integrations/awsoidc/deployservice_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_config_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDeployServiceConfig(t *testing.T) {
+	t.Run("ensure log level is set to debug", func(t *testing.T) {
+		base64Config, err := generateTeleportConfigString(DeployServiceRequest{
+			ProxyServerHostPort:  "host:port",
+			TeleportIAMTokenName: stringPointer("iam-token"),
+			DeploymentMode:       DatabaseServiceDeploymentMode,
+		})
+		require.NoError(t, err)
+
+		// Config must have the following string:
+		// severity: debug
+
+		base64SeverityDebug := base64.StdEncoding.EncodeToString([]byte("severity: debug"))
+		require.Contains(t, base64Config, base64SeverityDebug)
+	})
+}


### PR DESCRIPTION
Log in debug severity.

The default severity is Info, which might not be enough to understand what's going on when something is not working.

Demo:
<img width="1375" alt="image" src="https://github.com/gravitational/teleport/assets/689271/6240e3eb-0667-49ec-813d-f57a7e13fb23">
