### PR TITLE
[v11] Update eks helm guide for AWS PCA

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -72,6 +72,7 @@
     "Goland",
     "Grafana's",
     "Gtczk",
+    "HKEY",
     "HSTS",
     "Hqlo",
     "IAMR",
@@ -156,6 +157,7 @@
     "SECURITYADMIN",
     "SIEM",
     "SIGINT",
+    "SIGQUIT",
     "SLAVEOF",
     "SLOWLOG",
     "SSUBSCRIBE",
@@ -411,6 +413,7 @@
     "healthz",
     "highavailability",
     "highavailabilitycertmanager",
+    "highavailabilitycertmanageraddcommonname",
     "hostcert",
     "hostdb",
     "hostedzone",
@@ -593,11 +596,13 @@
     "pkill",
     "pkinit",
     "plugindata",
+    "portforward",
     "postgresqlselfhosted",
     "pprof",
     "preconfigured",
     "prereqs",
     "prioritise",
+    "privateca",
     "privkey",
     "priya",
     "programatically",
@@ -680,6 +685,7 @@
     "splunkforwarder",
     "sqlcl",
     "sqlcmd",
+    "sqlcmd",
     "sqlnet",
     "sqlserver",
     "sshcacerts",
@@ -691,6 +697,8 @@
     "storageenabled",
     "strslice",
     "structs",
+    "subgroups",
+    "subkind",
     "subkind",
     "sudoer",
     "syscalls",
@@ -717,6 +725,7 @@
     "timechart",
     "tlscacerts",
     "tlscert",
+    "tlsexistingcasecretname",
     "tmpfs",
     "tocless",
     "tokenconfig",
@@ -790,7 +799,5 @@
     "zxvf",
     "zztop"
   ],
-  "flagWords": [
-    "hte"
-  ]
+  "flagWords": ["hte"]
 }

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -127,9 +127,13 @@ these options:
 #### Using `cert-manager`
 
 You can use `cert-manager` to provision and automatically renew TLS credentials
-by completing ACME challenges via Let's Encrypt. We recommend this approach if
-you require CLI access to web applications using client certificates via
-the Teleport Application Service.
+by completing ACME challenges via Let's Encrypt.
+
+You can also use `cert-manager` with AWS Private Certificate Authority (PCA) in EKS using the
+`aws-privateca-issuer` plugin.
+
+This method uses a Kubernetes `LoadBalancer`, which will provision an underlying AWS Network Load
+Balancer (NLB) to handle incoming traffic.
 
 #### Using AWS Certificate Manager
 
@@ -371,6 +375,15 @@ highAvailability:
 podSecurityPolicy:
   enabled: false
 ```
+<Admonition type="note">
+If using an AWS PCA with cert-manager, you will need to 
+[ensure you set](../../reference/helm-reference/teleport-cluster.mdx#highavailabilitycertmanageraddcommonname)
+`highAvailability.certManager.addCommonName: true` in your values file.  You will also need to get the certificate authority
+certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`), 
+upload the full certificate chain to a secret, and 
+[reference the secret](../../reference/helm-reference/teleport-cluster.mdx#tlsexistingcasecretname)
+with `tls.existingCASecretName` in the values file.
+</Admonition>
 </TabItem>
 <TabItem label="AWS Certificate Manager">
 ```yaml
@@ -425,6 +438,15 @@ enterprise: true                                  # Indicate that this is a Tele
 podSecurityPolicy:
   enabled: false
 ```
+<Admonition type="note">
+If using an AWS PCA with cert-manager, you will need to 
+[ensure you set](../../reference/helm-reference/teleport-cluster.mdx#highavailabilitycertmanageraddcommonname)
+`highAvailability.certManager.addCommonName: true` in your values file.  You will also need to get the certificate authority
+certificate for the CA (`aws acm-pca get-certificate-authority-certificate --certificate-authority-arn <arn>`), 
+upload the full certificate chain to a secret, and 
+[reference the secret](../../reference/helm-reference/teleport-cluster.mdx#tlsexistingcasecretname)
+with `tls.existingCASecretName` in the values file.
+</Admonition>
 </TabItem>
 <TabItem label="AWS Certificate Manager">
 ```yaml


### PR DESCRIPTION
Backports #30176

* Update eks helm guide for AWS PCA

updating cert manger instructions when using AWS PCA plugin

* Update aws.mdx

* Update cspell.json

* Update docs/pages/deploy-a-cluster/helm-deployments/aws.mdx



* Update docs/pages/deploy-a-cluster/helm-deployments/aws.mdx



* Update aws.mdx

---------