### PR TITLE
[buddy] Discovery service panics on GKE clusters without labels

### DIFF
--- a/lib/services/kubernetes.go
+++ b/lib/services/kubernetes.go
@@ -256,7 +256,8 @@ func getOrSetDefaultGCPDescription(cluster gcp.GKECluster) string {
 
 // labelsFromGCPKubeCluster creates kube cluster labels.
 func labelsFromGCPKubeCluster(cluster gcp.GKECluster) map[string]string {
-	labels := maps.Clone(cluster.Labels)
+	labels := make(map[string]string)
+	maps.Copy(labels, cluster.Labels)
 	labels[types.CloudLabel] = types.CloudGCP
 	labels[types.DiscoveryLabelGCPLocation] = cluster.Location
 

--- a/lib/services/kubernetes_test.go
+++ b/lib/services/kubernetes_test.go
@@ -210,6 +210,40 @@ func TestNewKubeClusterFromGCPGKE(t *testing.T) {
 	require.False(t, actual.IsAWS())
 }
 
+func TestNewKubeClusterFromGCPGKEWithoutLabels(t *testing.T) {
+	expected, err := types.NewKubernetesClusterV3(types.Metadata{
+		Name:        "cluster1",
+		Description: "desc1",
+		Labels: map[string]string{
+			types.DiscoveryLabelGCPLocation:  "central-1",
+			types.DiscoveryLabelGCPProjectID: "p1",
+			types.CloudLabel:                 types.CloudGCP,
+		},
+	}, types.KubernetesClusterSpecV3{
+		GCP: types.KubeGCP{
+			Name:      "cluster1",
+			ProjectID: "p1",
+			Location:  "central-1",
+		},
+	})
+	require.NoError(t, err)
+
+	cluster := gcp.GKECluster{
+		Name:        "cluster1",
+		Status:      containerpb.Cluster_RUNNING,
+		Labels:      nil,
+		ProjectID:   "p1",
+		Location:    "central-1",
+		Description: "desc1",
+	}
+	actual, err := NewKubeClusterFromGCPGKE(cluster)
+	require.NoError(t, err)
+	require.Empty(t, cmp.Diff(expected, actual))
+	require.True(t, actual.IsGCP())
+	require.False(t, actual.IsAzure())
+	require.False(t, actual.IsAWS())
+}
+
 var kubeServerYAML = `---
 kind: kube_server
 version: v3


### PR DESCRIPTION
Fixes #30619.

For a GKE cluster without labels like
```console
$ gcloud container clusters list --format='json(status,resourceLabels)'
[
  {
    "status": "RUNNING"
  }
]
```
, Teleport with `discovery_service` enabled for GKE
```
discovery_service:
  enabled: "yes"
  discovery_group: "main"
  gcp:
    - types: ["gke"]
      locations: ["*"]
      project_ids: ["some-project-id-123456789"]
      tags:
        "*" : "*"
```
panics with the following output in its log
```
panic: assignment to entry in nil map
goroutine 363 [running]:
github.com/gravitational/teleport/lib/services.labelsFromGCPKubeCluster(...)
        github.com/gravitational/teleport/lib/services/kubernetes.go:260
github.com/gravitational/teleport/lib/services.NewKubeClusterFromGCPGKE({{0xc0024572b8, 0x4}, {0x0, 0x0}, {0xc002457560, 0xc}, {0xc00159a198, 0x17}, 0x2, 0x0})
        github.com/gravitational/teleport/lib/services/kubernetes.go:235 +0x1dc
github.com/gravitational/teleport/lib/srv/discovery/fetchers.(*gkeFetcher).getMatchingKubeCluster(0xc001580190, {{0xc0024572b8, 0x4}, {0x0, 0x0}, {0xc002457560, 0xc}, {0xc00159a198, 0x17}, 0x2, ...})
        github.com/gravitational/teleport/lib/srv/discovery/fetchers/gke.go:137 +0x58
github.com/gravitational/teleport/lib/srv/discovery/fetchers.(*gkeFetcher).getGKEClusters(0xc001580190, {0x98466c0?, 0xc0015806e0?})
        github.com/gravitational/teleport/lib/srv/discovery/fetchers/gke.go:96 +0x145
github.com/gravitational/teleport/lib/srv/discovery/fetchers.(*gkeFetcher).Get(0x0?, {0x98466c0?, 0xc0015806e0?})
        github.com/gravitational/teleport/lib/srv/discovery/fetchers/gke.go:82 +0x3b
github.com/gravitational/teleport/lib/srv/discovery/common.(*Watcher).fetchAndSend.func1()
        github.com/gravitational/teleport/lib/srv/discovery/common/watcher.go:129 +0x70
golang.org/x/sync/errgroup.(*Group).Go.func1()
        golang.org/x/sync@v0.3.0/errgroup/errgroup.go:75 +0x64
created by golang.org/x/sync/errgroup.(*Group).Go
        golang.org/x/sync@v0.3.0/errgroup/errgroup.go:72 +0xa5
```

The reason for that is because
1. the GCP client sets `Labels` equal to `nil` for a GKE cluster without labels.
2. the `Clone()` function in `exp/maps` returns `nil` when a `nil` is
   passed as an argument; see [0].

Fixed that by creating an empty labels map and then populating it using `Copy()`.

Co-authored-by: @tigrato 

[0] https://go-review.googlesource.com/c/exp/+/417274

buddies: #30618