### PR TITLE
[v13] chore: Bump golangci-lint to v1.54.1

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -294,7 +294,7 @@ RUN go install github.com/google/addlicense@v1.0.0
 RUN go install github.com/daixiang0/gci@v0.11.0
 
 # Install golangci-lint.
-RUN TAG='v1.54.0' && \
+RUN TAG='v1.54.1' && \
     curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
     sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
 


### PR DESCRIPTION
Backport #30435 to branch/v13.