### PR TITLE
Skip fatal error if `kube_cluster` is not available

### DIFF
--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -143,6 +143,7 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			f.log.WithError(err).Warnf("Failed to create cluster details for cluster %q.", cluster)
 			return trace.Wrap(err)
 		}
+		fmt.Println("#######registered", cluster)
 		f.clusterDetails[cluster] = details
 	}
 	return nil

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -143,7 +143,6 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			f.log.WithError(err).Warnf("Failed to create cluster details for cluster %q.", cluster)
 			return trace.Wrap(err)
 		}
-		fmt.Println("#######registered", cluster)
 		f.clusterDetails[cluster] = details
 	}
 	return nil

--- a/lib/kube/proxy/auth.go
+++ b/lib/kube/proxy/auth.go
@@ -129,18 +129,19 @@ func (f *Forwarder) getKubeDetails(ctx context.Context) error {
 			f.log.WithError(err).Warnf("failed to create KubernetesClusterV3 from credentials for cluster %q.", cluster)
 			continue
 		}
+
 		details, err := newClusterDetails(ctx,
 			clusterDetailsConfig{
 				cluster:   kubeCluster,
 				kubeCreds: clusterCreds,
-				log:       f.log.WithField("cluster", cluster),
+				log:       f.log.WithField("cluster", kubeCluster.GetName()),
 				checker:   f.cfg.CheckImpersonationPermissions,
 				component: serviceType,
 				clock:     f.cfg.Clock,
 			})
 		if err != nil {
 			f.log.WithError(err).Warnf("Failed to create cluster details for cluster %q.", cluster)
-			return trace.Wrap(err, "setting up details for cluster %q", cluster)
+			return trace.Wrap(err)
 		}
 		f.clusterDetails[cluster] = details
 	}

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -119,7 +119,7 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 	// Create the codec factory and the list of supported types for RBAC.
 	codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(creds.getKubeClient())
 	if err != nil {
-		cfg.log.WithError(err).Error("Failed to create cluster schema. Possibly the cluster is offline.")
+		cfg.log.WithError(err).Warn("Failed to create cluster schema. Possibly the cluster is offline.")
 		// If the cluster is offline, we will not be able to create the codec factory
 		// and the list of supported types for RBAC.
 		// We mark the cluster as offline and continue to create the kubeDetails but

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -60,6 +60,11 @@ type kubeDetails struct {
 	// The list is updated periodically to include the latest custom resources
 	// that are added to the cluster.
 	rbacSupportedTypes rbacSupportedResources
+	// isClusterOffline is true if the cluster is offline.
+	// An offline cluster will not be able to serve any requests until it comes back online.
+	// The cluster is marked as offline if the cluster schema cannot be created
+	// and the list of supported types for RBAC cannot be generated.
+	isClusterOffline bool
 
 	cancelFunc context.CancelFunc
 	wg         sync.WaitGroup
@@ -110,11 +115,16 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 		dynLabels.Sync()
 		go dynLabels.Start()
 	}
-
+	var isClusterOffline bool
 	// Create the codec factory and the list of supported types for RBAC.
 	codecFactory, rbacSupportedTypes, err := newClusterSchemaBuilder(creds.getKubeClient())
 	if err != nil {
-		return nil, trace.Wrap(err)
+		cfg.log.WithError(err).Error("Failed to create cluster schema. Possibly the cluster is offline.")
+		// If the cluster is offline, we will not be able to create the codec factory
+		// and the list of supported types for RBAC.
+		// We mark the cluster as offline and continue to create the kubeDetails but
+		// the offline cluster will not be able to serve any requests until it comes back online.
+		isClusterOffline = true
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
@@ -125,6 +135,7 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 		kubeCodecs:         codecFactory,
 		rbacSupportedTypes: rbacSupportedTypes,
 		cancelFunc:         cancel,
+		isClusterOffline:   isClusterOffline,
 	}
 
 	k.wg.Add(1)
@@ -147,6 +158,7 @@ func newClusterDetails(ctx context.Context, cfg clusterDetailsConfig) (_ *kubeDe
 				k.rwMu.Lock()
 				k.kubeCodecs = codecFactory
 				k.rbacSupportedTypes = rbacSupportedTypes
+				k.isClusterOffline = false
 				k.rwMu.Unlock()
 			}
 		}
