### PR TITLE
AWS OIDC: List EC2 Instance Connect Endpoints

### DIFF
--- a/lib/integrations/awsoidc/list_ec2ice.go
+++ b/lib/integrations/awsoidc/list_ec2ice.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/gravitational/trace"
+)
+
+// ListEC2ICERequest contains the required fields to list AWS EC2 Instance Connect Endpoints.
+type ListEC2ICERequest struct {
+	// Region is the AWS Region.
+	Region string
+
+	// VPCID is the VPC to filter EC2 Instance Connect Endpoints.
+	VPCID string
+
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string
+}
+
+// CheckAndSetDefaults checks if the required fields are present.
+func (req *ListEC2ICERequest) CheckAndSetDefaults() error {
+	if req.VPCID == "" {
+		return trace.BadParameter("vpc id is required")
+	}
+	if req.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	return nil
+}
+
+// EC2InstanceConnectEndpoint is the Teleport representation of an EC2 Instance Connect Endpoint
+type EC2InstanceConnectEndpoint struct {
+	// Name is the endpoint name.
+	Name string
+
+	// State is the endpoint state.
+	// Known values:
+	// create-in-progress | create-complete | create-failed | delete-in-progress | delete-complete | delete-failed
+	State string
+
+	// SubnetID is the subnet used by the endpoint.
+	// Please note that the Endpoint should be able to reach any subnet within the VPC.
+	SubnetID string
+}
+
+// ListEC2ICEResponse contains a page of AWS EC2 Instances as Teleport Servers.
+type ListEC2ICEResponse struct {
+	// EC2ICEs contains the page of EC2 Instance Connect Endpoint.
+	EC2ICEs []EC2InstanceConnectEndpoint
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string
+}
+
+// ListEC2ICEClient describes the required methods to List EC2 Instances using a 3rd Party API.
+type ListEC2ICEClient interface {
+	// DescribeInstanceConnectEndpoints describes the specified EC2 Instance Connect Endpoints or all EC2 Instance
+	// Connect Endpoints.
+	DescribeInstanceConnectEndpoints(ctx context.Context, params *ec2.DescribeInstanceConnectEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceConnectEndpointsOutput, error)
+}
+
+type defaultListEC2ICEClient struct {
+	*ec2.Client
+}
+
+// NewListEC2ICEClient creates a new ListEC2ICEClient using a AWSClientRequest.
+func NewListEC2ICEClient(ctx context.Context, req *AWSClientRequest) (ListEC2ICEClient, error) {
+	ec2Client, err := newEC2Client(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultListEC2ICEClient{
+		Client: ec2Client,
+	}, nil
+}
+
+// ListEC2ICE calls the following AWS API:
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInstanceConnectEndpoints.html
+// It returns a list of EC2 Instance Connect Endpoints and an optional NextToken that can be used to fetch the next page
+func ListEC2ICE(ctx context.Context, clt ListEC2ICEClient, req ListEC2ICERequest) (*ListEC2ICEResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	describeEC2ICE := &ec2.DescribeInstanceConnectEndpointsInput{
+		Filters: []ec2Types.Filter{{
+			Name:   aws.String("vpc-id"),
+			Values: []string{req.VPCID},
+		}},
+	}
+	if req.NextToken != "" {
+		describeEC2ICE.NextToken = &req.NextToken
+	}
+
+	ec2ICEs, err := clt.DescribeInstanceConnectEndpoints(ctx, describeEC2ICE)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ret := &ListEC2ICEResponse{}
+
+	if aws.ToString(ec2ICEs.NextToken) != "" {
+		ret.NextToken = *ec2ICEs.NextToken
+	}
+
+	ret.EC2ICEs = make([]EC2InstanceConnectEndpoint, 0, len(ec2ICEs.InstanceConnectEndpoints))
+	for _, ice := range ec2ICEs.InstanceConnectEndpoints {
+		name := aws.ToString(ice.InstanceConnectEndpointId)
+		subnetID := aws.ToString(ice.SubnetId)
+		state := ice.State
+
+		ret.EC2ICEs = append(ret.EC2ICEs, EC2InstanceConnectEndpoint{
+			Name:     name,
+			SubnetID: subnetID,
+			State:    string(state),
+		})
+	}
+
+	return ret, nil
+}

--- a/lib/integrations/awsoidc/list_ec2ice.go
+++ b/lib/integrations/awsoidc/list_ec2ice.go
@@ -27,9 +27,6 @@ import (
 
 // ListEC2ICERequest contains the required fields to list AWS EC2 Instance Connect Endpoints.
 type ListEC2ICERequest struct {
-	// Region is the AWS Region.
-	Region string
-
 	// VPCID is the VPC to filter EC2 Instance Connect Endpoints.
 	VPCID string
 
@@ -42,9 +39,6 @@ type ListEC2ICERequest struct {
 func (req *ListEC2ICERequest) CheckAndSetDefaults() error {
 	if req.VPCID == "" {
 		return trace.BadParameter("vpc id is required")
-	}
-	if req.Region == "" {
-		return trace.BadParameter("region is required")
 	}
 
 	return nil

--- a/lib/integrations/awsoidc/list_ec2ice_test.go
+++ b/lib/integrations/awsoidc/list_ec2ice_test.go
@@ -63,7 +63,7 @@ func (m mockListEC2ICEClient) DescribeInstanceConnectEndpoints(ctx context.Conte
 
 	if sliceEnd < totalEndpoints {
 		nextToken := strconv.Itoa(requestedPage + 1)
-		ret.NextToken = stringPointer(nextToken)
+		ret.NextToken = &nextToken
 	}
 
 	return ret, nil
@@ -97,7 +97,6 @@ func TestListEC2ICE(t *testing.T) {
 
 		// First page must return pageSize number of Endpoints
 		resp, err := ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
-			Region:    "us-east-1",
 			VPCID:     "vpc-123",
 			NextToken: "",
 		})
@@ -109,7 +108,6 @@ func TestListEC2ICE(t *testing.T) {
 
 		// Second page must return pageSize number of Endpoints
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
-			Region:    "us-east-1",
 			VPCID:     "vpc-abc",
 			NextToken: nextPageToken,
 		})
@@ -121,7 +119,6 @@ func TestListEC2ICE(t *testing.T) {
 
 		// Third page must return only the remaining Endpoints and an empty nextToken
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
-			Region:    "us-east-1",
 			VPCID:     "vpc-abc",
 			NextToken: nextPageToken,
 		})
@@ -141,7 +138,6 @@ func TestListEC2ICE(t *testing.T) {
 		{
 			name: "valid for listing instances",
 			req: ListEC2ICERequest{
-				Region:    "us-east-1",
 				VPCID:     "vpc-abcd",
 				NextToken: "",
 			},
@@ -165,17 +161,8 @@ func TestListEC2ICE(t *testing.T) {
 			errCheck: noErrorFunc,
 		},
 		{
-			name: "no region",
-			req: ListEC2ICERequest{
-				VPCID: "myintegration",
-			},
-			errCheck: trace.IsBadParameter,
-		},
-		{
-			name: "no vpc id",
-			req: ListEC2ICERequest{
-				Region: "us-east-1",
-			},
+			name:     "no vpc id",
+			req:      ListEC2ICERequest{},
 			errCheck: trace.IsBadParameter,
 		},
 	} {

--- a/lib/integrations/awsoidc/list_ec2ice_test.go
+++ b/lib/integrations/awsoidc/list_ec2ice_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+type mockListEC2ICEClient struct {
+	pageSize  int
+	accountID string
+	ec2ICEs   []ec2Types.Ec2InstanceConnectEndpoint
+}
+
+// Returns information about ec2 instances.
+// This API supports pagination.
+func (m mockListEC2ICEClient) DescribeInstanceConnectEndpoints(ctx context.Context, params *ec2.DescribeInstanceConnectEndpointsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceConnectEndpointsOutput, error) {
+	requestedPage := 1
+
+	totalEndpoints := len(m.ec2ICEs)
+
+	if params.NextToken != nil {
+		currentMarker, err := strconv.Atoi(*params.NextToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		requestedPage = currentMarker
+	}
+
+	sliceStart := m.pageSize * (requestedPage - 1)
+	sliceEnd := m.pageSize * requestedPage
+	if sliceEnd > totalEndpoints {
+		sliceEnd = totalEndpoints
+	}
+
+	ret := &ec2.DescribeInstanceConnectEndpointsOutput{
+		InstanceConnectEndpoints: m.ec2ICEs[sliceStart:sliceEnd],
+	}
+
+	if sliceEnd < totalEndpoints {
+		nextToken := strconv.Itoa(requestedPage + 1)
+		ret.NextToken = stringPointer(nextToken)
+	}
+
+	return ret, nil
+}
+
+func TestListEC2ICE(t *testing.T) {
+	ctx := context.Background()
+
+	noErrorFunc := func(err error) bool {
+		return err == nil
+	}
+
+	const pageSize = 100
+	t.Run("pagination", func(t *testing.T) {
+		totalEC2ICEs := 203
+
+		allEndpoints := make([]ec2Types.Ec2InstanceConnectEndpoint, 0, totalEC2ICEs)
+		for i := 0; i < totalEC2ICEs; i++ {
+			allEndpoints = append(allEndpoints, ec2Types.Ec2InstanceConnectEndpoint{
+				SubnetId:                  aws.String(fmt.Sprintf("subnet-%d", i)),
+				InstanceConnectEndpointId: aws.String("ice-name"),
+				State:                     "create-complete",
+			})
+		}
+
+		mockListClient := &mockListEC2ICEClient{
+			pageSize:  pageSize,
+			accountID: "123456789012",
+			ec2ICEs:   allEndpoints,
+		}
+
+		// First page must return pageSize number of Endpoints
+		resp, err := ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
+			Region:    "us-east-1",
+			VPCID:     "vpc-123",
+			NextToken: "",
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.NextToken)
+		require.Len(t, resp.EC2ICEs, pageSize)
+		nextPageToken := resp.NextToken
+		require.Equal(t, resp.EC2ICEs[0].SubnetID, "subnet-0")
+
+		// Second page must return pageSize number of Endpoints
+		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
+			Region:    "us-east-1",
+			VPCID:     "vpc-abc",
+			NextToken: nextPageToken,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.NextToken)
+		require.Len(t, resp.EC2ICEs, pageSize)
+		nextPageToken = resp.NextToken
+		require.Equal(t, resp.EC2ICEs[0].SubnetID, "subnet-100")
+
+		// Third page must return only the remaining Endpoints and an empty nextToken
+		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
+			Region:    "us-east-1",
+			VPCID:     "vpc-abc",
+			NextToken: nextPageToken,
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.NextToken)
+		require.Len(t, resp.EC2ICEs, 3)
+		require.Equal(t, resp.EC2ICEs[0].SubnetID, "subnet-200")
+	})
+
+	for _, tt := range []struct {
+		name          string
+		req           ListEC2ICERequest
+		mockEndpoints []ec2Types.Ec2InstanceConnectEndpoint
+		errCheck      func(error) bool
+		respCheck     func(*testing.T, *ListEC2ICEResponse)
+	}{
+		{
+			name: "valid for listing instances",
+			req: ListEC2ICERequest{
+				Region:    "us-east-1",
+				VPCID:     "vpc-abcd",
+				NextToken: "",
+			},
+			mockEndpoints: []ec2Types.Ec2InstanceConnectEndpoint{{
+				SubnetId:                  aws.String("subnet-123"),
+				InstanceConnectEndpointId: aws.String("ice-name"),
+				State:                     "create-complete",
+			},
+			},
+			respCheck: func(t *testing.T, ldr *ListEC2ICEResponse) {
+				require.Len(t, ldr.EC2ICEs, 1, "expected 1 endpoint, got %d", len(ldr.EC2ICEs))
+				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
+
+				endpoint := EC2InstanceConnectEndpoint{
+					Name:     "ice-name",
+					State:    "create-complete",
+					SubnetID: "subnet-123",
+				}
+				require.Empty(t, cmp.Diff(endpoint, ldr.EC2ICEs[0]))
+			},
+			errCheck: noErrorFunc,
+		},
+		{
+			name: "no region",
+			req: ListEC2ICERequest{
+				VPCID: "myintegration",
+			},
+			errCheck: trace.IsBadParameter,
+		},
+		{
+			name: "no vpc id",
+			req: ListEC2ICERequest{
+				Region: "us-east-1",
+			},
+			errCheck: trace.IsBadParameter,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockListClient := &mockListEC2ICEClient{
+				pageSize:  pageSize,
+				accountID: "123456789012",
+				ec2ICEs:   tt.mockEndpoints,
+			}
+			resp, err := ListEC2ICE(ctx, mockListClient, tt.req)
+			require.True(t, tt.errCheck(err), "unexpected err: %v", err)
+			if tt.respCheck != nil {
+				tt.respCheck(t, resp)
+			}
+		})
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -778,6 +778,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2ice", h.WithClusterAuth(h.awsOIDCListEC2ICE))
 
 	// AWS OIDC Integration specific endpoints:
 	// Unauthenticated access to OpenID Configuration - used for AWS OIDC IdP integration

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -317,7 +317,6 @@ func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p ht
 		listEC2ICEClient,
 		awsoidc.ListEC2ICERequest{
 			VPCID:     req.VPCID,
-			Region:    req.Region,
 			NextToken: req.NextToken,
 		},
 	)

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -266,13 +266,13 @@ func (h *Handler) awsOIDCListEC2(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	listDBsClient, err := awsoidc.NewListEC2Client(ctx, awsClientReq)
+	listEC2Client, err := awsoidc.NewListEC2Client(ctx, awsClientReq)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	resp, err := awsoidc.ListEC2(ctx,
-		listDBsClient,
+		listEC2Client,
 		awsoidc.ListEC2Request{
 			Integration: awsClientReq.IntegrationName,
 			Region:      req.Region,
@@ -291,5 +291,42 @@ func (h *Handler) awsOIDCListEC2(w http.ResponseWriter, r *http.Request, p httpr
 	return ui.AWSOIDCListEC2Response{
 		NextToken: resp.NextToken,
 		Servers:   servers,
+	}, nil
+}
+
+// awsOIDCListEC2ICE returns a list of EC2 Instance Connect Endpoints using the ListEC2ICE action of the AWS OIDC Integration.
+func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+	ctx := r.Context()
+
+	var req ui.AWSOIDCListEC2ICERequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	listEC2ICEClient, err := awsoidc.NewListEC2ICEClient(ctx, awsClientReq)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := awsoidc.ListEC2ICE(ctx,
+		listEC2ICEClient,
+		awsoidc.ListEC2ICERequest{
+			VPCID:     req.VPCID,
+			Region:    req.Region,
+			NextToken: req.NextToken,
+		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.AWSOIDCListEC2ICEResponse{
+		NextToken: resp.NextToken,
+		EC2ICEs:   resp.EC2ICEs,
 	}, nil
 }

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/types"
+	"github.com/gravitational/teleport/lib/integrations/awsoidc"
 )
 
 // IntegrationAWSOIDCSpec contain the specific fields for the `aws-oidc` subkind integration.
@@ -197,6 +198,27 @@ type AWSOIDCListEC2Request struct {
 type AWSOIDCListEC2Response struct {
 	// Servers contains the page of Servers
 	Servers []Server `json:"servers"`
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string `json:"nextToken,omitempty"`
+}
+
+// AWSOIDCListEC2ICERequest is a request to ListEC2ICEs using the AWS OIDC Integration.
+type AWSOIDCListEC2ICERequest struct {
+	// Region is the AWS Region.
+	Region string `json:"region"`
+	// VPCID is the VPC to filter EC2 Instance Connect Endpoints.
+	VPCID string `json:"vpcId"`
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string `json:"nextToken"`
+}
+
+// AWSOIDCListEC2ICEResponse contains a list of AWS Instance Connect Endpoints and a next token if more pages are available.
+type AWSOIDCListEC2ICEResponse struct {
+	// EC2ICEs contains the page of Endpoints
+	EC2ICEs []awsoidc.EC2InstanceConnectEndpoint `json:"ec2Ices"`
 
 	// NextToken is used for pagination.
 	// If non-empty, it can be used to request the next page.


### PR DESCRIPTION
Context
https://github.com/gravitational/teleport/issues/29317

In order for us to use the EC2 Instance Connect Endpoint, we must have one of those endpoints in the VPC for the EC2 instance we want to connect to.

In order to help the user with this pre-requirement, we will let them know if they have the EC2 Instance Connect Endpoint for VPC and its state (must be create-complete for the endpoint to be usable).

If they don't have a valid endpoint, they will be able to create one (but that will only be possible in a follow up PR).

Example response:
```
URL: .../integrations/aws-oidc/teleportdev/ec2ice
->
200
{
  "ec2Ices": [
    {
      "Name": "eice-0ebaf0ec7daa20cf0",
      "State": "create-complete",
      "SubnetID": "subnet-4017af0c"
    }
  ]
}
```