### PR TITLE
AWS OIDC: List Security Groups

### DIFF
--- a/lib/integrations/awsoidc/list_security_groups.go
+++ b/lib/integrations/awsoidc/list_security_groups.go
@@ -50,9 +50,9 @@ type SecurityGroup struct {
 	// This is just a friendly name and should not be used for further API calls
 	Name string
 
-	// SecurityGroupID is the security group ID.
+	// ID is the security group ID.
 	// This is the value that should be used when doing further API calls.
-	SecurityGroupID string
+	ID string
 }
 
 // ListSecurityGroupsResponse contains a page of SecurityGroups.
@@ -122,8 +122,8 @@ func ListSecurityGroups(ctx context.Context, clt ListSecurityGroupsClient, req L
 		sgID := aws.ToString(sg.GroupId)
 
 		ret.SecurityGroups = append(ret.SecurityGroups, SecurityGroup{
-			Name:            sgName,
-			SecurityGroupID: sgID,
+			Name: sgName,
+			ID:   sgID,
 		})
 	}
 

--- a/lib/integrations/awsoidc/list_security_groups.go
+++ b/lib/integrations/awsoidc/list_security_groups.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/gravitational/trace"
+)
+
+// ListSecurityGroupsRequest contains the required fields to list VPC Security Groups.
+type ListSecurityGroupsRequest struct {
+	// VPCID is the VPC to filter Security Groups.
+	VPCID string
+
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string
+}
+
+// CheckAndSetDefaults checks if the required fields are present.
+func (req *ListSecurityGroupsRequest) CheckAndSetDefaults() error {
+	if req.VPCID == "" {
+		return trace.BadParameter("vpc id is required")
+	}
+
+	return nil
+}
+
+// SecurityGroup is the Teleport representation of an EC2 Instance Connect Endpoint
+type SecurityGroup struct {
+	// Name is the Security Group name.
+	// This is just a friendly name and should not be used for further API calls
+	Name string
+
+	// SecurityGroupID is the security group ID.
+	// This is the value that should be used when doing further API calls.
+	SecurityGroupID string
+}
+
+// ListSecurityGroupsResponse contains a page of SecurityGroups.
+type ListSecurityGroupsResponse struct {
+	// SecurityGroups contains the page of VPC Security Groups.
+	SecurityGroups []SecurityGroup
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string
+}
+
+// ListSecurityGroupsClient describes the required methods to List Security Groups a 3rd Party API.
+type ListSecurityGroupsClient interface {
+	// DescribeSecurityGroups describes the specified security groups or all of your security groups.
+	DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error)
+}
+
+type defaultListSecurityGroupsClient struct {
+	*ec2.Client
+}
+
+// NewListSecurityGroupsClient creates a new ListSecurityGroupsClient using a AWSClientRequest.
+func NewListSecurityGroupsClient(ctx context.Context, req *AWSClientRequest) (ListSecurityGroupsClient, error) {
+	ec2Client, err := newEC2Client(ctx, req)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultListSecurityGroupsClient{
+		Client: ec2Client,
+	}, nil
+}
+
+// ListSecurityGroups calls the following AWS API:
+// https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSecurityGroups.html
+// It returns a list of VPC Security Groups and an optional NextToken that can be used to fetch the next page
+func ListSecurityGroups(ctx context.Context, clt ListSecurityGroupsClient, req ListSecurityGroupsRequest) (*ListSecurityGroupsResponse, error) {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	describeSecurityGroups := &ec2.DescribeSecurityGroupsInput{
+		Filters: []ec2Types.Filter{{
+			Name:   aws.String("vpc-id"),
+			Values: []string{req.VPCID},
+		}},
+	}
+	if req.NextToken != "" {
+		describeSecurityGroups.NextToken = &req.NextToken
+	}
+
+	securityGroupsResp, err := clt.DescribeSecurityGroups(ctx, describeSecurityGroups)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	ret := &ListSecurityGroupsResponse{}
+
+	if aws.ToString(securityGroupsResp.NextToken) != "" {
+		ret.NextToken = *securityGroupsResp.NextToken
+	}
+
+	ret.SecurityGroups = make([]SecurityGroup, 0, len(securityGroupsResp.SecurityGroups))
+	for _, sg := range securityGroupsResp.SecurityGroups {
+		sgName := aws.ToString(sg.GroupName)
+		sgID := aws.ToString(sg.GroupId)
+
+		ret.SecurityGroups = append(ret.SecurityGroups, SecurityGroup{
+			Name:            sgName,
+			SecurityGroupID: sgID,
+		})
+	}
+
+	return ret, nil
+}

