### PR TITLE
Remove `Tabs` components with one `TabItem`

### DIFF
--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,9 +1,6 @@
-You can sign in to your Teleport cluster using `tsh` and can use `tctl`
-remotely:
+Make sure you can connect to your Teleport cluster by authenticating with `tsh`
+so you can execute commands with the `tctl` admin tool:
 
-{/* Ignoring scope linting since we use this partial throughout the docs and
-cannot guarantee that it will line up with a page's configured scopes*/}
-{/*lint ignore scopes*/} 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
@@ -16,13 +13,11 @@ $ tctl status
 ```
 
 You can run subsequent `tctl` commands in this guide on your local machine.
-For full privileges, you can also run `tctl` commands on your Teleport Auth Service host.
+
+For full privileges, you can also run `tctl` commands on your Teleport Auth
+Service host.
 
 </TabItem>
-</Tabs>
-
-{/*lint ignore scopes*/}
-<Tabs>
 <TabItem scope={["cloud","team"]} label="Teleport Cloud">
 
 ```code
@@ -36,6 +31,5 @@ $ tctl status
 You must run subsequent `tctl` commands in this guide on your local machine.
 
 </TabItem>
-
 </Tabs>
 

--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -22,15 +22,12 @@ ERROR: failed direct dial to auth server: auth API: access denied [00]
 
 In particular, note the message `auth API: access denied`.
 
-<Tabs>
-<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-The Teleport Auth Service will also provide some additional context:
+In self-hosted Teleport deployments, the Teleport Auth Service will also provide
+some additional context:
+
 ```text
 [AUTH]      WARN lock targeting User:"bot-example" is in force: The bot user "bot-example" has been locked due to a certificate generation mismatch, possibly indicating a stolen certificate. auth/apiserver.go:224
 ```
-</TabItem>
-
-</Tabs>
 
 ### Explanation
 


### PR DESCRIPTION
In #30616, we replaced `ScopedBlocks` with `Tabs` components. This was because most `ScopedBlocks` included variations on the same text for multiple scopes, and replacing them with `TabItem`s was straightforward. However, some replacements included only a single `TabItem`, which displays awkwardly in the docs.

This change removes `Tabs` components with only one `TabItem`, replacing them with body text.