### PR TITLE
Review Requests: prevent reviews after request is resolved

### DIFF
--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -402,9 +402,9 @@ func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author t
 	// Resolved requests should not be updated.
 	switch {
 	case req.GetState().IsApproved():
-		return trace.AccessDenied("can't review access request, it is approved")
+		return trace.AccessDenied("the access request has been already approved")
 	case req.GetState().IsDenied():
-		return trace.AccessDenied("can't review access request, it is denied")
+		return trace.AccessDenied("the access request has been already denied")
 	}
 
 	req.SetReviews(append(req.GetReviews(), rev))

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -396,16 +396,18 @@ func ApplyAccessReview(req types.AccessRequest, rev types.AccessReview, author t
 		rev.Created = time.Now()
 	}
 
-	// set threshold indexes and store the review
+	// set threshold indexes
 	rev.ThresholdIndexes = tids
-	req.SetReviews(append(req.GetReviews(), rev))
 
-	// if request has already exited the pending state, then no further work
-	// needs to be done (subsequent reviews have no effect after initial
-	// state-transition).
-	if !req.GetState().IsPending() {
-		return nil
+	// Resolved requests should not be updated.
+	switch {
+	case req.GetState().IsApproved():
+		return trace.AccessDenied("can't review access request, it is approved")
+	case req.GetState().IsDenied():
+		return trace.AccessDenied("can't review access request, it is denied")
 	}
+
+	req.SetReviews(append(req.GetReviews(), rev))
 
 	// request is still pending, so check to see if this
 	// review introduces a state-transition.

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -347,7 +347,29 @@ func TestReviewThresholds(t *testing.T) {
 					author:  g.user(t, "proletariat", "intelligentsia", "military"),
 					propose: deny,
 					errCheck: func(tt require.TestingT, err error, i ...interface{}) {
-						require.ErrorContains(tt, err, "can't review access request, it is approved")
+						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is approved"))
+					},
+				},
+			},
+		},
+		{
+			desc:      "trying to approve an already denied request",
+			requestor: "bob", // permitted by role general
+			reviews: []review{
+				{ // 1 of 2 required denials
+					author:  g.user(t, "military"),
+					propose: deny,
+				},
+				{ // 2 of 2 required denials
+					author:  g.user(t, "military"),
+					propose: deny,
+					expect:  deny,
+				},
+				{ // tries to approve but it was already denied
+					author:  g.user(t, "military"),
+					propose: approve,
+					errCheck: func(tt require.TestingT, err error, i ...interface{}) {
+						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is denied"))
 					},
 				},
 			},

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -347,7 +347,7 @@ func TestReviewThresholds(t *testing.T) {
 					author:  g.user(t, "proletariat", "intelligentsia", "military"),
 					propose: deny,
 					errCheck: func(tt require.TestingT, err error, i ...interface{}) {
-						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is approved"))
+						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is approved"), i...)
 					},
 				},
 			},
@@ -369,7 +369,7 @@ func TestReviewThresholds(t *testing.T) {
 					author:  g.user(t, "military"),
 					propose: approve,
 					errCheck: func(tt require.TestingT, err error, i ...interface{}) {
-						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is denied"))
+						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is denied"), i...)
 					},
 				},
 			},

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -347,7 +347,7 @@ func TestReviewThresholds(t *testing.T) {
 					author:  g.user(t, "proletariat", "intelligentsia", "military"),
 					propose: deny,
 					errCheck: func(tt require.TestingT, err error, i ...interface{}) {
-						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is approved"), i...)
+						require.ErrorIs(tt, err, trace.AccessDenied("the access request has been already approved"), i...)
 					},
 				},
 			},
@@ -369,7 +369,7 @@ func TestReviewThresholds(t *testing.T) {
 					author:  g.user(t, "military"),
 					propose: approve,
 					errCheck: func(tt require.TestingT, err error, i ...interface{}) {
-						require.ErrorIs(tt, err, trace.AccessDenied("can't review access request, it is denied"), i...)
+						require.ErrorIs(tt, err, trace.AccessDenied("the access request has been already denied"), i...)
 					},
 				},
 			},


### PR DESCRIPTION
Return an error when trying to approve or deny a request after it was resolved.

Demo
Scenario:
- nr of required approvers: 1
- UserA approves and immediately UserB tries to approve as well

Screen from UserB:
![image](https://github.com/gravitational/teleport/assets/689271/4d084ec7-ad9e-4f2d-b34e-b89e3cc2f768)
