### PR TITLE
exclude types.RoleMDM from process.waitForInstanceClient()

### DIFF
--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1047,7 +1047,7 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 // For config v1 and v2, it will attempt to direct dial the auth server, and fallback to trying to tunnel
 // to the Auth Server through the proxy.
 func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client, error) {
-	if identity.ID.Role != types.RoleInstance {
+	if identity.ID.Role != types.RoleInstance && identity.ID.Role != types.RoleMDM {
 		clt, ok := process.waitForInstanceClient()
 		if !ok {
 			return nil, trace.Errorf("failed to get instance client for identity %q", identity.ID.Role)


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/30384 Introduced changes that would wait for instance client except for process with `types.RoleInstance` role. 

The Jamf service runs with `types.RoleMDM`. When running as a standalone service, it implicitly acquires `types.RoleInstance`
https://github.com/gravitational/teleport/blob/21d1d243d38daf12f692277047ff620a453b53c4/api/types/system_role.go#L63-L70

But when running as Hosted Plugin instance, it does not, so the Jamf plugin hits `process.waitForInstanceClient()` block and times out.  
This PR adds `types.RoleMDM` to exclusion, along with existing `types.RoleInstance`. 


Fixes https://github.com/gravitational/teleport.e/issues/2022