### PR TITLE
Completely hide the assist terminal window when not visible

### DIFF
--- a/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssist.tsx
+++ b/web/packages/teleport/src/Console/DocumentSsh/TerminalAssist/TerminalAssist.tsx
@@ -94,6 +94,7 @@ const ChatContainer = styled.div`
   transition: ${p => (p.visible ? 'opacity 0.5s ease-in-out' : 'none')};
   transition-delay: 0.2s;
   box-sizing: border-box;
+  visibility: ${p => (p.visible ? 'visible' : 'hidden')};
 `;
 
 const Header = styled.header`


### PR DESCRIPTION
The window was previously visible on screen with 0 opacity, so you could still click on the button to use a command when the chat window was open.

This changes the visibility to be hidden when the chat window has been closed.