### PR TITLE
Move golangci and Buf to GitHub actions

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -67,8 +67,12 @@ jobs:
         with:
           version: latest
       - uses: bufbuild/buf-lint-action@v1
-      # Breaking changes against master.
-      - uses: bufbuild/buf-breaking-action@v1
+      - name: buf breaking --against=parent
+        uses: bufbuild/buf-breaking-action@v1
+        with:
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
+      - name: buf breaking --against=master
+        uses: bufbuild/buf-breaking-action@v1
         if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
         with:
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master"
@@ -85,7 +89,3 @@ jobs:
       - name: Check if Operator CRDs are up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $(realpath .) && make crds-up-to-date
-
-      # TODO(codingllama): Do this using the Buf action.
-      - name: Check protos for breakage against parent
-        run: buf breaking . --against "https://github.com/${{ github.repository }}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -63,6 +63,16 @@ jobs:
           version: latest
           working-directory: build.assets/tooling
 
+      - uses: bufbuild/buf-setup-action@v1
+        with:
+          version: latest
+      - uses: bufbuild/buf-lint-action@v1
+      # Breaking changes against master.
+      - uses: bufbuild/buf-breaking-action@v1
+        if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
+        with:
+          against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master"
+
       - name: Run (non-action) linters
         run: make lint-no-actions
 
@@ -74,21 +84,6 @@ jobs:
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $(realpath .) && make crds-up-to-date
 
-      # The `buf breaking` check is twofold: we always check for compatibility
-      # breaks against the base of the PR, and in backports we check for
-      # compatibility breaks _from_ the tip of master. It's possible to add
-      # fields just to release branches and not master, but it requires
-      # reserving the appropriate field numbers and field names in master (as it
-      # should!).
-
-      # We run a separate fetch because even with a fetch-depth of 0 in
-      # actions/checkout I'm not sure that we're guaranteed to have all the refs
-      # we need (especially the tip of master in backports), but it's a shallow
-      # fetch for a specific tree by hash, so it should be pretty fast.
-
+      # TODO(codingllama): Do this using the Buf action.
       - name: Check protos for breakage against parent
         run: buf breaking . --against "https://github.com/${{ github.repository }}.git#branch=${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}"
-
-      - name: Check protos for breakage from master
-        if: ${{ github.base_ref != 'master' && github.event.merge_group.base_ref != 'refs/heads/master' }}
-        run: buf breaking "https://github.com/${{ github.repository }}.git#branch=master" --against .

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,8 +23,6 @@ jobs:
 
     container:
       image: ghcr.io/gravitational/teleport-buildbox:teleport14
-      env:
-        GO_LINT_FLAGS: --timeout=15m
 
     steps:
       - name: Checkout
@@ -37,8 +35,36 @@ jobs:
         # We have to add the current directory as a safe directory or else git commands will not work as expected.
         run: git config --global --add safe.directory $( realpath . ) && git diff --exit-code -- go.mod go.sum api/go.mod api/go.sum
 
-      - name: Run linter
-        run: make lint
+      # Run various golangci-lint checks.
+      # TODO(codingllama): Using go.work could save a bunch of repetition here.
+      - name: golangci-lint (api)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: api
+      - name: golangci-lint (teleport)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --build-tags libfido2,piv
+      - name: golangci-lint (kube-agent-updater)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: integrations/kube-agent-updater
+      - name: golangci-lint (assets/backport)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: assets/backport
+      - name: golangci-lint (build.assets/tooling)
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          working-directory: build.assets/tooling
+
+      - name: Run (non-action) linters
+        run: make lint-no-actions
 
       - name: Check if protos are up to date
         # We have to add the current directory as a safe directory or else git commands will not work as expected.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -73,6 +73,8 @@ jobs:
         with:
           against: "https://github.com/${GITHUB_REPOSITORY}.git#branch=master"
 
+      # TODO(codingllama): Consider https://github.com/actions-rs/clippy-check
+      #  for Rust.
       - name: Run (non-action) linters
         run: make lint-no-actions
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -65,6 +65,7 @@ jobs:
 
       - uses: bufbuild/buf-setup-action@v1
         with:
+          github_token: ${{ github.token }}
           version: latest
       - uses: bufbuild/buf-lint-action@v1
       - name: buf breaking --against=parent

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -73,6 +73,7 @@ output:
 
 run:
   go: '1.20'
+  build-tags: []
   skip-dirs:
     - (^|/)node_modules/
     - ^api/gen/
@@ -81,4 +82,4 @@ run:
     - ^rfd/
     - ^web/
   skip-dirs-use-default: false
-  timeout: 5m
+  timeout: 15m

--- a/Makefile
+++ b/Makefile
@@ -926,7 +926,14 @@ e2e-aws: $(TEST_LOG_DIR) ensure-gotestsum
 # changes (or last commit).
 #
 .PHONY: lint
-lint: lint-sh lint-helm lint-api lint-kube-agent-updater lint-go lint-license lint-rust lint-tools lint-protos
+lint: lint-api lint-go link-kube-agent-updater lint-tools lint-protos lint-no-actions
+
+#
+# Lints everything but Go sources.
+# Similar to lint.
+#
+.PHONY: lint-no-actions
+lint-no-actions: lint-sh lint-helm lint-license lint-rust
 
 .PHONY: lint-tools
 lint-tools: lint-build-tooling lint-backport

--- a/lib/auth/touchid/api_darwin.go
+++ b/lib/auth/touchid/api_darwin.go
@@ -290,7 +290,7 @@ func (touchIDImpl) ListCredentials() ([]CredentialInfo, error) {
 	})
 	if res < 0 {
 		errMsg := C.GoString(errMsgC)
-		return nil, errorFromStatus("listing credentials", int(res), errMsg)
+		return nil, errorFromStatus("listing credentials", res, errMsg)
 	}
 
 	return infos, nil

--- a/lib/srv/desktop/rdp/rdpclient/client.go
+++ b/lib/srv/desktop/rdp/rdpclient/client.go
@@ -655,6 +655,7 @@ func (c *Client) handleRemoteCopy(data []byte) C.CGOErrCode {
 //export tdp_sd_acknowledge
 func tdp_sd_acknowledge(handle C.uintptr_t, ack *C.CGOSharedDirectoryAcknowledge) C.CGOErrCode {
 	return cgo.Handle(handle).Value().(*Client).sharedDirectoryAcknowledge(tdp.SharedDirectoryAcknowledge{
+		//nolint:unconvert // Avoid hard dependencies on C types.
 		ErrCode:     uint32(ack.err_code),
 		DirectoryID: uint32(ack.directory_id),
 	})
@@ -702,8 +703,9 @@ func tdp_sd_create_request(handle C.uintptr_t, req *C.CGOSharedDirectoryCreateRe
 	return cgo.Handle(handle).Value().(*Client).sharedDirectoryCreateRequest(tdp.SharedDirectoryCreateRequest{
 		CompletionID: uint32(req.completion_id),
 		DirectoryID:  uint32(req.directory_id),
-		FileType:     uint32(req.file_type),
-		Path:         C.GoString(req.path),
+		//nolint:unconvert // Avoid hard dependencies on C types.
+		FileType: uint32(req.file_type),
+		Path:     C.GoString(req.path),
 	})
 }
 


### PR DESCRIPTION
Run certain lint checks using GitHub actions instead of the buildbox.

This allows for less ongoing maintenance work (actions are tagged to run using "latest") and for faster feedback cycles (if a PR changes the action itself, it's reflected immediately and not in the next buildbox push).