### PR TITLE
Fixes script-src directive

### DIFF
--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -64,7 +64,6 @@ type cspMap map[string][]string
 
 var defaultContentSecurityPolicy = cspMap{
 	"default-src": {"'self'"},
-	"script-src":  {"'self'"},
 	// specify CSP directives not covered by `default-src`
 	"base-uri":        {"'self'"},
 	"form-action":     {"'self'"},
@@ -80,12 +79,12 @@ var defaultConnectSrc = cspMap{"connect-src": {"'self'", "wss:"}}
 
 var stripeSecurityPolicy = cspMap{
 	// auto-pay plans in Cloud use stripe.com to manage billing information
-	"script-src": {"https://js.stripe.com"},
+	"script-src": {"'self'", "https://js.stripe.com"},
 	"frame-src":  {"https://js.stripe.com"},
 }
 
 var wasmSecurityPolicy = cspMap{
-	"script-src": {"'wasm-unsafe-eval'"},
+	"script-src": {"'self'", "'wasm-unsafe-eval'"},
 }
 
 // combineCSPMaps combines multiple CSP maps into a single map.

--- a/lib/httplib/httpheaders.go
+++ b/lib/httplib/httpheaders.go
@@ -64,6 +64,7 @@ type cspMap map[string][]string
 
 var defaultContentSecurityPolicy = cspMap{
 	"default-src": {"'self'"},
+	"script-src":  {"'self'"},
 	// specify CSP directives not covered by `default-src`
 	"base-uri":        {"'self'"},
 	"form-action":     {"'self'"},
@@ -79,7 +80,7 @@ var defaultConnectSrc = cspMap{"connect-src": {"'self'", "wss:"}}
 
 var stripeSecurityPolicy = cspMap{
 	// auto-pay plans in Cloud use stripe.com to manage billing information
-	"script-src": {"'self'", "https://js.stripe.com"},
+	"script-src": {"https://js.stripe.com"},
 	"frame-src":  {"https://js.stripe.com"},
 }
 

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -281,6 +281,7 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			urlPath:  "/web/index.js",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",
+				"script-src":      "'self'",
 				"base-uri":        "'self'",
 				"form-action":     "'self'",
 				"frame-ancestors": "'none'",
@@ -319,7 +320,7 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 				"form-action":     "'self'",
 				"frame-ancestors": "'none'",
 				"object-src":      "'none'",
-				"script-src":      "'wasm-unsafe-eval'",
+				"script-src":      "'self' 'wasm-unsafe-eval'",
 				"style-src":       "'self' 'unsafe-inline'",
 				"img-src":         "'self' data: blob:",
 				"font-src":        "'self' data:",

--- a/lib/httplib/httplib_test.go
+++ b/lib/httplib/httplib_test.go
@@ -281,7 +281,6 @@ func TestSetIndexContentSecurityPolicy(t *testing.T) {
 			urlPath:  "/web/index.js",
 			expectedCspVals: map[string]string{
 				"default-src":     "'self'",
-				"script-src":      "'self'",
 				"base-uri":        "'self'",
 				"form-action":     "'self'",
 				"frame-ancestors": "'none'",


### PR DESCRIPTION
In https://github.com/gravitational/teleport/pull/28334 I mistakenly set `script-src: 'wasm-unsafe-eval'` for all desktop routes, which breaks desktop access. This changes that to its proper value of `script-src: 'self' 'wasm-unsafe-eval'`