### PR TITLE
Add preset device trust roles

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -647,6 +647,20 @@ const (
 	// access to all user groups.
 	PresetGroupAccessRoleName = "group-access"
 
+	// PresetDeviceAdminRoleName is the name of the "device-admin" role.
+	// The role is used to administer trusted devices.
+	PresetDeviceAdminRoleName = "device-admin"
+
+	// PresetDeviceEnrollRoleName is the name of the "device-enroll" role.
+	// The role is used to grant device enrollment powers to users.
+	PresetDeviceEnrollRoleName = "device-enroll"
+
+	// PresetRequireTrustedDeviceRoleName is the name of the
+	// "require-trusted-device" role.
+	// The role is used as a basis for requiring trusted device access to
+	// resources.
+	PresetRequireTrustedDeviceRoleName = "require-trusted-device"
+
 	// SystemAutomaticAccessApprovalRoleName names a preset role that may
 	// automatically approve any Role Access Request
 	SystemAutomaticAccessApprovalRoleName = "@teleport-access-approver"

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -747,6 +747,9 @@ func createPresetRoles(ctx context.Context, rm PresetRoleManager) error {
 		services.NewPresetReviewerRole(),
 		services.NewPresetRequesterRole(),
 		services.NewSystemAutomaticAccessApproverRole(),
+		services.NewPresetDeviceAdminRole(),
+		services.NewPresetDeviceEnrollRole(),
+		services.NewPresetRequireTrustedDeviceRole(),
 	}
 
 	g, gctx := errgroup.WithContext(ctx)

--- a/lib/auth/init_test.go
+++ b/lib/auth/init_test.go
@@ -781,6 +781,9 @@ func TestPresets(t *testing.T) {
 			teleport.PresetGroupAccessRoleName,
 			teleport.PresetRequesterRoleName,
 			teleport.PresetReviewerRoleName,
+			teleport.PresetDeviceAdminRoleName,
+			teleport.PresetDeviceEnrollRoleName,
+			teleport.PresetRequireTrustedDeviceRoleName,
 		}, presetRoleNames...)
 
 		enterpriseSystemRoleNames := []string{

--- a/lib/services/presets.go
+++ b/lib/services/presets.go
@@ -364,6 +364,118 @@ func NewPresetGroupAccessRole() types.Role {
 	return role
 }
 
+// NewPresetDeviceAdminRole returns the preset "device-admin" role, or nil for
+// non-Enterprise builds.
+// The role is used to administer trusted devices.
+func NewPresetDeviceAdminRole() types.Role {
+	if modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil
+	}
+
+	return &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V6,
+		Metadata: types.Metadata{
+			Name:        teleport.PresetDeviceAdminRoleName,
+			Namespace:   apidefaults.Namespace,
+			Description: "Administer trusted devices",
+			Labels: map[string]string{
+				types.TeleportInternalResourceType: types.PresetResource,
+			},
+		},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Rules: []types.Rule{
+					types.NewRule(types.KindDevice, append(RW(), types.VerbCreateEnrollToken, types.VerbEnroll)),
+				},
+			},
+		},
+	}
+}
+
+// NewPresetDeviceEnrollRole returns the preset "device-enroll" role, or nil for
+// non-Enterprise builds.
+// The role is used to grant device enrollment powers to users.
+func NewPresetDeviceEnrollRole() types.Role {
+	if modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil
+	}
+
+	return &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V6,
+		Metadata: types.Metadata{
+			Name:        teleport.PresetDeviceEnrollRoleName,
+			Namespace:   apidefaults.Namespace,
+			Description: "Grant permission to enroll trusted devices",
+			Labels: map[string]string{
+				types.TeleportInternalResourceType: types.PresetResource,
+			},
+		},
+		Spec: types.RoleSpecV6{
+			Allow: types.RoleConditions{
+				Rules: []types.Rule{
+					types.NewRule(types.KindDevice, []string{types.VerbEnroll}),
+				},
+			},
+		},
+	}
+}
+
+// NewPresetRequireTrustedDeviceRole returns the preset "require-trusted-device"
+// role, or nil for non-Enterprise builds.
+// The role is used as a basis for requiring trusted device access to
+// resources.
+func NewPresetRequireTrustedDeviceRole() types.Role {
+	if modules.GetModules().BuildType() != modules.BuildEnterprise {
+		return nil
+	}
+
+	return &types.RoleV6{
+		Kind:    types.KindRole,
+		Version: types.V6,
+		Metadata: types.Metadata{
+			Name:        teleport.PresetRequireTrustedDeviceRoleName,
+			Namespace:   apidefaults.Namespace,
+			Description: "Require trusted device to access resources",
+			Labels: map[string]string{
+				types.TeleportInternalResourceType: types.PresetResource,
+			},
+		},
+		Spec: types.RoleSpecV6{
+			Options: types.RoleOptions{
+				DeviceTrustMode: constants.DeviceTrustModeRequired,
+			},
+			Allow: types.RoleConditions{
+				// All SSH nodes.
+				Logins: []string{"{{internal.logins}}"},
+				NodeLabels: types.Labels{
+					types.Wildcard: []string{types.Wildcard},
+				},
+
+				// All k8s nodes.
+				KubeGroups: []string{
+					"{{internal.kubernetes_groups}}",
+					// Common/example groups.
+					"system:masters",
+					"developers",
+					"viewers",
+				},
+				KubernetesLabels: types.Labels{
+					types.Wildcard: []string{types.Wildcard},
+				},
+
+				// All DB nodes.
+				DatabaseLabels: types.Labels{
+					types.Wildcard: []string{types.Wildcard},
+				},
+				DatabaseNames: []string{types.Wildcard},
+				DatabaseUsers: []string{types.Wildcard},
+			},
+		},
+	}
+}
+
 // bootstrapRoleMetadataLabels are metadata labels that will be applied to each role.
 // These are intended to add labels for older roles that didn't previously have them.
 func bootstrapRoleMetadataLabels() map[string]map[string]string {


### PR DESCRIPTION
Add the following preset/example roles:

* device-admin (as shown by [device trust docs][device-docs])
* device-enroll (lets users enroll their devices)
* require-trusted-device (meant as an example/starting point for enforcement)

[device-docs]: https://goteleport.com/docs/access-controls/device-trust/guide/?scope=enterprise#step-12-register-a-trusted-device