### PR TITLE
Log and ignore access denied errors when removing token after successful cluster join

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.test.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from 'design/utils/testing';
+import { AttemptStatus } from 'shared/hooks/useAsync';
+
+import {
+  makeLoggedInUser,
+  makeRootCluster,
+  makeServer,
+} from 'teleterm/services/tshd/testHelpers';
+import { MockAppContextProvider } from 'teleterm/ui/fixtures/MockAppContextProvider';
+import { MockWorkspaceContextProvider } from 'teleterm/ui/fixtures/MockWorkspaceContextProvider';
+import { MockAppContext } from 'teleterm/ui/fixtures/mocks';
+import Logger, { NullService } from 'teleterm/logger';
+
+import * as connectMyComputerContext from '../connectMyComputerContext';
+
+import { DocumentConnectMyComputerSetup } from './DocumentConnectMyComputerSetup';
+
+beforeAll(() => {
+  Logger.init(new NullService());
+});
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('documentConnectMyComputerSetup', () => {
+  const tests: Array<{
+    name: string;
+    expectedStatus: AttemptStatus;
+    mockAppContext?: (appContext: MockAppContext) => void;
+  }> = [
+    {
+      name: 'ignores access denied errors from deleting the token',
+      expectedStatus: 'success',
+      // TODO(ravicious): In the future, it's probably better to make default mocks set up a happy
+      // path and then use mockAppContext to reset any mocks that should behave differently for this
+      // particular test.
+      mockAppContext: appContext => {
+        jest
+          .spyOn(appContext.connectMyComputerService, 'deleteToken')
+          .mockRejectedValue(new Error('7 PERMISSION_DENIED: access denied'));
+      },
+    },
+    {
+      name: 'does not ignore other errors when deleting the token',
+      expectedStatus: 'error',
+      mockAppContext: appContext => {
+        jest
+          .spyOn(appContext.connectMyComputerService, 'deleteToken')
+          .mockRejectedValue(new Error('unknown error'));
+      },
+    },
+  ];
+  test.each(tests)('$name', async ({ expectedStatus, mockAppContext }) => {
+    const cluster = makeRootCluster({
+      loggedInUser: makeLoggedInUser({
+        acl: {
+          tokens: {
+            create: true,
+            list: true,
+            read: true,
+            edit: true,
+            pb_delete: true,
+            use: true,
+          },
+        },
+      }),
+    });
+    const doc = {
+      kind: 'doc.connect_my_computer_setup' as const,
+      rootClusterUri: cluster.uri,
+      title: '',
+      uri: '/docs/123' as const,
+    };
+    const appContext = new MockAppContext({});
+    appContext.clustersService.state.clusters.set(cluster.uri, cluster);
+    appContext.workspacesService.setState(draftState => {
+      draftState.rootClusterUri = cluster.uri;
+      draftState.workspaces[cluster.uri] = {
+        localClusterUri: cluster.uri,
+        documents: [doc],
+        location: doc.uri,
+        accessRequests: undefined,
+      };
+    });
+
+    jest
+      .spyOn(appContext.mainProcessClient, 'isAgentConfigFileCreated')
+      .mockResolvedValue(false);
+    jest
+      .spyOn(appContext.connectMyComputerService, 'createRole')
+      .mockResolvedValue({ certsReloaded: false });
+    jest
+      .spyOn(appContext.connectMyComputerService, 'createAgentConfigFile')
+      .mockResolvedValue({ token: '1234' });
+    jest
+      .spyOn(appContext.connectMyComputerService, 'runAgent')
+      .mockResolvedValue();
+    jest
+      .spyOn(appContext.connectMyComputerService, 'waitForNodeToJoin')
+      .mockResolvedValue(makeServer());
+
+    mockAppContext?.(appContext);
+
+    render(
+      <MockAppContextProvider appContext={appContext}>
+        <MockWorkspaceContextProvider rootClusterUri={cluster.uri}>
+          <connectMyComputerContext.ConnectMyComputerContextProvider
+            rootClusterUri={cluster.uri}
+          >
+            <DocumentConnectMyComputerSetup visible={true} doc={doc} />
+          </connectMyComputerContext.ConnectMyComputerContextProvider>
+        </MockWorkspaceContextProvider>
+      </MockAppContextProvider>
+    );
+
+    screen.getByText('Connect').click();
+
+    const step = await screen.findByTestId('Joining the cluster');
+
+    await waitFor(
+      () => expect(step).toHaveAttribute('data-teststatus', expectedStatus),
+      // This makes debugging easier, as the error output will show the DOM for this step only.
+      { container: step }
+    );
+  });
+});

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -209,6 +209,7 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
           // the user may not have permissions to remove the token, but it will expire in a few minutes anyway
           if (isAccessDeniedError(error)) {
             logger.error('Access denied when deleting a token.', error);
+            return;
           }
           throw error;
         }
@@ -331,7 +332,13 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
         `}
       >
         {steps.map(step => (
-          <Flex key={step.name} alignItems="baseline" gap={2}>
+          <Flex
+            key={step.name}
+            alignItems="baseline"
+            gap={2}
+            data-testid={step.name}
+            data-teststatus={step.attempt.status}
+          >
             {step.attempt.status === '' && <CirclePlay />}
             {step.attempt.status === 'processing' && (
               <Spinner


### PR DESCRIPTION
The RFD says:

https://github.com/gravitational/teleport/blob/master/rfd/0133-connect-my-computer.md#join-token

> The token is created with a TTL of 5 minutes. In the absence of https://github.com/gravitational/teleport/issues/7133, Connect will attempt to remove the token with the DeleteToken RPC after a successful join. As the permission to remove tokens is not necessarily tied to the ability to create tokens, we will log and ignore any errors from this call and depend on the short TTL in that scenario.

We did log the error, but we forgot to return early. This PR adds this single return and tests for both branches.

---

After you click Connect and begin the Connect My Computer setup, there are four `useAsync` attempts displayed as separate steps on the setup page. The test works by starting the setup and then simply waiting for the "Joining the cluster" step to change its status to the expected status.

In the future, this can be easily extended to other steps.