### PR TITLE
Fuzz Test Improvements 3

### DIFF
--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -113,6 +113,12 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/web \
     FuzzTdpMFACodecDecode fuzz_tdp_mfa_codec_decode
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/multiplexer \
+    FuzzReadProxyLineV1 fuzz_read_proxy_linec_v1
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/multiplexer \
+    FuzzReadProxyLineV2 fuzz_read_proxy_linec_v2
+
 }
 
 build_teleport_api_fuzzers() {

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -119,6 +119,9 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/auth/webauthn \
     FuzzParseCredentialRequestResponseBody fuzz_parse_credential_request_response_body
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/auth/webauthncli \
+    FuzzParseU2FRegistrationResponse fuzz_parse_u2f_registration_response
+
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/web \
     FuzzTdpMFACodecDecode fuzz_tdp_mfa_codec_decode
 

--- a/fuzz/oss-fuzz-build.sh
+++ b/fuzz/oss-fuzz-build.sh
@@ -77,6 +77,18 @@ build_teleport_fuzzers() {
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
     FuzzParseProxyHost fuzz_parse_proxy_host
 
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
+    FuzzParseLabelSpec fuzz_parse_label_spec
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
+    FuzzParseSearchKeywords fuzz_parse_search_keywords
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
+    FuzzParsePortForwardSpec fuzz_parse_port_forward_spec
+
+  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
+    FuzzParseDynamicPortForwardSpec fuzz_parse_dynamic_port_forward_spec
+
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/srv/regular \
     FuzzParseProxySubsys fuzz_parse_proxy_subsys
 
@@ -91,9 +103,6 @@ build_teleport_fuzzers() {
 
 # compile_native_go_fuzzer $TELEPORT_PREFIX/lib/auth \
 #   FuzzParseAndVerifyIID fuzz_parse_and_verify_iid
-
-  compile_native_go_fuzzer $TELEPORT_PREFIX/lib/client \
-    FuzzParseLabelSpec fuzz_parse_label_spec
 
   compile_native_go_fuzzer $TELEPORT_PREFIX/lib/srv/db/sqlserver/protocol \
     FuzzMSSQLLogin fuzz_mssql_login

--- a/lib/auth/webauthncli/fuzz_test.go
+++ b/lib/auth/webauthncli/fuzz_test.go
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package webauthncli
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func unverifiedBase64Bytes(str string) []byte {
+	bytes, _ := base64.StdEncoding.DecodeString(str)
+	return bytes
+}
+
+func FuzzParseU2FRegistrationResponse(f *testing.F) {
+	f.Add(unverifiedBase64Bytes("BQR+GkzX1lnNopfxpz1baMSaU1wlqZaJ7tGrOJ14p" +
+		"QucBTZR4sKwiJZTuponQvXwJuj3zdanzMH1Os7pjFy4IbEegHIXW/sZVdiZUsjdUQH6/WD0" +
+		"4rllLPEYiiocu/fS1zmntWNBAwI1DOgGJ4FSDsAIidZekwAapqsln+RaNiUgvC4WY0qSYGl" +
+		"3uDz2O6jbaBCjTcLzifcjyaQb3KGLs3EEPN1eNeJcjACVpyWUMZDSOlFkFaE4q0QMJqCCS3" +
+		"c3ng/cMIIBazCCARCgAwIBAgIBATAKBggqhkjOPQQDAjASMRAwDgYDVQQKEwdUZXN0IENBM" +
+		"B4XDTIzMDgxNjE4MjAwNloXDTIzMDgxNjE5MjAwNlowEjEQMA4GA1UEChMHVGVzdCBDQTBZ" +
+		"MBMGByqGSM49AgEGCCqGSM49AwEHA0IABH4aTNfWWc2il/GnPVtoxJpTXCWplonu0as4nXi" +
+		"lC5wFNlHiwrCIllO6midC9fAm6PfN1qfMwfU6zumMXLghsR6jVzBVMA4GA1UdDwEB/wQEAw" +
+		"ICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRF/" +
+		"vV/LdwWaAA1LA3uAYj9ErbjVzAKBggqhkjOPQQDAgNJADBGAiEAixVchjFZ+oEhTXJYCUtx" +
+		"xi/z4PooqF/tlNGKPUHPD6QCIQCqo129HBg5QaUjXc7dHxGVc3joct+CTSIwtyUKSN6twTB" +
+		"GAiEApJfP1bm0/sZTUZ8XeN86WdHVb4+Qz3lwB0d1GxkYM7YCIQCJyXkyu4Y7bm0YPP+XB8" +
+		"3IO2WCmJKNsCT8sZuRRs/ryw=="))
+	f.Add(unverifiedBase64Bytes("BQSEpSKEdxODGvlDbmWKkhqTzCriCEb72v5+dh1mf" +
+		"rZwPxa2DihjLO4LrrN79bz/IYT4AtlNlwP3mDDmv1dhl5XpgH5OJ92XUa+lHeR/ScWXrlld" +
+		"5saUtmuA9Osg3UFK2wActU2Yq0yT8pEzECZba/npHDmSHFs25i0FWiy7ZSSE0hyi2mACyXm" +
+		"yLyRyEg6mH84aVMvW9M0QjFMDmjaZpqcFbXVkf7luOrvLhzo2kUd4fgAZ5bsVlb6Ggfl7Kb" +
+		"0q3MPVMIIBajCCARCgAwIBAgIBATAKBggqhkjOPQQDAjASMRAwDgYDVQQKEwdUZXN0IENBM" +
+		"B4XDTIzMDgxNjE4MjIyMFoXDTIzMDgxNjE5MjIyMFowEjEQMA4GA1UEChMHVGVzdCBDQTBZ" +
+		"MBMGByqGSM49AgEGCCqGSM49AwEHA0IABISlIoR3E4Ma+UNuZYqSGpPMKuIIRvva/n52HWZ" +
+		"+tnA/FrYOKGMs7guus3v1vP8hhPgC2U2XA/eYMOa/V2GXlemjVzBVMA4GA1UdDwEB/wQEAw" +
+		"ICpDATBgNVHSUEDDAKBggrBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRHM" +
+		"KsFLCtx6PUVkpDw8DdKQf9C0zAKBggqhkjOPQQDAgNIADBFAiByA6ISaK+iwQ7TC40IPMXm" +
+		"mHzIf32b0YZwsHTUNf5jDgIhAPDBB5n3wR4d3F+R2PkvbwneqwcwkrrEzpBEXwwsEhpOMEQ" +
+		"CIFAYEWOJZevn6IxtTBg5w/krrHA9z0pzAHRs13KOPEHEAiArbTczB8nS3HIeCJqUt8wclg" +
+		"TVPnbu99FYtP5FueW8Hg=="))
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		require.NotPanics(t, func() {
+			_, _ = parseU2FRegistrationResponse(b)
+		})
+	})
+}

--- a/lib/client/api_test.go
+++ b/lib/client/api_test.go
@@ -47,124 +47,124 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+var parseProxyHostTestCases = []struct {
+	name      string
+	input     string
+	expectErr bool
+	expect    ParsedProxyHost
+}{
+	{
+		name:      "Empty port string",
+		input:     "example.org",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: true,
+			WebProxyAddr:             "example.org:3080",
+			SSHProxyAddr:             "example.org:3023",
+		},
+	}, {
+		name:      "Web proxy port only",
+		input:     "example.org:1234",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: false,
+			WebProxyAddr:             "example.org:1234",
+			SSHProxyAddr:             "example.org:3023",
+		},
+	}, {
+		name:      "Web proxy port with whitespace",
+		input:     "example.org: 1234",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: false,
+			WebProxyAddr:             "example.org:1234",
+			SSHProxyAddr:             "example.org:3023",
+		},
+	}, {
+		name:      "Web proxy port empty with whitespace",
+		input:     "example.org:  ,200",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: true,
+			WebProxyAddr:             "example.org:3080",
+			SSHProxyAddr:             "example.org:200",
+		},
+	}, {
+		name:      "SSH port only",
+		input:     "example.org:,200",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: true,
+			WebProxyAddr:             "example.org:3080",
+			SSHProxyAddr:             "example.org:200",
+		},
+	}, {
+		name:      "SSH port empty",
+		input:     "example.org:100,",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: false,
+			WebProxyAddr:             "example.org:100",
+			SSHProxyAddr:             "example.org:3023",
+		},
+	}, {
+		name:      "SSH port with whitespace",
+		input:     "example.org:100, 200 ",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: false,
+			WebProxyAddr:             "example.org:100",
+			SSHProxyAddr:             "example.org:200",
+		},
+	}, {
+		name:      "SSH port empty with whitespace",
+		input:     "example.org:100,  ",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: false,
+			WebProxyAddr:             "example.org:100",
+			SSHProxyAddr:             "example.org:3023",
+		},
+	}, {
+		name:      "Both ports specified",
+		input:     "example.org:100,200",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: false,
+			WebProxyAddr:             "example.org:100",
+			SSHProxyAddr:             "example.org:200",
+		},
+	}, {
+		name:      "Both ports empty with whitespace",
+		input:     "example.org: , ",
+		expectErr: false,
+		expect: ParsedProxyHost{
+			Host:                     "example.org",
+			UsingDefaultWebProxyPort: true,
+			WebProxyAddr:             "example.org:3080",
+			SSHProxyAddr:             "example.org:3023",
+		},
+	}, {
+		name:      "Too many parts",
+		input:     "example.org:100,200,300,400",
+		expectErr: true,
+		expect:    ParsedProxyHost{},
+	},
+}
+
 func TestParseProxyHostString(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name      string
-		input     string
-		expectErr bool
-		expect    ParsedProxyHost
-	}{
-		{
-			name:      "Empty port string",
-			input:     "example.org",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: true,
-				WebProxyAddr:             "example.org:3080",
-				SSHProxyAddr:             "example.org:3023",
-			},
-		}, {
-			name:      "Web proxy port only",
-			input:     "example.org:1234",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: false,
-				WebProxyAddr:             "example.org:1234",
-				SSHProxyAddr:             "example.org:3023",
-			},
-		}, {
-			name:      "Web proxy port with whitespace",
-			input:     "example.org: 1234",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: false,
-				WebProxyAddr:             "example.org:1234",
-				SSHProxyAddr:             "example.org:3023",
-			},
-		}, {
-			name:      "Web proxy port empty with whitespace",
-			input:     "example.org:  ,200",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: true,
-				WebProxyAddr:             "example.org:3080",
-				SSHProxyAddr:             "example.org:200",
-			},
-		}, {
-			name:      "SSH port only",
-			input:     "example.org:,200",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: true,
-				WebProxyAddr:             "example.org:3080",
-				SSHProxyAddr:             "example.org:200",
-			},
-		}, {
-			name:      "SSH port empty",
-			input:     "example.org:100,",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: false,
-				WebProxyAddr:             "example.org:100",
-				SSHProxyAddr:             "example.org:3023",
-			},
-		}, {
-			name:      "SSH port with whitespace",
-			input:     "example.org:100, 200 ",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: false,
-				WebProxyAddr:             "example.org:100",
-				SSHProxyAddr:             "example.org:200",
-			},
-		}, {
-			name:      "SSH port empty with whitespace",
-			input:     "example.org:100,  ",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: false,
-				WebProxyAddr:             "example.org:100",
-				SSHProxyAddr:             "example.org:3023",
-			},
-		}, {
-			name:      "Both ports specified",
-			input:     "example.org:100,200",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: false,
-				WebProxyAddr:             "example.org:100",
-				SSHProxyAddr:             "example.org:200",
-			},
-		}, {
-			name:      "Both ports empty with whitespace",
-			input:     "example.org: , ",
-			expectErr: false,
-			expect: ParsedProxyHost{
-				Host:                     "example.org",
-				UsingDefaultWebProxyPort: true,
-				WebProxyAddr:             "example.org:3080",
-				SSHProxyAddr:             "example.org:3023",
-			},
-		}, {
-			name:      "Too many parts",
-			input:     "example.org:100,200,300,400",
-			expectErr: true,
-			expect:    ParsedProxyHost{},
-		},
-	}
-
-	for _, testCase := range testCases {
+	for _, testCase := range parseProxyHostTestCases {
 		t.Run(testCase.name, func(t *testing.T) {
 			expected := testCase.expect
 			actual, err := ParseProxyHost(testCase.input)
@@ -284,94 +284,94 @@ func TestPortsParsing(t *testing.T) {
 	require.True(t, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
 }
 
-func TestDynamicPortsParsing(t *testing.T) {
-	tests := []struct {
-		spec    []string
-		isError bool
-		output  DynamicForwardedPorts
-	}{
-		{
-			spec:    nil,
-			isError: false,
-			output:  DynamicForwardedPorts{},
-		},
-		{
-			spec:    []string{},
-			isError: false,
-			output:  DynamicForwardedPorts{},
-		},
-		{
-			spec:    []string{"localhost"},
-			isError: true,
-			output:  DynamicForwardedPorts{},
-		},
-		{
-			spec:    []string{"localhost:123:456"},
-			isError: true,
-			output:  DynamicForwardedPorts{},
-		},
-		{
-			spec:    []string{"8080"},
-			isError: false,
-			output: DynamicForwardedPorts{
-				DynamicForwardedPort{
-					SrcIP:   "127.0.0.1",
-					SrcPort: 8080,
-				},
+var dynamicPortForwardParsingTestCases = []struct {
+	spec    []string
+	isError bool
+	output  DynamicForwardedPorts
+}{
+	{
+		spec:    nil,
+		isError: false,
+		output:  DynamicForwardedPorts{},
+	},
+	{
+		spec:    []string{},
+		isError: false,
+		output:  DynamicForwardedPorts{},
+	},
+	{
+		spec:    []string{"localhost"},
+		isError: true,
+		output:  DynamicForwardedPorts{},
+	},
+	{
+		spec:    []string{"localhost:123:456"},
+		isError: true,
+		output:  DynamicForwardedPorts{},
+	},
+	{
+		spec:    []string{"8080"},
+		isError: false,
+		output: DynamicForwardedPorts{
+			DynamicForwardedPort{
+				SrcIP:   "127.0.0.1",
+				SrcPort: 8080,
 			},
 		},
-		{
-			spec:    []string{":8080"},
-			isError: false,
-			output: DynamicForwardedPorts{
-				DynamicForwardedPort{
-					SrcIP:   "127.0.0.1",
-					SrcPort: 8080,
-				},
+	},
+	{
+		spec:    []string{":8080"},
+		isError: false,
+		output: DynamicForwardedPorts{
+			DynamicForwardedPort{
+				SrcIP:   "127.0.0.1",
+				SrcPort: 8080,
 			},
 		},
-		{
-			spec:    []string{":8080:8081"},
-			isError: true,
-			output:  DynamicForwardedPorts{},
-		},
-		{
-			spec:    []string{"[::1]:8080"},
-			isError: false,
-			output: DynamicForwardedPorts{
-				DynamicForwardedPort{
-					SrcIP:   "::1",
-					SrcPort: 8080,
-				},
+	},
+	{
+		spec:    []string{":8080:8081"},
+		isError: true,
+		output:  DynamicForwardedPorts{},
+	},
+	{
+		spec:    []string{"[::1]:8080"},
+		isError: false,
+		output: DynamicForwardedPorts{
+			DynamicForwardedPort{
+				SrcIP:   "::1",
+				SrcPort: 8080,
 			},
 		},
-		{
-			spec:    []string{"10.0.0.1:8080"},
-			isError: false,
-			output: DynamicForwardedPorts{
-				DynamicForwardedPort{
-					SrcIP:   "10.0.0.1",
-					SrcPort: 8080,
-				},
+	},
+	{
+		spec:    []string{"10.0.0.1:8080"},
+		isError: false,
+		output: DynamicForwardedPorts{
+			DynamicForwardedPort{
+				SrcIP:   "10.0.0.1",
+				SrcPort: 8080,
 			},
 		},
-		{
-			spec:    []string{":8080", "10.0.0.1:8080"},
-			isError: false,
-			output: DynamicForwardedPorts{
-				DynamicForwardedPort{
-					SrcIP:   "127.0.0.1",
-					SrcPort: 8080,
-				},
-				DynamicForwardedPort{
-					SrcIP:   "10.0.0.1",
-					SrcPort: 8080,
-				},
+	},
+	{
+		spec:    []string{":8080", "10.0.0.1:8080"},
+		isError: false,
+		output: DynamicForwardedPorts{
+			DynamicForwardedPort{
+				SrcIP:   "127.0.0.1",
+				SrcPort: 8080,
+			},
+			DynamicForwardedPort{
+				SrcIP:   "10.0.0.1",
+				SrcPort: 8080,
 			},
 		},
-	}
+	},
+}
 
-	for _, tt := range tests {
+func TestDynamicPortsParsing(t *testing.T) {
+	for _, tt := range dynamicPortForwardParsingTestCases {
 		specs, err := ParseDynamicPortForwardSpec(tt.spec)
 		if tt.isError {
 			require.NotNil(t, err)
@@ -636,36 +636,36 @@ func TestNewClient_getProxySSHPrincipal(t *testing.T) {
 	}
 }
 
+var parseSearchKeywordsTestCases = []struct {
+	name     string
+	spec     string
+	expected []string
+}{
+	{
+		name: "empty input",
+		spec: "",
+	},
+	{
+		name:     "simple input",
+		spec:     "foo",
+		expected: []string{"foo"},
+	},
+	{
+		name:     "complex input",
+		spec:     `"foo,bar","some phrase's",baz=qux's ,"some other  phrase"," another one  "`,
+		expected: []string{"foo,bar", "some phrase's", "baz=qux's", "some other  phrase", "another one"},
+	},
+	{
+		name:     "unicode input",
+		spec:     `"服务器环境=测试,操作系统类别", Linux , 机房=华北 `,
+		expected: []string{"服务器环境=测试,操作系统类别", "Linux", "机房=华北"},
+	},
+}
+
 func TestParseSearchKeywords(t *testing.T) {
 	t.Parallel()
 
-	testCases := []struct {
-		name     string
-		spec     string
-		expected []string
-	}{
-		{
-			name: "empty input",
-			spec: "",
-		},
-		{
-			name:     "simple input",
-			spec:     "foo",
-			expected: []string{"foo"},
-		},
-		{
-			name:     "complex input",
-			spec:     `"foo,bar","some phrase's",baz=qux's ,"some other  phrase"," another one  "`,
-			expected: []string{"foo,bar", "some phrase's", "baz=qux's", "some other  phrase", "another one"},
-		},
-		{
-			name:     "unicode input",
-			spec:     `"服务器环境=测试,操作系统类别", Linux , 机房=华北 `,
-			expected: []string{"服务器环境=测试,操作系统类别", "Linux", "机房=华北"},
-		},
-	}
-
-	for _, tc := range testCases {
+	for _, tc := range parseSearchKeywordsTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			m := ParseSearchKeywords(tc.spec, ',')
 			require.Equal(t, tc.expected, m)

--- a/lib/client/fuzz_test.go
+++ b/lib/client/fuzz_test.go
@@ -23,25 +23,65 @@ import (
 )
 
 func FuzzParseProxyHost(f *testing.F) {
+	for _, tc := range parseProxyHostTestCases {
+		f.Add(tc.input)
+	}
+
 	f.Fuzz(func(t *testing.T, proxyHost string) {
 		require.NotPanics(t, func() {
-			ParseProxyHost(proxyHost)
+			_, _ = ParseProxyHost(proxyHost)
 		})
 	})
 }
 
 func FuzzParseLabelSpec(f *testing.F) {
+	f.Add("XXXX=YYYY")
+	f.Add(`type="database";" role"=master,ver="mongoDB v1,2"`)
+
 	f.Fuzz(func(t *testing.T, spec string) {
 		require.NotPanics(t, func() {
-			ParseLabelSpec(spec)
+			_, _ = ParseLabelSpec(spec)
 		})
 	})
 }
 
 func FuzzParseSearchKeywords(f *testing.F) {
+	f.Add("XXXX,YYYY", ',')
+	f.Add(`XXXX"YYYY`, '"')
+	f.Add(`"XXXX"`, '"')
+	f.Add(`XXXX "YYYY" " ZZZZ  "`, ' ')
+	for _, tc := range parseSearchKeywordsTestCases {
+		f.Add(tc.spec, ',')
+	}
+
 	f.Fuzz(func(t *testing.T, spec string, customDelimiter rune) {
 		require.NotPanics(t, func() {
-			ParseSearchKeywords(spec, customDelimiter)
+			_ = ParseSearchKeywords(spec, customDelimiter)
+		})
+	})
+}
+
+func FuzzParsePortForwardSpec(f *testing.F) {
+	f.Add("80:XXXX:180")
+	f.Add("10.0.10.1:443:XXXX:1443")
+
+	f.Fuzz(func(t *testing.T, spec string) {
+		require.NotPanics(t, func() {
+			_, _ = ParsePortForwardSpec([]string{spec})
+		})
+	})
+}
+
+func FuzzParseDynamicPortForwardSpec(f *testing.F) {
+	for _, tc := range dynamicPortForwardParsingTestCases {
+		if len(tc.spec) == 1 {
+			f.Add(tc.spec[0])
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, spec string) {
+		require.NotPanics(t, func() {
+			_, _ = ParseDynamicPortForwardSpec([]string{spec})
 		})
 	})
 }

--- a/lib/multiplexer/proxyline_test.go
+++ b/lib/multiplexer/proxyline_test.go
@@ -586,6 +586,16 @@ func TestProxyLine_VerifySignature(t *testing.T) {
 	}
 }
 
+func FuzzReadProxyLineV1(f *testing.F) {
+	f.Add([]byte(sampleProxyV1Line))
+
+	f.Fuzz(func(t *testing.T, b []byte) {
+		require.NotPanics(t, func() {
+			_, _ = ReadProxyLine(bufio.NewReader(bytes.NewReader(b)))
+		})
+	})
+}
+
 func FuzzReadProxyLineV2(f *testing.F) {
 	f.Add(sampleProxyV2LineTLV)
 	f.Add(sampleProxyV2Line)

--- a/lib/restrictedsession/fuzz_test.go
+++ b/lib/restrictedsession/fuzz_test.go
@@ -23,6 +23,14 @@ import (
 )
 
 func FuzzParseIPSpec(f *testing.F) {
+	f.Add("127.0.0.111")
+	f.Add("127.0.0.111/8")
+	f.Add("192.168.0.0/16")
+	f.Add("2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+	f.Add("2001:0db8:85a3:0000:0000:8a2e:0370:7334/64")
+	f.Add("2001:db8::ff00:42:8329")
+	f.Add("2001:db8::ff00:42:8329/48")
+
 	f.Fuzz(func(t *testing.T, cidr string) {
 		require.NotPanics(t, func() {
 			ParseIPSpec(cidr)


### PR DESCRIPTION
This PR builds on the work done previously in #28066 and #29918

In this PR I am continuing to expand the fuzz coverage and seed corpus for fuzzing. In addition this ensures that all relevant fuzz functions are enabled in `oss-fuzz`.

Luckily no new issues were found in the areas covered by this PR.