@@ -166,10 +178,15 @@ func (k *kubeDetails) Close() {
 }
 
 // getClusterSupportedResources returns the codec factory and the list of supported types for RBAC.
-func (k *kubeDetails) getClusterSupportedResources() (*serializer.CodecFactory, rbacSupportedResources) {
+func (k *kubeDetails) getClusterSupportedResources() (*serializer.CodecFactory, rbacSupportedResources, error) {
 	k.rwMu.RLock()
 	defer k.rwMu.RUnlock()
-	return &(k.kubeCodecs), k.rbacSupportedTypes
+	// If the cluster is offline, return an error because we don't have the schema
+	// for the cluster.
+	if k.isClusterOffline {
+		return nil, nil, trace.BadParameter("kubernetes cluster %q is offline", k.kubeCluster.GetName())
+	}
+	return &(k.kubeCodecs), k.rbacSupportedTypes, nil
 }
 
 // getKubeClusterCredentials generates kube credentials for dynamic clusters.

--- a/lib/kube/proxy/cluster_details.go
+++ b/lib/kube/proxy/cluster_details.go
@@ -184,7 +184,7 @@ func (k *kubeDetails) getClusterSupportedResources() (*serializer.CodecFactory, 
 	// If the cluster is offline, return an error because we don't have the schema
 	// for the cluster.
 	if k.isClusterOffline {
-		return nil, nil, trace.BadParameter("kubernetes cluster %q is offline", k.kubeCluster.GetName())
+		return nil, nil, trace.ConnectionProblem(nil, "kubernetes cluster %q is offline", k.kubeCluster.GetName())
 	}
 	return &(k.kubeCodecs), k.rbacSupportedTypes, nil
 }

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -2283,8 +2283,13 @@ func (f *Forwarder) newClusterSessionLocal(ctx context.Context, authCtx authCont
 	if err != nil {
 		return nil, trace.NotFound("kubernetes cluster %q not found", authCtx.kubeClusterName)
 	}
+
+	codecFactory, rbacSupportedResources, err := details.getClusterSupportedResources()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	connCtx, cancel := context.WithCancel(ctx)
-	codecFactory, rbacSupportedResources := details.getClusterSupportedResources()
 	f.log.Debugf("Handling kubernetes session for %v using local credentials.", authCtx)
 	return &clusterSession{
 		parent:                 f,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -2262,8 +2262,11 @@ func (f *Forwarder) newClusterSessionRemoteCluster(ctx context.Context, authCtx 
 func (f *Forwarder) newClusterSessionSameCluster(ctx context.Context, authCtx authContext) (*clusterSession, error) {
 	// Try local creds first
 	sess, localErr := f.newClusterSessionLocal(ctx, authCtx)
-	if localErr == nil {
+	switch {
+	case localErr == nil:
 		return sess, nil
+	case trace.IsConnectionProblem(localErr):
+		return nil, trace.Wrap(localErr)
 	}
 
 	kubeServers := authCtx.kubeServers

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -213,7 +213,7 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (*types
 	if kubeDetails == nil {
 		return nil, apiResource, nil
 	}
-	codecFactory, rbacSupportedTypes := kubeDetails.getClusterSupportedResources()
+	codecFactory, rbacSupportedTypes, _ := kubeDetails.getClusterSupportedResources()
 
 	resourceType, ok := rbacSupportedTypes.getTeleportResourceKindFromAPIResource(apiResource)
 	switch {

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -213,7 +213,11 @@ func getResourceFromRequest(req *http.Request, kubeDetails *kubeDetails) (*types
 	if kubeDetails == nil {
 		return nil, apiResource, nil
 	}
-	codecFactory, rbacSupportedTypes, _ := kubeDetails.getClusterSupportedResources()
+
+	codecFactory, rbacSupportedTypes, err := kubeDetails.getClusterSupportedResources()
+	if err != nil {
+		return nil, apiResource, trace.Wrap(err)
+	}
 
 	resourceType, ok := rbacSupportedTypes.getTeleportResourceKindFromAPIResource(apiResource)
 	switch {


### PR DESCRIPTION
This PR skips a fatal error if the `kube_cluster` isn't available when the service starts and spins a goroutine that tries to register the cluster each 5min until the cluster becomes available.

Once the cluster is available, the goroutine registers it into the targets and exits.