### PR TITLE
Add action to detect binary bloat

### DIFF
--- a/.github/workflows/bloat-bypass.yaml
+++ b/.github/workflows/bloat-bypass.yaml
@@ -1,0 +1,37 @@
+# This workflow is required to ensure that required Github check passes even if
+# the actual "Bloat Check" workflow was skipped due to path filtering. Otherwise
+# it will stay forever pending.
+#
+# See "Handling skipped but required checks" for more info:
+#
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks
+#
+# Note both workflows must have the same name.
+
+name: Bloat Check
+run-name: Skip Bloat Check
+
+on:
+  push:
+    paths-ignore:
+      - '.github/workflows/bloat.yaml'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+    branches:
+      - master
+      - branch/**
+
+jobs:
+  bloat_check:
+    name: Bloat Check
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: none
+
+    steps:
+      - run: 'echo "No code changes"'

--- a/.github/workflows/bloat.yaml
+++ b/.github/workflows/bloat.yaml
@@ -1,0 +1,102 @@
+name: Bloat Check
+on:
+  push:
+    paths:
+      - '.github/workflows/bloat.yaml'
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+    branches:
+      - master
+      - branch/**
+
+jobs:
+  bloat_check:
+    name: Bloat Check
+    runs-on: ubuntu-latest
+    outputs:
+      base_stats_file: ${{ steps.build_base.outputs.base_stats_file }}
+      current_build_dir: ${{ steps.build_branch.outputs.build_dir }}
+
+    permissions:
+      contents: read
+
+    container:
+      image: ghcr.io/gravitational/teleport-buildbox-centos7:teleport14
+
+    steps:
+      - name: Checkout base
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.push.before }}
+
+      - name: Prepare workspace
+        uses: ./.github/actions/prepare-workspace
+
+      - name: Checkout shared-workflow
+        uses: actions/checkout@v3
+        with:
+          repository: gravitational/shared-workflows
+          path: .github/shared-workflows
+          ref: main
+
+      - name: Setup base cache
+        uses: actions/cache/restore@v3
+        id: cache-build-restore
+        with:
+          path: |
+            ~/teleport_base_build_stats
+          key: ${{ runner.os }}-${{ github.event.push.before }}
+
+      - name: Generate GitHub Token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.REVIEWERS_APP_ID }}
+          private_key: ${{ secrets.REVIEWERS_PRIVATE_KEY }}
+
+      - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
+        name: Build base
+        id: build_base
+        run: |
+          make WEBASSETS_SKIP_BUILD=1 BUILDDIR=base_build binaries
+          cd .github/shared-workflows/bot && go run main.go -workflow=binary-sizes --artifacts="tbot,tctl,teleport,tsh" --builddir="../../../base_build" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}"  >> ~/teleport_base_build_stats
+          echo "base_stats_file=~/teleport_base_build_stats" >> $GITHUB_OUTPUT
+          echo "base_stats=$(cat ~/teleport_base_build_stats)" >> $GITHUB_ENV
+      - if: ${{ steps.cache-build-restore.outputs.cache-hit != 'true' }}
+        name: Save base build
+        id: base-build-save
+        uses: actions/cache/save@v3
+        with:
+          path: |
+            ${{ steps.build_base.outputs.base_stats_file }}
+          key: ${{ runner.os }}-${{ github.event.push.before }}
+
+      - if: ${{ steps.cache-build-restore.outputs.cache-hit == 'true' }}
+        name: Restore base stats
+        id: restore-base-stats
+        run: |
+          echo "base_stats=$(cat ~/teleport_base_build_stats)" >> $GITHUB_ENV
+
+      - name: Checkout branch
+        uses: actions/checkout@v3
+        with:
+          clean: false
+          ref: ${{ github.event.push.after }}
+
+      - name: Checkout shared-workflow
+        uses: actions/checkout@v3
+        with:
+          repository: gravitational/shared-workflows
+          path: .github/shared-workflows
+          ref: tross/skip_items_on_pr
+
+      - name: Check branch for bloat
+        id: build_branch
+        run: |
+          make WEBASSETS_SKIP_BUILD=1 binaries
+          current=$(pwd)/build
+          cd .github/shared-workflows/bot && go run main.go -workflow=bloat --artifacts="tbot,tctl,teleport,tsh" --base="${base_stats}" --builddir="${current}" -token="${{ steps.generate_token.outputs.token }}" -reviewers="${{ secrets.reviewers }}" > $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Enables comparing binaries between consecutive commits on master and release branches to detect an increase in size. A warning is emitted if any of tbot, tctl, tsh, or teleport increase by more than 1MB. The action fails if binary size is increased by more than 3MB.