### PR TITLE
[v11] Remove ScopedBlocks from the docs

### DIFF
--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-discord.mdx
@@ -352,9 +352,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-email.mdx
@@ -38,20 +38,23 @@ in your Teleport cluster.
 
 ## Step 2/7. Install the Teleport email plugin
 
-<ScopedBlock scope={["enterprise", "oss"]}>
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
 We recommend installing Teleport plugins on the same host as the Teleport Proxy
 Service. This is an ideal location as plugins have a low memory footprint, and
 will require both public internet access and Teleport Auth Service access. 
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope="cloud">
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Install the Teleport email plugin on a host that can access both your
 Teleport Cloud tenant and your SMTP service.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Details title="Using a local SMTP server?">
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -344,9 +344,7 @@ Requests, you should still check the Teleport audit log to ensure that the right
 users are reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-mattermost.mdx
@@ -30,20 +30,23 @@ Requests in the Proxy or Auth Service.
 
 ## Step 2/8. Install the Teleport Mattermost plugin
 
-<ScopedBlock scope={["enterprise", "oss"]}>
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
 We recommend installing Teleport plugins on the same host as the Teleport Proxy
 Service. This is an ideal location as plugins have a low memory footprint, and
 will require both public internet access and Teleport Auth Service access.
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope="cloud">
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Install the Teleport Mattermost plugin on a host that can access both your
 Teleport Proxy Service and your Mattermost deployment.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Tabs>
 <TabItem label="Download">

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-msteams.mdx
@@ -400,9 +400,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -287,8 +287,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will need to request the credentials manually by *impersonating* the
 `access-plugin` role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise cluster and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `access-plugin`, define a role
 called `access-plugin-impersonator` by pasting the following YAML document into
@@ -599,9 +600,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-pagerduty.mdx
@@ -32,20 +32,23 @@ PagerDuty.
 
 - Either a Linux host or Kubernetes cluster where you will run the PagerDuty plugin.
 
-<ScopedBlock scope={["enterprise", "oss"]}>
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
 We recommend installing Teleport plugins on the same host as the Teleport Proxy
 Service. This is an ideal location as plugins have a low memory footprint, and
 will require both public internet access and Teleport Auth Service access.
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope="cloud">
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Install the Teleport PagerDuty plugin on a host that can access both your
 Teleport Cloud tenant and PagerDuty.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 (!docs/pages/includes/tctl.mdx!)
 

--- a/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
+++ b/docs/pages/access-controls/access-request-plugins/ssh-approval-slack.mdx
@@ -405,9 +405,7 @@ should still check the Teleport audit log to ensure that the right users are
 reviewing the right requests.
 
 When auditing Access Request reviews, check for events with the type `Access
-Request Reviewed` in the Teleport Web UI <ScopedBlock scope={["oss",
-"enterprise"]}>and `access_request.review` if reviewing the audit log on the
-Auth Service host</ScopedBlock>.
+Request Reviewed` in the Teleport Web UI.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -14,15 +14,11 @@ under the hood.
 The Access Request API makes it easy to dynamically approve or deny these
 requests.
 
-<ScopedBlock scope={["oss"]}>
-
 Just-in-time Access Requests are a feature of Teleport Enterprise.
 Open-source Teleport users can get a preview of how Access Requests work by
 requesting a role via the Teleport CLI. Full Access Request functionality,
 including Resource Access Requests and an intuitive and searchable UI are
 available in Teleport Enterprise.
-
-</ScopedBlock>
 
 ## Prerequisites
 

--- a/docs/pages/access-controls/compliance-frameworks/soc2.mdx
+++ b/docs/pages/access-controls/compliance-frameworks/soc2.mdx
@@ -7,14 +7,6 @@ h1: SOC 2 Compliance for SSH, Kubernetes, Databases, Desktops, and Web Apps
 Teleport is designed to meet SOC 2 requirements for the purposes of accessing infrastructure, change management, and system operations. This document outlines a high
 level overview of how Teleport can be used to help your company to become SOC 2 compliant.
 
-<ScopedBlock
-  scope={["oss"]}
->
-
-  This guide requires Teleport Cloud or Teleport Enterprise.
-
-</ScopedBlock>
-
 ## Achieving SOC 2 Compliance with Teleport
 SOC 2 or Service Organization Controls were developed by the American Institute of CPAs (AICPA). They are based on five trust services criteria: security, availability, processing integrity, confidentiality, and privacy.
 

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -207,3 +207,4 @@ $ tctl get roles --format text
 
 - [Mapping SSO and local users traits with role templates](./guides/role-templates.mdx)
 - [Create certs for CI/CD using impersonation](./guides/impersonation.mdx)
+

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -56,7 +56,8 @@ will be able to act as a system administrator and auditor at the same time.
 Next, follow the instructions to set up an authentication connector that maps
 users within your SSO solution to Teleport roles.
 
-  <ScopedBlock scope={["oss"]}>
+<Tabs>
+  <TabItem label="Teleport Community Edition" scope={["oss"]}>
 
     Save the file below as `github.yaml` and update the fields. You will need to
     set up a
@@ -93,9 +94,9 @@ users within your SSO solution to Teleport roles.
     $ tctl create github.yaml
     ```
 
-  </ScopedBlock>
+  </TabItem>
 
-  <ScopedBlock scope={["enterprise", "cloud"]}>
+  <TabItem label="Commercial Editions"  scope={["enterprise", "cloud"]}>
 
   Create a SAML or OIDC application that Teleport can integrate with, then
   create an authentication connector that maps users within your application to
@@ -152,7 +153,8 @@ users within your SSO solution to Teleport roles.
   </TabItem>
   </Tabs>
 
-  </ScopedBlock>
+  </TabItem>
+</Tabs>
 
 ## Step 3/3. Create a custom role
 

--- a/docs/pages/access-controls/guides/dual-authz.mdx
+++ b/docs/pages/access-controls/guides/dual-authz.mdx
@@ -13,13 +13,10 @@ Here are the most common scenarios:
 In this guide, we will set up Teleport's Just-in-Time Access Requests to require the approval
 of two team members for a privileged role `dbadmin`.
 
-<ScopedBlock scope="oss">
 
-  This guide requires a commercial edition of Teleport. The open source
-  edition of Teleport only supports [GitHub](../../access-controls/sso/github-sso.mdx) as
-  an SSO provider.
-
-</ScopedBlock>
+This guide requires a commercial edition of Teleport. The open source edition of
+Teleport only supports [GitHub](../../access-controls/sso/github-sso.mdx) as an
+SSO provider.
 
 <Admonition title="Note" type="tip">
   The steps below describe how to use Teleport with Mattermost. You can also [integrate with many other providers](../access-requests.mdx).
@@ -209,14 +206,9 @@ Bob can also assume granted Access Request roles using Web UI:
 
 ![Teleport Assume](../../../img/access-controls/dual-authz/teleport-7-bob-assume.png)
 
-
-{/* TODO: This H2 will show up in the table of contents when this section is invisible.
-We need a way to hide invisible H2s from the TOC. */}
-<ScopedBlock scope={["oss", "enterprise"]}>
-
 ## Troubleshooting
 
-### Cert errors in self-hosted deployments
+### Certificate errors in self-hosted deployments
 
 You may be getting certificate errors if Teleport's Auth Service is missing an address in the server certificate:
 
@@ -234,5 +226,3 @@ To fix the problem, update the Auth Service with a public address, and restart T
 auth_service:
   public_addr: ['localhost:3025', 'example.com:3025']
 ```
-
-</ScopedBlock>

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -145,7 +145,7 @@ $ tsh login --user=dev --proxy=proxy.example.com:3080
 
 ```
 
-</ScopedBlock>
+</TabItem>
 
 <ScopedBlock scope={["cloud"]}>
 
@@ -162,7 +162,9 @@ $ tsh login --user=dev --proxy=proxy.example.com:3080
 #   ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Affected users with existing sessions that aren't backed by a hardware key are prompted to sign in again
 on their next request. For example:

--- a/docs/pages/access-controls/guides/hardware-key-support.mdx
+++ b/docs/pages/access-controls/guides/hardware-key-support.mdx
@@ -129,26 +129,6 @@ role or to that cluster must use their hardware key for all Teleport requests.
 Affected users will be prompted to connect and touch their YubiKey to sign in. 
 The first time users sign in with their hardware key they might be required to immediately sign in again.
 
-<ScopedBlock scope={["oss","enterprise"]}>
-
-```code
-$ tsh login --user=dev --proxy=proxy.example.com:3080
-# Enter password for Teleport user dev:
-# Unmet private key policy "hardware_key_touch".
-# Relogging in with hardware-backed private key.
-# Enter password for Teleport user dev:
-# Tap your YubiKey
-# > Profile URL:        https://example.com
-#   Logged in as:       dev
-#   Cluster:            example.com
-#   ...
-
-```
-
-</TabItem>
-
-<ScopedBlock scope={["cloud"]}>
-
 ```code
 $ tsh login --user=dev --proxy=proxy.example.com:3080
 # Enter password for Teleport user dev:
@@ -161,10 +141,6 @@ $ tsh login --user=dev --proxy=proxy.example.com:3080
 #   Cluster:            example.com
 #   ...
 ```
-
-</TabItem>
-
-</Tabs>
 
 Affected users with existing sessions that aren't backed by a hardware key are prompted to sign in again
 on their next request. For example:

--- a/docs/pages/access-controls/guides/impersonation.mdx
+++ b/docs/pages/access-controls/guides/impersonation.mdx
@@ -118,22 +118,25 @@ $ tctl users add alice  --roles=impersonator,access
 
 Alice can log in using `tsh` and issue a cert for `jenkins`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=proxy.example.com --user=alice --auth=local
 $ tctl auth sign --user=jenkins --format=openssh --out=jenkins --ttl=240h
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice --auth=local
 $ tctl auth sign --user=jenkins --format=openssh --out=jenkins --ttl=240h
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Here is an example of how Alice can use the keys:
 
@@ -310,7 +313,8 @@ scanner.
 
 Alice will need to log in again to receive the newly updated traits:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Once Alice logs in again, she will receive a new certificate with updated roles.
@@ -319,8 +323,8 @@ $ tsh login --proxy=teleport.example.com --user=alice --auth=local
 $ tctl auth sign --user=security-scanner --format=openssh --out=security-scanner --ttl=10h
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Once Alice logs in again, she will receive a new certificate with updated roles.
@@ -329,7 +333,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=alice --auth=local
 $ tctl auth sign --user=security-scanner --format=openssh --out=security-scanner --ttl=10h
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Filter fields
 
@@ -343,3 +349,4 @@ Here is an explanation of the fields used in the `where` conditions within this 
 
 Check out our [predicate language](../../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources) 
 guide for a more in depth explanation of the language.
+

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -191,7 +191,8 @@ the last known locks. This decision strategy is encoded as one of the two modes:
   guaranteed to be up to date
 - `best_effort` mode keeps relying on the most recent locks
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 The cluster-wide mode defaults to `best_effort`. You can set up the default
 locking mode via API or CLI using a `cluster_auth_preference` resource or static
@@ -232,8 +233,8 @@ configuration file:
   </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 The cluster-wide mode defaults to `best_effort`. You can set up the default
 locking mode via API or CLI using a `cluster_auth_preference` resource:
@@ -257,7 +258,9 @@ $ tctl create -f cap.yaml
 # cluster auth preference has been updated
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 It is also possible to configure the locking mode for a particular role:
 
@@ -277,3 +280,4 @@ there is no user involved, the mode is taken from the cluster-wide setting.
 With multiple potentially conflicting locking modes (the cluster-wide default
 and the individual per-role settings) a single occurrence of `strict` suffices
 for the local lock view to become evaluated strictly.
+

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -15,12 +15,6 @@ the session, and terminate the session at will.
 In addition, Teleport administrators can [define rules](#join_sessions) that allow users to join each other's
 sessions from `tsh` and the Web UI.
 
-<ScopedBlock scope="oss">
-
-  Moderated Sessions requires Teleport Enterprise or Teleport Cloud.
-
-</ScopedBlock>
-
 ### Use cases
 
 Moderated Sessions are useful in the following scenarios:

--- a/docs/pages/access-controls/guides/passwordless.mdx
+++ b/docs/pages/access-controls/guides/passwordless.mdx
@@ -103,7 +103,8 @@ passwordless registration.
 To enable passwordless by default, add `connector_name: passwordless` to your
 cluster configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 <Tabs>
   <TabItem label="Static Config">
     Auth Server `teleport.yaml` file:
@@ -143,9 +144,9 @@ cluster configuration:
     ```
   </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 Create a `cap.yaml` file or get the existing configuration using
 `tctl get cluster_auth_preference`:
 
@@ -168,7 +169,9 @@ Update the configuration:
 $ tctl create -f cap.yaml
 # cluster auth preference has been updated
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Troubleshooting
 
@@ -242,7 +245,8 @@ $ tsh webauthnwin diag
 If you want to forbid passwordless access to your cluster, add `passwordless:
 false` to your configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 <Tabs>
   <TabItem label="Static Config">
     Auth Server `teleport.yaml` file:
@@ -283,9 +287,9 @@ false` to your configuration:
     ```
   </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 Create a `cap.yaml` file or get the existing configuration using
 `tctl get cluster_auth_preference`:
 
@@ -308,4 +312,7 @@ Update the configuration:
 $ tctl create -f cap.yaml
 # cluster auth preference has been updated
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
+

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -72,7 +72,8 @@ Per-session MFA can be enforced cluster-wide or only for some specific roles.
 
 ### Cluster-wide
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 To enforce MFA checks for all roles, edit your cluster authentication
 configuration:
@@ -120,8 +121,8 @@ $ tctl create -f cap.yaml
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Obtain your existing `cluster_auth_preference` resource:
 
@@ -148,7 +149,9 @@ Create the resource:
 $ tctl create -f cap.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Per role
 

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -140,7 +140,8 @@ $ tctl create -f traits.yaml
 Once Alice logs in, she will receive SSH and X.509 certificates with
 a new role. SSH logins and Kubernetes groups will also be set:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -156,8 +157,8 @@ $ tsh login --proxy=teleport.example.com --user=alice
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -173,7 +174,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=alice
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 
 ## SSO users
@@ -245,7 +248,8 @@ $ tctl create -f github.yaml
 Once Bob logs in using SSO, he will receive SSH and X.509 certificates with
 a new role and SSH logins generated using  the `sso-users` role template:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --auth=github
@@ -261,8 +265,8 @@ $ tsh login --proxy=teleport.example.com --auth=github
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --auth=github
@@ -278,7 +282,9 @@ $ tsh login --proxy=mytenant.teleport.sh --auth=github
 #  Extensions:         permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Interpolation rules
 
@@ -416,3 +422,4 @@ In this case, Alice would be allowed to request access to the RBAC roles `access
 role list) and `alpha-admin` and `beta-admin` (from the `claims_to_roles` mapping).
 
 The same syntax applies for Review Requests.
