### PR TITLE
Set cloud version to v13.3.4

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1559,7 +1559,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.3.2",
+      "version": "13.3.4",
       "major_version": "13",
       "sla": {
         "monthly_percentage": "99.9%",


### PR DESCRIPTION
Teleport Cloud tenants will be upgraded to v13.3.4 on Wednesday 8/23.

See: https://github.com/gravitational/cloud/issues/5742