### PR TITLE
Enable Connect My Computer for non-Team plan clusters

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.test.ts
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.test.ts
@@ -28,55 +28,41 @@ const testCases: {
   name: string;
   platform: Platform;
   canCreateToken: boolean;
-  isUsageBasedBilling: boolean;
   isFeatureFlagEnabled: boolean;
   expect: boolean;
 }[] = [
   {
-    name: 'darwin, can create token, usage based plan, feature flag enabled',
+    name: 'darwin, can create token, feature flag enabled',
     platform: 'darwin',
     canCreateToken: true,
-    isUsageBasedBilling: true,
     isFeatureFlagEnabled: true,
     expect: true,
   },
   {
-    name: 'linux, can create token, usage based plan, feature flag enabled',
+    name: 'linux, can create token, feature flag enabled',
     platform: 'linux',
     canCreateToken: true,
-    isUsageBasedBilling: true,
     isFeatureFlagEnabled: true,
     expect: true,
   },
   {
-    name: 'windows, can create token, usage based plan, feature flag enabled',
+    name: 'windows, can create token, feature flag enabled',
     platform: 'win32',
     canCreateToken: true,
-    isUsageBasedBilling: true,
     isFeatureFlagEnabled: true,
     expect: false,
   },
   {
-    name: 'darwin, cannot create token, usage based plan, feature flag enabled',
+    name: 'darwin, cannot create token, feature flag enabled',
     platform: 'darwin',
     canCreateToken: false,
-    isUsageBasedBilling: true,
     isFeatureFlagEnabled: true,
     expect: false,
   },
   {
-    name: 'darwin, can create token, non-usage based plan, feature flag enabled',
+    name: 'darwin, can create token, feature flag not enabled',
     platform: 'darwin',
     canCreateToken: true,
-    isUsageBasedBilling: false,
-    isFeatureFlagEnabled: true,
-    expect: false,
-  },
-  {
-    name: 'darwin, can create token, usage based plan, feature flag not enabled',
-    platform: 'darwin',
-    canCreateToken: true,
-    isUsageBasedBilling: true,
     isFeatureFlagEnabled: false,
     expect: false,
   },
@@ -84,10 +70,6 @@ const testCases: {
 
 test.each(testCases)('$name', testCase => {
   const cluster = makeRootCluster({
-    features: {
-      advancedAccessWorkflows: false,
-      isUsageBasedBilling: testCase.isUsageBasedBilling,
-    },
     loggedInUser: makeLoggedInUser({
       acl: {
         tokens: {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.ts
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/permissions.ts
@@ -45,7 +45,6 @@ export function canUseConnectMyComputer(
   return (
     isUnix &&
     rootCluster.loggedInUser?.acl?.tokens.create &&
-    rootCluster.features?.isUsageBasedBilling &&
     rootCluster.loggedInUser?.userType == tsh.UserType.USER_TYPE_LOCAL &&
     configService.get('feature.connectMyComputer').value
   );


### PR DESCRIPTION
[As discussed on Slack](https://gravitational.slack.com/archives/C03FJA391M3/p1691526423831009?thread_ts=1691513122.092849&cid=C03FJA391M3), we want to enable Connect My Computer for non-Team plan clusters as well.

I looked into that back when Sasha originally asked the question. I don't think any extra work is necessary to make Connect My Computer work with non-Team plan clusters. We run `teleport node configure` to configure the agent, so everything should work OOTB.

The docs describe a situation where, due to infrastructure constraints, [the user might want to connect the agent directly to the auth server](https://goteleport.com/docs/agents/join-services-to-your-cluster/join-token/#connecting-directly-to-the-auth-service). I believe we don't have to worry about this in our use case, but just to be safe [I asked about this on Slack](https://gravitational.slack.com/archives/C0DF0TPMY/p1692287749344639).