### PR TITLE
Support assume role for dynamic resources for 'teleport db configure create'

### DIFF
--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -66,12 +66,26 @@ db_service:
 	{{- range $name, $value := $resourceLabel }}
       "{{ $name }}": "{{ $value }}"
     {{- end }}
+    {{- if $.DatabaseAWSAssumeRoleARN }}
+    aws:
+      {{- if $.DatabaseAWSAssumeRoleARN }}
+      assume_role_arn: "{{ $.DatabaseAWSAssumeRoleARN }}"
+      {{- end }}
+      {{- if $.DatabaseAWSExternalID }}
+      external_id: "{{ $.DatabaseAWSExternalID }}"
+      {{- end }}
+    {{- end }}
   {{- end }}
   {{- else }}
   #
   # resources:
   # - labels:
   #     "env": "dev"
+  #  # Optional AWS role that the Database Service will assume to access the
+  #  # databases.
+  #  aws:
+  #    assume_role_arn: "arn:aws:iam::123456789012:role/example-role-name"
+  #    external_id: "example-external-id"
   {{- end }}
 
   # Matchers for registering AWS-hosted databases.

--- a/lib/config/database.go
+++ b/lib/config/database.go
@@ -81,11 +81,11 @@ db_service:
   # resources:
   # - labels:
   #     "env": "dev"
-  #  # Optional AWS role that the Database Service will assume to access the
-  #  # databases.
-  #  aws:
-  #    assume_role_arn: "arn:aws:iam::123456789012:role/example-role-name"
-  #    external_id: "example-external-id"
+  #   # Optional AWS role that the Database Service will assume to access the
+  #   # databases.
+  #   aws:
+  #     assume_role_arn: "arn:aws:iam::123456789012:role/example-role-name"
+  #     external_id: "example-external-id"
   {{- end }}
 
   # Matchers for registering AWS-hosted databases.

--- a/lib/config/database_test.go
+++ b/lib/config/database_test.go
@@ -539,6 +539,28 @@ func TestMakeDatabaseConfig(t *testing.T) {
 				},
 			}, databases.ResourceMatchers)
 		})
+
+		t.Run("assume role", func(t *testing.T) {
+			flags := DatabaseSampleFlags{
+				DynamicResourcesRawLabels: []string{
+					"env=dev",
+				},
+				DatabaseAWSAssumeRoleARN: "arn:aws:iam::123456789012:role/DBAccess",
+				DatabaseAWSExternalID:    "externalID123",
+			}
+			databases := generateAndParseConfig(t, flags)
+			require.Equal(t, []ResourceMatcher{
+				{
+					Labels: types.Labels{
+						"env": apiutils.Strings{"dev"},
+					},
+					AWS: ResourceMatcherAWS{
+						AssumeRoleARN: "arn:aws:iam::123456789012:role/DBAccess",
+						ExternalID:    "externalID123",
+					},
+				},
+			}, databases.ResourceMatchers)
+		})
 	})
 }
 


### PR DESCRIPTION
Minor UX improvement. Found while writing new DB access guides that `--aws-assume-role-arn` does not work with `teleport db configure create --dynamic-resources-labels`. 


```
$ teleport db configure create --dynamic-resources-labels env=prod --aws-assume-role-arn arn:aws:iam::123123123123:role/aaaa --aws-external-id external-id

#
# Teleport database agent configuration file.
# Configuration reference: https://goteleport.com/docs/database-access/reference/configuration/
#
version: v3
teleport:
  nodename: "STeves-MacBook-Pro.local"
  data_dir: "/var/lib/teleport"
  proxy_server: "0.0.0.0:3080"
  auth_token: "/tmp/token"

db_service:
  enabled: true

  # Matchers for database resources created with "tctl create" command or by the discovery service.
  # For more information about dynamic registration: https://goteleport.com/docs/database-access/guides/dynamic-registration/
  resources:
  - labels:
      "env": "prod"
    aws:
      assume_role_arn: "arn:aws:iam::123123123123:role/aaaa"
      external_id: "external-id"
...
```