--- a/lib/integrations/awsoidc/list_security_groups_test.go
+++ b/lib/integrations/awsoidc/list_security_groups_test.go
@@ -101,7 +101,7 @@ func TestListSecurityGroups(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.SecurityGroups, pageSize)
 		nextPageToken := resp.NextToken
-		require.Equal(t, resp.SecurityGroups[0].SecurityGroupID, "sg-0")
+		require.Equal(t, resp.SecurityGroups[0].ID, "sg-0")
 		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-0")
 
 		// Second page must return pageSize number of Endpoints
@@ -113,7 +113,7 @@ func TestListSecurityGroups(t *testing.T) {
 		require.NotEmpty(t, resp.NextToken)
 		require.Len(t, resp.SecurityGroups, pageSize)
 		nextPageToken = resp.NextToken
-		require.Equal(t, resp.SecurityGroups[0].SecurityGroupID, "sg-100")
+		require.Equal(t, resp.SecurityGroups[0].ID, "sg-100")
 		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-100")
 
 		// Third page must return only the remaining Endpoints and an empty nextToken
@@ -124,7 +124,7 @@ func TestListSecurityGroups(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, resp.NextToken)
 		require.Len(t, resp.SecurityGroups, 3)
-		require.Equal(t, resp.SecurityGroups[0].SecurityGroupID, "sg-200")
+		require.Equal(t, resp.SecurityGroups[0].ID, "sg-200")
 		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-200")
 	})
 
@@ -151,8 +151,8 @@ func TestListSecurityGroups(t *testing.T) {
 				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
 
 				sg := SecurityGroup{
-					Name:            "MySG-123",
-					SecurityGroupID: "sg-123",
+					Name: "MySG-123",
+					ID:   "sg-123",
 				}
 				require.Empty(t, cmp.Diff(sg, ldr.SecurityGroups[0]))
 			},

