### PR TITLE
[v13] Remove ScopedBlocks from the docs

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
+++ b/docs/pages/access-controls/access-request-plugins/opsgenie.mdx
@@ -122,8 +122,6 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={[
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -351,9 +351,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -342,9 +342,7 @@ Requests, you should still check the Teleport audit log to ensure that the right
 users are reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -29,20 +29,23 @@ Requests in the Proxy or Auth Service.
 
 ## Step 2/8. Install the Teleport Mattermost plugin
 
-<ScopedBlock scope={["enterprise", "oss"]}>
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
 We recommend installing Teleport plugins on the same host as the Teleport Proxy
 Service. This is an ideal location as plugins have a low memory footprint, and
 will require both public internet access and Teleport Auth Service access.
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope="cloud">
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Install the Teleport Mattermost plugin on a host that can access both your
 Teleport Proxy Service and your Mattermost deployment.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Tabs>
 <TabItem label="Download">

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -399,9 +399,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -288,8 +288,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will need to request the credentials manually by *impersonating* the
 `access-plugin` role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise cluster and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `access-plugin`, define a role
 called `access-plugin-impersonator` by pasting the following YAML document into
@@ -598,9 +599,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={[
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -405,9 +405,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -13,15 +13,11 @@ under the hood.
 The Access Request API makes it easy to dynamically approve or deny these
 requests.
 
-<ScopedBlock scope={["oss"]}>
-
 Just-in-time Access Requests are a feature of Teleport Enterprise.
 Open-source Teleport users can get a preview of how Access Requests work by
 requesting a role via the Teleport CLI. Full Access Request functionality,
 including Resource Access Requests and an intuitive and searchable UI are
 available in Teleport Enterprise.
-
-</ScopedBlock>
 
 ## Prerequisites
 

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -102,7 +102,8 @@ will be able to act as a system administrator and auditor at the same time.
 Next, follow the instructions to set up an authentication connector that maps
 users within your SSO solution to Teleport roles.
 
-  <ScopedBlock scope={["oss"]}>
+<Tabs>
+  <TabItem label="Teleport Community Edition" scope={["oss"]}>
 
     Save the file below as `github.yaml` and update the fields. You will need to
     set up a
@@ -139,9 +140,9 @@ users within your SSO solution to Teleport roles.
     $ tctl create github.yaml
     ```
 
-  </ScopedBlock>
+  </TabItem>
 
-  <ScopedBlock scope={["enterprise", "cloud"]}>
+  <TabItem label="Commercial Editions"  scope={["enterprise", "cloud"]}>
 
   Create a SAML or OIDC application that Teleport can integrate with, then
   create an authentication connector that maps users within your application to
@@ -198,7 +199,8 @@ users within your SSO solution to Teleport roles.
   </TabItem>
   </Tabs>
 
-  </ScopedBlock>
+  </TabItem>
+</Tabs>
 
 ## Step 3/3. Create a custom role
 

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -33,25 +33,29 @@ Teleport Enterprise contains two additional preset roles: `reviewer` and `reques
 - The `requester` role authorizes users to request resources.
 </Details>
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 Invite the local user Alice as cluster `editor`:
 
 ```code
 $ tctl users add alice --roles=editor
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 Invite the local user Alice as cluster `editor` and `reviewer`:
 
 ```code
 $ tctl users add alice --roles=editor,reviewer
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Once Alice signs up, she will be able to edit cluster configuration. You can list
 users and their roles using `tctl users ls`.
 
-<ScopedBlock scope={"oss"}>
+<Tabs>
+<TabItem scope={"oss"} label="Teleport Community Edition">
 ```code
 $ tctl users ls
 
@@ -59,8 +63,8 @@ $ tctl users ls
 # -------------------- --------------
 # alice                editor
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ tctl users ls
 
@@ -68,22 +72,27 @@ $ tctl users ls
 # -------------------- --------------
 # alice                editor, reviewer
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 You can update the user's roles using the `tctl users update` command:
 
-<ScopedBlock scope={"oss"}>
+<Tabs>
+<TabItem scope={"oss"} label="Teleport Community Edition">
 ```code
 # Once Alice logs back in, she will be able to view audit logs
 $ tctl users update alice --set-roles=editor,auditor
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 # Once Alice logs back in, she will be able to view audit logs
 $ tctl users update alice --set-roles=editor,reviewer,auditor
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Because Alice has two or more roles, permissions from those roles create a union. She
 will be able to act as a system administrator and auditor at the same time.
@@ -252,3 +261,4 @@ $ tctl get roles --format text
 
 - [Mapping SSO and local users traits with role templates](./guides/role-templates.mdx)
 - [Create certs for CI/CD using impersonation](./guides/impersonation.mdx)
+

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -208,13 +208,10 @@ Bob can also assume granted Access Request roles using Web UI:
 
 ![Teleport Assume](../../../img/access-controls/dual-authz/teleport-7-bob-assume.png)
 
-{/* TODO: This H2 will show up in the table of contents when this section is invisible.
-We need a way to hide invisible H2s from the TOC. */}
-<ScopedBlock scope={["enterprise"]}>
 
 ## Troubleshooting
 
-### Cert errors in self-hosted deployments
+### Certificate errors in self-hosted deployments
 
 You may be getting certificate errors if Teleport's Auth Service is missing an address in the server certificate:
 
@@ -232,5 +229,3 @@ To fix the problem, update the Auth Service with a public address, and restart T
 auth_service:
   public_addr: ['localhost:3025', 'example.com:3025']
 ```
-
-</ScopedBlock>

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -127,7 +127,8 @@ role or to that cluster must use their hardware key for all Teleport requests.
 Affected users will be prompted to connect and touch their YubiKey to sign in. 
 The first time users sign in with their hardware key they might be required to immediately sign in again.
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh login --user=dev --proxy=proxy.example.com:3080
@@ -143,26 +144,9 @@ $ tsh login --user=dev --proxy=proxy.example.com:3080
 
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["enterprise"]}>
-
-```code
-$ tsh login --user=dev --proxy=proxy.example.com:3080
-# Enter password for Teleport user dev:
-# Unmet private key policy "hardware_key_touch".
-# Relogging in with hardware-backed private key.
-# Enter password for Teleport user dev:
-# Tap your YubiKey
-# > Profile URL:        https://example.com
-#   Logged in as:       dev
-#   Cluster:            example.com
-#   ...
-```
-
-</ScopedBlock>
-
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```code
 $ tsh login --user=dev --proxy=proxy.example.com:3080
@@ -177,7 +161,26 @@ $ tsh login --user=dev --proxy=proxy.example.com:3080
 #   ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+
+```code
+$ tsh login --user=dev --proxy=proxy.example.com:3080
+# Enter password for Teleport user dev:
+# Unmet private key policy "hardware_key_touch".
+# Relogging in with hardware-backed private key.
+# Enter password for Teleport user dev:
+# Tap your YubiKey
+# > Profile URL:        https://example.com
+#   Logged in as:       dev
+#   Cluster:            example.com
+#   ...
+```
+
+</TabItem>
+
+</Tabs>
 
 Affected users with existing sessions that aren't backed by a hardware key are prompted to sign in again
 on their next request. For example:

--- a/docs/pages/access-controls/guides/impersonation.mdx
+++ b/docs/pages/access-controls/guides/impersonation.mdx
@@ -118,22 +118,25 @@ $ tctl users add alice  --roles=impersonator,access
 
 Alice can log in using `tsh` and issue a cert for `jenkins`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=proxy.example.com --user=alice --auth=local
 $ tctl auth sign --user=jenkins --format=openssh --out=jenkins --ttl=240h
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice --auth=local
 $ tctl auth sign --user=jenkins --format=openssh --out=jenkins --ttl=240h
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Here is an example of how Alice can use the keys:
 
@@ -310,7 +313,8 @@ scanner.
 
 Alice will need to log in again to receive the newly updated traits:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Once Alice logs in again, she will receive a new certificate with updated roles.
@@ -319,8 +323,8 @@ $ tsh login --proxy=teleport.example.com --user=alice --auth=local
 $ tctl auth sign --user=security-scanner --format=openssh --out=security-scanner --ttl=10h
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Once Alice logs in again, she will receive a new certificate with updated roles.
@@ -329,7 +333,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=alice --auth=local
 $ tctl auth sign --user=security-scanner --format=openssh --out=security-scanner --ttl=10h
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Filter fields
 
@@ -343,3 +349,4 @@ Here is an explanation of the fields used in the `where` conditions within this 
 
 Check out our [predicate language](../../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources) 
 guide for a more in depth explanation of the language.
+

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -199,7 +199,8 @@ the last known locks. This decision strategy is encoded as one of the two modes:
   guaranteed to be up to date
 - `best_effort` mode keeps relying on the most recent locks
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 The cluster-wide mode defaults to `best_effort`. You can set up the default
 locking mode via API or CLI using a `cluster_auth_preference` resource or static
@@ -240,8 +241,8 @@ configuration file:
   </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 The cluster-wide mode defaults to `best_effort`. You can set up the default
 locking mode via API or CLI using a `cluster_auth_preference` resource:
@@ -265,7 +266,9 @@ $ tctl create -f cap.yaml
 # cluster auth preference has been updated
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 It is also possible to configure the locking mode for a particular role:
 
@@ -285,3 +288,4 @@ there is no user involved, the mode is taken from the cluster-wide setting.
 With multiple potentially conflicting locking modes (the cluster-wide default
 and the individual per-role settings) a single occurrence of `strict` suffices
 for the local lock view to become evaluated strictly.
+

--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -69,7 +69,8 @@ between `tsh`, the Teleport Web UI, and different computers.
 
 Authenticate using your passwordless credential:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ tsh login --proxy=example.com --auth=passwordless
 # Tap your security key
@@ -82,8 +83,8 @@ $ tsh login --proxy=example.com --auth=passwordless
 #   Valid until:        2021-10-04 23:32:29 -0700 PDT [valid for 12h0m0s]
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ tsh login --proxy=example.com --auth=passwordless
 # Tap your security key
@@ -96,7 +97,9 @@ $ tsh login --proxy=example.com --auth=passwordless
 #   Valid until:        2021-10-04 23:32:29 -0700 PDT [valid for 12h0m0s]
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 A fully passwordless cluster defaults to passwordless logins, making
 `--auth=passwordless` unnecessary. See the next section to learn how to enable
@@ -118,7 +121,8 @@ passwordless registration.
 To enable passwordless by default, add `connector_name: passwordless` to your
 cluster configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 <Tabs>
   <TabItem label="Static Config">
     Auth Server `teleport.yaml` file:
@@ -158,9 +162,9 @@ cluster configuration:
     ```
   </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 Create a `cap.yaml` file or get the existing configuration using
 `tctl get cluster_auth_preference`:
 
@@ -183,7 +187,9 @@ Update the configuration:
 $ tctl create -f cap.yaml
 # cluster auth preference has been updated
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Troubleshooting
 
@@ -257,7 +263,8 @@ $ tsh webauthnwin diag
 If you want to forbid passwordless access to your cluster, add `passwordless:
 false` to your configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 <Tabs>
   <TabItem label="Static Config">
     Auth Server `teleport.yaml` file:
@@ -298,9 +305,9 @@ false` to your configuration:
     ```
   </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 Create a `cap.yaml` file or get the existing configuration using
 `tctl get cluster_auth_preference`:
 
@@ -323,4 +330,7 @@ Update the configuration:
 $ tctl create -f cap.yaml
 # cluster auth preference has been updated
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
+

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -70,7 +70,8 @@ Per-session MFA can be enforced cluster-wide or only for some specific roles.
 
 ### Cluster-wide
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 To enforce MFA checks for all roles, edit your cluster authentication
 configuration:
@@ -118,8 +119,8 @@ $ tctl create -f cap.yaml
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Obtain your existing `cluster_auth_preference` resource:
 
@@ -146,7 +147,9 @@ Create the resource:
 $ tctl create -f cap.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Per role
 

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -152,7 +152,8 @@ $ tctl create -f traits.yaml
 Once Alice logs in, she will receive SSH and X.509 certificates with
 a new role. SSH logins and Kubernetes groups will also be set:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -168,8 +169,8 @@ $ tsh login --proxy=teleport.example.com --user=alice
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -185,7 +186,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=alice
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## SSO users
 
@@ -260,7 +263,8 @@ $ tctl create -f github.yaml
 Once Bob logs in using SSO, he will receive SSH and X.509 certificates with
 a new role and SSH logins generated using  the `sso-users` role template:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --auth=github
@@ -276,8 +280,8 @@ $ tsh login --proxy=teleport.example.com --auth=github
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --auth=github
@@ -293,7 +297,9 @@ $ tsh login --proxy=mytenant.teleport.sh --auth=github
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Interpolation rules
 
@@ -440,3 +446,4 @@ In this case, Alice would be allowed to request access to the RBAC roles `access
 role list) and `alpha-admin` and `beta-admin` (from the `claims_to_roles` mapping).
 
 The same syntax applies for Review Requests.
+

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -179,7 +179,8 @@ Reference](../../reference/cli/tsh.mdx#tsh-global-flags) page.
 
 Once a WebAuthn device is registered, the user will be prompted for it on login:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh login --proxy=example.com
@@ -195,9 +196,9 @@ $ tsh login --proxy=example.com
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["enterprise"]}>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```code
 $ tsh login --proxy=example.com
@@ -213,9 +214,9 @@ $ tsh login --proxy=example.com
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh
@@ -231,7 +232,9 @@ $ tsh login --proxy=mytenant.teleport.sh
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note">
   WebAuthn for logging in to Teleport is only required for [local users](
@@ -272,7 +275,8 @@ auth_service:
 
 The migrated WebAuthn configuration is:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 <Tabs>
   <TabItem label="Static Config">
 
@@ -317,9 +321,9 @@ The migrated WebAuthn configuration is:
 
   </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 kind: cluster_auth_preference
@@ -340,9 +344,12 @@ spec:
     - "/path/to/u2f_attestation_ca.pem"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Next steps
 
 - [Passwordless](./passwordless.mdx)
 - [Set up per-session MFA checks](./per-session-mfa.mdx)
+

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -34,7 +34,8 @@ To manage cluster roles, a Teleport administrator can use the Web UI or the
 command line using [tctl resource commands](../reference/resources.mdx).
 To see the list of roles in a Teleport cluster, an administrator can execute:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -44,8 +45,8 @@ $ tsh login --user=myuser --proxy=teleport.example.com
 $ tctl get roles
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl.
@@ -53,7 +54,9 @@ $ tsh login --user=myuser --proxy=mytenant.teleport.sh
 $ tctl get roles
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 (!docs/pages/includes/backup-warning.mdx!)
 
@@ -437,3 +440,4 @@ Here is an explanation of the fields used in the `where` and `filter` conditions
 
 Check out our [predicate language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
 guide for a more in depth explanation of the language.
+

--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -46,7 +46,8 @@ information about the temporary user.
 You can inspect a temporary `user` resource created via your SSO integration
 by using the `tctl` command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl remotely
@@ -54,8 +55,8 @@ $ tsh login --proxy=proxy.example.com --user=myuser
 $ tctl get users/<username>
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl remotely
@@ -63,7 +64,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl get users
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Here is an example of a temporary `user` resource created when the GitHub user
 `myuser` signed in to GitHub to authenticate to Teleport. This resource
@@ -210,7 +213,8 @@ users.
 
 The following authentication connectors are supported:
 
-<ScopedBlock scope={["cloud", "enterprise"]}>
+<Tabs>
+<TabItem scope={["cloud", "enterprise"]} label="Commercial">
 
 |Type|Description|
 |---|---|
@@ -219,26 +223,29 @@ The following authentication connectors are supported:
 |`oidc`| The OIDC connector type uses the [OpenID Connect protocol](https://en.wikipedia.org/wiki/OpenID_Connect) to authenticate users<br/> and query their group membership.|
 |`github`| The GitHub connector uses GitHub SSO to authenticate users and query their group membership.|
 
-</ScopedBlock>
-<ScopedBlock scope={["oss"]}>
+</TabItem>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 |Type|Description|
 |---|---|
 |None|If no authentication connector is created, Teleport will use local authentication based user information stored in the Auth Service backend. You can manage user data via the `tctl users` command. |
 |`github`| The GitHub connector uses GitHub SSO to authenticate users and query their group membership.|
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Creating an authentication connector
 
-<ScopedBlock scope={["cloud", "enterprise"]}>
+<Tabs>
+<TabItem scope={["cloud", "enterprise"]} label="Commercial">
 
 Before you can create an authentication connector, you must enable
 authentication via that connector's protocol.
 
-To set the default authentication type as `saml` or `oidc`, <ScopedBlock
-scope={["enterprise"]}>either modify your Auth Service configuration file
-or </ScopedBlock>create a `cluster_auth_preference` resource.
+To set the default authentication type as `saml` or `oidc`, either modify your
+Auth Service configuration file (if using a self-hosted edition of Teleport) or
+create a `cluster_auth_preference` resource.
 
 <Tabs>
   <TabItem label="Static Config (Self-Hosted)" scope={["enterprise","oss"]}>
@@ -266,52 +273,15 @@ or </ScopedBlock>create a `cluster_auth_preference` resource.
 
   Create the resource:
 
-  <ScopedBlock scope={["enterprise"]}>
-
   ```code
   # Log in to your cluster with tsh so you can run tctl commands.
-  # You can also run tctl directly on the Auth Service host.
-  $ tsh login --proxy=teleport.example.com --user=myuser
+  $ tsh login --proxy=<Var name="mytenant.teleport.sh" /> --user=myuser
   $ tctl create -f cap.yaml
   ```
 
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
-  ```code
-  # Log in to your cluster with tsh so you can run tctl commands.
-  $ tsh login --proxy=mytenant.teleport.sh --user=myuser
-  $ tctl create -f cap.yaml
-  ```
-
-  </ScopedBlock>
   (!docs/pages/includes/sso/idp-initiated.mdx!)
   </TabItem>
 </Tabs>
-
-</ScopedBlock>
-
-<ScopedBlock scope="oss">
-
-Next, define an authentication connector. Create a file called `connector.yaml`
-with the following content:
-
-```yaml
-kind: cluster_auth_preference
-metadata:
-  name: cluster-auth-preference
-spec:
-  type: github
-  webauthn:
-    # Replace with the address of your Teleport cluster
-    rp_id: 'example.teleport.sh'
-version: v2
-
-```
-
-</ScopedBlock>
-
-<ScopedBlock scope={["cloud", "enterprise"]}>
 
 Next, define an authentication connector. Create a file called `connector.yaml`
 based on one of the following examples.
@@ -415,13 +385,35 @@ the entity descriptor from your IDP.
 We recommend "pinning" the entity descriptor by including the XML rather than
 fetching from a URL.
 
-</ScopedBlock>
+</TabItem>
+<TabItem scope="oss" label="Teleport Community Edition">
+
+Next, define an authentication connector. Create a file called `connector.yaml`
+with the following content:
+
+```yaml
+kind: cluster_auth_preference
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: github
+  webauthn:
+    # Replace with the address of your Teleport cluster
+    rp_id: 'example.teleport.sh'
+version: v2
+
+```
+
+</TabItem>
+</Tabs>
 
 Create the connector: 
 
 ```code
 $ tctl create -f connector.yaml
 ```
+
+
 
 ### User logins
 
@@ -546,10 +538,13 @@ of SSO buttons in the Teleport Web UI.
 Troubleshooting SSO configuration can be challenging. Usually a Teleport administrator
 must be able to:
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 - Ensure that HTTP/TLS certificates are configured properly for both Teleport
   proxy and the SSO provider.
-</ScopedBlock>
+</TabItem>
+</Tabs>
+
 - Be able to see what SAML/OIDC claims and values are getting exported and passed
   by the SSO provider to Teleport.
 - Be able to see how Teleport maps the received claims to role mappings as defined
@@ -602,3 +597,4 @@ spec:
       'env': 'dev'
 version: v5
 ```
+

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -68,7 +68,8 @@ $ tctl sso configure github \
 
 The contents of `github.yaml` should resemble the following:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```yaml
 kind: github
 metadata:
@@ -89,9 +90,9 @@ spec:
       team: GITHUB-TEAM
 version: v3
 ```
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["enterprise", "cloud"]}>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```yaml
 kind: github
 metadata:
@@ -113,7 +114,9 @@ spec:
       team: GITHUB-TEAM
 version: v3
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Details title="Mapping multiple roles">
 You can add multiple instances of the `--teams-to-roles` flag or edit the connector
@@ -251,7 +254,8 @@ Here is an example role configuration snippet using the trait variable:
 You can now log in with Teleport using GitHub SSO. Run the following to log out
 of Teleport and log in again using GitHub SSO.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh logout
@@ -261,8 +265,8 @@ If browser window does not open automatically, open it by clicking on the link:
  http://127.0.0.1:56334/6bf976e6-a4be-4898-94eb-8a7b01af2158
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh logout
@@ -272,7 +276,9 @@ If browser window does not open automatically, open it by clicking on the link:
  http://127.0.0.1:56334/6bf976e6-a4be-4898-94eb-8a7b01af2158
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 You can also log to the web UI using GitHub by clicking **Other sign-in options** at the login screen.
 
@@ -290,7 +296,8 @@ After logging in successfully, you will see the following:
 
 You will receive the details of your user session within the CLI:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 > Profile URL:        https://tele.example.com:443
@@ -305,10 +312,10 @@ You will receive the details of your user session within the CLI:
   Extensions:         permit-port-forwarding, permit-pty, private-key-policy
 ```
 
-</ScopedBlock>
+</TabItem>
 
 
-<ScopedBlock scope={["enterprise"]}>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```code
 > Profile URL:        https://tele.example.com:443
@@ -323,9 +330,9 @@ You will receive the details of your user session within the CLI:
   Extensions:         permit-port-forwarding, permit-pty, private-key-policy
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 > Profile URL:        https://mytenant.teleport.sh:443
@@ -341,7 +348,9 @@ You will receive the details of your user session within the CLI:
 
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Step 4/4. Configure authentication preference
 
@@ -397,3 +406,4 @@ After logging out of `tsh`, you can log back in without specifying
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -10,11 +10,15 @@ Teleport.
 
 ## Prerequisites
 
-- A GitHub organization with at least one team. <ScopedBlock scope="oss">This
-  organization must not have external SSO set up, or Teleport will refuse to
-  create the GitHub authentication connector.</ScopedBlock><ScopedBlock
-  scope={["enterprise", "cloud"]}>This organization can be hosted from either
-  GitHub Cloud or GitHub Enterprise Server.</ScopedBlock>
+- A GitHub organization with at least one team. 
+
+  In Teleport Community Edition and Teleport Team, this organization must not
+  have external SSO set up, or Teleport will refuse to create the GitHub
+  authentication connector.
+
+  In Teleport Enterprise and Enterprise Cloud, organization can be hosted from
+  either GitHub Cloud or GitHub Enterprise Server.
+
 - Teleport role with access to maintaining `github` resources for using `tctl`
   from the Desktop. This is available in the default `editor` role.
 
@@ -31,9 +35,8 @@ App's "Authentication callback URL" is the following:
 https://PROXY_ADDRESS/v1/webapi/github/
 ```
 
-`PROXY_ADDRESS` must be <ScopedBlock scope={["oss", "enterprise"]}>the public
-address of the Teleport Proxy Service</ScopedBlock><ScopedBlock
-scope="cloud">your Teleport Cloud tenant address</ScopedBlock>.
+Replace `PROXY_ADDRESS` with be the public address of the Teleport Proxy Service
+or your Teleport Cloud workspace URL (e.g., `example.teleport.sh`).
 
 The app must have the `read:org` scope in order to be able to read org and team
 membership details.
@@ -379,7 +382,8 @@ spec:
 version: v2
 ```
 
-For `rp_id`, use the public address of your <ScopedBlock scope={["oss", "enterprise"]}>Teleport Proxy Service</ScopedBlock><ScopedBlock scope="cloud">Teleport Cloud tenant</ScopedBlock>.
+For `rp_id`, use the public address of your Teleport Proxy Service or Teleport
+Cloud workspace.
 
 When you save and close the temporary file, `tctl` will update the resource:
 

--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -127,8 +127,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will request the credentials manually by *impersonating* the `register-apps`
 role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise deployment and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `register-apps`, create a file
 called `register-apps-impersonator.yaml` defining a role:

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -277,8 +277,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 case, we will request the credentials manually by *impersonating* the
 `sync-kubernetes-rbac` role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise deployment and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `sync-kubernetes-rbac`, define a role
 called `sync-kubernetes-rbac-impersonator` by pasting the following YAML document into

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -73,10 +73,13 @@ target application's API through Teleport App Access.
   title="CA and Key Pair Files"
 >
   Note the paths to your user's certificate/key pair in the command - `curl` will use a client certificate to authenticate with Teleport.
-  
-  <ScopedBlock scope={["oss", "enterprise"]}>
-    The Teleport Proxy Service is usually configured with a wildcard certificate issued by a public certificate authority such as Let's Encrypt. If your Teleport Proxy Service has been configured to use a self-signed certificate instead, you will need to include it in your `curl` command using `--cacert <path>`.
-  </ScopedBlock>
+ 
+  The Teleport Proxy Service is usually configured with a wildcard certificate
+  issued by a public certificate authority such as Let's Encrypt. If you are
+  running a self-hosted Teleport cluster, and your Teleport Proxy Service has
+  been configured to use a self-signed certificate instead, you will need to
+  include it in your `curl` command using `--cacert <path>`.
+
 </Admonition>
 
 As Grafana's API requires authentication, let's update the `curl` command to

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -72,7 +72,8 @@ version: v5
 
 To create an application resource, run:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -82,8 +83,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create app.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl remotely.
@@ -91,7 +92,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create app.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 After the resource has been created, it will appear among the list of available
 apps (in `tsh apps ls` or UI) as long as at least one Application Service

--- a/docs/pages/application-access/guides/dynamodb.mdx
+++ b/docs/pages/application-access/guides/dynamodb.mdx
@@ -20,12 +20,15 @@ This guide will help you to:
 - Set up the Teleport Application Service to access the AWS Console and API.
 - Connect to your DynamoDB databases through the Teleport Application Service.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![DynamoDB Self-Hosted](../../../img/application-access/guides/dynamodb_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![DynamoDB Cloud](../../../img/application-access/guides/dynamodb_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -159,3 +162,4 @@ $ tsh apps logout aws
 ## Next steps
 - More information on [AWS Management and API with Teleport Application Access](../../application-access/cloud-apis/aws-console.mdx).
 - Learn more about [AWS service endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html).
+

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -41,7 +41,8 @@ $ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=<pass> -d postgre
 
 Teleport Application Service requires a valid auth token to join the cluster.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 To generate one, run the following command on your Auth Service node:
 
 ```code
@@ -54,16 +55,18 @@ connect to cluster applications:
 ```code
 $ tctl users add --roles=access alice
 ```
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 To generate one, log into your Cloud tenant and run the following command:
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh
 $ tctl tokens add --type=app
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Save the generated token in `/tmp/token` on the node where Application Service
 will run.
@@ -146,3 +149,4 @@ $ psql postgres://postgres@localhost:55868/postgres
 ## Next steps
 
 - Learn about [access controls](../controls.mdx) for applications.
+

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -107,7 +107,8 @@ spec:
 You can create a new `app` resource by running the following commands, which
 assume that you have created a YAML file called `app.yaml` with your configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -118,8 +119,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create -f app.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -128,7 +129,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create -f app.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## CLI
 
@@ -210,3 +213,4 @@ To run this command, one of the user's roles must include the
 Application Service. To learn how to set up secure access to Azure via Teleport,
 read [Protect the Azure CLI with Teleport Application
 Access](cloud-apis/azure.mdx).
+

--- a/docs/pages/architecture/authorization.mdx
+++ b/docs/pages/architecture/authorization.mdx
@@ -351,15 +351,12 @@ options, Teleport will choose `strict` option.
 
 ### Just in Time Access Requests
 
-<ScopedBlock
-  scope={["oss"]}
->
-
 <Notice type="tip">
-  The full version of Just In Time Access Requests is available only in Teleport Cloud or Enterprise.
-</Notice>
 
-</ScopedBlock>
+  The full version of Just In Time Access Requests is available only in Teleport
+  Enterprise (including Enterprise Cloud).
+
+</Notice>
 
 Roles allow requesting elevated privileges - other roles or individual resources.
 
@@ -396,3 +393,4 @@ spec:
 - [Teleport Auth](authentication.mdx)
 - [Teleport Nodes](nodes.mdx)
 - [Teleport Proxy](proxy.mdx)
+

--- a/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
@@ -7,12 +7,6 @@ h1: Teleport HSM Support
 This guide will show you how to set up the Teleport Auth Service to use a
 hardware security module (HSM) to store and handle private keys.
 
-<ScopedBlock scope={["oss", "cloud"]}>
-
-This guide is intended for Teleport Enterprise users.
-
-</ScopedBlock>
-
 ## Prerequisites
 
 - Teleport v(=teleport.version=) Enterprise (self-hosted).
@@ -357,4 +351,5 @@ All CAs listed in the output of `tctl status` must be rotated.
 You are all set! Check the teleport logs for `Creating new HSM key pair` to
 confirm that the feature is working. You can also check that keys were created
 in your HSM using your HSM's admin tool.
+
 

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -19,7 +19,8 @@ work with Teleport.
 
 ### Get connection information
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 <Tabs>
 <TabItem label="Authenticated Proxy">
@@ -96,8 +97,8 @@ TLS authentication.
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Use the following command to start a local TLS proxy your GUI database client
 will be connecting to:
@@ -116,7 +117,9 @@ Use the displayed local proxy host/port and credentials paths when configuring
 your GUI client below. When entering the hostname, use `localhost` rather than
 `127.0.0.1`.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## MongoDB Compass
 
@@ -418,3 +421,4 @@ Use the SQL Server Authentication option and keep the Password field empty:
 ![DBeaver connection options](../../img/database-access/guides/sqlserver/dbeaver-connection@2x.png)
 
 Click OK to connect.
+

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -117,9 +117,7 @@ server and database access within a single window.
    ![A new instance of Teleport Connect](../../img/teleport-connect-init.png)
 
 1. Provide the address of your Teleport Cluster (e.g.
-<ScopedBlock scope={["oss", "enterprise"]}>`https://teleport.example.com`</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>`https://mytennant.teleport.sh`</ScopedBlock>
-) and click **NEXT**.
+   `https://example.teleport.sh`) and click **NEXT**.
 
 1. Teleport Connect will ask you for your username, password, and MFA. 
    
