### PR TITLE
OneOff: add success message

### DIFF
--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -234,7 +234,8 @@ func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *htt
 		fmt.Sprintf("--task-role=%s", taskRole),
 	}
 	script, err := oneoff.BuildScript(oneoff.OneOffScriptParams{
-		TeleportArgs: strings.Join(argsList, " "),
+		TeleportArgs:   strings.Join(argsList, " "),
+		SuccessMessage: "Success! You can now go back to the browser to complete the database enrollment.",
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/web/scripts/oneoff/oneoff.go
+++ b/lib/web/scripts/oneoff/oneoff.go
@@ -65,6 +65,9 @@ type OneOffScriptParams struct {
 	// Defaults to v<currentTeleportVersion>
 	// Eg, v13.1.0
 	TeleportVersion string
+
+	// SuccessMessage is a message shown to the user after the one off is completed.
+	SuccessMessage string
 }
 
 // CheckAndSetDefaults checks if the required params ara present.
@@ -87,6 +90,10 @@ func (p *OneOffScriptParams) CheckAndSetDefaults() error {
 
 	if p.TeleportVersion == "" {
 		p.TeleportVersion = "v" + teleport.Version
+	}
+
+	if p.SuccessMessage == "" {
+		p.SuccessMessage = "Completed successfully."
 	}
 
 	return nil

--- a/lib/web/scripts/oneoff/oneoff.sh
+++ b/lib/web/scripts/oneoff/oneoff.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 cdnBaseURL='{{.CDNBaseURL}}'
 teleportVersion='{{.TeleportVersion}}'
+successMessage='{{.SuccessMessage}}'
 
 # shellcheck disable=all
 tempDir=$({{.BinMktemp}} -d)
@@ -44,9 +45,9 @@ function main() {
     mkdir -p ./bin
     mv ./teleport/teleport ./bin/teleport
     echo "> ./bin/teleport ${teleportArgs}"
-    ./bin/teleport ${teleportArgs}
+    ./bin/teleport ${teleportArgs} && echo $successMessage
 
-    popd > /dev/null
+    popd > /dev/null    
 }
 
 main

--- a/lib/web/scripts/oneoff/oneoff_test.go
+++ b/lib/web/scripts/oneoff/oneoff_test.go
@@ -85,6 +85,7 @@ func TestOneOffScript(t *testing.T) {
 			CDNBaseURL:      testServer.URL,
 			TeleportVersion: "v13.1.0",
 			TeleportArgs:    "version",
+			SuccessMessage:  "Test was a success.",
 		})
 		require.NoError(t, err)
 
@@ -108,6 +109,7 @@ func TestOneOffScript(t *testing.T) {
 
 		require.Contains(t, string(out), "> ./bin/teleport version")
 		require.Contains(t, string(out), teleportVersionOutput)
+		require.Contains(t, string(out), "Test was a success.")
 	})
 
 	t.Run("invalid OS", func(t *testing.T) {


### PR DESCRIPTION
When the OneOff script completes, print a success message to let the user know that everything worked as expected and what their next action should be.

This PR also adds a success message when setting up the required IAM Policies for the AWS OIDC Integration DeployService.

Demo
<img width="734" alt="image" src="https://github.com/gravitational/teleport/assets/689271/e0107137-3c53-4024-8220-8acc93d37e0b">
