### PR TITLE
Make saml and app return same kind for the UI

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -3638,7 +3638,7 @@ func TestCheckAccessToRegisteredResource(t *testing.T) {
 			insertResource: func() {
 				resource := &types.AppServerV3{
 					Metadata: types.Metadata{Name: "test-app"},
-					Kind:     types.KindAppServer,
+					Kind:     types.KindApp,
 					Version:  types.V2,
 					Spec: types.AppServerSpecV3{
 						HostID: "hostid",
@@ -4211,7 +4211,7 @@ func TestClusterAppsGet(t *testing.T) {
 
 	resource := &types.AppServerV3{
 		Metadata: types.Metadata{Name: "test-app"},
-		Kind:     types.KindAppServer,
+		Kind:     types.KindApp,
 		Version:  types.V2,
 		Spec: types.AppServerSpecV3{
 			HostID: "hostid",
@@ -4273,7 +4273,7 @@ func TestClusterAppsGet(t *testing.T) {
 	require.Len(t, resp.Items, 3)
 	require.Equal(t, 3, resp.TotalCount)
 	require.ElementsMatch(t, resp.Items, []ui.App{{
-		Kind:        types.KindAppServer,
+		Kind:        types.KindApp,
 		Name:        "app1",
 		Description: resource.Spec.App.GetDescription(),
 		URI:         resource.Spec.App.GetURI(),
@@ -4284,7 +4284,7 @@ func TestClusterAppsGet(t *testing.T) {
 		AWSConsole:  true,
 		UserGroups:  []ui.UserGroupAndDescription{{Name: "ug1", Description: "ug1-description"}},
 	}, {
-		Kind:       types.KindAppServer,
+		Kind:       types.KindApp,
 		Name:       "app2",
 		URI:        "uri",
 		Labels:     []ui.Label{},
@@ -4293,7 +4293,7 @@ func TestClusterAppsGet(t *testing.T) {
 		PublicAddr: "publicaddrs",
 		AWSConsole: false,
 	}, {
-		Kind:        types.KindSAMLIdPServiceProvider,
+		Kind:        types.KindApp,
 		Name:        "test-saml-app",
 		Description: "SAML Application",
 		URI:         "",

--- a/lib/web/ui/app.go
+++ b/lib/web/ui/app.go
@@ -114,7 +114,7 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 	}
 
 	resultApp := App{
-		Kind:         app.GetKind(),
+		Kind:         types.KindApp,
 		Name:         app.GetName(),
 		Description:  app.GetDescription(),
 		URI:          app.GetURI(),
@@ -135,9 +135,9 @@ func MakeApp(app types.Application, c MakeAppsConfig) App {
 func MakeSAMLApp(app types.SAMLIdPServiceProvider, c MakeAppsConfig) App {
 	labels := makeLabels(app.GetAllLabels())
 	resultApp := App{
-		Kind:         app.GetKind(),
+		Kind:         types.KindApp,
 		Name:         app.GetName(),
-		Description:  app.GetMetadata().Description,
+		Description:  "SAML Application",
 		PublicAddr:   "",
 		Labels:       labels,
 		ClusterID:    c.AppClusterName,
@@ -168,7 +168,7 @@ func MakeApps(c MakeAppsConfig) []App {
 			}
 
 			resultApp := App{
-				Kind:         appOrSP.GetKind(),
+				Kind:         types.KindApp,
 				Name:         appOrSP.GetName(),
 				Description:  appOrSP.GetDescription(),
 				URI:          app.GetURI(),
@@ -191,7 +191,7 @@ func MakeApps(c MakeAppsConfig) []App {
 		} else {
 			labels := makeLabels(appOrSP.GetSAMLIdPServiceProvider().GetAllLabels())
 			resultApp := App{
-				Kind:         appOrSP.GetKind(),
+				Kind:         types.KindApp,
 				Name:         appOrSP.GetName(),
 				Description:  appOrSP.GetDescription(),
 				PublicAddr:   appOrSP.GetPublicAddr(),

--- a/lib/web/ui/app_test.go
+++ b/lib/web/ui/app_test.go
@@ -94,7 +94,7 @@ func TestMakeApps(t *testing.T) {
 				}))},
 			expected: []App{
 				{
-					Kind:       types.KindAppServer,
+					Kind:       types.KindApp,
 					Name:       "1",
 					URI:        "1.com",
 					PublicAddr: "1.com",
@@ -103,7 +103,7 @@ func TestMakeApps(t *testing.T) {
 					UserGroups: []UserGroupAndDescription{},
 				},
 				{
-					Kind:        types.KindAppServer,
+					Kind:        types.KindApp,
 					Name:        "2",
 					Description: "group 2 friendly name",
 					URI:         "2.com",
@@ -141,7 +141,7 @@ func TestMakeApps(t *testing.T) {
 			},
 			expected: []App{
 				{
-					Kind:       types.KindAppServer,
+					Kind:       types.KindApp,
 					Name:       "1",
 					URI:        "1.com",
 					PublicAddr: "1.com",
@@ -153,7 +153,7 @@ func TestMakeApps(t *testing.T) {
 					},
 				},
 				{
-					Kind:        types.KindAppServer,
+					Kind:        types.KindApp,
 					Name:        "2",
 					Description: "group 2 friendly name",
 					URI:         "2.com",
@@ -182,7 +182,7 @@ func TestMakeApps(t *testing.T) {
 			})},
 			expected: []App{
 				{
-					Kind:        types.KindSAMLIdPServiceProvider,
+					Kind:        types.KindApp,
 					Name:        "grafana_saml",
 					Description: "SAML Application",
 					PublicAddr:  "",


### PR DESCRIPTION
Previously, we sent apps and saml apps as the same "kind", (types.KindApp) when they were combined into a `AppOrSAMLIdPServiceProvider` but since we are now have separate types in the UnifiedResources request, we need to make sure both types stay as `types.KindApp` (and i also fixed the description not coming through correctly... even tho its a hardcoded value)

The tests were updated because they were written incorrectly. The original `clusterAppsGet` didn't care about kind and I sent the wrong ones, and I didn't catch the unified resource because I didn't have SAML apps i was testing with. 