+

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -180,31 +180,11 @@ Reference](../../reference/cli/tsh.mdx#tsh-global-flags) page.
 
 Once a WebAuthn device is registered, the user will be prompted for it on login:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
-
 ```code
-$ tsh login --proxy=example.com
+$ tsh login --proxy=example.teleport.sh
 # Enter password for Teleport user codingllama:
 # Tap any security key or enter a code from a OTP device:
-# > Profile URL:        https://example.com
-#   Logged in as:       codingllama
-#   Cluster:            example.com
-#   Roles:              access, editor
-#   Logins:             codingllama
-#   Kubernetes:         enabled
-#   Valid until:        2021-10-04 23:32:29 -0700 PDT [valid for 12h0m0s]
-#   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
-```
-
-</TabItem>
-
-<ScopedBlock scope={["cloud"]}>
-
-```code
-$ tsh login --proxy=mytenant.teleport.sh
-# Enter password for Teleport user codingllama:
-# Tap any security key or enter a code from a OTP device:
-# > Profile URL:        https://mytenant.teleport.sh
+# > Profile URL:        https://example.teleport.sh
 #   Logged in as:       codingllama
 #   Cluster:            mytenant.teleport.sh
 #   Roles:              access, editor
@@ -213,10 +193,6 @@ $ tsh login --proxy=mytenant.teleport.sh
 #   Valid until:        2021-10-04 23:32:29 -0700 PDT [valid for 12h0m0s]
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
-
-</TabItem>
-
-</Tabs>
 
 <Admonition type="note">
   WebAuthn for logging in to Teleport is only required for [local users](

--- a/docs/pages/access-controls/guides/webauthn.mdx
+++ b/docs/pages/access-controls/guides/webauthn.mdx
@@ -196,7 +196,7 @@ $ tsh login --proxy=example.com
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
 
 <ScopedBlock scope={["cloud"]}>
 
@@ -214,7 +214,9 @@ $ tsh login --proxy=mytenant.teleport.sh
 #   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note">
   WebAuthn for logging in to Teleport is only required for [local users](
@@ -255,7 +257,8 @@ auth_service:
 
 The migrated WebAuthn configuration is:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 <Tabs>
   <TabItem label="Static Config">
 
@@ -300,9 +303,9 @@ The migrated WebAuthn configuration is:
 
   </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 kind: cluster_auth_preference
@@ -323,9 +326,12 @@ spec:
     - "/path/to/u2f_attestation_ca.pem"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Next steps
 
 - [Passwordless](./passwordless.mdx)
 - [Set up per-session MFA checks](./per-session-mfa.mdx)
+

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -34,7 +34,8 @@ To manage cluster roles, a Teleport administrator can use the Web UI or the
 command line using [tctl resource commands](../reference/resources.mdx).
 To see the list of roles in a Teleport cluster, an administrator can execute:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -44,8 +45,8 @@ $ tsh login --user=myuser --proxy=teleport.example.com
 $ tctl get roles
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl.
@@ -53,7 +54,9 @@ $ tsh login --user=myuser --proxy=mytenant.teleport.sh
 $ tctl get roles
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 (!docs/pages/includes/backup-warning.mdx!)
 
@@ -376,3 +379,4 @@ Here is an explanation of the fields used in the `where` and `filter` conditions
 
 Check out our [predicate language](../reference/predicate-language.mdx#scoping-allowdeny-rules-in-role-resources)
 guide for a more in depth explanation of the language.
+

--- a/docs/pages/access-controls/sso.mdx
+++ b/docs/pages/access-controls/sso.mdx
@@ -46,8 +46,8 @@ information about the temporary user.
 You can inspect a temporary `user` resource created via your SSO integration
 by using the `tctl` command:
 
-
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl remotely
@@ -55,8 +55,8 @@ $ tsh login --proxy=proxy.example.com --user=myuser
 $ tctl get users/<username>
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl remotely
@@ -64,7 +64,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl get users
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Here is an example of a temporary `user` resource created when the GitHub user
 `myuser` signed in to GitHub to authenticate to Teleport. This resource
@@ -211,7 +213,8 @@ users.
 
 The following authentication connectors are supported:
 
-<ScopedBlock scope={["cloud", "enterprise"]}>
+<Tabs>
+<TabItem scope={["cloud", "enterprise"]} label="Commercial">
 
 |Type|Description|
 |---|---|
@@ -220,26 +223,29 @@ The following authentication connectors are supported:
 |`oidc`| The OIDC connector type uses the [OpenID Connect protocol](https://en.wikipedia.org/wiki/OpenID_Connect) to authenticate users<br/> and query their group membership.|
 |`github`| The GitHub connector uses GitHub SSO to authenticate users and query their group membership.|
 
-</ScopedBlock>
-<ScopedBlock scope={["oss"]}>
+</TabItem>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 |Type|Description|
 |---|---|
 |None|If no authentication connector is created, Teleport will use local authentication based user information stored in the Auth Service backend. You can manage user data via the `tctl users` command. |
 |`github`| The GitHub connector uses GitHub SSO to authenticate users and query their group membership.|
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Creating an authentication connector
 
-<ScopedBlock scope={["cloud", "enterprise"]}>
+<Tabs>
+<TabItem scope={["cloud", "enterprise"]} label="Commercial">
 
 Before you can create an authentication connector, you must enable
 authentication via that connector's protocol.
 
-To set the default authentication type as `saml` or `oidc`, <ScopedBlock
-scope={["enterprise"]}>either modify your Auth Service configuration file
-or </ScopedBlock>create a `cluster_auth_preference` resource.
+To set the default authentication type as `saml` or `oidc`, either modify your
+Auth Service configuration file (if using a self-hosted edition of Teleport) or
+create a `cluster_auth_preference` resource.
 
 <Tabs>
   <TabItem label="Static Config (Self-Hosted)" scope={["enterprise"]}>
@@ -267,52 +273,15 @@ or </ScopedBlock>create a `cluster_auth_preference` resource.
 
   Create the resource:
 
-  <ScopedBlock scope={["enterprise"]}>
-
   ```code
   # Log in to your cluster with tsh so you can run tctl commands.
-  # You can also run tctl directly on the Auth Service host.
-  $ tsh login --proxy=teleport.example.com --user=myuser
+  $ tsh login --proxy=<Var name="mytenant.teleport.sh" /> --user=myuser
   $ tctl create -f cap.yaml
   ```
 
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
-  ```code
-  # Log in to your cluster with tsh so you can run tctl commands.
-  $ tsh login --proxy=mytenant.teleport.sh --user=myuser
-  $ tctl create -f cap.yaml
-  ```
-
-  </ScopedBlock>
   (!docs/pages/includes/sso/idp-initiated.mdx!)
   </TabItem>
 </Tabs>
-
-</ScopedBlock>
-
-<ScopedBlock scope="oss">
-
-Next, define an authentication connector. Create a file called `connector.yaml`
-with the following content:
-
-```yaml
-kind: cluster_auth_preference
-metadata:
-  name: cluster-auth-preference
-spec:
-  type: github
-  webauthn:
-    # Replace with the address of your Teleport cluster
-    rp_id: 'example.teleport.sh'
-version: v2
-
-```
-
-</ScopedBlock>
-
-<ScopedBlock scope={["cloud", "enterprise"]}>
 
 Next, define an authentication connector. Create a file called `connector.yaml`
 based on one of the following examples.
@@ -416,13 +385,35 @@ the entity descriptor from your IDP.
 We recommend "pinning" the entity descriptor by including the XML rather than
 fetching from a URL.
 
-</ScopedBlock>
+</TabItem>
+<TabItem scope="oss" label="Teleport Community Edition">
+
+Next, define an authentication connector. Create a file called `connector.yaml`
+with the following content:
+
+```yaml
+kind: cluster_auth_preference
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: github
+  webauthn:
+    # Replace with the address of your Teleport cluster
+    rp_id: 'example.teleport.sh'
+version: v2
+
+```
+
+</TabItem>
+</Tabs>
 
 Create the connector: 
 
 ```code
 $ tctl create -f connector.yaml
 ```
+
+
 
 ### User logins
 
@@ -547,10 +538,13 @@ of SSO buttons in the Teleport Web UI.
 Troubleshooting SSO configuration can be challenging. Usually a Teleport administrator
 must be able to:
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 - Ensure that HTTP/TLS certificates are configured properly for both Teleport
   proxy and the SSO provider.
-</ScopedBlock>
+</TabItem>
+</Tabs>
+
 - Be able to see what SAML/OIDC claims and values are getting exported and passed
   by the SSO provider to Teleport.
 - Be able to see how Teleport maps the received claims to role mappings as defined
@@ -604,3 +598,4 @@ spec:
       'env': 'dev'
 version: v5
 ```
+

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -257,12 +257,10 @@ After logging in successfully, you will see the following:
 
 You will receive the details of your user session within the CLI:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
-
 ```code
-> Profile URL:        https://tele.example.com:443
+> Profile URL:        https://example.teleport.sh:443
   Logged in as:       jeff
-  Cluster:            tele.example.com
+  Cluster:            example.teleport.sh
   Roles:              access
   Logins:             jeff, ubuntu, debian, -teleport-internal-join
   Kubernetes:         enabled
@@ -271,27 +269,6 @@ You will receive the details of your user session within the CLI:
   Valid until:        2023-03-08 17:13:50 -0600 CST [valid for 7h51m0s]
   Extensions:         permit-port-forwarding, permit-pty, private-key-policy
 ```
-
-</TabItem>
-
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-
-```code
-> Profile URL:        https://mytenant.teleport.sh:443
-  Logged in as:       jeff
-  Cluster:            mytenant.teleport.sh
-  Roles:              access
-  Logins:             jeff, ubuntu, debian, -teleport-internal-join
-  Kubernetes:         enabled
-  Kubernetes users:   dev
-  Kubernetes groups:  developer
-  Valid until:        2023-03-08 17:13:50 -0600 CST [valid for 7h51m0s]
-  Extensions:         permit-port-forwarding, permit-pty, private-key-policy
-```
-
-</TabItem>
-
-</Tabs>
 
 ## Step 4/4. Configure authentication preference
 

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -212,7 +212,8 @@ Here is an example role configuration snippet using the trait variable:
 You can now log in with Teleport using GitHub SSO. Run the following to log out
 of Teleport and log in again using GitHub SSO.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh logout
@@ -222,8 +223,8 @@ If browser window does not open automatically, open it by clicking on the link:
  http://127.0.0.1:56334/6bf976e6-a4be-4898-94eb-8a7b01af2158
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh logout
@@ -233,7 +234,9 @@ If browser window does not open automatically, open it by clicking on the link:
  http://127.0.0.1:56334/6bf976e6-a4be-4898-94eb-8a7b01af2158
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 You can also log to the web UI using GitHub by clicking **Other sign-in options** at the login screen.
 
@@ -266,9 +269,9 @@ You will receive the details of your user session within the CLI:
   Extensions:         permit-port-forwarding, permit-pty, private-key-policy
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 > Profile URL:        https://mytenant.teleport.sh:443
@@ -283,7 +286,9 @@ You will receive the details of your user session within the CLI:
   Extensions:         permit-port-forwarding, permit-pty, private-key-policy
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Step 4/4. Configure authentication preference
 
@@ -337,3 +342,4 @@ After logging out of `tsh`, you can log back in without specifying
 ## Troubleshooting
 
 (!docs/pages/includes/sso/loginerrortroubleshooting.mdx!)
+

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -10,11 +10,15 @@ Teleport.
 
 ## Prerequisites
 
-- A GitHub organization with at least one team. <ScopedBlock scope="oss">This
-  organization must not have external SSO set up, or Teleport will refuse to
-  create the GitHub authentication connector.</ScopedBlock><ScopedBlock
-  scope={["enterprise", "cloud"]}>This organization can be hosted from either
-  GitHub Cloud or GitHub Enterprise Server.</ScopedBlock>
+- A GitHub organization with at least one team. 
+
+  In Teleport Community Edition and Teleport Team, this organization must not
+  have external SSO set up, or Teleport will refuse to create the GitHub
+  authentication connector.
+
+  In Teleport Enterprise and Enterprise Cloud, organization can be hosted from
+  either GitHub Cloud or GitHub Enterprise Server.
+
 - Teleport role with access to maintaining `github` resources for using `tctl`
   from the Desktop. This is available in the default `editor` role.
 
@@ -31,9 +35,8 @@ App's "Authentication callback URL" is the following:
 https://PROXY_ADDRESS/v1/webapi/github/
 ```
 
-`PROXY_ADDRESS` must be <ScopedBlock scope={["oss", "enterprise"]}>the public
-address of the Teleport Proxy Service</ScopedBlock><ScopedBlock
-scope="cloud">your Teleport Cloud tenant address</ScopedBlock>.
+Replace `PROXY_ADDRESS` with be the public address of the Teleport Proxy Service
+or your Teleport Cloud workspace URL (e.g., `example.teleport.sh`).
 
 The app must have the `read:org` scope in order to be able to read org and team
 membership details.
@@ -315,7 +318,8 @@ spec:
 version: v2
 ```
 
-For `rp_id`, use the public address of your <ScopedBlock scope={["oss", "enterprise"]}>Teleport Proxy Service</ScopedBlock><ScopedBlock scope="cloud">Teleport Cloud tenant</ScopedBlock>.
+For `rp_id`, use the public address of your Teleport Proxy Service or Teleport
+Cloud workspace.
 
 Once you've saved the changes, use `tctl` to update the resource:
 

--- a/docs/pages/access-controls/sso/oidc.mdx
+++ b/docs/pages/access-controls/sso/oidc.mdx
@@ -67,7 +67,8 @@ the `user` role depending on the value returned for `group` within the claims.
 
 Create the connector:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -77,8 +78,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create oidc-connector.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl remotely.
@@ -86,7 +87,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create oidc-connector.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Create Teleport Roles
 

--- a/docs/pages/api/automatically-register-agents.mdx
+++ b/docs/pages/api/automatically-register-agents.mdx
@@ -127,8 +127,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will request the credentials manually by *impersonating* the `register-apps`
 role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise deployment and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `register-apps`, create a file
 called `register-apps-impersonator.yaml` defining a role:

--- a/docs/pages/application-access/guides/api-access.mdx
+++ b/docs/pages/application-access/guides/api-access.mdx
@@ -73,10 +73,13 @@ target application's API through Teleport App Access.
   title="CA and Key Pair Files"
 >
   Note the paths to your user's certificate/key pair in the command - `curl` will use a client certificate to authenticate with Teleport.
+ 
+  The Teleport Proxy Service is usually configured with a wildcard certificate
+  issued by a public certificate authority such as Let's Encrypt. If you are
+  running a self-hosted Teleport cluster, and your Teleport Proxy Service has
+  been configured to use a self-signed certificate instead, you will need to
+  include it in your `curl` command using `--cacert <path>`.
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-    The Teleport Proxy Service is usually configured with a wildcard certificate issued by a public certificate authority such as Let's Encrypt. If your Teleport Proxy Service has been configured to use a self-signed certificate instead, you will need to include it in your `curl` command using `--cacert <path>`.
-  </ScopedBlock>
 </Admonition>
 
 As Grafana's API requires authentication, let's update the `curl` command to

--- a/docs/pages/application-access/guides/dynamic-registration.mdx
+++ b/docs/pages/application-access/guides/dynamic-registration.mdx
@@ -82,7 +82,8 @@ version: v5
 
 To create an application resource, run:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -92,8 +93,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create app.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl remotely.
@@ -101,7 +102,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create app.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 
 After the resource has been created, it will appear among the list of available

--- a/docs/pages/application-access/guides/tcp.mdx
+++ b/docs/pages/application-access/guides/tcp.mdx
@@ -42,7 +42,8 @@ $ docker run --name postgres -p 5432:5432 -e POSTGRES_PASSWORD=<pass> -d postgre
 
 Teleport Application Service requires a valid auth token to join the cluster.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 To generate one, run the following command on your Auth Service node:
 
 ```code
@@ -55,16 +56,18 @@ connect to cluster applications:
 ```code
 $ tctl users add --roles=access alice
 ```
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 To generate one, log into your Cloud tenant and run the following command:
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh
 $ tctl tokens add --type=app
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Save the generated token in `/tmp/token` on the node where Application Service
 will run.
@@ -147,3 +150,4 @@ $ psql postgres://postgres@localhost:55868/postgres
 ## Next steps
 
 - Learn about [access controls](../controls.mdx) for applications.
+

--- a/docs/pages/application-access/reference.mdx
+++ b/docs/pages/application-access/reference.mdx
@@ -103,7 +103,8 @@ spec:
 You can create a new `app` resource by running the following commands, which
 assume that you have created a YAML file called `app.yaml` with your configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -114,8 +115,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create -f app.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -124,7 +125,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create -f app.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## CLI
 

--- a/docs/pages/architecture/authorization.mdx
+++ b/docs/pages/architecture/authorization.mdx
@@ -334,15 +334,12 @@ options, Teleport will choose `strict` option.
 
 ### Just in Time Access Requests
 
-<ScopedBlock
-  scope={["oss"]}
->
-
 <Notice type="tip">
-  The full version of Just In Time Access Requests is available only in Teleport Cloud or Enterprise.
-</Notice>
 
-</ScopedBlock>
+  The full version of Just In Time Access Requests is available only in Teleport
+  Enterprise (including Enterprise Cloud).
+
+</Notice>
 
 Roles allow requesting elevated privileges - other roles or individual resources.
 
@@ -379,3 +376,4 @@ spec:
 - [Teleport Auth](authentication.mdx)
 - [Teleport Nodes](nodes.mdx)
 - [Teleport Proxy](proxy.mdx)
+

--- a/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/gcp-kms.mdx
@@ -26,12 +26,6 @@ only ever exists in KMS when this feature is enabled.
 Read on to [migrating an existing cluster](#migrating-an-existing-cluster) to
 learn more.
 
-<ScopedBlock scope={["oss", "cloud"]}>
-
-This guide is intended for self-hosted Teleport Enterprise users.
-
-</ScopedBlock>
-
 ## Prerequisites
 
 - Teleport version 11.1.1 or newer Enterprise (self-hosted).

--- a/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
+++ b/docs/pages/choose-an-edition/teleport-enterprise/hsm.mdx
@@ -7,12 +7,6 @@ h1: Teleport HSM Support
 This guide will show you how to set up the Teleport Auth Service to use a
 hardware security module (HSM) to store and handle private keys.
 
-<ScopedBlock scope={["oss", "cloud"]}>
-
-This guide is intended for Teleport Enterprise users.
-
-</ScopedBlock>
-
 ## Prerequisites
 
 - Teleport v(=teleport.version=) Enterprise (self-hosted).
@@ -362,4 +356,5 @@ All CAs listed in the output of `tctl status` must be rotated.
 You are all set! Check the teleport logs for `Creating new HSM key pair` to
 confirm that the feature is working. You can also check that keys were created
 in your HSM using your HSM's admin tool.
+
 

--- a/docs/pages/connect-your-client/gui-clients.mdx
+++ b/docs/pages/connect-your-client/gui-clients.mdx
@@ -67,7 +67,8 @@ Ensure that your environment includes the following:
 
 ### Get connection information
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 <Tabs>
 <TabItem label="Authenticated Proxy">
@@ -144,8 +145,8 @@ TLS authentication.
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Use the following command to start a local TLS proxy your GUI database client
 will be connecting to:
@@ -164,7 +165,9 @@ Use the displayed local proxy host/port and credentials paths when configuring
 your GUI client below. When entering the hostname, use `localhost` rather than
 `127.0.0.1`.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## SQL Server with Azure Data Studio
 

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -317,3 +317,4 @@ either directly or through proxy tunnels.
 {/*lint ignore messaging for page title*/}
 - [Database Access GUI Clients](./gui-clients.mdx) details
 how to connect many popular database GUI clients through Teleport.
+

--- a/docs/pages/connect-your-client/introduction.mdx
+++ b/docs/pages/connect-your-client/introduction.mdx
@@ -70,9 +70,7 @@ server and database access within a single window.
    ![A new instance of Teleport Connect](../../img/teleport-connect-init.png)
 
 1. Provide the address of your Teleport Cluster (e.g.
-<ScopedBlock scope={["oss", "enterprise"]}>`https://teleport.example.com`</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>`https://mytennant.teleport.sh`</ScopedBlock>
-) and click **NEXT**.
+   `https://example.teleport.sh`) and click **NEXT**.
 
 1. Teleport Connect will ask you for your username, password, and MFA. 
    
@@ -85,13 +83,15 @@ server and database access within a single window.
 
 ### Web UI
 
-Teleport provides a web interface for users to interact with Teleport, e.g., by accessing resources or creating Access Requests. This is usually
-found at the same URL used to connect to Teleport with (e.g.
-<ScopedBlock scope={["oss", "enterprise"]}>`https://teleport.example.com`</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>`https://mytenant.teleport.sh`</ScopedBlock>),
-but you should confirm the Web UI URL with the team that manages your Teleport deployment. The Web UI provides similar
-access to resources as Teleport Connect, and additional access to to Request and
-Activity logs for users with the right permissions.
+Teleport provides a web interface for users to interact with Teleport, e.g., by
+accessing resources or creating Access Requests. This is usually found at the
+same URL used to connect to Teleport with (e.g.  `https://example.teleport.sh`),
+but you should confirm the Web UI URL with the team that manages your Teleport
+deployment. 
+
+The Web UI provides similar access to resources as Teleport Connect, and
+additional access to to Request and Activity logs for users with the right
+permissions.
 
 ## Protocols
 
@@ -290,9 +290,7 @@ list those that are accessible to your user under <Icon name="database" size="sm
 Desktop access is available through the Teleport Web UI. 
 
 1. In your browser, navigate to your Teleport cluster (for example, 
-<ScopedBlock scope={["oss", "enterprise"]}>`https://teleport.example.com`</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>`https://mytennant.teleport.sh`</ScopedBlock>
-).
+`https://example.teleport.sh`).
 1. From the menu on the right, select <Icon name="desktop" inline size="sm"/> **Desktops**.
 1. Next to the desktop you want to access, click **CONNECT**. Select
 or type in a username available to your Teleport user.

