### PR TITLE
[v11] fix: Explicitly mention OTPs on tsh/Windows logins

### DIFF
--- a/lib/client/mfa.go
+++ b/lib/client/mfa.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/api/client/proto"
 	wanlib "github.com/gravitational/teleport/lib/auth/webauthn"
 	wancli "github.com/gravitational/teleport/lib/auth/webauthncli"
+	"github.com/gravitational/teleport/lib/auth/webauthnwin"
 	"github.com/gravitational/teleport/lib/utils/prompt"
 )
 
@@ -234,6 +235,13 @@ func PromptMFAChallenge(ctx context.Context, c *proto.MFAAuthenticateChallenge, 
 				prompt.SecondTouchMessage = ""
 			case hasTOTP: // Webauthn + OTP
 				prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key or enter a code from a %sOTP device", promptDevicePrefix, promptDevicePrefix)
+
+				// Customize Windows prompt directly.
+				// Note that the platform popup is a modal and will only go away if
+				// canceled.
+				webauthnwin.PromptPlatformMessage = "Follow the OS dialogs for platform authentication, or enter an OTP code here:"
+				defer webauthnwin.ResetPromptPlatformMessage()
+
 			default: // Webauthn only
 				prompt.FirstTouchMessage = fmt.Sprintf("Tap any %ssecurity key", promptDevicePrefix)
 			}


### PR DESCRIPTION
Backport #30302 to branch/v11

Explicitly mention OTPs, when running `tsh login` on Windows, if the user has
both OTP and WebAuthn registered.

"Platform" logins, like Windows WebAuthn, do not use the "normal" MFA prompts.
This makes sense, as the OS shows its own dialogs. In the case of Touch ID we
*know* the login will succeed, so it just takes over. For Windows, less so.

This customizes the Windows prompt when OTP and WebAuthn are possible. Note that
the Windows platform prompt is a modal and must be canceled before the OTP is
entered, that's why the message says "enter the code _here_".

Example:

```shell
$ tsh.exe login #(...)
> Enter password for Teleport user llama:
> Follow the OS dialogs for platform authentication, or enter an OTP code here:
*ESC to cancel modal*
*type OTP, enter*
> Profile URL: (...)
```

#25051