### PR TITLE
Connect My Computer: Auto start the agent

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/NavigationMenu.tsx
@@ -26,7 +26,6 @@ import { ClusterUri } from 'teleterm/ui/uri';
 import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { assertUnreachable } from 'teleterm/ui/utils';
 
-import { canUseConnectMyComputer } from './permissions';
 import {
   CurrentAction,
   useConnectMyComputerContext,
@@ -47,7 +46,7 @@ export function NavigationMenu(props: NavigationMenuProps) {
   const [isMenuOpened, setIsMenuOpened] = useState(false);
   const appCtx = useAppContext();
   const { documentsService, rootClusterUri } = useWorkspaceContext();
-  const { isAgentConfiguredAttempt, currentAction } =
+  const { isAgentConfiguredAttempt, currentAction, canUse } =
     useConnectMyComputerContext();
   // DocumentCluster renders this component only if the cluster exists.
   const cluster = appCtx.clustersService.findCluster(props.clusterUri);
@@ -57,11 +56,9 @@ export function NavigationMenu(props: NavigationMenuProps) {
   );
 
   // Don't show the navigation icon for leaf clusters.
-  if (cluster.leaf) {
+  if (cluster.leaf || !canUse) {
     return null;
   }
-
-  const rootCluster = cluster;
 
   function toggleMenu() {
     setIsMenuOpened(wasOpened => !wasOpened);
@@ -79,16 +76,6 @@ export function NavigationMenu(props: NavigationMenuProps) {
       rootClusterUri,
     });
     setIsMenuOpened(false);
-  }
-
-  if (
-    !canUseConnectMyComputer(
-      rootCluster,
-      appCtx.configService,
-      appCtx.mainProcessClient.getRuntimeSettings()
-    )
-  ) {
-    return null;
   }
 
   const setupMenuItem = (

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -197,6 +197,7 @@ test('starts the agent automatically if the workspace autoStart flag is true', a
       eventEmitter.on('', listener);
       return { cleanup: () => eventEmitter.off('', listener) };
     });
+
   jest
     .spyOn(appContext.workspacesService, 'getConnectMyComputerAutoStart')
     .mockReturnValue(true);

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -17,7 +17,7 @@
 import { EventEmitter } from 'node:events';
 
 import React from 'react';
-import { renderHook, act } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { makeErrorAttempt } from 'shared/hooks/useAsync';
 
 import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
@@ -26,30 +26,70 @@ import { WorkspaceContextProvider } from 'teleterm/ui/Documents';
 import { AgentProcessState } from 'teleterm/mainProcess/types';
 
 import {
+  makeLoggedInUser,
+  makeRootCluster,
+  makeServer,
+} from 'teleterm/services/tshd/testHelpers';
+import { createMockConfigService } from 'teleterm/services/config/fixtures/mocks';
+
+import {
   AgentProcessError,
   ConnectMyComputerContextProvider,
   useConnectMyComputerContext,
 } from './connectMyComputerContext';
 
-test('runAgentAndWaitForNodeToJoin re-throws errors that are thrown while spawning the process', async () => {
-  const mockedAppContext = new MockAppContext({});
+function getMocksWithConnectMyComputerEnabled() {
+  const rootCluster = makeRootCluster({
+    loggedInUser: makeLoggedInUser({
+      acl: {
+        tokens: {
+          create: true,
+          edit: false,
+          list: false,
+          use: false,
+          read: false,
+          pb_delete: false,
+        },
+      },
+    }),
+  });
+  const appContext = new MockAppContext({});
+
+  appContext.clustersService.setState(draftState => {
+    draftState.clusters.set(rootCluster.uri, rootCluster);
+  });
+  appContext.workspacesService.setState(draftState => {
+    draftState.rootClusterUri = rootCluster.uri;
+    draftState.workspaces[rootCluster.uri] = {
+      documents: [],
+      location: undefined,
+      localClusterUri: rootCluster.uri,
+      accessRequests: undefined,
+    };
+  });
+
+  return { appContext, rootCluster };
+}
+
+test('startAgent re-throws errors that are thrown while spawning the process', async () => {
+  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
   const eventEmitter = new EventEmitter();
   const errorStatus: AgentProcessState = {
     status: 'error',
     message: 'ENOENT',
   };
   jest
-    .spyOn(mockedAppContext.mainProcessClient, 'getAgentState')
+    .spyOn(appContext.mainProcessClient, 'getAgentState')
     .mockImplementation(() => errorStatus);
   jest
-    .spyOn(mockedAppContext.connectMyComputerService, 'runAgent')
+    .spyOn(appContext.connectMyComputerService, 'runAgent')
     .mockImplementation(async () => {
       // the error is emitted before the function resolves
       eventEmitter.emit('', errorStatus);
       return;
     });
   jest
-    .spyOn(mockedAppContext.mainProcessClient, 'subscribeToAgentUpdate')
+    .spyOn(appContext.mainProcessClient, 'subscribeToAgentUpdate')
     .mockImplementation((rootClusterUri, listener) => {
       eventEmitter.on('', listener);
       return { cleanup: () => eventEmitter.off('', listener) };
@@ -57,9 +97,9 @@ test('runAgentAndWaitForNodeToJoin re-throws errors that are thrown while spawni
 
   const { result } = renderHook(() => useConnectMyComputerContext(), {
     wrapper: ({ children }) => (
-      <MockAppContextProvider appContext={mockedAppContext}>
+      <MockAppContextProvider appContext={appContext}>
         <WorkspaceContextProvider value={null}>
-          <ConnectMyComputerContextProvider rootClusterUri={'/clusters/a'}>
+          <ConnectMyComputerContextProvider rootClusterUri={rootCluster.uri}>
             {children}
           </ConnectMyComputerContextProvider>
         </WorkspaceContextProvider>
@@ -80,4 +120,111 @@ test('runAgentAndWaitForNodeToJoin re-throws errors that are thrown while spawni
       message: 'ENOENT',
     },
   });
+});
+
+test('starting the agent flips the workspace autoStart flag to true', async () => {
+  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  const { result } = renderHook(() => useConnectMyComputerContext(), {
+    wrapper: ({ children }) => (
+      <MockAppContextProvider appContext={appContext}>
+        <WorkspaceContextProvider value={null}>
+          <ConnectMyComputerContextProvider rootClusterUri={rootCluster.uri}>
+            {children}
+          </ConnectMyComputerContextProvider>
+        </WorkspaceContextProvider>
+      </MockAppContextProvider>
+    ),
+  });
+
+  await act(() => result.current.startAgent());
+
+  expect(
+    appContext.workspacesService.getConnectMyComputerAutoStartFlag(
+      rootCluster.uri
+    )
+  ).toBeTruthy();
+});
+
+test('killing the agent flips the workspace autoStart flag to false', async () => {
+  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+
+  const { result } = renderHook(() => useConnectMyComputerContext(), {
+    wrapper: ({ children }) => (
+      <MockAppContextProvider appContext={appContext}>
+        <WorkspaceContextProvider value={null}>
+          <ConnectMyComputerContextProvider rootClusterUri={rootCluster.uri}>
+            {children}
+          </ConnectMyComputerContextProvider>
+        </WorkspaceContextProvider>
+      </MockAppContextProvider>
+    ),
+  });
+
+  await act(() => result.current.killAgent());
+
+  expect(
+    appContext.workspacesService.getConnectMyComputerAutoStartFlag(
+      rootCluster.uri
+    )
+  ).toBeFalsy();
+});
+
+test('starts the agent automatically if the workspace autoStart flag is true', async () => {
+  const { appContext, rootCluster } = getMocksWithConnectMyComputerEnabled();
+  appContext.configService = createMockConfigService({
+    'feature.connectMyComputer': true,
+  });
+
+  const eventEmitter = new EventEmitter();
+  let currentAgentProcessState: AgentProcessState = {
+    status: 'not-started',
+  };
+  jest
+    .spyOn(appContext.mainProcessClient, 'getAgentState')
+    .mockImplementation(() => currentAgentProcessState);
+  jest
+    .spyOn(appContext.connectMyComputerService, 'isAgentConfigFileCreated')
+    .mockResolvedValue(true);
+  jest
+    .spyOn(appContext.connectMyComputerService, 'runAgent')
+    .mockImplementation(async () => {
+      currentAgentProcessState = { status: 'running' };
+      eventEmitter.emit('', currentAgentProcessState);
+    });
+  jest
+    .spyOn(appContext.connectMyComputerService, 'waitForNodeToJoin')
+    .mockResolvedValue(makeServer());
+  jest.spyOn(appContext.connectMyComputerService, 'downloadAgent');
+  jest
+    .spyOn(appContext.mainProcessClient, 'subscribeToAgentUpdate')
+    .mockImplementation((rootClusterUri, listener) => {
+      eventEmitter.on('', listener);
+      return { cleanup: () => eventEmitter.off('', listener) };
+    });
+  jest
+    .spyOn(appContext.workspacesService, 'getConnectMyComputerAutoStartFlag')
+    .mockReturnValue(true);
+
+  const { result, waitFor } = renderHook(() => useConnectMyComputerContext(), {
+    wrapper: ({ children }) => (
+      <MockAppContextProvider appContext={appContext}>
+        <WorkspaceContextProvider value={null}>
+          <ConnectMyComputerContextProvider rootClusterUri={rootCluster.uri}>
+            {children}
+          </ConnectMyComputerContextProvider>
+        </WorkspaceContextProvider>
+      </MockAppContextProvider>
+    ),
+  });
+
+  await waitFor(
+    () =>
+      result.current.currentAction.kind === 'observe-process' &&
+      result.current.currentAction.agentProcessState.status === 'running'
+  );
+
+  expect(
+    appContext.connectMyComputerService.downloadAgent
+  ).toHaveBeenCalledTimes(1);
+  expect(appContext.connectMyComputerService.runAgent).toHaveBeenCalledTimes(1);
 });

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.test.tsx
@@ -139,9 +139,7 @@ test('starting the agent flips the workspace autoStart flag to true', async () =
   await act(() => result.current.startAgent());
 
   expect(
-    appContext.workspacesService.getConnectMyComputerAutoStartFlag(
-      rootCluster.uri
-    )
+    appContext.workspacesService.getConnectMyComputerAutoStart(rootCluster.uri)
   ).toBeTruthy();
 });
 
@@ -163,9 +161,7 @@ test('killing the agent flips the workspace autoStart flag to false', async () =
   await act(() => result.current.killAgent());
 
   expect(
-    appContext.workspacesService.getConnectMyComputerAutoStartFlag(
-      rootCluster.uri
-    )
+    appContext.workspacesService.getConnectMyComputerAutoStart(rootCluster.uri)
   ).toBeFalsy();
 });
 
@@ -202,7 +198,7 @@ test('starts the agent automatically if the workspace autoStart flag is true', a
       return { cleanup: () => eventEmitter.off('', listener) };
     });
   jest
-    .spyOn(appContext.workspacesService, 'getConnectMyComputerAutoStartFlag')
+    .spyOn(appContext.workspacesService, 'getConnectMyComputerAutoStart')
     .mockReturnValue(true);
 
   const { result, waitFor } = renderHook(() => useConnectMyComputerContext(), {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -161,9 +161,9 @@ export const ConnectMyComputerContextProvider: FC<{
           }),
         ]);
         setCurrentActionKind('observe-process');
-        workspacesService.setConnectMyComputerAutoStartFlag(
+        workspacesService.setConnectMyComputerAutoStart(
           props.rootClusterUri,
-          { shouldAutoStart: true }
+          true
         );
         return server;
       } catch (error) {
@@ -194,9 +194,9 @@ export const ConnectMyComputerContextProvider: FC<{
       setCurrentActionKind('kill');
       await connectMyComputerService.killAgent(props.rootClusterUri);
       setCurrentActionKind('observe-process');
-      workspacesService.setConnectMyComputerAutoStartFlag(
+      workspacesService.setConnectMyComputerAutoStart(
         props.rootClusterUri,
-        { shouldAutoStart: false }
+        false
       );
     }, [connectMyComputerService, props.rootClusterUri, workspacesService])
   );
@@ -249,9 +249,7 @@ export const ConnectMyComputerContextProvider: FC<{
     const shouldAutoStartAgent =
       isAgentConfigured &&
       canUse &&
-      workspacesService.getConnectMyComputerAutoStartFlag(
-        props.rootClusterUri
-      ) &&
+      workspacesService.getConnectMyComputerAutoStart(props.rootClusterUri) &&
       agentIsNotStarted;
     if (shouldAutoStartAgent) {
       downloadAndStartAgent();

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -77,7 +77,13 @@ const ConnectMyComputerContext = createContext<ConnectMyComputerContext>(null);
 export const ConnectMyComputerContextProvider: FC<{
   rootClusterUri: RootClusterUri;
 }> = props => {
-  const { mainProcessClient, connectMyComputerService } = useAppContext();
+  const {
+    mainProcessClient,
+    connectMyComputerService,
+    clustersService,
+    configService,
+  } = useAppContext();
+  clustersService.useState();
 
   const [
     isAgentConfiguredAttempt,
@@ -89,6 +95,17 @@ export const ConnectMyComputerContextProvider: FC<{
         connectMyComputerService.isAgentConfigFileCreated(props.rootClusterUri),
       [connectMyComputerService, props.rootClusterUri]
     )
+  );
+
+  const rootCluster = clustersService.findCluster(props.rootClusterUri);
+  const canUse = useMemo(
+    () =>
+      canUseConnectMyComputer(
+        rootCluster,
+        configService,
+        mainProcessClient.getRuntimeSettings()
+      ),
+    [configService, mainProcessClient, rootCluster]
   );
 
   const markAgentAsConfigured = useCallback(() => {

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.test.ts
@@ -124,6 +124,7 @@ describe('restoring workspace', () => {
           documents: testWorkspace.documents,
           location: testWorkspace.location,
         },
+        connectMyComputer: undefined,
       },
     });
   });
@@ -154,6 +155,7 @@ describe('restoring workspace', () => {
         documents: [clusterDocument],
         location: clusterDocument.uri,
         previous: undefined,
+        connectMyComputer: undefined,
       },
     });
   });

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -189,18 +189,18 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     this.persistState();
   }
 
-  setConnectMyComputerAutoStartFlag(
+  setConnectMyComputerAutoStart(
     rootClusterUri: RootClusterUri,
-    params: { shouldAutoStart: boolean }
+    autoStart: boolean
   ): void {
     this.setState(draftState => {
       draftState.workspaces[rootClusterUri].connectMyComputer = {
-        autoStart: params.shouldAutoStart,
+        autoStart,
       };
     });
   }
 
-  getConnectMyComputerAutoStartFlag(rootClusterUri: RootClusterUri): boolean {
+  getConnectMyComputerAutoStart(rootClusterUri: RootClusterUri): boolean {
     return this.state.workspaces[rootClusterUri].connectMyComputer?.autoStart;
   }
 

--- a/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
+++ b/web/packages/teleterm/src/ui/services/workspacesService/workspacesService.ts
@@ -57,6 +57,9 @@ export interface Workspace {
     isBarCollapsed: boolean;
     pending: PendingAccessRequest;
   };
+  connectMyComputer?: {
+    autoStart: boolean;
+  };
   previous?: {
     documents: Document[];
     location: DocumentUri;
@@ -186,6 +189,21 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
     this.persistState();
   }
 
+  setConnectMyComputerAutoStartFlag(
+    rootClusterUri: RootClusterUri,
+    params: { shouldAutoStart: boolean }
+  ): void {
+    this.setState(draftState => {
+      draftState.workspaces[rootClusterUri].connectMyComputer = {
+        autoStart: params.shouldAutoStart,
+      };
+    });
+  }
+
+  getConnectMyComputerAutoStartFlag(rootClusterUri: RootClusterUri): boolean {
+    return this.state.workspaces[rootClusterUri].connectMyComputer?.autoStart;
+  }
+
   setActiveWorkspace(clusterUri: RootClusterUri): Promise<void> {
     const setWorkspace = () => {
       this.setState(draftState => {
@@ -288,6 +306,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
                 documents: persistedWorkspaceDocuments,
               }
             : undefined,
+          connectMyComputer: persistedWorkspace?.connectMyComputer,
         };
         return workspaces;
       }, {});
@@ -397,6 +416,7 @@ export class WorkspacesService extends ImmutableStore<WorkspacesState> {
         localClusterUri: workspace.localClusterUri,
         location: workspace.previous?.location || workspace.location,
         documents: workspace.previous?.documents || workspace.documents,
+        connectMyComputer: workspace.connectMyComputer,
       };
     }
     this.statePersistenceService.saveWorkspacesState(stateToSave);


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/27881

This PR adds starting the agent automatically if the workspace `autoStart` flag is true.
You can read more about it in the [RFD [Agent lifecycle]](https://github.com/gravitational/teleport/blob/master/rfd/0133-connect-my-computer.md#agent-lifecycle). 

------
We didn't talk about it in the RFD, but I decided to put the `autoStart` flag in `connectMyComputer` object to make it clearer what it means. I was considering something like `connectMyComputerAutoStart`, but I guess the object is better because we can easily add more properties to it in the future.