### PR TITLE
docs: correct double quotes in tctl devices add example

### DIFF
--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -157,7 +157,7 @@ with the serial number obtained from the device you wish to enroll and <Var name
 with `macos` or `windows`, and execute the following command:
 
 ```code
-$ tctl devices add --os="<Var name="OS"/> --asset-tag=<Var name="(=devicetrust.asset_tag=)"/>"
+$ tctl devices add --os="<Var name="OS"/>" --asset-tag="<Var name="(=devicetrust.asset_tag=)"/>"
 Device <Var name="(=devicetrust.asset_tag=)"/>/<Var name="OS"/> added to the inventory
 ```
 


### PR DESCRIPTION
Currently this results in an error since the double quotes aren't set for each parameter