### PR TITLE
[v11] fix typo in s3 request metric

### DIFF
--- a/lib/observability/metrics/s3/api.go
+++ b/lib/observability/metrics/s3/api.go
@@ -130,7 +130,7 @@ func (m *APIMetrics) CompleteMultipartUploadWithContext(ctx context.Context, inp
 	start := time.Now()
 	output, err := m.S3API.CompleteMultipartUploadWithContext(ctx, input, opts...)
 
-	recordMetrics("create_multipart_upload", err, time.Since(start).Seconds())
+	recordMetrics("complete_multipart_upload", err, time.Since(start).Seconds())
 	return output, err
 }
 


### PR DESCRIPTION
Backport #30705 to branch/v11

Fixes typo in s3 requests CompleteMultipartUpload metric to give metric the proper operation label.