### PR TITLE
Add `--current-device` capabilities to `tsh` and `tctl`

### DIFF
--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -28,7 +28,9 @@ import (
 )
 
 func TestRunCeremony(t *testing.T) {
-	env := testenv.MustNew()
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
 	defer env.Close()
 
 	devices := env.DevicesClient
@@ -99,7 +101,7 @@ func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 	if err != nil {
 		return fmt.Errorf("enroll device init: %w", err)
 	}
-	enrollDeviceInit.Token = "fake device token"
+	enrollDeviceInit.Token = testenv.FakeEnrollmentToken
 	if err := stream.Send(&devicepb.EnrollDeviceRequest{
 		Payload: &devicepb.EnrollDeviceRequest_Init{
 			Init: enrollDeviceInit,

--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func TestAutoEnrollCeremony_Run(t *testing.T) {
-	env := testenv.MustNew()
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
 	defer env.Close()
 
 	devices := env.DevicesClient

--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -51,12 +51,6 @@ func NewCeremony() *Ceremony {
 	}
 }
 
-// RunCeremony performs the client-side device enrollment ceremony.
-// Equivalent to `NewCeremony().Run()`.
-func RunCeremony(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient, debug bool, enrollToken string) (*devicepb.Device, error) {
-	return NewCeremony().Run(ctx, devicesClient, debug, enrollToken)
-}
-
 type RunAdminOutcome int
 
 const (

--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	"github.com/gravitational/trace"
+	"github.com/gravitational/trace/trail"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/exp/slices"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
@@ -53,6 +55,114 @@ func NewCeremony() *Ceremony {
 // Equivalent to `NewCeremony().Run()`.
 func RunCeremony(ctx context.Context, devicesClient devicepb.DeviceTrustServiceClient, debug bool, enrollToken string) (*devicepb.Device, error) {
 	return NewCeremony().Run(ctx, devicesClient, debug, enrollToken)
+}
+
+type RunAdminOutcome int
+
+const (
+	_ RunAdminOutcome = iota // Zero means nothing happened.
+	DeviceEnrolled
+	DeviceRegistered
+	DeviceRegisteredAndEnrolled
+)
+
+// RunAdmin is a more powerful variant of Run: it attempts to register the
+// current device, creates an enrollment token and uses that token to call Run.
+//
+// Must be called by a user capable of performing all actions above, otherwise
+// it fails.
+//
+// Returns the created or enrolled device, an outcome marker and an error. The
+// zero outcome means everything failed.
+//
+// Note that the device may be created and the ceremony can still fail
+// afterwards, causing a return similar to "return dev, DeviceRegistered, err"
+// (where nothing is "nil").
+func (c *Ceremony) RunAdmin(
+	ctx context.Context,
+	devicesClient devicepb.DeviceTrustServiceClient,
+	debug bool,
+) (*devicepb.Device, RunAdminOutcome, error) {
+	// The init message contains the device collected data.
+	init, err := c.EnrollDeviceInit()
+	if err != nil {
+		return nil, 0, trace.Wrap(err)
+	}
+	cdd := init.DeviceData
+	osType := cdd.OsType
+	assetTag := cdd.SerialNumber
+
+	rewordAccessDenied := func(err error, action string) error {
+		if trace.IsAccessDenied(trail.FromGRPC(err)) {
+			log.WithError(err).Debug(
+				"Device Trust: Redacting access denied error with user-friendly message")
+			return trace.AccessDenied(
+				"User does not have permissions to %s. Contact your cluster device administrator.",
+				action,
+			)
+		}
+		return err
+	}
+
+	// Query for current device.
+	findResp, err := devicesClient.FindDevices(ctx, &devicepb.FindDevicesRequest{
+		IdOrTag: assetTag,
+	})
+	if err != nil {
+		return nil, 0, trace.Wrap(rewordAccessDenied(err, "list devices"))
+	}
+	var currentDev *devicepb.Device
+	for _, dev := range findResp.Devices {
+		if dev.OsType == osType {
+			currentDev = dev
+			log.Debugf(
+				"Found device %q/%v, id=%q",
+				currentDev.AssetTag, devicetrust.FriendlyOSType(currentDev.OsType), currentDev.Id,
+			)
+			break
+		}
+	}
+
+	// If missing, create the device.
+	var outcome RunAdminOutcome
+	if currentDev == nil {
+		currentDev, err = devicesClient.CreateDevice(ctx, &devicepb.CreateDeviceRequest{
+			Device: &devicepb.Device{
+				OsType:   osType,
+				AssetTag: assetTag,
+			},
+			CreateEnrollToken: true, // Save an additional RPC.
+		})
+		if err != nil {
+			return nil, outcome, trace.Wrap(rewordAccessDenied(err, "register devices"))
+		}
+		outcome = DeviceRegistered
+	}
+	// From here onwards, always return `currentDev` and `outcome`!
+
+	// If missing, create a new enrollment token.
+	if currentDev.EnrollToken.GetToken() == "" {
+		currentDev.EnrollToken, err = devicesClient.CreateDeviceEnrollToken(ctx, &devicepb.CreateDeviceEnrollTokenRequest{
+			DeviceId: currentDev.Id,
+		})
+		if err != nil {
+			return currentDev, outcome, trace.Wrap(rewordAccessDenied(err, "create device enrollment tokens"))
+		}
+		log.Debugf(
+			"Device Trust: Created enrollment token for device %q/%s",
+			currentDev.AssetTag,
+			devicetrust.FriendlyOSType(currentDev.OsType))
+	}
+	token := currentDev.EnrollToken.GetToken()
+
+	// Then proceed onto enrollment.
+	enrolled, err := c.Run(ctx, devicesClient, debug, token)
+	if err != nil {
+		return enrolled, outcome, trace.Wrap(err)
+	}
+
+	outcome++ // "0" becomes "Enrolled", "Registered" becomes "RegisteredAndEnrolled".
+	return enrolled, outcome, trace.Wrap(err)
 }
 
 // Run performs the client-side device enrollment ceremony.

--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -51,6 +51,8 @@ func NewCeremony() *Ceremony {
 	}
 }
 
+// RunAdminOutcome is the outcome of [Ceremony.RunAdmin].
+// It is used to communicate the actions performed.
 type RunAdminOutcome int
 
 const (

--- a/lib/devicetrust/enroll/enroll.go
+++ b/lib/devicetrust/enroll/enroll.go
@@ -112,7 +112,7 @@ func (c *Ceremony) RunAdmin(
 		if dev.OsType == osType {
 			currentDev = dev
 			log.Debugf(
-				"Found device %q/%v, id=%q",
+				"Device Trust: Found device %q/%v, id=%q",
 				currentDev.AssetTag, devicetrust.FriendlyOSType(currentDev.OsType), currentDev.Id,
 			)
 			break

--- a/lib/devicetrust/enroll/enroll_test.go
+++ b/lib/devicetrust/enroll/enroll_test.go
@@ -27,8 +27,65 @@ import (
 	"github.com/gravitational/teleport/lib/devicetrust/testenv"
 )
 
-func TestCeremony_Run(t *testing.T) {
+func TestCeremony_RunAdmin(t *testing.T) {
 	env := testenv.MustNew()
+	defer env.Close()
+
+	devices := env.DevicesClient
+	ctx := context.Background()
+
+	nonExistingDev, err := testenv.NewFakeMacOSDevice()
+	require.NoError(t, err, "NewFakeMacOSDevice failed")
+
+	registeredDev, err := testenv.NewFakeMacOSDevice()
+	require.NoError(t, err, "NewFakeMacOSDevice failed")
+
+	// Create the device corresponding to registeredDev.
+	_, err = devices.CreateDevice(ctx, &devicepb.CreateDeviceRequest{
+		Device: &devicepb.Device{
+			OsType:   registeredDev.GetDeviceOSType(),
+			AssetTag: registeredDev.SerialNumber,
+		},
+	})
+	require.NoError(t, err, "CreateDevice(registeredDev) failed")
+
+	tests := []struct {
+		name        string
+		dev         testenv.FakeDevice
+		wantOutcome enroll.RunAdminOutcome
+	}{
+		{
+			name:        "non-existing device",
+			dev:         nonExistingDev,
+			wantOutcome: enroll.DeviceRegisteredAndEnrolled,
+		},
+		{
+			name:        "registered device",
+			dev:         registeredDev,
+			wantOutcome: enroll.DeviceEnrolled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &enroll.Ceremony{
+				GetDeviceOSType:         test.dev.GetDeviceOSType,
+				EnrollDeviceInit:        test.dev.EnrollDeviceInit,
+				SignChallenge:           test.dev.SignChallenge,
+				SolveTPMEnrollChallenge: test.dev.SolveTPMEnrollChallenge,
+			}
+
+			enrolled, outcome, err := c.RunAdmin(ctx, devices, false /* debug */)
+			require.NoError(t, err, "RunAdmin failed")
+			assert.NotNil(t, enrolled, "RunAdmin returned nil device")
+			assert.Equal(t, test.wantOutcome, outcome, "RunAdmin outcome mismatch")
+		})
+	}
+}
+
+func TestCeremony_Run(t *testing.T) {
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
 	defer env.Close()
 
 	devices := env.DevicesClient

--- a/lib/devicetrust/enroll/enroll_test.go
+++ b/lib/devicetrust/enroll/enroll_test.go
@@ -90,7 +90,7 @@ func TestCeremony_Run(t *testing.T) {
 				SolveTPMEnrollChallenge: test.dev.SolveTPMEnrollChallenge,
 			}
 
-			got, err := c.Run(ctx, devices, false, "faketoken")
+			got, err := c.Run(ctx, devices, false /* debug */, testenv.FakeEnrollmentToken)
 			test.assertErr(t, err)
 			test.assertGotDevice(t, got)
 		})

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -129,7 +129,7 @@ func (c *DevicesCommand) TryRun(ctx context.Context, selectedCommand string, aut
 }
 
 type deviceAddCommand struct {
-	currentDeviceCommand
+	canOperateOnCurrentDevice
 
 	os        string // string from command line, distinct from inherited osType!
 	enroll    bool
@@ -258,7 +258,7 @@ func (c *deviceListCommand) Run(ctx context.Context, authClient auth.ClientI) er
 }
 
 type deviceRemoveCommand struct {
-	currentDeviceCommand
+	canOperateOnCurrentDevice
 
 	deviceID string
 }
@@ -297,7 +297,7 @@ func (c *deviceRemoveCommand) Run(ctx context.Context, authClient auth.ClientI) 
 }
 
 type deviceEnrollCommand struct {
-	currentDeviceCommand
+	canOperateOnCurrentDevice
 
 	deviceID string
 	ttl      time.Duration
@@ -343,7 +343,7 @@ func (c *deviceEnrollCommand) Run(ctx context.Context, authClient auth.ClientI) 
 }
 
 type deviceLockCommand struct {
-	currentDeviceCommand
+	canOperateOnCurrentDevice
 
 	deviceID string
 	message  string
@@ -448,9 +448,9 @@ func findDeviceID(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 	return deviceID, assetTag, nil
 }
 
-// currentDeviceCommand marks commands capable of operating against the current
-// device.
-type currentDeviceCommand struct {
+// canOperateOnCurrentDevice marks commands capable of operating against the
+// current device.
+type canOperateOnCurrentDevice struct {
 	osType   devicepb.OSType
 	assetTag string
 
@@ -459,7 +459,7 @@ type currentDeviceCommand struct {
 	currentDevice bool
 }
 
-func (c *currentDeviceCommand) setCurrentDevice() (bool, error) {
+func (c *canOperateOnCurrentDevice) setCurrentDevice() (bool, error) {
 	if !c.currentDevice {
 		return false, nil
 	}

--- a/tool/tctl/common/devices.go
+++ b/tool/tctl/common/devices.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/gravitational/trace/trail"
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	devicepb "github.com/gravitational/teleport/api/gen/proto/go/teleport/devicetrust/v1"
@@ -31,6 +32,7 @@ import (
 	"github.com/gravitational/teleport/lib/asciitable"
 	"github.com/gravitational/teleport/lib/auth"
 	"github.com/gravitational/teleport/lib/devicetrust"
+	dtnative "github.com/gravitational/teleport/lib/devicetrust/native"
 	"github.com/gravitational/teleport/lib/service/servicecfg"
 )
 
@@ -66,11 +68,11 @@ func (c *DevicesCommand) Initialize(app *kingpin.Application, cfg *servicecfg.Co
 
 	addCmd := devicesCmd.Command("add", "Register managed devices.")
 	addCmd.Flag("os", "Operating system").
-		Required().
 		EnumVar(&c.add.os, osTypes...)
 	addCmd.Flag("asset-tag", "Inventory identifier for the device (e.g., Mac serial number)").
-		Required().
 		StringVar(&c.add.assetTag)
+	addCmd.Flag("current-device", "Registers the current device. Overrides --os and --asset-tag.").
+		BoolVar(&c.add.currentDevice)
 	addCmd.Flag("enroll", "If set, creates a device enrollment token").
 		BoolVar(&c.add.enroll)
 	addCmd.Flag("enroll-ttl", "Time duration for the enrollment token").
@@ -81,15 +83,21 @@ func (c *DevicesCommand) Initialize(app *kingpin.Application, cfg *servicecfg.Co
 	rmCmd := devicesCmd.Command("rm", "Removes a managed device.")
 	rmCmd.Flag("device-id", "Device identifier").StringVar(&c.rm.deviceID)
 	rmCmd.Flag("asset-tag", "Inventory identifier for the device").StringVar(&c.rm.assetTag)
+	rmCmd.Flag("current-device", "Removes the current device. Overrides --device-id and --asset-tag.").
+		BoolVar(&c.rm.currentDevice)
 
 	enrollCmd := devicesCmd.Command("enroll", "Creates a new device enrollment token.")
 	enrollCmd.Flag("device-id", "Device identifier").StringVar(&c.enroll.deviceID)
 	enrollCmd.Flag("asset-tag", "Inventory identifier for the device").StringVar(&c.enroll.assetTag)
+	enrollCmd.Flag("current-device", "Enrolls the current device. Overrides --device-id and --asset-tag.").
+		BoolVar(&c.enroll.currentDevice)
 	enrollCmd.Flag("ttl", "Time duration for the enrollment token").DurationVar(&c.enroll.ttl)
 
 	lockCmd := devicesCmd.Command("lock", "Locks a device.")
 	lockCmd.Flag("device-id", "Device identifier").StringVar(&c.lock.deviceID)
 	lockCmd.Flag("asset-tag", "Inventory identifier for the device").StringVar(&c.lock.assetTag)
+	lockCmd.Flag("current-device", "Locks the current device. Overrides --device-id and --asset-tag.").
+		BoolVar(&c.lock.currentDevice)
 	lockCmd.Flag("message", "Message to display to locked-out users").StringVar(&c.lock.message)
 	lockCmd.Flag("expires", "Time point (RFC3339) when the lock expires").StringVar(&c.lock.expires)
 	lockCmd.Flag("ttl", "Time duration after which the lock expires").DurationVar(&c.lock.ttl)
@@ -121,16 +129,36 @@ func (c *DevicesCommand) TryRun(ctx context.Context, selectedCommand string, aut
 }
 
 type deviceAddCommand struct {
-	os        string
-	assetTag  string
+	currentDeviceCommand
+
+	os        string // string from command line, distinct from inherited osType!
 	enroll    bool
 	enrollTTL time.Duration
 }
 
 func (c *deviceAddCommand) Run(ctx context.Context, authClient auth.ClientI) error {
-	osType, ok := osTypeToEnum[c.os]
-	if !ok {
-		return trace.BadParameter("invalid --os: %v", c.os)
+	if _, err := c.setCurrentDevice(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	// Mimic our required flag errors.
+	if !c.currentDevice {
+		switch {
+		case c.os == "" && c.assetTag == "":
+			return trace.BadParameter("required flags [--os --asset-tag] not provided")
+		case c.os == "":
+			return trace.BadParameter("required flag --os not provided")
+		case c.assetTag == "":
+			return trace.BadParameter("required flag --asset-tag not provided")
+		}
+	}
+
+	if c.os != "" {
+		var ok bool
+		c.osType, ok = osTypeToEnum[c.os]
+		if !ok {
+			return trace.BadParameter("invalid --os: %v", c.os)
+		}
 	}
 
 	var enrollExpireTime *timestamppb.Timestamp
@@ -139,7 +167,7 @@ func (c *deviceAddCommand) Run(ctx context.Context, authClient auth.ClientI) err
 	}
 	created, err := authClient.DevicesClient().CreateDevice(ctx, &devicepb.CreateDeviceRequest{
 		Device: &devicepb.Device{
-			OsType:   osType,
+			OsType:   c.osType,
 			AssetTag: c.assetTag,
 		},
 		CreateEnrollToken:     c.enroll,
@@ -230,10 +258,19 @@ func (c *deviceListCommand) Run(ctx context.Context, authClient auth.ClientI) er
 }
 
 type deviceRemoveCommand struct {
-	deviceID, assetTag string
+	currentDeviceCommand
+
+	deviceID string
 }
 
 func (c *deviceRemoveCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+	switch ok, err := c.setCurrentDevice(); {
+	case err != nil:
+		return trace.Wrap(err)
+	case ok:
+		c.deviceID = ""
+	}
+
 	switch {
 	case c.deviceID == "" && c.assetTag == "":
 		return trace.BadParameter("either --device-id or --asset-tag must be set")
@@ -260,11 +297,20 @@ func (c *deviceRemoveCommand) Run(ctx context.Context, authClient auth.ClientI) 
 }
 
 type deviceEnrollCommand struct {
-	deviceID, assetTag string
-	ttl                time.Duration
+	currentDeviceCommand
+
+	deviceID string
+	ttl      time.Duration
 }
 
 func (c *deviceEnrollCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+	switch ok, err := c.setCurrentDevice(); {
+	case err != nil:
+		return trace.Wrap(err)
+	case ok:
+		c.deviceID = ""
+	}
+
 	switch {
 	case c.deviceID == "" && c.assetTag == "":
 		return trace.BadParameter("either --device-id or --asset-tag must be set")
@@ -297,13 +343,26 @@ func (c *deviceEnrollCommand) Run(ctx context.Context, authClient auth.ClientI) 
 }
 
 type deviceLockCommand struct {
-	deviceID, assetTag string
-	message            string
-	expires            string
-	ttl                time.Duration
+	currentDeviceCommand
+
+	deviceID string
+	message  string
+	expires  string
+	ttl      time.Duration
 }
 
 func (c *deviceLockCommand) Run(ctx context.Context, authClient auth.ClientI) error {
+	switch ok, err := c.setCurrentDevice(); {
+	case err != nil:
+		return trace.Wrap(err)
+	case ok:
+		c.deviceID = ""
+		// Print here, otherwise device information isn't apparent.
+		// In other command modes the user just wrote the ID or asset tag in the
+		// command line.
+		fmt.Printf("Locking device %q.\n", c.assetTag)
+	}
+
 	switch {
 	case c.deviceID == "" && c.assetTag == "":
 		return trace.BadParameter("either --device-id or --asset-tag must be set")
@@ -387,4 +446,35 @@ func findDeviceID(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 	}
 
 	return deviceID, assetTag, nil
+}
+
+// currentDeviceCommand marks commands capable of operating against the current
+// device.
+type currentDeviceCommand struct {
+	osType   devicepb.OSType
+	assetTag string
+
+	// currentDevice means osType and assetTag are set according to the current
+	// device.
+	currentDevice bool
+}
+
+func (c *currentDeviceCommand) setCurrentDevice() (bool, error) {
+	if !c.currentDevice {
+		return false, nil
+	}
+
+	cdd, err := dtnative.CollectDeviceData()
+	if err != nil {
+		return false, trace.Wrap(err)
+	}
+
+	c.osType = cdd.OsType
+	c.assetTag = cdd.SerialNumber
+	log.Debugf(
+		"Running device command against current device: %q/%v",
+		c.assetTag,
+		devicetrust.FriendlyOSType(c.osType),
+	)
+	return true, nil
 }

--- a/tool/tsh/common/device.go
+++ b/tool/tsh/common/device.go
@@ -31,9 +31,10 @@ import (
 type deviceCommand struct {
 	enroll *deviceEnrollCommand
 
-	// collect and keyget are debug commands.
-	collect *deviceCollectCommand
-	keyget  *deviceKeygetCommand
+	// collect, assetTag and keyget are debug commands.
+	collect  *deviceCollectCommand
+	assetTag *deviceAssetTagCommand
+	keyget   *deviceKeygetCommand
 
 	// activateCredential is a hidden command invoked on an elevated child
 	// process
@@ -44,6 +45,7 @@ func newDeviceCommand(app *kingpin.Application) *deviceCommand {
 	root := &deviceCommand{
 		enroll:             &deviceEnrollCommand{},
 		collect:            &deviceCollectCommand{},
+		assetTag:           &deviceAssetTagCommand{},
 		keyget:             &deviceKeygetCommand{},
 		activateCredential: &deviceActivateCredentialCommand{},
 	}
@@ -61,6 +63,7 @@ func newDeviceCommand(app *kingpin.Application) *deviceCommand {
 
 	// "tsh device" hidden debug commands.
 	root.collect.CmdClause = parentCmd.Command("collect", "Simulate enroll/authn device data collection").Hidden()
+	root.assetTag.CmdClause = parentCmd.Command("asset-tag", "Print the detected device asset tag").Hidden()
 	root.keyget.CmdClause = parentCmd.Command("keyget", "Get information about the device key").Hidden()
 	root.activateCredential.CmdClause = parentCmd.Command("tpm-activate-credential", "").Hidden()
 	root.activateCredential.Flag("encrypted-credential", "").
@@ -133,6 +136,20 @@ func (c *deviceCollectCommand) run(cf *CLIConf) error {
 		return trace.Wrap(err)
 	}
 	fmt.Printf("DeviceCollectedData %s\n", val)
+	return nil
+}
+
+type deviceAssetTagCommand struct {
+	*kingpin.CmdClause
+}
+
+func (c *deviceAssetTagCommand) run(cf *CLIConf) error {
+	cdd, err := dtnative.CollectDeviceData()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	fmt.Println(cdd.SerialNumber)
 	return nil
 }
 

--- a/tool/tsh/common/tsh.go
+++ b/tool/tsh/common/tsh.go
@@ -1440,6 +1440,8 @@ func Run(ctx context.Context, args []string, opts ...CliOption) error {
 		err = deviceCmd.enroll.run(&cf)
 	case deviceCmd.collect.FullCommand():
 		err = deviceCmd.collect.run(&cf)
+	case deviceCmd.assetTag.FullCommand():
+		err = deviceCmd.assetTag.run(&cf)
 	case deviceCmd.keyget.FullCommand():
 		err = deviceCmd.keyget.run(&cf)
 	case deviceCmd.activateCredential.FullCommand():


### PR DESCRIPTION
Add the ability to act on the current device more easily.

1. `tsh device asset-tag` is a debug command we planned for, but never executed. It's a simpler version of `tsh device collect`.

2. `tsh device enroll --current-device` attempts to enroll the current device. It's focused on device admins, as it requires various permissions end-users typically won't have.

3. `tctl` has a `--current-device` flag added to various commands. It substitutes the need to provide `--asset-tag` and `--os`.

The changes above are all focused on "day 1" experience, thus are catered to powerful Teleport users - powerful as in with various administrative permissions.