### PR TITLE
Semver version validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1102,6 +1102,7 @@ $(VERSRC): Makefile
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
+	cd build.assets/tooling && go run ./cmd/check -check valid -tag $(GITTAG)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))

--- a/build.assets/tooling/cmd/check/main_test.go
+++ b/build.assets/tooling/cmd/check/main_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCheckPrerelease(t *testing.T) {
+func TestCheckIsBareRelease(t *testing.T) {
 	tests := []struct {
 		desc    string
 		tag     string
@@ -50,10 +50,15 @@ func TestCheckPrerelease(t *testing.T) {
 			tag:     "v8.0.1",
 			wantErr: require.NoError,
 		},
+		{
+			desc:    "fail-leading-zero",
+			tag:     "v13.3.3-tcsc.02",
+			wantErr: require.Error,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.desc, func(t *testing.T) {
-			test.wantErr(t, checkPrerelease(test.tag))
+			test.wantErr(t, checkIsBareRelease(test.tag))
 		})
 	}
 

--- a/version.mk
+++ b/version.mk
@@ -30,7 +30,7 @@ func init() { Gitref = \"$(GITREF)\" }\n"
 # setver updates version.go and gitref.go with VERSION and GITREF vars
 #
 .PHONY:setver
-setver: helm-version tsh-version
+setver: validate-semver helm-version tsh-version
 	@printf $(VERSION_GO) | gofmt > version.go
 	@printf $(API_VERSION_GO) | gofmt > ./api/version.go
 	@printf $(UPDATER_VERSION_GO) | gofmt > ./integrations/kube-agent-updater/version.go
@@ -56,3 +56,7 @@ PLIST_FILES := $(abspath $(TSH_APP_PLISTS))
 .PHONY:tsh-version
 tsh-version:
 	cd build.assets/tooling && go run ./cmd/update-plist-version $(VERSION) $(PLIST_FILES)
+
+.PHONY:validate-semver
+validate-semver:
+	cd build.assets/tooling && go run ./cmd/check -check valid -tag v$(VERSION)


### PR DESCRIPTION
Tagging a release with an invalid semver string (especially an _almost-but-
not-quite-valid_ semver string) can cause an incorrect environment to be
selected when publishing packages during promotion, with the attendant 
risk of polluting production artefact repositories.

This change attempts to force the use of correctly-formed semver strings by
 - validating the semver string on application (i.e. as part of `make version`)
 - validating that the GITTAG value used to trigger a build is valid semver, and
 - as a harm reduction measure, changing the semver `check` tool to interpret 
   an invalid semver string as if it had pre-release or build metadata.
  This is a backstop, just in case a malformed tag sneaks through outside of
  our automation.
  
Changelog: none