### PR TITLE
Update access duration logic and tests for dry run requests

### DIFF
--- a/lib/auth/auth_with_roles_test.go
+++ b/lib/auth/auth_with_roles_test.go
@@ -6388,6 +6388,7 @@ func mustAccessRequest(t *testing.T, user string, state types.RequestState, crea
 	accessRequest.SetCreationTime(created)
 	accessRequest.SetExpiry(expires)
 	accessRequest.SetAccessExpiry(expires)
+	accessRequest.SetMaxDuration(expires)
 	accessRequest.SetSessionTLL(expires)
 	accessRequest.SetThresholds([]types.AccessReviewThreshold{{Name: "default", Approve: 1, Deny: 1}})
 	accessRequest.SetRoleThresholdMapping(map[string]types.ThresholdIndexSets{

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1158,7 +1158,7 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest) (
 	// This prevents the time drift that can occur as the value is set on the client side.
 	// TODO(jakule): Replace with MaxAccessDuration that is a duration (5h, 4d etc), and not a point in time.
 	if req.GetDryRun() {
-		maxDuration = maxAccessDuration - 10
+		maxDuration = maxAccessDuration
 	} else if maxDuration < 0 {
 		return 0, trace.BadParameter("invalid maxDuration: must be greater than creation time")
 	}

--- a/lib/services/access_request.go
+++ b/lib/services/access_request.go
@@ -1126,6 +1126,8 @@ func (m *RequestValidator) Validate(ctx context.Context, req types.AccessRequest
 
 		accessTTL := now.Add(ttl)
 		req.SetAccessExpiry(accessTTL)
+		// Adjusted max access duration is equal to the access expiry time.
+		req.SetMaxDuration(accessTTL)
 	}
 
 	return nil
@@ -1151,7 +1153,13 @@ func (m *RequestValidator) calculateMaxAccessDuration(req types.AccessRequest) (
 	}
 
 	maxDuration := maxDurationTime.Sub(req.GetCreationTime())
-	if maxDuration < 0 {
+
+	// For dry run requests, the max_duration is set to 7 days.
+	// This prevents the time drift that can occur as the value is set on the client side.
+	// TODO(jakule): Replace with MaxAccessDuration that is a duration (5h, 4d etc), and not a point in time.
+	if req.GetDryRun() {
+		maxDuration = maxAccessDuration - 10
+	} else if maxDuration < 0 {
 		return 0, trace.BadParameter("invalid maxDuration: must be greater than creation time")
 	}
 

--- a/lib/services/access_request_test.go
+++ b/lib/services/access_request_test.go
@@ -2004,6 +2004,8 @@ func TestMaxDuration(t *testing.T) {
 		expectedAccessDuration time.Duration
 		// expectedSessionTTL is the expected session TTL
 		expectedSessionTTL time.Duration
+		// DryRun is true if the request is a dry run
+		dryRun bool
 	}{
 		{
 			desc:                   "role maxDuration is respected",
@@ -2012,6 +2014,15 @@ func TestMaxDuration(t *testing.T) {
 			maxDuration:            7 * day,
 			expectedAccessDuration: 3 * day,
 			expectedSessionTTL:     8 * time.Hour,
+		},
+		{
+			desc:                   "dry run allows for longer maxDuration then 7d",
+			requestor:              "alice",
+			roles:                  []string{"requestedRole"},
+			maxDuration:            10 * day,
+			expectedAccessDuration: 3 * day,
+			expectedSessionTTL:     8 * time.Hour,
+			dryRun:                 true,
 		},
 		{
 			desc:                   "maxDuration not set, default maxTTL (8h)",
@@ -2105,9 +2116,11 @@ func TestMaxDuration(t *testing.T) {
 
 			req.SetCreationTime(now)
 			req.SetMaxDuration(now.Add(tt.maxDuration))
+			req.SetDryRun(tt.dryRun)
 
 			require.NoError(t, validator.Validate(context.Background(), req, identity))
 			require.Equal(t, now.Add(tt.expectedAccessDuration), req.GetAccessExpiry())
+			require.Equal(t, now.Add(tt.expectedAccessDuration), req.GetMaxDuration())
 			require.Equal(t, now.Add(tt.expectedSessionTTL), req.GetSessionTLL())
 		})
 	}


### PR DESCRIPTION
Adjusted the handling of 'maxDuration' for dry run requests in the access request service to prevent time drift occurrences. Max access duration in this case is now explicitly set to 7 days. Also added a test case in access_request_test.go to verify this change. The TODO note is about replacing the 'maxDuration' that currently uses point in time with 'MaxAccessDuration' that uses duration like 5 hours, 4 days etc.