### PR TITLE
Include SAML apps when filtering by app kind

### DIFF
--- a/api/types/resource.go
+++ b/api/types/resource.go
@@ -477,8 +477,12 @@ func MatchKinds(resource ResourceWithLabels, kinds []string) bool {
 		return true
 	}
 	resourceKind := resource.GetKind()
-
-	return slices.Contains(kinds, resourceKind)
+	switch resourceKind {
+	case KindApp, KindSAMLIdPServiceProvider:
+		return slices.Contains(kinds, KindApp)
+	default:
+		return slices.Contains(kinds, resourceKind)
+	}
 }
 
 // IsValidLabelKey checks if the supplied string matches the


### PR DESCRIPTION
Currently, SAML is only included when not filtering exists. SAML apps should be included when the filtered "kinds" includes apps. As far as I'm aware, there is no filter for SAML only.