--- a/docs/pages/connect-your-client/tsh.mdx
+++ b/docs/pages/connect-your-client/tsh.mdx
@@ -23,7 +23,8 @@ terminal for the CLI reference.
 For the impatient, here's an example of how a user would typically use
 [`tsh`](../reference/cli/tsh.mdx):
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 
 ```code
 # Log into a Teleport cluster. This command retrieves the user's certificates
@@ -47,8 +48,8 @@ $ ssh user@host
 $ tsh logout
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Login into a Teleport cluster. This command retrieves the user's certificates
@@ -72,7 +73,9 @@ $ ssh user@host
 $ tsh logout
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 In other words, Teleport was designed to be fully compatible with existing
 SSH-based workflows and does not require users to learn anything new, other than
@@ -95,7 +98,8 @@ login and the OS login. A Teleport identity will have to be passed via the
 `--user` flag while the OS login will be passed as `login@host` using syntax
 compatible with the traditional `ssh` command.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Authenticate against the "work" cluster as joe and then
@@ -103,8 +107,8 @@ compatible with the traditional `ssh` command.
 $ tsh ssh --proxy=work.example.com --user=joe root@node
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Authenticate against the "work" cluster as joe and then
@@ -112,7 +116,9 @@ $ tsh ssh --proxy=work.example.com --user=joe root@node
 $ tsh ssh --proxy=mytenant.teleport.sh --user=joe root@node
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh ssh](../reference/cli/tsh.mdx#tsh-ssh)
 
@@ -120,7 +126,8 @@ $ tsh ssh --proxy=mytenant.teleport.sh --user=joe root@node
 
 To retrieve a user's certificate, execute:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Full form:
@@ -133,8 +140,8 @@ $ tsh login --proxy=work.example.com
 $ tsh login --proxy=work.example.com:5000
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Full form:
@@ -143,7 +150,9 @@ $ tsh login --proxy=proxy_host:<https_proxy_port>
 $ tsh login --proxy=mytenant.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh login](../reference/cli/tsh.mdx#tsh-login)
 
@@ -165,7 +174,8 @@ This allows you to authenticate just once, maybe at the beginning of the day. Su
 
 A Teleport cluster can be configured for multiple user identity sources. For example, a cluster may have a local user called `admin` while regular users should [authenticate via GitHub](../access-controls/sso/github-sso.mdx). In this case, you have to pass `--auth` flag to `tsh login` to specify which identity storage to use:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in using the local Teleport 'admin' user:
@@ -175,8 +185,8 @@ $ tsh --proxy=proxy.example.com --auth=local --user=admin login
 $ tsh --proxy=proxy.example.com --auth=github login
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in using the local Teleport 'admin' user:
@@ -186,29 +196,34 @@ $ tsh --proxy=mytenant.teleport.sh --auth=local --user=admin login
 $ tsh --proxy=mytenant.teleport.sh --auth=github login
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 When using an external identity provider to log in, `tsh` will need to open a
 web browser to complete the authentication flow. By default, `tsh` will use your
 system's default browser. If you wish to suppress this behavior, you can use the
 `--browser=none` flag:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Don't open the system default browser when logging in
 $ tsh login --proxy=work.example.com --browser=none
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Don't open the system default browser when logging in
 $ tsh login --proxy=mytenant.teleport.sh --browser=none
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 In this situation, a link will be printed on the screen. You can copy and paste this link into
 a browser of your choice to continue the login flow.
@@ -220,7 +235,8 @@ a browser of your choice to continue the login flow.
 To inspect the SSH certificates in `~/.tsh`, a user may execute the following
 command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh status
@@ -235,8 +251,8 @@ $ tsh status
 #  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh status
@@ -251,7 +267,9 @@ $ tsh status
 #  Extensions:   permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh status](../reference/cli/tsh.mdx#tsh-status)
 
@@ -277,7 +295,8 @@ variable to `false` in your shell profile to make this permanent.
 [`tsh login`](../reference/cli/tsh.mdx#tsh-login) can also save the user certificate into a
 file:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Authenticate the user against proxy.example.com and save the user
@@ -288,8 +307,8 @@ $ tsh login --proxy=proxy.example.com --out=joe
 $ tsh ssh --proxy=proxy.example.com -i joe joe@db
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Authenticate the user against mytenant.teleport.sh and save the user
@@ -300,14 +319,17 @@ $ tsh login --proxy=mytenant.teleport.sh --out=joe
 $ tsh ssh --proxy=mytenant.teleport.sh -i joe joe@db
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 By default, the `--out` flag will create an identity file suitable for `tsh -i`.
 If compatibility with OpenSSH is needed, `--format=openssh` must be specified.
 In this case, the identity will be saved into two files, `joe` and
 `joe-cert.pub`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=proxy.example.com --out=joe --format=openssh
@@ -318,8 +340,8 @@ $ ls -lh
 # -rw------- 1 joe staff 1.5K Aug 10 16:16 joe-cert.pub
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --out=joe --format=openssh
@@ -330,7 +352,9 @@ $ ls -lh
 # -rw------- 1 joe staff 1.5K Aug 10 16:16 joe-cert.pub
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### SSH certificates for automation
 
@@ -345,7 +369,8 @@ In this example, we're creating a certificate with a TTL of one hour for the
 `jenkins` user and storing it in a `jenkins.pem` file, which can be later used with
 `-i` (identity) flag for `tsh`.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -355,8 +380,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl auth sign --ttl=1h --user=jenkins --out=jenkins.pem
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport Cloud cluster so you can use tctl locally.
@@ -364,7 +389,9 @@ $ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
 $ tctl auth sign --ttl=1h --user=jenkins --out=jenkins.pem
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tctl auth sign](../reference/cli/tctl.mdx#tctl-auth-sign)
 
@@ -426,7 +453,8 @@ the most popular `ssh` flags like `-p`, `-l` or `-L`. For example, if you have
 the following alias defined in your `~/.bashrc`: `alias ssh="tsh ssh"` then you
 can continue using familiar SSH syntax:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Have this alias configured, perhaps via ~/.bashrc
@@ -442,8 +470,8 @@ $ ssh -o ForwardAgent=yes user@node
 $ ssh -o AddKeysToAgent=yes user@node
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Have this alias configured, perhaps via ~/.bashrc
@@ -459,9 +487,9 @@ $ ssh -o ForwardAgent=yes user@node
 $ ssh -o AddKeysToAgent=yes user@node
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ### Proxy ports
 
@@ -476,7 +504,9 @@ $ tsh --proxy=proxy.example.com:5000 <subcommand>
 
 This `tsh` command will use port `5000` of the Proxy Service.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Port forwarding
 
@@ -518,20 +548,23 @@ This command:
 
 While implementing `ProxyJump` for Teleport, we have extended the feature to `tsh`.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh ssh -J proxy.example.com telenode
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh ssh -J mytenant.teleport.sh telenode
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Known limitations:
 
@@ -648,7 +681,8 @@ tunnels from behind-firewall environments into a Teleport Proxy Service you have
 These features are called **Trusted Clusters**. Refer to [the Trusted Clusters guide](../management/admin/trustedclusters.mdx)
 to learn how a Trusted Cluster can be configured.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Assuming the Teleport Proxy Server called `work` is configured with a few Trusted
 Clusters, a user may use the `tsh clusters` command to see a list of all Trusted Clusters on the server:
@@ -662,8 +696,8 @@ $ tsh --proxy=work clusters
 # production       offline
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Assuming the Teleport Cloud tenant called `mytenant.teleport.sh` is configured with a few trusted
 clusters, a user may use the `tsh clusters` command to see a list of all Trusted Clusters on the server:
@@ -677,13 +711,16 @@ $ tsh --proxy=mytenant.teleport.sh clusters
 # production       offline
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 [CLI Docs - tsh clusters](../reference/cli/tsh.mdx#tsh-clusters)
 
 Now you can use the `--cluster` flag with any `tsh` command. For example, to list SSH nodes that are members of the `production` cluster, simply run:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh --proxy=work ls --cluster=production
@@ -694,8 +731,8 @@ $ tsh --proxy=work ls --cluster=production
 # db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh --proxy=mytenant.teleport.sh ls --cluster=production
@@ -706,11 +743,14 @@ $ tsh --proxy=mytenant.teleport.sh ls --cluster=production
 # db-2          xxxxxxxxx     10.0.20.41:3022    kernel:4.2
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Similarly, if you want to SSH into `db-1` inside the `production` cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh --proxy=work ssh --cluster=production db-1
@@ -721,8 +761,8 @@ firewall without open ports. This works because the `production` cluster
 establishes a reverse SSH tunnel back into the Proxy Service called `work`, and
 this tunnel is used to establish inbound SSH connections.
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh --proxy=mytenant.teleport.sh ssh --cluster=production db-1
@@ -733,7 +773,9 @@ firewall without open ports. This works because the `production` cluster
 establishes a reverse SSH tunnel back into your Teleport Cloud tenant's Proxy
 Service, and this tunnel is used to establish inbound SSH connections.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## X11 forwarding
 

--- a/docs/pages/contributing/documentation/reference.mdx
+++ b/docs/pages/contributing/documentation/reference.mdx
@@ -491,7 +491,8 @@ with `scope` set and `scopeOnly={false}`.
 Any Markdown and MDX components can be included within a `ScopedBlock`.
 
 ```jsx
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
   Here are some options for installing the Teleport Auth and Proxy Services on
   your own infrastructure.
@@ -500,7 +501,9 @@ Any Markdown and MDX components can be included within a `ScopedBlock`.
   {/* TabItems that vary between scopes */}
   </Tabs>
 
-</ScopedBlock>
+</TabItem>
+</Tabs>
+
 ```
 
 ## Scopes
@@ -714,3 +717,4 @@ To embed a video in a docs page, use the `video` tag:
 Your browser does not support the video tag.
 </video>
 ```
+

--- a/docs/pages/contributing/documentation/reference.mdx
+++ b/docs/pages/contributing/documentation/reference.mdx
@@ -464,48 +464,6 @@ Here is an image:
 When including the partial, the docs engine will rewrite the link path to load
 the image in `docs/img/screenshot.png`.
 
