### PR TITLE
update tsh db env/config ux

### DIFF
--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -1310,49 +1310,53 @@ func pickActiveDatabase(cf *CLIConf, tc *client.TeleportClient) (*tlsca.RouteToD
 // filtered out - this is to avoid requiring additional selectors
 // when a user gives an exact database name.
 func filterActiveDatabases(ctx context.Context, tc *client.TeleportClient, activeRoutes []tlsca.RouteToDatabase) ([]tlsca.RouteToDatabase, types.Databases, error) {
+	if len(activeRoutes) == 0 {
+		// nothing to filter
+		return nil, nil, nil
+	}
 	prefix := tc.DatabaseService
-	if prefix == "" && len(activeRoutes) == 1 {
-		prefix = activeRoutes[0].ServiceName
-	}
-
-	haveSelectors := len(tc.Labels) > 0 || tc.PredicateExpression != ""
-	var selectedRoutes []tlsca.RouteToDatabase
-	for _, db := range activeRoutes {
-		if db.ServiceName == prefix && !haveSelectors {
-			// short-circuit to select the exact match when we don't have
-			// label or predicate selectors.
-			return []tlsca.RouteToDatabase{db}, nil, nil
+	if len(tc.Labels) == 0 && tc.PredicateExpression == "" {
+		if prefix == "" && len(activeRoutes) == 1 {
+			return activeRoutes, nil, nil
 		}
-		if strings.HasPrefix(db.ServiceName, prefix) {
-			selectedRoutes = append(selectedRoutes, db)
+		// when we have a name but don't have label or predicate query, look for
+		// a route that matches the name exactly to maybe avoid calling
+		// ListDatabases API below.
+		for _, route := range activeRoutes {
+			if route.ServiceName == prefix {
+				return []tlsca.RouteToDatabase{route}, nil, nil
+			}
 		}
 	}
-	if len(selectedRoutes) == 0 || !haveSelectors {
-		// nothing to filter further, avoid making API call.
-		return selectedRoutes, nil, nil
-	}
 
-	// make a ListDatabases API call and match on full database name.
+	// make a ListDatabases API call filtered by prefix name
 	databases, err := listDatabasesByPrefix(ctx, tc, prefix)
 	if err != nil {
 		return nil, nil, trace.Wrap(err)
 	}
-	selectedRoutes = nil
+	databasesByName := databases.ToMap()
+
+	// when a database matches the prefix fully, look for a
+	// corresponding active route.
+	if db, ok := databasesByName[prefix]; ok {
+		for _, route := range activeRoutes {
+			if route.ServiceName == db.GetName() {
+				return []tlsca.RouteToDatabase{route}, types.Databases{db}, nil
+			}
+		}
+		// no active route, but return the fetched databases if the caller is
+		// interested.
+		return nil, databases, nil
+	}
+
+	// otherwise, just filter routes to those that match the names of the
+	// databases.
+	var selectedRoutes []tlsca.RouteToDatabase
 	var activeDBs types.Databases
 	for _, route := range activeRoutes {
-		for _, db := range databases {
-			if db.GetName() == route.ServiceName {
-				if db.GetName() == prefix {
-					// when label/query selectors are used and multiple
-					// databases come back, but one of them matches the prefix
-					// exactly, short-circuit to return just that db.
-					// We can't do that before calling the API because the
-					// labels/query might not actually match the active db.
-					return []tlsca.RouteToDatabase{route}, types.Databases{db}, nil
-				}
-				selectedRoutes = append(selectedRoutes, route)
-				activeDBs = append(activeDBs, db)
-			}
+		if db, ok := databasesByName[route.ServiceName]; ok {
+			selectedRoutes = append(selectedRoutes, route)
+			activeDBs = append(activeDBs, db)
 		}
 	}
 	return selectedRoutes, activeDBs, nil


### PR DESCRIPTION
stacked on related change for `tsh db connect`: https://github.com/gravitational/teleport/pull/30527

This PR changes `tsh db env` and `tsh db config` such that when a given db name doesn't match any active cert fully,
it calls the ListDatabases API to check if any inactive databases fully match.

## Example UX Diff:

Suppose we have two databases, one a prefix of the other and not logged into:
```
$ tsh db ls
Name                                      Description                   Allowed Users Labels Connect                  
----------------------------------------- ----------------------------- ------------- ------ ------------------------ 
postgres                                  Example dyn database resource [* alice]                                     
> postgres2 (user: alice, db: postgres... Example dyn database resource [* alice]            tsh db connect postgres2 
```

Prior behavior: (Note that `postgres-2` is used, because "postgres" is a prefix of its name)
```
$ tsh db env postgres
export PGSSLROOTCERT=/Users/gavin/.tsh/keys/mars.local.gd/cas/mars.local.gd.pem
export PGSSLCERT=/Users/gavin/.tsh/keys/mars.local.gd/martian-db/mars.local.gd/postgres2-x509.pem
export PGDATABASE=postgres
export PGPORT=6543
export PGSSLMODE=verify-full
export PGSSLKEY=/Users/gavin/.tsh/keys/mars.local.gd/martian
export PGUSER=alice
export PGGSSENCMODE=disable
export PGHOST=postgres.mars.local.gd
```

New behavior:
```
$ tsh db env postgres
ERROR: not logged into database "postgres"
```
