### PR TITLE
Flesh out the Application Access intro

### DIFF
--- a/docs/pages/application-access/introduction.mdx
+++ b/docs/pages/application-access/introduction.mdx
@@ -1,13 +1,15 @@
 ---
 title: Protect Applications with Teleport
-description: How to set up Teleport to protect internal apps and cloud provider APIs
+description: How to set up Teleport to protect applications and cloud provider APIs
 ---
 
-Teleport is designed to provide secure access to cloud provider APIs and
-internal applications. Examples include: 
+Teleport can provide secure access to applications and cloud provider APIs.
+
+Examples include: 
 
 - The AWS management console.
 - The `aws`, `gcloud`, `gsutil`, and `az` CLIs.
+- Applications configured for single sign-on through Okta.
 - Internal control panels.
 - Tools, such as wikis, that are available only when connected to a VPN.
 - Infrastructure dashboards, such as Kubernetes or Grafana.
@@ -40,7 +42,7 @@ internal applications. Examples include:
 Learn how to register an application with Teleport in our [getting started
 guide](./getting-started.mdx).
 
-## Protect cloud provider APIs
+## Cloud provider APIs
 
 You can use Teleport to provide secure access to your cloud provider's APIs.
 This means that you can prevent unauthorized usage of management consoles and
@@ -53,7 +55,7 @@ CLI tools with the same RBAC system you use to protect your infrastructure.
 - [Azure CLI Applications](./cloud-apis/azure.mdx): How to access Azure CLI
   applications and SDKs with Teleport.
 
-## Protect internal applications
+## Internal applications
 
 You can use Teleport to enable secure access to internal applications. For
 example, a load balancer might display network telemetry through a control panel
@@ -71,10 +73,19 @@ These guides explain how to protect internal applications  with Teleport:
 - [Dynamic Registration](./guides/dynamic-registration.mdx): Register/unregister apps without restarting Teleport.
 - [Interactive Lab](https://play.instruqt.com/teleport/invite/rgvuva4gzkon): Try Teleport using our guided Teleport application access lab.
 
-## Use Teleport-signed JSON Web Tokens
+## Teleport-signed JSON Web Tokens
 
 These guides explain how web apps registered with Teleport can use
 Teleport-signed JSON web tokens to implement authentication and authorization.
 
 - [Introduction](./jwt/introduction.mdx): Introduction to JWT tokens with application access.
 - [Elasticsearch](./jwt/elasticsearch.mdx): How to use JWT authentication with Elasticsearch.
+
+## Okta applications
+
+Teleport can import and grant access to Okta applications and user groups. Users
+can access Okta applications through the Teleport Web UI and `tsh`, and
+administrators can manage access to these applications by defining RBAC policies
+in Teleport roles.
+
+Learn more about the [Teleport Okta integration](./okta.mdx).


### PR DESCRIPTION
Fixes #27161

Mention the Okta integration to ensure that the "Application Access" section introduction mentions all major categories of application access features.