### PR TITLE
[v13] Add `--current-device` capabilities to `tsh`

### DIFF
--- a/lib/devicetrust/authn/authn_test.go
+++ b/lib/devicetrust/authn/authn_test.go
@@ -28,7 +28,9 @@ import (
 )
 
 func TestRunCeremony(t *testing.T) {
-	env := testenv.MustNew()
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
 	defer env.Close()
 
 	devices := env.DevicesClient
@@ -99,7 +101,7 @@ func enrollDevice(ctx context.Context, devices devicepb.DeviceTrustServiceClient
 	if err != nil {
 		return fmt.Errorf("enroll device init: %w", err)
 	}
-	enrollDeviceInit.Token = "fake device token"
+	enrollDeviceInit.Token = testenv.FakeEnrollmentToken
 	if err := stream.Send(&devicepb.EnrollDeviceRequest{
 		Payload: &devicepb.EnrollDeviceRequest_Init{
 			Init: enrollDeviceInit,

--- a/lib/devicetrust/enroll/auto_enroll_test.go
+++ b/lib/devicetrust/enroll/auto_enroll_test.go
@@ -26,7 +26,9 @@ import (
 )
 
 func TestAutoEnrollCeremony_Run(t *testing.T) {
-	env := testenv.MustNew()
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
 	defer env.Close()
 
 	devices := env.DevicesClient

--- a/lib/devicetrust/enroll/enroll_test.go
+++ b/lib/devicetrust/enroll/enroll_test.go
@@ -27,8 +27,65 @@ import (
 	"github.com/gravitational/teleport/lib/devicetrust/testenv"
 )
 
-func TestCeremony_Run(t *testing.T) {
+func TestCeremony_RunAdmin(t *testing.T) {
 	env := testenv.MustNew()
+	defer env.Close()
+
+	devices := env.DevicesClient
+	ctx := context.Background()
+
+	nonExistingDev, err := testenv.NewFakeMacOSDevice()
+	require.NoError(t, err, "NewFakeMacOSDevice failed")
+
+	registeredDev, err := testenv.NewFakeMacOSDevice()
+	require.NoError(t, err, "NewFakeMacOSDevice failed")
+
+	// Create the device corresponding to registeredDev.
+	_, err = devices.CreateDevice(ctx, &devicepb.CreateDeviceRequest{
+		Device: &devicepb.Device{
+			OsType:   registeredDev.GetDeviceOSType(),
+			AssetTag: registeredDev.SerialNumber,
+		},
+	})
+	require.NoError(t, err, "CreateDevice(registeredDev) failed")
+
+	tests := []struct {
+		name        string
+		dev         testenv.FakeDevice
+		wantOutcome enroll.RunAdminOutcome
+	}{
+		{
+			name:        "non-existing device",
+			dev:         nonExistingDev,
+			wantOutcome: enroll.DeviceRegisteredAndEnrolled,
+		},
+		{
+			name:        "registered device",
+			dev:         registeredDev,
+			wantOutcome: enroll.DeviceEnrolled,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := &enroll.Ceremony{
+				GetDeviceOSType:         test.dev.GetDeviceOSType,
+				EnrollDeviceInit:        test.dev.EnrollDeviceInit,
+				SignChallenge:           test.dev.SignChallenge,
+				SolveTPMEnrollChallenge: test.dev.SolveTPMEnrollChallenge,
+			}
+
+			enrolled, outcome, err := c.RunAdmin(ctx, devices, false /* debug */)
+			require.NoError(t, err, "RunAdmin failed")
+			assert.NotNil(t, enrolled, "RunAdmin returned nil device")
+			assert.Equal(t, test.wantOutcome, outcome, "RunAdmin outcome mismatch")
+		})
+	}
+}
+
+func TestCeremony_Run(t *testing.T) {
+	env := testenv.MustNew(
+		testenv.WithAutoCreateDevice(true),
+	)
 	defer env.Close()
 
 	devices := env.DevicesClient
@@ -90,7 +147,7 @@ func TestCeremony_Run(t *testing.T) {
 				SolveTPMEnrollChallenge: test.dev.SolveTPMEnrollChallenge,
 			}
 
-			got, err := c.Run(ctx, devices, false, "faketoken")
+			got, err := c.Run(ctx, devices, false /* debug */, testenv.FakeEnrollmentToken)
 			test.assertErr(t, err)
 			test.assertGotDevice(t, got)
 		})

--- a/tool/tsh/tsh.go
+++ b/tool/tsh/tsh.go
@@ -1369,6 +1369,8 @@ func Run(ctx context.Context, args []string, opts ...cliOption) error {
 		err = deviceCmd.enroll.run(&cf)
 	case deviceCmd.collect.FullCommand():
 		err = deviceCmd.collect.run(&cf)
+	case deviceCmd.assetTag.FullCommand():
+		err = deviceCmd.assetTag.run(&cf)
 	case deviceCmd.keyget.FullCommand():
 		err = deviceCmd.keyget.run(&cf)
 	case deviceCmd.activateCredential.FullCommand():


### PR DESCRIPTION
Partial backport of #30636 to branch/v13.

Add the ability to act on the current device more easily.

1. `tsh device asset-tag` is a debug command we planned for, but never executed. It's a simpler version of `tsh device collect`.

2. `tsh device enroll --current-device` attempts to enroll the current device. It's focused on device admins, as it requires various permissions end-users typically won't have.

The changes above are all focused on "day 1" experience, thus are catered to powerful Teleport users - powerful as in with various administrative permissions.

(New tctl functionality backported to e/).