--- a/lib/integrations/awsoidc/list_security_groups_test.go
+++ b/lib/integrations/awsoidc/list_security_groups_test.go
@@ -1,0 +1,179 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	ec2Types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/google/go-cmp/cmp"
+	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/require"
+)
+
+type mockListSecurityGroupsClient struct {
+	pageSize int
+	sgs      []ec2Types.SecurityGroup
+}
+
+// Returns information about ec2 instances.
+// This API supports pagination.
+func (m mockListSecurityGroupsClient) DescribeSecurityGroups(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+	requestedPage := 1
+
+	totalSG := len(m.sgs)
+
+	if params.NextToken != nil {
+		currentMarker, err := strconv.Atoi(*params.NextToken)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+		requestedPage = currentMarker
+	}
+
+	sliceStart := m.pageSize * (requestedPage - 1)
+	sliceEnd := m.pageSize * requestedPage
+	if sliceEnd > totalSG {
+		sliceEnd = totalSG
+	}
+
+	ret := &ec2.DescribeSecurityGroupsOutput{
+		SecurityGroups: m.sgs[sliceStart:sliceEnd],
+	}
+
+	if sliceEnd < totalSG {
+		nextToken := strconv.Itoa(requestedPage + 1)
+		ret.NextToken = &nextToken
+	}
+
+	return ret, nil
+}
+
+func TestListSecurityGroups(t *testing.T) {
+	ctx := context.Background()
+
+	noErrorFunc := func(err error) bool {
+		return err == nil
+	}
+
+	const pageSize = 100
+	t.Run("pagination", func(t *testing.T) {
+		totalSecurityGroups := 203
+
+		allSGs := make([]ec2Types.SecurityGroup, 0, totalSecurityGroups)
+		for i := 0; i < totalSecurityGroups; i++ {
+			allSGs = append(allSGs, ec2Types.SecurityGroup{
+				GroupId:   aws.String(fmt.Sprintf("sg-%d", i)),
+				GroupName: aws.String(fmt.Sprintf("MySG-%d", i)),
+			})
+		}
+
+		mockListClient := &mockListSecurityGroupsClient{
+			pageSize: pageSize,
+			sgs:      allSGs,
+		}
+
+		// First page must return pageSize number of Security Groups
+		resp, err := ListSecurityGroups(ctx, mockListClient, ListSecurityGroupsRequest{
+			VPCID:     "vpc-123",
+			NextToken: "",
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.NextToken)
+		require.Len(t, resp.SecurityGroups, pageSize)
+		nextPageToken := resp.NextToken
+		require.Equal(t, resp.SecurityGroups[0].SecurityGroupID, "sg-0")
+		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-0")
+
+		// Second page must return pageSize number of Endpoints
+		resp, err = ListSecurityGroups(ctx, mockListClient, ListSecurityGroupsRequest{
+			VPCID:     "vpc-abc",
+			NextToken: nextPageToken,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.NextToken)
+		require.Len(t, resp.SecurityGroups, pageSize)
+		nextPageToken = resp.NextToken
+		require.Equal(t, resp.SecurityGroups[0].SecurityGroupID, "sg-100")
+		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-100")
+
+		// Third page must return only the remaining Endpoints and an empty nextToken
+		resp, err = ListSecurityGroups(ctx, mockListClient, ListSecurityGroupsRequest{
+			VPCID:     "vpc-abc",
+			NextToken: nextPageToken,
+		})
+		require.NoError(t, err)
+		require.Empty(t, resp.NextToken)
+		require.Len(t, resp.SecurityGroups, 3)
+		require.Equal(t, resp.SecurityGroups[0].SecurityGroupID, "sg-200")
+		require.Equal(t, resp.SecurityGroups[0].Name, "MySG-200")
+	})
+
+	for _, tt := range []struct {
+		name      string
+		req       ListSecurityGroupsRequest
+		mockSGs   []ec2Types.SecurityGroup
+		errCheck  func(error) bool
+		respCheck func(*testing.T, *ListSecurityGroupsResponse)
+	}{
+		{
+			name: "valid for listing instances",
+			req: ListSecurityGroupsRequest{
+				VPCID:     "vpc-abcd",
+				NextToken: "",
+			},
+			mockSGs: []ec2Types.SecurityGroup{{
+				GroupId:   aws.String("sg-123"),
+				GroupName: aws.String("MySG-123"),
+			},
+			},
+			respCheck: func(t *testing.T, ldr *ListSecurityGroupsResponse) {
+				require.Len(t, ldr.SecurityGroups, 1, "expected 1 SG, got %d", len(ldr.SecurityGroups))
+				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
+
+				sg := SecurityGroup{
+					Name:            "MySG-123",
+					SecurityGroupID: "sg-123",
+				}
+				require.Empty(t, cmp.Diff(sg, ldr.SecurityGroups[0]))
+			},
+			errCheck: noErrorFunc,
+		},
+		{
+			name:     "no vpc id",
+			req:      ListSecurityGroupsRequest{},
+			errCheck: trace.IsBadParameter,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			mockListClient := &mockListSecurityGroupsClient{
+				pageSize: pageSize,
+				sgs:      tt.mockSGs,
+			}
+			resp, err := ListSecurityGroups(ctx, mockListClient, tt.req)
+			require.True(t, tt.errCheck(err), "unexpected err: %v", err)
+			if tt.respCheck != nil {
+				tt.respCheck(t, resp)
+			}
+		})
+	}
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -798,6 +798,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2ice", h.WithClusterAuth(h.awsOIDCListEC2ICE))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployec2ice", h.WithClusterAuth(h.awsOIDCDeployEC2ICE))
+	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/securitygroups", h.WithClusterAuth(h.awsOIDCListSecurityGroups))
 	h.GET("/webapi/scripts/integrations/configure/eice-iam.sh", h.WithLimiter(h.awsOIDCConfigureEICEIAM))
 
 	// AWS OIDC Integration specific endpoints:

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -331,6 +331,42 @@ func (h *Handler) awsOIDCListEC2(w http.ResponseWriter, r *http.Request, p httpr
 	}, nil
 }
 
