### PR TITLE
Update TLS configuration in auth helpers

### DIFF
--- a/lib/auth/helpers.go
+++ b/lib/auth/helpers.go
@@ -734,10 +734,6 @@ func NewTestTLSServer(cfg TestTLSServerConfig) (*TestTLSServer, error) {
 	}
 	tlsConfig.Time = cfg.AuthServer.Clock().Now
 
-	// Go 1.21 changed the default behavior of TLS servers.
-	// See https://go.dev/doc/go1.21#crypto/tls.
-	tlsConfig.SessionTicketsDisabled = true
-
 	accessPoint, err := NewAdminAuthServer(srv.AuthServer.AuthServer, srv.AuthServer.AuditLog)
 	if err != nil {
 		return nil, trace.Wrap(err)


### PR DESCRIPTION
Removed the line that disables Session Tickets (added after Go 1.21 upgrade) to restore the default behavior of TLS servers. It looks like this change introduced a flakiness in a few tests.