@@ -132,13 +130,15 @@ server and database access within a single window.
 
 ### Web UI
 
-Teleport provides a web interface for users to interact with Teleport, e.g., by accessing resources or creating Access Requests. This is usually
-found at the same URL used to connect to Teleport with (e.g.
-<ScopedBlock scope={["oss", "enterprise"]}>`https://teleport.example.com`</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>`https://mytenant.teleport.sh`</ScopedBlock>),
-but you should confirm the Web UI URL with the team that manages your Teleport deployment. The Web UI provides similar
-access to resources as Teleport Connect, and additional access to to Request and
-Activity logs for users with the right permissions.
+Teleport provides a web interface for users to interact with Teleport, e.g., by
+accessing resources or creating Access Requests. This is usually found at the
+same URL used to connect to Teleport with (e.g.  `https://example.teleport.sh`),
+but you should confirm the Web UI URL with the team that manages your Teleport
+deployment. 
+
+The Web UI provides similar access to resources as Teleport Connect, and
+additional access to to Request and Activity logs for users with the right
+permissions.
 
 ## Protocols
 
@@ -337,9 +337,7 @@ list those that are accessible to your user under <Icon name="database" size="sm
 Desktop access is available through the Teleport Web UI. 
 
 1. In your browser, navigate to your Teleport cluster (for example, 
-<ScopedBlock scope={["oss", "enterprise"]}>`https://teleport.example.com`</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>`https://mytennant.teleport.sh`</ScopedBlock>
-).
+`https://example.teleport.sh`).
 1. From the menu on the right, select <Icon name="desktop" inline size="sm"/> **Desktops**.
 1. Next to the desktop you want to access, click **CONNECT**. Select
 or type in a username available to your Teleport user.

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -17,7 +17,8 @@ Teleport, and includes links to more detailed documentation at the end.
 [downloading](https://goteleport.com/download/) and installing `tsh`, sign in to
 your Teleport cluster:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 <Tabs>
 <TabItem label="Local user">
 
@@ -58,9 +59,9 @@ required for your particular use case.
 
 </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["enterprise", "cloud"]}>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 <Tabs>
 <TabItem label="Local user">
 ```code
@@ -100,7 +101,9 @@ required for your particular use case.
 
 </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Teleport Connect
 
@@ -361,3 +364,4 @@ either directly or through proxy tunnels.
 {/*lint ignore messaging for page title*/}
 - [Database Access GUI Clients](./gui-clients.mdx) details
 how to connect many popular database GUI clients through Teleport.
+

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -23,7 +23,8 @@ terminal for the CLI reference.
 For the impatient, here's an example of how a user would typically use
 [`tsh`](../reference/cli/tsh.mdx):
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 
 ```code
 # Log into a Teleport cluster. This command retrieves the user's certificates
