### PR TITLE
pam: free conversation buffer on error

### DIFF
--- a/lib/pam/pam.c
+++ b/lib/pam/pam.c
@@ -111,6 +111,7 @@ int converse(int n, const struct pam_message **msg, struct pam_response **resp, 
         }
     }
     memset(aresp, 0, n * sizeof *aresp);
+    free(aresp);
     *resp = NULL;
     return PAM_CONV_ERR;
 }


### PR DESCRIPTION
As per pam_conv(3):

> On failure, the conversation function should release any resources
> it has allocated, and return one of the predefined PAM error codes.

Fixes gravitational/teleport-private#661