### PR TITLE
Add a banner to Dockerfile used for CI testing

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -1,3 +1,9 @@
+###################################################################################
+#                                                                                 #
+#      DO NOT USE FOR PRODUCTION BUILD OR ANYTHING OTHER THAN CI TESTING!         #
+#                                                                                 #
+###################################################################################
+
 # This Dockerfile makes the "build box" the container used to:
 # * run test and linters in CI
 # * building other Docker images


### PR DESCRIPTION
Included a comment at the top of the Dockerfile used for Continuous Integration (CI) to not use it for anything else than CI. We have had multiple incidents of people accidentally breaking the production build by changing this image. Currently none of our production builds are using it, but the history shows that this will probably change soon...