### PR TITLE
Improve dependabot PR experience

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,7 +23,7 @@ updates:
       - dependency-name: github.com/vulcand/predicate
     open-pull-requests-limit: 10
     groups:
-      api-dependencies:
+      go:
         update-types:
           - "minor"
           - "patch"
@@ -41,7 +41,7 @@ updates:
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
     groups:
-      teleport-dependencies:
+      go:
         update-types:
           - "minor"
           - "patch"
@@ -62,7 +62,7 @@ updates:
       - dependency-name: github.com/alecthomas/kingpin/v2
     open-pull-requests-limit: 10
     groups:
-      assets-aws-dependencies:
+      go:
         update-types:
           - "minor"
           - "patch"
@@ -81,7 +81,7 @@ updates:
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
     groups:
-      assets-backport-dependencies:
+      go:
         update-types:
           - "minor"
           - "patch"
@@ -102,7 +102,7 @@ updates:
       - dependency-name: github.com/alecthomas/kingpin/v2
     open-pull-requests-limit: 10
     groups:
-      build-assets-tooling-dependencies:
+      go:
         update-types:
           - "minor"
           - "patch"
@@ -121,7 +121,7 @@ updates:
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
     groups:
-      kube-agent-updater-dependencies:
+      go:
         update-types:
           - "minor"
           - "patch"
@@ -140,7 +140,7 @@ updates:
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
     groups:
-      rust-dependencies:
+      rust:
         update-types:
           - "minor"
           - "patch"
@@ -159,7 +159,7 @@ updates:
       time: "09:00" # 9am UTC
     open-pull-requests-limit: 10
     groups:
-      rdpclient-dependencies:
+      rust:
         update-types:
           - "minor"
           - "patch"

--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -22,7 +22,6 @@ on:
 jobs:
   build:
     name: Build API
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
     runs-on: ubuntu-latest
 
     permissions:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   lint:
-    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
     name: Lint (Go)
     runs-on: ubuntu-22.04-16core
 


### PR DESCRIPTION
Updates the job names to reflect the language of the PR instead of the directory name. This makes the PR titles less redundant and makes it more obvious which language the updates are for.

Stop skipping the lint and build api workflows on dependabot PRs. Now that the batcher isn't bundling the dependabot PRs we should run CI checks on them prior to landing in the merge queue.