### PR TITLE
Refactor AgentKind to UnifiedResource - build fix

### DIFF
--- a/web/packages/teleport/src/services/agents/types.ts
+++ b/web/packages/teleport/src/services/agents/types.ts
@@ -30,7 +30,8 @@ export type UnifiedResource =
   | Node
   | Kube
   | Desktop
-  | WindowsDesktopService;
+  | WindowsDesktopService
+  | UserGroup;
 
 export type UnifiedResourceKind = UnifiedResource['kind'];
 

--- a/web/packages/teleport/src/services/userGroups/makeUserGroup.ts
+++ b/web/packages/teleport/src/services/userGroups/makeUserGroup.ts
@@ -23,6 +23,7 @@ export function makeUserGroup(json): UserGroup {
   const applications = json.applications || [];
 
   return {
+    kind: 'user_group',
     name,
     description,
     labels,

--- a/web/packages/teleport/src/services/userGroups/types.ts
+++ b/web/packages/teleport/src/services/userGroups/types.ts
@@ -18,6 +18,7 @@ import { AgentLabel } from 'teleport/services/agents';
 
 // UserGroup is a remote user group.
 export type UserGroup = {
+  kind: 'user_group';
   // Name is name of the user group.
   name: string;
   // Description is the description of the user group.


### PR DESCRIPTION
The 'AgentKind' was replaced with 'UnifiedResource' in 'useNewRequest.ts'. This was done to ensure more consistent type usage across the application. The 'kind' property was added to several objects in test files and 'user group' was added as a type to 'UnifiedResource' to accommodate this change.