### PR TITLE
[v13] Add `teleport_proxy_db_active_connections_total` gauge.

### DIFF
--- a/docs/pages/includes/metrics.mdx
+++ b/docs/pages/includes/metrics.mdx
@@ -109,6 +109,7 @@
 | `teleport_proxy_db_connection_dial_failures_total`     | counter   | Teleport Proxy | Number of failed dial attempts from Proxy to DB service made.                                                                            |
 | `teleport_proxy_db_attempted_servers_total`            | histogram | Teleport Proxy | Number of servers processed during connection attempt to the DB service from Proxy service.                                              |
 | `teleport_proxy_db_connection_tls_config_time_seconds` | histogram | Teleport Proxy | Time to fetch TLS configuration for the connection to DB service from Proxy service.                                                     |
+| `teleport_proxy_db_active_connections_total`           | gauge     | Teleport Proxy | Number of currently active connections to DB service from Proxy service.                                                                 |
 
 ### Kubernetes Access
 

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -442,9 +442,9 @@ func (s *ProxyServer) SQLServerProxy() *sqlserver.Proxy {
 func (s *ProxyServer) Connect(ctx context.Context, proxyCtx *common.ProxyContext, clientSrcAddr, clientDstAddr net.Addr) (net.Conn, error) {
 	var labels prometheus.Labels
 	if len(proxyCtx.Servers) > 0 {
-		labels = getLabelsFromDb(proxyCtx.Servers[0].GetDatabase())
+		labels = getLabelsFromDB(proxyCtx.Servers[0].GetDatabase())
 	} else {
-		labels = getLabelsFromDb(nil)
+		labels = getLabelsFromDB(nil)
 	}
 
 	labels["available_db_servers"] = strconv.Itoa(len(proxyCtx.Servers))
@@ -519,9 +519,9 @@ func (s *ProxyServer) Proxy(ctx context.Context, proxyCtx *common.ProxyContext, 
 
 	var labels prometheus.Labels
 	if len(proxyCtx.Servers) > 0 {
-		labels = getLabelsFromDb(proxyCtx.Servers[0].GetDatabase())
+		labels = getLabelsFromDB(proxyCtx.Servers[0].GetDatabase())
 	} else {
-		labels = getLabelsFromDb(nil)
+		labels = getLabelsFromDB(nil)
 	}
 
 	activeConnections.With(labels).Inc()
@@ -598,7 +598,7 @@ func (s *ProxyServer) getDatabaseServers(ctx context.Context, identity tlsca.Ide
 // getConfigForServer returns TLS config used for establishing connection
 // to a remote database server over reverse tunnel.
 func (s *ProxyServer) getConfigForServer(ctx context.Context, identity tlsca.Identity, server types.DatabaseServer) (*tls.Config, error) {
-	defer observeLatency(tlsConfigTime.With(getLabelsFromDb(server.GetDatabase())))()
+	defer observeLatency(tlsConfigTime.With(getLabelsFromDB(server.GetDatabase())))()
 
 	privateKey, err := native.GeneratePrivateKey()
 	if err != nil {
@@ -674,7 +674,7 @@ func observeLatency(o prometheus.Observer) func() {
 
 var commonLabels = []string{teleport.ComponentLabel, "db_protocol", "db_type"}
 
-func getLabelsFromDb(db types.Database) prometheus.Labels {
+func getLabelsFromDB(db types.Database) prometheus.Labels {
 	if db != nil {
 		return map[string]string{
 			teleport.ComponentLabel: proxyServerComponent,

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -517,6 +517,16 @@ func (s *ProxyServer) Proxy(ctx context.Context, proxyCtx *common.ProxyContext, 
 		return trace.Wrap(err)
 	}
 
+	var labels prometheus.Labels
+	if len(proxyCtx.Servers) > 0 {
+		labels = getLabelsFromDb(proxyCtx.Servers[0].GetDatabase())
+	} else {
+		labels = getLabelsFromDb(nil)
+	}
+
+	activeConnections.With(labels).Inc()
+	defer activeConnections.With(labels).Dec()
+
 	return trace.Wrap(utils.ProxyConn(ctx, clientConn, serviceConn))
 }
 
@@ -736,7 +746,17 @@ var (
 		commonLabels,
 	)
 
+	activeConnections = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: teleport.MetricNamespace,
+			Subsystem: "proxy_db",
+			Name:      "active_connections_total",
+			Help:      "Number of currently active connections to DB service from Proxy service.",
+		},
+		commonLabels,
+	)
+
 	prometheusCollectors = []prometheus.Collector{
-		connectionSetupTime, tlsConfigTime, dialAttempts, dialFailures, dialAttemptedServers,
+		connectionSetupTime, tlsConfigTime, dialAttempts, dialFailures, dialAttemptedServers, activeConnections,
 	}
 )


### PR DESCRIPTION
Backport #30549 to branch/v13