### PR TITLE
improve ControlMaster error reporting

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4463,15 +4463,12 @@ func testExternalClient(t *testing.T, suite *integrationTestSuite) {
 			if tt.outError {
 				require.Error(t, err)
 			} else {
-				if err != nil {
-					// If an *exec.ExitError is returned, parse it and return stderr. If this
-					// is not done then c.Assert will just print a byte array for the error.
-					er, ok := err.(*exec.ExitError)
-					if ok {
-						t.Fatalf("Unexpected error: %v", string(er.Stderr))
-					}
+				// ensure stderr is printed as a string rather than bytes
+				var stderr string
+				if e, ok := err.(*exec.ExitError); ok {
+					stderr = string(e.Stderr)
 				}
-				require.NoError(t, err)
+				require.NoError(t, err, "stderr=%q", stderr)
 				require.Equal(t, tt.outExecOutput, strings.TrimSpace(string(output)))
 			}
 		})


### PR DESCRIPTION
The `ControlMaster` test coverage has been a bit flaky historically, but its difficult to tell what is going on because the failures are resulting in an empty failure message.  I've been unable to replicate the failures locally (and none have happened in the past month, so it's possible that the issue has been fixed indirectly).  Regardless, the error reporting is problematic.  This PR ensures that the original error message is always preserved, so that if we observe additional flakiness in the future we'll have a better jumping off point to investigate from.

Related:  https://github.com/gravitational/teleport/issues/16224