### PR TITLE
Fix ARM build process and environment setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ CGOFLAG = CGO_ENABLED=1
 
 # ARM builds need to specify the correct C compiler
 ifeq ($(IS_NATIVE_BUILD),"no")
-CC=arm-linux-gnueabi-gcc
+CC=arm-linux-gnueabihf-gcc
 endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.

--- a/Makefile
+++ b/Makefile
@@ -242,7 +242,7 @@ CGOFLAG = CGO_ENABLED=1
 
 # ARM builds need to specify the correct C compiler
 ifeq ($(IS_NATIVE_BUILD),"no")
-CC=arm-linux-gnueabihf-gcc
+CC=arm-linux-gnueabi-gcc
 endif
 
 # Add -debugtramp=2 to work around 24 bit CALL/JMP instruction offset.

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -43,19 +43,20 @@ RUN apt-get -y update && \
 ARG NODE_VERSION
 ENV NODE_PATH="/usr/local/lib/nodejs-linux"
 ENV PATH="$PATH:${NODE_PATH}/bin"
-RUN NODE_ARCH=$(if [ "$BUILDARCH" = 'amd64' ]; then echo 'x64'; else echo 'arm64'; fi) && \
+RUN NODE_ARCH="$(if [ "$BUILDARCH" = 'amd64' ]; then echo 'x64'; else echo 'arm64'; fi)" && \
     NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
     NODE_FILE="$(mktemp node-XXXXXX.tar.xz)" && \
     mkdir -p "$NODE_PATH" && \
     curl -o "$NODE_FILE" -fsSL "$NODE_URL" && \
-    tar -xJf "$NODE_FILE" -C /usr/local/lib/nodejs-linux --strip-components=1
+    tar -xJf "$NODE_FILE" -C /usr/local/lib/nodejs-linux --strip-components=1 && \
+    rm -f "$NODE_FILE"
 RUN corepack enable yarn
 
 # Install Go.
 ARG GOLANG_VERSION
 RUN mkdir -p /opt && \
     cd /opt && \
-    curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | tar xz && \
+    curl -fsSL "https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-$BUILDARCH.tar.gz" | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
@@ -65,10 +66,11 @@ ENV GOPATH="/go" \
     PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
 # Add the CI user.
+# This images is not used in CI, but because we used to use it in CI, we keep the same UID/GID and name.
 ARG UID
 ARG GID
-RUN groupadd ci --gid=$GID -o && \
-    useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
+RUN groupadd ci --gid="$GID" -o && \
+    useradd ci --uid="$UID" --gid="$GID" --create-home --shell=/bin/sh && \
     mkdir -p -m0700 /var/lib/teleport && \
     chown -R ci /var/lib/teleport
 

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -26,20 +26,15 @@ RUN apt-get -y update && \
         gnupg \
         gzip \
         libc6-dev \
-        libelf-dev \
         libpam-dev \
-        libssl-dev \
         locales \
-        openssh-client \
         pkg-config \
         sudo \
         unzip \
         zip \
-        zlib1g-dev \
-        gcc-arm-linux-gnueabi \
-        libc6-armel-cross \
-        libc6-dev-armel-cross \
-        linux-libc-dev-armhf-cross \
+        # ARM dependencies
+        libc6-dev-armhf-cross \
+        gcc-arm-linux-gnueabihf \
         && \
     dpkg-reconfigure locales && \
     apt-get -y clean && \

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -1,8 +1,77 @@
-ARG BUILDBOX_VERSION
-FROM public.ecr.aws/gravitational/teleport-buildbox:$BUILDBOX_VERSION
+FROM docker.io/library/debian:11
 
-USER root
+COPY locale.gen /etc/locale.gen
+COPY profile /etc/profile
+
+ENV LANGUAGE="en_US.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8" \
+    LC_CTYPE="en_US.UTF-8" \
+    DEBIAN_FRONTEND="noninteractive"
+
+# BUILDARCH is automatically set by DOCKER when building the image with Build Kit (MacOS by deafult).
+# https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
+ARG BUILDARCH
 
 RUN apt-get -y update && \
