### PR TITLE
Replace caret symbol with Windows key in Terminal utility

### DIFF
--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/utils.ts
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/utils.ts
@@ -23,5 +23,5 @@ export function getMetaKeySymbol() {
     return '⌘';
   }
 
-  return '^';
+  return '⊞';
 }


### PR DESCRIPTION
The caret symbol (^) previously used in the Terminal utility was not universally recognized or understanding. To increase usability, it has been replaced with the Windows key symbol (⊞). This should make the tool more intuitive to use for a wider range of users.