### PR TITLE
update `tsh proxy kube` cluster selection ux

### DIFF
--- a/tool/tsh/common/kube.go
+++ b/tool/tsh/common/kube.go
@@ -1298,11 +1298,12 @@ func (c *kubeLoginCommand) selectorsOrWildcard() string {
 
 // checkClusterSelection checks the kube clusters selected by user input.
 func (c *kubeLoginCommand) checkClusterSelection(cf *CLIConf, tc *client.TeleportClient, clusters types.KubeClusters) error {
-	clusters = filterKubeClusters(c.kubeCluster, clusters)
-	switch {
-	// If the user is trying to login to a specific cluster, check that it
-	// exists and that a cluster matched the name/prefix unambiguously.
-	case c.kubeCluster != "" && len(clusters) == 1:
+	clusters = matchClustersByName(c.kubeCluster, clusters)
+	err := checkClusterSelection(cf, clusters, c.kubeCluster)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if c.kubeCluster != "" && len(clusters) == 1 {
 		// Populate settings using the selected kube cluster, which contains
 		// the full cluster name.
 		c.kubeCluster = clusters[0].GetName()
@@ -1310,14 +1311,28 @@ func (c *kubeLoginCommand) checkClusterSelection(cf *CLIConf, tc *client.Telepor
 		// is automatically selected.
 		cf.KubernetesCluster = c.kubeCluster
 		tc.KubernetesCluster = c.kubeCluster
+	}
+	return nil
+}
+
+func checkClusterSelection(cf *CLIConf, clusters types.KubeClusters, name string) error {
+	switch {
+	// If the user is trying to login to a specific cluster, check that it
+	// exists and that a cluster matched the name/prefix unambiguously.
+	case name != "" && len(clusters) == 1:
 		return nil
 	// allow multiple selection without a name.
-	case c.kubeCluster == "" && len(clusters) > 0:
+	case name == "" && len(clusters) > 0:
 		return nil
 	}
 
 	// anything else is an error.
-	selectors := c.getSelectors()
+	selectors := resourceSelectors{
+		kind:   "kubernetes cluster",
+		name:   name,
+		labels: cf.Labels,
+		query:  cf.PredicateExpression,
+	}
 	if len(clusters) == 0 {
 		if selectors.IsEmpty() {
 			return trace.NotFound("no kubernetes clusters found, check 'tsh kube ls' for a list of known clusters")
@@ -1337,7 +1352,7 @@ func (c *kubeLoginCommand) getSelectors() resourceSelectors {
 	}
 }
 
-func filterKubeClusters(nameOrPrefix string, clusters types.KubeClusters) types.KubeClusters {
+func matchClustersByName(nameOrPrefix string, clusters types.KubeClusters) types.KubeClusters {
 	if nameOrPrefix == "" {
 		return clusters
 	}

--- a/tool/tsh/common/kube_proxy.go
+++ b/tool/tsh/common/kube_proxy.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
+	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/api/utils/keys"
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth/native"
@@ -53,6 +54,9 @@ type proxyKubeCommand struct {
 	namespace         string
 	port              string
 	format            string
+
+	labels              string
+	predicateExpression string
 }
 
 func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
@@ -68,10 +72,15 @@ func newProxyKubeCommand(parent *kingpin.CmdClause) *proxyKubeCommand {
 	c.Flag("kube-namespace", "Configure the default Kubernetes namespace.").Short('n').StringVar(&c.namespace)
 	c.Flag("port", "Specifies the source port used by the proxy listener").Short('p').StringVar(&c.port)
 	c.Flag("format", envVarFormatFlagDescription()).Short('f').Default(envVarDefaultFormat()).EnumVar(&c.format, envVarFormats...)
+	c.Flag("labels", labelHelp).StringVar(&c.labels)
+	c.Flag("query", queryHelp).StringVar(&c.predicateExpression)
 	return c
 }
 
 func (c *proxyKubeCommand) run(cf *CLIConf) error {
+	cf.Labels = c.labels
+	cf.PredicateExpression = c.predicateExpression
+	cf.SiteName = c.siteName
 	tc, err := makeClient(cf)
 	if err != nil {
 		return trace.Wrap(err)
@@ -106,22 +115,36 @@ func (c *proxyKubeCommand) run(cf *CLIConf) error {
 }
 
 func (c *proxyKubeCommand) prepare(cf *CLIConf, tc *client.TeleportClient) (*clientcmdapi.Config, kubeconfig.LocalProxyClusters, error) {
-	defaultConfig, err := kubeconfig.Load("")
+	defaultConfig, err := kubeconfig.Load(getKubeConfigPath(cf, ""))
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
 
 	// Use kube clusters from arg.
-	if len(c.kubeClusters) > 0 {
-		if c.siteName == "" {
-			c.siteName = tc.SiteName
+	if len(c.kubeClusters) > 0 || cf.Labels != "" || cf.PredicateExpression != "" {
+		_, kubeClusters, err := fetchKubeClusters(cf.Context, tc)
+		if err != nil {
+			return nil, nil, trace.Wrap(err)
 		}
-
+		switch len(c.kubeClusters) {
+		case 0:
+			// if no names are given, check just the labels/predicate selection.
+			if err := checkClusterSelection(cf, kubeClusters, ""); err != nil {
+				return nil, nil, trace.Wrap(err)
+			}
+		default:
+			// otherwise, check that each name matches exactly one kube cluster.
+			matchMap := matchClustersByNames(kubeClusters, c.kubeClusters...)
+			if err := checkMultipleClusterSelections(cf, matchMap); err != nil {
+				return nil, nil, trace.Wrap(err)
+			}
+			kubeClusters = combineMatchedClusters(matchMap)
+		}
 		var clusters kubeconfig.LocalProxyClusters
-		for _, kubeCluster := range c.kubeClusters {
+		for _, kc := range kubeClusters {
 			clusters = append(clusters, kubeconfig.LocalProxyCluster{
-				TeleportCluster:   c.siteName,
-				KubeCluster:       kubeCluster,
+				TeleportCluster:   tc.SiteName,
+				KubeCluster:       kc.GetName(),
 				Impersonate:       c.impersonateUser,
 				ImpersonateGroups: c.impersonateGroups,
 				Namespace:         c.namespace,
@@ -495,6 +518,39 @@ func issueKubeCert(ctx context.Context, tc *client.TeleportClient, proxy *client
 	cert.Leaf = leaf
 
 	return cert, nil
+}
+
+// checkMultipleClusterSelections takes a map of name selectors to matched
+// clusters and checks that each matching is valid.
+func checkMultipleClusterSelections(cf *CLIConf, matchMap map[string]types.KubeClusters) error {
+	for name, clusters := range matchMap {
+		err := checkClusterSelection(cf, clusters, name)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+	}
+	return nil
+}
+
+// combineMatchedClusters combineMatchedClusters takes a map from name selector
+// to matched clusters and combines all the matched clusters into a deduplicated
+// slice.
+func combineMatchedClusters(matchMap map[string]types.KubeClusters) types.KubeClusters {
+	var out types.KubeClusters
+	for _, clusters := range matchMap {
+		out = append(out, clusters...)
+	}
+	return types.DeduplicateKubeClusters(out)
+}
+
+// matchClustersByNames maps each name to the clusters it matches by exact name
+// or by prefix.
+func matchClustersByNames(clusters types.KubeClusters, names ...string) map[string]types.KubeClusters {
+	matchesForNames := make(map[string]types.KubeClusters)
+	for _, name := range names {
+		matchesForNames[name] = matchClustersByName(name, clusters)
+	}
+	return matchesForNames
 }
 
 // proxyKubeTemplate is the message that gets printed to a user when a kube proxy is started.


### PR DESCRIPTION
This PR allows a user to run `tsh proxy kube` and choose kube cluster(s) by labels, query predicate, name, and/or prefix of name.
Also fixes the `--cluster` flag not being propagated.

`tsh proxy kube` already allowed multiple names to be specified, e.g. `tsh proxy kube name1 name2 name3` - this PR will allow matching those names by unambiguous prefix individually. If any of them are ambiguous, it's an error, which is consistent with other commands.

Part of the implementation for [RFD 129](https://github.com/gravitational/teleport/blob/master/rfd/0129-discovery-name-templating.md).

Related issue:
- https://github.com/gravitational/teleport/issues/22438

Changelog: `tsh proxy kube` now supports `--labels` and `--query` optional arguments.