-    apt-get -y install gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu && \
-    apt-get -y autoclean && apt-get -y clean
+    apt-get -y install software-properties-common && \
+    apt-get update -y --fix-missing && \
+    apt-get -q -y upgrade && \
+    apt-get install -q -y --no-install-recommends \
+        apt-utils \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        gnupg \
+        gzip \
+        libc6-dev \
+        libelf-dev \
+        libpam-dev \
+        libssl-dev \
+        locales \
+        openssh-client \
+        pkg-config \
+        sudo \
+        unzip \
+        zip \
+        zlib1g-dev \
+        gcc-arm-linux-gnueabi \
+        libc6-armel-cross \
+        libc6-dev-armel-cross \
+        linux-libc-dev-armhf-cross \
+        && \
+    dpkg-reconfigure locales && \
+    apt-get -y clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Node.js.
+ARG NODE_VERSION
+ENV NODE_PATH="/usr/local/lib/nodejs-linux"
+ENV PATH="$PATH:${NODE_PATH}/bin"
+RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
+    export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
+    mkdir -p ${NODE_PATH} && \
+    curl -o /tmp/nodejs.tar.xz -fsSL ${NODE_URL} && \
+    tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
+RUN corepack enable yarn
+
+# Install Go.
+ARG GOLANG_VERSION
+RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | tar xz && \
+    mkdir -p /go/src/github.com/gravitational/teleport && \
+    chmod a+w /go && \
+    chmod a+w /var/lib && \
+    chmod a-w /
+ENV GOPATH="/go" \
+    GOROOT="/opt/go" \
+    PATH="$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
+
+# Add the CI user.
+ARG UID
+ARG GID
+RUN groupadd ci --gid=$GID -o && \
+    useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
+    mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport
+
+VOLUME ["/go/src/github.com/gravitational/teleport"]

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -9,7 +9,7 @@ ENV LANGUAGE="en_US.UTF-8" \
     LC_CTYPE="en_US.UTF-8" \
     DEBIAN_FRONTEND="noninteractive"
 
-# BUILDARCH is automatically set by DOCKER when building the image with Build Kit (MacOS by deafult).
+# BUILDARCH is automatically set by DOCKER when building the image with Build Kit (MacOS by default).
 # https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope
 ARG BUILDARCH
 

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -1,3 +1,7 @@
+# This Dockerfile is used to build Teleport on ARM only.
+# We are using the official Debian 11 image as a base image
+# because the finaly binary must be compatible with distroless
+# images that are also Debian 11 based: https://github.com/GoogleContainerTools/distroless
 FROM docker.io/library/debian:11
 
 COPY locale.gen /etc/locale.gen
@@ -14,16 +18,11 @@ ENV LANGUAGE="en_US.UTF-8" \
 ARG BUILDARCH
 
 RUN apt-get -y update && \
-    apt-get -y install software-properties-common && \
-    apt-get update -y --fix-missing && \
-    apt-get -q -y upgrade && \
     apt-get install -q -y --no-install-recommends \
-        apt-utils \
         build-essential \
         ca-certificates \
         curl \
         git \
-        gnupg \
         gzip \
         libc6-dev \
         libpam-dev \
@@ -33,8 +32,8 @@ RUN apt-get -y update && \
         unzip \
         zip \
         # ARM dependencies
-        libc6-dev-armhf-cross \
         gcc-arm-linux-gnueabihf \
+        libc6-dev-armhf-cross \
         && \
     dpkg-reconfigure locales && \
     apt-get -y clean && \
@@ -44,16 +43,19 @@ RUN apt-get -y update && \
 ARG NODE_VERSION
 ENV NODE_PATH="/usr/local/lib/nodejs-linux"
 ENV PATH="$PATH:${NODE_PATH}/bin"
-RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
-    export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
-    mkdir -p ${NODE_PATH} && \
-    curl -o /tmp/nodejs.tar.xz -fsSL ${NODE_URL} && \
-    tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
+RUN NODE_ARCH=$(if [ "$BUILDARCH" = 'amd64' ]; then echo 'x64'; else echo 'arm64'; fi) && \
+    NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
+    NODE_FILE="$(mktemp node-XXXXXX.tar.xz)" && \
+    mkdir -p "$NODE_PATH" && \
+    curl -o "$NODE_FILE" -fsSL "$NODE_URL" && \
+    tar -xJf "$NODE_FILE" -C /usr/local/lib/nodejs-linux --strip-components=1
 RUN corepack enable yarn
 
 # Install Go.
 ARG GOLANG_VERSION
-RUN mkdir -p /opt && cd /opt && curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | tar xz && \
+RUN mkdir -p /opt && \
+    cd /opt && \
+    curl -fsSL https://storage.googleapis.com/golang/$GOLANG_VERSION.linux-${BUILDARCH}.tar.gz | tar xz && \
     mkdir -p /go/src/github.com/gravitational/teleport && \
     chmod a+w /go && \
     chmod a+w /var/lib && \
