### PR TITLE
Release 11.3.21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Security fixes
 
-* TODO(jent): Update this when security fix lands
+* Security improvements with possible `medium` severity DoS conditions through protocol level attacks. [#30854](https://github.com/gravitational/teleport/pull/30854)
 
 ## 11.3.20 (08/04/23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Improved audit logging support for large SQL Server queries. [#30245](https://github.com/gravitational/teleport/pull/30245)
 * Explicitly mention _registered_ and _new_ device when running `tsh mfa add` on Windows. [#30217](https://github.com/gravitational/teleport/pull/30217)
 * Tighten discovery service permissions. [#29996](https://github.com/gravitational/teleport/pull/29996)
+* helm: Add support for custom annodations in the teleport-kube-agent Secret. [#30840](https://github.com/gravitational/teleport/pull/30840)
 
 ### Security fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 * Improved audit logging support for large SQL Server queries. [#30245](https://github.com/gravitational/teleport/pull/30245)
 * Explicitly mention _registered_ and _new_ device when running `tsh mfa add` on Windows. [#30217](https://github.com/gravitational/teleport/pull/30217)
 * Tighten discovery service permissions. [#29996](https://github.com/gravitational/teleport/pull/29996)
-* helm: Add support for custom annodations in the teleport-kube-agent Secret. [#30840](https://github.com/gravitational/teleport/pull/30840)
+* helm: Add support for custom annotations in the teleport-kube-agent Secret. [#30840](https://github.com/gravitational/teleport/pull/30840)
 
 ### Security fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 11.3.21 (08/22/23)
+
+* Fixed S3 metric name for completed multipart uploads. [#30712](https://github.com/gravitational/teleport/pull/30712)
+* Fixed Teleport Connect to properly show errors from the remote end. [#30694](https://github.com/gravitational/teleport/pull/30694)
+* Fixed Review Requests to disallow reviews after request is resolved. [#30688](https://github.com/gravitational/teleport/pull/30688)
+* Fixed Discovery service panics on GKE clusters without labels. [#30648](https://github.com/gravitational/teleport/pull/30648)
+* Fixed memory leak using PAM libraries. [#30519](https://github.com/gravitational/teleport/pull/30519)
+* Fixed "user is not managed" error when accessing ElastiCache and MemoryDB. [#30358](https://github.com/gravitational/teleport/pull/30358)
+* Fixed resources being deleted from Firestore on update. [#30289](https://github.com/gravitational/teleport/pull/30289)
+* Updated LDAP desktop discovery to handle slow DNS queries better. [#30465](https://github.com/gravitational/teleport/pull/30465)
+* Updated SAML certificate parsing to allow leading/trailing spaces. [#30452](https://github.com/gravitational/teleport/pull/30452)
+* Improved audit logging support for large SQL Server queries. [#30245](https://github.com/gravitational/teleport/pull/30245)
+* Explicitly mention _registered_ and _new_ device when running `tsh mfa add` on Windows. [#30217](https://github.com/gravitational/teleport/pull/30217)
+* Tighten discovery service permissions. [#29996](https://github.com/gravitational/teleport/pull/29996)
+
+### Security fixes
+
+* TODO(jent): Update this when security fix lands
+
 ## 11.3.20 (08/04/23)
 
 * Updated Go to 1.20.7. [#29907](https://github.com/gravitational/teleport/pull/29907)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@
 #   Stable releases:   "1.0.0"
 #   Pre-releases:      "1.0.0-alpha.1", "1.0.0-beta.2", "1.0.0-rc.3"
 #   Master/dev branch: "1.0.0-dev"
-VERSION=11.3.20
+VERSION=11.3.21
 
 DOCKER_IMAGE ?= teleport
 

--- a/api/version.go
+++ b/api/version.go
@@ -3,7 +3,7 @@
 package api
 
 const (
-	Version = "11.3.20"
+	Version = "11.3.21"
 )
 
 // Gitref variable is automatically set to the output of git-describe

--- a/build.assets/macos/tsh/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tsh/tsh.app/Contents/Info.plist
@@ -19,13 +19,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>11.3.20</string>
+		<string>11.3.21</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>11.3.20</string>
+		<string>11.3.21</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
+++ b/build.assets/macos/tshdev/tsh.app/Contents/Info.plist
@@ -17,13 +17,13 @@
 		<key>CFBundlePackageType</key>
 		<string>APPL</string>
 		<key>CFBundleShortVersionString</key>
-		<string>11.3.20</string>
+		<string>11.3.21</string>
 		<key>CFBundleSupportedPlatforms</key>
 		<array>
 			<string>MacOSX</string>
 		</array>
 		<key>CFBundleVersion</key>
-		<string>11.3.20</string>
+		<string>11.3.21</string>
 		<key>DTCompiler</key>
 		<string>com.apple.compilers.llvm.clang.1_0</string>
 		<key>DTPlatformBuild</key>

--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "11.3.20"
+.version: &version "11.3.21"
 
 name: teleport-cluster
 apiVersion: v2

--- a/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "11.3.20"
+.version: &version "11.3.21"
 
 name: teleport-operator
 apiVersion: v2

--- a/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/deployment_test.yaml.snap
@@ -3,7 +3,7 @@ sets Deployment annotations when specified:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -45,7 +45,7 @@ sets Pod annotations when specified:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -87,7 +87,7 @@ should add PersistentVolumeClaim as volume when in custom mode and persistence.e
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -129,7 +129,7 @@ should add PersistentVolumeClaim as volume when in standalone mode and persisten
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -168,7 +168,7 @@ should add PersistentVolumeClaim as volume when in standalone mode and persisten
         claimName: RELEASE-NAME
 should add an operator side-car when operator is enabled:
   1: |
-    image: public.ecr.aws/gravitational/teleport-operator:11.3.20
+    image: public.ecr.aws/gravitational/teleport-operator:11.3.21
     imagePullPolicy: IfNotPresent
     livenessProbe:
       httpGet:
@@ -206,7 +206,7 @@ should add emptyDir for data in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -259,7 +259,7 @@ should add emptyDir for data in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -307,7 +307,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
     - args:
       - --diag-addr=0.0.0.0:3000
       - --insecure
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -349,7 +349,7 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -392,7 +392,7 @@ should add named PersistentVolumeClaim as volume when in custom mode and persist
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -482,7 +482,7 @@ should expose diag port:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -524,7 +524,7 @@ should have Recreate strategy in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -578,7 +578,7 @@ should have multiple replicas when replicaCount is set:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -632,7 +632,7 @@ should mount ConfigMap for config in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -685,7 +685,7 @@ should mount ConfigMap for config in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -732,7 +732,7 @@ should mount ConfigMap for config in custom mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -774,7 +774,7 @@ should mount ConfigMap for config in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -828,7 +828,7 @@ should mount GCP credentials for initContainer in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -901,7 +901,7 @@ should mount GCP credentials in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -960,7 +960,7 @@ should mount TLS certs for initContainer when cert-manager is enabled:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1042,7 +1042,7 @@ should mount TLS certs when cert-manager is enabled:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1107,7 +1107,7 @@ should mount cert-manager TLS secret when highAvailability.certManager.enabled i
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1155,7 +1155,7 @@ should mount extraVolumes and extraVolumeMounts:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1205,7 +1205,7 @@ should mount tls.existingCASecretName and set environment when set in values:
       env:
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1264,7 +1264,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: some-value
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1318,7 +1318,7 @@ should mount tls.existingSecretName when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1366,7 +1366,7 @@ should not add PersistentVolumeClaim as volume when in custom mode and persisten
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1407,7 +1407,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1449,7 +1449,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1491,7 +1491,7 @@ should not add PersistentVolumeClaim as volume when in standalone mode and persi
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1574,7 +1574,7 @@ should not have more than one replica in standalone mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1628,7 +1628,7 @@ should not have strategy in AWS mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1681,7 +1681,7 @@ should not have strategy in GCP mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1728,7 +1728,7 @@ should not have strategy in custom mode:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1770,7 +1770,7 @@ should not mount TLS secrets when when highAvailability.certManager.enabled is f
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1824,7 +1824,7 @@ should not mount secret when credentialSecretName is blank in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1865,7 +1865,7 @@ should not set securityContext when is empty object (default value):
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1910,7 +1910,7 @@ should provision initContainer correctly when set in values:
       env:
       - name: SOME_ENVIRONMENT_VARIABLE
         value: some-value
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1986,7 +1986,7 @@ should set affinity when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2031,7 +2031,7 @@ should set environment when extraEnv set in values:
       env:
       - name: SOME_ENVIRONMENT_VARIABLE
         value: some-value
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2073,7 +2073,7 @@ should set imagePullPolicy when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -2115,7 +2115,7 @@ should set nodeSelector when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2160,7 +2160,7 @@ should set postStart command if set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       lifecycle:
         postStart:
@@ -2208,7 +2208,7 @@ should set priorityClassName when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2251,7 +2251,7 @@ should set probeTimeoutSeconds when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2303,7 +2303,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2344,7 +2344,7 @@ should set resources when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2393,7 +2393,7 @@ should set securityContext when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2454,7 +2454,7 @@ should set tolerations when set in values:
     containers:
     - args:
       - --diag-addr=0.0.0.0:3000
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/Chart.yaml
+++ b/examples/chart/teleport-kube-agent/Chart.yaml
@@ -1,4 +1,4 @@
-.version: &version "11.3.20"
+.version: &version "11.3.21"
 
 name: teleport-kube-agent
 apiVersion: v2

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/deployment_test.yaml.snap
@@ -30,7 +30,7 @@ sets Deployment annotations when specified if action is Upgrade:
             env:
             - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
               value: "true"
-            image: public.ecr.aws/gravitational/teleport:11.3.20
+            image: public.ecr.aws/gravitational/teleport:11.3.21
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -101,7 +101,7 @@ sets Deployment labels when specified if action is Upgrade:
           env:
           - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
             value: "true"
-          image: public.ecr.aws/gravitational/teleport:11.3.20
+          image: public.ecr.aws/gravitational/teleport:11.3.21
           imagePullPolicy: IfNotPresent
           livenessProbe:
             failureThreshold: 6
@@ -159,7 +159,7 @@ sets Pod annotations when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -217,7 +217,7 @@ sets Pod labels when specified if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -275,7 +275,7 @@ should add emptyDir for data when existingDataVolume is not set if action is Upg
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -334,7 +334,7 @@ should add insecureSkipProxyTLSVerify to args when set in values if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -392,7 +392,7 @@ should correctly configure existingDataVolume when set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -448,7 +448,7 @@ should expose diag port if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -518,7 +518,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -588,7 +588,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -646,7 +646,7 @@ should have one replica when replicaCount is not set if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -704,7 +704,7 @@ should mount extraVolumes and extraVolumeMounts if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -769,7 +769,7 @@ should mount tls.existingCASecretName and set environment when set in values if 
         value: "true"
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -837,7 +837,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: http://username:password@my.proxy.host:3128
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -901,7 +901,7 @@ should provision initContainer correctly when set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -995,7 +995,7 @@ should set SecurityContext if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1073,7 +1073,7 @@ should set affinity when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1131,7 +1131,7 @@ should set default serviceAccountName when not set in values if action is Upgrad
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1202,7 +1202,7 @@ should set environment when extraEnv set in values if action is Upgrade:
         value: "true"
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1318,7 +1318,7 @@ should set imagePullPolicy when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1376,7 +1376,7 @@ should set nodeSelector if set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1436,7 +1436,7 @@ should set not set priorityClassName when not set in values if action is Upgrade
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1506,7 +1506,7 @@ should set preferred affinity when more than one replica is used if action is Up
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1564,7 +1564,7 @@ should set priorityClassName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1623,7 +1623,7 @@ should set probeTimeoutSeconds when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1691,7 +1691,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set if
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1749,7 +1749,7 @@ should set resources when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1814,7 +1814,7 @@ should set serviceAccountName when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1872,7 +1872,7 @@ should set tolerations when set in values if action is Upgrade:
       env:
       - name: TELEPORT_INSTALL_METHOD_HELM_KUBE_AGENT
         value: "true"
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
+++ b/examples/chart/teleport-kube-agent/tests/__snapshot__/statefulset_test.yaml.snap
@@ -16,7 +16,7 @@ sets Pod annotations when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -84,7 +84,7 @@ sets Pod labels when specified:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -176,7 +176,7 @@ sets StatefulSet labels when specified:
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport:11.3.20
+            image: public.ecr.aws/gravitational/teleport:11.3.21
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -255,7 +255,7 @@ should add insecureSkipProxyTLSVerify to args when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -323,7 +323,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and action
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -411,7 +411,7 @@ should add volumeClaimTemplate for data volume when using StatefulSet and is Fre
                   fieldPath: metadata.namespace
             - name: RELEASE_NAME
               value: RELEASE-NAME
-            image: public.ecr.aws/gravitational/teleport:11.3.20
+            image: public.ecr.aws/gravitational/teleport:11.3.21
             imagePullPolicy: IfNotPresent
             livenessProbe:
               failureThreshold: 6
@@ -489,7 +489,7 @@ should add volumeMount for data volume when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -557,7 +557,7 @@ should expose diag port:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -625,7 +625,7 @@ should generate Statefulset when storage is disabled and mode is a Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -707,7 +707,7 @@ should have multiple replicas when replicaCount is set (using .replicaCount, dep
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -787,7 +787,7 @@ should have multiple replicas when replicaCount is set (using highAvailability.r
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -855,7 +855,7 @@ should have one replica when replicaCount is not set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -923,7 +923,7 @@ should install Statefulset when storage is disabled and mode is a Fresh Install:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -993,7 +993,7 @@ should mount extraVolumes and extraVolumeMounts:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1068,7 +1068,7 @@ should mount tls.existingCASecretName and set environment when set in values:
         value: RELEASE-NAME
       - name: SSL_CERT_FILE
         value: /etc/teleport-tls-ca/ca.pem
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1148,7 +1148,7 @@ should mount tls.existingCASecretName and set extra environment when set in valu
         value: /etc/teleport-tls-ca/ca.pem
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1224,7 +1224,7 @@ should not add emptyDir for data when using StatefulSet:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1292,7 +1292,7 @@ should provision initContainer correctly when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1396,7 +1396,7 @@ should set SecurityContext:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1484,7 +1484,7 @@ should set affinity when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1552,7 +1552,7 @@ should set default serviceAccountName when not set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1633,7 +1633,7 @@ should set environment when extraEnv set in values:
         value: RELEASE-NAME
       - name: HTTPS_PROXY
         value: http://username:password@my.proxy.host:3128
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1769,7 +1769,7 @@ should set imagePullPolicy when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 6
@@ -1837,7 +1837,7 @@ should set nodeSelector if set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1919,7 +1919,7 @@ should set preferred affinity when more than one replica is used:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -1987,7 +1987,7 @@ should set probeTimeoutSeconds when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2065,7 +2065,7 @@ should set required affinity when highAvailability.requireAntiAffinity is set:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2133,7 +2133,7 @@ should set resources when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2208,7 +2208,7 @@ should set serviceAccountName when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2276,7 +2276,7 @@ should set storage.requests when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2344,7 +2344,7 @@ should set storage.storageClassName when set in values and action is an Upgrade:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6
@@ -2412,7 +2412,7 @@ should set tolerations when set in values:
             fieldPath: metadata.namespace
       - name: RELEASE_NAME
         value: RELEASE-NAME
-      image: public.ecr.aws/gravitational/teleport:11.3.20
+      image: public.ecr.aws/gravitational/teleport:11.3.21
       imagePullPolicy: IfNotPresent
       livenessProbe:
         failureThreshold: 6

--- a/lib/auth/trustedcluster.go
+++ b/lib/auth/trustedcluster.go
@@ -652,7 +652,7 @@ func (a *Server) sendValidateRequestToProxy(host string, validateRequest *Valida
 		return nil, trace.Wrap(err)
 	}
 
-	var validateResponseRaw *ValidateTrustedClusterResponseRaw
+	var validateResponseRaw ValidateTrustedClusterResponseRaw
 	err = json.Unmarshal(out.Bytes(), &validateResponseRaw)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/client/redirect.go
+++ b/lib/client/redirect.go
@@ -196,13 +196,13 @@ func (rd *Redirector) issueSSOLoginConsoleRequest(req SSOLoginConsoleReq) (*SSOL
 		return nil, trace.Wrap(err)
 	}
 
-	var re *SSOLoginConsoleResponse
+	var re SSOLoginConsoleResponse
 	err = json.Unmarshal(out.Bytes(), &re)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	return re, nil
+	return &re, nil
 }
 
 // Done is called when redirector is closed
@@ -247,13 +247,13 @@ func (rd *Redirector) callback(w http.ResponseWriter, r *http.Request) (*auth.SS
 		return nil, trace.BadParameter("failed to decrypt response: in %v, err: %v", r.URL.String(), err)
 	}
 
-	var re *auth.SSHLoginResponse
+	var re auth.SSHLoginResponse
 	err = json.Unmarshal(plaintext, &re)
 	if err != nil {
 		return nil, trace.BadParameter("failed to decrypt response: in %v, err: %v", r.URL.String(), err)
 	}
 
-	return re, nil
+	return &re, nil
 }
 
 // Close closes redirector and releases all resources

--- a/lib/srv/desktop/tdp/proto.go
+++ b/lib/srv/desktop/tdp/proto.go
@@ -604,6 +604,8 @@ func DecodeMFA(in byteReader) (*MFA, error) {
 
 	if length > maxMFADataLength {
 		return nil, trace.BadParameter("mfa challenge data exceeds maximum length")
+	} else if length == 0 {
+		return nil, trace.BadParameter("mfa data missing")
 	}
 
 	b := make([]byte, int(length))
@@ -644,6 +646,8 @@ func DecodeMFAChallenge(in byteReader) (*MFA, error) {
 
 	if length > maxMFADataLength {
 		return nil, trace.BadParameter("mfa challenge data exceeds maximum length")
+	} else if length == 0 {
+		return nil, trace.BadParameter("mfa challenge data missing")
 	}
 
 	b := make([]byte, int(length))
@@ -651,17 +655,14 @@ func DecodeMFAChallenge(in byteReader) (*MFA, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	var req *client.MFAAuthenticateChallenge
+	var req client.MFAAuthenticateChallenge
 	if err := json.Unmarshal(b, &req); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
 	return &MFA{
 		Type:                     mt,
-		MFAAuthenticateChallenge: req,
+		MFAAuthenticateChallenge: &req,
 	}, nil
 }
 

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2463,7 +2463,7 @@ func (h *Handler) siteNodeConnect(
 	if params == "" {
 		return nil, trace.BadParameter("missing params")
 	}
-	var req *TerminalRequest
+	var req TerminalRequest
 	if err := json.Unmarshal([]byte(params), &req); err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -2490,13 +2490,13 @@ func (h *Handler) siteNodeConnect(
 
 	if req.SessionID.IsZero() {
 		// An existing session ID was not provided so we need to create a new one.
-		sessionData, err = h.generateSession(ctx, clt, req, clusterName, sessionCtx.cfg.User)
+		sessionData, err = h.generateSession(ctx, clt, &req, clusterName, sessionCtx.cfg.User)
 		if err != nil {
 			h.log.WithError(err).Debug("Unable to generate new ssh session.")
 			return nil, trace.Wrap(err)
 		}
 	} else {
-		sessionData, displayLogin, err = h.fetchExistingSession(ctx, clt, req, clusterName)
+		sessionData, displayLogin, err = h.fetchExistingSession(ctx, clt, &req, clusterName)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}

--- a/lib/web/cookie.go
+++ b/lib/web/cookie.go
@@ -42,11 +42,11 @@ func DecodeCookie(b string) (*SessionCookie, error) {
 	if err != nil {
 		return nil, err
 	}
-	var c *SessionCookie
+	var c SessionCookie
 	if err := json.Unmarshal(bytes, &c); err != nil {
 		return nil, err
 	}
-	return c, nil
+	return &c, nil
 }
 
 func SetSessionCookie(w http.ResponseWriter, user, sid string) error {

--- a/version.go
+++ b/version.go
@@ -3,7 +3,7 @@
 package teleport
 
 const (
-	Version = "11.3.20"
+	Version = "11.3.21"
 )
 
 // Gitref variable is automatically set to the output of git-describe


### PR DESCRIPTION
* Fixed S3 metric name for completed multipart uploads. [#30712](https://github.com/gravitational/teleport/pull/30712)
* Fixed Teleport Connect to properly show errors from the remote end. [#30694](https://github.com/gravitational/teleport/pull/30694)
* Fixed Review Requests to disallow reviews after request is resolved. [#30688](https://github.com/gravitational/teleport/pull/30688)
* Fixed Discovery service panics on GKE clusters without labels. [#30648](https://github.com/gravitational/teleport/pull/30648)
* Fixed memory leak using PAM libraries. [#30519](https://github.com/gravitational/teleport/pull/30519)
* Fixed "user is not managed" error when accessing ElastiCache and MemoryDB. [#30358](https://github.com/gravitational/teleport/pull/30358)
* Fixed resources being deleted from Firestore on update. [#30289](https://github.com/gravitational/teleport/pull/30289)
* Updated LDAP desktop discovery to handle slow DNS queries better. [#30465](https://github.com/gravitational/teleport/pull/30465)
* Updated SAML certificate parsing to allow leading/trailing spaces. [#30452](https://github.com/gravitational/teleport/pull/30452)
* Improved audit logging support for large SQL Server queries. [#30245](https://github.com/gravitational/teleport/pull/30245)
* Explicitly mention _registered_ and _new_ device when running `tsh mfa add` on Windows. [#30217](https://github.com/gravitational/teleport/pull/30217)
* Tighten discovery service permissions. [#29996](https://github.com/gravitational/teleport/pull/29996)
* helm: Add support for custom annodations in the teleport-kube-agent Secret. [#30840](https://github.com/gravitational/teleport/pull/30840)

### Security fix

* Security improvements with possible `medium` severity DoS conditions through protocol level attacks. [#30854](https://github.com/gravitational/teleport/pull/30854)