### PR TITLE
[v13] Fix PIV support for `tsh proxy kube`

### DIFF
--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -41,12 +41,12 @@ like `tctl edit`. With touch required, hardware key support provides better secu
     - Standard Teleport API requests such as `tsh ls`, `tctl create`, and so on.
     - Server access.
     - Database access with `tsh proxy db` instead of `tsh db connect`.
+    - Kubernetes access with `tsh proxy kube` instead of `tsh kube login`.
   
   Not yet supported:
 
     - Teleport Web UI (except for user registration and reset password).
     - Agent forwarding functionality such as `tsh ssh -A`, Proxy Recording mode, and OpenSSH integration.
-    - Kubernetes access.
     - Desktop access.
     - Application access.
 
@@ -238,7 +238,7 @@ Yubikey for Hardware Key support, you might get an error on rare occasions.
 Depending on your settings, you might be asked to tap your Yubikey many times.
 Each tap is necessary to safely authenticate you.
 
-For example, if you have `second_factor: webauthn` set in your `cluster_auth_preference, 
+For example, if you have `second_factor: webauthn` set in your `cluster_auth_preference`, 
 and `require_session_mfa: hardware_key_touch` set on your role,
 you'll see the following output when you first sign in:
 

--- a/lib/client/interfaces.go
+++ b/lib/client/interfaces.go
@@ -419,11 +419,7 @@ func (k *Key) KubeTLSCert(kubeClusterName string) (tls.Certificate, error) {
 	if !ok {
 		return tls.Certificate{}, trace.NotFound("TLS certificate for kubernetes cluster %q not found", kubeClusterName)
 	}
-	keyPem, err := k.PrivateKey.RSAPrivateKeyPEM()
-	if err != nil {
-		return tls.Certificate{}, trace.Wrap(err)
-	}
-	tlsCert, err := keys.X509KeyPair(certPem, keyPem)
+	tlsCert, err := k.PrivateKey.TLSCertificate(certPem)
 	if err != nil {
 		return tls.Certificate{}, trace.Wrap(err)
 	}

--- a/tool/tsh/kube_proxy.go
+++ b/tool/tsh/kube_proxy.go
@@ -38,6 +38,7 @@ import (
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/asciitable"
+	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -171,7 +172,6 @@ func (c *proxyKubeCommand) printTemplate(cf *CLIConf, localProxy *kubeLocalProxy
 
 type kubeLocalProxy struct {
 	tc             *client.TeleportClient
-	profile        *client.ProfileStatus
 	clusters       kubeconfig.LocalProxyClusters
 	kubeConfigPath string
 
@@ -202,12 +202,9 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 		return nil, trace.Wrap(err)
 	}
 
-	keyPem, err := utils.ReadPath(profile.KeyPath())
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	localClientKey, err := keys.ParsePrivateKey(keyPem)
+	// Generate a new private key for the proxy. The client's existing private key may be
+	// a hardware-backed private key, which cannot be added to the local proxy kube config.
+	localClientKey, err := native.GeneratePrivateKey()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -223,7 +220,6 @@ func makeKubeLocalProxy(cf *CLIConf, tc *client.TeleportClient, clusters kubecon
 
 	kubeProxy := &kubeLocalProxy{
 		tc:        tc,
-		profile:   profile,
 		clusters:  clusters,
 		clientKey: localClientKey,
 		localCAs:  cas,


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/30205 to branch/v13

Excludes Teleport Connect Kube access change which is coming in v14