### PR TITLE
Discover RDS: remove aurora engine

### DIFF
--- a/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
+++ b/web/packages/teleport/src/Discover/Database/EnrollRdsDatabase/EnrollRdsDatabase.story.tsx
@@ -107,7 +107,7 @@ const fixtures: CheckedAwsRdsDatabase[] = [
   },
   {
     name: 'alpaca',
-    engine: 'aurora',
+    engine: 'aurora-mysql',
     uri: '',
     labels: [
       { name: 'env', value: 'prod' },

--- a/web/packages/teleport/src/services/integrations/integrations.test.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.test.ts
@@ -157,11 +157,11 @@ test('fetchAwsDatabases response', async () => {
 
 describe('fetchAwsDatabases() request body formatting', () => {
   test.each`
-    protocol             | expectedEngines               | expectedRdsType
-    ${'mysql'}           | ${['mysql', 'mariadb']}       | ${'instance'}
-    ${'postgres'}        | ${['postgres']}               | ${'instance'}
-    ${'aurora-mysql'}    | ${['aurora', 'aurora-mysql']} | ${'cluster'}
-    ${'aurora-postgres'} | ${['aurora-postgresql']}      | ${'cluster'}
+    protocol             | expectedEngines          | expectedRdsType
+    ${'mysql'}           | ${['mysql', 'mariadb']}  | ${'instance'}
+    ${'postgres'}        | ${['postgres']}          | ${'instance'}
+    ${'aurora-mysql'}    | ${['aurora-mysql']}      | ${'cluster'}
+    ${'aurora-postgres'} | ${['aurora-postgresql']} | ${'cluster'}
   `(
     'format protocol $protocol',
     async ({ protocol, expectedEngines, expectedRdsType }) => {

--- a/web/packages/teleport/src/services/integrations/integrations.ts
+++ b/web/packages/teleport/src/services/integrations/integrations.ts
@@ -93,7 +93,7 @@ export const integrationService = {
         body = {
           ...req,
           rdsType: 'cluster',
-          engines: ['aurora', 'aurora-mysql'],
+          engines: ['aurora-mysql'],
         };
         break;
       case 'aurora-postgres':

--- a/web/packages/teleport/src/services/integrations/types.ts
+++ b/web/packages/teleport/src/services/integrations/types.ts
@@ -158,7 +158,6 @@ export type Regions = keyof typeof awsRegionMap;
 // used when requesting lists of rds databases of the
 // specified engine.
 export type RdsEngine =
-  | 'aurora' // (for MySQL 5.6-compatible Aurora)
   | 'aurora-mysql' // (for MySQL 5.7-compatible and MySQL 8.0-compatible Aurora)
   | 'aurora-postgresql'
   | 'mariadb'


### PR DESCRIPTION
'aurora' was an engine identifier for the first version of the Amazon Aurora offering.

It reached end of life in 28th Februray 2023
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html

We must remove it from the list of available engines, otherwise AWS will return an error "unrecognized engine: aurora".

This ends up being an alternative PR to the following
https://github.com/gravitational/teleport/pull/30269

Fixes: https://github.com/gravitational/teleport/issues/29974