### PR TITLE
Work around go-ldap's lack of errors.Is support

### DIFF
--- a/lib/srv/desktop/windows_server.go
+++ b/lib/srv/desktop/windows_server.go
@@ -494,8 +494,13 @@ func (s *WindowsService) initializeLDAP() error {
 		s.ldapInitialized = false
 
 		// failures due to timeouts might be transient, so retry more frequently
+		//
+		// TODO(zmb3): errors.Is does not work properly on ldap.Error
+		// (remove the extra errors.As() check when https://github.com/go-ldap/ldap/pull/461 merges)
 		retryAfter := windowsDesktopServiceCertRetryInterval
-		if errors.Is(err, context.DeadlineExceeded) {
+		var ldapErr *ldap.Error
+		if errors.Is(err, context.DeadlineExceeded) ||
+			(errors.As(err, &ldapErr) && errors.Is(ldapErr.Err, context.DeadlineExceeded)) {
 			retryAfter = ldapTimeoutRetryInterval
 		}
 


### PR DESCRIPTION
This is hopefully a temporary change that can be removed when the upstream fix [1] is merged.

[1] https://github.com/go-ldap/ldap/pull/461