### PR TITLE
Add extraVolumeMounts to the Operator sidecar container

### DIFF
--- a/examples/chart/teleport-cluster/.lint/operator-extravolume.yaml
+++ b/examples/chart/teleport-cluster/.lint/operator-extravolume.yaml
@@ -1,0 +1,8 @@
+clusterName: test-cluster-name
+operator:
+  enabled: true
+installCRDs: true
+auth:
+  extraVolumeMounts:
+  - name: teleport-join-tokens
+    mountPath: /etc/teleport-join-tokens

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -262,6 +262,9 @@ spec:
           name: auth-serviceaccount-token
           readOnly: true
   {{- end }}
+{{- if .Values.auth.extraVolumeMounts }}
+  {{- toYaml .Values.auth.extraVolumeMounts | nindent 8 }}
+{{- end }}
 {{ end }}
 {{- if $projectedServiceAccountToken }}
       automountServiceAccountToken: false

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -1,3 +1,7 @@
+should add an extra volume to the operator side-car when operator and extra volume are enabled:
+  1: |
+    mountPath: /etc/teleport-join-tokens
+    name: teleport-join-tokens
 should add an operator side-car when operator is enabled:
   1: |
     image: public.ecr.aws/gravitational/teleport-operator:14.0.0-dev

--- a/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
+++ b/examples/chart/teleport-cluster/tests/auth_deployment_test.yaml
@@ -516,6 +516,17 @@ tests:
       - matchSnapshot:
           path: spec.template.spec.containers[1]
 
+  - it: should add an extra volume to the operator side-car when operator and extra volume are enabled
+    template: auth/deployment.yaml
+    values:
+      - ../.lint/operator-extravolume.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[1].volumeMounts[3].name
+          value: teleport-join-tokens
+      - matchSnapshot:
+          path: spec.template.spec.containers[1].volumeMounts[3]
+
   - it: should add named PersistentVolumeClaim as volume when in standalone mode, persistence.existingClaimName is set and persistence.enabled is true
     template: auth/deployment.yaml
     values:


### PR DESCRIPTION
When we start the sidecar contiainer, it seems to require access to the files referenced in the config file.

```
2023-08-08T10:47:12Z	ERROR	setup	failed to connect to teleport cluster, backing off	{"error": "failed to create auth client config\n\topen /etc/teleport-join-tokens/kube-agent-dev-join-token: no such file or directory"}
main.main.func1
	/go/src/github.com/gravitational/teleport/integrations/operator/main.go:128
github.com/gravitational/teleport/api/utils/retryutils.(*Linear).For
	/go/src/github.com/gravitational/teleport/api/utils/retryutils/retry.go:184
main.main
	/go/src/github.com/gravitational/teleport/integrations/operator/main.go:125
runtime.main
	/opt/go/src/runtime/proc.go:250
2023-08-08T10:47:13Z	ERROR	setup	failed to setup teleport client	{"error": "context canceled"}
```

This is because we use the extraVolume to mount these in place for the auth container.
When we enable the Operator sidecar, it fails to access these files.

This change fixes that by adding an extraVolumeMount to the operator manifest.