### PR TITLE
small change to tsh error messages

### DIFF
--- a/tool/tsh/common/db.go
+++ b/tool/tsh/common/db.go
@@ -394,6 +394,9 @@ func makeLogoutMessage(cf *CLIConf, logout, activeRoutes []tlsca.RouteToDatabase
 			labels: cf.Labels,
 			query:  cf.PredicateExpression,
 		}
+		if selectors.IsEmpty() {
+			return "", trace.NotFound("Not logged into any databases")
+		}
 		return "", trace.NotFound("Not logged into %v", selectors)
 	case 1:
 		return fmt.Sprintf("Logged out of database %v", logout[0].ServiceName), nil
@@ -1627,11 +1630,13 @@ func (r resourceSelectors) IsEmpty() bool {
 func formatAmbiguityErrTemplate(cf *CLIConf, selectors resourceSelectors, listCommand, matchTable, fullNameExample string) string {
 	data := map[string]any{
 		"command":     cf.CommandWithBinary(),
-		"selectors":   strings.TrimSpace(selectors.String()),
 		"listCommand": strings.TrimSpace(listCommand),
 		"kind":        strings.TrimSpace(selectors.kind),
 		"matchTable":  strings.TrimSpace(matchTable),
 		"example":     strings.TrimSpace(fullNameExample),
+	}
+	if !selectors.IsEmpty() {
+		data["selectors"] = strings.TrimSpace(selectors.String())
 	}
 	var sb strings.Builder
 	_ = ambiguityErrTemplate.Execute(&sb, data)
@@ -1694,7 +1699,11 @@ You can start a local proxy for database GUI clients:
 
 	// ambiguityErrTemplate is the error message printed when a resource is
 	// specified ambiguously by name prefix and/or labels.
-	ambiguityErrTemplate = template.Must(template.New("").Parse("{{ .selectors }} matches multiple {{ .kind }}s:" + `
+	ambiguityErrTemplate = template.Must(template.New("").Parse(`{{if .selectors -}}
+{{ .selectors }} matches multiple {{ .kind }}s:
+{{- else -}}
+multiple {{ .kind }}s are available:
+{{- end }}
 
 {{ .matchTable }}
 


### PR DESCRIPTION
This PR just slightly improves the wording around error messages.

- Logout message for `tsh db logout` without any databases logged in: 
  - errror message: `Not logged into any databases` vs `Not logged into database`

- ambiguous error message when `tsh db env` is given and multiple active databases are available:
  - `multiple databases are available ...*snip*...` vs `database matches multiple databases ...*snip*...`