### PR TITLE
[v13] docs: remove default designation in cloud proxies

### DIFF
--- a/docs/pages/choose-an-edition/teleport-cloud/architecture.mdx
+++ b/docs/pages/choose-an-edition/teleport-cloud/architecture.mdx
@@ -41,7 +41,7 @@ The Teleport [Auth Service](../../architecture/authentication.mdx) is deployed w
 ### Proxies
 The Teleport [Proxy Service](../../architecture/proxy.mdx) is deployed to multiple AWS regions around the world for low-latency access to distributed infrastructure.
 
-- us-west-2 (default)
+- us-west-2
 - us-east-1
 - eu-central-1
 - ap-south-1


### PR DESCRIPTION
Backport #30846 to branch/v13