### PR TITLE
[v13] Add Teleport Connect to Headless docs (fix)

### DIFF
--- a/docs/pages/access-controls/guides/headless.mdx
+++ b/docs/pages/access-controls/guides/headless.mdx
@@ -35,7 +35,7 @@ For example:
 - Machines for Headless WebAuthn activities have [Linux](../../installation.mdx#linux), [macOS](../../installation.mdx#macos) or [Windows](../../installation.mdx#windows-tsh-client-only) `tsh` binary v12.2+ installed.
 - Machines used to approve Headless WebAuthn requests have a Web browser with [WebAuthn support](
   https://developers.yubico.com/WebAuthn/WebAuthn_Browser_Support/) or `tsh` binary v12.2+ installed.
-- Optional: Teleport Connect v13.3.1+ for [seamless headless approval](#optional-teleport-connect).
+- Optional: Teleport Connect v13.3.1+ for [seamless Headless WebAuthn approval](#optional-teleport-connect).
 
 ## Step 1/3. Configuration
 
@@ -181,8 +181,8 @@ alice@server01 $
 
 ## Optional: Teleport Connect
 
-Teleport Connect v13.3.1+ can also be used to approve headless logins.
-Teleport Connect will automatically detect the headless login attempt
+Teleport Connect v13.3.1+ can also be used to approve Headless WebAuthn logins.
+Teleport Connect will automatically detect the Headless WebAuthn login attempt
 and allow you to approve or cancel the request.
 
 <Figure width="700">
@@ -196,7 +196,7 @@ You will be prompted to tap your MFA key to complete the approval process.
 </Figure>
 
 <Notice type="note">
-  This also requires a v13.3.1+ Teleport Auth server.
+  This also requires a v13.3.1+ Teleport Auth Service.
 </Notice>
 
 ## Troubleshooting

--- a/docs/pages/connect-your-client/teleport-connect.mdx
+++ b/docs/pages/connect-your-client/teleport-connect.mdx
@@ -212,7 +212,7 @@ Below is the list of the supported config properties.
 | `keymap.openClusters`         | `Command+E` on macOS<br/>`Ctrl+E` on Windows/Linux                                                                   | Shortcut to open the cluster selector.                                 |
 | `keymap.openProfiles`         | `Command+I` on macOS<br/>`Ctrl+I` on Windows/Linux                                                                   | Shortcut to open the profile selector.                                 |
 | `keymap.openSearchBar`        | `Command+K` on macOS<br/>`Ctrl+K` on Windows/Linux                                                                   | Shortcut to open the search bar.                                       |
-| `headless.skipConfirm` | false | Skips the confirmation prompt for headless login approval and instead prompts for WebAuthn immediately. |
+| `headless.skipConfirm` | false | Skips the confirmation prompt for Headless WebAuthn approval and instead prompts for WebAuthn immediately. |
 
 <Admonition
   type="note"


### PR DESCRIPTION
Backport https://github.com/gravitational/teleport/pull/30300 to branch/v13

My previous backport mistakenly did not include the suggestions from code review.