### PR TITLE
[v13] Redirect directly to Okta apps from proxy.

### DIFF
--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -130,7 +131,7 @@ func NewHandler(ctx context.Context, c *HandlerConfig) (*Handler, error) {
 	h.router.UseRawPath = true
 	h.router.POST("/x-teleport-auth", makeRouterHandler(h.handleAuth))
 	h.router.GET("/teleport-logout", h.withRouterAuth(h.handleLogout))
-	h.router.NotFound = h.withAuth(h.handleForward)
+	h.router.NotFound = h.withAuth(h.handleHttp)
 
 	return h, nil
 }
@@ -281,8 +282,49 @@ func (h *Handler) HealthCheckAppServer(ctx context.Context, publicAddr string, c
 	return nil
 }
 
-// handleForward forwards the request to the application service.
-func (h *Handler) handleForward(w http.ResponseWriter, r *http.Request, session *session) error {
+// handleHttp forwards the request to the application service or redirects
+// to the application directly.
+func (h *Handler) handleHttp(w http.ResponseWriter, r *http.Request, session *session) error {
+	var redirectURI string
+	session.tr.servers.Range(func(serverID, appServerInterface any) bool {
+		appServer, ok := appServerInterface.(types.AppServer)
+		if !ok {
+			h.log.Warnf("Failed to load AppServer, invalid type %T", appServerInterface)
+			return true
+		}
+
+		// If encounter an app server that is to be redirected to, stop iterating.
+		if redirectInsteadOfForward(appServer) {
+			redirectURI = appServer.GetApp().GetURI()
+			return false
+		}
+
+		return true
+	})
+
+	if redirectURI != "" {
+		http.Redirect(w, r, redirectURI, http.StatusFound)
+		return nil
+	}
+
+	if r.Body != nil {
+		// We replace the request body with a NopCloser so that the request body can
+		// be closed multiple times. This is needed because Go's HTTP RoundTripper
+		// will close the request body once called, even if the request
+		// fails. This is a problem because fwd can retry the request if no app servers
+		// are available. This retry process happens in `handleForwardError`.
+		// If the request body is closed, the retry will fail.
+		// Because the request body is closed after the first request, we need to
+		// replace the request body with a NopCloser so that the closed body can be
+		// used again and finally closed when the request handling finishes.
+		// Teleport only retries requests if DialContext returns a trace.ConnectionProblem.
+		// Because of this,  we can safely assume that the request body is never read
+		// under those conditions so the retry attempt will start reading from the beginning
+		// of the request body.
+		originalBody := r.Body
+		defer originalBody.Close()
+		r.Body = io.NopCloser(originalBody)
+	}
 	session.fwd.ServeHTTP(w, r)
 	return nil
 }
@@ -618,4 +660,10 @@ func makeAppRedirectURL(r *http.Request, proxyPublicAddr, hostname string) strin
 	}
 
 	return u.String()
+}
+
+// redirectInsteadOfForward returns true if an application shouldn't be forwarded, but
+// should be redirected directly to the public address instead.
+func redirectInsteadOfForward(appServer types.AppServer) bool {
+	return appServer.GetApp().Origin() == types.OriginOkta
 }

--- a/lib/web/app/match.go
+++ b/lib/web/app/match.go
@@ -101,6 +101,11 @@ func MatchName(name string) Matcher {
 // doesn't return any error.
 func MatchHealthy(proxyClient reversetunnel.Tunnel, clusterName string) Matcher {
 	return func(ctx context.Context, appServer types.AppServer) bool {
+		// Redirected apps don't need to be dialed, as the proxy will redirect to them.
+		if redirectInsteadOfForward(appServer) {
+			return true
+		}
+
 		conn, err := dialAppServer(ctx, proxyClient, clusterName, appServer)
 		if err != nil {
 			return false


### PR DESCRIPTION
Backporting https://github.com/gravitational/teleport/pull/30293 to branch/v13