### PR TITLE
Build version checker - multiple fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6160,8 +6160,8 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - mkdir -pv "/go/vars"
-  - (go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo
-    "build") > "/go/vars/release-environment.txt"
+  - (CC=gcc go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote"
+    || echo "build") > "/go/vars/release-environment.txt"
   depends_on:
   - Check out code
 - name: Publish Teleport to stable/${DRONE_TAG} apt repo
@@ -8521,8 +8521,8 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
   - mkdir -pv $(dirname "/go/vars/release-is-prerelease")
   - cd "/tmp/repo/build.assets/tooling"
-  - go run ./cmd/check -tag $DRONE_TAG -check prerelease &> /dev/null || echo 'Version
-    is a prerelease' > "/go/vars/release-is-prerelease"
+  - CC=gcc go run ./cmd/check -tag $DRONE_TAG -check prerelease &> /dev/null || echo
+    'Version is a prerelease' > "/go/vars/release-is-prerelease"
   - printf 'Version is '; [ ! -f "/go/vars/release-is-prerelease" ] && printf 'not
     '; echo 'a prerelease'
 - name: Wait for docker
@@ -17069,6 +17069,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: a0cd6e281f864553c31bf642861283cdfa54275907721fcbd1949b3ca239a3e1
+hmac: 54c72179e16cb5f8c2c7bfecdb28ce2bfcbe73c671b555b610a9e353f656abd3
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -6160,8 +6160,8 @@ steps:
   commands:
   - cd "/go/src/github.com/gravitational/teleport/build.assets/tooling"
   - mkdir -pv "/go/vars"
-  - (CC=gcc go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote"
-    || echo "build") > "/go/vars/release-environment.txt"
+  - (CGO_ENABLED=0 go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo
+    "promote" || echo "build") > "/go/vars/release-environment.txt"
   depends_on:
   - Check out code
 - name: Publish Teleport to stable/${DRONE_TAG} apt repo
@@ -8521,8 +8521,8 @@ steps:
   - git checkout -qf "${DRONE_TAG}"
   - mkdir -pv $(dirname "/go/vars/release-is-prerelease")
   - cd "/tmp/repo/build.assets/tooling"
-  - CC=gcc go run ./cmd/check -tag $DRONE_TAG -check prerelease &> /dev/null || echo
-    'Version is a prerelease' > "/go/vars/release-is-prerelease"
+  - CGO_ENABLED=0 go run ./cmd/check -tag $DRONE_TAG -check prerelease &> /dev/null
+    || echo 'Version is a prerelease' > "/go/vars/release-is-prerelease"
   - printf 'Version is '; [ ! -f "/go/vars/release-is-prerelease" ] && printf 'not
     '; echo 'a prerelease'
 - name: Wait for docker
@@ -17069,6 +17069,6 @@ image_pull_secrets:
 - DOCKERHUB_CREDENTIALS
 ---
 kind: signature
-hmac: 54c72179e16cb5f8c2c7bfecdb28ce2bfcbe73c671b555b610a9e353f656abd3
+hmac: a464984a266882f6e40d0a808978c505708671e13d479674c42ff411a2cc1d3a
 
 ...

--- a/Makefile
+++ b/Makefile
@@ -1102,7 +1102,7 @@ $(VERSRC): Makefile
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
-	cd build.assets/tooling && go run ./cmd/check -check valid -tag $(GITTAG)
+	cd build.assets/tooling && CC=gcc go run ./cmd/check -check valid -tag $(GITTAG)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))

--- a/Makefile
+++ b/Makefile
@@ -1102,7 +1102,7 @@ $(VERSRC): Makefile
 update-tag: TAG_REMOTE ?= origin
 update-tag:
 	@test $(VERSION)
-	cd build.assets/tooling && CC=gcc go run ./cmd/check -check valid -tag $(GITTAG)
+	cd build.assets/tooling && CGO_ENABLED=0 go run ./cmd/check -check valid -tag $(GITTAG)
 	git tag $(GITTAG)
 	git tag api/$(GITTAG)
 	(cd e && git tag $(GITTAG) && git push origin $(GITTAG))

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -9,6 +9,8 @@ SRCDIR=/go/src/github.com/gravitational/teleport
 GOMODCACHE ?= /tmp/gomodcache
 # TODO(hugoShaka) remove HELM_PLUGINS with teleport13 buildbox
 DOCKERFLAGS := --rm=true -v "$$(pwd)/../":$(SRCDIR) -v /tmp:/tmp -w $(SRCDIR) -h $(HOSTNAME) -e GOMODCACHE=$(GOMODCACHE) -e HELM_PLUGINS=/home/ci/.local/share/helm/plugins-new
