### PR TITLE
AWS OIDC: Create EC2 Instance Connect Endpoint

### DIFF
--- a/lib/integrations/awsoidc/create_ec2ice.go
+++ b/lib/integrations/awsoidc/create_ec2ice.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/gravitational/trace"
+)
+
+// CreateEC2ICERequest contains the required fields to create an AWS EC2 Instance Connect Endpoint.
+type CreateEC2ICERequest struct {
+	// Cluster is the Teleport Cluster Name.
+	// Used to tag resources created in AWS.
+	Cluster string
+
+	// IntegrationName is the integration name.
+	// Used to tag resources created in AWS.
+	IntegrationName string
+
+	// SubnetID is the Subnet where the Endpoint will be created.
+	SubnetID string
+
+	// SecurityGroupIDs is a list of SecurityGroups to assign to the Endpoint.
+	// If an empty list is provided, the Endpoint will receive the default SG for the Subnet's VPC.
+	SecurityGroupIDs []string
+
+	// ResourceCreationTags is used to add tags when creating resources in AWS.
+	// Defaults to:
+	// - teleport.dev/cluster: <cluster>
+	// - teleport.dev/origin: aws-oidc-integration
+	// - teleport.dev/integration: <integrationName>
+	ResourceCreationTags awsTags
+}
+
+// CheckAndSetDefaults checks if the required fields are present.
+func (req *CreateEC2ICERequest) CheckAndSetDefaults() error {
+	if req.Cluster == "" {
+		return trace.BadParameter("cluster is required")
+	}
+
+	if req.IntegrationName == "" {
+		return trace.BadParameter("integration is required")
+	}
+
+	if req.SubnetID == "" {
+		return trace.BadParameter("subnet id is required")
+	}
+
+	if len(req.ResourceCreationTags) == 0 {
+		req.ResourceCreationTags = DefaultResourceCreationTags(req.Cluster, req.IntegrationName)
+	}
+
+	return nil
+}
+
+// CreateEC2ICEResponse contains the newly created EC2 Instance Connect Endpoint name.
+type CreateEC2ICEResponse struct {
+	// Name is the Endpoint ID.
+	Name string
+}
+
+// CreateEC2ICE describes the required methods to List EC2 Instances using a 3rd Party API.
+type CreateEC2ICEClient interface {
+	// CreateInstanceConnectEndpoint creates an EC2 Instance Connect Endpoint. An EC2 Instance Connect Endpoint
+	// allows you to connect to an instance, without requiring the instance to have a
+	// public IPv4 address. For more information, see Connect to your instances
+	// without requiring a public IPv4 address using EC2 Instance Connect Endpoint (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Connect-using-EC2-Instance-Connect-Endpoint.html)
+	// in the Amazon EC2 User Guide.
+	CreateInstanceConnectEndpoint(ctx context.Context, params *ec2.CreateInstanceConnectEndpointInput, optFns ...func(*ec2.Options)) (*ec2.CreateInstanceConnectEndpointOutput, error)
+}
+
+type defaultCreateEC2ICEClient struct {
+	*ec2.Client
+}
+
+// NewCreateEC2ICEClient creates a new CreateEC2ICEClient using a AWSClientRequest.
+func NewCreateEC2ICEClient(ctx context.Context, req *AWSClientRequest) (CreateEC2ICEClient, error) {
+	ec2Client, err := newEC2Client(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultCreateEC2ICEClient{
+		Client: ec2Client,
+	}, nil
+}
+
+// CreateEC2ICE calls the following AWS API:
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_CreateInstanceConnectEndpoint.html
+// It creates an EC2 Instance Connect Endpoint using the provided Subnet and Security Group IDs.
+func CreateEC2ICE(ctx context.Context, clt CreateEC2ICEClient, req CreateEC2ICERequest) (*CreateEC2ICEResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	createEC2ICEInput := &ec2.CreateInstanceConnectEndpointInput{
+		SubnetId:         &req.SubnetID,
+		SecurityGroupIds: req.SecurityGroupIDs,
+		TagSpecifications: []ec2types.TagSpecification{{
+			ResourceType: ec2types.ResourceTypeInstanceConnectEndpoint,
+			Tags:         req.ResourceCreationTags.ToEC2Tags(),
+		}},
+	}
+
+	ec2ICEndpoint, err := clt.CreateInstanceConnectEndpoint(ctx, createEC2ICEInput)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if ec2ICEndpoint == nil || ec2ICEndpoint.InstanceConnectEndpoint == nil || ec2ICEndpoint.InstanceConnectEndpoint.InstanceConnectEndpointId == nil {
+		return nil, trace.BadParameter("endpoint was created but failed to get its name")
+	}
+
+	return &CreateEC2ICEResponse{
+		Name: *ec2ICEndpoint.InstanceConnectEndpoint.InstanceConnectEndpointId,
+	}, nil
+}

--- a/lib/integrations/awsoidc/create_ec2ice_test.go
+++ b/lib/integrations/awsoidc/create_ec2ice_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+type mockCreateEC2ICEClient struct {
+	name string
+	err  error
+}
+
+func (m mockCreateEC2ICEClient) CreateInstanceConnectEndpoint(ctx context.Context, params *ec2.CreateInstanceConnectEndpointInput, optFns ...func(*ec2.Options)) (*ec2.CreateInstanceConnectEndpointOutput, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+
+	return &ec2.CreateInstanceConnectEndpointOutput{
+		InstanceConnectEndpoint: &ec2Types.Ec2InstanceConnectEndpoint{
+			InstanceConnectEndpointId: &m.name,
+		},
+	}, nil
+}
+
+func TestCreateEC2ICE(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		mockCreateClient := &mockCreateEC2ICEClient{
+			name: "eice-123",
+		}
+		resp, err := CreateEC2ICE(ctx, mockCreateClient, CreateEC2ICERequest{
+			Cluster:         "c1",
+			IntegrationName: "i1",
+			SubnetID:        "subnet-id123",
+		})
+		require.NoError(t, err)
+		require.Equal(t, "eice-123", resp.Name)
+	})
+	t.Run("vpc reached the max allowed number of EC2 ICE", func(t *testing.T) {
+		mockCreateClient := &mockCreateEC2ICEClient{
+			err: fmt.Errorf("api error ResourceLimitExceeded: You've reached the quota for the maximum number of Instance Connect Endpoints for this subnet. Delete unused Instance Connect Endpoints, or request a quota increase."),
+		}
+		_, err := CreateEC2ICE(ctx, mockCreateClient, CreateEC2ICERequest{
+			Cluster:         "c1",
+			IntegrationName: "i1",
+			SubnetID:        "subnet-id123",
+		})
+		require.ErrorContains(t, err, "api error ResourceLimitExceeded: You've reached the quota for the maximum number of Instance Connect Endpoints for this subnet. Delete unused Instance Connect Endpoints, or request a quota increase.")
+	})
+}
+
+func TestCreateEC2ICERequest(t *testing.T) {
+	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	baseReqFn := func() CreateEC2ICERequest {
+		return CreateEC2ICERequest{
+			Cluster:          "teleport-cluster",
+			IntegrationName:  "teleportdev",
+			SubnetID:         "subnet-123",
+			SecurityGroupIDs: []string{"sg-1", "sg-2"},
+		}
+	}
+
+	for _, tt := range []struct {
+		name            string
+		req             func() CreateEC2ICERequest
+		errCheck        require.ErrorAssertionFunc
+		reqWithDefaults CreateEC2ICERequest
+	}{
+		{
+			name: "no fields",
+			req: func() CreateEC2ICERequest {
+				return CreateEC2ICERequest{}
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing teleport cluster name",
+			req: func() CreateEC2ICERequest {
+				r := baseReqFn()
+				r.Cluster = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing integration name",
+			req: func() CreateEC2ICERequest {
+				r := baseReqFn()
+				r.IntegrationName = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing subnet id",
+			req: func() CreateEC2ICERequest {
+				r := baseReqFn()
+				r.SubnetID = ""
+				return r
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name:     "fill defaults",
+			req:      baseReqFn,
+			errCheck: require.NoError,
+			reqWithDefaults: CreateEC2ICERequest{
+				Cluster:          "teleport-cluster",
+				IntegrationName:  "teleportdev",
+				SubnetID:         "subnet-123",
+				SecurityGroupIDs: []string{"sg-1", "sg-2"},
+				ResourceCreationTags: awsTags{
+					"teleport.dev/origin":      "integration_awsoidc",
+					"teleport.dev/cluster":     "teleport-cluster",
+					"teleport.dev/integration": "teleportdev",
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			r := tt.req()
+			err := r.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+
+			if err != nil {
+				return
+			}
+
+			require.Empty(t, cmp.Diff(tt.reqWithDefaults, r))
+		})
+	}
+}

--- a/lib/integrations/awsoidc/deployservice.go
+++ b/lib/integrations/awsoidc/deployservice.go
@@ -137,7 +137,7 @@ type DeployServiceRequest struct {
 	IntegrationName string
 
 	// ResourceCreationTags is used to add tags when creating resources in AWS.
-	ResourceCreationTags awsTags
+	ResourceCreationTags AWSTags
 
 	// DeploymentMode is the identifier of a deployment mode - which Teleport Services to enable and their configuration.
 	DeploymentMode string
@@ -236,7 +236,7 @@ func (r *DeployServiceRequest) CheckAndSetDefaults() error {
 	}
 
 	if r.ResourceCreationTags == nil {
-		r.ResourceCreationTags = DefaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
+		r.ResourceCreationTags = defaultResourceCreationTags(r.TeleportClusterName, r.IntegrationName)
 	}
 
 	if len(r.DatabaseResourceMatcherLabels) == 0 {

--- a/lib/integrations/awsoidc/deployservice_iam_config.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config.go
@@ -74,7 +74,7 @@ type DeployServiceIAMConfigureRequest struct {
 	// - teleport.dev/cluster: <cluster>
 	// - teleport.dev/origin: aws-oidc-integration
 	// - teleport.dev/integration: <integrationName>
-	ResourceCreationTags awsTags
+	ResourceCreationTags AWSTags
 
 	// partitionID is the AWS Partition ID.
 	// Eg, aws, aws-cn, aws-us-gov
@@ -113,7 +113,7 @@ func (r *DeployServiceIAMConfigureRequest) CheckAndSetDefaults() error {
 	}
 
 	if len(r.ResourceCreationTags) == 0 {
-		r.ResourceCreationTags = DefaultResourceCreationTags(r.Cluster, r.IntegrationName)
+		r.ResourceCreationTags = defaultResourceCreationTags(r.Cluster, r.IntegrationName)
 	}
 
 	r.partitionID = awsapiutils.GetPartitionFromRegion(r.Region)

--- a/lib/integrations/awsoidc/deployservice_iam_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config_test.go
@@ -71,7 +71,7 @@ func TestDeployServiceIAMConfigReqDefaults(t *testing.T) {
 				partitionID:                        "aws",
 				IntegrationRoleDeployServicePolicy: "DeployService",
 				TaskRoleBoundaryPolicyName:         "taskroleBoundary",
-				ResourceCreationTags: awsTags{
+				ResourceCreationTags: AWSTags{
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "myintegration",
 					"teleport.dev/origin":      "integration_awsoidc",

--- a/lib/integrations/awsoidc/deployservice_test.go
+++ b/lib/integrations/awsoidc/deployservice_test.go
@@ -147,7 +147,7 @@ func TestDeployServiceRequest(t *testing.T) {
 				TeleportIAMTokenName: stringPointer("discover-aws-oidc-iam-token"),
 				IntegrationName:      "teleportdev",
 				ProxyServerHostPort:  "proxy.example.com:3080",
-				ResourceCreationTags: awsTags{
+				ResourceCreationTags: AWSTags{
 					"teleport.dev/origin":      "integration_awsoidc",
 					"teleport.dev/cluster":     "mycluster",
 					"teleport.dev/integration": "teleportdev",

--- a/lib/integrations/awsoidc/tags.go
+++ b/lib/integrations/awsoidc/tags.go
@@ -27,10 +27,10 @@ import (
 	"github.com/gravitational/teleport/api/types"
 )
 
-type awsTags map[string]string
+type AWSTags map[string]string
 
-// String converts awsTags into a ',' separated list of k:v
-func (d awsTags) String() string {
+// String converts AWSTags into a ',' separated list of k:v
+func (d AWSTags) String() string {
 	tagsString := make([]string, 0, len(d))
 	for k, v := range d {
 		tagsString = append(tagsString, fmt.Sprintf("%s:%s", k, v))
@@ -39,13 +39,13 @@ func (d awsTags) String() string {
 	return strings.Join(tagsString, ", ")
 }
 
-// DefaultResourceCreationTags returns the default tags that should be applied when creating new AWS resources.
+// defaultResourceCreationTags returns the default tags that should be applied when creating new AWS resources.
 // The following tags are returned:
 // - teleport.dev/cluster: <clusterName>
 // - teleport.dev/origin: aws-oidc-integration
 // - teleport.dev/integration: <integrationName>
-func DefaultResourceCreationTags(clusterName, integrationName string) awsTags {
-	return awsTags{
+func defaultResourceCreationTags(clusterName, integrationName string) AWSTags {
+	return AWSTags{
 		types.ClusterLabel:     clusterName,
 		types.OriginLabel:      types.OriginIntegrationAWSOIDC,
 		types.IntegrationLabel: integrationName,
@@ -53,7 +53,7 @@ func DefaultResourceCreationTags(clusterName, integrationName string) awsTags {
 }
 
 // ToECSTags returns the default tags using the expected type for ECS resources: [ecsTypes.Tag]
-func (d awsTags) ToECSTags() []ecsTypes.Tag {
+func (d AWSTags) ToECSTags() []ecsTypes.Tag {
 	ecsTags := make([]ecsTypes.Tag, 0, len(d))
 	for k, v := range d {
 		k, v := k, v
@@ -66,7 +66,7 @@ func (d awsTags) ToECSTags() []ecsTypes.Tag {
 }
 
 // ToEC2Tags the default tags using the expected type for EC2 resources: [ec2Types.Tag]
-func (d awsTags) ToEC2Tags() []ec2Types.Tag {
+func (d AWSTags) ToEC2Tags() []ec2Types.Tag {
 	ec2Tags := make([]ec2Types.Tag, 0, len(d))
 	for k, v := range d {
 		k, v := k, v
@@ -78,8 +78,8 @@ func (d awsTags) ToEC2Tags() []ec2Types.Tag {
 	return ec2Tags
 }
 
-// MatchesECSTags checks if the awsTags are present and have the same value in resourceTags.
-func (d awsTags) MatchesECSTags(resourceTags []ecsTypes.Tag) bool {
+// MatchesECSTags checks if the AWSTags are present and have the same value in resourceTags.
+func (d AWSTags) MatchesECSTags(resourceTags []ecsTypes.Tag) bool {
 	resourceTagsMap := make(map[string]string, len(resourceTags))
 	for _, tag := range resourceTags {
 		resourceTagsMap[*tag.Key] = *tag.Value
@@ -96,7 +96,7 @@ func (d awsTags) MatchesECSTags(resourceTags []ecsTypes.Tag) bool {
 }
 
 // ToIAMTags returns the default tags using the expected type for IAM resources: [iamTypes.Tag]
-func (d awsTags) ToIAMTags() []iamTypes.Tag {
+func (d AWSTags) ToIAMTags() []iamTypes.Tag {
 	iamTags := make([]iamTypes.Tag, 0, len(d))
 	for k, v := range d {
 		k, v := k, v

--- a/lib/integrations/awsoidc/tags.go
+++ b/lib/integrations/awsoidc/tags.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strings"
 
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 
@@ -62,6 +63,19 @@ func (d awsTags) ToECSTags() []ecsTypes.Tag {
 		})
 	}
 	return ecsTags
+}
+
+// ToEC2Tags the default tags using the expected type for EC2 resources: [ec2Types.Tag]
+func (d awsTags) ToEC2Tags() []ec2Types.Tag {
+	ec2Tags := make([]ec2Types.Tag, 0, len(d))
+	for k, v := range d {
+		k, v := k, v
+		ec2Tags = append(ec2Tags, ec2Types.Tag{
+			Key:   &k,
+			Value: &v,
+		})
+	}
+	return ec2Tags
 }
 
 // MatchesECSTags checks if the awsTags are present and have the same value in resourceTags.

--- a/lib/integrations/awsoidc/tags_test.go
+++ b/lib/integrations/awsoidc/tags_test.go
@@ -29,9 +29,9 @@ import (
 func TestDefaultTags(t *testing.T) {
 	clusterName := "mycluster"
 	integrationName := "myawsaccount"
-	d := DefaultResourceCreationTags(clusterName, integrationName)
+	d := defaultResourceCreationTags(clusterName, integrationName)
 
-	expectedTags := awsTags{
+	expectedTags := AWSTags{
 		"teleport.dev/cluster":     "mycluster",
 		"teleport.dev/integration": "myawsaccount",
 		"teleport.dev/origin":      "integration_awsoidc",

--- a/lib/integrations/awsoidc/tags_test.go
+++ b/lib/integrations/awsoidc/tags_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	ecsTypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
 	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/stretchr/testify/require"
@@ -53,6 +54,15 @@ func TestDefaultTags(t *testing.T) {
 			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
 		}
 		require.ElementsMatch(t, expectedECSTags, d.ToECSTags())
+	})
+
+	t.Run("ec2 tags", func(t *testing.T) {
+		expectedEC2Tags := []ec2Types.Tag{
+			{Key: aws.String("teleport.dev/cluster"), Value: aws.String("mycluster")},
+			{Key: aws.String("teleport.dev/integration"), Value: aws.String("myawsaccount")},
+			{Key: aws.String("teleport.dev/origin"), Value: aws.String("integration_awsoidc")},
+		}
+		require.ElementsMatch(t, expectedEC2Tags, d.ToEC2Tags())
 	})
 
 	t.Run("resource is teleport managed", func(t *testing.T) {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -780,6 +780,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2ice", h.WithClusterAuth(h.awsOIDCListEC2ICE))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployec2ice", h.WithClusterAuth(h.awsOIDCDeployEC2ICE))
 	h.GET("/webapi/scripts/integrations/configure/eice-iam.sh", h.WithLimiter(h.awsOIDCConfigureEICEIAM))
 
 	// AWS OIDC Integration specific endpoints:

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -43,7 +43,7 @@ func (h *Handler) awsOIDCListDatabases(w http.ResponseWriter, r *http.Request, p
 		return nil, trace.Wrap(err)
 	}
 
-	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	awsClientReq, err := h.awsOIDCClientRequest(ctx, req.Region, p, sctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -297,7 +297,7 @@ func (h *Handler) awsOIDCListEC2(w http.ResponseWriter, r *http.Request, p httpr
 		return nil, trace.Wrap(err)
 	}
 
-	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	awsClientReq, err := h.awsOIDCClientRequest(ctx, req.Region, p, sctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -339,7 +339,7 @@ func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p ht
 		return nil, trace.Wrap(err)
 	}
 
-	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	awsClientReq, err := h.awsOIDCClientRequest(ctx, req.Region, p, sctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -376,7 +376,7 @@ func (h *Handler) awsOIDCDeployEC2ICE(w http.ResponseWriter, r *http.Request, p 
 		return nil, trace.Wrap(err)
 	}
 
-	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	awsClientReq, err := h.awsOIDCClientRequest(ctx, req.Region, p, sctx, site)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -366,3 +366,40 @@ func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p ht
 		EC2ICEs:   resp.EC2ICEs,
 	}, nil
 }
+
+// awsOIDCDeployC2ICE creates an EC2 Instance Connect Endpoint.
+func (h *Handler) awsOIDCDeployEC2ICE(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+	ctx := r.Context()
+
+	var req ui.AWSOIDCDeployEC2ICERequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	createEC2ICEClient, err := awsoidc.NewCreateEC2ICEClient(ctx, awsClientReq)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := awsoidc.CreateEC2ICE(ctx,
+		createEC2ICEClient,
+		awsoidc.CreateEC2ICERequest{
+			Cluster:          h.auth.clusterName,
+			IntegrationName:  awsClientReq.IntegrationName,
+			SubnetID:         req.SubnetID,
+			SecurityGroupIDs: req.SecurityGroupIDs,
+		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.AWSOIDCDeployEC2ICEResponse{
+		Name: resp.Name,
+	}, nil
+}

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -232,7 +232,7 @@ type AWSOIDCDeployEC2ICERequest struct {
 	// SubnetID is the subnet id for the EC2 Instance Connect Endpoint.
 	SubnetID string `json:"subnetID"`
 	// SecurityGroupIDs is the list of SecurityGroups to apply to the Endpoint.
-	// If an empty list is provided, the Endpoint will receive the default SG for the Subnet's VPC.
+	// If not specified, the Endpoint will receive the default SG for the Subnet's VPC.
 	SecurityGroupIDs []string `json:"securityGroupIds"`
 }
 

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -224,3 +224,20 @@ type AWSOIDCListEC2ICEResponse struct {
 	// If non-empty, it can be used to request the next page.
 	NextToken string `json:"nextToken,omitempty"`
 }
+
+// AWSOIDCDeployEC2ICERequest is a request to create an AWS EC2 Instance Connect Endpoint.
+type AWSOIDCDeployEC2ICERequest struct {
+	// Region is the AWS Region.
+	Region string `json:"region"`
+	// SubnetID is the subnet id for the EC2 Instance Connect Endpoint.
+	SubnetID string `json:"subnetID"`
+	// SecurityGroupIDs is the list of SecurityGroups to apply to the Endpoint.
+	// If an empty list is provided, the Endpoint will receive the default SG for the Subnet's VPC.
+	SecurityGroupIDs []string `json:"securityGroupIds"`
+}
+
+// AWSOIDCDeployEC2ICEResponse contains a list of AWS Instance Connect Endpoints and a next token if more pages are available.
+type AWSOIDCDeployEC2ICEResponse struct {
+	// Name is the endpoint Name that was created.
+	Name string `json:"name"`
+}


### PR DESCRIPTION
Context: https://github.com/gravitational/teleport/issues/29317

This PR adds a new action that creates an EC2 Instance Connect Endpoint which is a pre-requirement for accessing EC2 instances directly (and without them having a public IP).

Demo
![image](https://github.com/gravitational/teleport/assets/689271/be10a77c-231f-4f07-8e18-751489612a47)