+// awsOIDCListSecurityGroups returns a list of VPC Security Groups the ListSecurityGroups action of the AWS OIDC Integration.
+func (h *Handler) awsOIDCListSecurityGroups(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
+	ctx := r.Context()
+
+	var req ui.AWSOIDCListSecurityGroupsRequest
+	if err := httplib.ReadJSON(r, &req); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	awsClientReq, err := h.awsOIDCClientRequest(r.Context(), req.Region, p, sctx, site)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	listSGClient, err := awsoidc.NewListSecurityGroupsClient(ctx, awsClientReq)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	resp, err := awsoidc.ListSecurityGroups(ctx,
+		listSGClient,
+		awsoidc.ListSecurityGroupsRequest{
+			VPCID:     req.VPCID,
+			NextToken: req.NextToken,
+		},
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return ui.AWSOIDCListSecurityGroupsResponse{
+		NextToken:       resp.NextToken,
+		SecurityGroupss: resp.SecurityGroups,
+	}, nil
+}
+
 // awsOIDCListEC2ICE returns a list of EC2 Instance Connect Endpoints using the ListEC2ICE action of the AWS OIDC Integration.
 func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p httprouter.Params, sctx *SessionContext, site reversetunnelclient.RemoteSite) (any, error) {
 	ctx := r.Context()

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -362,8 +362,8 @@ func (h *Handler) awsOIDCListSecurityGroups(w http.ResponseWriter, r *http.Reque
 	}
 
 	return ui.AWSOIDCListSecurityGroupsResponse{
-		NextToken:       resp.NextToken,
-		SecurityGroupss: resp.SecurityGroups,
+		NextToken:      resp.NextToken,
+		SecurityGroups: resp.SecurityGroups,
 	}, nil
 }
 

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -212,7 +212,7 @@ type AWSOIDCListEC2Response struct {
 type AWSOIDCListSecurityGroupsRequest struct {
 	// Region is the AWS Region.
 	Region string `json:"region"`
-	// VPCID is the VPC to filter EC2 Instance Connect Endpoints.
+	// VPCID is the VPC to filter security groups by.
 	VPCID string `json:"vpcId"`
 	// NextToken is the token to be used to fetch the next page.
 	// If empty, the first page is fetched.
@@ -222,7 +222,7 @@ type AWSOIDCListSecurityGroupsRequest struct {
 // AWSOIDCListSecurityGroupsResponse contains a list of VPC Security Groups and a next token if more pages are available.
 type AWSOIDCListSecurityGroupsResponse struct {
 	// SecurityGroups contains the page of SecurityGroups
-	SecurityGroupss []awsoidc.SecurityGroup `json:"securityGroups"`
+	SecurityGroups []awsoidc.SecurityGroup `json:"securityGroups"`
 
 	// NextToken is used for pagination.
 	// If non-empty, it can be used to request the next page.

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -208,6 +208,27 @@ type AWSOIDCListEC2Response struct {
 	NextToken string `json:"nextToken,omitempty"`
 }
 
+// AWSOIDCListSecurityGroupsRequest is a request to ListSecurityGroups using the AWS OIDC Integration.
+type AWSOIDCListSecurityGroupsRequest struct {
+	// Region is the AWS Region.
+	Region string `json:"region"`
+	// VPCID is the VPC to filter EC2 Instance Connect Endpoints.
+	VPCID string `json:"vpcId"`
+	// NextToken is the token to be used to fetch the next page.
+	// If empty, the first page is fetched.
+	NextToken string `json:"nextToken"`
+}
+
+// AWSOIDCListSecurityGroupsResponse contains a list of VPC Security Groups and a next token if more pages are available.
+type AWSOIDCListSecurityGroupsResponse struct {
+	// SecurityGroups contains the page of SecurityGroups
+	SecurityGroupss []awsoidc.SecurityGroup `json:"securityGroups"`
+
+	// NextToken is used for pagination.
+	// If non-empty, it can be used to request the next page.
+	NextToken string `json:"nextToken,omitempty"`
+}
+
 // AWSOIDCListEC2ICERequest is a request to ListEC2ICEs using the AWS OIDC Integration.
 type AWSOIDCListEC2ICERequest struct {
 	// Region is the AWS Region.


### PR DESCRIPTION
Context: https://github.com/gravitational/teleport/issues/29317

When creating an EC2 Instance Connect Endpoint, we can optionally provide a list of Security Groups to apply to it.
The default SG for the VPC is used if none SG is provided. Sometimes the default is not what the users want.

This PR adds an endpoint that the UI will use to list possible SG for the current VPC.
The user will then one or more SG and those are going to be applied to the EC2 Instance Connect Endpoint


Demo:
```
... /integrations/aws-oidc/teleportdev/securitygroups
->
200
{
   "securityGroups":[
      {
         "Name":"launch-wizard-3",
         "SecurityGroupID":"sg-01f0c6606f58fb035"
      },
      {
         "Name":"launch-wizard-9",
         "SecurityGroupID":"sg-044891c291faa4648"
      },
      {
         "Name":"default",
         "SecurityGroupID":"sg-23aa8a58"
      },
      // ...
   ]
}
```