### PR TITLE
fix connector close

### DIFF
--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -295,7 +295,11 @@ func (a *Server) generateCerts(
 	}
 
 	// Emit audit event
-	log.Infof("Node %q [%v] has joined the cluster.", req.NodeName, req.HostID)
+	if req.Role == types.RoleInstance {
+		log.Infof("Node %q [%v] has joined the cluster. role=%s, systemRoles=%+v", req.NodeName, req.HostID, req.Role, systemRoles)
+	} else {
+		log.Infof("Node %q [%v] has joined the cluster. role=%s", req.NodeName, req.HostID, req.Role)
+	}
 	joinEvent := &apievents.InstanceJoin{
 		Metadata: apievents.Metadata{
 			Type: events.InstanceJoinEvent,

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -311,7 +311,7 @@ func (c *Connector) UseTunnel() bool {
 
 // Close closes resources associated with connector
 func (c *Connector) Close() error {
-	if c.Client != nil {
+	if c.Client != nil && !inheritsInstanceClient(c.ClientIdentity.ID.Role) {
 		return c.Client.Close()
 	}
 	return nil


### PR DESCRIPTION
https://github.com/gravitational/teleport/pull/30384 caused instance clients to be shared between services.  This ended up breaking some things related to the jamf plugin (see https://github.com/gravitational/teleport.e/issues/2022).  Certificate issuance logic for the jamf plugin specifically was was rolled back by https://github.com/gravitational/teleport/pull/30701.

After some investigation, it seems like the test failures were caused because the shared client was being closed by the plugins on exit.  Having whatever service exits first closing the common client didn't cause any issues when dealing with normal services since they all had the same lifetime anyway, but with plugins that might be created or destroyed across the lifetime of the service, it was very problematic.  This PR updates `Connector.Close` to only close the client if it 'owns' the client.

This PR was initially developed based on the state of master prior to https://github.com/gravitational/teleport/pull/30701 and appears to fix the same test failures fixed by that PR.  _However_, this PR does not revert the changes made there, since the original inciting issue included some "permission denied" error logs that I don't believe had anything to do with premature closure of a client.  Those need to be investigated further, but I believe the root problem is that the instance cert, being initialized on startup, didn't contain sufficient permissions to perform the actions needed by a lazily initialized plugin (since at the time the instance cert was created, it didn't know it needed said permissions).  Thats just a hunch through.  Still looking into it.