### PR TITLE
[Web] Fix contrast in SelectCreatable component

### DIFF
--- a/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.tsx
+++ b/web/packages/teleport/src/Discover/Shared/SelectCreatable/SelectCreatable.tsx
@@ -21,7 +21,9 @@ import { Cross } from 'design/Icon';
 
 const styles = theme => ({
   multiValue: (base, state) => {
-    return state.data.isFixed ? { ...base, backgroundColor: 'gray' } : base;
+    return state.data.isFixed
+      ? { ...base, backgroundColor: `${theme.colors.spotBackground[2]}` }
+      : { ...base, backgroundColor: `${theme.colors.spotBackground[0]}` };
   },
   multiValueLabel: (base, state) => {
     if (state.data.isFixed) {
@@ -32,7 +34,7 @@ const styles = theme => ({
       return { ...base, paddingRight: 6 };
     }
 
-    return { ...base, color: theme.colors.text.primaryInverse };
+    return { ...base, color: theme.colors.text.primary };
   },
   multiValueRemove: (base, state) => {
     return state.data.isFixed || state.isDisabled
@@ -40,11 +42,37 @@ const styles = theme => ({
       : {
           ...base,
           cursor: 'pointer',
-          color: theme.colors.text.primaryInverse,
+          color: theme.colors.text.primary,
         };
   },
   menuList: base => {
-    return { ...base, color: theme.colors.text.primaryInverse };
+    return {
+      ...base,
+      color: theme.colors.text.primary,
+      backgroundColor: theme.colors.spotBackground[0],
+    };
+  },
+
+  control: base => ({
+    ...base,
+    backgroundColor: theme.colors.levels.surface,
+  }),
+
+  input: base => ({
+    ...base,
+    color: theme.colors.text.primary,
+  }),
+
+  menu: base => ({ ...base, backgroundColor: theme.colors.levels.elevated }),
+
+  option: (base, state) => {
+    if (state.isFocused) {
+      return {
+        ...base,
+        backgroundColor: theme.colors.spotBackground[1],
+      };
+    }
+    return base;
   },
 });
 


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/29674

Fixes the low contrast in light theme for the `SelectCreatable` component found in various Discover flows.

## Implementation

I initially tried to just use our existing themed `Select` component (which we use for the roles selector in the `Create User` dialog), however doing so meant that we would lose the ability to have `isFixed` items. As an alternative I manually added the styles here to match it as close as possible.

## Demo
![image](https://github.com/gravitational/teleport/assets/56373201/9e70fdbc-f8db-496b-ae78-3b8623a7c313)

![image](https://github.com/gravitational/teleport/assets/56373201/25fd0be4-2825-42d8-84ca-3df5d9dac87d)
