### PR TITLE
[v13] Update docs version automatically

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -2,7 +2,7 @@ name: Post-release
 
 on:
   release:
-    types: [published]
+    types: [released] # released does not include prereleases
   workflow_dispatch:
 
 permissions:
@@ -49,3 +49,52 @@ jobs:
     uses: gravitational/teleport/.github/workflows/update-ami-ids.yaml@master
     with:
       version: ${{ needs.release.outputs.version }}
+
+  update-docs-version:
+    name: Update docs version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Release Branch
+        id: get-branch
+        run: |
+          TAG=${{ github.event.release.tag_name }}
+          BRANCH="branch/$(echo -n $TAG | cut -d '.' -f 1)"
+          MAJOR=${BRANCH#"branch/v"} # trim the 'branch/v' prefix
+          VERSION=${TAG#"v"} # trim the leading v to get just the version
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Github token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ vars.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
+      - name: Checkout Release Branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.get-branch.outputs.branch }}
+
+      - name: Make PR
+        run: |
+          BRANCH_NAME="release-auto-branch-$(date +%s)"
+          git config --global user.email "noreply@github.com"
+          git config --global user.name "GitHub"
+
+          # update versions in docs/config.json
+          jq --arg major ${{ steps.get-branch.outputs.major }} \
+             --arg version ${{ steps.get-branch.outputs.version }} \
+             '.variables.teleport.major_version |= $major |
+              .variables.teleport.version |= $version |
+              .variables.teleport.plugin.version |= $version' \
+              docs/config.json > docs/confignew.json
+          cat docs/confignew.json
+          mv docs/confignew.json docs/config.json
+
+          git add docs/config.json
+          git switch -c $BRANCH_NAME
+          git commit -am "[auto] docs: Update version to ${{ github.event.release.tag_name }}"
+          git push --set-upstream origin $BRANCH_NAME
+          gh pr create --fill --label=automated --label=documentation

--- a/docs/postrelease.md
+++ b/docs/postrelease.md
@@ -4,10 +4,16 @@ This checklist is to be run after cutting a release.
 
 ### All releases
 
-- [ ] Create PR to update default Teleport version in Teleport docs
-  - Example: https://github.com/gravitational/teleport/pull/7033
-- [ ] Create PR to update default AMI versions in Makefile and AMIs.md under https://github.com/gravitational/teleport/blob/master/assets/aws
-  - Example command: `TELEPORT_VERSION=6.2.0 make -C assets/aws create-update-pr`
+Our GitHub Actions workflows will create two PRs when a release is published:
+
+1. A PR against the release branch that updates the default version in our docs.
+2. A PR that updates the AWS AMI IDs for the new release. (This job only runs
+   for releases on the latest release branch)
+
+The AWS AMI ID PR can be merged right away.
+
+The docs version PR should be merged after the `gravitational/teleport-plugins` release
+is published, since the PR will include an update to the plugins version as well.
 
 ### Major releases only
 


### PR DESCRIPTION
* Update docs version automatically

Adds a new job to the post-release workflow that automatically updates the docs version when a new release is published.

Note: we do the plugin version as well, even though it's likely that the teleport-plugins release is still outstanding. That's okay though, we can wait to merge the PR if we want to.

Closes #12961
Backports #30584 