@@ -47,8 +48,8 @@ $ ssh user@host
 $ tsh logout
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Login into a Teleport cluster. This command retrieves the user's certificates
@@ -72,7 +73,9 @@ $ ssh user@host
 $ tsh logout
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 In other words, Teleport was designed to be fully compatible with existing
 SSH-based workflows and does not require users to learn anything new, other than
@@ -112,7 +115,8 @@ login and the OS login. A Teleport identity will have to be passed via the
 `--user` flag while the OS login will be passed as `login@host` using syntax
 compatible with the traditional `ssh` command.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Authenticate against the "work" cluster as joe and then
@@ -120,8 +124,8 @@ compatible with the traditional `ssh` command.
 $ tsh ssh --proxy=work.example.com --user=joe root@node
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Authenticate against the "work" cluster as joe and then
@@ -129,7 +133,9 @@ $ tsh ssh --proxy=work.example.com --user=joe root@node
 $ tsh ssh --proxy=mytenant.teleport.sh --user=joe root@node
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh ssh](../reference/cli/tsh.mdx#tsh-ssh)
 
@@ -137,7 +143,8 @@ $ tsh ssh --proxy=mytenant.teleport.sh --user=joe root@node
 
 To retrieve a user's certificate, execute:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Full form:
@@ -150,8 +157,8 @@ $ tsh login --proxy=work.example.com
 $ tsh login --proxy=work.example.com:5000
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Full form:
@@ -160,7 +167,9 @@ $ tsh login --proxy=proxy_host:<https_proxy_port>
 $ tsh login --proxy=mytenant.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh login](../reference/cli/tsh.mdx#tsh-login)
 
@@ -182,7 +191,8 @@ This allows you to authenticate just once, maybe at the beginning of the day. Su
 
 A Teleport cluster can be configured for multiple user identity sources. For example, a cluster may have a local user called `admin` while regular users should [authenticate via GitHub](../access-controls/sso/github-sso.mdx). In this case, you have to pass `--auth` flag to `tsh login` to specify which identity storage to use:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in using the local Teleport 'admin' user:
@@ -192,8 +202,8 @@ $ tsh --proxy=proxy.example.com --auth=local --user=admin login
 $ tsh --proxy=proxy.example.com --auth=github login
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in using the local Teleport 'admin' user:
@@ -203,29 +213,34 @@ $ tsh --proxy=mytenant.teleport.sh --auth=local --user=admin login
 $ tsh --proxy=mytenant.teleport.sh --auth=github login
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 When using an external identity provider to log in, `tsh` will need to open a
 web browser to complete the authentication flow. By default, `tsh` will use your
 system's default browser. If you wish to suppress this behavior, you can use the
 `--browser=none` flag:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Don't open the system default browser when logging in
 $ tsh login --proxy=work.example.com --browser=none
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Don't open the system default browser when logging in
 $ tsh login --proxy=mytenant.teleport.sh --browser=none
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 In this situation, a link will be printed on the screen. You can copy and paste this link into
 a browser of your choice to continue the login flow.
@@ -237,7 +252,8 @@ a browser of your choice to continue the login flow.
 To inspect the SSH certificates in `~/.tsh`, a user may execute the following
 command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh status
@@ -252,8 +268,8 @@ $ tsh status
 #  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh status
@@ -268,7 +284,9 @@ $ tsh status
 #  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh status](../reference/cli/tsh.mdx#tsh-status)
 
@@ -294,7 +312,8 @@ variable to `false` in your shell profile to make this permanent.
 [`tsh login`](../reference/cli/tsh.mdx#tsh-login) can also save the user certificate into a
 file:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Authenticate the user against proxy.example.com and save the user
@@ -305,8 +324,8 @@ $ tsh login --proxy=proxy.example.com --out=joe
 $ tsh ssh --proxy=proxy.example.com -i joe joe@db
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Authenticate the user against mytenant.teleport.sh and save the user
@@ -317,14 +336,17 @@ $ tsh login --proxy=mytenant.teleport.sh --out=joe
 $ tsh ssh --proxy=mytenant.teleport.sh -i joe joe@db
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 By default, the `--out` flag will create an identity file suitable for `tsh -i`.
 If compatibility with OpenSSH is needed, `--format=openssh` must be specified.
 In this case, the identity will be saved into two files, `joe` and
 `joe-cert.pub`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=proxy.example.com --out=joe --format=openssh
@@ -335,8 +357,8 @@ $ ls -lh
 # -rw------- 1 joe staff 1.5K Aug 10 16:16 joe-cert.pub
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --out=joe --format=openssh
@@ -347,7 +369,9 @@ $ ls -lh
 # -rw------- 1 joe staff 1.5K Aug 10 16:16 joe-cert.pub
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### SSH certificates for automation
 
@@ -367,7 +391,8 @@ In this example, we're creating a certificate with a TTL of one hour for the
 `jenkins` user and storing it in a `jenkins.pem` file, which can be later used with
 `-i` (identity) flag for `tsh`.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -377,8 +402,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl auth sign --ttl=1h --user=jenkins --out=jenkins.pem
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport Cloud cluster so you can use tctl locally.
@@ -386,7 +411,9 @@ $ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
 $ tctl auth sign --ttl=1h --user=jenkins --out=jenkins.pem
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tctl auth sign](../reference/cli/tctl.mdx#tctl-auth-sign)
 
@@ -444,7 +471,8 @@ the most popular `ssh` flags like `-p`, `-l` or `-L`. For example, if you have
 the following alias defined in your `~/.bashrc`: `alias ssh="tsh ssh"` then you
 can continue using familiar SSH syntax:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Have this alias configured, perhaps via ~/.bashrc
@@ -460,8 +488,8 @@ $ ssh -o ForwardAgent=yes user@node
 $ ssh -o AddKeysToAgent=yes user@node
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Have this alias configured, perhaps via ~/.bashrc
@@ -477,9 +505,9 @@ $ ssh -o ForwardAgent=yes user@node
 $ ssh -o AddKeysToAgent=yes user@node
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ### Proxy ports
 
@@ -494,7 +522,9 @@ $ tsh --proxy=proxy.example.com:5000 <subcommand>
 
 This `tsh` command will use port `5000` of the Proxy Service.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Port forwarding
 
@@ -536,20 +566,23 @@ This command:
 
 While implementing `ProxyJump` for Teleport, we have extended the feature to `tsh`.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh ssh -J proxy.example.com telenode
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh ssh -J mytenant.teleport.sh telenode
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Known limitations:
 
@@ -666,7 +699,8 @@ tunnels from behind-firewall environments into a Teleport Proxy Service you have
 These features are called **Trusted Clusters**. Refer to [the Trusted Clusters guide](../management/admin/trustedclusters.mdx)
 to learn how a Trusted Cluster can be configured.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Assuming the Teleport Proxy Server called `work` is configured with a few Trusted
 Clusters, a user may use the `tsh clusters` command to see a list of all Trusted Clusters on the server:
@@ -680,8 +714,8 @@ $ tsh --proxy=work clusters
 # production       offline
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Assuming the Teleport Cloud tenant called `mytenant.teleport.sh` is configured with a few trusted
 clusters, a user may use the `tsh clusters` command to see a list of all Trusted Clusters on the server:
@@ -695,13 +729,16 @@ $ tsh --proxy=mytenant.teleport.sh clusters
 # production       offline
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh clusters](../reference/cli/tsh.mdx#tsh-clusters)
 
 Now you can use the `--cluster` flag with any `tsh` command. For example, to list SSH nodes that are members of the `production` cluster, simply run:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh --proxy=work ls --cluster=production
@@ -712,8 +749,8 @@ $ tsh --proxy=work ls --cluster=production
 # db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh --proxy=mytenant.teleport.sh ls --cluster=production
@@ -724,11 +761,14 @@ $ tsh --proxy=mytenant.teleport.sh ls --cluster=production
 # db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Similarly, if you want to SSH into `db-1` inside the `production` cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh --proxy=work ssh --cluster=production db-1
@@ -739,8 +779,8 @@ firewall without open ports. This works because the `production` cluster
 establishes a reverse SSH tunnel back into the Proxy Service called `work`, and
 this tunnel is used to establish inbound SSH connections.
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh --proxy=mytenant.teleport.sh ssh --cluster=production db-1
@@ -751,7 +791,9 @@ firewall without open ports. This works because the `production` cluster
 establishes a reverse SSH tunnel back into your Teleport Cloud tenant's Proxy
 Service, and this tunnel is used to establish inbound SSH connections.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## X11 forwarding
 

--- a/docs/pages/contributing/documentation/reference.mdx
+++ b/docs/pages/contributing/documentation/reference.mdx
@@ -491,7 +491,8 @@ with `scope` set and `scopeOnly={false}`.
 Any Markdown and MDX components can be included within a `ScopedBlock`.
 
 ```jsx
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
   Here are some options for installing the Teleport Auth and Proxy Services on
   your own infrastructure.
@@ -500,7 +501,9 @@ Any Markdown and MDX components can be included within a `ScopedBlock`.
   {/* TabItems that vary between scopes */}
   </Tabs>
 
-</ScopedBlock>
+</TabItem>
+</Tabs>
+
 ```
 
 ## Scopes
@@ -714,3 +717,4 @@ To embed a video in a docs page, use the `video` tag:
 Your browser does not support the video tag.
 </video>
 ```
+

--- a/docs/pages/contributing/documentation/reference.mdx
+++ b/docs/pages/contributing/documentation/reference.mdx
@@ -464,48 +464,6 @@ Here is an image:
 When including the partial, the docs engine will rewrite the link path to load
 the image in `docs/img/screenshot.png`.
 
-## ScopedBlock
-
-Use the `ScopedBlock` component if you want to render some Markdown only for
-users of open source Teleport, Teleport Cloud, or Teleport Enterprise.
-
-`ScopedBlock` has a single property, `scope`, that works the same as it does for
-other components we use in the documentation. See our
-[explanation](./reference.mdx#scopes) of how to use the `scope` property.
-
-Use this instead of the `Tabs` component when:
-
-- You want to conceal details that aren't relevant to the reader's scope.
-- The components you use don't look presentable within a `TabItem`, e.g., you're
-  including a separate `Tabs` component for each scope.
-
-<Notice type="warning">
-
-Readers may not notice that it is possible to adjust the scope of a docs page,
-so only use this component if there is no risk of a reader losing important
-information by not seeing a `ScopedBlock`. Otherwise, consider a `Details` block
-with `scope` set and `scopeOnly={false}`.
-
-</Notice>
-
-Any Markdown and MDX components can be included within a `ScopedBlock`.
-
-```jsx
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-  Here are some options for installing the Teleport Auth and Proxy Services on
-  your own infrastructure.
-
-  <Tabs>
-  {/* TabItems that vary between scopes */}
-  </Tabs>
-
-</TabItem>
-</Tabs>
-
-```
-
 ## Scopes
 
 There are three versions of Teleport: `oss`, `enterprise`, and `cloud`. Readers can switch the scope of the documentation using a dropdown menu at the top of the page.

--- a/docs/pages/database-access/architecture.mdx
+++ b/docs/pages/database-access/architecture.mdx
@@ -15,21 +15,24 @@ databases:
 
 In it, we have the following Teleport components:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 - [Teleport Proxy](../architecture/proxy.mdx). A stateless service
   that performs a function of an authentication gateway, serves the Web UI, and
   accepts database (and other) client connections.
   
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 - [Teleport Proxy](../architecture/proxy.mdx). A stateless service that performs
   a function of an authentication gateway, serves the Web UI, and accepts
   database (and other) client connections. This service is accessible at your
   Teleport Cloud tenant URL, e.g., `mytenant.teleport.sh`.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 - [Teleport Auth Service](../architecture/authentication.mdx). Serves as
   cluster's certificate authority, handles user authentication/authorization
@@ -145,3 +148,4 @@ for a more in-depth description of the feature scope and design.
 
 See [Core Concepts](../core-concepts.mdx) for general Teleport
 architecture principles.
+

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -5,12 +5,15 @@ description: Getting started with Teleport database access and AWS Aurora Postgr
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="PostgreSQL AWS Aurora" dbConfigure="AWS Aurora database with IAM authentication" dbName="Aurora" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Self-Hosted](../../img/database-access/guides/rds_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access RDS Cloud](../../img/database-access/guides/rds_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -91,7 +94,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 On the node where you will run the Teleport Database Service, start Teleport and
 point it to your Aurora database instance. Make sure to update the database
@@ -108,8 +112,8 @@ $ teleport db start \
   --aws-region=us-west-1
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 On the node where you will run the Teleport Database Service, start Teleport and
 point it to your Aurora database instance. Make sure to update the database
@@ -126,7 +130,9 @@ $ teleport db start \
   --aws-region=us-west-1
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition
   type="note"
@@ -160,16 +166,19 @@ EOF
 
 Create the Teleport user assigned the `db` role we've just created:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ tctl users add --roles=access,db alice
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ tctl users add --roles=access,requester,db alice
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Step 4/4. Connect
 
@@ -178,20 +187,23 @@ the local user is created, we're ready to connect to the database.
 
 Log in to Teleport with the user we've just created.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Now we can inspect available databases:
 
@@ -218,3 +230,4 @@ Access use-case, for example:
 - Learn how to configure [GUI clients](../connect-your-client/gui-clients.mdx).
 - Learn about database access [role-based access control](./rbac.mdx).
 - See [frequently asked questions](./faq.mdx).
+

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -15,12 +15,15 @@ description: How to configure Teleport database access with AWS Keyspaces (Apach
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS Keyspaces (Apache Cassandra)" dbConfigure="AWS Keyspaces database with IAM authentication" dbName="AWS Keyspaces" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redis Self-Hosted](../../../img/database-access/guides/cassandra_keyspaces_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Redis Cloud](../../../img/database-access/guides/cassandra_keyspaces_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -41,7 +44,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Create a configuration for the Teleport Database Service, pointing the
 `--proxy` flag to the address of your Teleport Proxy Service:
@@ -57,8 +61,8 @@ $ teleport db configure create \
   --labels=env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Create a configuration for the Teleport Database Service, pointing the
 `--proxy` flag to the address of your Teleport Proxy Service:
@@ -74,7 +78,9 @@ $ teleport db configure create \
   --labels=env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 (!docs/pages/includes/aws-credentials.mdx service="the Teleport Database Service"!)
 
@@ -134,7 +140,8 @@ assume the IAM roles:
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
   ```code
   $ tsh login --proxy=teleport.example.com --user=alice
@@ -144,8 +151,8 @@ databases:
   # keyspaces             [*]           env=dev
   ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
   ```code
   $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -155,7 +162,9 @@ databases:
   # keyspaces             [*]           env=dev
   ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To connect to a particular database instance using the `KeyspacesReader`  AWS IAM Keyspaces role as a database user:
 ```code
@@ -183,3 +192,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/aws-dynamodb.mdx
+++ b/docs/pages/database-access/guides/aws-dynamodb.mdx
@@ -5,12 +5,15 @@ description: How to access AWS DynamoDB with Teleport database access
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS DynamoDB" dbConfigure="AWS DynamoDB database with IAM authentication" dbName="AWS DynamoDB" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![DynamoDB Self-Hosted](../../../img/database-access/guides/aws-dynamodb_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![DynamoDB Cloud](../../../img/database-access/guides/aws-dynamodb_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -231,3 +234,4 @@ Type "help", "copyright", "credits" or "license" for more information.
 - See [Dynamic Database Registration](./dynamic-registration.mdx) to learn how
   to use resource labels to keep Teleport up to date with accessible databases in
   your infrastructure.
+

--- a/docs/pages/database-access/guides/aws-opensearch.mdx
+++ b/docs/pages/database-access/guides/aws-opensearch.mdx
@@ -5,12 +5,15 @@ description: How to access AWS OpenSearch with Teleport database access
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS OpenSearch" dbConfigure="AWS OpenSearch Service via REST API with IAM Authentication" dbName="AWS OpenSearch" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![OpenSearch Self-Hosted](../../../img/database-access/guides/aws-opensearch/opensearch_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![OpenSearch Cloud](../../../img/database-access/guides/aws-opensearch/opensearch_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -349,3 +352,4 @@ opensearchsql> select * from movies;
 #+----------------+---------+---------------+--------+-------------+
 opensearchsql>
 ```
+

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -17,12 +17,15 @@ Teleport `12.0`.
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Azure PostgreSQL or MySQL" dbConfigure="Azure PostgreSQL or MySQL database with IAM authentication" dbName="Azure PostgreSQL or MySQL" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Azure PostgreSQL/MySQL Self-Hosted](../../../img/database-access/guides/azure_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Azure PostgreSQL/MySQL Cloud](../../../img/database-access/guides/azure_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -371,7 +374,8 @@ You can create multiple database users identified by the same service principal.
 Log in to your Teleport cluster. Your Azure database should appear in the list of
 available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -381,8 +385,8 @@ $ tsh db ls
 # azure-db                     env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -392,7 +396,9 @@ $ tsh db ls
 # azure-db                     env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -431,3 +437,4 @@ $ tsh db logout azure-db
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/azure-redis.mdx
+++ b/docs/pages/database-access/guides/azure-redis.mdx
@@ -5,13 +5,16 @@ description: How to configure Teleport database access with Azure Cache for Redi
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Azure Cache for Redis" dbConfigure="Azure Cache for Redis with IAM authentication" dbName="Azure Cache for Redis" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Azure Cache for Redis Self-Hosted](../../../img/database-access/guides/azure/redis-self-hosted.png)
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Azure Cache for Redis Cloud](../../../img/database-access/guides/azure/redis-cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -38,7 +41,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Create the Database Service configuration, specifying a region like this:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create \
@@ -47,8 +51,8 @@ $ teleport db configure create \
   --token=/tmp/token \
   --azure-redis-discovery=eastus
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db configure create \
@@ -57,7 +61,9 @@ $ teleport db configure create \
   --token=/tmp/token \
   --azure-redis-discovery=eastus
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with Azure Cache for
 Redis auto-discovery enabled in the `eastus` region and place it at the
@@ -149,7 +155,8 @@ and replace the subscription in `assignableScopes` with your own subscription id
 Log in to your Teleport cluster. Your Azure Cache for Redis databases should
 appear in the list of available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -160,9 +167,9 @@ my-azure-redis            Azure Redis server in East US            [*]          
 my-azure-redis-enterprise Azure Redis Enterprise server in East US [*]           ...
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -173,7 +180,9 @@ my-azure-redis            Azure Redis server in East US            [*]          
 my-azure-redis-enterprise Azure Redis Enterprise server in East US [*]           ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Override default database name">
 By default, Teleport uses the name of the Azure Cache for Redis resource as the
@@ -209,3 +218,4 @@ $ tsh db logout my-azure-redis
 ## Further reading
 - [Understand Azure Role Definitions - AssignableScopes](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions#assignablescopes)
 - [Azure RBAC custom roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles)
+

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -16,12 +16,15 @@ description: How to configure Teleport database access with Azure SQL Server usi
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Azure SQL Server" dbConfigure="Azure SQL Server using Azure Active Directory authentication" dbName="Azure SQL Server" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Azure SQL Server Azure Active Directory Self-Hosted](../../../img/database-access/guides/sqlserver/sql-aad.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Azure SQL Server Azure Active Directory Cloud](../../../img/database-access/guides/sqlserver/cloud-sql-aad.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -182,7 +185,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create \
@@ -192,8 +196,8 @@ $ teleport db configure create \
    --azure-sqlserver-discovery=eastus
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```code
 $ teleport db configure create \
    -o file \
@@ -201,7 +205,9 @@ $ teleport db configure create \
    --proxy=mytenant.teleport.sh:443 \
    --azure-sqlserver-discovery=eastus
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with Azure SQL
 Server auto-discovery enabled in the `eastus` region and place it at the
@@ -225,7 +231,8 @@ Server auto-discovery enabled in the `eastus` region and place it at the
 Log in to your Teleport cluster. Your database should appear in the list of
 available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -236,8 +243,8 @@ sqlserver          Azure SQL Server in westeurope     [*]           ...
 sqlserver-managed  Azure Managed SQL Server in eastus [*]           ...
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -248,7 +255,9 @@ sqlserver          Azure SQL Server in westeurope     [*]           ...
 sqlserver-managed  Azure Managed SQL Server in eastus [*]           ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -304,3 +313,4 @@ To check if the VM has access, you can do the following on the VM:
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -15,12 +15,15 @@ description: How to configure Teleport database access with Cassandra and Scylla
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Cassandra or ScyllaDB" dbConfigure="Cassandra or ScyllaDB with mutual TLS authentication" dbName="Cassandra or ScyllaDB" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Cassandra Self-Hosted](../../../img/database-access/guides/cassandra_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Cassandra Cloud](../../../img/database-access/guides/cassandra_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -138,7 +141,8 @@ Follow the instructions for your database to enable TLS communication with your 
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
   ```code
   $ tsh login --proxy=teleport.example.com --user=alice
@@ -148,8 +152,8 @@ databases:
   # cassandra Cassandra Example [*]           env=dev
   ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
   ```code
   $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -159,7 +163,9 @@ databases:
   # cassandra Cassandra Example [*]           env=dev
   ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To connect to a particular database instance :
 ```code
@@ -183,3 +189,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -5,12 +5,15 @@ description: How to configure Teleport database access with self-hosted Cockroac
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="CockroachDB" dbConfigure="CockroachDB with mutual TLS authentication" dbName="CockroachDB" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access CockroachDB Self-Hosted](../../../img/database-access/guides/cockroachdb_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access CockroachDB Cloud](../../../img/database-access/guides/cockroachdb_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -163,3 +166,4 @@ $ tsh db logout roach
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
 - [CockroachDB client authentication](https://www.cockroachlabs.com/docs/stable/authentication.html#client-authentication)
+

--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -21,10 +21,9 @@ description: How to configure Teleport database access with Elasticsearch.
 
 - A self-hosted Elasticsearch database. Elastic Cloud [does not support client certificates](https://www.elastic.co/guide/en/cloud/current/ec-restrictions.html#ec-restrictions-security), which are required for setting up the Database Service.
 
-- A host where you will run the Teleport Database Service. If you are already running the Teleport
-  Database Service, you must ensure that it uses Teleport version 10.3 or newer in order to connect
-  to Elasticsearch. <ScopedBlock scope={["oss", "enterprise"]}> This can also be the same instance
-  of Teleport running your Auth and/or Proxy service(s).</ScopedBlock>
+- A host where you will run the Teleport Database Service. If you are already
+  running the Teleport Database Service, you must ensure that it uses Teleport
+  version 10.3 or newer in order to connect to Elasticsearch.
 
   See [Installation](../../installation.mdx) for details.
 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -6,12 +6,15 @@ videoBanner: mu_ZKTjnFJ8
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="MongoDB Atlas cluster" dbConfigure="MongoDB Atlas with mutual TLS authentication or AWS IAM" dbName="MongoDB Atlas" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access MongoDB Self-Hosted](../../../img/database-access/guides/mongodbatlas_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access MongoDB Cloud](../../../img/database-access/guides/mongodbatlas_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -32,7 +35,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Next, start the Database Service.
 
-<ScopedBlock scope={["enterprise","oss"]}>
+<Tabs>
+<TabItem scope={["enterprise","oss"]} label="Self-Hosted">
 
 <Tabs>
 <TabItem label="Teleport CLI">
@@ -93,9 +97,9 @@ See the full [YAML reference](../reference/configuration.mdx) for details.
 
 </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 <Tabs>
 <TabItem label="Teleport CLI">
 
@@ -141,7 +145,9 @@ See the full [YAML reference](../reference/configuration.mdx) for details.
 
 </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 See below for details on how to configure the Teleport Database Service.
 
@@ -361,3 +367,4 @@ $ tsh db logout
 - [Which certificate authority signs MongoDB Atlas cluster TLS certificates?](https://docs.atlas.mongodb.com/reference/faq/security/#which-certificate-authority-signs-mongodb-atlas-cluster-tls-certificates-)
 - [Self-managed X.509 authentication](https://docs.atlas.mongodb.com/security-self-managed-x509/)
 - [AWS IAM authentication](https://www.mongodb.com/docs/atlas/security/passwordless-authentication/)
+

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -6,12 +6,15 @@ videoBanner: 6lgVObxoLkc
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="MongoDB cluster" dbConfigure="MongoDB cluster with mutual TLS authentication" dbName="MongoDB" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access MongoDB Self-Hosted](../../../img/database-access/guides/mongodb_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access MongoDB Cloud](../../../img/database-access/guides/mongodb_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -192,7 +195,8 @@ in the MongoDB documentation for more details.
 
 Log in to your Teleport cluster and see available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -202,8 +206,8 @@ $ tsh db ls
 # example-mongo Example MongoDB env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -213,7 +217,9 @@ $ tsh db ls
 # example-mongo Example MongoDB env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -247,3 +253,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -5,12 +5,15 @@ description: How to configure Teleport database access with GCP Cloud SQL MySQL.
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="MySQL on Google Cloud SQL" dbConfigure="MySQL on Google Cloud SQL with a service account" dbName="MySQL on Google Cloud SQL" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access CloudSQL Self-Hosted](../../../img/database-access/guides/cloudsql_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access CloudSQL Cloud](../../../img/database-access/guides/cloudsql_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -128,7 +131,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 Below is an example of a Database Service configuration file that proxies
 a single Cloud SQL MySQL database. Save this file as `/etc/teleport.yaml`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -171,8 +175,8 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -213,7 +217,9 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition
   type="tip"
@@ -245,7 +251,8 @@ in the Google Cloud documentation for more details.
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -255,8 +262,8 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL MySQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -266,7 +273,9 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL MySQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 our [RBAC](../rbac.mdx) guide for more details.
@@ -297,3 +306,4 @@ $ tsh db logout cloudsql
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
+

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -5,12 +5,15 @@ description: How to configure Teleport database access with self-hosted MySQL/Ma
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="MySQL or MariaDB" dbConfigure="MySQL or MariaDB database with mutual TLS authentication" dbName="MySQL or MariaDB" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access MySQL Self-Hosted](../../../img/database-access/guides/mysql_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access MySQL Cloud](../../../img/database-access/guides/mysql_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -160,7 +163,8 @@ Install and configure Teleport where you will run the Teleport Database Service:
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -170,8 +174,8 @@ $ tsh db ls
 # example-mysql Example MySQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -181,7 +185,9 @@ $ tsh db ls
 # example-mysql Example MySQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 the [RBAC](../rbac.mdx) guide for more details.
@@ -212,3 +218,4 @@ $ tsh db logout example-mysql
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
+

--- a/docs/pages/database-access/guides/oracle-self-hosted.mdx
+++ b/docs/pages/database-access/guides/oracle-self-hosted.mdx
@@ -10,12 +10,15 @@ description: How to configure Teleport database access with Oracle.
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Oracle" dbConfigure="Oracle with mutual TLS authentication" dbName="Oracle" !)
 
-<ScopedBlock scope={["enterprise"]}>
+<Tabs>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 ![Teleport Database Access Self-hosted Oracle](../../../img/database-access/guides/oracle_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Oracle Cloud](../../../img/database-access/guides/oracle_selfhosted_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -270,3 +273,4 @@ $ tsh db logout
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
 
 - Learn more about  `sqlnet.ora` and `listener.ora` configuration from the [Parameters for the sqlnet.ora File](https://docs.oracle.com/en/database/oracle/oracle-database/18/netrf/parameters-for-the-sqlnet-ora-file.html#GUID-28040885-6832-4FFC-9258-0EF19FE9A3AC) and [Oracle Net Listener Parameters in the listener.ora File](https://docs.oracle.com/en/database/oracle/oracle-database/18/netrf/Oracle-Net-Listener-parameters-in-listener-ora-file.html#GUID-F9FA0DF5-2FAF-45CA-B6A1-F0166C7BFE54) Oracle documentation.
+

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -6,12 +6,15 @@ videoBanner: br9LZ3ZXqCk
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="PostgreSQL on Google Cloud SQL" dbConfigure="PostgreSQL on Google Cloud SQL with a service account" dbName="PostgreSQL on Google Cloud SQL" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access CloudSQL Self-Hosted](../../../img/database-access/guides/cloudsql_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access CloudSQL Cloud](../../../img/database-access/guides/cloudsql_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -191,7 +194,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 Below is an example of a Database Service configuration file that proxies
 a single Cloud SQL PostgreSQL database. Save this to `/etc/teleport.yaml`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -235,8 +239,8 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -278,7 +282,9 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Notice
   type="tip"
@@ -317,7 +323,8 @@ $ echo 'GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json' | sudo tee -a 
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -327,8 +334,8 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL PostgreSQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -338,7 +345,9 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL PostgreSQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 our [RBAC](../rbac.mdx) guide for more details.
@@ -377,3 +386,4 @@ $ tsh db logout cloudsql
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
+

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -6,12 +6,15 @@ videoBanner: UFhT52d5bYg
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS Redshift" dbConfigure="AWS Redshift database with IAM authentication" dbName="AWS Redshift" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redshift Self-Hosted](../../../img/database-access/guides/redshift_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Redshift Cloud](../../../img/database-access/guides/redshift_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -40,7 +43,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 On the node that is running the Database Service, create a configuration file:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create \
@@ -50,8 +54,8 @@ $ teleport db configure create \
    --redshift-discovery=us-west-1
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db configure create \
@@ -61,7 +65,9 @@ $ teleport db configure create \
    --redshift-discovery=us-west-1
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with Redshift
 database auto-discovery enabled on the `us-west-1` region and place it at the
@@ -92,7 +98,8 @@ may not propagate immediately and can take a few minutes to come into effect.
 
 ## Step 5/5. Connect
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Once the Database Service has started and joined the cluster, log in to see the
 registered databases. Replace `--proxy` with the address of your Teleport Proxy
@@ -106,8 +113,8 @@ $ tsh db ls
 # my-redshift Redshift cluster in us-east-1  ...
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Once the Database Service has started and joined the cluster, log in to see the
 registered databases. Replace `--proxy` with the address of your Teleport Cloud
@@ -121,7 +128,9 @@ $ tsh db ls
 # my-redshift Redshift cluster in us-east-1  ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Note">
   You can override the database name by applying the `TeleportDatabaseName` AWS tag to the resource. The value of the tag will be used as the database name.
@@ -164,3 +173,4 @@ $ tsh db logout my-redshift
 - Learn how to [restrict access](../rbac.mdx) to certain users and databases.
 - View the [High Availability (HA)](../guides/ha.mdx) guide.
 - Take a look at the YAML configuration [reference](../reference/configuration.mdx).
+

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -5,12 +5,15 @@ description: How to configure Teleport database access with self-hosted PostgreS
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="PostgreSQL" dbConfigure="PostgreSQL database with mutual TLS authentication" dbName="PostgreSQL" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access PostgreSQL Self-Hosted](../../../img/database-access/guides/postgresqlselfhosted_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access PostgreSQL Cloud](../../../img/database-access/guides/postgresqlselfhosted_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -109,7 +112,8 @@ Install and configure Teleport where you will run the Teleport Database Service:
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -119,8 +123,8 @@ $ tsh db ls
 # example-postgres Example PostgreSQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -130,7 +134,9 @@ $ tsh db ls
 # example-postgres Example PostgreSQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 [RBAC](../rbac.mdx) section for more details.
@@ -160,3 +166,4 @@ $ tsh db logout
 ## Next steps
 
 - Set up [automatic database user provisioning](../rbac/configuring-auto-user-provisioning.mdx).
+

--- a/docs/pages/database-access/guides/rds-proxy.mdx
+++ b/docs/pages/database-access/guides/rds-proxy.mdx
@@ -5,12 +5,15 @@ description: How to configure Teleport database access with AWS RDS Proxy.
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS RDS proxy" dbConfigure="AWS RDS proxy with IAM authentication" dbName="AWS RDS proxy" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Proxy Self-Hosted](../../../img/database-access/guides/rds-proxy_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access RDS Proxy Cloud](../../../img/database-access/guides/rds-proxy_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Supported Engine Family">
 Teleport currently supports RDS Proxy instances with engine family
@@ -204,3 +207,4 @@ $ tsh db logout rds-proxy
   and [Setting up AWS Identity and Access Management (IAM)
   policies](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy-setup.html)
   for RDS Proxy
+

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -16,12 +16,15 @@ In this guide, you will:
 1. Join the AWS RDS or Aurora databases to your Teleport cluster.
 1. Connect to the AWS RDS or Aurora database via the Teleport Database Service.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Self-Hosted](../../../img/database-access/guides/rds_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access RDS Cloud](../../../img/database-access/guides/rds_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Supported versions">
 
@@ -452,3 +455,4 @@ $ tsh db logout <Var name="postgres-rds" />
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
 - Set up [automatic database user provisioning](../rbac/configuring-auto-user-provisioning.mdx).
+

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -5,12 +5,15 @@ description: How to configure Teleport database access with AWS ElastiCache and 
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="AWS ElastiCache and MemoryDB for Redis cluster" dbConfigure="AWS ElastiCache and MemoryDB for Redis cluster database with IAM authentication" dbName="AWS ElastiCache and MemoryDB for Redis" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Self-Hosted](../../../img/database-access/guides/redis_elasticache_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud","team"]}>
+</TabItem>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
 ![Teleport Database Access RDS Cloud](../../../img/database-access/guides/redis_elasticache_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -40,7 +43,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Create the Database Service configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 <Tabs>
   <TabItem label="ElastiCache">
@@ -63,8 +67,8 @@ Create the Database Service configuration:
   </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 <Tabs>
   <TabItem label="ElastiCache">
@@ -87,7 +91,9 @@ Create the Database Service configuration:
   </TabItem>
 </Tabs>
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with ElastiCache or
 MemoryDB database auto-discovery enabled on the `us-west-1` region and place it
@@ -202,7 +208,8 @@ some time (up to 20 minutes) to discover this user once the tag is added.
 Once the Database Service has started and joined the cluster, log in to see the
 registered databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
@@ -214,8 +221,8 @@ $ tsh db ls
 # my-memorydb                 MemoryDB cluster in us-west-1                             ...
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -228,7 +235,9 @@ $ tsh db ls
 # my-memorydb                 MemoryDB cluster in us-west-1                             ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Note">
   You can override the database name by applying the `TeleportDatabaseName` AWS tag to the resource. The value of the tag will be used as the database name.
@@ -291,3 +300,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -7,12 +7,15 @@ If you want to configure Redis Standalone, please read [Database Access with Red
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Redis cluster" dbConfigure="Redis cluster database with mutual TLS authentication" dbName="Redis cluster" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redis Cluster Self-Hosted](../../../img/database-access/guides/rediscluster_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud","team"]}>
+</TabItem>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
 ![Teleport Database Access Redis Cluster Cloud](../../../img/database-access/guides/rediscluster_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -205,3 +208,4 @@ communicating with Redis Cluster:
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/redis.mdx
+++ b/docs/pages/database-access/guides/redis.mdx
@@ -7,12 +7,15 @@ If you want to configure Redis Cluster, please read [Database Access with Redis 
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Redis" dbConfigure="Redis database with mutual TLS authentication" dbName="Redis" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redis Self-Hosted](../../../img/database-access/guides/redis_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud","team"]}>
+</TabItem>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
 ![Teleport Database Access Redis Cloud](../../../img/database-access/guides/redis_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -130,3 +133,4 @@ returns the <nobr>`ERR Teleport: not supported by Teleport`</nobr> error.
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/redshift-serverless.mdx
+++ b/docs/pages/database-access/guides/redshift-serverless.mdx
@@ -10,12 +10,15 @@ This guide will help you to:
 - Set up Teleport to access your AWS Redshift Serverless workgroups.
 - Connect to your databases through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redshift Self-Hosted](../../../img/database-access/guides/redshift_selfhosted_serverless.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Redshift Cloud](../../../img/database-access/guides/redshift_cloud_serverless.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -357,3 +360,4 @@ prior to logging in as this new IAM role to avoid or resolve user permission iss
 - Learn how to [restrict access](../rbac.mdx) to certain users and databases.
 - View the [High Availability (HA)](../guides/ha.mdx) guide.
 - Take a look at the YAML configuration [reference](../reference/configuration.mdx).
+

--- a/docs/pages/database-access/guides/snowflake.mdx
+++ b/docs/pages/database-access/guides/snowflake.mdx
@@ -15,12 +15,15 @@ description: How to configure Teleport database access with Snowflake.
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Snowflake" dbConfigure="Snowflake database with key pair authentication" dbName="Snowflake" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
   ![Teleport Database Access Snowflake Self-Hosted](../../../img/database-access/guides/snowflake_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
   ![Teleport Database Access Snowflake Cloud](../../../img/database-access/guides/snowflake_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -153,3 +156,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/sql-server-ad-pkinit.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad-pkinit.mdx
@@ -5,7 +5,8 @@ description: How to configure Microsoft SQL Server access with Active Directory 
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Microsoft SQL Server" dbConfigure="Microsoft SQL Server database with PKINIT authentication" dbName="Microsoft SQL Server" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'stepBefore' } } }%%
 graph LR
@@ -29,8 +30,8 @@ style local fill:#C0C0C0,stroke: #000000
   e-->d
 end
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'stepBefore' } } }%%
 graph LR
@@ -54,7 +55,9 @@ style local fill:#C0C0C0,stroke: #000000
   e-->d
 end
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 This guide will focus on SQL Servers using self-hosted Active Directory
 authentication.
@@ -320,7 +323,8 @@ master> CREATE LOGIN [EXAMPLE\alice] FROM WINDOWS WITH DEFAULT_DATABASE = [maste
 Log in to your Teleport cluster. Your SQL Server database should appear in the
 list of available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -330,8 +334,8 @@ $ tsh db ls
 # sqlserver                     env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -341,7 +345,9 @@ $ tsh db ls
 # sqlserver                     env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -416,3 +422,4 @@ skipping TLS verification in production environments.
 ## Further reading
 
 - [Kerberos PKINIT authentication](https://web.mit.edu/kerberos/krb5-1.13/doc/admin/pkinit.html).
+

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -6,7 +6,8 @@ videoBanner: k2wz79XCexY
 
 (!docs/pages/includes/database-access/db-introduction.mdx  dbType="Microsoft SQL Server" dbConfigure="Microsoft SQL Server database with Active Directory authentication" dbName="Microsoft SQL Server" !)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'stepBefore' } } }%%
 graph LR
@@ -30,8 +31,8 @@ style local fill:#C0C0C0,stroke: #000000
   e-->d
 end
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```mermaid
 %%{ init: { 'flowchart': { 'curve': 'stepBefore' } } }%%
 graph LR
@@ -55,7 +56,9 @@ style local fill:#C0C0C0,stroke: #000000
   e-->d
 end
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 This guide will focus on Amazon RDS for SQL Server using AWS-managed Active
 Directory authentication.
@@ -249,7 +252,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
   Active Directory domain as the SQL Server.
 </Admonition>
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Configure the Teleport Database Service. Make sure to update `--proxy` to
 point to your Teleport Proxy Service address and `--uri` to the SQL Server
@@ -269,8 +273,8 @@ endpoint.
     --labels=env=dev
   ```
   
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Configure the Teleport Database Service. Make sure to update `--proxy` to
 point to your Teleport Cloud tenant address and `--uri` to the SQL Server
@@ -290,7 +294,9 @@ endpoint.
     --labels=env=dev
   ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Provide Active Directory parameters:
 
@@ -353,7 +359,8 @@ master> CREATE LOGIN [EXAMPLE\alice] FROM WINDOWS WITH DEFAULT_DATABASE = [maste
 Log in to your Teleport cluster. Your SQL Server database should appear in the
 list of available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -363,8 +370,8 @@ $ tsh db ls
 # sqlserver                     env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -374,7 +381,9 @@ $ tsh db ls
 # sqlserver                     env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -434,3 +443,4 @@ skipping TLS verification in production environments.
 
 - [Manually join a Linux instance](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/join_linux_instance.html) in the AWS documentation.
 - [Introduction to `adutil`](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-ad-auth-adutil-introduction) in the Microsoft documentation.
+

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -21,7 +21,8 @@ the Database Service, including:
 
 Starts Teleport Database Service.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db start \
@@ -32,8 +33,8 @@ $ teleport db start \
     --uri=postgres.example.com:5432
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db start \
@@ -44,7 +45,9 @@ $ teleport db start \
     --uri=postgres.mytenant.teleport.sh:5432
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 | Flag | Description |
 | - | - |
@@ -70,7 +73,8 @@ $ teleport db start \
 
 Creates a sample Database Service configuration.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create --rds-discovery=us-west-1 --rds-discovery=us-west-2
@@ -83,8 +87,8 @@ $ teleport db configure create \
   --labels=env=prod
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db configure create --rds-discovery=us-west-1 --rds-discovery=us-west-2
@@ -97,7 +101,9 @@ $ teleport db configure create \
   --labels=env=prod
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 | Flag | Description |
 | - | - |
@@ -347,3 +353,4 @@ $ tsh db config --format=cmd example
 | Flag | Description |
 | - | - |
 | `--format` | Output format: `text` is default, `cmd` to print native database client connect command. |
+

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -184,7 +184,8 @@ spec:
 You can create a new `db` resource by running the following commands, which
 assume that you have created a YAML file called `db.yaml` with your configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -195,8 +196,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create -f db.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl from your local machine.
@@ -205,4 +206,7 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create -f db.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
+

--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -487,7 +487,8 @@ $ ssh -i ${TF_VAR_key_name}.pem -o ProxyCommand="ssh -i ${TF_VAR_key_name}.pem -
 
 4 - Use the `tctl` command to create an admin user for Teleport:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 # From EC2 host
 $ sudo tctl users add teleport-admin --roles=editor,access --logins=root
@@ -497,8 +498,8 @@ $ sudo tctl users add teleport-admin --roles=editor,access --logins=root
 # NOTE: Make sure teleport.example.com:443 points at a Teleport proxy which users can access.
 # When the user 'teleport-admin' activates their account, they will be assigned roles [editor, access]
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 # From EC2 host
 $ sudo tctl users add teleport-admin --roles=editor,access,reviewer --logins=root
@@ -508,7 +509,9 @@ $ sudo tctl users add teleport-admin --roles=editor,access,reviewer --logins=roo
 # NOTE: Make sure teleport.example.com:443 points at a Teleport proxy which users can access.
 # When the user 'teleport-admin' activates their account, they will be assigned roles [editor, access, reviewer]
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 5 - Click the link to launch the Teleport web UI and finish setting up your user. You will need to scan the QR
 code with an TOTP-compatible app like Google Authenticator or Authy. You will also set a password for the
@@ -524,7 +527,8 @@ You can [download the Teleport package containing the `tsh` client from here](ht
 
 - the client is the same for both OSS and Enterprise versions of Teleport.
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ tsh login --proxy=${TF_VAR_route53_domain} --user=teleport-admin
 # Enter password for Teleport user teleport-admin:
@@ -546,8 +550,8 @@ $ tsh ls
 $ tsh ssh root@ip-172-31-11-69-ec2-internal
 # [root@ip-172-31-11-69 ~]#
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ tsh login --proxy=${TF_VAR_route53_domain} --user=teleport-admin
 # Enter password for Teleport user teleport-admin:
@@ -569,7 +573,9 @@ $ tsh ls
 $ tsh ssh root@ip-172-31-11-69-ec2-internal
 # [root@ip-172-31-11-69 ~]#
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Restarting/checking Teleport services
 
@@ -899,3 +905,4 @@ $ ./connect.sh node
 ### AWS quotas
 
 (!docs/pages/includes/aws-quotas.mdx!)
+

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -286,7 +286,8 @@ Edit your `aws-values.yaml` file (created below) to refer to the name of your se
 
 ## Step 5/7. Set values to configure the cluster
 
-<ScopedBlock scope="enterprise">
+<Tabs>
+<TabItem scope="enterprise" label="Teleport Enterprise">
 
 Before you can install Teleport in your Kubernetes cluster, you will need to
 create a secret that contains your Teleport license information.
@@ -300,12 +301,15 @@ this secret as long as your file is named `license.pem`.
 $ kubectl -n <Var name="namespace" /> create secret generic license --from-file=license.pem
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, configure the `teleport-cluster` Helm chart to use the `aws` mode. Create
 a file called `aws-values.yaml` and write the values you've chosen above to it:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 <Tabs>
 <TabItem label="cert-manager">
@@ -384,8 +388,8 @@ can also optionally provide these two values under `annotations.ingress`:
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 <Tabs>
 <TabItem label="cert-manager">
@@ -465,7 +469,9 @@ can also optionally provide these two values under `annotations.ingress`:
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Install the chart with the values from your `aws-values.yaml` file using this command:
 
@@ -647,7 +653,8 @@ $ aws route53 get-change --id "${CHANGEID?}" | jq '.ChangeInfo.Status'
 Create a user to be able to log into Teleport. This needs to be done on the Teleport auth server,
 so we can run the command using `kubectl`:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ kubectl --namespace <Var name="namespace" /> exec deploy/<Var name="release-name" />-auth -- tctl users add test --roles=access,editor
 
@@ -656,8 +663,8 @@ https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
 
 NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ kubectl --namespace teleport exec deploy/teleport-auth -- tctl users add test --roles=access,editor,reviewer
 
@@ -666,7 +673,9 @@ https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
 
 NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Load the user creation link to create a password and set up 2-factor authentication for the Teleport user via the web UI.
 
@@ -769,3 +778,4 @@ users and setting up RBAC.
 See the [high availability section of our Helm chart reference](../../reference/helm-reference/teleport-cluster.mdx#highavailability) for more details on high availability.
 
 Read the [`cert-manager` documentation](https://cert-manager.io/docs/).
+

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -123,7 +123,9 @@ $ kubectl label namespace teleport 'pod-security.kubernetes.io/enforce=baseline'
 namespace/teleport labeled
 ```
 
-<ScopedBlock scope="enterprise">
+If you are running a self-hosted Teleport Enterprise cluster, you  will need to
+create a secret that contains your Teleport license information before you can
+install Teleport.
 
 Before you can install Teleport in your Kubernetes cluster, you will need to
 create a secret that contains your Teleport license information.
@@ -133,11 +135,9 @@ create a secret that contains your Teleport license information.
 Create a secret from your license file. Teleport will automatically discover
 this secret as long as your file is named `license.pem`.
 
-```code
-$ kubectl -n teleport create secret generic license --from-file=license.pem
-```
-
-</ScopedBlock>
+  ```code
+  $ kubectl -n teleport create secret generic license --from-file=license.pem
+  ```
 
 <Admonition type="note" title="External proxy port">
 Note that although the `proxy_service` listens on port 3080 inside the pod,
@@ -210,7 +210,8 @@ If you're not migrating an existing Teleport cluster, you'll need to create a
 user to be able to log into Teleport. This needs to be done on the Teleport
 auth server, so we can run the command using `kubectl`:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ kubectl --namespace teleport exec deployment/teleport-auth -- tctl users add test --roles=access,editor
 
@@ -219,8 +220,8 @@ https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
 
 NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ kubectl --namespace teleport exec deployment/teleport-auth -- tctl users add test --roles=access,editor,reviewer
 
@@ -229,7 +230,9 @@ https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
 
 NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note">
 If you didn't set up DNS for your hostname earlier, remember to replace
@@ -277,3 +280,4 @@ users and setting up RBAC.
 To see all of the options you can set in the values file for the
 `teleport-cluster` Helm chart, consult our [reference
 guide](../../reference/helm-reference/teleport-cluster.mdx).
+

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -121,7 +121,8 @@ Once you get the value for the external IP (it may take a few minutes for this f
 ## Step 3/4. Create and set up Teleport user
 Now we create a Teleport user by executing the `tctl` command with `kubectl`.
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ kubectl --namespace teleport-cluster exec deployment/teleport-cluster-auth -- tctl users add tadmin --roles=access,editor --logins=ubuntu
 
@@ -130,8 +131,8 @@ https://tele.example.com:443/web/invite/<invite-token>
 
 NOTE: Make sure tele.example.com:443 points at a Teleport proxy which users can access.
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ kubectl --namespace teleport-cluster exec deployment/teleport-cluster-auth -- tctl users add tadmin --roles=access,editor,reviewer --logins=ubuntu
 
@@ -140,7 +141,9 @@ https://tele.example.com:443/web/invite/<invite-token>
 
 NOTE: Make sure tele.example.com:443 points at a Teleport proxy which users can access.
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Copy the link shown after executing the above command and open the link in a web browser to complete the user registration process (the link is `https://tele.example.com:443/web/invite/<invite-token>` in the above case).
 <Figure align="left" bordered caption="Set up user">
@@ -211,7 +214,8 @@ $ export KUBECONFIG=${HOME?}/teleport-kubeconfig.yaml
 
 </Admonition>
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code 
 $ tsh login --proxy=tele.example.com:443 --auth=local --user=tadmin
 Enter password for Teleport user tadmin:
@@ -226,8 +230,8 @@ Enter your OTP token:
   Valid until:        2021-10-27 06:37:15 +0000 UTC [valid for 12h0m0s]
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code 
 $ tsh login --proxy=tele.example.com:443 --auth=local --user=tadmin
 Enter password for Teleport user tadmin:
@@ -242,7 +246,9 @@ Enter your OTP token:
   Valid until:        2021-10-27 06:37:15 +0000 UTC [valid for 12h0m0s]
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Select the Kubernetes cluster
 
@@ -278,3 +284,4 @@ Teleport:
 - [Set up Machine ID with Kubernetes](../../machine-id/guides/kubernetes.mdx)
 - [Federated Access using Trusted Clusters](../../kubernetes-access/manage-access/federation.mdx)
 - [Single-Sign On and Kubernetes Access Control](../../kubernetes-access/controls.mdx)
+

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -301,7 +301,8 @@ Next, configure the `teleport-cluster` Helm chart to use the `gcp` mode. Create 
 file called `gcp-values.yaml` file and write the values you've chosen above to
 it:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```yaml
 chartMode: gcp
@@ -323,8 +324,8 @@ podSecurityPolicy:
   enabled: false
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```yaml
 chartMode: gcp
@@ -343,7 +344,9 @@ highAvailability:
 enterprise: true                                  # Indicate that this is a Teleport Enterprise deployment
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Install the chart with the values from your `gcp-values.yaml` file using this command:
 
@@ -415,7 +418,8 @@ $ gcloud dns record-sets transaction execute --zone="${MYZONE?}"
 Create a user to be able to log into Teleport. This needs to be done on the Teleport auth server,
 so we can run the command using `kubectl`:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ kubectl --namespace teleport exec deploy/teleport-auth -- tctl users add test --roles=access,editor
 
@@ -424,8 +428,8 @@ https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
 
 NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ kubectl --namespace teleport exec deploy/teleport-auth -- tctl users add test --roles=access,editor,reviewer
 
@@ -434,7 +438,9 @@ https://teleport.example.com:443/web/invite/91cfbd08bc89122275006e48b516cc68
 
 NOTE: Make sure teleport.example.com:443 points at a Teleport proxy that users can access.
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Load the user creation link to create a password and set up 2-factor authentication for the Teleport user via the web UI.
 
@@ -506,3 +512,4 @@ Access](../../access-controls/introduction.mdx) section to get started enrolling
 users and setting up RBAC.
 
 See the [high availability section of our Helm chart reference](../../reference/helm-reference/teleport-cluster.mdx#highavailability) for more details on high availability.
+

--- a/docs/pages/desktop-access/active-directory.mdx
+++ b/docs/pages/desktop-access/active-directory.mdx
@@ -67,11 +67,9 @@ In this step, you will use the Teleport Web UI to download and run two scripts:
 ### Install Active Directory
 
 In your web browser, access the Teleport Web UI at the address of your Proxy
-Service host, e.g., <ScopedBlock scope={["oss", "enterprise"]}>
-`teleport.example.com`</ScopedBlock><ScopedBlock scope={["cloud"]}>
-`mytennant.teleport.sh`</ScopedBlock>. Go to the Desktops section, 
-then select **Add Desktop**. Select **Active Directory** resource to start
-the guided enrollment from the **Enroll New Resource** section.
+Service host, e.g., `example.teleport.sh`. Go to the Desktops section, then
+select **Add Desktop**. Select **Active Directory** resource to start the guided
+enrollment from the **Enroll New Resource** section.
 
 If you already have Active Directory installed on your Windows Server host, skip
 to the next step. Otherwise, copy and paste the first command provided into a

--- a/docs/pages/includes/database-access/db-introduction.mdx
+++ b/docs/pages/includes/database-access/db-introduction.mdx
@@ -7,3 +7,4 @@ In this guide, you will:
 1. Configure an {{ dbConfigure }}.
 1. Join the {{ dbName }} database to your Teleport cluster.
 1. Connect to the {{ dbName }} database via the Teleport Database Service.
+

--- a/docs/pages/includes/database-access/tctl-auth-sign.mdx
+++ b/docs/pages/includes/database-access/tctl-auth-sign.mdx
@@ -3,11 +3,9 @@ databases must be configured with Teleport's certificate authority to be
 able to verify client certificates. They also need a certificate/key pair that
 Teleport can verify.
 
-<ScopedBlock scope={["cloud"]}>
-
-Your Teleport Cloud user
-must be allowed to impersonate the system role `Db` in order to be able to
-generate the database certificate.
+If you are using Teleport Cloud, your Teleport user must be allowed to
+impersonate the system role `Db` in order to be able to generate the database
+certificate.
 
 Include the following `allow` rule in in your Teleport Cloud user's role:
 
@@ -18,4 +16,3 @@ allow:
     roles: ["Db"]
 ```
 
-</ScopedBlock>

--- a/docs/pages/includes/enterprise/oidcauthentication.mdx
+++ b/docs/pages/includes/enterprise/oidcauthentication.mdx
@@ -1,12 +1,7 @@
 Configure Teleport to use OIDC authentication as the default instead of the local
 user database. 
 
-<ScopedBlock scope={["enterprise"]}>
-
-You can either edit your Teleport configuration file or create a dynamic
-resource.
-
-</ScopedBlock> 
+Follow the instructions for your Teleport edition:
 
 <Tabs>
   <TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
@@ -41,3 +36,4 @@ resource.
   ```
   </TabItem>
 </Tabs>
+

--- a/docs/pages/includes/enterprise/samlauthentication.mdx
+++ b/docs/pages/includes/enterprise/samlauthentication.mdx
@@ -51,3 +51,4 @@ auth_service:
 If you need to log in again before configuring your SAML provider, use the flag <nobr>`--auth=local`</nobr>.
 
 </Admonition>
+

--- a/docs/pages/includes/plugins/rbac-update.mdx
+++ b/docs/pages/includes/plugins/rbac-update.mdx
@@ -38,8 +38,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will need to request the credentials manually by *impersonating* the
 `access-plugin` role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise deployment and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `access-plugin`, define a role
 called `access-plugin-impersonator` by pasting the following YAML document into

--- a/docs/pages/includes/plugins/rbac.mdx
+++ b/docs/pages/includes/plugins/rbac.mdx
@@ -38,8 +38,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will need to request the credentials manually by *impersonating* the
 `access-plugin` role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise deployment and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `access-plugin`, define a role
 called `access-plugin-impersonator` by pasting the following YAML document into

--- a/docs/pages/includes/sso/loginerrortroubleshooting.mdx
+++ b/docs/pages/includes/sso/loginerrortroubleshooting.mdx
@@ -1,14 +1,13 @@
 Troubleshooting SSO configuration can be challenging. Usually a Teleport administrator
 must be able to:
 
-<ScopedBlock scope={["enterprise"]}>
-- Ensure that HTTP/TLS certificates are configured properly for both the Teleport
-  Proxy Service and the SSO provider.
-</ScopedBlock>
 - Be able to see what SAML/OIDC claims and values are getting exported and passed
   by the SSO provider to Teleport.
 - Be able to see how Teleport maps the received claims to role mappings as defined
   in the connector.
+- For self-hosted Teleport Enterprise clusters, ensure that HTTP/TLS
+  certificates are configured properly for both the Teleport Proxy Service and
+  the SSO provider.
 
 If something is not working, we recommend to:
 
@@ -58,3 +57,4 @@ spec:
       'env': 'dev'
 version: v5
 ```
+

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,9 +1,6 @@
-Make sure you can connect to Teleport. Log in to your cluster using `tsh`, then use `tctl`
-remotely:
+Make sure you can connect to your Teleport cluster by authenticating with `tsh`
+so you can execute commands with the `tctl` admin tool:
 
-{/* Ignoring scope linting since we use this partial throughout the docs and
-cannot guarantee that it will line up with a page's configured scopes*/}
-{/*lint ignore scopes*/} 
 <Tabs>
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
@@ -17,13 +14,10 @@ $ tctl status
 
 You can run subsequent `tctl` commands in this guide on your local machine.
 
-For full privileges, you can also run `tctl` commands on your Auth Service host.
+For full privileges, you can also run `tctl` commands on your Teleport Auth
+Service host.
 
 </TabItem>
-</Tabs>
-
-{/*lint ignore scopes*/}
-<Tabs>
 <TabItem scope={["cloud","team"]} label="Teleport Cloud">
 
 ```code
@@ -37,6 +31,5 @@ $ tctl status
 You must run subsequent `tctl` commands in this guide on your local machine.
 
 </TabItem>
-
 </Tabs>
 

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -4,7 +4,8 @@ remotely:
 {/* Ignoring scope linting since we use this partial throughout the docs and
 cannot guarantee that it will line up with a page's configured scopes*/}
 {/*lint ignore scopes*/} 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=email@example.com
@@ -18,9 +19,12 @@ You can run subsequent `tctl` commands in this guide on your local machine.
 
 For full privileges, you can also run `tctl` commands on your Auth Service host.
 
-</ScopedBlock>
+</TabItem>
+</Tabs>
+
 {/*lint ignore scopes*/}
-<ScopedBlock scope={["cloud","team"]}>
+<Tabs>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
 
 ```code
 $ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
@@ -32,4 +36,7 @@ $ tctl status
 
 You must run subsequent `tctl` commands in this guide on your local machine.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
+

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -81,7 +81,8 @@ Currently supported distributions (and `ID`) are:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-<ScopedBlock scope="oss">
+<Tabs>
+<TabItem scope="oss" label="Teleport Community Edition">
 
 <Details title="Using APT or YUM for versions prior to Teleport 10?" scopeOnly={false}>
 
@@ -97,13 +98,15 @@ We will also continue to maintain the legacy APT repo at
 Check the [Downloads](https://goteleport.com/download/) page for the most
 up-to-date information.
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Check the [Cloud Downloads](./choose-an-edition/teleport-cloud/downloads.mdx) page for the most up-to-date
 information on obtaining Teleport binaries compatible with Teleport Cloud.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Docker
 
@@ -472,3 +475,4 @@ infrastructure. Get started with:
 - [Application Access](application-access/introduction.mdx)
 - [Desktop Access](desktop-access/introduction.mdx)
 - [Machine ID](machine-id/introduction.mdx)
+

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -137,21 +137,6 @@ the foreground to better understand how it works.
 <Tabs>
   <TabItem label="Token-based Joining">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
-  ```code
-  $ export TELEPORT_ANONYMOUS_TELEMETRY=1
-  $ sudo tbot start \
-     --data-dir=/var/lib/teleport/bot \
-     --destination-dir=/opt/machine-id \
-     --token=(=presets.tokens.first=) \
-     --join-method=token \
-     --auth-server=teleport.example.com:443
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
   ```code
   $ export TELEPORT_ANONYMOUS_TELEMETRY=1
   $ sudo tbot start \
@@ -161,14 +146,10 @@ the foreground to better understand how it works.
      --join-method=token \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
   <TabItem label="IAM Method">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
   ```code
   $ export TELEPORT_ANONYMOUS_TELEMETRY=1
   $ sudo tbot start \
@@ -176,23 +157,8 @@ the foreground to better understand how it works.
      --destination-dir=/opt/machine-id \
      --token=iam-token \
      --join-method=iam \
-     --auth-server=teleport.example.com:443
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
-  ```code
-  $ export TELEPORT_ANONYMOUS_TELEMETRY=1
-  $ tbot start \
-     --data-dir=/var/lib/teleport/bot \
-     --destination-dir=/opt/machine-id \
-     --token=iam-token \
-     --join-method=iam \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
 </Tabs>

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -44,14 +44,17 @@ Before you create a bot user, you need to determine which role(s) you want to
 assign to it. You can use the `tctl` command below to examine what roles exist
 on your system.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 On your client machine, log in to Teleport using `tsh`, then use `tctl` to examine
 what roles exist on your system.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 Connect to the Teleport Auth Server and use `tctl` to examine what roles exist on
 your system.
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ```code
 $ tctl get roles --format=text
@@ -200,15 +203,16 @@ this by omitting this.
 
 Replace the following fields with values from your own cluster.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 - `token` is the token output by the `tctl bots add` command or the name of your IAM method token.
 - `destination-dir` is where Machine ID writes user certificates that can be used by applications and tools.
 - `data-dir` is where Machine ID writes its private data, including its own short-lived renewable certificates. These should not be used by applications and tools.
 - `auth-server` is the address of your Teleport Cloud Proxy Server, for example `example.teleport.sh:443`.
 
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 
 - `token` is the token output by the `tctl bots add` command or the name of your IAM method token.
 - `ca-pin` is the CA Pin for your Teleport cluster, and is output by the `tctl bots add` command.
@@ -219,7 +223,9 @@ Replace the following fields with values from your own cluster.
    Auth Server is direct connectivity is available.
   `teleport.example.com:443`.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Now that Machine ID has successfully started, let's investigate the
 `/opt/machine-id` directory to see what was written to disk.
@@ -275,16 +281,19 @@ $ ssh -F /opt/machine-id/ssh_config root@node-name.example.com
 In addition to the `ssh` client you can use `tsh`. Replace the `--proxy` parameter
 with your proxy address. 
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 ```code
 $ tsh ssh --proxy=teleport.example.com -i /opt/machine-id/identity root@node-name
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```code
 $ tsh ssh --proxy=mytenant.teleport.sh -i /opt/machine-id/identity root@node-name
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Roles must have logins defined">
   The below error can occur when the bot does not have permission to log in to
@@ -323,3 +332,4 @@ use-case, for example:
 - [Machine ID with Databases](./guides/databases.mdx)
 
 [More information about `TELEPORT_ANONYMOUS_TELEMETRY`.](./reference/telemetry.mdx)
+

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -67,7 +67,8 @@ configured above. Be sure to note the bot join token and CA PIN.
 Next, on the bot node, create a Machine ID configuration file at
 `/etc/tbot.yaml`:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud" scope={["cloud","team"]}>
 ```yaml
 auth_server: "example.teleport.sh:443"
 onboarding:
@@ -81,8 +82,8 @@ destinations:
   - directory: /opt/machine-id
     app: grafana-example
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 ```yaml
 auth_server: "teleport.example.com:443"
 onboarding:
@@ -96,7 +97,8 @@ destinations:
   - directory: /opt/machine-id
     app: grafana-example
 ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Be sure to configure the `token` and `ca_pins` fields to match the output from
 `tctl bots add ...`, and set `app` to match the desired name as shown in

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -172,7 +172,8 @@ certificate files can be used:
 
 You may use these credentials with any client application that supports them.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 The Teleport Proxy makes apps available via subdomains of its public web
 address. Given an app named `grafana-example` and a Teleport Proxy at
 `https://example.teleport.sh:443`, the app may be accessed at
@@ -185,8 +186,8 @@ $ curl --user admin:admin \
   --key /opt/machine-id/key \
   https://grafana-example.example.teleport.sh/api/users
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 The Teleport Proxy makes apps available via subdomains of its public web
 address. Given an app named `grafana-example` and a Teleport Proxy at
 `https://teleport.example.com:443`, the app may be accessed at
@@ -199,7 +200,9 @@ $ curl --user admin:admin \
   --key /opt/machine-id/key \
   https://grafana-example.teleport.example.com/api/users
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that in the example above, we include `--user` to provide a local username
 and password to our Grafana instance. This is not necessary if your application
@@ -220,16 +223,19 @@ Service, it's also possible to open a local proxy to the app using
 `tbot proxy app ...` in situations where the Teleport Proxy Service's app endpoints are
 unavailable:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```code
 $ tbot proxy --destination-dir=/opt/machine-id --proxy=example.teleport.sh:443 app --port=1234 grafana-example
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 ```code
 $ tbot proxy --destination-dir=/opt/machine-id --proxy=teleport.example.com:443 app --port=1234 grafana-example
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 You may now connect to the app via a local proxy at `http://localhost:1234`:
 
@@ -288,3 +294,4 @@ has been configured to use both the client certificate and key.
   Application to remove the need for additional login credentials.
 
 [More information about `TELEPORT_ANONYMOUS_TELEMETRY`.](../reference/telemetry.mdx)
+

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -95,7 +95,8 @@ credentials.
 
 Start by creating a configuration file for Machine ID at `/etc/tbot.yaml`:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud" scope={["cloud","team"]}>
 ```yaml
 auth_server: "example.teleport.sh:443"
 onboarding:
@@ -117,8 +118,8 @@ destinations:
     configs:
       - mongo
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 ```yaml
 auth_server: "teleport.example.com:443"
 onboarding:
@@ -140,7 +141,8 @@ destinations:
     configs:
       - mongo
 ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Be sure to configure the `token` and `ca_pins` fields to match the output from
 `tctl bots add ...`. We've also included the `mongo` config template in the

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -69,21 +69,24 @@ $ tctl create -f role.yaml
 
 With the role created, create a new bot and allow it to assume the new role.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 On your client machine, log in to Teleport using `tsh` before using `tctl` to
 create the bot:
 
 ```code
 $ tctl bots add app --roles=machine-id-db
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 Connect to the Teleport Auth Server and use `tctl` to create the bot:
 
 ```code
 $ tctl bots add app --roles=machine-id-db
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Step 2/3. Configure and start Machine ID
 
@@ -292,3 +295,4 @@ access controls.
 ## Next steps
 
 [More information about `TELEPORT_ANONYMOUS_TELEMETRY`.](../reference/telemetry.mdx)
+

--- a/docs/pages/machine-id/guides/host-certificate.mdx
+++ b/docs/pages/machine-id/guides/host-certificate.mdx
@@ -167,21 +167,6 @@ First, create a basic configuration file using the following parameters:
 <Tabs>
   <TabItem label="Token-based Joining">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
-  ```code
-  $ tbot configure \
-     --data-dir=/var/lib/teleport/bot \
-     --token=(=presets.tokens.first=) \
-     --join-method=token \
-     --certificate-ttl=1h0m0s \
-     --ca-pin=(=presets.ca_pin=) \
-     --auth-server=auth.example.com:3025
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
   ```code
   $ tbot configure \
      --data-dir=/var/lib/teleport/bot \
@@ -191,27 +176,10 @@ First, create a basic configuration file using the following parameters:
      --ca-pin=(=presets.ca_pin=) \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
   <TabItem label="IAM method">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
-  ```code
-  $ tbot configure \
-     --data-dir=/var/lib/teleport/bot \
-     --token=iam-token \
-     --join-method=iam \
-     --certificate-ttl=1h0m0s \
-     --ca-pin=(=presets.ca_pin=) \
-     --auth-server=auth.example.com:3025
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
   ```code
   $ tbot configure \
      --data-dir=/var/lib/teleport/bot \
@@ -221,8 +189,6 @@ First, create a basic configuration file using the following parameters:
      --ca-pin=(=presets.ca_pin=) \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
 </Tabs>

--- a/docs/pages/machine-id/guides/jenkins.mdx
+++ b/docs/pages/machine-id/guides/jenkins.mdx
@@ -77,15 +77,16 @@ spec:
       "group": "api"
 ```
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 On your client machine, log in to Teleport using `tsh` before using `tctl`.
 
 ```code
 $ tctl create -f api-workers.yaml
 $ tctl bots add jenkins --roles=api-workers
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 Connect to the Teleport Auth Server and use `tctl` to examine what roles exist on
 your system.
 
@@ -93,7 +94,9 @@ your system.
 $ tctl create -f api-workers.yaml
 $ tctl bots add jenkins --roles=api-workers
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Machine ID allows you to use Linux Access Control Lists (ACLs) to control
 access to certificates on disk. You will use this to limit the access Jenkins
@@ -208,3 +211,4 @@ familiar Teleport access controls.
 ## Next steps
 
 [More information about `TELEPORT_ANONYMOUS_TELEMETRY`.](../reference/telemetry.mdx)
+

--- a/docs/pages/machine-id/guides/jenkins.mdx
+++ b/docs/pages/machine-id/guides/jenkins.mdx
@@ -130,7 +130,8 @@ $ sudo tbot init \
 
 Next, you need to start Machine ID in the background of each Jenkins worker.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud" scope={["cloud","team"]}>
   First create a configuration file for Machine ID at `/etc/tbot.yaml`.
 
   ```yaml
@@ -145,8 +146,8 @@ Next, you need to start Machine ID in the background of each Jenkins worker.
   destinations:
     - directory: /opt/machine-id
   ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 First create a configuration file for Machine ID at `/etc/tbot.yaml`.
   ```yaml
   auth_server: "auth.example.com:3025"
@@ -160,7 +161,8 @@ First create a configuration file for Machine ID at `/etc/tbot.yaml`.
   destinations:
     - directory: /opt/machine-id
   ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Next, create a systemd.unit file at `/etc/systemd/system/machine-id.service`.
 

--- a/docs/pages/machine-id/guides/kubernetes.mdx
+++ b/docs/pages/machine-id/guides/kubernetes.mdx
@@ -152,7 +152,8 @@ note the bot join token and CA PIN.
 Next, on the bot node, create a Machine ID configuration file at
 `/etc/tbot.yaml`:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud"  scope={["cloud","team"]}>
 ```yaml
 auth_server: "example.teleport.sh:443"
 onboarding:
@@ -166,8 +167,8 @@ destinations:
   - directory: /opt/machine-id
     kubernetes_cluster: example-k8s-cluster
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 ```yaml
 auth_server: "teleport.example.com:443"
 onboarding:
@@ -181,7 +182,8 @@ destinations:
   - directory: /opt/machine-id
     kubernetes_cluster: example-k8s-cluster
 ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Be sure to configure the `token` and `ca_pins` fields to match the output from
 `tctl bots add ...`, and set `kubernetes_cluster` to match the cluster name as

--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -22,15 +22,12 @@ ERROR: failed direct dial to auth server: auth API: access denied [00]
 
 In particular, note the message `auth API: access denied`.
 
-<Tabs>
-<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-The Teleport Auth Service will also provide some additional context:
+In self-hosted Teleport deployments, the Teleport Auth Service will also provide
+some additional context:
+
 ```text
 [AUTH]      WARN lock targeting User:"bot-example" is in force: The bot user "bot-example" has been locked due to a certificate generation mismatch, possibly indicating a stolen certificate. auth/apiserver.go:224
 ```
-</TabItem>
-
-</Tabs>
 
 ### Explanation
 

--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -22,12 +22,15 @@ ERROR: failed direct dial to auth server: auth API: access denied [00]
 
 In particular, note the message `auth API: access denied`.
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 The Teleport Auth Service will also provide some additional context:
 ```text
 [AUTH]      WARN lock targeting User:"bot-example" is in force: The bot user "bot-example" has been locked due to a certificate generation mismatch, possibly indicating a stolen certificate. auth/apiserver.go:224
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Explanation
 
@@ -340,3 +343,4 @@ Kubernetes public address is populated in `proxy.kube.public_addr`.
 ```bash
 curl https://teleport.example.com:443/webapi/ping | jq
 ```
+

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -100,7 +100,8 @@ starting Teleport.
 On the host where you will run your Node, paste the following content into
 `/etc/teleport.yaml` and adjust it for your environment:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -125,8 +126,8 @@ ssh_service:
     environment: dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -147,7 +148,9 @@ ssh_service:
     environment: dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, start Teleport with the invite token you created earlier:
 
@@ -181,7 +184,8 @@ your Node.
 
 Run the following command to get the current logins for your user:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh status
@@ -195,8 +199,8 @@ $ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```code
 $ tsh status
@@ -210,8 +214,8 @@ $ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 tsh status
@@ -225,7 +229,9 @@ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 In this example, `-teleport-nologin-d4bc1dad-ce49-4bbe-925d-a67f8d2d6afe` means
 that no logins have been assigned to the user.
@@ -279,7 +285,8 @@ Teleport configuration file.
 
 Edit `/etc/teleport.yaml` to define a `commands` array as shown below:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -306,8 +313,8 @@ ssh_service:
     period: 1h0m0s
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -334,7 +341,9 @@ ssh_service:
     period: 1h0m0s
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Notice that the `command` setting is an array where the first element
 is a valid executable and each subsequent element is an argument.
@@ -404,3 +413,4 @@ For more information, see
 You can also use labels to limit the access that different roles have to
 specific classes of resources. For more information, see
 [Teleport Role Templates](../../access-controls/guides/role-templates.mdx).
+

--- a/docs/pages/management/admin/troubleshooting.mdx
+++ b/docs/pages/management/admin/troubleshooting.mdx
@@ -7,17 +7,12 @@ In this guide, we will explain how to address issues or unexpected behavior in y
 Teleport cluster.
 
 You can use these steps to get more visibility into the `teleport` process so
-you can troubleshoot <ScopedBlock scope={["oss", "enterprise"]}>the Auth
-Service, Proxy Service, and </ScopedBlock> resource-specific services such as
-the Application Service and Database Service.
+you can troubleshoot the Auth Service, Proxy Service, and Teleport agent
+services such as the Application Service and Database Service.
 
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
-
-<ScopedBlock scope="cloud">
-- A host where you have installed and configured the `teleport` binary.
-</ScopedBlock>
 
 - (!docs/pages/includes/tctl.mdx!)
 
@@ -121,8 +116,6 @@ Teleport v8.3.7 git:v8.3.7-0-ga8d066935 go1.17.3
 You can also collect the versions of the Teleport Auth Service, Proxy
 Service, and client tools to rule out version compatibility issues.
 
-<ScopedBlock scope="cloud">
-
 To see the version of the Auth Service and Proxy Service, run the following
 command:
 
@@ -135,8 +128,6 @@ User CA  never updated
 Jwt CA   never updated
 CA pin   (=presets.ca_pin=)
 ```
-
-</ScopedBlock>
 
 Get the versions of your client tools:
 
@@ -200,3 +191,4 @@ does not explicitly indicate that something is misconfigured.
 ### `ssh: overflow reading version string`
 
 (!docs/pages/includes/tls-multiplexing-warnings.mdx!)
+

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -395,8 +395,7 @@ Change the fields of `trusted_cluster.yaml` as follows:
 
 #### `metadata.name`
 
-Use the name of your root cluster, e.g., <ScopedBlock
-scope={["oss", "enterprise"]}>`teleport.example.com`</ScopedBlock><ScopedBlock scope="cloud">`mytenant.teleport.sh`</ScopedBlock>.
+Use the name of your root cluster, e.g., `example.teleport.sh`.
 
 #### `spec.token`
 

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -147,7 +147,8 @@ required for accessing a shell on the Node.
 
 On your local machine, log in to your leaf cluster using your Teleport username:
 
-<ScopedBlock scope="cloud">
+<Tabs>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 ```code
 # Log out of all clusters to begin this guide from a clean state
@@ -155,8 +156,8 @@ $ tsh logout
 $ tsh login --proxy=leafcluster.teleport.sh --user=myuser
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["oss", "enterprise"]}>
+</TabItem>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log out of all clusters to begin this guide from a clean state
@@ -164,7 +165,9 @@ $ tsh logout
 $ tsh login --proxy=leafcluster.example.com --user=myuser
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Create a file called `visitor.yaml` with the
 following content:
@@ -202,22 +205,25 @@ you can satisfy the conditions of the role and access the Node.
 
 Make sure that you are logged in to your root cluster.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh logout
 $ tsh login --proxy=rootcluster.example.com --user=myuser
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh logout
 $ tsh login --proxy=rootcluster.teleport.sh --user=myuser
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Create a file called `user.yaml` with your current user configuration. Replace
 `myuser` with your Teleport username:
@@ -263,7 +269,8 @@ You can create a join token using the `tctl` tool.
 
 First, log out of all clusters and log in to the root cluster.
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh logout
@@ -278,8 +285,8 @@ $ tsh login --user=myuser --proxy=rootcluster.example.com
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```code
 $ tsh logout
@@ -294,8 +301,8 @@ $ tsh login --user=myuser --proxy=rootcluster.example.com
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --user=myuser --proxy=myrootclustertenant.teleport.sh
@@ -309,7 +316,9 @@ $ tsh login --user=myuser --proxy=myrootclustertenant.teleport.sh
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Execute the following command on your development machine:
 
@@ -398,7 +407,8 @@ This is join token you created earlier.
 This is the reverse tunnel address of the Proxy Service in the root cluster. Run
 the following command to retrieve the value you should use:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ PROXY=rootcluster.example.com
@@ -406,8 +416,8 @@ $ curl https://${PROXY?}/webapi/ping | jq 'if .proxy.tls_routing_enabled == true
 "rootcluster.example.com:443"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ PROXY=rootcluster.teleport.sh
@@ -415,29 +425,34 @@ $ curl https://${PROXY?}/webapi/ping | jq 'if .proxy.tls_routing_enabled == true
 "rootcluster.teleport.sh:443"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 #### `web_proxy_addr`
 
 This is the address of the Proxy Service on the root cluster. Obtain this with the
 following command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ curl https://${PROXY?}/webapi/ping | jq .proxy.ssh.public_addr
 "teleport.example.com:443"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ curl https://${PROXY?}/webapi/ping | jq .proxy.ssh.public_addr
 "mytenant.teleport.sh:443"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 #### `spec.role_map`
 
@@ -566,20 +581,23 @@ $ tsh logout
 
 Log in to the leaf cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --user=myuser --proxy=leafcluster.example.com
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --user=myuser --proxy=leafcluster.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Create the Trusted Cluster:
 
@@ -614,7 +632,8 @@ Log out of the leaf cluster and log back in to the root cluster. When you run
 `tsh clusters`, you should see listings for both the root cluster and the leaf
 cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh clusters
@@ -624,8 +643,8 @@ Cluster Name                                          Status Cluster Type Select
 rootcluster.example.com                               online root         *
 leafcluster.example.com                               online leaf
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh clusters
@@ -634,7 +653,9 @@ Cluster Name                                          Status Cluster Type Select
 rootcluster.teleport.sh                               online root         *
 leafcluster.teleport.sh                               online leaf
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Step 3/5. Manage access to your Trusted Cluster
 
@@ -670,7 +691,8 @@ version: v3
 Still logged in to the root cluster, use `tctl` to update the labels on the leaf
 cluster:
 
-<ScopedBlock scope="cloud">
+<Tabs>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl update rc/leafcluster.teleport.sh --set-labels=env=demo
@@ -678,8 +700,8 @@ $ tctl update rc/leafcluster.teleport.sh --set-labels=env=demo
 # Cluster leafcluster.teleport.sh has been updated
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["oss", "enterprise"]}>
+</TabItem>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl update rc/leafcluster.example.com --set-labels=env=demo
@@ -687,7 +709,9 @@ $ tctl update rc/leafcluster.example.com --set-labels=env=demo
 # Cluster leafcluster.example.com has been updated
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Change cluster access privileges
 
@@ -748,22 +772,25 @@ Node in your leaf cluster as a user of your root cluster.
 
 First, make sure that you are logged in to root cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh logout
 $ tsh --proxy=rootcluster.example.com --user=myuser login
 ```
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh logout
 $ tsh --proxy=rootcluster.teleport.sh --user=myuser login
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To log in to your Node, confirm that your Node is joined to your leaf cluster:
 
@@ -848,20 +875,23 @@ cluster and editing the `trusted_cluster` resource you created earlier.
 
 Retrieve the Trusted Cluster resource you created earlier:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl get trusted_cluster/rootcluster.example.com > trusted_cluster.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl get trusted_cluster/rootcluster.teleport.sh > trusted_cluster.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Make the following change to the resource:
 
@@ -895,39 +925,45 @@ On the leaf cluster, run the following command. This performs the same tasks as
 setting `enabled` to `false` in a `trusted_cluster` resource, but also removes
 the Trusted Cluster resource from the Auth Service backend:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl rm trusted_cluster/rootcluster.example.com
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl rm trusted_cluster/rootcluster.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, run the following command on the root cluster. This command deletes the
 certificate authorities associated with the remote cluster and removes the
 `remote_cluster` resource from the root cluster's Auth Service backend.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl rm rc/leafcluster.example.com
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl rm rc/leafcluster.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="Removing the relationship from the root side only">
 
@@ -1018,4 +1054,5 @@ should check to see the following:
 
 - Read more about how Trusted Clusters fit into Teleport's overall architecture:
   [Architecture Introduction](../../architecture/trustedclusters.mdx).
+
 

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -6,10 +6,6 @@ description: Learn how to manage local users in Teleport. Local users are stored
 In Teleport, **local users** are users managed directly via Teleport, rather
 than a third-party identity provider.
 
-Local user accounts can be used alongside external user accounts managed via
-GitHub<ScopedBlock scope={["enterprise", "cloud"]}> as well as OIDC and SAML
-2.0</ScopedBlock>.
-
 This guide shows you how to:
 
 - [Add local users](./users.mdx#adding-local-users)

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -37,16 +37,19 @@ Let's look at this table:
 
 Let's add a new user to Teleport using the `tctl` tool:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 ```code
 $ tctl users add joe --logins=joe,root --roles=access,editor
 ```
-</ScopedBlock>
-<ScopedBlock scope={["enterprise", "cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise", "cloud"]} label="Commercial">
 ```code
 $ tctl users add joe --logins=joe,root --roles=access,editor,reviewer
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Teleport generates an auto-expiring token (with a TTL of one hour) and prints
 the token URL, which must be used before the TTL expires.
@@ -138,3 +141,4 @@ information, see [GitHub SSO](../../access-controls/sso/github-sso.mdx).
 
 </TabItem>
 </Tabs>
+

--- a/docs/pages/management/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/management/export-audit-events/elastic-stack.mdx
@@ -17,12 +17,8 @@ stores them in Elasticsearch for visualization and alerting in Kibana.
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-- Logstash version 8.4.1 or above running on a Linux host. Logstash must be
-  listening on a TCP port that is open to traffic from <ScopedBlock
-  scope={["oss", "enterprise"]}>the Teleport Auth
-  Service</ScopedBlock><ScopedBlock scope="cloud">your Teleport Cloud
-  tenant</ScopedBlock>. In this guide, you will also run the Event Handler
-  plugin on this host.
+- Logstash version 8.4.1 or above running on a Linux host. In this guide, you
+  will also run the Event Handler plugin on this host.
 
 - Elasticsearch and Kibana version 8.4.1 or above, either running via an Elastic
   Cloud account or on your own infrastructure. You will need permissions to

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1058,7 +1058,8 @@ These flags are available for all commands `--debug, --config` . Run
 
 ### Examples
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl get users
@@ -1072,8 +1073,8 @@ $ tctl get clusters,users
 $ tctl get all > state.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl get users
@@ -1085,7 +1086,9 @@ $ tctl get cluster/east
 $ tctl get clusters,users
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## tctl edit
 
@@ -1393,4 +1396,5 @@ Print the version of your `tctl` binary:
 ```code
 tctl version
 ```
+
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -290,22 +290,10 @@ into a server using a third-party tool. Compare the two equivalent commands:
     To use the `ssh` client generate a SSH configuration file and postfix
     the cluster name after the node name.
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
     ```code
     $ tsh config > ssh_config_teleport
-    $ ssh -F ssh_config_teleport root@ip-172-31-41-144.tele.example.com
+    $ ssh -F ssh_config_teleport root@ip-172-31-41-144.example.teleport.sh
     ```
-
-   </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
-    ```code
-    $ tsh config > ssh_config_teleport
-    $ ssh -F ssh_config_teleport root@ip-172-31-41-144.mytenant.teleport.sh
-    ```
-
-   </ScopedBlock>
 
   </TabItem>
 </Tabs>

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -93,7 +93,8 @@ On your server, save `token.file` to an appropriate, secure, directory you have
 the rights and access to read. Next, generate a configuration file enabling
 Teleport's SSH Service.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Change `tele.example.com` to the address of your Teleport Proxy Service. Assign
 the `--token` flag to the path where you saved `token.file`.
@@ -106,8 +107,8 @@ $ sudo teleport node configure \
    --proxy=tele.example.com:443
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
  Change `mytenant.teleport.sh` to your Teleport Cloud tenant address. Assign the
  `--token` flag to the path where you saved `token.file`.
@@ -120,7 +121,9 @@ $ sudo teleport node configure \
    --proxy=mytenant.teleport.sh:443
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The `teleport node configure` command above placed a configuration file at
 `/etc/teleport.yaml`. The last step is to start Teleport, pointing it at this
@@ -164,7 +167,8 @@ We can use `tsh` to SSH into the cluster:
 
 ### Log in to the cluster
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 On your local machine, log in to your cluster through `tsh`, assigning the
 `--proxy` flag to the address of your Teleport Proxy Service:
@@ -174,8 +178,8 @@ On your local machine, log in to your cluster through `tsh`, assigning the
 $ tsh login --proxy=tele.example.com --user=myuser
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 On your local machine, log in to your cluster through `tsh`, assigning the
 `--proxy` flag to the address of your Teleport Cloud tenant:
@@ -185,14 +189,17 @@ On your local machine, log in to your cluster through `tsh`, assigning the
 $ tsh login --proxy=mytenant.teleport.sh:443 --user=myuser
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 You'll be prompted to supply the password and second factor we set up
 previously.
 
 `myuser` will now see something similar to:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```txt
 > Profile URL:      https://tele.example.com:443
@@ -208,8 +215,8 @@ Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 In this example, `myuser` is now logged into the `tele.example.com` cluster
 through Teleport SSH.
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```txt
 > Profile URL:        https://mytenant.teleport.sh:443
@@ -225,7 +232,9 @@ Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 In this example, `myuser` is now logged into the `mytenant.teleport.sh`
 cluster through Teleport SSH.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Display cluster resources
 
@@ -394,3 +403,4 @@ further Getting Started exercises.
 - [How to SSH properly](https://goteleport.com/blog/how-to-ssh-properly/)
 - Consider whether [OpenSSH or Teleport SSH](https://goteleport.com/blog/openssh-vs-teleport/) is right for you.
 - [Labels](../management/admin/labels.mdx)
+

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -88,7 +88,8 @@ authenticate the `sshd` host using the host certificate you generated earlier.
 
 First, make sure you have logged in to your Teleport cluster:
 
-<ScopedBlock scope={["oss"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh status
@@ -102,8 +103,8 @@ $ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```code
 $ tsh status
@@ -117,8 +118,8 @@ $ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh status
@@ -132,7 +133,9 @@ $ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 On your local machine, run the following `tsh` command. This will print a
 configuration block that tells your SSH client to use credentials managed by
@@ -230,7 +233,8 @@ First, define environment variables for the address of your Teleport cluster,
 the username you will use to log in to your `sshd` host, and the port on your
 `sshd` host you are using for SSH traffic:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # See the available logins you can use to access your sshd host
@@ -241,8 +245,8 @@ $ CLUSTER=teleport.example.com
 $ PORT=22
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # See the available logins you can use to access your sshd host
@@ -253,7 +257,9 @@ $ CLUSTER=mytenant.teleport.sh
 $ PORT=22
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, SSH in to your remote host:
 
@@ -332,3 +338,4 @@ the lock remains in force.
 
 For more information, read our
 [Session and Identity Locking Guide](../../access-controls/guides/locking.mdx).
+

--- a/docs/pages/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/server-access/guides/ssh-pam.mdx
@@ -115,7 +115,8 @@ include:
 
 ## Display a Message of the Day (MOTD) with Teleport
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 A cluster-wide Message of the Day can be set in the `auth_service` configuration.
 
@@ -138,15 +139,17 @@ the traditional Unix `/etc/motd` file. The `/etc/motd` file is normally
 displayed by login(1) after a user has logged in but before the shell is run. It
 is generally used for important system-wide announcements.
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 You can set a per-Node Message of the Day using the traditional Unix `/etc/motd`
 file. The `/etc/motd` file is normally displayed by login(1) after a user has
 logged in but before the shell is run. It is generally used for important
 system-wide announcements.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 This feature can help you inform users that activity on the Node is being audited
 and recorded.
@@ -298,3 +301,4 @@ ssh_service:
     # use the "auth" modules in the PAM config
     use_pam_auth: true
 ```
+


### PR DESCRIPTION
Backports a series of PRs removing `ScopedBlock`s from the documentation:

- #30616
- #30629
- #30769

Also removes the remaining `ScopedBlock`s from v13 of the docs.