### PR TITLE
Remove "aurora" engine from db fetcher

### DIFF
--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -1927,6 +1927,8 @@ const (
 	// RDSEngineMariaDB is RDS engine name for MariaDB instances.
 	RDSEngineMariaDB = "mariadb"
 	// RDSEngineAurora is RDS engine name for Aurora MySQL 5.6 compatible clusters.
+	// This reached EOF on Feb 28, 2023.
+	// https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.MySQL56.EOL.html
 	RDSEngineAurora = "aurora"
 	// RDSEngineAuroraMySQL is RDS engine name for Aurora MySQL 5.7 compatible clusters.
 	RDSEngineAuroraMySQL = "aurora-mysql"

--- a/lib/srv/discovery/fetchers/db/aws_rds.go
+++ b/lib/srv/discovery/fetchers/db/aws_rds.go
@@ -195,7 +195,6 @@ func rdsInstanceEngines() []string {
 // only databases with engines Teleport supports.
 func auroraEngines() []string {
 	return []string{
-		services.RDSEngineAurora,
 		services.RDSEngineAuroraMySQL,
 		services.RDSEngineAuroraPostgres,
 	}


### PR DESCRIPTION
This is db discovery equivalent change to #30544.

The current implementation works fine with the fallback Gavin implemented in #18328.
```
Teleport supports an engine which is unrecognized in this AWS region. Querying engine names individually. error:[InvalidParameterValue: Unrecognized engine name: aurora
status code: 400, request id: 617375a6-0a41-4f82-a3df-bdbcb5e6eb6b] labels:map[*:[*]] region:us-west-2 role:{  {} [] 0} 
```
However, removing the deprecated `aurora` engine avoids this debug message and reduces the number of API calls from 3 to 1 API call per fetcher discovery. So a tiny performance improvement.

Not backporting.