### PR TITLE
Refactor agent status calculation

### DIFF
--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -142,6 +142,10 @@ export type AgentProcessState =
       stackTrace?: string;
     }
   | {
+      // TODO(ravicious): 'error' should not be considered a separate process state. Instead,
+      // AgentRunner.start should not resolve until 'spawn' is emitted or reject if 'error' is
+      // emitted. AgentRunner.kill should not resolve until 'exit' is emitted or reject if 'error'
+      // is emitted.
       status: 'error';
       message: string;
     };

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -333,8 +333,9 @@ function prettifyCurrentAction(currentAction: CurrentAction): {
           }
         }
         case 'error': {
-          // TODO(ravicious): This can probably happen only just before killing the process? Error
-          // during spawn is already handled by the 'start' branch.
+          // TODO(ravicious): This can happen only just before killing the process. 'error' should
+          // not be considered a separate process state. See the comment above the 'error' status
+          // definition.
           return {
             Icon: StyledWarning,
             title: 'An error occurred to agent process',

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -221,6 +221,11 @@ export function prettifyCurrentAction(currentAction: CurrentAction): {
   error?: string;
   stackTrace?: string;
 } {
+  const noop = {
+    Icon: StyledIndicator,
+    title: '',
+  };
+
   switch (currentAction.kind) {
     case 'download': {
       switch (currentAction.attempt.status) {
@@ -240,7 +245,7 @@ export function prettifyCurrentAction(currentAction: CurrentAction): {
           };
         }
         case 'success': {
-          return; // noop, not used, at this point it should be start processing.
+          return noop; // noop, not used, at this point it should be start processing.
         }
         default: {
           return assertUnreachable(currentAction.attempt.status);
@@ -288,7 +293,7 @@ export function prettifyCurrentAction(currentAction: CurrentAction): {
           break;
         }
         case 'success': {
-          return; // noop, not used, at this point it should be observe-process running.
+          return noop; // noop, not used, at this point it should be observe-process running.
         }
         default: {
           return assertUnreachable(currentAction.attempt.status);
@@ -358,7 +363,7 @@ export function prettifyCurrentAction(currentAction: CurrentAction): {
           };
         }
         case 'success': {
-          return; // noop, not used, at this point it should be observe-process exited.
+          return noop; // noop, not used, at this point it should be observe-process exited.
         }
         default: {
           return assertUnreachable(currentAction.attempt.status);

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -215,7 +215,7 @@ function renderLabels(labelsList: tsh.Label[]): JSX.Element[] {
   ));
 }
 
-export function prettifyCurrentAction(currentAction: CurrentAction): {
+function prettifyCurrentAction(currentAction: CurrentAction): {
   Icon: React.FC<IconProps>;
   title: string;
   error?: string;

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -34,15 +34,17 @@ import { CircleCheck, Laptop, Moon, Warning } from 'design/Icon';
 import Indicator from 'design/Indicator';
 
 import {
-  AgentState,
+  AgentProcessError,
+  CurrentAction,
   useConnectMyComputerContext,
 } from 'teleterm/ui/ConnectMyComputer';
 import Document from 'teleterm/ui/Document';
 import * as types from 'teleterm/ui/services/workspacesService';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
+import { assertUnreachable } from 'teleterm/ui/utils';
+import { codeOrSignal } from 'teleterm/ui/utils/process';
 
 import { useAgentProperties } from '../useAgentProperties';
-
 import { StackTrace } from '../StackTrace';
 
 import type * as tsh from 'teleterm/services/tshd/types';
@@ -57,7 +59,7 @@ export function DocumentConnectMyComputerStatus(
   props: DocumentConnectMyComputerStatusProps
 ) {
   const {
-    agentState,
+    currentAction,
     agentNode,
     downloadAndStartAgent,
     killAgent,
@@ -66,7 +68,7 @@ export function DocumentConnectMyComputerStatus(
   const { documentsService, rootClusterUri } = useWorkspaceContext();
   const { roleName, systemUsername, hostname } = useAgentProperties();
 
-  const prettyAgentState = prettifyAgentState(agentState);
+  const prettyCurrentAction = prettifyCurrentAction(currentAction);
 
   function replaceWithSetupDocument(): void {
     documentsService.replace(
@@ -76,6 +78,23 @@ export function DocumentConnectMyComputerStatus(
       })
     );
   }
+
+  const isRunning =
+    currentAction.kind === 'observe-process' &&
+    currentAction.agentProcessState.status === 'running';
+  const isKilling =
+    currentAction.kind === 'kill' &&
+    currentAction.attempt.status === 'processing';
+  const isDownloading =
+    currentAction.kind === 'download' &&
+    currentAction.attempt.status === 'processing';
+  const isStarting =
+    currentAction.kind === 'start' &&
+    currentAction.attempt.status === 'processing';
+
+  const showDisconnectButton = isRunning || isKilling;
+  const disableDisconnectButton = isKilling;
+  const disableConnectButton = isDownloading || isStarting;
 
   return (
     <Document visible={props.visible}>
@@ -143,31 +162,32 @@ export function DocumentConnectMyComputerStatus(
           )}
         </Transition>
         <Flex mt={3} mb={2} gap={1} display="flex" alignItems="center">
-          {prettyAgentState.Icon && <prettyAgentState.Icon size="medium" />}
-          {prettyAgentState.title}
+          {prettyCurrentAction.Icon && (
+            <prettyCurrentAction.Icon size="medium" />
+          )}
+          {prettyCurrentAction.title}
         </Flex>
-        {prettyAgentState.error && (
+        {prettyCurrentAction.error && (
           <Alert
             css={`
               white-space: pre-wrap;
             `}
           >
-            {prettyAgentState.error}
+            {prettyCurrentAction.error}
           </Alert>
         )}
-        {prettyAgentState.stackTrace && (
-          <StackTrace lines={prettyAgentState.stackTrace} />
+        {prettyCurrentAction.stackTrace && (
+          <StackTrace lines={prettyCurrentAction.stackTrace} />
         )}
         <Text mb={4} mt={1}>
           Connecting your computer will allow any cluster user with the role{' '}
           <strong>{roleName}</strong> to access it as an SSH resource with the
           user <strong>{systemUsername}</strong>.
         </Text>
-        {agentState.status === 'process-running' ||
-        agentState.status === 'killing' ? (
+        {showDisconnectButton ? (
           <ButtonPrimary
             block
-            disabled={agentState.status === 'killing'}
+            disabled={disableDisconnectButton}
             onClick={killAgent}
           >
             Disconnect
@@ -175,10 +195,7 @@ export function DocumentConnectMyComputerStatus(
         ) : (
           <ButtonPrimary
             block
-            disabled={
-              agentState.status === 'downloading' ||
-              agentState.status === 'starting'
-            }
+            disabled={disableConnectButton}
             onClick={downloadAndStartAgent}
           >
             Connect
@@ -198,91 +215,155 @@ function renderLabels(labelsList: tsh.Label[]): JSX.Element[] {
   ));
 }
 
-function prettifyAgentState(agentState: AgentState): {
+export function prettifyCurrentAction(currentAction: CurrentAction): {
   Icon: React.FC<IconProps>;
   title: string;
   error?: string;
   stackTrace?: string;
 } {
-  switch (agentState.status) {
-    case 'downloading': {
-      //TODO(gzdunek) add progress
-      return {
-        Icon: StyledIndicator,
-        title: 'Verifying binary',
-      };
+  switch (currentAction.kind) {
+    case 'download': {
+      switch (currentAction.attempt.status) {
+        case '':
+        case 'processing': {
+          // TODO(gzdunek) add progress
+          return {
+            Icon: StyledIndicator,
+            title: 'Verifying binary',
+          };
+        }
+        case 'error': {
+          return {
+            Icon: StyledWarning,
+            title: 'Failed to download agent',
+            error: currentAction.attempt.statusText,
+          };
+        }
+        case 'success': {
+          return; // noop, not used, at this point it should be start processing.
+        }
+        default: {
+          return assertUnreachable(currentAction.attempt.status);
+        }
+      }
     }
-    case 'starting':
-      return {
-        Icon: StyledIndicator,
-        title: 'Starting',
-      };
-    case 'killing':
-      return {
-        Icon: StyledIndicator,
-        title: 'Stopping',
-      };
-    case 'process-not-started': {
-      return {
-        Icon: Moon,
-        title: 'Agent not running',
-      };
-    }
-    case 'process-running': {
-      return {
-        Icon: props => <CircleCheck {...props} color="success" />,
-        title: 'Agent running',
-      };
-    }
-    case 'process-exited': {
-      const { code, signal, exitedSuccessfully } = agentState;
-      const codeOrSignal = [
-        // code can be 0, so we cannot just check it the same way as the signal.
-        code != null && `code ${code}`,
-        signal && `signal ${signal}`,
-      ]
-        .filter(Boolean)
-        .join(' ');
+    case 'start': {
+      switch (currentAction.attempt.status) {
+        case '':
+        case 'processing': {
+          return {
+            Icon: StyledIndicator,
+            title: 'Starting',
+          };
+        }
+        case 'error': {
+          if (currentAction.attempt.statusText !== AgentProcessError.name) {
+            return {
+              Icon: StyledWarning,
+              title: 'Failed to start agent',
+              error: currentAction.attempt.statusText,
+            };
+          }
 
-      return {
-        Icon: exitedSuccessfully ? Moon : StyledWarning,
-        title: [`Agent process exited with ${codeOrSignal}`].join('\n'),
-        stackTrace: agentState.stackTrace,
-      };
+          if (currentAction.agentProcessState.status === 'error') {
+            return {
+              Icon: StyledWarning,
+              title:
+                'Failed to start agent – an error occurred while spawning the agent process',
+              error: currentAction.agentProcessState.message,
+            };
+          }
+
+          if (currentAction.agentProcessState.status === 'exited') {
+            const { code, signal } = currentAction.agentProcessState;
+            return {
+              Icon: StyledWarning,
+              title: `Failed to start agent - the agent process quit unexpectedly with ${codeOrSignal(
+                code,
+                signal
+              )}`,
+              stackTrace: currentAction.agentProcessState.stackTrace,
+            };
+          }
+          break;
+        }
+        case 'success': {
+          return; // noop, not used, at this point it should be observe-process running.
+        }
+        default: {
+          return assertUnreachable(currentAction.attempt.status);
+        }
+      }
+      break;
     }
-    case 'download-error': {
-      return {
-        Icon: StyledWarning,
-        title: 'Failed to download agent',
-        error: agentState.message,
-      };
+    case 'observe-process': {
+      switch (currentAction.agentProcessState.status) {
+        case 'not-started': {
+          return {
+            Icon: Moon,
+            title: 'Agent not running',
+          };
+        }
+        case 'running': {
+          return {
+            Icon: props => <CircleCheck {...props} color="success" />,
+            title: 'Agent running',
+          };
+        }
+        case 'exited': {
+          const { code, signal, exitedSuccessfully } =
+            currentAction.agentProcessState;
+
+          if (exitedSuccessfully) {
+            return {
+              Icon: Moon,
+              title: 'Agent not running',
+            };
+          } else {
+            return {
+              Icon: StyledWarning,
+              title: `Agent process exited with ${codeOrSignal(code, signal)}`,
+              stackTrace: currentAction.agentProcessState.stackTrace,
+            };
+          }
+        }
+        case 'error': {
+          // TODO(ravicious): This can probably happen only just before killing the process? Error
+          // during spawn is already handled by the 'start' branch.
+          return {
+            Icon: StyledWarning,
+            title: 'An error occurred to agent process',
+            error: currentAction.agentProcessState.message,
+          };
+        }
+        default: {
+          return assertUnreachable(currentAction.agentProcessState);
+        }
+      }
     }
-    case 'kill-error': {
-      return {
-        Icon: StyledWarning,
-        title: 'Failed to kill agent',
-        error: agentState.message,
-      };
-    }
-    case 'join-error': {
-      return {
-        Icon: StyledWarning,
-        title: 'Failed to join cluster',
-        error: agentState.message,
-      };
-    }
-    case 'process-error': {
-      return {
-        Icon: StyledWarning,
-        title: 'An error occurred to the agent process',
-        error: agentState.message,
-      };
-    }
-    default: {
-      return {
-        Icon: null,
-        title: '',
-      };
+    case 'kill': {
+      switch (currentAction.attempt.status) {
+        case '':
+        case 'processing': {
+          return {
+            Icon: StyledIndicator,
+            title: 'Stopping',
+          };
+        }
+        case 'error': {
+          return {
+            Icon: StyledWarning,
+            title: 'Failed to stop agent',
+            error: currentAction.attempt.statusText,
+          };
+        }
+        case 'success': {
+          return; // noop, not used, at this point it should be observe-process exited.
+        }
+        default: {
+          return assertUnreachable(currentAction.attempt.status);
+        }
+      }
     }
   }
 }

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -234,7 +234,7 @@ export function prettifyCurrentAction(currentAction: CurrentAction): {
           // TODO(gzdunek) add progress
           return {
             Icon: StyledIndicator,
-            title: 'Verifying binary',
+            title: 'Verifying agent binary',
           };
         }
         case 'error': {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/StackTrace.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/StackTrace.tsx
@@ -24,7 +24,7 @@ interface StacktraceProps {
 export function StackTrace(props: StacktraceProps): JSX.Element {
   return (
     <>
-      <Text mb={2}>Last 10 lines of error logs:</Text>
+      <Text mb={2}>Last 10 lines of logs:</Text>
       <Flex
         width="100%"
         color="light"

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -18,6 +18,7 @@ import { EventEmitter } from 'node:events';
 
 import React from 'react';
 import { renderHook, act } from '@testing-library/react-hooks';
+import { makeErrorAttempt } from 'shared/hooks/useAsync';
 
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
 import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
@@ -71,8 +72,12 @@ test('runAgentAndWaitForNodeToJoin re-throws errors that are thrown while spawni
     [, error] = await result.current.startAgent();
   });
   expect(error).toBeInstanceOf(AgentProcessError);
-  expect(result.current.agentState).toStrictEqual({
-    status: 'process-error',
-    message: 'ENOENT',
+  expect(result.current.currentAction).toStrictEqual({
+    kind: 'start',
+    attempt: makeErrorAttempt(AgentProcessError.name),
+    agentProcessState: {
+      status: 'error',
+      message: 'ENOENT',
+    },
   });
 });

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -244,6 +244,8 @@ function throwOnAgentProcessErrors(
     const rejectOnError = (agentProcessState: AgentProcessState) => {
       if (
         agentProcessState.status === 'exited' ||
+        // TODO(ravicious): 'error' should not be considered a separate process state. See the
+        // comment above the 'error' status definition.
         agentProcessState.status === 'error'
       ) {
         reject(new AgentProcessError());

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -32,59 +32,35 @@ import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 import { Server } from 'teleterm/services/tshd/types';
 
+import { assertUnreachable } from '../utils';
+
 import type {
   AgentProcessState,
   MainProcessClient,
 } from 'teleterm/mainProcess/types';
 
-export type AgentState =
+export type CurrentAction =
   | {
-      status: 'process-not-started';
+      kind: 'download';
+      attempt: Attempt<void>;
     }
   | {
-      status: 'process-running';
+      kind: 'start';
+      attempt: Attempt<Server>;
+      agentProcessState: AgentProcessState;
     }
   | {
-      status: 'process-exited';
-      code: number | null;
-      signal: NodeJS.Signals | null;
-      exitedSuccessfully: boolean;
-      /** Fragment of a stack trace when the process did not exit successfully. */
-      stackTrace?: string;
+      kind: 'observe-process';
+      agentProcessState: AgentProcessState;
     }
   | {
-      status: 'process-error';
-      message: string;
-    }
-  | {
-      status: 'downloading';
-    }
-  | {
-      status: 'download-error';
-      message: string;
-    }
-  | {
-      status: 'starting';
-    }
-  | {
-      status: 'join-error';
-      message: string;
-    }
-  | {
-      status: 'killing';
-    }
-  | {
-      status: 'kill-error';
-      message: string;
-    }
-  | {
-      status: '';
+      kind: 'kill';
+      attempt: Attempt<void>;
     };
 
-type CurrentAttempt = 'download' | 'start' | 'process' | 'kill';
-
 export interface ConnectMyComputerContext {
-  agentState: AgentState;
+  currentAction: CurrentAction;
+  agentProcessState: AgentProcessState;
   agentNode: Server | undefined;
   startAgent(): Promise<[Server, Error]>;
   downloadAgent(): Promise<[void, Error]>;
@@ -117,8 +93,8 @@ export const ConnectMyComputerContextProvider: FC<{
     setAgentConfiguredAttempt(makeSuccessAttempt(true));
   }, [setAgentConfiguredAttempt]);
 
-  const [currentAttempt, setCurrentAttempt] =
-    useState<CurrentAttempt>('process');
+  const [currentActionKind, setCurrentActionKind] =
+    useState<CurrentAction['kind']>('observe-process');
 
   const [agentProcessState, setAgentProcessState] = useState<AgentProcessState>(
     () =>
@@ -131,14 +107,14 @@ export const ConnectMyComputerContextProvider: FC<{
 
   const [downloadAgentAttempt, downloadAgent] = useAsync(
     useCallback(async () => {
-      setCurrentAttempt('download');
+      setCurrentActionKind('download');
       await connectMyComputerService.downloadAgent();
     }, [connectMyComputerService])
   );
 
   const [startAgentAttempt, startAgent] = useAsync(
     useCallback(async () => {
-      setCurrentAttempt('start');
+      setCurrentActionKind('start');
       await connectMyComputerService.runAgent(props.rootClusterUri);
 
       const abortController = new AbortController();
@@ -159,7 +135,7 @@ export const ConnectMyComputerContextProvider: FC<{
             );
           }),
         ]);
-        setCurrentAttempt('process');
+        setCurrentActionKind('observe-process');
         return server;
       } catch (error) {
         // in case of any error kill the agent
@@ -181,9 +157,9 @@ export const ConnectMyComputerContextProvider: FC<{
 
   const [killAgentAttempt, killAgent] = useAsync(
     useCallback(async () => {
-      setCurrentAttempt('kill');
+      setCurrentActionKind('kill');
       await connectMyComputerService.killAgent(props.rootClusterUri);
-      setCurrentAttempt('process');
+      setCurrentActionKind('observe-process');
     }, [connectMyComputerService, props.rootClusterUri])
   );
 
@@ -196,21 +172,41 @@ export const ConnectMyComputerContextProvider: FC<{
   }, [mainProcessClient, props.rootClusterUri]);
 
   useEffect(() => {
-    checkIfAgentIsConfigured();
-  }, [checkIfAgentIsConfigured]);
+    if (isAgentConfiguredAttempt.status === '') {
+      checkIfAgentIsConfigured();
+    }
+  }, [checkIfAgentIsConfigured, isAgentConfiguredAttempt]);
 
-  const computedAgentState = computeAgentState({
-    currentAttempt,
-    downloadAgentAttempt,
-    startAgentAttempt,
-    agentProcessStateAttempt: makeSuccessAttempt(agentProcessState),
-    killAgentAttempt,
-  });
+  let currentAction: CurrentAction;
+  const kind = currentActionKind;
+
+  switch (kind) {
+    case 'download': {
+      currentAction = { kind, attempt: downloadAgentAttempt };
+      break;
+    }
+    case 'start': {
+      currentAction = { kind, attempt: startAgentAttempt, agentProcessState };
+      break;
+    }
+    case 'observe-process': {
+      currentAction = { kind, agentProcessState };
+      break;
+    }
+    case 'kill': {
+      currentAction = { kind, attempt: killAgentAttempt };
+      break;
+    }
+    default: {
+      assertUnreachable(kind);
+    }
+  }
 
   return (
     <ConnectMyComputerContext.Provider
       value={{
-        agentState: computedAgentState,
+        currentAction,
+        agentProcessState,
         agentNode: startAgentAttempt.data,
         killAgent,
         startAgent,
@@ -235,117 +231,6 @@ export const useConnectMyComputerContext = () => {
 
   return context;
 };
-
-/**
- * Returns agent state based on multiple sources.
- * Not all possible cases are handled, for example `download.success` -
- * it is expected that the next state that the user should see is `start.processing`.
- */
-function computeAgentState({
-  currentAttempt,
-  downloadAgentAttempt,
-  startAgentAttempt,
-  agentProcessStateAttempt,
-  killAgentAttempt,
-}: {
-  currentAttempt: CurrentAttempt;
-  downloadAgentAttempt: Attempt<void>;
-  startAgentAttempt: Attempt<Server>;
-  agentProcessStateAttempt: Attempt<AgentProcessState>;
-  killAgentAttempt: Attempt<void>;
-}): AgentState {
-  const agentProcessState = agentProcessStateAttempt.data;
-  switch (currentAttempt) {
-    case 'download': {
-      switch (downloadAgentAttempt.status) {
-        case 'processing': {
-          return { status: 'downloading' };
-        }
-        case 'error': {
-          return {
-            status: 'download-error',
-            message: downloadAgentAttempt.statusText,
-          };
-        }
-      }
-      break;
-    }
-    case 'start': {
-      switch (startAgentAttempt.status) {
-        case 'processing': {
-          return { status: 'starting' };
-        }
-        case 'error': {
-          if (startAgentAttempt.statusText === AgentProcessError.name) {
-            if (agentProcessState.status === 'exited') {
-              return {
-                ...agentProcessState,
-                status: 'process-exited',
-              };
-            }
-            if (agentProcessState.status === 'error') {
-              return {
-                ...agentProcessState,
-                status: 'process-error',
-              };
-            }
-          }
-          return {
-            status: 'join-error',
-            message: startAgentAttempt.statusText,
-          };
-        }
-      }
-      break;
-    }
-    case 'process': {
-      switch (agentProcessStateAttempt.status) {
-        case 'success': {
-          if (agentProcessState.status === 'exited') {
-            return {
-              ...agentProcessState,
-              status: 'process-exited',
-            };
-          }
-          if (agentProcessState.status === 'error') {
-            return {
-              ...agentProcessState,
-              status: 'process-error',
-            };
-          }
-          if (agentProcessState.status === 'running') {
-            return {
-              ...agentProcessState,
-              status: 'process-running',
-            };
-          }
-          if (agentProcessState.status === 'not-started') {
-            return {
-              ...agentProcessState,
-              status: 'process-not-started',
-            };
-          }
-        }
-      }
-      break;
-    }
-    case 'kill': {
-      switch (killAgentAttempt.status) {
-        case 'processing': {
-          return { status: 'killing' };
-        }
-        case 'error': {
-          return {
-            status: 'kill-error',
-            message: killAgentAttempt.statusText,
-          };
-        }
-      }
-      break;
-    }
-  }
-  return { status: '' };
-}
 
 /**
  * Waits for `error` and `exit` events from the agent process and throws when they occur.

--- a/web/packages/teleterm/src/ui/utils/process.ts
+++ b/web/packages/teleterm/src/ui/utils/process.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function codeOrSignal(
+  code: number | null,
+  signal: NodeJS.Signals | null
+) {
+  return [
+    // code can be 0, so we cannot just check it the same way as the signal.
+    code != null && `code ${code}`,
+    signal && `signal ${signal}`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}


### PR DESCRIPTION
Ultimately, the point is that the attempt objects already represent states of async operations quite well. With attempts, we can explicitly check state of each step. We can also use attempt statuses to further map them to other statuses, like in NavigationMenu. IMHO the way NavigationMenu is written right now is easier to understand than it used to be with `isInErrorState`.

The only outlier is when the process is simply running (`observe-process`). There's no attempt and `agentProcessState` is ultimately impossible to convert to an `Attempt` – those two enums describe two totally different types of interactions.

I don't think it's necessary to represent process exit/error during joining in the same way as during `observe-process`. The start attempt already tells us when something goes wrong and we can make use of that.

The best way to review it is to look at the changes in the context and then inspect how they impact Setup, NavigationMenu and Status.

Be wary that I haven't run this code yet, only verified with TS and Jest.

Related PR: #29976