-## ScopedBlock
-
-Use the `ScopedBlock` component if you want to render some Markdown only for
-users of open source Teleport, Teleport Cloud, or Teleport Enterprise.
-
-`ScopedBlock` has a single property, `scope`, that works the same as it does for
-other components we use in the documentation. See our
-[explanation](./reference.mdx#scopes) of how to use the `scope` property.
-
-Use this instead of the `Tabs` component when:
-
-- You want to conceal details that aren't relevant to the reader's scope.
-- The components you use don't look presentable within a `TabItem`, e.g., you're
-  including a separate `Tabs` component for each scope.
-
-<Notice type="warning">
-
-Readers may not notice that it is possible to adjust the scope of a docs page,
-so only use this component if there is no risk of a reader losing important
-information by not seeing a `ScopedBlock`. Otherwise, consider a `Details` block
-with `scope` set and `scopeOnly={false}`.
-
-</Notice>
-
-Any Markdown and MDX components can be included within a `ScopedBlock`.
-
-```jsx
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-
-  Here are some options for installing the Teleport Auth and Proxy Services on
-  your own infrastructure.
-
-  <Tabs>
-  {/* TabItems that vary between scopes */}
-  </Tabs>
-
-</TabItem>
-</Tabs>
-
-```
-
 ## Scopes
 
 There are three versions of Teleport: `oss`, `enterprise`, and `cloud`. Readers can switch the scope of the documentation using a dropdown menu at the top of the page.

--- a/docs/pages/database-access/architecture.mdx
+++ b/docs/pages/database-access/architecture.mdx
@@ -15,21 +15,24 @@ databases:
 
 In it, we have the following Teleport components:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 - [Teleport Proxy](../architecture/proxy.mdx). A stateless service
   that performs a function of an authentication gateway, serves the Web UI, and
   accepts database (and other) client connections.
   
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 - [Teleport Proxy](../architecture/proxy.mdx). A stateless service that performs
   a function of an authentication gateway, serves the Web UI, and accepts
   database (and other) client connections. This service is accessible at your
   Teleport Cloud tenant URL, e.g., `mytenant.teleport.sh`.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 - [Teleport Auth Service](../architecture/authentication.mdx). Serves as
   cluster's certificate authority, handles user authentication/authorization
@@ -145,3 +148,4 @@ for a more in-depth description of the feature scope and design.
 
 See [Core Concepts](../core-concepts.mdx) for general Teleport
 architecture principles.
+

--- a/docs/pages/database-access/getting-started.mdx
+++ b/docs/pages/database-access/getting-started.mdx
@@ -12,12 +12,15 @@ In this guide, you will:
 1. Join the Aurora database to your Teleport cluster.
 1. Connect to the Aurora database via the Teleport Database Service.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Self-Hosted](../../img/database-access/guides/rds_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access RDS Cloud](../../img/database-access/guides/rds_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -104,7 +107,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 On the node where you will run the Teleport Database Service, start Teleport and
 point it to your Aurora database instance. Make sure to update the database
@@ -121,8 +125,8 @@ $ teleport db start \
   --aws-region=us-west-1
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 On the node where you will run the Teleport Database Service, start Teleport and
 point it to your Aurora database instance. Make sure to update the database
@@ -139,7 +143,9 @@ $ teleport db start \
   --aws-region=us-west-1
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition
   type="note"
@@ -184,20 +190,23 @@ the local user is created, we're ready to connect to the database.
 
 Log in to Teleport with the user we've just created.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Now we can inspect available databases:
 
@@ -224,3 +233,4 @@ Access use-case, for example:
 - Learn how to configure [GUI clients](../connect-your-client/gui-clients.mdx).
 - Learn about database access [role-based access control](./rbac.mdx).
 - See [frequently asked questions](./faq.mdx).
+

--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -20,12 +20,15 @@ This guide will help you to:
 - Set up Teleport to access AWS Keyspaces (Apache Cassandra).
 - Connect to your database through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redis Self-Hosted](../../../img/database-access/guides/cassandra_keyspaces_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Redis Cloud](../../../img/database-access/guides/cassandra_keyspaces_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -45,7 +48,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 (!docs/pages/includes/install-linux.mdx!)
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Start the Teleport Database Service, pointing the `--auth-server` flag to the
 address of your Teleport Proxy Service:
@@ -61,16 +65,8 @@ $ teleport db start \
   --labels=env=dev
 ```
 
-<Admonition type="note">
-
-The `--auth-server` flag must point to the Teleport cluster's Proxy Service
-endpoint because the Database Service always connects back to the cluster over a
-reverse tunnel.
-
-</Admonition>
-
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Start the Teleport Database Service, pointing the `--auth-server` flag to the
 address of your Teleport Cloud tenant:
@@ -86,7 +82,9 @@ $ teleport db start \
   --labels=env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="tip">
   You can start the Database Service using a configuration file instead of CLI flags.
@@ -150,7 +148,8 @@ assume the IAM roles:
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
   ```code
   $ tsh login --proxy=teleport.example.com --user=alice
@@ -160,8 +159,8 @@ databases:
   # keyspaces             [*]           env=dev
   ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
   ```code
   $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -171,7 +170,9 @@ databases:
   # keyspaces             [*]           env=dev
   ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To connect to a particular database instance using the `KeyspacesReader`  AWS IAM Keyspaces role as a database user:
 ```code
@@ -199,3 +200,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -20,12 +20,15 @@ This guide will help you to:
 - Set up access to Azure Database for PostgreSQL or Azure Database for MySQL.
 - Connect to the database server through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Azure PostgreSQL/MySQL Self-Hosted](../../../img/database-access/guides/azure_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Azure PostgreSQL/MySQL Cloud](../../../img/database-access/guides/azure_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note">
     Teleport uses Azure Active Directory authentication with Azure PostgreSQL
@@ -274,7 +277,8 @@ You can create multiple database users identified by the same service principal.
 Log in to your Teleport cluster. Your Azure database should appear in the list of
 available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -284,8 +288,8 @@ $ tsh db ls
 # azure-db                     env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -295,7 +299,9 @@ $ tsh db ls
 # azure-db                     env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -321,3 +327,4 @@ $ tsh db logout azure-db
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -55,7 +55,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Create the Database Service configuration, specifying a region like this:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 <Tabs>
 <TabItem label="PostgreSQL">
@@ -82,8 +83,8 @@ Create the Database Service configuration, specifying a region like this:
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 <Tabs>
 <TabItem label="PostgreSQL">
@@ -110,7 +111,9 @@ Create the Database Service configuration, specifying a region like this:
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with Azure MySQL/Postgres
 database auto-discovery enabled in the `eastus` region and place it at the

--- a/docs/pages/database-access/guides/azure-redis.mdx
+++ b/docs/pages/database-access/guides/azure-redis.mdx
@@ -9,13 +9,16 @@ This guide will help you to:
 - Set up access to Azure Cache for Redis.
 - Connect to the database server through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Azure Cache for Redis Self-Hosted](../../../img/database-access/guides/azure/redis-self-hosted.png)
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Azure Cache for Redis Cloud](../../../img/database-access/guides/azure/redis-cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -43,7 +46,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Create the Database Service configuration, specifying a region like this:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create \
@@ -52,8 +56,8 @@ $ teleport db configure create \
   --token=/tmp/token \
   --azure-redis-discovery=eastus
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db configure create \
@@ -62,7 +66,9 @@ $ teleport db configure create \
   --token=/tmp/token \
   --azure-redis-discovery=eastus
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with Azure Cache for
 Redis auto-discovery enabled in the `eastus` region and place it at the
@@ -154,7 +160,8 @@ and replace the subscription in `assignableScopes` with your own subscription id
 Log in to your Teleport cluster. Your Azure Cache for Redis databases should
 appear in the list of available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -165,9 +172,9 @@ my-azure-redis            Azure Redis server in East US            [*]          
 my-azure-redis-enterprise Azure Redis Enterprise server in East US [*]           ...
 ```
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -178,7 +185,9 @@ my-azure-redis            Azure Redis server in East US            [*]          
 my-azure-redis-enterprise Azure Redis Enterprise server in East US [*]           ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Override default database name">
 By default, Teleport uses the name of the Azure Cache for Redis resource as the
@@ -214,3 +223,4 @@ $ tsh db logout my-azure-redis
 ## Further reading
 - [Understand Azure Role Definitions - AssignableScopes](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions#assignablescopes)
 - [Azure RBAC custom roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles)
+

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -25,12 +25,15 @@ This guide will help you to:
 - Set up access to Azure SQL Server using Azure Active Directory authentication.
 - Connect to Azure SQL Server through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Azure SQL Server Azure Active Directory Self-Hosted](../../../img/database-access/guides/sqlserver/sql-aad.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Azure SQL Server Azure Active Directory Cloud](../../../img/database-access/guides/sqlserver/cloud-sql-aad.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -105,7 +108,9 @@ ALTER ROLE db_datareader ADD MEMBER [sqlserver-identity];
 
 Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+
 ```code
 $ teleport db configure create \
    -o file \
@@ -116,8 +121,9 @@ $ teleport db configure create \
    --uri=my-server.database.windows.net:1433 \
    --labels=env=dev
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```code
 $ teleport db configure create \
    -o file \
@@ -129,7 +135,9 @@ $ teleport db configure create \
    --labels=env=dev
    --azure-sqlserver-discovery=eastus
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition
   type="tip"
@@ -148,7 +156,9 @@ $ teleport db configure create \
 Log in to your Teleport cluster. Your database should appear in the list of
 available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
@@ -156,8 +166,10 @@ $ tsh db ls
 # --------- ------------------- -------
 # sqlserver                     env=dev
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
 $ tsh db ls
@@ -165,7 +177,10 @@ $ tsh db ls
 # --------- ------------------- -------
 # sqlserver                     env=dev
 ```
-</ScopedBlock>
+
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -201,3 +216,4 @@ Remember: you must create the users on all databases you want to connect.
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/cassandra-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cassandra-self-hosted.mdx
@@ -19,12 +19,15 @@ This guide will help you to:
 - Set up Teleport to access your self-hosted Cassandra or ScyllaDB.
 - Connect to your database through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Cassandra Self-Hosted](../../../img/database-access/guides/cassandra_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Cassandra Cloud](../../../img/database-access/guides/cassandra_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -142,7 +145,8 @@ Follow the instructions for your database to enable TLS communication with your 
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
   ```code
   $ tsh login --proxy=teleport.example.com --user=testuser
@@ -152,8 +156,8 @@ databases:
   # cassandra Cassandra Example [*]           env=dev
   ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
   ```code
   $ tsh login --proxy=mytenant.teleport.sh --user=testuser
@@ -163,7 +167,9 @@ databases:
   # cassandra Cassandra Example [*]           env=dev
   ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To connect to a particular database instance :
 ```code
@@ -187,3 +193,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/cockroachdb-self-hosted.mdx
@@ -9,12 +9,15 @@ In this guide, you will:
 - Configure mutual TLS authentication between Teleport and your CockroachDB cluster.
 - Connect to your CockroachDB cluster via Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access CockroachDB Self-Hosted](../../../img/database-access/guides/cockroachdb_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access CockroachDB Cloud](../../../img/database-access/guides/cockroachdb_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -167,3 +170,4 @@ $ tsh db logout roach
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
 - [CockroachDB client authentication](https://www.cockroachlabs.com/docs/stable/authentication.html#client-authentication)
+

--- a/docs/pages/database-access/guides/dynamodb.mdx
+++ b/docs/pages/database-access/guides/dynamodb.mdx
@@ -12,12 +12,15 @@ This guide will help you to:
 - Set up the Teleport Application Service to access the AWS Console and API.
 - Connect to your DynamoDB databases through the Teleport Application Service.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
-![DynamoDB Self-Hosted](../../../img/database-access/guides/dynamodb_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
-![DynamoDB Cloud](../../../img/database-access/guides/dynamodb_cloud.png)
-</ScopedBlock>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+![DynamoDB Self-Hosted](../../../img/application-access/guides/dynamodb_selfhosted.png)
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+![DynamoDB Cloud](../../../img/application-access/guides/dynamodb_cloud.png)
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -320,3 +323,4 @@ $ tsh apps logout aws-dynamodb
 ## Next steps
 - More information on [AWS Management and API with Teleport Application Access](../../application-access/guides/aws-console.mdx).
 - Learn more about [AWS service endpoints](https://docs.aws.amazon.com/general/latest/gr/rande.html).
+

--- a/docs/pages/database-access/guides/dynamodb.mdx
+++ b/docs/pages/database-access/guides/dynamodb.mdx
@@ -12,16 +12,6 @@ This guide will help you to:
 - Set up the Teleport Application Service to access the AWS Console and API.
 - Connect to your DynamoDB databases through the Teleport Application Service.
 
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
-![DynamoDB Self-Hosted](../../../img/application-access/guides/dynamodb_selfhosted.png)
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
-![DynamoDB Cloud](../../../img/application-access/guides/dynamodb_cloud.png)
-</TabItem>
-
-</Tabs>
-
 ## Prerequisites
 
 - AWS account with DynamoDB databases.

--- a/docs/pages/database-access/guides/elastic.mdx
+++ b/docs/pages/database-access/guides/elastic.mdx
@@ -21,10 +21,9 @@ This guide will help you to configure secured access to an Elasticsearch databas
 
 - A self-hosted Elasticsearch database. Elastic Cloud [does not support client certificates](https://www.elastic.co/guide/en/cloud/current/ec-restrictions.html#ec-restrictions-security), which are required for setting up the Database Service.
 
-- A host where you will run the Teleport Database Service. If you are already running the Teleport
-  Database Service, you must ensure that it uses Teleport version 10.3 or newer in order to connect
-  to Elasticsearch. <ScopedBlock scope={["oss", "enterprise"]}> This can also be the same instance
-  of Teleport running your Auth and/or Proxy service(s).</ScopedBlock>
+- A host where you will run the Teleport Database Service. If you are already
+  running the Teleport Database Service, you must ensure that it uses Teleport
+  version 10.3 or newer in order to connect to Elasticsearch.
 
   See [Installation](../../installation.mdx) for details.
 

--- a/docs/pages/database-access/guides/mongodb-atlas.mdx
+++ b/docs/pages/database-access/guides/mongodb-atlas.mdx
@@ -10,12 +10,15 @@ In this guide, you will:
 - Configure MongoDB Atlas authentication.
 - Connect to your Atlas cluster through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access MongoDB Self-Hosted](../../../img/database-access/guides/mongodbatlas_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access MongoDB Cloud](../../../img/database-access/guides/mongodbatlas_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -37,7 +40,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Next, start the Database Service.
 
-<ScopedBlock scope={["enterprise","oss"]}>
+<Tabs>
+<TabItem scope={["enterprise","oss"]} label="Self-Hosted">
 
 <Tabs>
 <TabItem label="Teleport CLI">
@@ -98,9 +102,9 @@ See the full [YAML reference](../reference/configuration.mdx) for details.
 
 </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 <Tabs>
 <TabItem label="Teleport CLI">
 
@@ -148,7 +152,9 @@ See the full [YAML reference](../reference/configuration.mdx) for details.
 
 </TabItem>
 </Tabs>
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 See below for details on how to configure the Teleport Database Service.
 

--- a/docs/pages/database-access/guides/mongodb-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mongodb-self-hosted.mdx
@@ -10,12 +10,15 @@ In this guide, you will:
 - Configure mutual TLS authentication between Teleport and your MongoDB cluster.
 - Connect to your MongoDB instance through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access MongoDB Self-Hosted](../../../img/database-access/guides/mongodb_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access MongoDB Cloud](../../../img/database-access/guides/mongodb_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -196,7 +199,8 @@ in the MongoDB documentation for more details.
 
 Log in to your Teleport cluster and see available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -206,8 +210,8 @@ $ tsh db ls
 # example-mongo Example MongoDB env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -217,7 +221,9 @@ $ tsh db ls
 # example-mongo Example MongoDB env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -251,3 +257,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/mysql-cloudsql.mdx
+++ b/docs/pages/database-access/guides/mysql-cloudsql.mdx
@@ -9,12 +9,15 @@ This guide will help you to:
 - Set up Teleport to access your MySQL on Google Cloud SQL.
 - Connect to your databases through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access CloudSQL Self-Hosted](../../../img/database-access/guides/cloudsql_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access CloudSQL Cloud](../../../img/database-access/guides/cloudsql_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -133,7 +136,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 Below is an example of a Database Service configuration file that proxies
 a single Cloud SQL MySQL database. Save this file as `/etc/teleport.yaml`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -176,8 +180,8 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -218,7 +222,9 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition
   type="tip"
@@ -250,7 +256,8 @@ in the Google Cloud documentation for more details.
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -260,8 +267,8 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL MySQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -271,7 +278,9 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL MySQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 our [RBAC](../rbac.mdx) guide for more details.
@@ -302,3 +311,4 @@ $ tsh db logout cloudsql
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
+

--- a/docs/pages/database-access/guides/mysql-self-hosted.mdx
+++ b/docs/pages/database-access/guides/mysql-self-hosted.mdx
@@ -9,12 +9,15 @@ This guide will help you to:
 - Set up Teleport to access your MySQL or MariaDB database.
 - Connect to your databases through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access MySQL Self-Hosted](../../../img/database-access/guides/mysql_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access MySQL Cloud](../../../img/database-access/guides/mysql_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -161,7 +164,8 @@ Install and configure Teleport where you will run the Teleport Database Service:
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=testuser
@@ -171,8 +175,8 @@ $ tsh db ls
 # example-mysql Example MySQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=testuser
@@ -182,7 +186,9 @@ $ tsh db ls
 # example-mysql Example MySQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 the [RBAC](../rbac.mdx) guide for more details.
@@ -213,3 +219,4 @@ $ tsh db logout example-mysql
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
+

--- a/docs/pages/database-access/guides/postgres-cloudsql.mdx
+++ b/docs/pages/database-access/guides/postgres-cloudsql.mdx
@@ -10,12 +10,15 @@ This guide will help you to:
 - Set up Teleport to access your PostgreSQL on Google Cloud SQL.
 - Connect to your databases through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access CloudSQL Self-Hosted](../../../img/database-access/guides/cloudsql_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access CloudSQL Cloud](../../../img/database-access/guides/cloudsql_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -197,7 +200,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 Below is an example of a Database Service configuration file that proxies
 a single Cloud SQL PostgreSQL database. Save this file as `/etc/teleport.yaml`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -241,8 +245,8 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -284,7 +288,9 @@ proxy_service:
   enabled: "no"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Notice
   type="tip"
@@ -323,7 +329,8 @@ $ echo 'GOOGLE_APPLICATION_CREDENTIALS=/path/to/credentials.json' | sudo tee -a 
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -333,8 +340,8 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL PostgreSQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -344,7 +351,9 @@ $ tsh db ls
 # cloudsql GCP Cloud SQL PostgreSQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 our [RBAC](../rbac.mdx) guide for more details.
@@ -383,3 +392,4 @@ $ tsh db logout cloudsql
 # Remove credentials for all database instances.
 $ tsh db logout
 ```
+

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -10,12 +10,15 @@ This guide will help you to:
 - Set up Teleport to access your AWS Redshift instances.
 - Connect to your databases through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redshift Self-Hosted](../../../img/database-access/guides/redshift_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access Redshift Cloud](../../../img/database-access/guides/redshift_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -43,7 +46,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 On the node that is running the Database Service, create a configuration file:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create \
@@ -53,8 +57,8 @@ $ teleport db configure create \
    --redshift-discovery=us-west-1
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db configure create \
@@ -64,7 +68,9 @@ $ teleport db configure create \
    --redshift-discovery=us-west-1
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with Redshift
 database auto-discovery enabled on the `us-west-1` region and place it at the
@@ -103,7 +109,8 @@ may not propagate immediately and can take a few minutes to come into effect.
 
 ## Step 5/5. Connect
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Once the Database Service has started and joined the cluster, log in to see the
 registered databases. Replace `--proxy` with the address of your Teleport Proxy
@@ -117,8 +124,8 @@ $ tsh db ls
 # my-redshift Redshift cluster in us-east-1  ...
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Once the Database Service has started and joined the cluster, log in to see the
 registered databases. Replace `--proxy` with the address of your Teleport Cloud
@@ -132,7 +139,9 @@ $ tsh db ls
 # my-redshift Redshift cluster in us-east-1  ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Note">
   You can override the database name by applying the `teleport.dev/database_name` AWS tag to the resource. The value of the tag will be used as the database name.
@@ -175,3 +184,4 @@ $ tsh db logout my-redshift
 - Learn how to [restrict access](../rbac.mdx) to certain users and databases.
 - View the [High Availability (HA)](../guides/ha.mdx) guide.
 - Take a look at the YAML configuration [reference](../reference/configuration.mdx).
+

--- a/docs/pages/database-access/guides/postgres-self-hosted.mdx
+++ b/docs/pages/database-access/guides/postgres-self-hosted.mdx
@@ -9,12 +9,15 @@ This guide will help you to:
 - Set up Teleport to access your self-hosted PostgreSQL.
 - Connect to your databases through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access PostgreSQL Self-Hosted](../../../img/database-access/guides/postgresqlselfhosted_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access PostgreSQL Cloud](../../../img/database-access/guides/postgresqlselfhosted_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -110,7 +113,8 @@ Install and configure Teleport where you will run the Teleport Database Service:
 Once the Database Service has joined the cluster, log in to see the available
 databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=testuser
@@ -120,8 +124,8 @@ $ tsh db ls
 # example-postgres Example PostgreSQL env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=testuser
@@ -131,7 +135,9 @@ $ tsh db ls
 # example-postgres Example PostgreSQL env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that you will only be able to see databases your role has access to. See
 [RBAC](../rbac.mdx) section for more details.

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -10,12 +10,15 @@ This guide will help you to:
 - Set up Teleport to access your RDS instances and Aurora clusters.
 - Connect to your databases through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Self-Hosted](../../../img/database-access/guides/rds_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ![Teleport Database Access RDS Cloud](../../../img/database-access/guides/rds_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Supported versions">
     The following products are not compatible with database access as they don't support IAM authentication:

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -55,28 +55,13 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Create the Database Service configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
-
 ```code
 $ teleport db configure create \
    -o file \
-   --proxy=teleport.example.com:3080 \
+   --proxy=example.teleport.sh:443 \
    --token=/tmp/token \
    --rds-discovery=us-west-1
 ```
-
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
-
-```code
-$ teleport db configure create \
-   -o file \
-   --proxy=mytenant.teleport.sh:443 \
-   --token=/tmp/token \
-   --rds-discovery=us-west-1
-```
-
-</ScopedBlock>
 
 The command will generate a Database Service configuration with RDS/Aurora
 database auto-discovery enabled on the `us-west-1` region and place it at the
@@ -151,10 +136,8 @@ for more information.
 Once the Database Service has started and joined the cluster, log in to see the
 registered databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
-
 ```code
-$ tsh login --proxy=teleport.example.com --user=alice
+$ tsh login --proxy=example.teleport.sh --user=alice
 $ tsh db ls
 # Name                           Description                                   Labels
 # ------------------------------ --------------------------------------------- --------
@@ -163,22 +146,6 @@ $ tsh db ls
 # aurora-mysql-custom-myendpoint Aurora cluster in us-west-1 (custom endpoint) ...
 # aurora-mysql-reader            Aurora cluster in us-west-1 (reader endpoint) ...
 ```
-
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
-
-```code
-$ tsh login --proxy=mytenant.teleport.sh --user=alice
-$ tsh db ls
-# Name                           Description                                   Labels
-# ------------------------------ --------------------------------------------- --------
-# postgres-rds                   RDS instance in us-west-1                     ...
-# aurora-mysql                   Aurora cluster in us-west-1                   ...
-# aurora-mysql-custom-myendpoint Aurora cluster in us-west-1 (custom endpoint) ...
-# aurora-mysql-reader            Aurora cluster in us-west-1 (reader endpoint) ...
-```
-
-</ScopedBlock>
 
 <Admonition type="note" title="Note">
   Primary, reader, and custom endpoints of Aurora clusters have names of

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -9,12 +9,15 @@ This guide will help you to:
 - Set up Teleport to access your ElastiCache and MemoryDB for Redis clusters.
 - Connect to your clusters through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access RDS Self-Hosted](../../../img/database-access/guides/redis_elasticache_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
 ![Teleport Database Access RDS Cloud](../../../img/database-access/guides/redis_elasticache_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -43,7 +46,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
 
 Create the Database Service configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 <Tabs>
   <TabItem label="ElastiCache">
@@ -66,8 +70,8 @@ Create the Database Service configuration:
   </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 <Tabs>
   <TabItem label="ElastiCache">
@@ -90,7 +94,9 @@ Create the Database Service configuration:
   </TabItem>
 </Tabs>
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The command will generate a Database Service configuration with ElastiCache or
 MemoryDB database auto-discovery enabled on the `us-west-1` region and place it
@@ -146,7 +152,8 @@ some time (up to 20 minutes) to discover this user once the tag is added.
 Once the Database Service has started and joined the cluster, log in to see the
 registered databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
 $ tsh db ls
@@ -158,8 +165,8 @@ $ tsh db ls
 # my-memorydb                 MemoryDB cluster in us-west-1                             ...
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -172,7 +179,9 @@ $ tsh db ls
 # my-memorydb                 MemoryDB cluster in us-west-1                             ...
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Note">
   You can override the database name by applying the `teleport.dev/database_name` AWS tag to the resource. The value of the tag will be used as the database name.
@@ -235,3 +244,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/redis-cluster.mdx
+++ b/docs/pages/database-access/guides/redis-cluster.mdx
@@ -21,12 +21,15 @@ This guide will help you to:
 - Configure mutual TLS authentication between Teleport and Redis Cluster.
 - Connect to Redis through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redis Cluster Self-Hosted](../../../img/database-access/guides/rediscluster_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
 ![Teleport Database Access Redis Cluster Cloud](../../../img/database-access/guides/rediscluster_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -219,3 +222,4 @@ communicating with Redis Cluster:
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/redis.mdx
+++ b/docs/pages/database-access/guides/redis.mdx
@@ -21,12 +21,15 @@ This guide will help you to:
 - Configure mutual TLS authentication between Teleport and Redis.
 - Connect to Redis through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 ![Teleport Database Access Redis Self-Hosted](../../../img/database-access/guides/redis_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
 ![Teleport Database Access Redis Cloud](../../../img/database-access/guides/redis_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -145,3 +148,4 @@ returns the <nobr>`ERR Teleport: not supported by Teleport`</nobr> error.
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/snowflake.mdx
+++ b/docs/pages/database-access/guides/snowflake.mdx
@@ -19,12 +19,15 @@ This guide will help you to:
 - Assign Teleport's public key to a Snowflake user.
 - Connect to Snowflake through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
   ![Teleport Database Access Snowflake Self-Hosted](../../../img/database-access/guides/snowflake_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
   ![Teleport Database Access Snowflake Cloud](../../../img/database-access/guides/snowflake_cloud.png)
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Prerequisites
 
@@ -157,3 +160,4 @@ $ tsh db logout
 ## Next steps
 
 (!docs/pages/includes/database-access/guides-next-steps.mdx!)
+

--- a/docs/pages/database-access/guides/sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/sql-server-ad.mdx
@@ -25,12 +25,14 @@ This guide will help you to:
 - Set up access to SQL Server using Active Directory authentication.
 - Connect to SQL Server through Teleport.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem label="Self-Hosted" scope={["oss", "enterprise"]}>
 ![Teleport Database Access SQL Server Self-Hosted](../../../img/database-access/guides/sqlserver_selfhosted.png)
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem label="Teleport Cloud" scope={["team", "cloud"]}>
 ![Teleport Database Access SQL Server Cloud](../../../img/database-access/guides/sqlserver_cloud.png)
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 This guide will focus on Amazon RDS for SQL Server using AWS-managed Active
 Directory authentication.
@@ -225,7 +227,8 @@ Install Teleport on the host where you will run the Teleport Database Service:
   Active Directory domain as the SQL Server.
 </Admonition>
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Configure the Teleport Database Service. Make sure to update `--proxy` to
 point to your Teleport Proxy Service address and `--uri` to the SQL Server
@@ -245,8 +248,8 @@ endpoint.
     --labels=env=dev
   ```
   
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Configure the Teleport Database Service. Make sure to update `--proxy` to
 point to your Teleport Cloud tenant address and `--uri` to the SQL Server
@@ -266,7 +269,9 @@ endpoint.
     --labels=env=dev
   ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Provide Active Directory parameters:
 
@@ -331,7 +336,8 @@ master> CREATE LOGIN [EXAMPLE\alice] FROM WINDOWS WITH DEFAULT_DATABASE = [maste
 Log in to your Teleport cluster. Your SQL Server database should appear in the
 list of available databases:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=alice
@@ -341,8 +347,8 @@ $ tsh db ls
 # sqlserver                     env=dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --proxy=mytenant.teleport.sh --user=alice
@@ -352,7 +358,9 @@ $ tsh db ls
 # sqlserver                     env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To retrieve credentials for a database and connect to it:
 
@@ -402,3 +410,4 @@ Add the Certificate Authority (CA) `ca_cert_file` into the `tls` section so Tele
 
 - [Manually join a Linux instance](https://docs.aws.amazon.com/directoryservice/latest/admin-guide/join_linux_instance.html) in the AWS documentation.
 - [Introduction to `adutil`](https://docs.microsoft.com/en-us/sql/linux/sql-server-linux-ad-auth-adutil-introduction) in the Microsoft documentation.
+

--- a/docs/pages/database-access/reference/cli.mdx
+++ b/docs/pages/database-access/reference/cli.mdx
@@ -21,7 +21,8 @@ the Database Service, including:
 
 Starts Teleport Database Service.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db start \
@@ -32,8 +33,8 @@ $ teleport db start \
     --uri=postgres.example.com:5432
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db start \
@@ -44,7 +45,9 @@ $ teleport db start \
     --uri=postgres.mytenant.teleport.sh:5432
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 | Flag | Description |
 | - | - |
@@ -70,7 +73,8 @@ $ teleport db start \
 
 Creates a sample Database Service configuration.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create --rds-discovery=us-west-1 --rds-discovery=us-west-2
@@ -83,8 +87,8 @@ $ teleport db configure create \
   --labels=env=prod
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db configure create --rds-discovery=us-west-1 --rds-discovery=us-west-2
@@ -97,7 +101,9 @@ $ teleport db configure create \
   --labels=env=prod
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 | Flag | Description |
 | - | - |
@@ -337,3 +343,4 @@ $ tsh db config --format=cmd example
 | Flag | Description |
 | - | - |
 | `--format` | Output format: `text` is default, `cmd` to print native database client connect command. |
+

--- a/docs/pages/database-access/reference/configuration.mdx
+++ b/docs/pages/database-access/reference/configuration.mdx
@@ -169,7 +169,8 @@ spec:
 You can create a new `db` resource by running the following commands, which
 assume that you have created a YAML file called `db.yaml` with your configuration:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -180,8 +181,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create -f db.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl from your local machine.
@@ -190,4 +191,7 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create -f db.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
+

--- a/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/aws-terraform.mdx
@@ -860,3 +860,4 @@ $ ./connect.sh node
 ### AWS quotas
 
 (!docs/pages/includes/aws-quotas.mdx!)
+

--- a/docs/pages/deploy-a-cluster/deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/gcp.mdx
@@ -7,13 +7,6 @@ We've created this guide to give customers an overview of how to use Teleport on
 [Google Cloud](https://cloud.google.com/gcp/) (GCP). This guide provides a
 high-level introduction to setting up and running Teleport in production.
 
-<ScopedBlock scope="cloud">
-
-This guide shows you how to deploy the Auth Service and Proxy Service, which
-Teleport Cloud manages for you.
-
-</ScopedBlock>
-
 We have split this guide into:
 
 - [GCP Teleport Introduction](#gcp-teleport-introduction)

--- a/docs/pages/deploy-a-cluster/deployments/ibm.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/ibm.mdx
@@ -7,13 +7,6 @@ We've created this guide to give customers an overview of how to use Teleport on
 [IBM Cloud](https://www.ibm.com/cloud). This guide provides a high-level
 introduction to setting up and running Teleport in production.
 
-<ScopedBlock scope="cloud">
-
-This guide shows you how to deploy the Auth Service and Proxy Service, which
-Teleport Cloud manages for you.
-
-</ScopedBlock>
-
 We have split this guide into:
 
 - [Teleport on IBM FAQ](#teleport-on-ibm-cloud-faq)

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -328,7 +328,8 @@ Edit your `values.yaml` file to refer to the name of your secret:
 
 ## Step 5/7. Set values to configure the cluster
 
-<ScopedBlock scope="enterprise">
+<Tabs>
+<TabItem scope="enterprise" label="Teleport Enterprise">
 
 Before you can install Teleport in your Kubernetes cluster, you will need to
 create a secret that contains your Teleport license information.
@@ -342,12 +343,15 @@ this secret as long as your file is named `license.pem`.
 $ kubectl -n teleport create secret generic license --from-file=license.pem
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, configure the `teleport-cluster` Helm chart to use the `aws` mode. Create
 a file called `aws-values.yaml` and write the values you've chosen above to it:
 
-<ScopedBlock scope={["oss", "cloud"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 <Tabs>
 <TabItem label="cert-manager">
@@ -399,8 +403,8 @@ podSecurityPolicy:
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 <Tabs>
 <TabItem label="cert-manager">
@@ -454,7 +458,9 @@ podSecurityPolicy:
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Install the chart with the values from your `aws-values.yaml` file using this command:
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/aws.mdx
@@ -6,12 +6,6 @@ description: Install and configure an HA Teleport cluster using an AWS EKS clust
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and AWS products (DynamoDB and S3).
 
-<ScopedBlock scope="cloud">
-
-(!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
-
-</ScopedBlock>
-
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
 ## Prerequisites

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -89,20 +89,10 @@ this secret as long as your file is named `license.pem`.
   $ kubectl -n teleport create secret generic license --from-file=license.pem
   ```
 
-After the `ConfigMap` has been created<ScopedBlock scope="enterprise"> and you
-have deployed the secret containing your license file</ScopedBlock>, you can
-deploy the Helm chart into a Kubernetes cluster with a command like this:
+Next, deploy the Helm chart into a Kubernetes cluster with a command like this:
 
-<ScopedBlock scope={["oss", "cloud"]}>
-
-```code
-$ helm install teleport teleport/teleport-cluster \
-  --namespace teleport \
-  --set chartMode=custom
-```
-
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+<Tabs>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```code
 $ helm install teleport teleport/teleport-cluster \
@@ -111,7 +101,17 @@ $ helm install teleport teleport/teleport-cluster \
   --set enterprise=true
 ```
 
-</ScopedBlock>
+</TabItem>
+<TabItem scope={["oss", "cloud"]} label="Other Editions">
+
+```code
+$ helm install teleport teleport/teleport-cluster \
+  --namespace teleport \
+  --set chartMode=custom
+```
+
+</TabItem>
+</Tabs>
 
 <Admonition type="warning">
   Most settings from `values.yaml` will not be applied in `custom` mode.

--- a/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/custom.mdx
@@ -73,19 +73,9 @@ $ kubectl create namespace teleport
 $ kubectl --namespace teleport create configmap teleport --from-file=teleport.yaml
 ```
 
-<Admonition type="note">
-  The name of the `ConfigMap` used must match the name of the Helm release that you install below (the name just after `helm install`).
-  In this example, it's `teleport`.
-
-  The name (key) of the configuration file uploaded to your `ConfigMap` must be `teleport.yaml`. If your configuration file is named differently
-  on disk, you can specify the key that should be used in the `kubectl` command:
-
-  ```code
-  $ kubectl --namespace teleport create configmap teleport --from-file=teleport.yaml=my-teleport-config-file.yaml
-  ```
-</Admonition>
-
-<ScopedBlock scope="enterprise">
+If you are running a self-hosted Teleport Enterprise cluster, you  will need to
+create a secret that contains your Teleport license information before you can
+install Teleport.
 
 Before you can install Teleport in your Kubernetes cluster, you will need to
 create a secret that contains your Teleport license information.
@@ -95,11 +85,9 @@ create a secret that contains your Teleport license information.
 Create a secret from your license file. Teleport will automatically discover
 this secret as long as your file is named `license.pem`.
 
-```code
-$ kubectl -n teleport create secret generic license --from-file=license.pem
-```
-
-</ScopedBlock>
+  ```code
+  $ kubectl -n teleport create secret generic license --from-file=license.pem
+  ```
 
 After the `ConfigMap` has been created<ScopedBlock scope="enterprise"> and you
 have deployed the secret containing your license file</ScopedBlock>, you can

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -257,3 +257,4 @@ Teleport:
 - [Set up Machine ID with Kubernetes](../../machine-id/guides/kubernetes.mdx)
 - [Federated Access using Trusted Clusters](../../kubernetes-access/guides/federation.mdx)
 - [Single-Sign On and Kubernetes Access Control](../../kubernetes-access/controls.mdx)
+

--- a/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/digitalocean.mdx
@@ -3,8 +3,6 @@ title: Get started with Teleport on DigitalOcean Kubernetes
 description: How to get started with Teleport on DigitalOcean Kubernetes
 ---
 
-<ScopedBlock title="Teleport Cloud customers" scope={["cloud"]}>
-
 This guide shows you how to deploy the Teleport Auth Service and Proxy Service
 on a DigitalOcean Kubernetes cluster. These services are fully managed in
 Teleport Cloud.
@@ -15,9 +13,6 @@ cluster:
 
 - [Connect a Kubernetes Cluster to
   Teleport](../../kubernetes-access/getting-started.mdx):
-
-</ScopedBlock>
-
 
 This guide will show you how to get started with Teleport on DigitalOcean
 Kubernetes.
@@ -257,4 +252,5 @@ Teleport:
 - [Set up Machine ID with Kubernetes](../../machine-id/guides/kubernetes.mdx)
 - [Federated Access using Trusted Clusters](../../kubernetes-access/guides/federation.mdx)
 - [Single-Sign On and Kubernetes Access Control](../../kubernetes-access/controls.mdx)
+
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -302,7 +302,8 @@ Next, configure the `teleport-cluster` Helm chart to use the `gcp` mode. Create 
 file called `gcp-values.yaml` file and write the values you've chosen above to
 it:
 
-<ScopedBlock scope={["oss", "cloud"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```yaml
 chartMode: gcp
@@ -320,8 +321,8 @@ highAvailability:
     issuerName: letsencrypt-production            # Name of the cert-manager Issuer to use (as configured above)
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["enterprise"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 ```yaml
 chartMode: gcp
@@ -340,7 +341,9 @@ highAvailability:
 enterprise: true                                  # Indicate that this is a Teleport Enterprise deployment
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Install the chart with the values from your `gcp-values.yaml` file using this command:
 

--- a/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/gcp.mdx
@@ -6,12 +6,6 @@ description: Install and configure an HA Teleport cluster using a Google Cloud G
 In this guide, we'll go through how to set up a High Availability Teleport cluster with multiple replicas in Kubernetes
 using Teleport Helm charts and Google Cloud Platform products (Firestore and Google Cloud Storage).
 
-<ScopedBlock scope="cloud">
-
-(!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
-
-</ScopedBlock>
-
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
 ## Prerequisites

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -3,14 +3,8 @@ title: Getting Started - Kubernetes with SSO
 description: Getting started with Teleport. Let's deploy Teleport in a Kubernetes with SSO and Audit logs
 ---
 
-<ScopedBlock title="Teleport Cloud customers" scope={["cloud"]}>
-This guide shows you how to deploy the Teleport Auth Service and Proxy Service on a Kubernetes cluster. These services are fully managed in Teleport Cloud.
-
-Instead, Teleport Cloud users should consult the following guide, which shows you how to connect a Teleport Kubernetes Service instance to an existing Teleport cluster:
-
-</ScopedBlock>
-
-Teleport can provide secure, unified access to your Kubernetes clusters. This guide will show you how to:
+Teleport can provide secure, unified access to your Kubernetes clusters. This
+guide will show you how to:
 
 - Deploy Teleport in a Kubernetes cluster.
 - Set up Single Sign-On (SSO) for authentication to your Teleport cluster.

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -12,12 +12,7 @@ Instead, Teleport Cloud users should consult the following guide, which shows yo
 
 Teleport can provide secure, unified access to your Kubernetes clusters. This guide will show you how to:
 
-<ScopedBlock scope={["enterprise"]}>
-- Deploy Teleport Enterprise in a Kubernetes cluster.
-</ScopedBlock>
-<ScopedBlock scope={["oss","cloud"]}>
 - Deploy Teleport in a Kubernetes cluster.
-</ScopedBlock>
 - Set up Single Sign-On (SSO) for authentication to your Teleport cluster.
 
 While completing this guide, you will deploy one Teleport pod each for the Auth Service and Proxy Service in your Kubernetes cluster, and a load balancer that allows outside traffic to your Teleport cluster. Users can then access your Kubernetes cluster via the Teleport cluster running within it.

--- a/docs/pages/deploy-a-cluster/helm-deployments/migration.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/migration.mdx
@@ -13,14 +13,6 @@ to use the newer `teleport-cluster` Helm chart instead.
   consider [following a different guide](../helm-deployments.mdx) and storing your cluster's data in AWS DynamoDB or Google Cloud Firestore.
 </Admonition>
 
-<ScopedBlock scope="cloud">
-
-(!docs/pages/kubernetes-access/helm/includes/teleport-cluster-cloud-warning.mdx!)
-
-You can also view this guide as a user of another Teleport edition:
-
-</ScopedBlock>
-
 ## Prerequisites
 
 (!docs/pages/kubernetes-access/helm/includes/teleport-cluster-prereqs.mdx!)

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -32,28 +32,23 @@ general access to Windows desktops.
 
 ## Prerequisites
 
-<ScopedBlock scope={["oss", "enterprise"]}>
-- One or more hosts to run the Teleport Auth and Proxy services on.
-</ScopedBlock>
 - A server or virtual machine running a Windows Server operating system.
   In this guide, we'll install Active Directory on this server in order
   to support passwordless logins with Teleport to the Windows desktops
   in the Active Directory domain.
-- A Linux host where you will run the Teleport Desktop Service.
-  <ScopedBlock scope={["oss", "enterprise"]}> This guide assumes that you will
-  run Teleport's Windows Desktop Service on a dedicated host. To install Desktop
-  Access into an existing Teleport instance running other services, see the
-  [Manual Setup](manual-setup.mdx) guide for Desktop Access.</ScopedBlock>
+- A Linux host where you will run the Teleport Desktop Service. This guide
+  assumes that you will run Teleport's Windows Desktop Service on a dedicated
+  host. To install the Desktop Service into an existing Teleport instance
+  running other services, see the [Manual Setup](manual-setup.mdx) guide.
 - An Active Directory domain, configured for LDAPS (Teleport requires an
-  encrypted LDAP connection). Typically this means installing
-  [AD CS](https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/)
+  encrypted LDAP connection). Typically this means installing [AD
+  CS](https://learn.microsoft.com/en-us/windows-server/identity/ad-cs/)
 
 ## Step 1/2. Run the discovery wizard
 
-In your web browser, access the teleport Web UI at <ScopedBlock scope={["oss", "enterprise"]}>
-`teleport.example.com`</ScopedBlock><ScopedBlock scope={["cloud"]}>
-`mytennant.teleport.sh`</ScopedBlock>. Click on your user name at the top right
-and select **Manage Access**, Select "Desktop" from the main menu, then **NEXT**:
+In your web browser, access the Teleport Web UI at `example.teleport.sh`. Click
+on your user name at the top right and select **Manage Access**, Select
+"Desktop" from the main menu, then **NEXT**:
 
 If you already have Active Directory installed, skip to the next step. Otherwise,
 copy and paste the first command provided into a Windows PowerShell window. If
@@ -168,7 +163,7 @@ Service, and then use the following configuration:
 version: v3
 teleport:
   auth_token: /path/to/token
-  proxy_server: mytenant.teleport.sh:443 # replace with your cloud tenant
+  proxy_server: example.teleport.sh:443 # replace with your cloud tenant
 windows_desktop_service:
   enabled: yes
   ldap:

--- a/docs/pages/desktop-access/troubleshooting.mdx
+++ b/docs/pages/desktop-access/troubleshooting.mdx
@@ -58,7 +58,8 @@ Policy](./manual-setup.mdx#create-another-gpo-and-import-the-teleport-ca). Note 
 Teleport CA was rotated since the last import, you will have to fetch the
 new CA using the following command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -68,8 +69,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl auth export --type=windows >user-ca.cer
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl remotely.
@@ -77,7 +78,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl auth export --type=windows >user-ca.cer
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 If that doesn't help, log into the target host directly, open PowerShell and
 run `gpupdate.exe /force`. This forces a Group Policy sync and should pick up

--- a/docs/pages/includes/database-access/db-configure-start.mdx
+++ b/docs/pages/includes/database-access/db-configure-start.mdx
@@ -12,7 +12,8 @@ your terminal, and manually adjust `/etc/teleport.yaml`.
 
 Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db configure create \
@@ -25,8 +26,8 @@ $ teleport db configure create \
    --labels=env=dev 
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db configure create \
@@ -39,7 +40,9 @@ $ teleport db configure create \
    --labels=env=dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Configure the Database Service to start automatically when the host boots up by
 creating a systemd service for it. The instructions depend on how you installed
@@ -76,7 +79,8 @@ $ sudo systemctl start teleport
 You can start the Teleport Database Service without configuration file using a
 CLI command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ teleport db start \
@@ -92,8 +96,8 @@ Note that the `--auth-server` flag must point to the Teleport cluster's Proxy
 Service endpoint because the Database Service always connects back to the
 cluster over a reverse tunnel.
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ teleport db start \
@@ -108,7 +112,9 @@ $ teleport db start \
 Note that the `--auth-server` flag must point to your Teleport Cloud tenant
 address.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 </TabItem>
 </Tabs>

--- a/docs/pages/includes/database-access/db-helm-install.mdx
+++ b/docs/pages/includes/database-access/db-helm-install.mdx
@@ -1,5 +1,6 @@
 {{ dbName="test" }}
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 Install the Teleport Kube Agent into your Kubernetes Cluster
 with the Teleport Database Service configuration.
 
@@ -18,8 +19,8 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --version (=teleport.version=)
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 Install the Teleport Kube Agent into your Kubernetes Cluster
 with the Teleport Database Service configuration.
 
@@ -38,4 +39,7 @@ $ helm install teleport-kube-agent teleport/teleport-kube-agent \
   --version (=cloud.version=)
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
+

--- a/docs/pages/includes/database-access/tctl-auth-sign.mdx
+++ b/docs/pages/includes/database-access/tctl-auth-sign.mdx
@@ -3,11 +3,9 @@ databases must be configured with Teleport's certificate authority to be
 able to verify client certificates. They also need a certificate/key pair that
 Teleport can verify.
 
-<ScopedBlock scope={["cloud"]}>
-
-Your Teleport Cloud user
-must be allowed to impersonate the system role `Db` in order to be able to
-generate the database certificate.
+If you are using Teleport Cloud, your Teleport user must be allowed to
+impersonate the system role `Db` in order to be able to generate the database
+certificate.
 
 Include the following `allow` rule in in your Teleport Cloud user's role:
 
@@ -18,4 +16,3 @@ allow:
     roles: ["Db"]
 ```
 
-</ScopedBlock>

--- a/docs/pages/includes/enterprise/oidcauthentication.mdx
+++ b/docs/pages/includes/enterprise/oidcauthentication.mdx
@@ -1,12 +1,7 @@
 Configure Teleport to use OIDC authentication as the default instead of the local
 user database. 
 
-<ScopedBlock scope={["oss", "enterprise"]}>
-
-You can either edit your Teleport configuration file or create a dynamic
-resource.
-
-</ScopedBlock> 
+Follow the instructions for your Teleport edition:
 
 <Tabs>
   <TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
@@ -41,3 +36,4 @@ resource.
   ```
   </TabItem>
 </Tabs>
+

--- a/docs/pages/includes/enterprise/samlauthentication.mdx
+++ b/docs/pages/includes/enterprise/samlauthentication.mdx
@@ -2,11 +2,6 @@
 - Configure Teleport to use SAML authentication as the default instead of the local
 user database.
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-  You can either edit the Teleport Auth Service configuration file or create a dynamic
-  resource.
-  </ScopedBlock>
-
   <Tabs>
   <TabItem label="Static Config (Self-Hosted)" scope={["oss", "enterprise"]}>
 

--- a/docs/pages/includes/install-linux.mdx
+++ b/docs/pages/includes/install-linux.mdx
@@ -1,15 +1,18 @@
-<ScopedBlock scope={["enterprise"]}>
+<Tabs>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
 
 Visit your [Teleport account](https://teleport.sh) and select the URL for your package of choice.
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope={["cloud"]}>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Visit the [Downloads Page](../choose-an-edition/teleport-cloud/downloads.mdx)
 and select the URL for your package of choice.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, use the appropriate commands for your environment to install your package.
 

--- a/docs/pages/includes/plugins/rbac-update.mdx
+++ b/docs/pages/includes/plugins/rbac-update.mdx
@@ -38,8 +38,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will need to request the credentials manually by *impersonating* the
 `access-plugin` role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise deployment and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `access-plugin`, define a role
 called `access-plugin-impersonator` by pasting the following YAML document into

--- a/docs/pages/includes/plugins/rbac.mdx
+++ b/docs/pages/includes/plugins/rbac.mdx
@@ -38,8 +38,9 @@ As with all Teleport users, the Teleport Auth Service authenticates the
 will need to request the credentials manually by *impersonating* the
 `access-plugin` role and user.
 
-<ScopedBlock scope={["oss", "enterprise"]}>If you are using `tctl` from the Auth
-Service host, you will already have impersonation privileges.</ScopedBlock>
+If you are running a self-hosted Teleport Enterprise deployment and are using
+`tctl` from the Auth Service host, you will already have impersonation
+privileges.
 
 To grant your user impersonation privileges for `access-plugin`, define a role
 called `access-plugin-impersonator` by pasting the following YAML document into

--- a/docs/pages/includes/sso/loginerrortroubleshooting.mdx
+++ b/docs/pages/includes/sso/loginerrortroubleshooting.mdx
@@ -1,14 +1,15 @@
 Troubleshooting SSO configuration can be challenging. Usually a Teleport administrator
 must be able to:
 
-<ScopedBlock scope={["oss","enterprise"]}>
-- Ensure that HTTP/TLS certificates are configured properly for both Teleport
-  proxy and the SSO provider.
-</ScopedBlock>
-- Be able to see what SAML/OIDC claims and values are getting exported and passed
-  by the SSO provider to Teleport.
-- Be able to see how Teleport maps the received claims to role mappings as defined
-  in the connector.
+- If self-hosting Teleport, ensure that HTTP/TLS certificates are configured
+  properly for both Teleport proxy and the SSO provider.
+- Be able to see what SAML/OIDC claims and values are getting exported and
+  passed by the SSO provider to Teleport.
+- Be able to see how Teleport maps the received claims to role mappings as
+  defined in the connector.
+- For self-hosted Teleport Enterprise clusters, ensure that HTTP/TLS
+  certificates are configured properly for both the Teleport Proxy Service and
+  the SSO provider.
 
 If something is not working, we recommend to:
 
@@ -58,3 +59,4 @@ spec:
       'env': 'dev'
 version: v5
 ```
+

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,9 +1,8 @@
-<Details 
-title="Make sure you can connect to Teleport" 
->
+Make sure you can connect to your Teleport cluster by authenticating with `tsh`
+so you can execute commands with the `tctl` admin tool:
 
-To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
-remotely:
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --proxy=teleport.example.com --user=email@example.com
@@ -15,7 +14,21 @@ $ tctl status
 
 You can run subsequent `tctl` commands in this guide on your local machine.
 
-For full privileges, self-hosted Teleport users can also run `tctl` commands on
-your Auth Service host.
+For full privileges, you can also run `tctl` commands on your Teleport Auth
+Service host.
 
-</Details>
+</TabItem>
+<TabItem scope={["cloud","team"]} label="Teleport Cloud">
+
+```code
+$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
+$ tctl status
+# Cluster  myinstance.teleport.sh
+# Version  (=cloud.version=)
+# CA pin   sha256:sha-hash-here
+```
+
+You must run subsequent `tctl` commands in this guide on your local machine.
+
+</TabItem>
+</Tabs>

--- a/docs/pages/includes/tctl.mdx
+++ b/docs/pages/includes/tctl.mdx
@@ -1,8 +1,5 @@
 <Details 
 title="Make sure you can connect to Teleport" 
-scope={["oss", "enterprise"]} 
-scopeOnly={true}
-opened={true}
 >
 
 To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
@@ -18,27 +15,7 @@ $ tctl status
 
 You can run subsequent `tctl` commands in this guide on your local machine.
 
-For full privileges, you can also run `tctl` commands on your Auth Service host.
-
-</Details>
-<Details 
-title="Make sure you can connect to Teleport" 
-scope={["cloud"]}
-scopeOnly={true}
-opened={true}
->
-
-To connect to Teleport, log in to your cluster using `tsh`, then use `tctl`
-remotely:
-
-```code
-$ tsh login --proxy=myinstance.teleport.sh --user=email@example.com
-$ tctl status
-# Cluster  myinstance.teleport.sh
-# Version  (=cloud.version=)
-# CA pin   sha256:sha-hash-here
-```
-
-You must run subsequent `tctl` commands in this guide on your local machine.
+For full privileges, self-hosted Teleport users can also run `tctl` commands on
+your Auth Service host.
 
 </Details>

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -43,7 +43,8 @@ All installations include `teleport`, `tsh`, `tctl`, and `tbot`.
 
 (!docs/pages/includes/install-linux.mdx!)
 
-<ScopedBlock scope="oss">
+<Tabs>
+<TabItem scope="oss" label="Teleport Community Edition">
 
 <Details title="Using APT or YUM for versions prior to Teleport 10?" scopeOnly={false}>
 
@@ -59,13 +60,15 @@ We will also continue to maintain the legacy APT repo at
 Check the [Downloads](https://goteleport.com/download/) page for the most
 up-to-date information.
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 Check the [Cloud Downloads](./choose-an-edition/teleport-cloud/downloads.mdx) page for the most up-to-date
 information on obtaining Teleport binaries compatible with Teleport Cloud.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Docker
 
@@ -225,3 +228,4 @@ infrastructure. Get started with:
 - [Application Access](application-access/introduction.mdx)
 - [Desktop Access](desktop-access/introduction.mdx)
 - [Machine ID](machine-id/introduction.mdx)
+

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -144,12 +144,9 @@ Teleport packages](https://goteleport.com/download). Binaries provided by Homebr
 are not signed by Teleport, so features that require signed and notarized binaries
 (TouchID) are not available in Homebrew builds.
 
-<ScopedBlock scope={["enterprise", "cloud"]}>
-
-The Homebrew version of Teleport lacks the ability to maintain SAML/OIDC authentication
-connectors through the `tctl` binary. We recommend installing the official Teleport Enterprise edition of `tctl`.
-
-</ScopedBlock>
+The Homebrew version of Teleport lacks the ability to maintain SAML/OIDC
+authentication connectors through the `tctl` binary. We recommend installing the
+official Teleport Enterprise edition of `tctl`.
 
 </Notice>
 

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -120,7 +120,8 @@ spec:
 
 Create or update this role using `tctl`:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -130,8 +131,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl create -f member.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl remotely.
@@ -139,7 +140,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl create -f member.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Assign this role to a user in OIDC or SAML connector:
 

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -46,14 +46,17 @@ Before you create a bot user, you need to determine which role(s) you want to
 assign to it. You can use the `tctl` command below to examine what roles exist
 on your system.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 On your client machine, log in to Teleport using `tsh`, then use `tctl` to examine
 what roles exist on your system.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 Connect to the Teleport Auth Server and use `tctl` to examine what roles exist on
 your system.
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ```code
 $ tctl get roles --format=text
@@ -201,7 +204,8 @@ the foreground to better understand how it works.
 
 Replace the following fields with values from your own cluster.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 - `token` is the token output by the `tctl bots add` command or the name of your IAM method token.
 - `ca-pin` is the CA Pin for your Teleport cluster, and is output by the `tctl bots add` command.
@@ -209,8 +213,8 @@ Replace the following fields with values from your own cluster.
 - `data-dir` is where Machine ID writes its private data, including its own short-lived renewable certificates. These should not be used by applications and tools.
 - `auth-server` is the address of your Teleport Cloud Proxy Server, for example `example.teleport.sh:443`.
 
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 
 - `token` is the token output by the `tctl bots add` command or the name of your IAM method token.
 - `ca-pin` is the CA Pin for your Teleport cluster, and is output by the `tctl bots add` command.
@@ -221,7 +225,9 @@ Replace the following fields with values from your own cluster.
   than your Auth Server, use the public web address of your Proxy Service
   instead (e.g., `auth.example.com:443`). 
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Now that Machine ID has successfully started, let's investigate the
 `/opt/machine-id` directory to see what was written to disk.
@@ -267,9 +273,22 @@ node-name  127.0.0.1:3022 arch=x86_64,group=api-servers
 To use Machine ID with the OpenSSH integration, run the following command to
 connect to `node-name` within cluster `example.com`.
 
+In addition to the `ssh` client you can use `tsh`. Replace the `--proxy` parameter
+with your proxy address. 
+
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
+```code
+$ tsh ssh --proxy=teleport.example.com -i /opt/machine-id/identity root@node-name
 ```
-ssh -F /opt/machine-id/ssh_config root@node-name.example.com
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+```code
+$ tsh ssh --proxy=mytenant.teleport.sh -i /opt/machine-id/identity root@node-name
 ```
+</TabItem>
+
+</Tabs>
 
 <Admonition type="note" title="Roles must have logins defined">
   The below error can occur when the bot does not have permission to log in to

--- a/docs/pages/machine-id/getting-started.mdx
+++ b/docs/pages/machine-id/getting-started.mdx
@@ -142,21 +142,6 @@ the foreground to better understand how it works.
 <Tabs>
   <TabItem label="Token-based Joining">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
-  ```code
-  $ tbot start \
-     --data-dir=/var/lib/teleport/bot \
-     --destination-dir=/opt/machine-id \
-     --token=(=presets.tokens.first=) \
-     --join-method=token \
-     --ca-pin=(=presets.ca_pin=) \
-     --auth-server=auth.example.com:3025
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
   ```code
   $ tbot start \
      --data-dir=/var/lib/teleport/bot \
@@ -166,38 +151,18 @@ the foreground to better understand how it works.
      --ca-pin=(=presets.ca_pin=) \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
   <TabItem label="IAM Method">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
   ```code
   $ tbot start \
      --data-dir=/var/lib/teleport/bot \
      --destination-dir=/opt/machine-id \
      --token=iam-token \
      --join-method=iam \
-     --ca-pin=(=presets.ca_pin=) \
-     --auth-server=auth.example.com:3025
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
-  ```code
-  $ tbot start \
-     --data-dir=/var/lib/teleport/bot \
-     --destination-dir=/opt/machine-id \
-     --token=iam-token \
-     --join-method=iam \
-     --ca-pin=(=presets.ca_pin=) \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
 </Tabs>

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -12,12 +12,15 @@ controls that Teleport provides for human users.
 
 ## Prerequisites
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 You will need Teleport Cloud 10.1.0 or later.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 You will need a running Teleport cluster version 10.1.0 or later.
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 If you have not already connected your application to Teleport, follow
 the [Application Access Getting Started Guide](../../application-access/getting-started.mdx).

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -75,7 +75,8 @@ configured above. Be sure to note the bot join token and CA PIN.
 Next, on the bot node, create a Machine ID configuration file at
 `/etc/tbot.yaml`:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud" scope={["cloud","team"]}>
 ```yaml
 auth_server: "example.teleport.sh:443"
 onboarding:
@@ -89,8 +90,8 @@ destinations:
   - directory: /opt/machine-id
     app: grafana-example
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 ```yaml
 auth_server: "teleport.example.com:443"
 onboarding:
@@ -104,7 +105,8 @@ destinations:
   - directory: /opt/machine-id
     app: grafana-example
 ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Be sure to configure the `token` and `ca_pins` fields to match the output from
 `tctl bots add ...`, and set `app` to match the desired name as shown in

--- a/docs/pages/machine-id/guides/applications.mdx
+++ b/docs/pages/machine-id/guides/applications.mdx
@@ -175,7 +175,8 @@ certificate files can be used:
 
 You may use these credentials with any client application that supports them.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 The Teleport Proxy makes apps available via subdomains of its public web
 address. Given an app named `grafana-example` and a Teleport Proxy at
 `https://example.teleport.sh:443`, the app may be accessed at
@@ -188,8 +189,8 @@ $ curl --user admin:admin \
   --key /opt/machine-id/key \
   https://grafana-example.example.teleport.sh/api/users
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 The Teleport Proxy makes apps available via subdomains of its public web
 address. Given an app named `grafana-example` and a Teleport Proxy at
 `https://teleport.example.com:443`, the app may be accessed at
@@ -202,7 +203,9 @@ $ curl --user admin:admin \
   --key /opt/machine-id/key \
   https://grafana-example.teleport.example.com/api/users
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Note that in the example above, we include `--user` to provide a local username
 and password to our Grafana instance. This is not necessary if your application
@@ -223,16 +226,19 @@ Service, it's also possible to open a local proxy to the app using
 `tbot proxy app ...` in situations where the Teleport Proxy Service's app endpoints are
 unavailable:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```code
 $ tbot proxy --destination-dir=/opt/machine-id --proxy=example.teleport.sh:443 app --port=1234 grafana-example
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 ```code
 $ tbot proxy --destination-dir=/opt/machine-id --proxy=teleport.example.com:443 app --port=1234 grafana-example
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 You may now connect to the app via a local proxy at `http://localhost:1234`:
 
@@ -289,3 +295,4 @@ has been configured to use both the client certificate and key.
   your bot may access.
 - Configure [JWTs](../../application-access/jwt/introduction.mdx) for your
   Application to remove the need for additional login credentials.
+

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -78,21 +78,24 @@ $ tctl create -f role.yaml
 
 With the role created, create a new bot and allow it to assume the new role.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 On your client machine, log in to Teleport using `tsh` before using `tctl` to
 create the bot:
 
 ```code
 $ tctl bots add app --roles=machine-id-db
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 Connect to the Teleport Auth Server and use `tctl` to create the bot:
 
 ```code
 $ tctl bots add app --roles=machine-id-db
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Step 2/3. Configure and start Machine ID
 

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -16,13 +16,16 @@ Teleport provides for human users.
 
 ## Prerequisites
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 You will need Teleport Cloud 9.3.0 or later.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 You will need to be running the Teleport Proxy and Auth Services, version 9.3.0 or
 later.
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 If you have not already put your database behind the Teleport Database Service,
 follow the [database access getting started guide](../../database-access/getting-started.mdx).

--- a/docs/pages/machine-id/guides/databases.mdx
+++ b/docs/pages/machine-id/guides/databases.mdx
@@ -104,7 +104,8 @@ credentials.
 
 Start by creating a configuration file for Machine ID at `/etc/tbot.yaml`:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud" scope={["cloud","team"]}>
 ```yaml
 auth_server: "example.teleport.sh:443"
 onboarding:
@@ -126,8 +127,8 @@ destinations:
     configs:
       - mongo
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 ```yaml
 auth_server: "teleport.example.com:443"
 onboarding:
@@ -149,7 +150,8 @@ destinations:
     configs:
       - mongo
 ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Be sure to configure the `token` and `ca_pins` fields to match the output from
 `tctl bots add ...`. We've also included the `mongo` config template in the

--- a/docs/pages/machine-id/guides/host-certificate.mdx
+++ b/docs/pages/machine-id/guides/host-certificate.mdx
@@ -171,21 +171,6 @@ First, create a basic configuration file using the following parameters:
 <Tabs>
   <TabItem label="Token-based Joining">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
-  ```code
-  $ tbot configure \
-     --data-dir=/var/lib/teleport/bot \
-     --token=(=presets.tokens.first=) \
-     --join-method=token \
-     --certificate-ttl=1h0m0s \
-     --ca-pin=(=presets.ca_pin=) \
-     --auth-server=auth.example.com:3025
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
   ```code
   $ tbot configure \
      --data-dir=/var/lib/teleport/bot \
@@ -195,27 +180,10 @@ First, create a basic configuration file using the following parameters:
      --ca-pin=(=presets.ca_pin=) \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
   <TabItem label="IAM method">
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
-  ```code
-  $ tbot configure \
-     --data-dir=/var/lib/teleport/bot \
-     --token=iam-token \
-     --join-method=iam \
-     --certificate-ttl=1h0m0s \
-     --ca-pin=(=presets.ca_pin=) \
-     --auth-server=auth.example.com:3025
-  ```
-
-  </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
   ```code
   $ tbot configure \
      --data-dir=/var/lib/teleport/bot \
@@ -225,8 +193,6 @@ First, create a basic configuration file using the following parameters:
      --ca-pin=(=presets.ca_pin=) \
      --auth-server=example.teleport.sh:443
   ```
-
-  </ScopedBlock>
 
   </TabItem>
 </Tabs>

--- a/docs/pages/machine-id/guides/jenkins.mdx
+++ b/docs/pages/machine-id/guides/jenkins.mdx
@@ -132,7 +132,8 @@ $ sudo tbot init \
 
 Next, you need to start Machine ID in the background of each Jenkins worker.
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud" scope={["cloud","team"]}>
   First create a configuration file for Machine ID at `/etc/tbot.yaml`.
 
   ```yaml
@@ -147,8 +148,8 @@ Next, you need to start Machine ID in the background of each Jenkins worker.
   destinations:
     - directory: /opt/machine-id
   ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 First create a configuration file for Machine ID at `/etc/tbot.yaml`.
   ```yaml
   auth_server: "auth.example.com:3025"
@@ -162,7 +163,8 @@ First create a configuration file for Machine ID at `/etc/tbot.yaml`.
   destinations:
     - directory: /opt/machine-id
   ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Next, create a systemd.unit file at `/etc/systemd/system/machine-id.service`.
 

--- a/docs/pages/machine-id/guides/jenkins.mdx
+++ b/docs/pages/machine-id/guides/jenkins.mdx
@@ -79,15 +79,16 @@ spec:
       "group": "api"
 ```
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 On your client machine, log in to Teleport using `tsh` before using `tctl`.
 
 ```code
 $ tctl create -f api-workers.yaml
 $ tctl bots add jenkins --roles=api-workers
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 Connect to the Teleport Auth Server and use `tctl` to examine what roles exist on
 your system.
 
@@ -95,7 +96,9 @@ your system.
 $ tctl create -f api-workers.yaml
 $ tctl bots add jenkins --roles=api-workers
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Machine ID allows you to use Linux Access Control Lists (ACLs) to control
 access to certificates on disk. You will use this to limit the access Jenkins
@@ -201,3 +204,4 @@ steps {
 You are all set. You have provided Jenkins with short-lived certificates tied
 to a machine identity that can be rotated, audited, and controlled with all the
 familiar Teleport access controls.
+

--- a/docs/pages/machine-id/guides/kubernetes.mdx
+++ b/docs/pages/machine-id/guides/kubernetes.mdx
@@ -150,7 +150,8 @@ note the bot join token and CA PIN.
 Next, on the bot node, create a Machine ID configuration file at
 `/etc/tbot.yaml`:
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem label="Teleport Cloud"  scope={["cloud","team"]}>
 ```yaml
 auth_server: "example.teleport.sh:443"
 onboarding:
@@ -164,8 +165,8 @@ destinations:
   - directory: /opt/machine-id
     kubernetes_cluster: example-k8s-cluster
 ```
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem label="Self-Hosted" scope={["oss","enterprise"]}>
 ```yaml
 auth_server: "teleport.example.com:443"
 onboarding:
@@ -179,7 +180,8 @@ destinations:
   - directory: /opt/machine-id
     kubernetes_cluster: example-k8s-cluster
 ```
-</ScopedBlock>
+</TabItem>
+</Tabs>
 
 Be sure to configure the `token` and `ca_pins` fields to match the output from
 `tctl bots add ...`, and set `kubernetes_cluster` to match the cluster name as

--- a/docs/pages/machine-id/guides/kubernetes.mdx
+++ b/docs/pages/machine-id/guides/kubernetes.mdx
@@ -12,12 +12,15 @@ controls that Teleport provides for human users.
 
 ## Prerequisites
 
-<ScopedBlock scope={["cloud"]}>
+<Tabs>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 You will need Teleport Cloud 10.1.0 or later.
-</ScopedBlock>
-<ScopedBlock scope={["oss","enterprise"]}>
+</TabItem>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 You will need a running Teleport cluster version 10.1.0 or later.
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 If you have not already connected your Kubernetes cluster to Teleport, follow
 the [Kubernetes Access Getting Started Guide](../../kubernetes-access/getting-started.mdx).

--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -22,15 +22,12 @@ ERROR: failed direct dial to auth server: auth API: access denied [00]
 
 In particular, note the message `auth API: access denied`.
 
-<Tabs>
-<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
-The Teleport Auth Service will also provide some additional context:
+In self-hosted Teleport deployments, the Teleport Auth Service will also provide
+some additional context:
+
 ```text
 [AUTH]      WARN lock targeting User:"bot-example" is in force: The bot user "bot-example" has been locked due to a certificate generation mismatch, possibly indicating a stolen certificate. auth/apiserver.go:224
 ```
-</TabItem>
-
-</Tabs>
 
 ### Explanation
 

--- a/docs/pages/machine-id/troubleshooting.mdx
+++ b/docs/pages/machine-id/troubleshooting.mdx
@@ -22,12 +22,15 @@ ERROR: failed direct dial to auth server: auth API: access denied [00]
 
 In particular, note the message `auth API: access denied`.
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss","enterprise"]} label="Self-Hosted">
 The Teleport Auth Service will also provide some additional context:
 ```text
 [AUTH]      WARN lock targeting User:"bot-example" is in force: The bot user "bot-example" has been locked due to a certificate generation mismatch, possibly indicating a stolen certificate. auth/apiserver.go:224
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Explanation
 
@@ -340,3 +343,4 @@ Kubernetes public address is populated in `proxy.kube.public_addr`.
 ```bash
 curl https://teleport.example.com:443/webapi/ping | jq
 ```
+

--- a/docs/pages/management/admin/adding-nodes.mdx
+++ b/docs/pages/management/admin/adding-nodes.mdx
@@ -48,9 +48,7 @@ by executing [`tctl auth rotate`](../../reference/cli/tctl.mdx#tctl-auth-rotate)
     
 </Notice>
 
-On you local machine, retrieve the CA pin of the Auth Service <ScopedBlock
-scope="cloud"> by running the following command on your local
-machine</ScopedBlock>:
+On you local machine, retrieve the CA pin of the Auth Service:
 
 ```code
 $ export CA_PIN=$(tctl status | awk '/CA pin/{print $3}')
@@ -145,7 +143,8 @@ $ export CA_PIN=<Var name="ca-pin" />
 $ export INVITE_TOKEN=<Var name="invite-token" />
 ```
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Still on the host where you will run your Node, assign the address of your Auth
 Service to an environment variable, including the domain name (or IP address)
@@ -155,8 +154,8 @@ and port:
 $ export ADDR=teleport.example.com:3025
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Still on the host where you will run your Node, assign the address of your
 Teleport Cloud tenant to an environment variable, including the domain name (or
@@ -166,7 +165,9 @@ IP address) and port `443`:
 $ export ADDR=mytenant.teleport.sh:443
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Details title="Alternative: Connect to the Proxy Service via Teleport Node Tunneling" scope={["oss", "enterprise"]} scopeOnly opened={false}>
 

--- a/docs/pages/management/admin/labels.mdx
+++ b/docs/pages/management/admin/labels.mdx
@@ -101,7 +101,8 @@ starting Teleport.
 On the host where you will run your Node, paste the following content into
 `/etc/teleport.yaml` and adjust it for your environment:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -126,8 +127,8 @@ ssh_service:
     environment: dev
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -148,7 +149,9 @@ ssh_service:
     environment: dev
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, start Teleport with the invite token you created earlier:
 
@@ -182,7 +185,8 @@ your Node.
 
 Run the following command to get the current logins for your user:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh status
@@ -196,8 +200,23 @@ $ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
+
+```code
+$ tsh status
+> Profile URL:        https://teleport.example.com:443
+  Logged in as:       myuser
+  Cluster:            teleport.example.com
+  Roles:              access, editor, reviewer
+  Logins:             -teleport-nologin-d4bc1dad-ce49-4bbe-925d-a67f8d2d6afe
+  Kubernetes:         enabled
+  Valid until:        2022-04-27 22:26:50 -0400 EDT [valid for 11h40m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 tsh status
@@ -211,7 +230,9 @@ tsh status
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 In this example, `-teleport-nologin-d4bc1dad-ce49-4bbe-925d-a67f8d2d6afe` means
 that no logins have been assigned to the user.
@@ -258,7 +279,8 @@ Teleport configuration file.
 
 Edit `/etc/teleport.yaml` to define a `commands` array as shown below:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```yaml
 version: v3
@@ -285,8 +307,8 @@ ssh_service:
     period: 1h0m0s
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```yaml
 version: v3
@@ -313,7 +335,9 @@ ssh_service:
     period: 1h0m0s
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Notice that the `command` setting is an array where the first element
 is a valid executable and each subsequent element is an argument.
@@ -384,3 +408,4 @@ For more information, see
 You can also use labels to limit the access that different roles have to
 specific classes of resources. For more information, see
 [Teleport Role Templates](../../access-controls/guides/role-templates.mdx).
+

--- a/docs/pages/management/admin/troubleshooting.mdx
+++ b/docs/pages/management/admin/troubleshooting.mdx
@@ -7,19 +7,14 @@ In this guide, we will explain how to address issues or unexpected behavior in y
 Teleport cluster.
 
 You can use these steps to get more visibility into the `teleport` process so
-you can troubleshoot <ScopedBlock scope={["oss", "enterprise"]}>the Auth
-Service, Proxy Service, and </ScopedBlock> resource-specific services such as
-the Application Service and Database Service.
+you can troubleshoot the Auth Service, Proxy Service, and Teleport agent
+services such as the Application Service and Database Service.
 
 ## Prerequisites
 
 (!docs/pages/includes/edition-prereqs-tabs.mdx!)
 
-<ScopedBlock scope="cloud">
-- A host where you have installed and configured the `teleport` binary.
-</ScopedBlock>
-
-(!docs/pages/includes/tctl.mdx!)
+- (!docs/pages/includes/tctl.mdx!)
 
 ## Step 1/3. Enable verbose logging
 
@@ -121,8 +116,6 @@ Teleport v8.3.7 git:v8.3.7-0-ga8d066935 go1.17.3
 You can also collect the versions of the Teleport Auth Service, Proxy
 Service, and client tools to rule out version compatibility issues.
 
-<ScopedBlock scope="cloud">
-
 To see the version of the Auth Service and Proxy Service, run the following
 command:
 
@@ -135,8 +128,6 @@ User CA  never updated
 Jwt CA   never updated
 CA pin   (=presets.ca_pin=)
 ```
-
-</ScopedBlock>
 
 Get the versions of your client tools:
 
@@ -200,3 +191,4 @@ does not explicitly indicate that something is misconfigured.
 ## `ssh: overflow reading version string`
 
 (!docs/pages/includes/tls-multiplexing-warnings.mdx!)
+

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -373,8 +373,7 @@ Change the fields of `trusted_cluster.yaml` as follows:
 
 #### `metadata.name`
 
-Use the name of your root cluster, e.g., <ScopedBlock
-scope={["oss", "enterprise"]}>`teleport.example.com`</ScopedBlock><ScopedBlock scope="cloud">`mytenant.teleport.sh`</ScopedBlock>.
+Use the name of your root cluster, e.g., `example.teleport.sh`.
 
 #### `spec.token`
 

--- a/docs/pages/management/admin/trustedclusters.mdx
+++ b/docs/pages/management/admin/trustedclusters.mdx
@@ -125,7 +125,8 @@ required for accessing a shell on the Node.
 
 On your local machine, log in to your leaf cluster using your Teleport username:
 
-<ScopedBlock scope="cloud">
+<Tabs>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 ```code
 # Log out of all clusters to begin this guide from a clean state
@@ -133,8 +134,8 @@ $ tsh logout
 $ tsh login --proxy=leafcluster.teleport.sh --user=myuser
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["oss", "enterprise"]}>
+</TabItem>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log out of all clusters to begin this guide from a clean state
@@ -142,7 +143,9 @@ $ tsh logout
 $ tsh login --proxy=leafcluster.example.com --user=myuser
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Create a file called `visitor.yaml` with the
 following content:
@@ -180,22 +183,25 @@ you can satisfy the conditions of the role and access the Node.
 
 Make sure that you are logged in to your root cluster.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh logout
 $ tsh login --proxy=rootcluster.example.com --user=myuser
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh logout
 $ tsh login --proxy=rootcluster.teleport.sh --user=myuser
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Create a file called `user.yaml` with your current user configuration. Replace
 `myuser` with your Teleport username:
@@ -241,7 +247,8 @@ You can create a join token using the `tctl` tool.
 
 First, log out of all clusters and log in to the root cluster.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh logout
@@ -256,8 +263,24 @@ $ tsh login --user=myuser --proxy=rootcluster.example.com
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
+
+```code
+$ tsh logout
+$ tsh login --user=myuser --proxy=rootcluster.example.com
+> Profile URL:        https://rootcluster.example.com:443
+  Logged in as:       myuser
+  Cluster:            rootcluster.example.com
+  Roles:              access, auditor, editor, reviewer
+  Logins:             root
+  Kubernetes:         enabled
+  Valid until:        2022-04-29 03:07:22 -0400 EDT [valid for 12h0m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --user=myuser --proxy=myrootclustertenant.teleport.sh
@@ -271,7 +294,9 @@ $ tsh login --user=myuser --proxy=myrootclustertenant.teleport.sh
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Execute the following command on your development machine:
 
@@ -360,7 +385,8 @@ This is join token you created earlier.
 This is the reverse tunnel address of the Proxy Service in the root cluster. Run
 the following command to retrieve the value you should use:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ PROXY=rootcluster.example.com
@@ -368,8 +394,8 @@ $ curl https://${PROXY?}/webapi/ping | jq 'if .proxy.tls_routing_enabled == true
 "rootcluster.example.com:443"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ PROXY=rootcluster.teleport.sh
@@ -377,29 +403,34 @@ $ curl https://${PROXY?}/webapi/ping | jq 'if .proxy.tls_routing_enabled == true
 "rootcluster.teleport.sh:443"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 #### `web_proxy_addr`
 
 This is the address of the Proxy Service on the root cluster. Obtain this with the
 following command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ curl https://${PROXY?}/webapi/ping | jq .proxy.ssh.public_addr
 "teleport.example.com:443"
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ curl https://${PROXY?}/webapi/ping | jq .proxy.ssh.public_addr
 "mytenant.teleport.sh:443"
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 #### `spec.role_map`
 
@@ -528,20 +559,23 @@ $ tsh logout
 
 Log in to the leaf cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh login --user=myuser --proxy=leafcluster.example.com
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh login --user=myuser --proxy=leafcluster.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Create the Trusted Cluster:
 
@@ -576,7 +610,8 @@ Log out of the leaf cluster and log back in to the root cluster. When you run
 `tsh clusters`, you should see listings for both the root cluster and the leaf
 cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh clusters
@@ -586,8 +621,8 @@ Cluster Name                                          Status Cluster Type Select
 rootcluster.example.com                               online root         *
 leafcluster.example.com                               online leaf
 ```
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh clusters
@@ -596,7 +631,9 @@ Cluster Name                                          Status Cluster Type Select
 rootcluster.teleport.sh                               online root         *
 leafcluster.teleport.sh                               online leaf
 ```
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## Step 3/5. Manage access to your Trusted Cluster
 
@@ -632,7 +669,8 @@ version: v3
 Still logged in to the root cluster, use `tctl` to update the labels on the leaf
 cluster:
 
-<ScopedBlock scope="cloud">
+<Tabs>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl update rc/leafcluster.teleport.sh --set-labels=env=demo
@@ -640,8 +678,8 @@ $ tctl update rc/leafcluster.teleport.sh --set-labels=env=demo
 # Cluster leafcluster.teleport.sh has been updated
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["oss", "enterprise"]}>
+</TabItem>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl update rc/leafcluster.example.com --set-labels=env=demo
@@ -649,7 +687,9 @@ $ tctl update rc/leafcluster.example.com --set-labels=env=demo
 # Cluster leafcluster.example.com has been updated
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Change cluster access privileges
 
@@ -710,22 +750,25 @@ Node in your leaf cluster as a user of your root cluster.
 
 First, make sure that you are logged in to root cluster:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tsh logout
 $ tsh --proxy=rootcluster.example.com --user=myuser login
 ```
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh logout
 $ tsh --proxy=rootcluster.teleport.sh --user=myuser login
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 To log in to your Node, confirm that your Node is joined to your leaf cluster:
 
@@ -810,20 +853,23 @@ cluster and editing the `trusted_cluster` resource you created earlier.
 
 Retrieve the Trusted Cluster resource you created earlier:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl get trusted_cluster/rootcluster.example.com > trusted_cluster.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl get trusted_cluster/rootcluster.teleport.sh > trusted_cluster.yaml
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Make the following change to the resource:
 
@@ -857,39 +903,45 @@ On the leaf cluster, run the following command. This performs the same tasks as
 setting `enabled` to `false` in a `trusted_cluster` resource, but also removes
 the Trusted Cluster resource from the Auth Service backend:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl rm trusted_cluster/rootcluster.example.com
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl rm trusted_cluster/rootcluster.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, run the following command on the root cluster. This command deletes the
 certificate authorities associated with the remote cluster and removes the
 `remote_cluster` resource from the root cluster's Auth Service backend.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl rm rc/leafcluster.example.com
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl rm rc/leafcluster.teleport.sh
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition type="Removing the relationship from the root side only">
 
@@ -979,4 +1031,5 @@ should check to see the following:
 ## Further reading
 - Read more about how Trusted Clusters fit into Teleport's overall architecture:
   [Architecture Introduction](../../architecture/trustedclusters.mdx).
+
 

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -6,10 +6,6 @@ description: Learn how to manage local users in Teleport. Local users are stored
 In Teleport, **local users** are users managed directly via Teleport, rather
 than a third-party identity provider.
 
-Local user accounts can be used alongside external user accounts managed via
-GitHub<ScopedBlock scope={["enterprise", "cloud"]}> as well as OIDC and SAML
-2.0</ScopedBlock>.
-
 This guide shows you how to:
 
 - [Add local users](./users.mdx#adding-local-users)

--- a/docs/pages/management/admin/users.mdx
+++ b/docs/pages/management/admin/users.mdx
@@ -131,3 +131,4 @@ information, see [GitHub SSO](../../access-controls/sso/github-sso.mdx).
 
 </TabItem>
 </Tabs>
+

--- a/docs/pages/management/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/management/export-audit-events/elastic-stack.mdx
@@ -17,12 +17,8 @@ stores them in Elasticsearch for visualization and alerting in Kibana.
 
 (!docs/pages/includes/commercial-prereqs-tabs.mdx!)
 
-- Logstash version 8.4.1 or above running on a Linux host. Logstash must be
-  listening on a TCP port that is open to traffic from <ScopedBlock
-  scope={["oss", "enterprise"]}>the Teleport Auth
-  Service</ScopedBlock><ScopedBlock scope="cloud">your Teleport Cloud
-  tenant</ScopedBlock>. In this guide, you will also run the Event Handler
-  plugin on this host.
+- Logstash version 8.4.1 or above running on a Linux host. In this guide, you
+  will also run the Event Handler plugin on this host.
 
 - Elasticsearch and Kibana version 8.4.1 or above, either running via an Elastic
   Cloud account or on your own infrastructure. You will need permissions to

--- a/docs/pages/management/export-audit-events/elastic-stack.mdx
+++ b/docs/pages/management/export-audit-events/elastic-stack.mdx
@@ -220,7 +220,8 @@ Like all Teleport users, `teleport-event-handler` needs signed credentials in
 order to connect to your Teleport cluster. You will use the `tctl auth sign`
 command to request these credentials for the plugin. 
 
-<ScopedBlock scope={["enterprise", "oss"]}>
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
 The format of the credentials depends on whether you have set up your network to
 give the plugin direct access to the Teleport Auth Service, or if all Teleport
@@ -270,9 +271,9 @@ connect to the Auth Service.
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope="cloud">
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 The following `tctl auth sign` command impersonates the `teleport-event-handler`
 user, generates signed credentials, and writes an identity file to the local
@@ -293,7 +294,9 @@ Service's gRPC endpoint.
 
 You will refer to this file later when configuring the plugin.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 <Admonition
   title="Certificate Lifetime"

--- a/docs/pages/management/export-audit-events/splunk.mdx
+++ b/docs/pages/management/export-audit-events/splunk.mdx
@@ -221,7 +221,8 @@ Like all Teleport users, `teleport-event-handler` needs signed credentials in
 order to connect to your Teleport cluster. You will use the `tctl auth sign`
 command to request these credentials for the plugin.
 
-<ScopedBlock scope={["enterprise", "oss"]}>
+<Tabs>
+<TabItem scope={["enterprise", "oss"]} label="Self-Hosted">
 
 The format of the credentials depends on whether you have set up your Teleport
 cluster so clients and services connect to the Teleport Proxy Service or to the
@@ -273,9 +274,9 @@ connect to the Auth Service.
 </TabItem>
 </Tabs>
 
-</ScopedBlock>
+</TabItem>
 
-<ScopedBlock scope="cloud">
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 The following `tctl auth sign` command impersonates the `teleport-event-handler`
 user, generates signed credentials, and writes an identity file to the local
@@ -297,7 +298,9 @@ Service's gRPC endpoint.
 
 You will refer to this file later when configuring the plugin.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Move the credentials you generated to the host where you are running the
 Teleport Event Handler plugin.

--- a/docs/pages/management/guides.mdx
+++ b/docs/pages/management/guides.mdx
@@ -9,7 +9,6 @@ layout: tocless-doc
   - [Docker](./guides/docker.mdx). Getting started with Teleport Open Source using Docker.
   - [EC2 tags as Teleport Nodes](./guides/ec2-tags.mdx). How to set up Teleport Node labels based on EC2 tags.
   - [Joining Nodes via AWS IAM Role](./guides/joining-nodes-aws-iam.mdx). Use the IAM join method to add Nodes to your Teleport cluster on AWS.
-  <ScopedBlock scope={["oss", "enterprise"]}>
   - [Joining Nodes via AWS EC2 Identity Document](./guides/joining-nodes-aws-ec2.mdx). Use the EC2 join method to add Nodes to your Teleport cluster on AWS.
-  </ScopedBlock>
   - [Using Teleport's Certificate Authority with GitHub](./guides/ssh-key-extensions.mdx). Use Teleport's short-lived certificates with GitHub's Certificate Authority.
+

--- a/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
+++ b/docs/pages/management/guides/joining-nodes-aws-ec2.mdx
@@ -7,13 +7,9 @@ This guide will explain how to use the **EC2 join method** to configure Teleport
 Nodes and Proxy Service instances to join your Teleport cluster without sharing
 any secrets when they are running in AWS.
 
-<ScopedBlock scope="cloud">
-
 The EC2 join method is not available in Teleport Cloud. Teleport Cloud customers
 can use the [IAM join method](./joining-nodes-aws-iam.mdx) or
 [secret tokens](../admin/adding-nodes.mdx).
-
-</ScopedBlock>
 
 The EC2 join method is available in self-hosted versions of Teleport 7.3+. It is
 available to any Teleport Node or Proxy running on an EC2 instance. Only one

--- a/docs/pages/management/guides/ssh-key-extensions.mdx
+++ b/docs/pages/management/guides/ssh-key-extensions.mdx
@@ -15,7 +15,8 @@ Teleport supports exporting user SSH certificates with configurable key extensio
 
 In order to export the Teleport CA, execute the following command:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # Log in to your cluster with tsh so you can use tctl from your local machine.
@@ -25,8 +26,8 @@ $ tsh login --proxy=teleport.example.com --user=myuser
 $ tctl auth export --type=user | sed 's/^cert-authority //g'
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # Log in to your Teleport cluster so you can use tctl remotely.
@@ -34,7 +35,9 @@ $ tsh login --proxy=mytenant.teleport.sh --user=myuser
 $ tctl auth export --type=user | sed 's/^cert-authority //g'
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, follow the instructions in the guide below to import your Teleport CA into GitHub:
 

--- a/docs/pages/management/operations/scaling.mdx
+++ b/docs/pages/management/operations/scaling.mdx
@@ -6,13 +6,6 @@ description: How to configure Teleport for large-scale deployments
 This section explains the recommended configuration settings for large-scale
 deployments of Teleport.
 
-<ScopedBlock scope="cloud">
-
-For Teleport Cloud customers, the settings in this guide are configured
-automatically.
-
-</ScopedBlock>
-
 (!docs/pages/includes/cloud/call-to-action.mdx!)
 
 ## Prerequisites

--- a/docs/pages/reference/backends.mdx
+++ b/docs/pages/reference/backends.mdx
@@ -8,12 +8,6 @@ default everything is stored in a local directory at the Auth server.
 Integration with other storage types is implemented based on the nature of the
 stored data (size, read/write ratio, mutability, etc.).
 
-<ScopedBlock scope={["cloud"]}>
-
-Teleport Cloud manages Auth Service and Proxy Service data for you, so there is
-no need to configure a backend.
-</ScopedBlock>
-
 | Data type | Description | Supported storage backends |
 | - | - | - |
 | core cluster state | Cluster configuration (e.g. users, roles, auth connectors) and identity (e.g. certificate authorities, registered nodes, trusted clusters). | Local directory (SQLite), etcd, AWS DynamoDB, GCP Firestore |

--- a/docs/pages/reference/cli/tctl.mdx
+++ b/docs/pages/reference/cli/tctl.mdx
@@ -1045,7 +1045,8 @@ These flags are available for all commands `--debug, --config` . Run
 
 ### Examples
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 $ tctl get users
@@ -1059,8 +1060,8 @@ $ tctl get clusters,users
 $ tctl get all > state.yaml
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tctl get users
@@ -1072,7 +1073,9 @@ $ tctl get cluster/east
 $ tctl get clusters,users
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ## tctl status
 
@@ -1221,4 +1224,5 @@ Print the version of your `tctl` binary:
 ```code
 tctl version
 ```
+
 

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -276,22 +276,10 @@ The `tsh ssh` command allows users to do anything they could if they were to SSH
   To use the `ssh` client generate a SSH configuration file and postfix
   the cluster name after the node name.
 
-  <ScopedBlock scope={["oss", "enterprise"]}>
-
     ```code
     $ tsh config > ssh_config_teleport
-    $ ssh -F ssh_config_teleport root@ip-172-31-41-144.tele.example.com
+    $ ssh -F ssh_config_teleport root@ip-172-31-41-144.example.teleport.sh
     ```
-
-   </ScopedBlock>
-  <ScopedBlock scope={["cloud"]}>
-
-    ```code
-    $ tsh config > ssh_config_teleport
-    $ ssh -F ssh_config_teleport root@ip-172-31-41-144.mytenant.teleport.sh
-    ```
-
-   </ScopedBlock>
 
   </TabItem>
 </Tabs>

--- a/docs/pages/server-access/getting-started.mdx
+++ b/docs/pages/server-access/getting-started.mdx
@@ -90,7 +90,8 @@ server.
 On your Node, save `token.file` to an appropriate, secure, directory you have
 the rights and access to read.
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 Start the Node. Change `tele.example.com` to the address of your Teleport Proxy
 Service. Assign the `--token` flag to the path where you saved
@@ -104,8 +105,8 @@ $ sudo teleport start \
    --auth-server=tele.example.com:443
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 Start the Node. Change `mytenant.teleport.sh` to your Teleport Cloud tenant
 address. Assign the `--token` flag to the path where you saved `token.file`.
@@ -118,7 +119,9 @@ $ sudo teleport start \
    --auth-server=mytenant.teleport.sh:443
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 ### Access the Web UI
 
@@ -154,7 +157,8 @@ We can use `tsh` to SSH into the cluster:
 
 ### Log in to the cluster
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 On your local machine, log in to your cluster through `tsh`, assigning the
 `--proxy` flag to the address of your Teleport Proxy Service:
@@ -164,8 +168,8 @@ On your local machine, log in to your cluster through `tsh`, assigning the
 $ tsh login --proxy=tele.example.com --user=tele-admin
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 On your local machine, log in to your cluster through `tsh`, assigning the
 `--proxy` flag to the address of your Teleport Cloud tenant:
@@ -175,13 +179,16 @@ On your local machine, log in to your cluster through `tsh`, assigning the
 $ tsh login --proxy=mytenant.teleport.sh --user=tele-admin
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 You'll be prompted to supply the password and second factor we set up previously.
 
 `tele-admin` will now see something similar to:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```txt
 > Profile URL:        https://tele.example.com:443
@@ -197,9 +204,8 @@ Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 In this example, `tele-admin` is now logged into the `tele.example.com` cluster
 through Teleport SSH.
 
-
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```txt
 > Profile URL:        https://mytenant.teleport.sh:443
@@ -215,8 +221,9 @@ Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
 In this example, `tele-admin` is now logged into the `mytenant.teleport.sh`
 cluster through Teleport SSH.
 
+</TabItem>
 
-</ScopedBlock>
+</Tabs>
 
 ### Display cluster resources
 
@@ -367,3 +374,4 @@ Feel free to shut down, clean up, and delete your resources, or use them in furt
 - [How to SSH properly](https://goteleport.com/blog/how-to-ssh-properly/)
 - Consider whether [OpenSSH or Teleport SSH](https://goteleport.com/blog/openssh-vs-teleport/) is right for you.
 - [Labels](../management/admin/labels.mdx)
+

--- a/docs/pages/server-access/guides/openssh.mdx
+++ b/docs/pages/server-access/guides/openssh.mdx
@@ -200,7 +200,8 @@ generated earlier.
 First, make sure you are running OpenSSH's `ssh-agent` and have logged
 in to your Teleport cluster:
 
-<ScopedBlock scope={["oss","enterprise"]}>
+<Tabs>
+<TabItem scope={["oss"]} label="Teleport Community Edition">
 
 ```code
 $ tsh status
@@ -212,12 +213,25 @@ $ tsh status
   Kubernetes:         enabled
   Valid until:        2022-05-06 22:54:01 -0400 EDT [valid for 11h53m0s]
   Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
-$ eval `ssh-agent`
-Agent pid 5931
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["enterprise"]} label="Teleport Enterprise">
+
+```code
+$ tsh status
+> Profile URL:        https://teleport.example.com:443
+  Logged in as:       myuser
+  Cluster:            teleport.example.com
+  Roles:              access, auditor, editor, reviewer, host-certifier
+  Logins:             ubuntu, root
+  Kubernetes:         enabled
+  Valid until:        2022-05-06 22:54:01 -0400 EDT [valid for 11h53m0s]
+  Extensions:         permit-agent-forwarding, permit-port-forwarding, permit-pty
+```
+
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 $ tsh status
@@ -233,7 +247,9 @@ $ eval `ssh-agent`
 Agent pid 5931
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 The `ssh-agent` command prints additional commands to export the `SSH_AUTH_SOCK`
 and `SSH_AGENT_PID` environment variables. These variables allow OpenSSH clients
@@ -427,7 +443,8 @@ First, define environment variables for the address of your Teleport cluster,
 the username you will use to log in to your `sshd` host, and the port on your
 `sshd` host you are using for SSH traffic:
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
 # See the available logins you can use to access your sshd host
@@ -438,8 +455,8 @@ $ CLUSTER=teleport.example.com
 $ PORT=22
 ```
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
 # See the available logins you can use to access your sshd host
@@ -450,7 +467,9 @@ $ CLUSTER=mytenant.teleport.sh
 $ PORT=22
 ```
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 Next, SSH in to your remote host:
 

--- a/docs/pages/server-access/guides/recording-proxy-mode.mdx
+++ b/docs/pages/server-access/guides/recording-proxy-mode.mdx
@@ -15,15 +15,10 @@ when gradually transitioning large server fleets to Teleport.
   ![Teleport OpenSSH Recording Proxy](../../../img/server-access/openssh-proxy.svg)
 </Figure>
 
-
-<ScopedBlock scope={["cloud"]}>
-
 Teleport Cloud only supports session recording at the Node level. If you are
 interested in setting up session recording, read our
 [Server Access Getting Started Guide](../getting-started.mdx) so you can start
 replacing your OpenSSH servers with Teleport Nodes.
-
-</ScopedBlock>
 
 We consider Recording Proxy Mode to be less secure than recording at the Node
 level for two reasons:

--- a/docs/pages/server-access/guides/ssh-pam.mdx
+++ b/docs/pages/server-access/guides/ssh-pam.mdx
@@ -115,7 +115,8 @@ include:
 
 ## Display a Message of the Day (MOTD) with Teleport
 
-<ScopedBlock scope={["oss", "enterprise"]}>
+<Tabs>
+<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 A cluster-wide Message of the Day can be set in the `auth_service` configuration.
 
@@ -138,15 +139,17 @@ the traditional Unix `/etc/motd` file. The `/etc/motd` file is normally
 displayed by login(1) after a user has logged in but before the shell is run. It
 is generally used for important system-wide announcements.
 
-</ScopedBlock>
-<ScopedBlock scope={["cloud"]}>
+</TabItem>
+<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 You can set a per-Node Message of the Day using the traditional Unix `/etc/motd`
 file. The `/etc/motd` file is normally displayed by login(1) after a user has
 logged in but before the shell is run. It is generally used for important
 system-wide announcements.
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 This feature can help you inform users that activity on the Node is being audited
 and recorded.
@@ -300,3 +303,4 @@ ssh_service:
     # use the "auth" modules in the PAM config
     use_pam_auth: true
 ```
+

--- a/docs/pages/try-out-teleport/docker-compose.mdx
+++ b/docs/pages/try-out-teleport/docker-compose.mdx
@@ -13,21 +13,24 @@ use Teleport with OpenSSH, Ansible, and Teleport's native client, `tsh`.
 This guide is intended as a local lab for educational purposes. If you would
 like to set up Teleport for production usage, please see:
 
-<ScopedBlock scope="oss">
+<Tabs>
+<TabItem scope="oss" label="Teleport Community Edition">
 
 [Getting Started on a Linux Server](../try-out-teleport/linux-server.mdx)
 
-</ScopedBlock>
-<ScopedBlock scope="cloud">
+</TabItem>
+<TabItem scope="cloud" label="Teleport Enterprise Cloud">
 
 [Getting Started](../choose-an-edition/teleport-cloud/getting-started.mdx)
 
-</ScopedBlock>
-<ScopedBlock scope="enterprise">
+</TabItem>
+<TabItem scope="enterprise" label="Teleport Enterprise">
 
 [Getting Started](../choose-an-edition/teleport-enterprise/getting-started.mdx)
 
-</ScopedBlock>
+</TabItem>
+
+</Tabs>
 
 </Admonition>
 

--- a/docs/pages/try-out-teleport/linux-server.mdx
+++ b/docs/pages/try-out-teleport/linux-server.mdx
@@ -120,13 +120,6 @@ Take a look at the [Installation Guide](../installation.mdx) for more options.
 
 </Details>
 
-<ScopedBlock scope={["enterprise"]}>
-(!docs/pages/includes/enterprise/obtainlicense.mdx!)
-
-Save your license file on the host where you will install Teleport at the path
-`/var/lib/teleport/license.pem`.
-</ScopedBlock>
-
 ### Configure Teleport
 
 Generate a configuration file for Teleport using the `teleport configure` command.


### PR DESCRIPTION
Backports a series of PRs removing `ScopedBlock`s from the documentation:

- #30616
- #30629
- #30769

Also removes the remaining `ScopedBlock`s from v13 of the docs.