### PR TITLE
drop ctx from emitter signature

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -909,12 +909,12 @@ func (c *Client) GenerateOpenSSHCert(ctx context.Context, req *proto.OpenSSHCert
 }
 
 // EmitAuditEvent sends an auditable event to the auth server.
-func (c *Client) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
+func (c *Client) EmitAuditEvent(event events.AuditEvent) error {
 	grpcEvent, err := events.ToOneOf(event)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	_, err = c.grpc.EmitAuditEvent(ctx, grpcEvent)
+	_, err = c.grpc.EmitAuditEvent(context.Background(), grpcEvent)
 	if err != nil {
 		return trail.FromGRPC(err)
 	}

--- a/api/types/events/api.go
+++ b/api/types/events/api.go
@@ -74,7 +74,7 @@ type AuditEvent interface {
 // Emitter emits audit events.
 type Emitter interface {
 	// EmitAuditEvent emits a single audit event.
-	EmitAuditEvent(context.Context, AuditEvent) error
+	EmitAuditEvent(AuditEvent) error
 }
 
 // PreparedSessionEvent is an event that has been prepared by

--- a/examples/dynamoathenamigration/migration.go
+++ b/examples/dynamoathenamigration/migration.go
@@ -155,7 +155,7 @@ type s3downloader interface {
 }
 
 type eventsEmitter interface {
-	EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error
+	EmitAuditEvent(in apievents.AuditEvent) error
 }
 
 func newMigrateTask(ctx context.Context, cfg Config, awsCfg aws.Config) (*task, error) {
@@ -841,7 +841,7 @@ func (t *task) emitEvents(ctx context.Context, eventsC <-chan apievents.AuditEve
 					if !ok {
 						return nil
 					}
-					if err := t.eventsEmitter.EmitAuditEvent(workerCtx, e); err != nil {
+					if err := t.eventsEmitter.EmitAuditEvent(e); err != nil {
 						return trace.Wrap(err)
 					} else {
 						mu.Lock()

--- a/examples/dynamoathenamigration/migration_test.go
+++ b/examples/dynamoathenamigration/migration_test.go
@@ -177,7 +177,7 @@ type mockEmitter struct {
 	failAfterNCalls int
 }
 
-func (m *mockEmitter) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error {
+func (m *mockEmitter) EmitAuditEvent(in apievents.AuditEvent) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.failAfterNCalls > 0 && len(m.events) >= m.failAfterNCalls {
@@ -189,12 +189,9 @@ func (m *mockEmitter) EmitAuditEvent(ctx context.Context, in apievents.AuditEven
 	// less iterations in tests to generate checkpoint file from all workers.
 	// Without it, in rare cases after 50 events still some worker were not able
 	// to read message because of other processing it immediately.
-	select {
-	case <-time.After(time.Duration(rand.Intn(50)+50) * time.Microsecond):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+
+	<-time.After(time.Duration(rand.Intn(50)+50) * time.Microsecond)
+	return nil
 }
 
 // requireEventsEqualInAnyOrder compares slices of auditevents ignoring order.

--- a/lib/auth/access.go
+++ b/lib/auth/access.go
@@ -33,7 +33,7 @@ func (a *Server) UpsertRole(ctx context.Context, role types.Role) error {
 		return trace.Wrap(err)
 	}
 
-	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.RoleCreate{
+	if err := a.emitter.EmitAuditEvent(&apievents.RoleCreate{
 		Metadata: apievents.Metadata{
 			Type: events.RoleCreatedEvent,
 			Code: events.RoleCreatedCode,
@@ -86,7 +86,7 @@ func (a *Server) DeleteRole(ctx context.Context, name string) error {
 		return trace.Wrap(err)
 	}
 
-	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.RoleDelete{
+	if err := a.emitter.EmitAuditEvent(&apievents.RoleDelete{
 		Metadata: apievents.Metadata{
 			Type: events.RoleDeletedEvent,
 			Code: events.RoleDeletedCode,
@@ -108,7 +108,7 @@ func (a *Server) UpsertLock(ctx context.Context, lock types.Lock) error {
 	}
 
 	um := authz.ClientUserMetadata(ctx)
-	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.LockCreate{
+	if err := a.emitter.EmitAuditEvent(&apievents.LockCreate{
 		Metadata: apievents.Metadata{
 			Type: events.LockCreatedEvent,
 			Code: events.LockCreatedCode,
@@ -131,7 +131,7 @@ func (a *Server) DeleteLock(ctx context.Context, lockName string) error {
 		return trace.Wrap(err)
 	}
 
-	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.LockDelete{
+	if err := a.emitter.EmitAuditEvent(&apievents.LockDelete{
 		Metadata: apievents.Metadata{
 			Type: events.LockDeletedEvent,
 			Code: events.LockDeletedCode,

--- a/lib/auth/accountrecovery.go
+++ b/lib/auth/accountrecovery.go
@@ -207,14 +207,14 @@ func (s *Server) verifyRecoveryCode(ctx context.Context, user string, givenCode 
 		event.Status.Error = traceErr.Error()
 		event.Status.UserMessage = traceErr.Error()
 
-		if err := s.emitter.EmitAuditEvent(s.closeCtx, event); err != nil {
+		if err := s.emitter.EmitAuditEvent(event); err != nil {
 			log.WithFields(logrus.Fields{"user": user}).Warn("Failed to emit account recovery code used failed event.")
 		}
 
 		return trace.AccessDenied(startRecoveryBadAuthnErrMsg)
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, event); err != nil {
+	if err := s.emitter.EmitAuditEvent(event); err != nil {
 		log.WithFields(logrus.Fields{"user": user}).Warn("Failed to emit account recovery code used event.")
 	}
 
@@ -549,7 +549,7 @@ func (s *Server) generateAndUpsertRecoveryCodes(ctx context.Context, username st
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.RecoveryCodeGenerate{
+	if err := s.emitter.EmitAuditEvent(&apievents.RecoveryCodeGenerate{
 		Metadata: apievents.Metadata{
 			Type: events.RecoveryCodeGeneratedEvent,
 			Code: events.RecoveryCodesGenerateCode,

--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -4709,7 +4709,7 @@ func TestLocalServiceRolesHavePermissionsForUploaderService(t *testing.T) {
 			})
 
 			t.Run("EmitAuditEvent", func(t *testing.T) {
-				err := s.EmitAuditEvent(ctx, &apievents.UserLogin{
+				err := s.EmitAuditEvent(&apievents.UserLogin{
 					Metadata: apievents.Metadata{
 						Type: events.UserLoginEvent,
 						Code: events.UserLocalLoginFailureCode,

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -430,7 +430,7 @@ func (s *Server) validateGenerationLabel(ctx context.Context, user types.User, c
 
 		// Emit an audit event.
 		userMetadata := authz.ClientUserMetadata(ctx)
-		if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.RenewableCertificateGenerationMismatch{
+		if err := s.emitter.EmitAuditEvent(&apievents.RenewableCertificateGenerationMismatch{
 			Metadata: apievents.Metadata{
 				Type: events.RenewableCertificateGenerationMismatchEvent,
 				Code: events.RenewableCertificateGenerationMismatchCode,

--- a/lib/auth/github.go
+++ b/lib/auth/github.go
@@ -135,7 +135,7 @@ func (a *Server) upsertGithubConnector(ctx context.Context, connector types.Gith
 	if err := a.UpsertGithubConnector(ctx, connector); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.GithubConnectorCreate{
+	if err := a.emitter.EmitAuditEvent(&apievents.GithubConnectorCreate{
 		Metadata: apievents.Metadata{
 			Type: events.GithubConnectorCreatedEvent,
 			Code: events.GithubConnectorCreatedCode,
@@ -289,7 +289,7 @@ func (a *Server) deleteGithubConnector(ctx context.Context, connectorName string
 		return trace.Wrap(err)
 	}
 
-	if err := a.emitter.EmitAuditEvent(a.closeCtx, &apievents.GithubConnectorDelete{
+	if err := a.emitter.EmitAuditEvent(&apievents.GithubConnectorDelete{
 		Metadata: apievents.Metadata{
 			Type: events.GithubConnectorDeletedEvent,
 			Code: events.GithubConnectorDeletedCode,
@@ -395,7 +395,7 @@ func validateGithubAuthCallbackHelper(ctx context.Context, m githubManager, diag
 		event.Status.Error = trace.Unwrap(err).Error()
 		event.Status.UserMessage = err.Error()
 
-		if err := emitter.EmitAuditEvent(ctx, event); err != nil {
+		if err := emitter.EmitAuditEvent(event); err != nil {
 			log.WithError(err).Warn("Failed to emit GitHub login failed event.")
 		}
 		return nil, trace.Wrap(err)
@@ -407,7 +407,7 @@ func validateGithubAuthCallbackHelper(ctx context.Context, m githubManager, diag
 	event.Status.Success = true
 	event.User = auth.Username
 
-	if err := emitter.EmitAuditEvent(ctx, event); err != nil {
+	if err := emitter.EmitAuditEvent(event); err != nil {
 		log.WithError(err).Warn("Failed to emit GitHub login event.")
 	}
 
@@ -935,7 +935,7 @@ func (c *githubAPIClient) getTeams() ([]teamResponse, error) {
 
 			// Print warning to Teleport logs as well as the Audit Log.
 			log.Warnf(warningMessage)
-			if err := c.authServer.emitter.EmitAuditEvent(c.authServer.closeCtx, &apievents.UserLogin{
+			if err := c.authServer.emitter.EmitAuditEvent(&apievents.UserLogin{
 				Metadata: apievents.Metadata{
 					Type: events.UserLoginEvent,
 					Code: events.UserSSOLoginFailureCode,

--- a/lib/auth/grpcserver.go
+++ b/lib/auth/grpcserver.go
@@ -159,7 +159,7 @@ func (g *GRPCServer) EmitAuditEvent(ctx context.Context, req *apievents.OneOf) (
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	err = auth.EmitAuditEvent(ctx, event)
+	err = auth.EmitAuditEvent(event)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -300,7 +300,7 @@ func (g *GRPCServer) CreateAuditStream(stream authpb.AuthService_CreateAuditStre
 					},
 					SessionURL: sessionData.URL,
 				}
-				if err := g.Emitter.EmitAuditEvent(auth.CloseContext(), event); err != nil {
+				if err := g.Emitter.EmitAuditEvent(event); err != nil {
 					return trace.Wrap(err)
 				}
 			}
@@ -2279,7 +2279,7 @@ func (g *GRPCServer) AddMFADevice(stream authpb.AuthService_AddMFADeviceServer) 
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	if err := g.Emitter.EmitAuditEvent(g.serverContext(), &apievents.MFADeviceAdd{
+	if err := g.Emitter.EmitAuditEvent(&apievents.MFADeviceAdd{
 		Metadata: apievents.Metadata{
 			Type:        events.MFADeviceAddEvent,
 			Code:        events.MFADeviceAddEventCode,

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -248,7 +248,7 @@ func (a *Server) generateCertsBot(
 			log.WithError(err).Warn("Unable to encode join attributes for audit event.")
 		}
 	}
-	if err := a.emitter.EmitAuditEvent(ctx, joinEvent); err != nil {
+	if err := a.emitter.EmitAuditEvent(joinEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit bot join event.")
 	}
 	return certs, nil
@@ -320,7 +320,7 @@ func (a *Server) generateCerts(
 			log.WithError(err).Warn("Unable to encode join attributes for audit event.")
 		}
 	}
-	if err := a.emitter.EmitAuditEvent(ctx, joinEvent); err != nil {
+	if err := a.emitter.EmitAuditEvent(joinEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit instance join event.")
 	}
 	return certs, nil

--- a/lib/auth/methods.go
+++ b/lib/auth/methods.go
@@ -171,7 +171,7 @@ func (s *Server) AuthenticateUser(ctx context.Context, req AuthenticateUserReque
 			return nil, trace.Wrap(err)
 		}
 	}
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, event); err != nil {
+	if err := s.emitter.EmitAuditEvent(event); err != nil {
 		log.WithError(err).Warn("Failed to emit login event.")
 	}
 	return user, trace.Wrap(err)
@@ -685,7 +685,7 @@ func (s *Server) AuthenticateSSHUser(ctx context.Context, req AuthenticateSSHReq
 
 // emitNoLocalAuthEvent creates and emits a local authentication is disabled message.
 func (s *Server) emitNoLocalAuthEvent(username string) {
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.AuthAttempt{
+	if err := s.emitter.EmitAuditEvent(&apievents.AuthAttempt{
 		Metadata: apievents.Metadata{
 			Type: events.AuthAttemptEvent,
 			Code: events.AuthAttemptFailureCode,

--- a/lib/auth/oidc.go
+++ b/lib/auth/oidc.go
@@ -41,7 +41,7 @@ func (a *Server) UpsertOIDCConnector(ctx context.Context, connector types.OIDCCo
 	if err := a.Services.UpsertOIDCConnector(ctx, connector); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.emitter.EmitAuditEvent(ctx, &apievents.OIDCConnectorCreate{
+	if err := a.emitter.EmitAuditEvent(&apievents.OIDCConnectorCreate{
 		Metadata: apievents.Metadata{
 			Type: events.OIDCConnectorCreatedEvent,
 			Code: events.OIDCConnectorCreatedCode,
@@ -62,7 +62,7 @@ func (a *Server) DeleteOIDCConnector(ctx context.Context, connectorName string) 
 	if err := a.Services.DeleteOIDCConnector(ctx, connectorName); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.emitter.EmitAuditEvent(ctx, &apievents.OIDCConnectorDelete{
+	if err := a.emitter.EmitAuditEvent(&apievents.OIDCConnectorDelete{
 		Metadata: apievents.Metadata{
 			Type: events.OIDCConnectorDeletedEvent,
 			Code: events.OIDCConnectorDeletedCode,

--- a/lib/auth/password.go
+++ b/lib/auth/password.go
@@ -144,7 +144,7 @@ func (s *Server) ChangePassword(ctx context.Context, req *proto.ChangePasswordRe
 		return trace.Wrap(err)
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.UserPasswordChange{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserPasswordChange{
 		Metadata: apievents.Metadata{
 			Type: events.UserPasswordChangeEvent,
 			Code: events.UserPasswordChangeCode,

--- a/lib/auth/saml.go
+++ b/lib/auth/saml.go
@@ -59,7 +59,7 @@ func (a *Server) UpsertSAMLConnector(ctx context.Context, connector types.SAMLCo
 	if err := a.Services.UpsertSAMLConnector(ctx, connector); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.emitter.EmitAuditEvent(ctx, &apievents.SAMLConnectorCreate{
+	if err := a.emitter.EmitAuditEvent(&apievents.SAMLConnectorCreate{
 		Metadata: apievents.Metadata{
 			Type: events.SAMLConnectorCreatedEvent,
 			Code: events.SAMLConnectorCreatedCode,
@@ -80,7 +80,7 @@ func (a *Server) DeleteSAMLConnector(ctx context.Context, connectorID string) er
 	if err := a.Services.DeleteSAMLConnector(ctx, connectorID); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := a.emitter.EmitAuditEvent(ctx, &apievents.SAMLConnectorDelete{
+	if err := a.emitter.EmitAuditEvent(&apievents.SAMLConnectorDelete{
 		Metadata: apievents.Metadata{
 			Type: events.SAMLConnectorDeletedEvent,
 			Code: events.SAMLConnectorDeletedCode,

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -169,7 +169,7 @@ func (a *Server) UpsertTrustedCluster(ctx context.Context, trustedCluster types.
 		return nil, trace.Wrap(err)
 	}
 
-	if err := a.emitter.EmitAuditEvent(ctx, &apievents.TrustedClusterCreate{
+	if err := a.emitter.EmitAuditEvent(&apievents.TrustedClusterCreate{
 		Metadata: apievents.Metadata{
 			Type: events.TrustedClusterCreateEvent,
 			Code: events.TrustedClusterCreateCode,
@@ -237,7 +237,7 @@ func (a *Server) DeleteTrustedCluster(ctx context.Context, name string) error {
 		return trace.Wrap(err)
 	}
 
-	if err := a.emitter.EmitAuditEvent(ctx, &apievents.TrustedClusterDelete{
+	if err := a.emitter.EmitAuditEvent(&apievents.TrustedClusterDelete{
 		Metadata: apievents.Metadata{
 			Type: events.TrustedClusterDeleteEvent,
 			Code: events.TrustedClusterDeleteCode,

--- a/lib/auth/user.go
+++ b/lib/auth/user.go
@@ -59,7 +59,7 @@ func (s *Server) CreateUser(ctx context.Context, user types.User) error {
 		connectorName = user.GetCreatedBy().Connector.ID
 	}
 
-	if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserCreate{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserCreate{
 		Metadata: apievents.Metadata{
 			Type: events.UserCreateEvent,
 			Code: events.UserCreateCode,
@@ -101,7 +101,7 @@ func (s *Server) UpdateUser(ctx context.Context, user types.User) error {
 		connectorName = user.GetCreatedBy().Connector.ID
 	}
 
-	if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserCreate{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserCreate{
 		Metadata: apievents.Metadata{
 			Type: events.UserUpdatedEvent,
 			Code: events.UserUpdateCode,
@@ -150,7 +150,7 @@ func (s *Server) UpsertUser(user types.User) error {
 		connectorName = user.GetCreatedBy().Connector.ID
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.UserCreate{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserCreate{
 		Metadata: apievents.Metadata{
 			Type: events.UserCreateEvent,
 			Code: events.UserCreateCode,
@@ -194,7 +194,7 @@ func (s *Server) CompareAndSwapUser(ctx context.Context, new, existing types.Use
 		connectorName = new.GetCreatedBy().Connector.ID
 	}
 
-	if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserCreate{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserCreate{
 		Metadata: apievents.Metadata{
 			Type: events.UserUpdatedEvent,
 			Code: events.UserUpdateCode,
@@ -245,7 +245,7 @@ func (s *Server) DeleteUser(ctx context.Context, user string) error {
 	}
 
 	// If the user was successfully deleted, emit an event.
-	if err := s.emitter.EmitAuditEvent(s.closeCtx, &apievents.UserDelete{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserDelete{
 		Metadata: apievents.Metadata{
 			Type: events.UserDeleteEvent,
 			Code: events.UserDeleteCode,

--- a/lib/auth/usertoken.go
+++ b/lib/auth/usertoken.go
@@ -164,7 +164,7 @@ func (s *Server) CreateResetPasswordToken(ctx context.Context, req CreateUserTok
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserTokenCreate{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserTokenCreate{
 		Metadata: apievents.Metadata{
 			Type: events.ResetPasswordTokenCreateEvent,
 			Code: events.ResetPasswordTokenCreateCode,
@@ -424,7 +424,7 @@ func (s *Server) createRecoveryToken(ctx context.Context, username, tokenType st
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserTokenCreate{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserTokenCreate{
 		Metadata: apievents.Metadata{
 			Type: events.RecoveryTokenCreateEvent,
 			Code: events.RecoveryTokenCreateCode,
@@ -519,7 +519,7 @@ func (s *Server) createPrivilegeToken(ctx context.Context, username, tokenKind s
 		return nil, trace.Wrap(err)
 	}
 
-	if err := s.emitter.EmitAuditEvent(ctx, &apievents.UserTokenCreate{
+	if err := s.emitter.EmitAuditEvent(&apievents.UserTokenCreate{
 		Metadata: apievents.Metadata{
 			Type: events.PrivilegeTokenCreateEvent,
 			Code: events.PrivilegeTokenCreateCode,

--- a/lib/bpf/bpf.go
+++ b/lib/bpf/bpf.go
@@ -412,7 +412,7 @@ func (s *Service) emitCommandEvent(eventBytes []byte) {
 			Path:       argv[0],
 			Argv:       argv[1:],
 		}
-		if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionCommandEvent); err != nil {
+		if err := ctx.Emitter.EmitAuditEvent(sessionCommandEvent); err != nil {
 			log.WithError(err).Warn("Failed to emit command event.")
 		}
 
@@ -470,7 +470,7 @@ func (s *Service) emitDiskEvent(eventBytes []byte) {
 		ReturnCode: event.ReturnCode,
 	}
 	// Logs can be DoS by event failures here
-	_ = ctx.Emitter.EmitAuditEvent(ctx.Context, sessionDiskEvent)
+	_ = ctx.Emitter.EmitAuditEvent(sessionDiskEvent)
 }
 
 // emit4NetworkEvent will parse and emit IPv4 events to the Audit Log.
@@ -532,7 +532,7 @@ func (s *Service) emit4NetworkEvent(eventBytes []byte) {
 		SrcAddr:    srcAddr.String(),
 		TCPVersion: 4,
 	}
-	if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
+	if err := ctx.Emitter.EmitAuditEvent(sessionNetworkEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit network event.")
 	}
 }
@@ -602,7 +602,7 @@ func (s *Service) emit6NetworkEvent(eventBytes []byte) {
 		SrcAddr:    srcAddr.String(),
 		TCPVersion: 6,
 	}
-	if err := ctx.Emitter.EmitAuditEvent(ctx.Context, sessionNetworkEvent); err != nil {
+	if err := ctx.Emitter.EmitAuditEvent(sessionNetworkEvent); err != nil {
 		log.WithError(err).Warn("Failed to emit network event.")
 	}
 }

--- a/lib/events/athena/athena.go
+++ b/lib/events/athena/athena.go
@@ -418,8 +418,8 @@ func New(ctx context.Context, cfg Config) (*Log, error) {
 	return l, nil
 }
 
-func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error {
-	return trace.Wrap(l.publisher.EmitAuditEvent(ctx, in))
+func (l *Log) EmitAuditEvent(in apievents.AuditEvent) error {
+	return trace.Wrap(l.publisher.EmitAuditEvent(in))
 }
 
 func (l *Log) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {

--- a/lib/events/athena/athena_test.go
+++ b/lib/events/athena/athena_test.go
@@ -435,7 +435,7 @@ func TestPublisherConsumer(t *testing.T) {
 			// we need to clone input because it's used for assertions and
 			// EmitAuditEvent modifies input in case id/time is empty.
 			clonedInput := apiutils.CloneProtoMsg(tt.input)
-			err := p.EmitAuditEvent(ctx, clonedInput)
+			err := p.EmitAuditEvent(clonedInput)
 			require.NoError(t, err)
 
 			// wait for event to be propagated.

--- a/lib/events/athena/integration_test.go
+++ b/lib/events/athena/integration_test.go
@@ -133,7 +133,7 @@ func TestIntegrationAthenaLargeEvents(t *testing.T) {
 			Time:  ac.clock.Now().UTC(),
 		},
 	}
-	err := ac.log.EmitAuditEvent(ctx, in)
+	err := ac.log.EmitAuditEvent(in)
 	require.NoError(t, err)
 
 	var history []apievents.AuditEvent
@@ -508,11 +508,11 @@ type eventuallyConsitentAuditLogger struct {
 	emitWasAfterLastDelay bool
 }
 
-func (e *eventuallyConsitentAuditLogger) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error {
+func (e *eventuallyConsitentAuditLogger) EmitAuditEvent(in apievents.AuditEvent) error {
 	e.mu.Lock()
 	e.emitWasAfterLastDelay = true
 	e.mu.Unlock()
-	return e.inner.EmitAuditEvent(ctx, in)
+	return e.inner.EmitAuditEvent(in)
 }
 
 func (e *eventuallyConsitentAuditLogger) SearchEvents(ctx context.Context, req events.SearchEventsRequest) ([]apievents.AuditEvent, string, error) {

--- a/lib/events/athena/publisher.go
+++ b/lib/events/athena/publisher.go
@@ -99,7 +99,7 @@ func newPublisherFromAthenaConfig(cfg Config) *publisher {
 // Events are marshaled as oneOf from apievents and encoded using base64.
 // For large events, payload is publihsed to S3, and on SNS there is only passed
 // location on S3.
-func (p *publisher) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error {
+func (p *publisher) EmitAuditEvent(in apievents.AuditEvent) error {
 	// Teleport emitter layer above makes sure that they are filled.
 	// We fill it just to be sure in case some problems with layer above, it's
 	// better to generate it, then skip event.
@@ -118,7 +118,7 @@ func (p *publisher) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-
+	ctx := context.Background()
 	b64Encoded := base64.StdEncoding.EncodeToString(marshaledProto)
 	if len(b64Encoded) > maxSNSMessageSize {
 		if uint64(len(b64Encoded)) > maxS3BasedSize {

--- a/lib/events/athena/publisher_test.go
+++ b/lib/events/athena/publisher_test.go
@@ -93,7 +93,7 @@ func Test_EmitAuditEvent(t *testing.T) {
 					Uploader:     tt.uploader,
 				},
 			}
-			err := p.EmitAuditEvent(context.Background(), tt.in)
+			err := p.EmitAuditEvent(tt.in)
 			require.NoError(t, err)
 			out := fq.dequeue()
 			tt.wantCheck(t, out)

--- a/lib/events/auditlog.go
+++ b/lib/events/auditlog.go
@@ -853,17 +853,17 @@ func (l *AuditLog) fetchSessionEvents(fileName string, afterN int) ([]EventField
 }
 
 // EmitAuditEvent adds a new event to the local file log
-func (l *AuditLog) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (l *AuditLog) EmitAuditEvent(event apievents.AuditEvent) error {
 	// If an external logger has been set, use it as the emitter, otherwise
 	// fallback to the local disk based emitter.
-	var emitAuditEvent func(ctx context.Context, event apievents.AuditEvent) error
+	var emitAuditEvent func(event apievents.AuditEvent) error
 
 	if l.ExternalLog != nil {
 		emitAuditEvent = l.ExternalLog.EmitAuditEvent
 	} else {
 		emitAuditEvent = l.getLocalLog().EmitAuditEvent
 	}
-	err := emitAuditEvent(ctx, event)
+	err := emitAuditEvent(event)
 	if err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/events/auditlog_test.go
+++ b/lib/events/auditlog_test.go
@@ -73,7 +73,7 @@ func TestLogRotation(t *testing.T) {
 			Metadata:     apievents.Metadata{Type: "resize", Time: now},
 			TerminalSize: "10:10",
 		}
-		err := alog.EmitAuditEvent(ctx, event)
+		err := alog.EmitAuditEvent(event)
 		require.NoError(t, err)
 		logfile := alog.CurrentFile()
 
@@ -169,7 +169,7 @@ func TestExternalLog(t *testing.T) {
 	defer alog.Close()
 
 	evt := &apievents.SessionConnect{}
-	require.NoError(t, alog.EmitAuditEvent(context.Background(), evt))
+	require.NoError(t, alog.EmitAuditEvent(evt))
 
 	require.Len(t, m.Emitter.Events(), 1)
 	require.Equal(t, m.Emitter.Events()[0], evt)

--- a/lib/events/complete.go
+++ b/lib/events/complete.go
@@ -250,7 +250,7 @@ func (u *UploadCompleter) CheckUploads(ctx context.Context) error {
 			},
 			SessionURL: uploadData.URL,
 		}
-		err = u.cfg.AuditLog.EmitAuditEvent(ctx, session)
+		err = u.cfg.AuditLog.EmitAuditEvent(session)
 		if err != nil {
 			return trace.Wrap(err)
 		}
@@ -354,7 +354,7 @@ loop:
 	if err := checkAndSetEventFields(sessionEndEvent, u.cfg.Clock, utils.NewRealUID(), sessionEndEvent.GetClusterName()); err != nil {
 		return trace.Wrap(err)
 	}
-	if err := u.cfg.AuditLog.EmitAuditEvent(ctx, sessionEndEvent); err != nil {
+	if err := u.cfg.AuditLog.EmitAuditEvent(sessionEndEvent); err != nil {
 		return trace.Wrap(err)
 	}
 	return nil

--- a/lib/events/discard.go
+++ b/lib/events/discard.go
@@ -56,7 +56,7 @@ func (d *DiscardAuditLog) SearchSessionEvents(ctx context.Context, req SearchSes
 	return make([]apievents.AuditEvent, 0), "", nil
 }
 
-func (d *DiscardAuditLog) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (d *DiscardAuditLog) EmitAuditEvent(event apievents.AuditEvent) error {
 	return nil
 }
 
@@ -138,7 +138,7 @@ func NewDiscardEmitter() *DiscardEmitter {
 type DiscardEmitter struct{}
 
 // EmitAuditEvent discards audit event
-func (*DiscardEmitter) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (*DiscardEmitter) EmitAuditEvent(event apievents.AuditEvent) error {
 	log.WithFields(log.Fields{
 		"event_id":    event.GetID(),
 		"event_type":  event.GetType(),

--- a/lib/events/dynamoevents/dynamoevents.go
+++ b/lib/events/dynamoevents/dynamoevents.go
@@ -356,7 +356,8 @@ const (
 )
 
 // EmitAuditEvent emits audit event
-func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error {
+func (l *Log) EmitAuditEvent(in apievents.AuditEvent) error {
+	ctx := context.Background()
 	sessionID := getSessionID(in)
 	if err := l.putAuditEvent(ctx, sessionID, in); err != nil {
 		switch {

--- a/lib/events/dynamoevents/dynamoevents_test.go
+++ b/lib/events/dynamoevents/dynamoevents_test.go
@@ -119,7 +119,7 @@ func TestSizeBreak(t *testing.T) {
 
 	const eventCount int = 10
 	for i := 0; i < eventCount; i++ {
-		err := tt.suite.Log.EmitAuditEvent(context.Background(), &apievents.UserLogin{
+		err := tt.suite.Log.EmitAuditEvent(&apievents.UserLogin{
 			Method:       events.LoginMethodSAML,
 			Status:       apievents.Status{Success: true},
 			UserMetadata: apievents.UserMetadata{User: "bob"},
@@ -193,7 +193,7 @@ func TestLargeTableRetrieve(t *testing.T) {
 
 	const eventCount = 4000
 	for i := 0; i < eventCount; i++ {
-		err := tt.suite.Log.EmitAuditEvent(context.Background(), &apievents.UserLogin{
+		err := tt.suite.Log.EmitAuditEvent(&apievents.UserLogin{
 			Method:       events.LoginMethodSAML,
 			Status:       apievents.Status{Success: true},
 			UserMetadata: apievents.UserMetadata{User: "bob"},
@@ -266,7 +266,7 @@ func TestEmitAuditEventForLargeEvents(t *testing.T) {
 		},
 		DatabaseQuery: strings.Repeat("A", maxItemSize),
 	}
-	err := tt.suite.Log.EmitAuditEvent(ctx, dbQueryEvent)
+	err := tt.suite.Log.EmitAuditEvent(dbQueryEvent)
 	require.NoError(t, err)
 
 	result, _, err := tt.suite.Log.SearchEvents(ctx, events.SearchEventsRequest{
@@ -285,7 +285,7 @@ func TestEmitAuditEventForLargeEvents(t *testing.T) {
 		},
 		Path: strings.Repeat("A", maxItemSize),
 	}
-	err = tt.suite.Log.EmitAuditEvent(ctx, appReqEvent)
+	err = tt.suite.Log.EmitAuditEvent(appReqEvent)
 	require.ErrorContains(t, err, "ValidationException: Item size has exceeded the maximum allowed size")
 }
 

--- a/lib/events/emitter_test.go
+++ b/lib/events/emitter_test.go
@@ -118,15 +118,12 @@ func TestProtoStreamer(t *testing.T) {
 }
 
 func TestWriterEmitter(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	defer cancel()
-
 	evts := eventstest.GenerateTestSession(eventstest.SessionParams{PrintEvents: 0})
 	buf := &bytes.Buffer{}
 	emitter := events.NewWriterEmitter(utils.NopWriteCloser(buf))
 
 	for _, event := range evts {
-		err := emitter.EmitAuditEvent(ctx, event)
+		err := emitter.EmitAuditEvent(event)
 		require.NoError(t, err)
 	}
 
@@ -151,7 +148,7 @@ func TestAsyncEmitter(t *testing.T) {
 		ctx, cancel := context.WithTimeout(ctx, time.Second)
 		defer cancel()
 		for _, event := range evts {
-			err := emitter.EmitAuditEvent(ctx, event)
+			err := emitter.EmitAuditEvent(event)
 			require.NoError(t, err)
 		}
 		require.NoError(t, ctx.Err())
@@ -166,10 +163,8 @@ func TestAsyncEmitter(t *testing.T) {
 
 		require.NoError(t, err)
 		defer emitter.Close()
-		ctx, cancel := context.WithTimeout(ctx, time.Second)
-		defer cancel()
 		for _, event := range evts {
-			err := emitter.EmitAuditEvent(ctx, event)
+			err := emitter.EmitAuditEvent(event)
 			require.NoError(t, err)
 		}
 
@@ -192,13 +187,10 @@ func TestAsyncEmitter(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(ctx, time.Second)
-		defer cancel()
-
 		emitsDoneC := make(chan struct{}, len(evts))
 		for _, e := range evts {
 			go func(event apievents.AuditEvent) {
-				emitter.EmitAuditEvent(ctx, event)
+				emitter.EmitAuditEvent(event)
 				emitsDoneC <- struct{}{}
 			}(e)
 		}

--- a/lib/events/eventstest/channel.go
+++ b/lib/events/eventstest/channel.go
@@ -40,14 +40,10 @@ func NewChannelEmitter(capacity int) *ChannelEmitter {
 	}
 }
 
-func (e *ChannelEmitter) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (e *ChannelEmitter) EmitAuditEvent(event apievents.AuditEvent) error {
 	e.log.Infof("EmitAuditEvent(%v)", event)
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case e.events <- event:
-		return nil
-	}
+	e.events <- event
+	return nil
 }
 
 func (e *ChannelEmitter) C() <-chan apievents.AuditEvent {

--- a/lib/events/eventstest/counter.go
+++ b/lib/events/eventstest/counter.go
@@ -17,7 +17,6 @@ limitations under the License.
 package eventstest
 
 import (
-	"context"
 	"sync/atomic"
 
 	"github.com/gravitational/teleport/api/types/events"
@@ -33,7 +32,7 @@ type CounterEmitter struct {
 	count int64
 }
 
-func (c *CounterEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
+func (c *CounterEmitter) EmitAuditEvent(event events.AuditEvent) error {
 	atomic.AddInt64(&c.count, 1)
 	return nil
 }

--- a/lib/events/eventstest/mock_auditlog.go
+++ b/lib/events/eventstest/mock_auditlog.go
@@ -50,6 +50,6 @@ func (m *MockAuditLog) StreamSessionEvents(ctx context.Context, sid session.ID, 
 	return events, errors
 }
 
-func (m *MockAuditLog) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
-	return m.Emitter.EmitAuditEvent(ctx, event)
+func (m *MockAuditLog) EmitAuditEvent(event apievents.AuditEvent) error {
+	return m.Emitter.EmitAuditEvent(event)
 }

--- a/lib/events/eventstest/mock_recorder_emitter.go
+++ b/lib/events/eventstest/mock_recorder_emitter.go
@@ -35,7 +35,7 @@ func (e *MockRecorderEmitter) Write(_ []byte) (int, error) {
 }
 
 // EmitAuditEvent emits audit event
-func (e *MockRecorderEmitter) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (e *MockRecorderEmitter) EmitAuditEvent(event apievents.AuditEvent) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 	e.events = append(e.events, event)

--- a/lib/events/eventstest/slow.go
+++ b/lib/events/eventstest/slow.go
@@ -17,7 +17,6 @@ limitations under the License.
 package eventstest
 
 import (
-	"context"
 	"time"
 
 	"github.com/gravitational/teleport/api/types/events"
@@ -37,11 +36,7 @@ type slowEmitter struct {
 	delay time.Duration
 }
 
-func (s *slowEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
-	select {
-	case <-time.After(s.delay):
-		return nil
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+func (s *slowEmitter) EmitAuditEvent(event events.AuditEvent) error {
+	<-time.After(s.delay)
+	return nil
 }

--- a/lib/events/filelog.go
+++ b/lib/events/filelog.go
@@ -123,7 +123,7 @@ type FileLog struct {
 }
 
 // EmitAuditEvent adds a new event to the log.
-func (l *FileLog) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (l *FileLog) EmitAuditEvent(event apievents.AuditEvent) error {
 	l.rw.RLock()
 	defer l.rw.RUnlock()
 

--- a/lib/events/filelog_test.go
+++ b/lib/events/filelog_test.go
@@ -43,7 +43,7 @@ func TestFileLogPagination(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = log.EmitAuditEvent(ctx, &events.SessionJoin{
+	err = log.EmitAuditEvent(&events.SessionJoin{
 		Metadata: events.Metadata{
 			ID:   "a",
 			Type: SessionJoinEvent,
@@ -55,7 +55,7 @@ func TestFileLogPagination(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = log.EmitAuditEvent(ctx, &events.SessionJoin{
+	err = log.EmitAuditEvent(&events.SessionJoin{
 		Metadata: events.Metadata{
 			ID:   "b",
 			Type: SessionJoinEvent,
@@ -67,7 +67,7 @@ func TestFileLogPagination(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = log.EmitAuditEvent(ctx, &events.SessionJoin{
+	err = log.EmitAuditEvent(&events.SessionJoin{
 		Metadata: events.Metadata{
 			ID:   "c",
 			Type: SessionJoinEvent,
@@ -116,7 +116,7 @@ func TestSearchSessionEvents(t *testing.T) {
 	require.Nil(t, err)
 	clock.Advance(1 * time.Minute)
 
-	require.NoError(t, log.EmitAuditEvent(ctx, &events.SessionEnd{
+	require.NoError(t, log.EmitAuditEvent(&events.SessionEnd{
 		Metadata: events.Metadata{
 			ID:   "a",
 			Type: SessionEndEvent,
@@ -137,7 +137,7 @@ func TestSearchSessionEvents(t *testing.T) {
 	require.Equal(t, result[0].GetID(), "a")
 
 	// emit a non-session event, it should not show up in the next query
-	require.NoError(t, log.EmitAuditEvent(ctx, &events.SessionJoin{
+	require.NoError(t, log.EmitAuditEvent(&events.SessionJoin{
 		Metadata: events.Metadata{
 			ID:   "b",
 			Type: SessionJoinEvent,
@@ -158,7 +158,7 @@ func TestSearchSessionEvents(t *testing.T) {
 	require.Equal(t, result[0].GetID(), "a")
 
 	// emit a desktop session event, it should show up in the next query
-	require.NoError(t, log.EmitAuditEvent(ctx, &events.WindowsDesktopSessionEnd{
+	require.NoError(t, log.EmitAuditEvent(&events.WindowsDesktopSessionEnd{
 		Metadata: events.Metadata{
 			ID:   "c",
 			Type: WindowsDesktopSessionEndEvent,
@@ -239,7 +239,6 @@ func TestLargeEvent(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
 			clock := clockwork.NewFakeClockAt(time.Now())
 
 			log, err := NewFileLog(FileLogConfig{
@@ -254,7 +253,7 @@ func TestLargeEvent(t *testing.T) {
 
 			for _, v := range tc.in {
 				v.SetTime(clock.Now().UTC())
-				log.EmitAuditEvent(ctx, v)
+				log.EmitAuditEvent(v)
 			}
 			events := mustSearchEvent(t, log, start)
 			for _, ch := range tc.checks {

--- a/lib/events/firestoreevents/firestoreevents.go
+++ b/lib/events/firestoreevents/firestoreevents.go
@@ -305,7 +305,7 @@ func New(cfg EventsConfig) (*Log, error) {
 }
 
 // EmitAuditEvent emits audit event
-func (l *Log) EmitAuditEvent(ctx context.Context, in apievents.AuditEvent) error {
+func (l *Log) EmitAuditEvent(in apievents.AuditEvent) error {
 	data, err := utils.FastMarshal(in)
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -293,7 +293,7 @@ func (l *Log) periodicCleanup(ctx context.Context, cleanupInterval, retentionPer
 var _ events.AuditLogger = (*Log)(nil)
 
 // EmitAuditEvent implements [events.AuditLogger].
-func (l *Log) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (l *Log) EmitAuditEvent(event apievents.AuditEvent) error {
 	var sessionID uuid.UUID
 	if s := events.GetSessionID(event); s != "" {
 		u, err := uuid.Parse(s)
@@ -309,7 +309,7 @@ func (l *Log) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) er
 	}
 
 	eventID := uuid.New()
-
+	ctx := context.Background()
 	// if an event with the same event_id exists, it means that we inserted it
 	// and then failed to receive the success reply from the commit
 	if _, err := pgcommon.RetryIdempotent(ctx, l.log, func() (struct{}, error) {

--- a/lib/events/search_limiter_test.go
+++ b/lib/events/search_limiter_test.go
@@ -40,7 +40,7 @@ func TestSearchEventsLimiter(t *testing.T) {
 		})
 		require.NoError(t, err)
 		for i := 0; i < 20; i++ {
-			require.NoError(t, s.EmitAuditEvent(context.Background(), &apievents.AccessRequestCreate{}))
+			require.NoError(t, s.EmitAuditEvent(&apievents.AccessRequestCreate{}))
 		}
 	})
 
@@ -181,6 +181,6 @@ func (m *mockAuditLogger) SearchSessionEvents(ctx context.Context, req events.Se
 	return m.searchEventsRespFn()
 }
 
-func (m *mockAuditLogger) EmitAuditEvent(context.Context, apievents.AuditEvent) error {
+func (m *mockAuditLogger) EmitAuditEvent(apievents.AuditEvent) error {
 	return m.emitAuditEventRespFn()
 }

--- a/lib/events/test/suite.go
+++ b/lib/events/test/suite.go
@@ -92,7 +92,7 @@ func (s *EventsSuite) EventPagination(t *testing.T) {
 	names := []string{"bob", "jack", "daisy", "evan"}
 
 	for i, name := range names {
-		err := s.Log.EmitAuditEvent(context.Background(), &apievents.UserLogin{
+		err := s.Log.EmitAuditEvent(&apievents.UserLogin{
 			Method:       events.LoginMethodSAML,
 			Status:       apievents.Status{Success: true},
 			UserMetadata: apievents.UserMetadata{User: name},
@@ -215,7 +215,7 @@ func (s *EventsSuite) EventPagination(t *testing.T) {
 	baseTime2 := time.Date(2019, time.August, 10, 14, 43, 47, 0, time.UTC)
 
 	for _, name := range names {
-		err := s.Log.EmitAuditEvent(context.Background(), &apievents.UserLogin{
+		err := s.Log.EmitAuditEvent(&apievents.UserLogin{
 			Method:       events.LoginMethodSAML,
 			Status:       apievents.Status{Success: true},
 			UserMetadata: apievents.UserMetadata{User: name},
@@ -261,7 +261,7 @@ Outer:
 func (s *EventsSuite) SessionEventsCRUD(t *testing.T) {
 	loginTime := s.Clock.Now().UTC()
 	// Bob has logged in
-	err := s.Log.EmitAuditEvent(context.Background(), &apievents.UserLogin{
+	err := s.Log.EmitAuditEvent(&apievents.UserLogin{
 		Method:       events.LoginMethodSAML,
 		Status:       apievents.Status{Success: true},
 		UserMetadata: apievents.UserMetadata{User: "bob"},
@@ -301,7 +301,7 @@ func (s *EventsSuite) SessionEventsCRUD(t *testing.T) {
 	// sessionStartTime must be greater than loginTime, because in search we assume
 	// order.
 	sessionStartTime := loginTime.Add(1 * time.Minute)
-	err = s.Log.EmitAuditEvent(context.Background(), &apievents.SessionStart{
+	err = s.Log.EmitAuditEvent(&apievents.SessionStart{
 		Metadata: apievents.Metadata{
 			ID:    uuid.NewString(),
 			Time:  sessionStartTime,
@@ -318,7 +318,7 @@ func (s *EventsSuite) SessionEventsCRUD(t *testing.T) {
 	require.NoError(t, err)
 
 	sessionEndTime := s.Clock.Now().Add(time.Hour).UTC()
-	err = s.Log.EmitAuditEvent(context.Background(), &apievents.SessionEnd{
+	err = s.Log.EmitAuditEvent(&apievents.SessionEnd{
 		Metadata: apievents.Metadata{
 			ID:    uuid.NewString(),
 			Time:  sessionEndTime,
@@ -417,7 +417,7 @@ func (s *EventsSuite) SearchSessionEventsBySessionID(t *testing.T) {
 				SessionID: id,
 			},
 		}
-		err := s.Log.EmitAuditEvent(context.Background(), event)
+		err := s.Log.EmitAuditEvent(event)
 		require.NoError(t, err)
 	}
 	from := time.Time{}

--- a/lib/events/usageevents/usageevents.go
+++ b/lib/events/usageevents/usageevents.go
@@ -17,8 +17,6 @@ limitations under the License.
 package usageevents
 
 import (
-	"context"
-
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
@@ -45,7 +43,7 @@ var _ apievents.Emitter = (*UsageLogger)(nil)
 // reportAuditEvent tries to convert the audit event into a usage event, and
 // submits the usage event if successful, but silently ignores events if no
 // reporter is configured.
-func (u *UsageLogger) reportAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (u *UsageLogger) reportAuditEvent(event apievents.AuditEvent) error {
 	if u.reporter == nil {
 		return nil
 	}
@@ -57,15 +55,15 @@ func (u *UsageLogger) reportAuditEvent(ctx context.Context, event apievents.Audi
 	return nil
 }
 
-func (u *UsageLogger) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
-	if err := u.reportAuditEvent(ctx, event); err != nil {
+func (u *UsageLogger) EmitAuditEvent(event apievents.AuditEvent) error {
+	if err := u.reportAuditEvent(event); err != nil {
 		// We don't ever want this to fail or bubble up errors, so the best we
 		// can do is complain to the logs.
 		u.Warnf("Failed to filter audit event: %+v", err)
 	}
 
 	if u.inner != nil {
-		return u.inner.EmitAuditEvent(ctx, event)
+		return u.inner.EmitAuditEvent(event)
 	}
 
 	return nil

--- a/lib/kube/grpc/grpc.go
+++ b/lib/kube/grpc/grpc.go
@@ -178,7 +178,6 @@ func (s *Server) authorize(ctx context.Context) (*authz.Context, error) {
 // the roles used to perform the search.
 func (s *Server) emitAuditEvent(ctx context.Context, userContext *authz.Context, req *proto.ListKubernetesResourcesRequest) error {
 	err := s.cfg.Emitter.EmitAuditEvent(
-		ctx,
 		&apievents.AccessRequestResourceSearch{
 			Metadata: apievents.Metadata{
 				Type: events.AccessRequestResourceSearch,

--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -897,7 +897,7 @@ func (f *Forwarder) emitAuditEvent(req *http.Request, sess *clusterSession, stat
 	}
 
 	r.populateEvent(event)
-	if err := f.cfg.AuthClient.EmitAuditEvent(f.ctx, event); err != nil {
+	if err := f.cfg.AuthClient.EmitAuditEvent(event); err != nil {
 		f.log.WithError(err).Warn("Failed to emit event.")
 	}
 }
@@ -1480,7 +1480,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 		SessionRecording: ctx.recordingConfig.GetMode(),
 	}
 
-	if err := f.cfg.Emitter.EmitAuditEvent(f.ctx, sessionStartEvent); err != nil {
+	if err := f.cfg.Emitter.EmitAuditEvent(sessionStartEvent); err != nil {
 		f.log.WithError(err).Warn("Failed to emit event.")
 	}
 
@@ -1501,7 +1501,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 	}
 
 	defer func() {
-		if err := f.cfg.Emitter.EmitAuditEvent(f.ctx, execEvent); err != nil {
+		if err := f.cfg.Emitter.EmitAuditEvent(execEvent); err != nil {
 			f.log.WithError(err).Warn("Failed to emit exec event.")
 		}
 
@@ -1524,7 +1524,7 @@ func (f *Forwarder) execNonInteractive(ctx *authContext, w http.ResponseWriter, 
 			SessionRecording:          ctx.recordingConfig.GetMode(),
 		}
 
-		if err := f.cfg.Emitter.EmitAuditEvent(f.ctx, sessionEndEvent); err != nil {
+		if err := f.cfg.Emitter.EmitAuditEvent(sessionEndEvent); err != nil {
 			f.log.WithError(err).Warn("Failed to emit session end event.")
 		}
 	}()
@@ -1795,7 +1795,7 @@ func (f *Forwarder) portForward(authCtx *authContext, w http.ResponseWriter, req
 		if !success {
 			portForward.Code = events.PortForwardFailureCode
 		}
-		if err := f.cfg.Emitter.EmitAuditEvent(f.ctx, portForward); err != nil {
+		if err := f.cfg.Emitter.EmitAuditEvent(portForward); err != nil {
 			f.log.WithError(err).Warn("Failed to emit event.")
 		}
 	}

--- a/lib/kube/proxy/sess.go
+++ b/lib/kube/proxy/sess.go
@@ -567,7 +567,7 @@ func (s *session) launch() error {
 		if err := s.recorder.RecordEvent(s.forwarder.ctx, sessionStartEvent); err != nil {
 			s.forwarder.log.WithError(err).Warn("Failed to record session start event.")
 		}
-		if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionStartEvent.GetAuditEvent()); err != nil {
+		if err := s.emitter.EmitAuditEvent(sessionStartEvent.GetAuditEvent()); err != nil {
 			s.forwarder.log.WithError(err).Warn("Failed to emit session start event.")
 		}
 	} else {
@@ -786,7 +786,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 
 		}
 
-		if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, execEvent); err != nil {
+		if err := s.emitter.EmitAuditEvent(execEvent); err != nil {
 			s.forwarder.log.WithError(err).Warn("Failed to emit exec event.")
 		}
 
@@ -806,7 +806,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 			BytesReceived: s.io.CountWritten(),
 		}
 
-		if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionDataEvent); err != nil {
+		if err := s.emitter.EmitAuditEvent(sessionDataEvent); err != nil {
 			s.forwarder.log.WithError(err).Warn("Failed to emit session data event.")
 		}
 
@@ -833,7 +833,7 @@ func (s *session) lockedSetupLaunch(request *remoteCommandRequest, q url.Values,
 			if err := s.recorder.RecordEvent(s.forwarder.ctx, sessionEndEvent); err != nil {
 				s.forwarder.log.WithError(err).Warn("Failed to record session end event.")
 			}
-			if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionEndEvent.GetAuditEvent()); err != nil {
+			if err := s.emitter.EmitAuditEvent(sessionEndEvent.GetAuditEvent()); err != nil {
 				s.forwarder.log.WithError(err).Warn("Failed to emit session end event.")
 			}
 		} else {
@@ -894,7 +894,7 @@ func (s *session) join(p *party) error {
 		},
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionJoinEvent); err != nil {
+	if err := s.emitter.EmitAuditEvent(sessionJoinEvent); err != nil {
 		s.forwarder.log.WithError(err).Warn("Failed to emit event.")
 	}
 
@@ -1030,7 +1030,7 @@ func (s *session) unlockedLeave(id uuid.UUID) (bool, error) {
 		},
 	}
 
-	if err := s.emitter.EmitAuditEvent(s.forwarder.ctx, sessionLeaveEvent); err != nil {
+	if err := s.emitter.EmitAuditEvent(sessionLeaveEvent); err != nil {
 		s.forwarder.log.WithError(err).Warn("Failed to emit event.")
 	}
 

--- a/lib/restrictedsession/restricted.go
+++ b/lib/restrictedsession/restricted.go
@@ -41,13 +41,11 @@ var log = logrus.WithFields(logrus.Fields{
 	trace.Component: teleport.ComponentRestrictedSession,
 })
 
-var (
-	lostRestrictedEvents = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: teleport.MetricLostRestrictedEvents,
-			Help: "Number of lost restricted events.",
-		},
-	)
+var lostRestrictedEvents = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: teleport.MetricLostRestrictedEvents,
+		Help: "Number of lost restricted events.",
+	},
 )
 
 //go:embed bytecode
@@ -292,7 +290,7 @@ func (l *auditEventLoop) loop() {
 			continue
 		}
 
-		if err = ctx.Emitter.EmitAuditEvent(ctx.Context, event); err != nil {
+		if err = ctx.Emitter.EmitAuditEvent(event); err != nil {
 			log.WithError(err).Warn("Failed to emit network event.")
 		}
 	}

--- a/lib/srv/app/common/audit.go
+++ b/lib/srv/app/common/audit.go
@@ -230,7 +230,7 @@ func (a *audit) EmitEvent(ctx context.Context, e apievents.AuditEvent) error {
 	var emitErr error
 	// AppSessionRequest events should only go to session recording
 	if event.GetType() != events.AppSessionRequestEvent {
-		emitErr = a.cfg.Emitter.EmitAuditEvent(ctx, event)
+		emitErr = a.cfg.Emitter.EmitAuditEvent(event)
 	}
 
 	return trace.NewAggregate(recErr, emitErr)

--- a/lib/srv/authhandlers.go
+++ b/lib/srv/authhandlers.go
@@ -258,7 +258,7 @@ func (h *AuthHandlers) CheckPortForward(addr string, ctx *ServerContext) error {
 		userErrorMessage := "port forwarding not allowed"
 
 		// Emit port forward failure event
-		if err := h.c.Emitter.EmitAuditEvent(h.c.Server.Context(), &apievents.PortForward{
+		if err := h.c.Emitter.EmitAuditEvent(&apievents.PortForward{
 			Metadata: apievents.Metadata{
 				Type: events.PortForwardEvent,
 				Code: events.PortForwardFailureCode,
@@ -341,7 +341,7 @@ func (h *AuthHandlers) UserKeyAuth(conn ssh.ConnMetadata, key ssh.PublicKey) (*s
 			h.log.WithError(err).Warn("Failed to append Trace to ConnectionDiagnostic.")
 		}
 
-		if err := h.c.Emitter.EmitAuditEvent(h.c.Server.Context(), &apievents.AuthAttempt{
+		if err := h.c.Emitter.EmitAuditEvent(&apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,
 				Code: events.AuthAttemptFailureCode,

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -991,7 +991,7 @@ func (c *ServerContext) reportStats(conn utils.Stater) {
 	if !c.srv.UseTunnel() {
 		sessionDataEvent.ConnectionMetadata.LocalAddr = c.ServerConn.LocalAddr().String()
 	}
-	if err := c.GetServer().EmitAuditEvent(c.GetServer().Context(), sessionDataEvent); err != nil {
+	if err := c.GetServer().EmitAuditEvent(sessionDataEvent); err != nil {
 		c.WithError(err).Warn("Failed to emit session data event.")
 	}
 

--- a/lib/srv/db/common/audit.go
+++ b/lib/srv/db/common/audit.go
@@ -181,7 +181,7 @@ func (a *audit) EmitEvent(ctx context.Context, event events.AuditEvent) {
 	if err := a.cfg.Recorder.RecordEvent(ctx, preparedEvent); err != nil {
 		a.log.WithError(err).Errorf("Failed to record session event: %s - %s.", event.GetType(), event.GetID())
 	}
-	if err := a.cfg.Emitter.EmitAuditEvent(ctx, preparedEvent.GetAuditEvent()); err != nil {
+	if err := a.cfg.Emitter.EmitAuditEvent(preparedEvent.GetAuditEvent()); err != nil {
 		a.log.WithError(err).Errorf("Failed to emit audit event: %s - %s.", event.GetType(), event.GetID())
 	}
 }

--- a/lib/srv/desktop/audit.go
+++ b/lib/srv/desktop/audit.go
@@ -513,7 +513,7 @@ func (s *WindowsService) onSharedDirectoryWriteResponse(
 }
 
 func (s *WindowsService) emit(ctx context.Context, event events.AuditEvent) {
-	if err := s.cfg.Emitter.EmitAuditEvent(ctx, event); err != nil {
+	if err := s.cfg.Emitter.EmitAuditEvent(event); err != nil {
 		s.cfg.Log.WithError(err).Errorf("Failed to emit audit event %v", event)
 	}
 }

--- a/lib/srv/discovery/discovery_test.go
+++ b/lib/srv/discovery/discovery_test.go
@@ -101,7 +101,7 @@ type mockEmitter struct {
 	t            *testing.T
 }
 
-func (me *mockEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
+func (me *mockEmitter) EmitAuditEvent(event events.AuditEvent) error {
 	if me.eventHandler != nil {
 		me.eventHandler(me.t, event, me.server)
 	}

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -492,7 +492,7 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 				scpEvent.Code = events.SCPDownloadCode
 			}
 		}
-		if err := ctx.session.emitAuditEvent(ctx.srv.Context(), scpEvent); err != nil {
+		if err := ctx.session.emitAuditEvent(scpEvent); err != nil {
 			log.WithError(err).Warn("Failed to emit scp event.")
 		}
 	} else {
@@ -512,7 +512,7 @@ func emitExecAuditEvent(ctx *ServerContext, cmd string, execErr error) {
 		} else {
 			execEvent.Code = events.ExecCode
 		}
-		if err := ctx.session.emitAuditEvent(ctx.srv.Context(), execEvent); err != nil {
+		if err := ctx.session.emitAuditEvent(execEvent); err != nil {
 			log.WithError(err).Warn("Failed to emit exec event.")
 		}
 	}

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -904,7 +904,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ch ssh.Channel, r
 	}
 	defer conn.Close()
 
-	if err := s.EmitAuditEvent(s.closeContext, &apievents.PortForward{
+	if err := s.EmitAuditEvent(&apievents.PortForward{
 		Metadata: apievents.Metadata{
 			Type: events.PortForwardEvent,
 			Code: events.PortForwardCode,
@@ -1269,7 +1269,7 @@ func (s *Server) handleX11Forward(ctx context.Context, ch ssh.Channel, req *ssh.
 			s.replyError(ch, req, err)
 			err = nil
 		}
-		if err := s.EmitAuditEvent(ctx, event); err != nil {
+		if err := s.EmitAuditEvent(event); err != nil {
 			s.log.WithError(err).Warn("Failed to emit x11-forward event.")
 		}
 	}()

--- a/lib/srv/forward/subsystem.go
+++ b/lib/srv/forward/subsystem.go
@@ -150,7 +150,7 @@ func (r *remoteSubsystem) emitAuditEvent(err error) {
 		subsystemEvent.Code = events.SubsystemCode
 	}
 
-	if err := srv.EmitAuditEvent(srv.Context(), subsystemEvent); err != nil {
+	if err := srv.EmitAuditEvent(subsystemEvent); err != nil {
 		r.log.WithError(err).Warn("Failed to emit subsystem audit event.")
 	}
 }

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -437,7 +437,7 @@ func (w *Monitor) emitDisconnectEvent(reason string) error {
 		},
 		Reason: reason,
 	}
-	return trace.Wrap(w.Emitter.EmitAuditEvent(w.Context, event))
+	return trace.Wrap(w.Emitter.EmitAuditEvent(event))
 }
 
 func (w *Monitor) handleLockInForce(lockErr error) {

--- a/lib/srv/regular/sftp.go
+++ b/lib/srv/regular/sftp.go
@@ -175,7 +175,7 @@ func (s *sftpSubsys) Start(ctx context.Context, serverConn *ssh.ServerConn, ch s
 			sftpEvent.UserMetadata = userMeta
 			sftpEvent.ConnectionMetadata = connectionMeta
 
-			if err := serverCtx.GetServer().EmitAuditEvent(ctx, &sftpEvent); err != nil {
+			if err := serverCtx.GetServer().EmitAuditEvent(&sftpEvent); err != nil {
 				log.WithError(err).Warn("Failed to emit SFTP event.")
 			}
 		}

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -1241,7 +1241,7 @@ func (s *Server) HandleNewChan(ctx context.Context, ccx *sshutils.ConnectionCont
 			d, ok := ccx.IncrSessions(max)
 			if !ok {
 				// user has exceeded their max concurrent ssh sessions.
-				if err := s.EmitAuditEvent(s.ctx, &apievents.SessionReject{
+				if err := s.EmitAuditEvent(&apievents.SessionReject{
 					Metadata: apievents.Metadata{
 						Type: events.SessionRejectedEvent,
 						Code: events.SessionRejectedCode,
@@ -1413,7 +1413,7 @@ func (s *Server) handleDirectTCPIPRequest(ctx context.Context, ccx *sshutils.Con
 
 	// Emit a port forwarding event if the command exited successfully.
 	if err := cmd.Wait(); err == nil {
-		if err := s.EmitAuditEvent(s.ctx, &apievents.PortForward{
+		if err := s.EmitAuditEvent(&apievents.PortForward{
 			Metadata: apievents.Metadata{
 				Type: events.PortForwardEvent,
 				Code: events.PortForwardCode,
@@ -1799,7 +1799,7 @@ func (s *Server) handleX11Forward(ch ssh.Channel, req *ssh.Request, ctx *srv.Ser
 			s.replyError(ch, req, err)
 			err = nil
 		}
-		if err := s.EmitAuditEvent(s.ctx, event); err != nil {
+		if err := s.EmitAuditEvent(event); err != nil {
 			s.Logger.WithError(err).Warn("Failed to emit x11-forward event.")
 		}
 	}()

--- a/lib/srv/server/ssm_install.go
+++ b/lib/srv/server/ssm_install.go
@@ -156,5 +156,5 @@ func (si *SSMInstaller) checkCommand(ctx context.Context, req SSMRunRequest, com
 		Status:     aws.StringValue(cmdOut.Status),
 	}
 
-	return trace.Wrap(si.Emitter.EmitAuditEvent(ctx, &event))
+	return trace.Wrap(si.Emitter.EmitAuditEvent(&event))
 }

--- a/lib/srv/server/ssm_install_test.go
+++ b/lib/srv/server/ssm_install_test.go
@@ -56,7 +56,7 @@ type mockEmitter struct {
 	events []events.AuditEvent
 }
 
-func (me *mockEmitter) EmitAuditEvent(ctx context.Context, event events.AuditEvent) error {
+func (me *mockEmitter) EmitAuditEvent(event events.AuditEvent) error {
 	me.events = append(me.events, event)
 	return nil
 }

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -906,7 +906,7 @@ func (s *session) emitSessionStartEvent(ctx *ServerContext) {
 	if err := s.recordEvent(ctx.srv.Context(), preparedEvent); err != nil {
 		s.log.WithError(err).Warn("Failed to record session start event.")
 	}
-	if err := s.emitAuditEvent(ctx.srv.Context(), preparedEvent.GetAuditEvent()); err != nil {
+	if err := s.emitAuditEvent(preparedEvent.GetAuditEvent()); err != nil {
 		s.log.WithError(err).Warn("Failed to emit session start event.")
 	}
 }
@@ -940,7 +940,7 @@ func (s *session) emitSessionJoinEvent(ctx *ServerContext) {
 		if err := s.recordEvent(ctx.srv.Context(), preparedEvent); err != nil {
 			s.log.WithError(err).Warn("Failed to record session join event.")
 		}
-		if err := s.emitAuditEvent(ctx.srv.Context(), preparedEvent.GetAuditEvent()); err != nil {
+		if err := s.emitAuditEvent(preparedEvent.GetAuditEvent()); err != nil {
 			s.log.WithError(err).Warn("Failed to emit session join event.")
 		}
 	} else {
@@ -985,7 +985,7 @@ func (s *session) emitSessionLeaveEvent(ctx *ServerContext) {
 		if err := s.recordEvent(ctx.srv.Context(), preparedEvent); err != nil {
 			s.log.WithError(err).Warn("Failed to record session leave event.")
 		}
-		if err := s.emitAuditEvent(ctx.srv.Context(), preparedEvent.GetAuditEvent()); err != nil {
+		if err := s.emitAuditEvent(preparedEvent.GetAuditEvent()); err != nil {
 			s.log.WithError(err).Warn("Failed to emit session leave event.")
 		}
 	} else {
@@ -1060,7 +1060,7 @@ func (s *session) emitSessionEndEvent() {
 		if err := s.recordEvent(ctx.srv.Context(), preparedEvent); err != nil {
 			s.log.WithError(err).Warn("Failed to record session end event.")
 		}
-		if err := s.emitAuditEvent(ctx.srv.Context(), preparedEvent.GetAuditEvent()); err != nil {
+		if err := s.emitAuditEvent(preparedEvent.GetAuditEvent()); err != nil {
 			s.log.WithError(err).Warn("Failed to emit session end event.")
 		}
 	} else {
@@ -2045,8 +2045,8 @@ func (s *session) trackSession(ctx context.Context, teleportUser string, policyS
 }
 
 // emitAuditEvent emits audit events.
-func (s *session) emitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
-	return s.emitter.EmitAuditEvent(ctx, event)
+func (s *session) emitAuditEvent(event apievents.AuditEvent) error {
+	return s.emitter.EmitAuditEvent(event)
 }
 
 func (s *session) recordEvent(ctx context.Context, event apievents.PreparedSessionEvent) error {

--- a/lib/srv/sess_test.go
+++ b/lib/srv/sess_test.go
@@ -748,8 +748,8 @@ func (m *mockRecorder) Done() <-chan struct{} {
 	return ch
 }
 
-func (m *mockRecorder) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
-	return m.emitter.EmitAuditEvent(ctx, event)
+func (m *mockRecorder) EmitAuditEvent(event apievents.AuditEvent) error {
+	return m.emitter.EmitAuditEvent(event)
 }
 
 type trackerService struct {

--- a/lib/srv/session_control.go
+++ b/lib/srv/session_control.go
@@ -40,13 +40,11 @@ import (
 	"github.com/gravitational/teleport/lib/services"
 )
 
-var (
-	userSessionLimitHitCount = prometheus.NewCounter(
-		prometheus.CounterOpts{
-			Name: teleport.MetricUserMaxConcurrentSessionsHit,
-			Help: "Number of times a user exceeded their max concurrent ssh connections",
-		},
-	)
+var userSessionLimitHitCount = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Name: teleport.MetricUserMaxConcurrentSessionsHit,
+		Help: "Number of times a user exceeded their max concurrent ssh connections",
+	},
 )
 
 func init() {
@@ -318,7 +316,7 @@ func (s *SessionController) emitRejection(ctx context.Context, userMetadata apie
 	ctx, span := s.cfg.tracer.Start(emitCtx, "SessionController/emitRejection")
 	defer span.End()
 
-	if err := s.cfg.Emitter.EmitAuditEvent(ctx, &apievents.SessionReject{
+	if err := s.cfg.Emitter.EmitAuditEvent(&apievents.SessionReject{
 		Metadata: apievents.Metadata{
 			Type: events.SessionRejectedEvent,
 			Code: events.SessionRejectedCode,

--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3042,7 +3042,7 @@ func TestSearchClusterEvents(t *testing.T) {
 	})
 
 	for _, e := range sessionEvents {
-		require.NoError(t, s.proxyClient.EmitAuditEvent(s.ctx, e))
+		require.NoError(t, s.proxyClient.EmitAuditEvent(e))
 	}
 
 	sort.Sort(sort.Reverse(byTimeAndIndex(sessionEvents)))

--- a/lib/web/app/auth.go
+++ b/lib/web/app/auth.go
@@ -57,7 +57,7 @@ func (h *Handler) handleAuth(w http.ResponseWriter, r *http.Request, p httproute
 	if err := checkSubjectToken(subjectCookieValue, ws); err != nil {
 		h.log.Warnf("Request failed: %v.", err)
 
-		h.c.AuthClient.EmitAuditEvent(h.closeContext, &apievents.AuthAttempt{
+		h.c.AuthClient.EmitAuditEvent(&apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,
 				Code: events.AuthAttemptFailureCode,

--- a/lib/web/app/handler.go
+++ b/lib/web/app/handler.go
@@ -169,7 +169,7 @@ func (h *Handler) HandleConnection(ctx context.Context, clientConn net.Conn) err
 
 		userMeta := identity.GetUserMetadata()
 		userMeta.Login = ws.GetUser()
-		h.c.AuthClient.EmitAuditEvent(h.closeContext, &apievents.AuthAttempt{
+		h.c.AuthClient.EmitAuditEvent(&apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,
 				Code: events.AuthAttemptFailureCode,
@@ -406,7 +406,7 @@ func (h *Handler) getAppSessionFromCert(r *http.Request) (types.WebSession, erro
 
 		userMeta := identity.GetUserMetadata()
 		userMeta.Login = ws.GetUser()
-		h.c.AuthClient.EmitAuditEvent(h.closeContext, &apievents.AuthAttempt{
+		h.c.AuthClient.EmitAuditEvent(&apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,
 				Code: events.AuthAttemptFailureCode,
@@ -446,7 +446,7 @@ func (h *Handler) getAppSessionFromCookie(r *http.Request) (types.WebSession, er
 	}
 	if ws.GetBearerToken() != subjectValue {
 		err := trace.AccessDenied("subject session token does not match")
-		h.c.AuthClient.EmitAuditEvent(h.closeContext, &apievents.AuthAttempt{
+		h.c.AuthClient.EmitAuditEvent(&apievents.AuthAttempt{
 			Metadata: apievents.Metadata{
 				Type: events.AuthAttemptEvent,
 				Code: events.AuthAttemptFailureCode,

--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -76,7 +76,7 @@ func TestAuthPOST(t *testing.T) {
 		cookieValue = "5588e2be54a2834b4f152c56bafcd789f53b15477129d2ab4044e9a3c1bf0f3b" // random value we set in the header and expect to get back as a cookie
 	)
 
-	fakeClock := clockwork.NewFakeClockAt(time.Date(2017, 05, 10, 18, 53, 0, 0, time.UTC))
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2017, 0o5, 10, 18, 53, 0, 0, time.UTC))
 	clusterName := "test-cluster"
 	publicAddr := "proxy.goteleport.com:443"
 
@@ -330,7 +330,7 @@ func TestMatchApplicationServers(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	fakeClock := clockwork.NewFakeClockAt(time.Date(2017, 05, 10, 18, 53, 0, 0, time.UTC))
+	fakeClock := clockwork.NewFakeClockAt(time.Date(2017, 0o5, 10, 18, 53, 0, 0, time.UTC))
 	authClient := &mockAuthClient{
 		clusterName: clusterName,
 		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr),
@@ -449,7 +449,7 @@ func TestHealthCheckAppServer(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			fakeClock := clockwork.NewFakeClockAt(time.Date(2017, 05, 10, 18, 53, 0, 0, time.UTC))
+			fakeClock := clockwork.NewFakeClockAt(time.Date(2017, 0o5, 10, 18, 53, 0, 0, time.UTC))
 			appSession := createAppSession(t, fakeClock, key, cert, clusterName, tc.publicAddr)
 			authClient := &mockAuthClient{
 				clusterName: clusterName,
@@ -607,7 +607,7 @@ type mockClusterName struct {
 	name string
 }
 
-func (c *mockAuthClient) EmitAuditEvent(ctx context.Context, event apievents.AuditEvent) error {
+func (c *mockAuthClient) EmitAuditEvent(event apievents.AuditEvent) error {
 	c.mtx.Lock()
 	defer c.mtx.Unlock()
 	c.emittedEvents = append(c.emittedEvents, event)
@@ -665,7 +665,6 @@ func (r *fakeRemoteListener) Accept() (net.Conn, error) {
 	}
 
 	return conn, nil
-
 }
 
 func (r *fakeRemoteListener) Close() error {

--- a/lib/web/apps.go
+++ b/lib/web/apps.go
@@ -61,7 +61,6 @@ func (h *Handler) clusterAppsGet(w http.ResponseWriter, r *http.Request, p httpr
 	}
 
 	page, err := apiclient.GetResourcePage[types.AppServerOrSAMLIdPServiceProvider](r.Context(), clt, req)
-
 	if err != nil {
 		// If the error returned is due to types.KindAppOrSAMLIdPServiceProvider being unsupported, then fallback to attempting to just fetch types.AppServers.
 		// This is for backwards compatibility with leaf clusters that don't support this new type yet.
@@ -293,7 +292,7 @@ func (h *Handler) createAppSession(w http.ResponseWriter, r *http.Request, p htt
 			AppName:       result.App.GetName(),
 		},
 	}
-	if err := h.cfg.Emitter.EmitAuditEvent(h.cfg.Context, appSessionStartEvent); err != nil {
+	if err := h.cfg.Emitter.EmitAuditEvent(appSessionStartEvent); err != nil {
 		return nil, trace.Wrap(err)
 	}
 


### PR DESCRIPTION
As reported in https://github.com/gravitational/teleport-private/issues/873, usage of following signature:
```
EmitAuditEvent(context.Context, AuditEvent) error
```
is not trivial, because is hard to tell what kind of ctx should be passed here. If we are passing exit context, it will be proper use. However passing here ctx from request can result is dropping audit events when ctx is canceled. 

This PR proposes removing ctx from Emitter signature.

TODO:
- [x] integrated test dynamo/athena
- [ ] manual tests dynamo/athena backend/ localfile
- [ ] enterprise update