@@ -67,6 +69,7 @@ ARG UID
 ARG GID
 RUN groupadd ci --gid=$GID -o && \
     useradd ci --uid=$UID --gid=$GID --create-home --shell=/bin/sh && \
-    mkdir -p -m0700 /var/lib/teleport && chown -R ci /var/lib/teleport
+    mkdir -p -m0700 /var/lib/teleport && \
+    chown -R ci /var/lib/teleport
 
 VOLUME ["/go/src/github.com/gravitational/teleport"]

--- a/build.assets/Dockerfile-arm
+++ b/build.assets/Dockerfile-arm
@@ -1,6 +1,6 @@
 # This Dockerfile is used to build Teleport on ARM only.
 # We are using the official Debian 11 image as a base image
-# because the finaly binary must be compatible with distroless
+# because the final binary must be compatible with distroless
 # images that are also Debian 11 based: https://github.com/GoogleContainerTools/distroless
 FROM docker.io/library/debian:11
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -186,12 +186,18 @@ buildbox-centos7-fips:
 # with the correct UID and GID created, so those arguments are not needed here.
 #
 .PHONY:buildbox-arm
-buildbox-arm: buildbox
+buildbox-arm:
 	@if [[ $${DRONE} == "true" ]] && ! docker inspect --type=image $(BUILDBOX_ARM) 2>&1 >/dev/null; then docker pull $(BUILDBOX_ARM) || true; fi;
 	docker build \
 		--build-arg BUILDBOX_VERSION=$(BUILDBOX_VERSION) \
 		--cache-from $(BUILDBOX) \
 		--cache-from $(BUILDBOX_ARM) \
+		--build-arg UID=$(UID) \
+        --build-arg GID=$(GID) \
+        --build-arg BUILDARCH=$(RUNTIME_ARCH) \
+        --build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+        --build-arg RUST_VERSION=$(RUST_VERSION) \
+        --build-arg NODE_VERSION=$(NODE_VERSION) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
 
 CONNECT_VERSION ?= $(VERSION)
@@ -384,7 +390,10 @@ release-386:
 
 .PHONY: release-arm
 release-arm: buildbox-arm
-	$(MAKE) release ARCH=arm BUILDBOX_NAME=$(BUILDBOX_ARM)
+	@echo "Build Assets Release (32 bits)"
+	 docker run -e ARCH=arm $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_ARM) \
+		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=arm RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=yes
+	#$(MAKE) release ARCH=arm BUILDBOX_NAME=$(BUILDBOX_ARM)
 
 .PHONY: release-amd64-centos7
 release-amd64-centos7: buildbox-centos7

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -196,7 +196,6 @@ buildbox-arm:
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
 

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -193,11 +193,11 @@ buildbox-arm:
 		--cache-from $(BUILDBOX) \
 		--cache-from $(BUILDBOX_ARM) \
 		--build-arg UID=$(UID) \
-        --build-arg GID=$(GID) \
-        --build-arg BUILDARCH=$(RUNTIME_ARCH) \
-        --build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-        --build-arg RUST_VERSION=$(RUST_VERSION) \
-        --build-arg NODE_VERSION=$(NODE_VERSION) \
+		--build-arg GID=$(GID) \
+		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
+		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
+		--build-arg RUST_VERSION=$(RUST_VERSION) \
+		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--tag $(BUILDBOX_ARM) -f Dockerfile-arm .
 
 CONNECT_VERSION ?= $(VERSION)
@@ -390,10 +390,7 @@ release-386:
 
 .PHONY: release-arm
 release-arm: buildbox-arm
-	@echo "Build Assets Release (32 bits)"
-	 docker run -e ARCH=arm $(DOCKERFLAGS) $(NOROOT) $(BUILDBOX_ARM) \
-		/usr/bin/make release -e ADDFLAGS="$(ADDFLAGS)" OS=$(OS) ARCH=arm RUNTIME=$(GOLANG_VERSION) FIDO2=$(FIDO2) PIV=$(PIV) REPRODUCIBLE=yes
-	#$(MAKE) release ARCH=arm BUILDBOX_NAME=$(BUILDBOX_ARM)
+	$(MAKE) release ARCH=arm BUILDBOX_NAME=$(BUILDBOX_ARM)
 
 .PHONY: release-amd64-centos7
 release-amd64-centos7: buildbox-centos7


### PR DESCRIPTION
Fix the ARM build process by using the Debian 11-based Docker image instead of the CI image that requires a newer GLibc version.

Build https://drone.platform.teleport.sh/gravitational/teleport/27432