### PR TITLE
Run latest golangci-lint and buf in Docker boxes

### DIFF
--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -303,9 +303,8 @@ RUN go install github.com/daixiang0/gci@v0.11.0
 RUN go install gotest.tools/gotestsum@v1.10.1
 
 # Install golangci-lint.
-RUN TAG='v1.54.1' && \
-    curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/$TAG/install.sh" | \
-    sh -s -- -b "$(go env GOPATH)/bin" "$TAG"
+RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh" | \
+    sh -s -- -b "$(go env GOPATH)/bin"
 
 # Install Buf.
 ARG BUF_VERSION # eg, "1.19.0"

--- a/build.assets/Dockerfile
+++ b/build.assets/Dockerfile
@@ -307,11 +307,7 @@ RUN curl -fsSL "https://raw.githubusercontent.com/golangci/golangci-lint/master/
     sh -s -- -b "$(go env GOPATH)/bin"
 
 # Install Buf.
-ARG BUF_VERSION # eg, "1.19.0"
-RUN BIN='/usr/local/bin' && \
-  VERSION="$BUF_VERSION" && \
-  curl -fsSL "https://github.com/bufbuild/buf/releases/download/v$VERSION/buf-$(uname -s)-$(uname -m)" -o "${BIN}/buf" && \
-  chmod +x "$BIN/buf"
+RUN go install github.com/bufbuild/buf/cmd/buf@latest
 
 # Copy BPF libraries.
 ARG LIBBPF_VERSION

--- a/build.assets/Dockerfile-grpcbox
+++ b/build.assets/Dockerfile-grpcbox
@@ -33,12 +33,7 @@ RUN VERSION="$PROTOC_VERSION" && \
   rm -f "$PB_FILE"
 
 # buf
-# eg, "1.19.0"
-ARG BUF_VERSION
-RUN BIN='/usr/local/bin' && \
-  VERSION="$BUF_VERSION" && \
-  curl -fsSL "https://github.com/bufbuild/buf/releases/download/v$VERSION/buf-$(uname -s)-$(uname -m)" -o "${BIN}/buf" && \
-  chmod +x "$BIN/buf"
+RUN go install github.com/bufbuild/buf/cmd/buf@latest
 
 # Pre-install go-runned binaries.
 # This is meant to be the only step that changes depending on the Teleport

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -131,7 +131,6 @@ buildbox:
 			--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 			--build-arg NODE_VERSION=$(NODE_VERSION) \
 			--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \
-			--build-arg BUF_VERSION=$(BUF_VERSION) \
 			--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 			--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 			--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \
@@ -588,7 +587,7 @@ build-multiarch:
 .PHONY:generate-eventschema
 generate-eventschema:
 	$(eval PROTOBUF_MOD_PATH := $(shell go mod download --json github.com/gogo/protobuf | awk -F: '/"Dir"/ { print $$2 }' | tr -d ' ",'))
-	
+
 	cd tooling && go build -o ./bin/protoc-gen-eventschema ./cmd/protoc-gen-eventschema/
 
 	protoc \

--- a/build.assets/grpcbox.mk
+++ b/build.assets/grpcbox.mk
@@ -26,7 +26,6 @@ GRPCBOX_RUN := $(DOCKER) run -it --rm -v "$$(pwd)/../:/workdir" -w /workdir $(GR
 .PHONY: grpcbox
 grpcbox:
 	DOCKER_BUILDKIT=1 $(DOCKER) build \
-		--build-arg BUF_VERSION=$(BUF_VERSION) \
 		--build-arg GOGO_PROTO_TAG=$(GOGO_PROTO_TAG) \
 		--build-arg NODE_GRPC_TOOLS_VERSION=$(NODE_GRPC_TOOLS_VERSION) \
 		--build-arg NODE_PROTOC_TS_VERSION=$(NODE_PROTOC_TS_VERSION) \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -14,7 +14,6 @@ LIBBPF_VERSION ?= 1.0.1
 LIBPCSCLITE_VERSION ?= 1.9.9-teleport
 
 # Protogen related versions.
-BUF_VERSION ?= 1.26.1
 # Keep in sync with api/proto/buf.yaml (and buf.lock).
 GOGO_PROTO_TAG ?= v1.3.2
 NODE_GRPC_TOOLS_VERSION ?= 1.12.4


### PR DESCRIPTION
CI is [already][1] [running][2] latest, so this makes sure the Docker boxes eventually catch up.

[1]: https://github.com/gravitational/teleport/blob/a31a9af32ac02e1c150cb65d384527ad37f4cf52/.github/workflows/lint.yaml#L42
[2]: https://github.com/gravitational/teleport/blob/a31a9af32ac02e1c150cb65d384527ad37f4cf52/.github/workflows/lint.yaml#L73