### PR TITLE
Deflake `TestKubeServerWatcher` and `TestNodeWatcher` tests

### DIFF
--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -1028,7 +1028,7 @@ func TestKubeServerWatcher(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(w.Close)
-
+	require.NoError(t, w.WaitInitialization())
 	newKubeServer := func(t *testing.T, name, addr, hostID string) types.KubeServer {
 		kube, err := types.NewKubernetesClusterV3(
 			types.Metadata{

--- a/lib/services/watcher_test.go
+++ b/lib/services/watcher_test.go
@@ -958,7 +958,7 @@ func TestNodeWatcher(t *testing.T) {
 	})
 	require.NoError(t, err)
 	t.Cleanup(w.Close)
-
+	require.NoError(t, w.WaitInitialization())
 	// Add some node servers.
 	nodes := make([]types.Server, 0, 5)
 	for i := 0; i < 5; i++ {


### PR DESCRIPTION
This PR fixes `TestKubeServerWatcher` and `TestNodeWatcher`.

The flakiness arose from the fact that the test didn't wait till the watcher is initialized. Since the watch loop runs in a separate goroutine it's not immediately scheduled. If the watcher is stale - happens on stale conditions or if it wasn't properly initialized because `watchLoop` didn't run yet - `GetKubernetesServers` goes directly to the backend trying to fetch the most recent data and replaces the watcher state. If the `watchLoop` starts before the delete operation but only replaces the watcher state after the delete operation finishes, it is possible to have the same exact state before the deletion.
This PR forces the test to wait for init so the out-of-order update won't happen.

The same happens with `TestNodeWatcher`.

Fixes #30566
Fixes #24534