### PR TITLE
[v13] Update eks helm guide for AWS PCA

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -76,6 +76,7 @@
     "Goland",
     "Grafana's",
     "Gtczk",
+    "HKEY",
     "HSTS",
     "Hqlo",
     "IAMR",
@@ -423,6 +424,7 @@
     "healthz",
     "highavailability",
     "highavailabilitycertmanager",
+    "highavailabilitycertmanageraddcommonname",
     "hostcert",
     "hostdb",
     "hostedzone",
@@ -472,7 +474,6 @@
     "kubeconfig",
     "kubeconfigs",
     "kubectl",
-    "portforward",
     "kvno",
     "lastname",
     "ldapsearch",
@@ -610,11 +611,13 @@
     "pkill",
     "pkinit",
     "plugindata",
+    "portforward",
     "postgresqlselfhosted",
     "pprof",
     "preconfigured",
     "prereqs",
     "prioritise",
+    "privateca",
     "privkey",
     "priya",
     "programatically",
@@ -709,8 +712,8 @@
     "strslice",
     "structs",
     "subgroups",
-    "subkind",
     "subgroups",
+    "subkind",
     "sudoer",
     "syscalls",
     "sysvinit",
@@ -738,6 +741,7 @@
     "timechart",
     "tlscacerts",
     "tlscert",
+    "tlsexistingcasecretname",
     "tmpfs",
     "tocless",
     "tokenconfig",
@@ -814,7 +818,5 @@
     "zxvf",
     "zztop"
   ],
-  "flagWords": [
-    "hte"
-  ]
+  "flagWords": ["hte"]
 }

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -82,6 +82,9 @@ these options:
 You can use `cert-manager` to provision and automatically renew TLS credentials
 by completing ACME challenges via Let's Encrypt.
 
+You can also use `cert-manager` with AWS Private Certificate Authority (PCA) in EKS using the
+`aws-privateca-issuer` plugin.
+
 This method uses a Kubernetes `LoadBalancer`, which will provision an underlying AWS Network Load
 Balancer (NLB) to handle incoming traffic.
 
@@ -330,6 +333,15 @@ highAvailability:
 podSecurityPolicy:
   enabled: false
 ```
+<Admonition type="note">
+If using an AWS PCA with cert-manager, you will need to 
+[ensure you set](../../reference/helm-reference/teleport-cluster.mdx#highavailabilitycertmanageraddcommonname)
+`highAvailability.certManager.addCommonName: true` in your values file.  You will also need to get the certificate authority
+certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`), 
+upload the full certificate chain to a secret, and 
+[reference the secret](../../reference/helm-reference/teleport-cluster.mdx#tlsexistingcasecretname)
+with `tls.existingCASecretName` in the values file.
+</Admonition>
 </TabItem>
 <TabItem label="AWS Certificate Manager">
 ```yaml
@@ -411,6 +423,15 @@ enterprise: true                                  # Indicate that this is a Tele
 podSecurityPolicy:
   enabled: false
 ```
+<Admonition type="note">
+If using an AWS PCA with cert-manager, you will need to 
+[ensure you set](../../reference/helm-reference/teleport-cluster.mdx#highavailabilitycertmanageraddcommonname)
+`highAvailability.certManager.addCommonName: true` in your values file.  You will also need to get the certificate authority
+certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`), 
+upload the full certificate chain to a secret, and 
+[reference the secret](../../reference/helm-reference/teleport-cluster.mdx#tlsexistingcasecretname)
+with `tls.existingCASecretName` in the values file.
+</Admonition>
 </TabItem>
 <TabItem label="AWS Certificate Manager">
 ```yaml


### PR DESCRIPTION
Backports #30176

* Update eks helm guide for AWS PCA

updating cert manger instructions when using AWS PCA plugin

* Update aws.mdx

* Update cspell.json

* Update docs/pages/deploy-a-cluster/helm-deployments/aws.mdx



* Update docs/pages/deploy-a-cluster/helm-deployments/aws.mdx



* Update aws.mdx

---------