+# Teleport version - some targets require this to be set
+VERSION ?= $(shell egrep ^VERSION ../Makefile | cut -d= -f2)
 
 ADDFLAGS ?=
 BATSFLAGS :=

--- a/dronegen/container_image_triggers.go
+++ b/dronegen/container_image_triggers.go
@@ -169,7 +169,7 @@ func recordPrereleaseStatus(shellVersion, recordFilePath string) step {
 		fmt.Sprintf("mkdir -pv $(dirname %q)", recordFilePath),
 		fmt.Sprintf("cd %q", path.Join(clonePath, "build.assets", "tooling")),
 		// If the tag is a prerelease, create a file who's existence shows that it is one
-		fmt.Sprintf("go run ./cmd/check -tag %s -check prerelease &> /dev/null || echo 'Version is a prerelease' > %q", shellVersion, recordFilePath),
+		fmt.Sprintf("CC=gcc go run ./cmd/check -tag %s -check prerelease &> /dev/null || echo 'Version is a prerelease' > %q", shellVersion, recordFilePath),
 		fmt.Sprintf("printf 'Version is '; [ ! -f \"%s\" ] && printf 'not '; echo 'a prerelease'", recordFilePath),
 	)
 

--- a/dronegen/container_image_triggers.go
+++ b/dronegen/container_image_triggers.go
@@ -169,7 +169,7 @@ func recordPrereleaseStatus(shellVersion, recordFilePath string) step {
 		fmt.Sprintf("mkdir -pv $(dirname %q)", recordFilePath),
 		fmt.Sprintf("cd %q", path.Join(clonePath, "build.assets", "tooling")),
 		// If the tag is a prerelease, create a file who's existence shows that it is one
-		fmt.Sprintf("CC=gcc go run ./cmd/check -tag %s -check prerelease &> /dev/null || echo 'Version is a prerelease' > %q", shellVersion, recordFilePath),
+		fmt.Sprintf("CGO_ENABLED=0 go run ./cmd/check -tag %s -check prerelease &> /dev/null || echo 'Version is a prerelease' > %q", shellVersion, recordFilePath),
 		fmt.Sprintf("printf 'Version is '; [ ! -f \"%s\" ] && printf 'not '; echo 'a prerelease'", recordFilePath),
 	)
 

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -72,7 +72,7 @@ func buildPromoteOsPackagePipelines(packageDeployments []osPackageDeployment) pi
 			Commands: []string{
 				fmt.Sprintf("cd %q", path.Join(clonePath, "build.assets", "tooling")),
 				fmt.Sprintf("mkdir -pv %q", path.Dir(releaseEnvironmentFilePath)),
-				fmt.Sprintf(`(go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo "build") > %q`, releaseEnvironmentFilePath),
+				fmt.Sprintf(`(CC=gcc go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo "build") > %q`, releaseEnvironmentFilePath),
 			},
 		},
 	}

--- a/dronegen/os_repos.go
+++ b/dronegen/os_repos.go
@@ -72,7 +72,7 @@ func buildPromoteOsPackagePipelines(packageDeployments []osPackageDeployment) pi
 			Commands: []string{
 				fmt.Sprintf("cd %q", path.Join(clonePath, "build.assets", "tooling")),
 				fmt.Sprintf("mkdir -pv %q", path.Dir(releaseEnvironmentFilePath)),
-				fmt.Sprintf(`(CC=gcc go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo "build") > %q`, releaseEnvironmentFilePath),
+				fmt.Sprintf(`(CGO_ENABLED=0 go run ./cmd/check -tag ${DRONE_TAG} -check prerelease && echo "promote" || echo "build") > %q`, releaseEnvironmentFilePath),
 			},
 		},
 	}

--- a/version.mk
+++ b/version.mk
@@ -59,4 +59,4 @@ tsh-version:
 
 .PHONY:validate-semver
 validate-semver:
-	cd build.assets/tooling && CC=gcc go run ./cmd/check -check valid -tag v$(VERSION)
+	cd build.assets/tooling && CGO_ENABLED=0 go run ./cmd/check -check valid -tag v$(VERSION)

--- a/version.mk
+++ b/version.mk
@@ -59,4 +59,4 @@ tsh-version:
 
 .PHONY:validate-semver
 validate-semver:
-	cd build.assets/tooling && go run ./cmd/check -check valid -tag v$(VERSION)
+	cd build.assets/tooling && CC=gcc go run ./cmd/check -check valid -tag v$(VERSION)


### PR DESCRIPTION
Export Teleport version in Makefile in build.assets and force `gcc` compiler when running the tool (otherwise, `go` fails to run on a cross-compiled platform).