### PR TITLE
Improve error wrapping in Machine ID identity renewal

### DIFF
--- a/lib/tbot/bot_identity.go
+++ b/lib/tbot/bot_identity.go
@@ -120,23 +120,23 @@ func (b *Bot) renewBotIdentity(
 	if b.cfg.Onboarding.RenewableJoinMethod() {
 		// When using a renewable join method, we use GenerateUserCerts to
 		// request a new certificate using our current identity.
-		authClient, err := b.AuthenticatedUserClientFromIdentity(ctx, b.ident())
+		authClient, err := b.AuthenticatedUserClientFromIdentity(ctx, currentIdentity)
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "creating auth client")
 		}
 		defer authClient.Close()
 		newIdentity, err = botIdentityFromAuth(
 			ctx, b.log, currentIdentity, authClient, b.cfg.CertificateTTL,
 		)
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "renewing identity with existing identity")
 		}
 	} else {
 		// When using the non-renewable join methods, we rejoin each time rather
 		// than using certificate renewal.
 		newIdentity, err = botIdentityFromToken(b.log, b.cfg)
 		if err != nil {
-			return trace.Wrap(err)
+			return trace.Wrap(err, "renewing identity with token")
 		}
 	}
 
@@ -144,7 +144,7 @@ func (b *Bot) renewBotIdentity(
 	b.setIdent(newIdentity)
 
 	if err := identity.SaveIdentity(ctx, newIdentity, botDestination, identity.BotKinds()...); err != nil {
-		return trace.Wrap(err)
+		return trace.Wrap(err, "saving new identity")
 	}
 	b.log.WithField("identity", describeTLSIdentity(b.log, newIdentity)).Debug("Bot identity persisted.")
 
@@ -172,7 +172,7 @@ func botIdentityFromAuth(
 		Expires:   time.Now().Add(ttl),
 	})
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "calling GenerateUserCerts")
 	}
 
 	newIdentity, err := identity.ReadIdentityFromStore(
@@ -181,7 +181,7 @@ func botIdentityFromAuth(
 		identity.BotKinds()...,
 	)
 	if err != nil {
-		return nil, trace.Wrap(err)
+		return nil, trace.Wrap(err, "reading renewed identity")
 	}
 
 	return newIdentity, nil


### PR DESCRIPTION
This has historically been a pretty problematic section of code, improving the wrapping should make things a little clearer. Also ensures that `b.AuthenticatedUserClientFromIdentity` here is using the correct 