### PR TITLE
reduce alert log spam

### DIFF
--- a/lib/auth/auth.go
+++ b/lib/auth/auth.go
@@ -1140,7 +1140,7 @@ func (a *Server) handleUpgradeEnrollPrompt(ctx context.Context, msg string, shou
 	const alertTTL = time.Minute * 30
 
 	if !shouldPrompt {
-		if err := a.DeleteClusterAlert(ctx, upgradeEnrollAlertID); err != nil {
+		if err := a.DeleteClusterAlert(ctx, upgradeEnrollAlertID); err != nil && !trace.IsNotFound(err) {
 			log.Warnf("Failed to delete %s alert: %v", upgradeEnrollAlertID, err)
 		}
 		return


### PR DESCRIPTION
Fixes an issue where logs were frequently peppered with `NotFound` errors from alert cleanup logic.