### PR TITLE
assist: Implement audit query generation tool

### DIFF
--- a/gen/go/eventschema/getters.go
+++ b/gen/go/eventschema/getters.go
@@ -207,3 +207,12 @@ func sqlFieldName(path []string) string {
 func viewSchemaLine(jsonField, viewField, fieldType string) string {
 	return fmt.Sprintf("  , CAST(json_extract(event_data, '%s') AS %s) as %s\n", jsonField, fieldType, viewField)
 }
+
+func IsValidEventType(input string) bool {
+	for _, eventType := range eventTypes {
+		if input == eventType {
+			return true
+		}
+	}
+	return false
+}

--- a/gen/go/eventschema/getters.go
+++ b/gen/go/eventschema/getters.go
@@ -208,6 +208,7 @@ func viewSchemaLine(jsonField, viewField, fieldType string) string {
 	return fmt.Sprintf("  , CAST(json_extract(event_data, '%s') AS %s) as %s\n", jsonField, fieldType, viewField)
 }
 
+// IsValidEventType takes a string and returns whether it represents a valid event type.
 func IsValidEventType(input string) bool {
 	for _, eventType := range eventTypes {
 		if input == eventType {

--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gravitational/teleport/lib/ai/model"
 	"github.com/gravitational/teleport/lib/ai/model/output"
 	"github.com/gravitational/teleport/lib/ai/model/tools"
+	"github.com/gravitational/teleport/lib/ai/testutils"
 	"github.com/gravitational/teleport/lib/modules"
 )
 
@@ -315,4 +316,44 @@ func generateAccessRequestResponse(t *testing.T) string {
 	dataBytes = append(dataBytes, []byte("data: [DONE]\n\n")...)
 
 	return string(dataBytes)
+}
+
+func TestChat_Complete_AuditQuery(t *testing.T) {
+	// Test setup: generate the responses that will be served by our OpenAI mock
+	action := model.PlanOutput{
+		Action:      "Audit Query Generation",
+		ActionInput: "Lists user who connected to a server as root.",
+		Reasoning:   "foo",
+	}
+	selectedAction, err := json.Marshal(action)
+	require.NoError(t, err)
+	generatedQuery := "SELECT user FROM session_start WHERE login='root'"
+
+	responses := []string{
+		// The model must select the audit query tool
+		string(selectedAction),
+		// Then the audit query tool chooses to request session.start events
+		"session.start",
+		// Finally the tool builds a query based on the provided schemas
+		generatedQuery,
+	}
+	server := httptest.NewServer(testutils.GetTestHandlerFn(t, responses))
+	t.Cleanup(server.Close)
+
+	cfg := openai.DefaultConfig("secret-test-token")
+	cfg.BaseURL = server.URL
+
+	client := NewClientFromConfig(cfg)
+
+	// End of test setup, we run the agent
+	chat := client.NewAuditQuery("bob")
+
+	ctx := context.Background()
+	result, _, err := chat.Complete(ctx, "List users who connected to a server as root", func(action *model.AgentAction) {})
+	require.NoError(t, err)
+
+	// We check that the agent returns the expected response
+	message, ok := result.(*output.Message)
+	require.True(t, ok)
+	require.Equal(t, generatedQuery, message.Content)
 }

--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -349,6 +349,9 @@ func TestChat_Complete_AuditQuery(t *testing.T) {
 	chat := client.NewAuditQuery("bob")
 
 	ctx := context.Background()
+	// We insert a message to make the conversation not empty and skip the
+	// greeting message.
+	chat.Insert(openai.ChatMessageRoleUser, "Hello")
 	result, _, err := chat.Complete(ctx, "List users who connected to a server as root", func(action *model.AgentAction) {})
 	require.NoError(t, err)
 

--- a/lib/ai/client.go
+++ b/lib/ai/client.go
@@ -64,9 +64,7 @@ func (client *Client) NewChat(toolContext *modeltools.ToolContext) *Chat {
 		tools = append(tools, &modeltools.AccessRequestCreateTool{},
 			&modeltools.AccessRequestsListTool{},
 			&modeltools.AccessRequestListRequestableRolesTool{},
-			&modeltools.AccessRequestListRequestableResourcesTool{},
-			&modeltools.AuditQueryGenerationTool{LLM: client.svc},
-		)
+			&modeltools.AccessRequestListRequestableResourcesTool{})
 	}
 
 	return &Chat{
@@ -98,6 +96,20 @@ func (client *Client) NewCommand(username string) *Chat {
 		// Cl100k is used by GPT-3 and GPT-4.
 		tokenizer: codec.NewCl100kBase(),
 		agent:     model.NewAgent(toolContext, &modeltools.CommandGenerationTool{}),
+	}
+}
+
+func (client *Client) NewAuditQuery(username string) *Chat {
+	toolContext := &modeltools.ToolContext{User: username}
+	return &Chat{
+		client: client,
+		messages: []openai.ChatCompletionMessage{
+			{
+				Role:    openai.ChatMessageRoleSystem,
+				Content: model.PromptCharacter(username),
+			},
+		},
+		agent: model.NewAgent(toolContext, &modeltools.AuditQueryGenerationTool{LLM: client.svc}),
 	}
 }
 

--- a/lib/ai/client.go
+++ b/lib/ai/client.go
@@ -64,7 +64,9 @@ func (client *Client) NewChat(toolContext *modeltools.ToolContext) *Chat {
 		tools = append(tools, &modeltools.AccessRequestCreateTool{},
 			&modeltools.AccessRequestsListTool{},
 			&modeltools.AccessRequestListRequestableRolesTool{},
-			&modeltools.AccessRequestListRequestableResourcesTool{})
+			&modeltools.AccessRequestListRequestableResourcesTool{},
+			&modeltools.AuditQueryGenerationTool{LLM: client.svc},
+		)
 	}
 
 	return &Chat{

--- a/lib/ai/model/agent.go
+++ b/lib/ai/model/agent.go
@@ -253,6 +253,22 @@ func (a *Agent) takeNextStep(ctx context.Context, state *executionState, progres
 
 		log.Tracef("agent decided on command generation, let's translate to an agentFinish")
 		return stepOutput{finish: &agentFinish{output: completion}}, nil
+	case *tools.AuditQueryGenerationTool:
+		log.Tracef("Tool called with input:'%s'", action.Input)
+		tableName, err := tool.ChooseEventTable(ctx, action.Input, state.tokenCount)
+		if err != nil {
+			return stepOutput{}, trace.Wrap(err)
+		}
+
+		log.Tracef("Tool chose to query table '%s'", tableName)
+		query, err := tool.GenerateQuery(ctx, tableName, action.Input, state.tokenCount)
+		if err != nil {
+			return stepOutput{}, trace.Wrap(err)
+		}
+		log.Tracef("Tool generated query: %s", query)
+
+		completion := &output.Message{Content: fmt.Sprintf("You must run the query:\n\n```sql\n%s\n```", query)}
+		return stepOutput{finish: &agentFinish{output: completion}}, nil
 	default:
 		runOut, err := tool.Run(ctx, a.toolCtx, action.Input)
 		if err != nil {

--- a/lib/ai/model/tools/auditquery.go
+++ b/lib/ai/model/tools/auditquery.go
@@ -89,7 +89,6 @@ You MUST RESPOND ONLY with a single table name. If no table can answer the quest
 			Temperature: 0,
 		},
 	)
-
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -157,7 +156,6 @@ Today's date is DATE('%s')`, time.Now().Format("2006-01-02")),
 			Temperature: 0,
 		},
 	)
-
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/lib/ai/model/tools/auditquery.go
+++ b/lib/ai/model/tools/auditquery.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package tools
 
 import (

--- a/lib/ai/model/tools/auditquery.go
+++ b/lib/ai/model/tools/auditquery.go
@@ -1,0 +1,151 @@
+package tools
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gravitational/trace"
+	"github.com/sashabaranov/go-openai"
+
+	"github.com/gravitational/teleport/gen/go/eventschema"
+	"github.com/gravitational/teleport/lib/ai/tokens"
+)
+
+type AuditQueryGenerationTool struct {
+	LLM *openai.Client
+}
+
+func (t *AuditQueryGenerationTool) Name() string {
+	return "Audit Query Generation"
+}
+
+func (t *AuditQueryGenerationTool) Description() string {
+	return `Generates a SQL query that can be ran against teleport audit events.
+The input must be a single string describing what the query must achieve.`
+}
+
+func (t *AuditQueryGenerationTool) Run(_ context.Context, _ *ToolContext, _ string) (string, error) {
+	// This is stubbed because AuditQueryGenerationTool is handled specially.
+	// This is because execution of this tool breaks the loop and returns a command suggestion to the user.
+	// It is still handled as a tool because testing has shown that the LLM behaves better when it is treated as a tool.
+	//
+	// In addition, treating it as a Tool interface item simplifies the display and prompt assembly logic significantly.
+	return "", trace.NotImplemented("not implemented")
+}
+
+func (t *AuditQueryGenerationTool) ChooseEventTable(ctx context.Context, input string, tc *tokens.TokenCount) (string, error) {
+	tableList, err := eventschema.QueryableEventList()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	prompt := []openai.ChatCompletionMessage{
+		{
+			Role: openai.ChatMessageRoleSystem,
+			Content: `You are a tool that find the correct table to run a query on.
+You will be given a list of tables, and a request from the user.
+You MUST RESPOND ONLY with a single table name. If no table can answer the question, respond 'none'.`,
+		},
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: tableList,
+		},
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: fmt.Sprintf("The user request is: %s", input),
+		},
+	}
+	promptTokens, err := tokens.NewPromptTokenCounter(prompt)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	tc.AddPromptCounter(promptTokens)
+
+	response, err := t.LLM.CreateChatCompletion(
+		ctx,
+		openai.ChatCompletionRequest{
+			Model:       openai.GPT4,
+			Messages:    prompt,
+			Temperature: 0,
+		},
+	)
+
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	completion := response.Choices[0].Message.Content
+	completionTokens, err := tokens.NewSynchronousTokenCounter(completion)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	tc.AddCompletionCounter(completionTokens)
+
+	eventType := strings.ToLower(completion)
+	if !eventschema.IsValidEventType(eventType) {
+		return "", trace.CompareFailed("Model response is not a valid event type: '%s'", eventType)
+	}
+
+	return eventType, nil
+
+}
+
+func (t *AuditQueryGenerationTool) GenerateQuery(ctx context.Context, eventType, input string, tc *tokens.TokenCount) (string, error) {
+	// get query
+	eventSchema, err := eventschema.GetEventSchemaFromType(eventType)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	tableSchema, err := eventSchema.TableSchema()
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	prompt := []openai.ChatCompletionMessage{
+		{
+			Role: openai.ChatMessageRoleSystem,
+			Content: fmt.Sprintf(`You are a tool that generates Athena SQL queries to inspect audit events.
+You will be given the schema of a table and a user request.
+You MUST RESPOND ONLY with an SQL query that answers the user request.
+If the request cannot be answered, respond 'none'.
+Today's date is DATE('%s')`, time.Now().Format("2006-01-02")),
+		},
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: fmt.Sprintf("The schema of the table `%s` is:\n\n%s", eventType, tableSchema),
+		},
+		{
+			Role:    openai.ChatMessageRoleUser,
+			Content: fmt.Sprintf("The user request is: %s", input),
+		},
+	}
+	promptTokens, err := tokens.NewPromptTokenCounter(prompt)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	tc.AddPromptCounter(promptTokens)
+
+	response, err := t.LLM.CreateChatCompletion(
+		ctx,
+		openai.ChatCompletionRequest{
+			Model:       openai.GPT4,
+			Messages:    prompt,
+			Temperature: 0,
+		},
+	)
+
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	completion := response.Choices[0].Message.Content
+	completionTokens, err := tokens.NewSynchronousTokenCounter(completion)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	tc.AddCompletionCounter(completionTokens)
+
+	return completion, nil
+}

--- a/lib/ai/model/tools/auditquery.go
+++ b/lib/ai/model/tools/auditquery.go
@@ -60,7 +60,7 @@ func (t *AuditQueryGenerationTool) ChooseEventTable(ctx context.Context, input s
 	prompt := []openai.ChatCompletionMessage{
 		{
 			Role: openai.ChatMessageRoleSystem,
-			Content: `You are a tool that find the correct table to run a query on.
+			Content: `Your job it to find the correct table to run a query on.
 You will be given a list of tables, and a request from the user.
 You MUST RESPOND ONLY with a single table name. If no table can answer the question, respond 'none'.`,
 		},


### PR DESCRIPTION
This PR implements the audit query generation tool. The tool is invoked with a single string input like `List all users who connected to serverX yesterday` and returns a text message with the equivalent SQL query.

Adding a dedicated output type (like for command execution and other agent-stopping plugins) will happen in a subsequent PR for the sake of reviewability.