### PR TITLE
Respect `[HTTP(S)|NO]_PROXY` envs when dialing directly to Kube via SPDY

### DIFF
--- a/lib/kube/proxy/forwarder.go
+++ b/lib/kube/proxy/forwarder.go
@@ -50,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/httpstream"
 	"k8s.io/apimachinery/pkg/util/httpstream/wsstream"
+	utilnet "k8s.io/apimachinery/pkg/util/net"
 	"k8s.io/client-go/tools/remotecommand"
 	"k8s.io/client-go/transport/spdy"
 	kubeexec "k8s.io/client-go/util/exec"
@@ -2070,6 +2071,13 @@ func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	proxier := utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
+	// When the target cluster is not served by this teleport service, the
+	// proxier must be nil to avoid using it through the reverse tunnel.
+	if sess.kubeAPICreds == nil {
+		proxier = nil
+	}
+
 	upgradeRoundTripper := NewSpdyRoundTripperWithDialer(roundTripperConfig{
 		ctx:                   req.Context(),
 		authCtx:               ctx,
@@ -2078,6 +2086,7 @@ func (f *Forwarder) getExecutor(ctx authContext, sess *clusterSession, req *http
 		pingPeriod:            f.cfg.ConnPingPeriod,
 		originalHeaders:       req.Header,
 		useIdentityForwarding: useImpersonation,
+		proxier:               proxier,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
 	if sess.kubeAPICreds != nil {
@@ -2101,6 +2110,12 @@ func (f *Forwarder) getSPDYDialer(ctx authContext, sess *clusterSession, req *ht
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+	proxier := utilnet.NewProxierWithNoProxyCIDR(http.ProxyFromEnvironment)
+	// When the target cluster is not served by this teleport service, the
+	// proxier must be nil to avoid using it through the reverse tunnel.
+	if sess.kubeAPICreds == nil {
+		proxier = nil
+	}
 	upgradeRoundTripper := NewSpdyRoundTripperWithDialer(roundTripperConfig{
 		ctx:                   req.Context(),
 		authCtx:               ctx,
@@ -2109,6 +2124,7 @@ func (f *Forwarder) getSPDYDialer(ctx authContext, sess *clusterSession, req *ht
 		pingPeriod:            f.cfg.ConnPingPeriod,
 		originalHeaders:       req.Header,
 		useIdentityForwarding: useImpersonation,
+		proxier:               proxier,
 	})
 	rt := http.RoundTripper(upgradeRoundTripper)
 	if sess.kubeAPICreds != nil {
@@ -2205,19 +2221,19 @@ func (s *clusterSession) monitorConn(conn net.Conn, err error) (net.Conn, error)
 }
 
 func (s *clusterSession) Dial(network, addr string) (net.Conn, error) {
-	return s.monitorConn(s.dial(s.requestContext, network))
+	return s.monitorConn(s.dial(s.requestContext, network, addr))
 }
 
 func (s *clusterSession) DialWithContext(opts ...contextDialerOption) func(ctx context.Context, network, addr string) (net.Conn, error) {
 	return func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return s.monitorConn(s.dial(ctx, network, opts...))
+		return s.monitorConn(s.dial(ctx, network, addr, opts...))
 	}
 }
 
-func (s *clusterSession) dial(ctx context.Context, network string, opts ...contextDialerOption) (net.Conn, error) {
+func (s *clusterSession) dial(ctx context.Context, network, addr string, opts ...contextDialerOption) (net.Conn, error) {
 	dialer := s.parent.getContextDialerFunc(s, opts...)
 
-	conn, err := dialer(ctx, network, s.targetAddr)
+	conn, err := dialer(ctx, network, addr)
 
 	return conn, trace.Wrap(err)
 }


### PR DESCRIPTION
This PR enables support for proxy env's when dialing directly to the Kubernetes Cluster - `kubernetes_service` and `legacy_proxy` when the cluster is local - for the SPDY protocol used by `kubectl exec` and `kubectl portforward`.

PR #30583 introduced support for normal HTTP requests but missed support for SPDY requests.

Fixes #30550