### PR TITLE
[Assist] Add Assist to the terminal UI

### DIFF
--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/ActionBar.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/ActionBar.tsx
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+import { Copy, Cross } from 'design/Icon';
+import { BrainIcon } from 'design/SVGIcon';
+
+interface Position {
+  top: number;
+  left: number;
+}
+
+interface ActionBarProps {
+  position: Position;
+  visible: boolean;
+  onAskAssist: () => void;
+  onClose: () => void;
+  onCopy: () => void;
+}
+
+const Container = styled.div`
+  position: absolute;
+  background: ${p => p.theme.colors.levels.popout};
+  border: 1px solid ${p => p.theme.colors.spotBackground[1]};
+  box-shadow: 0 0 10px ${p => p.theme.colors.spotBackground[1]};
+  border-radius: 10px;
+  line-height: 1;
+  z-index: 100;
+  transform: translate(-50%, 0);
+  display: flex;
+  overflow: hidden;
+  padding: ${p => p.theme.space[1] / 2}px;
+  transition: opacity 0.2s ease-in-out;
+  opacity: ${p => (p.visible ? 1 : 0)};
+  pointer-events: ${p => (p.visible ? 'auto' : 'none')};
+`;
+
+const Button = styled.div`
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space[2]}px;
+  padding: ${p => p.theme.space[1]}px ${p => p.theme.space[2]}px;
+  border-radius: 5px;
+  cursor: pointer;
+
+  &:hover {
+    background: ${p => p.theme.colors.spotBackground[0]};
+  }
+`;
+
+const CloseButton = styled(Button)`
+  padding: ${p => p.theme.space[2]}px;
+`;
+
+export function ActionBar(props: ActionBarProps) {
+  const left = Math.max(props.position.left, 110); // make sure the bar is not off the edge of the screen
+
+  function handleAskAssist() {
+    props.onClose();
+    props.onAskAssist();
+  }
+
+  function handleCopy() {
+    props.onClose();
+    props.onCopy();
+  }
+
+  return (
+    <Container
+      visible={props.visible}
+      style={{ left, top: props.position.top }}
+    >
+      <Button onClick={handleCopy}>
+        <Copy size={16} />
+        Copy
+      </Button>
+
+      <Button onClick={handleAskAssist}>
+        <BrainIcon size={14} />
+        Ask Assist
+      </Button>
+
+      <CloseButton onClick={props.onClose}>
+        <Cross size={14} />
+      </CloseButton>
+    </Container>
+  );
+}

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/MessageBox.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/MessageBox.tsx
@@ -1,0 +1,111 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { ChangeEvent, useEffect, useRef, useState } from 'react';
+import styled from 'styled-components';
+
+import { useTerminalAssist } from 'teleport/Console/DocumentSsh/TerminalAssist/TerminalAssistContext';
+
+interface MessageBoxProps {
+  onUseCommand: (command: string) => void;
+}
+
+const Container = styled.div`
+  padding: 0 ${p => p.theme.space[2]}px ${p => p.theme.space[2] - 2}px
+    ${p => p.theme.space[2]}px;
+`;
+
+const Input = styled.input`
+  width: 100%;
+  background: ${props => props.theme.colors.levels.popout};
+  color: ${props => props.theme.colors.text.main};
+  border: 2px solid ${props => props.theme.colors.spotBackground[1]};
+  border-radius: 18px;
+  resize: none;
+  padding: ${p => p.theme.space[3]}px;
+  font-size: 14px;
+  line-height: 1;
+  box-sizing: border-box;
+  overflow-y: hidden;
+
+  &:focus {
+    outline: none;
+    border-color: ${props => props.theme.colors.spotBackground[2]};
+  }
+
+  ::placeholder {
+    color: ${props => props.theme.colors.text.muted};
+  }
+`;
+
+export function MessageBox(props: MessageBoxProps) {
+  const { close, getLastSuggestedCommand, loading, send, visible } =
+    useTerminalAssist();
+
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  const [value, setValue] = useState('');
+
+  function handleChange(event: ChangeEvent<HTMLTextAreaElement>) {
+    setValue(event.target.value);
+  }
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (!visible || event.key !== 'Enter') {
+      return;
+    }
+
+    if (event.metaKey) {
+      const lastCommand = getLastSuggestedCommand();
+
+      if (lastCommand) {
+        close();
+
+        props.onUseCommand(lastCommand);
+      }
+
+      return;
+    }
+
+    if (loading || !value) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    send(value);
+    setValue('');
+  }
+
+  useEffect(() => {
+    if (visible) {
+      ref.current.focus();
+    }
+  }, [visible]);
+
+  return (
+    <Container>
+      <Input
+        ref={ref}
+        value={value}
+        onKeyDown={handleKeyDown}
+        onChange={handleChange}
+        placeholder="Ask a question..."
+      />
+    </Container>
+  );
+}

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/MessageBox.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/MessageBox.tsx
@@ -24,8 +24,8 @@ interface MessageBoxProps {
 }
 
 const Container = styled.div`
-  padding: 0 ${p => p.theme.space[2]}px ${p => p.theme.space[2] - 2}px
-    ${p => p.theme.space[2]}px;
+  padding: 0 ${p => p.theme.space[2]}px
+    ${p => p.theme.space[2] + p.theme.space[1]}px ${p => p.theme.space[2]}px;
 `;
 
 const Input = styled.input`

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/MessageItem.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/MessageItem.tsx
@@ -1,0 +1,187 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import styled from 'styled-components';
+
+import {
+  Message,
+  MessageType,
+} from 'teleport/Console/DocumentSsh/TerminalAssist/types';
+import {
+  Key,
+  KeyShortcut,
+} from 'teleport/Console/DocumentSsh/TerminalAssist/Shared';
+import { getMetaKeySymbol } from 'teleport/Console/DocumentSsh/TerminalAssist/utils';
+
+interface MessageItemProps {
+  message: Message;
+  onUseCommand: (command: string) => void;
+  lastMessage?: boolean;
+}
+
+const UserMessage = styled.div`
+  padding: ${p => p.theme.space[2]}px ${p => p.theme.space[3]}px;
+  border: 1px solid ${p => p.theme.colors.spotBackground[0]};
+  box-shadow: 0 0 3px ${p => p.theme.colors.spotBackground[0]};
+  border-radius: 7px;
+`;
+
+const MessageContainer = styled.div`
+  display: flex;
+  width: 100%;
+`;
+
+const UserMessageContainer = styled(MessageContainer)`
+  justify-content: flex-end;
+`;
+
+const Explanation = styled.div`
+  background: ${props => props.theme.colors.spotBackground[0]};
+  border-radius: 15px;
+  padding: ${p => p.theme.space[3]}px;
+  overflow: hidden;
+`;
+
+const Reasoning = styled.div`
+  font-size: 14px;
+  border-left: 2px solid ${p => p.theme.colors.spotBackground[1]};
+  padding: ${p => p.theme.space[1]}px 0 ${p => p.theme.space[1]}px
+    ${p => p.theme.space[2]}px;
+  margin: ${p => p.theme.space[1]}px 0;
+`;
+
+const SuggestedCommand = styled.div`
+  background: ${props => props.theme.colors.spotBackground[0]};
+  border-radius: 15px;
+  padding: ${p => p.theme.space[3]}px;
+  overflow: hidden;
+`;
+
+const SuggestedCommandTitle = styled.div`
+  font-weight: 700;
+  color: ${props => props.theme.colors.text.slightlyMuted};
+`;
+
+const Command = styled.pre.attrs({
+  'data-scrollbar': 'default',
+})`
+  margin: 0 -${p => p.theme.space[2]}px -${p => p.theme.space[2]}px;
+  padding: ${p => p.theme.space[2]}px;
+  font-family: ${p => p.theme.fonts.mono};
+  overflow-x: auto;
+  font-size: 13px;
+`;
+
+const SuggestedCommandButtons = styled.div`
+  display: flex;
+  gap: ${p => p.theme.space[2]}px;
+  margin-top: ${p => p.theme.space[3]}px;
+`;
+
+const SuggestedCommandButton = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space[2]}px;
+  font-size: 14px;
+  padding: ${p => p.theme.space[2]}px ${p => p.theme.space[3]}px;
+  border: 1px solid ${p => p.theme.colors.spotBackground[1]};
+  border-radius: 7px;
+  line-height: 1;
+  font-weight: bold;
+  cursor: pointer;
+
+  ${KeyShortcut} {
+    background: ${p => p.theme.colors.spotBackground[0]};
+    border-color: ${p => p.theme.colors.spotBackground[0]};
+    color: ${p => p.theme.colors.text.main};
+    opacity: 0.7;
+
+    span {
+      opacity: 0.5;
+    }
+  }
+`;
+
+const UseCommandButton = styled(SuggestedCommandButton)`
+  background: ${p => p.theme.colors.buttons.primary.default};
+  color: ${p => p.theme.colors.buttons.primary.text};
+
+  ${KeyShortcut} {
+    background: ${p => p.theme.colors.buttons.primary.default};
+    border-color: ${p => p.theme.colors.buttons.primary.default};
+  }
+
+  ${Key} {
+    color: ${p => p.theme.colors.buttons.primary.text};
+  }
+`;
+
+export function MessageItem(props: MessageItemProps) {
+  function handleUseCommand() {
+    if (props.message.type !== MessageType.SuggestedCommand) {
+      return;
+    }
+
+    props.onUseCommand(props.message.command);
+  }
+
+  if (props.message.type === MessageType.User) {
+    return (
+      <UserMessageContainer>
+        <UserMessage>{props.message.value}</UserMessage>
+      </UserMessageContainer>
+    );
+  }
+
+  if (props.message.type === MessageType.SuggestedCommand) {
+    return (
+      <MessageContainer>
+        <SuggestedCommand>
+          <SuggestedCommandTitle>Suggested command</SuggestedCommandTitle>
+
+          <Reasoning>{props.message.reasoning}</Reasoning>
+
+          <Command>{props.message.command}</Command>
+
+          <SuggestedCommandButtons>
+            <UseCommandButton onClick={handleUseCommand}>
+              Use
+              {props.lastMessage && (
+                <KeyShortcut>
+                  <Key>
+                    {getMetaKeySymbol()}
+                    <span>+</span>⏎
+                  </Key>
+                </KeyShortcut>
+              )}
+            </UseCommandButton>
+          </SuggestedCommandButtons>
+        </SuggestedCommand>
+      </MessageContainer>
+    );
+  }
+
+  if (props.message.type === MessageType.Explanation) {
+    return (
+      <MessageContainer>
+        <Explanation>{props.message.value}</Explanation>
+      </MessageContainer>
+    );
+  }
+
+  return null;
+}

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/Shared.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/Shared.tsx
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import styled from 'styled-components';
+
+export const Key = styled.div`
+  line-height: 1;
+  background: ${p => p.theme.colors.spotBackground[1]};
+  padding: 2px;
+  border: 1px solid ${p => p.theme.colors.spotBackground[1]};
+  border-radius: ${p => p.theme.space[1]}px;
+  font-weight: 700;
+  color: ${p => p.theme.colors.text.muted};
+`;
+
+export const KeyShortcut = styled.div`
+  display: flex;
+  align-items: center;
+  gap: ${p => p.theme.space[1]}px;
+  opacity: 0.5;
+  font-size: 12px;
+  pointer-events: none;
+  user-select: none;
+  transition: opacity 0.2s ease-in-out;
+`;

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssist.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssist.tsx
@@ -1,0 +1,205 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { useEffect } from 'react';
+import styled from 'styled-components';
+
+import { BrainIcon, CloseIcon } from 'design/SVGIcon';
+
+import { HeaderIcon, Tooltip } from 'teleport/Assist/shared';
+import {
+  TypingContainer,
+  TypingDot,
+} from 'teleport/Assist/Conversation/Typing';
+import { useTerminalAssist } from 'teleport/Console/DocumentSsh/TerminalAssist/TerminalAssistContext';
+import {
+  Key,
+  KeyShortcut,
+} from 'teleport/Console/DocumentSsh/TerminalAssist/Shared';
+import { MessageItem } from 'teleport/Console/DocumentSsh/TerminalAssist/MessageItem';
+import { getMetaKeySymbol } from 'teleport/Console/DocumentSsh/TerminalAssist/utils';
+import { MessageBox } from 'teleport/Console/DocumentSsh/TerminalAssist/MessageBox';
+
+interface TerminalAssistProps {
+  onUseCommand: (command: string) => void;
+  onClose: () => void;
+}
+
+const Container = styled.div`
+  position: fixed;
+  bottom: 10px;
+  right: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: ${p => p.theme.space[2]}px;
+  z-index: 1000;
+`;
+
+const Button = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: opacity 0.2s ease-in-out;
+  cursor: pointer;
+  width: 50px;
+  height: 50px;
+  position: relative;
+  z-index: 2;
+
+  svg path {
+    fill: white;
+  }
+`;
+
+const Background = styled.div`
+  position: absolute;
+  bottom: 32px;
+  right: 2px;
+  border-radius: ${p => (p.visible ? '25px' : '25px')};
+  background: ${p => (p.visible ? p.theme.colors.levels.popout : '#311c79')};
+  width: ${p => (p.visible ? '500px' : '50px')};
+  height: ${p => (p.visible ? '600px' : '50px')};
+  transition: all
+    ${p =>
+      p.visible
+        ? '0.5s cubic-bezier(0.33, 1.2, 0.68, 1)'
+        : '0.3s cubic-bezier(0.33, 1, 0.68, 1)'};
+  transform-origin: bottom right;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.4);
+`;
+
+const ChatContainer = styled.div`
+  position: absolute;
+  bottom: 30px;
+  right: 2px;
+  width: 500px;
+  height: 600px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  opacity: ${p => (p.visible ? 1 : 0)};
+  transition: ${p => (p.visible ? 'opacity 0.5s ease-in-out' : 'none')};
+  transition-delay: 0.2s;
+  box-sizing: border-box;
+`;
+
+const Header = styled.header`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: ${p => p.theme.space[2]}px ${p => p.theme.space[3]}px
+    ${p => p.theme.space[2]}px ${p => p.theme.space[2] + p.theme.space[3]}px;
+  border-bottom: 1px solid ${p => p.theme.colors.spotBackground[0]};
+  user-select: none;
+  box-sizing: border-box;
+`;
+
+const ScrollArea = styled.div.attrs({
+  'data-scrollbar': 'default',
+})`
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column-reverse;
+  padding: 0 ${p => p.theme.space[2]}px ${p => p.theme.space[2]}px
+    ${p => p.theme.space[2]}px;
+  gap: ${p => p.theme.space[2]}px;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  font-size: 16px;
+`;
+
+export function TerminalAssist(props: TerminalAssistProps) {
+  const { close, loading, messages, open, visible } = useTerminalAssist();
+
+  useEffect(() => {
+    function keyDownHandler(e: KeyboardEvent) {
+      if (e.metaKey && e.key === '/') {
+        e.preventDefault();
+        e.stopPropagation();
+
+        visible ? close() : open();
+      }
+    }
+
+    window.addEventListener('keydown', keyDownHandler);
+
+    return () => {
+      window.removeEventListener('keydown', keyDownHandler);
+    };
+  }, [visible]);
+
+  function handleUseCommand(command: string) {
+    props.onUseCommand(command);
+    close();
+  }
+
+  return (
+    <Container>
+      <Background visible={visible} />
+
+      <ChatContainer visible={visible}>
+        <Header>
+          <Title>Assist</Title>
+
+          <HeaderIcon onClick={close}>
+            <CloseIcon size={24} />
+
+            <Tooltip position="right">Hide Assist</Tooltip>
+          </HeaderIcon>
+        </Header>
+
+        <ScrollArea>
+          {loading && (
+            <TypingContainer>
+              <TypingDot style={{ animationDelay: '0s' }} />
+              <TypingDot style={{ animationDelay: '0.2s' }} />
+              <TypingDot style={{ animationDelay: '0.4s' }} />
+            </TypingContainer>
+          )}
+
+          {messages.map((m, i) => (
+            <MessageItem
+              key={i}
+              message={m}
+              lastMessage={i === 0}
+              onUseCommand={handleUseCommand}
+            />
+          ))}
+        </ScrollArea>
+
+        <MessageBox onUseCommand={handleUseCommand} />
+      </ChatContainer>
+
+      <Button
+        style={{
+          opacity: visible ? 0 : 1,
+          pointerEvents: visible ? 'none' : 'auto',
+        }}
+        onClick={() => open()}
+      >
+        <BrainIcon size={22} />
+      </Button>
+
+      <KeyShortcut style={{ opacity: visible ? 0 : 0.5 }}>
+        <Key>{getMetaKeySymbol()}</Key>+
+        <Key style={{ padding: '2px 6px' }}>/</Key>
+      </KeyShortcut>
+    </Container>
+  );
+}

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssistContext.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssistContext.tsx
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, {
+  createContext,
+  PropsWithChildren,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { Author, ServerMessage } from 'teleport/Assist/types';
+import { getAccessToken, getHostName } from 'teleport/services/api';
+import useStickyClusterId from 'teleport/useStickyClusterId';
+import cfg from 'teleport/config';
+import {
+  ExplanationMessage,
+  Message,
+  MessageType,
+  SuggestedCommandMessage,
+  UserMessage,
+} from 'teleport/Console/DocumentSsh/TerminalAssist/types';
+
+interface TerminalAssistContextValue {
+  close: () => void;
+  explainSelection: (selection: string) => void;
+  getLastSuggestedCommand: () => string;
+  loading: boolean;
+  messages: Message[];
+  open: () => void;
+  send: (message: string) => void;
+  visible: boolean;
+}
+
+const TerminalAssistContext = createContext<TerminalAssistContextValue>(null);
+
+export function TerminalAssistContextProvider(
+  props: PropsWithChildren<unknown>
+) {
+  const { clusterId } = useStickyClusterId();
+
+  const [visible, setVisible] = useState(false);
+
+  const socketRef = useRef<WebSocket | null>(null);
+  const socketUrl = cfg.getAssistActionWebSocketUrl(
+    getHostName(),
+    clusterId,
+    getAccessToken(),
+    'ssh-cmdgen'
+  );
+
+  const [loading, setLoading] = useState(false);
+
+  // note: we store messages in reverse order so that we can use flex-direction: column-reverse
+  // to automatically scroll to the bottom of the list
+  const [messages, setMessages] = useState<Message[]>([]);
+
+  useEffect(() => {
+    socketRef.current = new WebSocket(socketUrl);
+
+    socketRef.current.onmessage = e => {
+      const data = JSON.parse(e.data) as ServerMessage;
+      const payload = JSON.parse(data.payload) as {
+        action: string;
+        input: string;
+        reasoning: string;
+      };
+      const input = JSON.parse(payload.input) as {
+        command: string;
+      };
+
+      const message: SuggestedCommandMessage = {
+        author: Author.Teleport,
+        type: MessageType.SuggestedCommand,
+        command: input.command,
+        reasoning: payload.reasoning,
+      };
+
+      setLoading(false);
+      setMessages(m => [message, ...m]);
+    };
+  }, []);
+
+  function close() {
+    setVisible(false);
+  }
+
+  function open() {
+    setVisible(true);
+  }
+
+  function explainSelection(selection: string) {
+    if (!visible) {
+      setVisible(true);
+    }
+
+    setLoading(true);
+
+    const encodedOutput = btoa(selection);
+
+    const socketUrl = cfg.getAssistActionWebSocketUrl(
+      getHostName(),
+      clusterId,
+      getAccessToken(),
+      'ssh-explain'
+    );
+
+    const ws = new WebSocket(socketUrl);
+
+    ws.onopen = () => {
+      ws.send(encodedOutput);
+    };
+
+    ws.onmessage = event => {
+      const message = event.data;
+      const msg = JSON.parse(message) as ServerMessage;
+
+      const explanation: ExplanationMessage = {
+        author: Author.Teleport,
+        type: MessageType.Explanation,
+        value: msg.payload,
+      };
+
+      setMessages(m => [explanation, ...m]);
+      setLoading(false);
+
+      ws.close();
+    };
+  }
+
+  function send(message: string) {
+    setLoading(true);
+
+    const userMessage: UserMessage = {
+      author: Author.User,
+      type: MessageType.User,
+      value: message,
+    };
+
+    socketRef.current.send(message);
+
+    setMessages(m => [userMessage, ...m]);
+  }
+
+  function getLastSuggestedCommand() {
+    if (messages[0] && messages[0].type === MessageType.SuggestedCommand) {
+      return (messages[0] as SuggestedCommandMessage).command;
+    }
+  }
+
+  return (
+    <TerminalAssistContext.Provider
+      value={{
+        close,
+        explainSelection,
+        getLastSuggestedCommand,
+        loading,
+        messages,
+        open,
+        send,
+        visible,
+      }}
+    >
+      {props.children}
+    </TerminalAssistContext.Provider>
+  );
+}
+
+export function useTerminalAssist() {
+  return useContext(TerminalAssistContext);
+}

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/index.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { TerminalAssist } from './TerminalAssist';

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/types.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Author } from 'teleport/Assist/types';
+
+export enum MessageType {
+  User,
+  SuggestedCommand,
+  Explanation,
+}
+
+export interface UserMessage {
+  author: Author.User;
+  type: MessageType.User;
+  value: string;
+}
+
+export interface SuggestedCommandMessage {
+  author: Author.Teleport;
+  type: MessageType.SuggestedCommand;
+  command: string;
+  reasoning: string;
+}
+
+export interface ExplanationMessage {
+  author: Author.Teleport;
+  type: MessageType.Explanation;
+  value: string;
+}
+
+export type Message =
+  | UserMessage
+  | SuggestedCommandMessage
+  | ExplanationMessage;

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/utils.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/utils.ts
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
+import { getPlatform } from 'design/theme/utils';
+
 export function getMetaKeySymbol() {
-  if (
-    navigator.userAgentData?.platform === 'macOS' ||
-    navigator.platform.includes('Mac') // deprecated but Safari doesn't support navigator.userAgentData
-  ) {
+  const platform = getPlatform();
+
+  if (platform.isMac) {
     return '⌘';
   }
 

--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/utils.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/utils.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function getMetaKeySymbol() {
+  if (
+    navigator.userAgentData?.platform === 'macOS' ||
+    navigator.platform.includes('Mac') // deprecated but Safari doesn't support navigator.userAgentData
+  ) {
+    return '⌘';
+  }
+
+  return '^';
+}

--- a/web/packages/teleport/src/config.ts
+++ b/web/packages/teleport/src/config.ts
@@ -733,6 +733,25 @@ const cfg = {
     );
   },
 
+  getAssistActionWebSocketUrl(
+    hostname: string,
+    clusterId: string,
+    accessToken: string,
+    action: string
+  ) {
+    const searchParams = new URLSearchParams();
+
+    searchParams.set('access_token', accessToken);
+    searchParams.set('action', action);
+
+    return (
+      generatePath(cfg.api.assistConversationWebSocketPath, {
+        hostname,
+        clusterId,
+      }) + `?${searchParams.toString()}`
+    );
+  },
+
   getAssistConversationHistoryUrl(conversationId: string) {
     return generatePath(cfg.api.assistConversationHistoryPath, {
       conversationId,


### PR DESCRIPTION
This adds an Assist chatbox to the terminal UI if Assist has been enabled for the cluster

<img width="537" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/8d46f9ec-c5ef-4a04-872e-d8adeea6311c">

It also adds a new action bar when text has been selected in the terminal, allowing users to copy the output or ask assist what it means.

<img width="503" alt="image" src="https://github.com/gravitational/teleport/assets/7922109/6140f80c-a60f-4bcf-b79d-aa2a024d6aad">
