### PR TITLE
Add proper implementation of waitForNodeToJoin

### DIFF
--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -74,7 +74,7 @@
     "eslint-plugin-react": "^7.27.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-testing-library": "^5.6.0",
-    "events": "1.0.2",
+    "events": "3.3.0",
     "fork-ts-checker-webpack-plugin": "^8.0.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^27.3.1",

--- a/web/packages/shared/utils/wait.ts
+++ b/web/packages/shared/utils/wait.ts
@@ -19,10 +19,10 @@ export function wait(ms: number, abortSignal?: AbortSignal): Promise<void> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(resolve, ms);
     if (abortSignal) {
-      abortSignal.onabort = () => {
+      abortSignal.addEventListener('abort', () => {
         clearTimeout(timeout);
         reject(new DOMException('Wait was aborted.', 'AbortError'));
-      };
+      });
     }
   });
 }

--- a/web/packages/shared/utils/wait.ts
+++ b/web/packages/shared/utils/wait.ts
@@ -16,13 +16,21 @@
 
 /** Resolves after a given duration */
 export function wait(ms: number, abortSignal?: AbortSignal): Promise<void> {
+  if (abortSignal?.aborted) {
+    return Promise.reject(new DOMException('Wait was aborted.', 'AbortError'));
+  }
+
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(resolve, ms);
-    if (abortSignal) {
-      abortSignal.addEventListener('abort', () => {
-        clearTimeout(timeout);
-        reject(new DOMException('Wait was aborted.', 'AbortError'));
-      });
-    }
+    const abort = () => {
+      clearTimeout(timeout);
+      reject(new DOMException('Wait was aborted.', 'AbortError'));
+    };
+    const done = () => {
+      abortSignal?.removeEventListener('abort', abort);
+      resolve();
+    };
+
+    const timeout = setTimeout(done, ms);
+    abortSignal?.addEventListener('abort', abort, { once: true });
   });
 }

--- a/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
+++ b/web/packages/teleterm/src/mainProcess/createAgentConfigFile.ts
@@ -117,16 +117,27 @@ export function generateAgentConfigPaths(
   };
 }
 
+export function getAgentsDir(userDataDir: string): string {
+  // Why not put agentsDir into runtimeSettings? That's because we don't want the renderer to have
+  // access to this value as it could lead to bad security practices.
+  //
+  // If agentsDir was sent from the renderer to tshd and the main process, those recipients could
+  // not trust that agentsDir has not been tampered with. Instead, the renderer should merely send
+  // the root cluster URI and the recipients should build the path to the specific agent dir from
+  // that, with agentsDir being supplied out of band.
+  return path.resolve(userDataDir, 'agents');
+}
+
 function getAgentDirectoryOrThrow(
   userDataDir: string,
   profileName: string
 ): string {
-  const agentsDirectory = path.resolve(userDataDir, 'agents');
-  const resolved = path.resolve(agentsDirectory, profileName);
+  const agentsDir = getAgentsDir(userDataDir);
+  const resolved = path.resolve(agentsDir, profileName);
 
   // check if the path doesn't contain any unexpected segments
   const isValidPath =
-    path.dirname(resolved) === agentsDirectory &&
+    path.dirname(resolved) === agentsDir &&
     path.basename(resolved) === profileName;
   if (!isValidPath) {
     throw new Error(`The agent config path is incorrect: ${resolved}`);

--- a/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/mainProcess/fixtures/mocks.ts
@@ -108,6 +108,10 @@ export class MockMainProcessClient implements MainProcessClient {
     return { status: 'not-started' };
   }
 
+  getAgentLogs(): string {
+    return '';
+  }
+
   subscribeToAgentUpdate() {
     return { cleanup: () => undefined };
   }

--- a/web/packages/teleterm/src/mainProcess/mainProcess.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcess.ts
@@ -361,6 +361,18 @@ export default class MainProcess {
       }
     );
 
+    ipcMain.on(
+      'main-process-connect-my-computer-get-agent-logs',
+      (
+        event,
+        args: {
+          rootClusterUri: RootClusterUri;
+        }
+      ) => {
+        event.returnValue = this.agentRunner.getLogs(args.rootClusterUri);
+      }
+    );
+
     subscribeToTerminalContextMenuEvent();
     subscribeToTabContextMenuEvent();
     subscribeToConfigServiceEvents(this.configService);

--- a/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
+++ b/web/packages/teleterm/src/mainProcess/mainProcessClient.ts
@@ -112,6 +112,12 @@ export default function createMainProcessClient(): MainProcessClient {
         clusterProperties
       );
     },
+    getAgentLogs(clusterProperties: { rootClusterUri: RootClusterUri }) {
+      return ipcRenderer.sendSync(
+        'main-process-connect-my-computer-get-agent-logs',
+        clusterProperties
+      );
+    },
     subscribeToAgentUpdate: (rootClusterUri, listener) => {
       const onChange = (
         _,

--- a/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
+++ b/web/packages/teleterm/src/mainProcess/runtimeSettings.ts
@@ -25,6 +25,7 @@ import { staticConfig } from 'teleterm/staticConfig';
 
 import { GrpcServerAddresses, RuntimeSettings } from './types';
 import { loadInstallationId } from './loadInstallationId';
+import { getAgentsDir } from './createAgentConfigFile';
 
 const { argv, env } = process;
 
@@ -64,6 +65,8 @@ export function getRuntimeSettings(): RuntimeSettings {
   // Before switching to the recommended path, we need to investigate the impact of this change.
   // https://www.electronjs.org/docs/latest/api/app#appgetpathname
   const logsDir = path.join(userDataDir, 'logs');
+  // DO NOT expose agentsDir through RuntimeSettings. See the comment in getAgentsDir.
+  const agentsDir = getAgentsDir(userDataDir);
 
   const tshd = {
     insecure: isInsecure,
@@ -79,6 +82,7 @@ export function getRuntimeSettings(): RuntimeSettings {
       `--certs-dir=${getCertsDir()}`,
       `--prehog-addr=${staticConfig.prehogAddress}`,
       `--kubeconfigs-dir=${kubeConfigsDir}`,
+      `--agents-dir=${agentsDir}`,
     ],
   };
   const sharedProcess = {

--- a/web/packages/teleterm/src/mainProcess/types.ts
+++ b/web/packages/teleterm/src/mainProcess/types.ts
@@ -109,6 +109,7 @@ export type MainProcessClient = {
   }): Promise<boolean>;
   killAgent(args: { rootClusterUri: RootClusterUri }): Promise<void>;
   getAgentState(args: { rootClusterUri: RootClusterUri }): AgentProcessState;
+  getAgentLogs(args: { rootClusterUri: RootClusterUri }): string;
   subscribeToAgentUpdate: SubscribeToAgentUpdate;
 };
 

--- a/web/packages/teleterm/src/services/tshd/createAbortController.test.ts
+++ b/web/packages/teleterm/src/services/tshd/createAbortController.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import createAbortController from './createAbortController';
+
+test('abort controller emits the abort event only once', () => {
+  const listener = jest.fn();
+  const controller = createAbortController();
+
+  controller.signal.addEventListener(listener);
+  controller.abort();
+
+  // This makes sure that the implementation doesn't depend solely on `emitter.once('abort', cb)` to
+  // implement this. Once a signal has been aborted, its state changes and it cannot be reused.
+  //
+  // This mirrors the browser implementation.
+  const listenerAddedAfterAbort = jest.fn();
+  controller.signal.addEventListener(listenerAddedAfterAbort);
+  controller.abort();
+
+  expect(listener).toHaveBeenCalledTimes(1);
+  expect(listenerAddedAfterAbort).not.toHaveBeenCalled();
+});
+
+test('abort updates signal.aborted', () => {
+  const controller = createAbortController();
+  expect(controller.signal.aborted).toBe(false);
+
+  controller.abort();
+  expect(controller.signal.aborted).toBe(true);
+});

--- a/web/packages/teleterm/src/services/tshd/createAbortController.ts
+++ b/web/packages/teleterm/src/services/tshd/createAbortController.ts
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+// This file works both in the browser and Node.js.
+// In Node environment, it imports the built-in events module.
+// In browser environment, it imports the events package.
 import { EventEmitter } from 'events';
 
 import { TshAbortController } from './types';

--- a/web/packages/teleterm/src/services/tshd/createAbortController.ts
+++ b/web/packages/teleterm/src/services/tshd/createAbortController.ts
@@ -22,9 +22,15 @@ import { TshAbortController } from './types';
  * Creates a version of AbortController that can be passed through Electron contextBridge
  */
 export default function createAbortController(): TshAbortController {
+  let hasBeenAborted = false;
   const emitter = new EventEmitter();
 
   const signal = {
+    // TODO(ravicious): Consider aligning the interface of TshAbortSignal with the interface of
+    // browser's AbortSignal so that those two can be used interchangeably, for example in the wait
+    // function from the shared package.
+    //
+    // TshAbortSignal doesn't accept the event name as the first argument.
     addEventListener(cb: (...args: any[]) => void) {
       emitter.addListener('abort', cb);
     },
@@ -37,6 +43,11 @@ export default function createAbortController(): TshAbortController {
   return {
     signal,
     abort() {
+      if (hasBeenAborted) {
+        return;
+      }
+
+      hasBeenAborted = true;
       emitter.emit('abort');
     },
   };

--- a/web/packages/teleterm/src/services/tshd/createFileTransferStream.ts
+++ b/web/packages/teleterm/src/services/tshd/createFileTransferStream.ts
@@ -23,7 +23,7 @@ import { TshAbortSignal } from './types';
 
 export function createFileTransferStream(
   stream: ClientReadableStream<FileTransferProgress>,
-  abortSignal?: TshAbortSignal
+  abortSignal: TshAbortSignal
 ): FileTransferListeners {
   abortSignal.addEventListener(() => stream.cancel());
 

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -16,86 +16,71 @@
 
 import { makeRootCluster } from 'teleterm/services/tshd/testHelpers';
 
-import {
-  AuthSettings,
-  AccessRequest,
-  Cluster,
-  CreateAccessRequestParams,
-  CreateGatewayParams,
-  Gateway,
-  GetDatabasesResponse,
-  GetKubesResponse,
-  GetRequestableRolesParams,
-  GetServersResponse,
-  LoginLocalParams,
-  LoginPasswordlessParams,
-  LoginSsoParams,
-  ReviewAccessRequestParams,
-  GetResourcesParams,
-  TshAbortController,
-  TshAbortSignal,
-  TshClient,
-  GetRequestableRolesResponse,
-  UpdateHeadlessAuthenticationStateParams,
-} from '../types';
+import * as types from '../types';
 
-export class MockTshClient implements TshClient {
-  listRootClusters: () => Promise<Cluster[]>;
+export class MockTshClient implements types.TshClient {
+  listRootClusters: () => Promise<types.Cluster[]>;
   listLeafClusters = () => Promise.resolve([]);
-  getKubes: (params: GetResourcesParams) => Promise<GetKubesResponse>;
-  getDatabases: (params: GetResourcesParams) => Promise<GetDatabasesResponse>;
+  getKubes: (
+    params: types.GetResourcesParams
+  ) => Promise<types.GetKubesResponse>;
+  getDatabases: (
+    params: types.GetResourcesParams
+  ) => Promise<types.GetDatabasesResponse>;
   listDatabaseUsers: (dbUri: string) => Promise<string[]>;
   getRequestableRoles: (
-    params: GetRequestableRolesParams
-  ) => Promise<GetRequestableRolesResponse>;
-  getServers: (params: GetResourcesParams) => Promise<GetServersResponse>;
+    params: types.GetRequestableRolesParams
+  ) => Promise<types.GetRequestableRolesResponse>;
+  getServers: (
+    params: types.GetResourcesParams
+  ) => Promise<types.GetServersResponse>;
   assumeRole: (
     clusterUri: string,
     requestIds: string[],
     dropIds: string[]
   ) => Promise<void>;
   deleteAccessRequest: (clusterUri: string, requestId: string) => Promise<void>;
-  getAccessRequests: (clusterUri: string) => Promise<AccessRequest[]>;
+  getAccessRequests: (clusterUri: string) => Promise<types.AccessRequest[]>;
   getAccessRequest: (
     clusterUri: string,
     requestId: string
-  ) => Promise<AccessRequest>;
+  ) => Promise<types.AccessRequest>;
   reviewAccessRequest: (
     clusterUri: string,
-    params: ReviewAccessRequestParams
-  ) => Promise<AccessRequest>;
+    params: types.ReviewAccessRequestParams
+  ) => Promise<types.AccessRequest>;
   createAccessRequest: (
-    params: CreateAccessRequestParams
-  ) => Promise<AccessRequest>;
-  createAbortController: () => TshAbortController;
-  addRootCluster: (addr: string) => Promise<Cluster>;
+    params: types.CreateAccessRequestParams
+  ) => Promise<types.AccessRequest>;
+  createAbortController: () => types.TshAbortController;
+  addRootCluster: (addr: string) => Promise<types.Cluster>;
 
-  listGateways: () => Promise<Gateway[]>;
-  createGateway: (params: CreateGatewayParams) => Promise<Gateway>;
+  listGateways: () => Promise<types.Gateway[]>;
+  createGateway: (params: types.CreateGatewayParams) => Promise<types.Gateway>;
   removeGateway: (gatewayUri: string) => Promise<undefined>;
   setGatewayTargetSubresourceName: (
     gatewayUri: string,
     targetSubresourceName: string
-  ) => Promise<Gateway>;
+  ) => Promise<types.Gateway>;
   setGatewayLocalPort: (
     gatewayUri: string,
     localPort: string
-  ) => Promise<Gateway>;
+  ) => Promise<types.Gateway>;
 
   getCluster = () => Promise.resolve(makeRootCluster());
-  getAuthSettings: (clusterUri: string) => Promise<AuthSettings>;
+  getAuthSettings: (clusterUri: string) => Promise<types.AuthSettings>;
   removeCluster = () => Promise.resolve();
   loginLocal: (
-    params: LoginLocalParams,
-    abortSignal?: TshAbortSignal
+    params: types.LoginLocalParams,
+    abortSignal?: types.TshAbortSignal
   ) => Promise<undefined>;
   loginSso: (
-    params: LoginSsoParams,
-    abortSignal?: TshAbortSignal
+    params: types.LoginSsoParams,
+    abortSignal?: types.TshAbortSignal
   ) => Promise<undefined>;
   loginPasswordless: (
-    params: LoginPasswordlessParams,
-    abortSignal?: TshAbortSignal
+    params: types.LoginPasswordlessParams,
+    abortSignal?: types.TshAbortSignal
   ) => Promise<undefined>;
   logout = () => Promise.resolve();
   transferFile: () => undefined;
@@ -107,6 +92,6 @@ export class MockTshClient implements TshClient {
   deleteConnectMyComputerToken = () => Promise.resolve();
 
   updateHeadlessAuthenticationState: (
-    params: UpdateHeadlessAuthenticationStateParams
+    params: types.UpdateHeadlessAuthenticationStateParams
   ) => Promise<void>;
 }

--- a/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
+++ b/web/packages/teleterm/src/services/tshd/fixtures/mocks.ts
@@ -90,6 +90,7 @@ export class MockTshClient implements types.TshClient {
   createConnectMyComputerNodeToken = () =>
     Promise.resolve({ token: 'abc', labelsList: [] });
   deleteConnectMyComputerToken = () => Promise.resolve();
+  waitForConnectMyComputerNodeJoin: () => Promise<types.WaitForConnectMyComputerNodeJoinResponse>;
 
   updateHeadlessAuthenticationState: (
     params: types.UpdateHeadlessAuthenticationStateParams

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -247,6 +247,10 @@ export type TshClient = {
     clusterUri: uri.RootClusterUri,
     token: string
   ) => Promise<void>;
+  waitForConnectMyComputerNodeJoin: (
+    rootClusterUri: uri.RootClusterUri,
+    abortSignal: TshAbortSignal
+  ) => Promise<WaitForConnectMyComputerNodeJoinResponse>;
 
   updateHeadlessAuthenticationState: (
     params: UpdateHeadlessAuthenticationStateParams,
@@ -341,9 +345,12 @@ export type Label = apiLabel.Label.AsObject;
 
 export type CreateConnectMyComputerRoleResponse =
   apiService.CreateConnectMyComputerRoleResponse.AsObject;
-
 export type CreateConnectMyComputerNodeTokenResponse =
   apiService.CreateConnectMyComputerNodeTokenResponse.AsObject;
+export type WaitForConnectMyComputerNodeJoinResponse =
+  apiService.WaitForConnectMyComputerNodeJoinResponse.AsObject & {
+    server: Server;
+  };
 
 // Replaces object property with a new type
 type Modify<T, R> = Omit<T, keyof R> & R;

--- a/web/packages/teleterm/src/services/tshd/types.ts
+++ b/web/packages/teleterm/src/services/tshd/types.ts
@@ -264,6 +264,7 @@ export type TshAbortController = {
 };
 
 export type TshAbortSignal = {
+  readonly aborted: boolean;
   addEventListener(cb: (...args: any[]) => void): void;
   removeEventListener(cb: (...args: any[]) => void): void;
 };

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -26,6 +26,7 @@ import { useWorkspaceContext } from 'teleterm/ui/Documents';
 import { retryWithRelogin } from 'teleterm/ui/utils';
 import {
   AgentProcessError,
+  NodeWaitJoinTimeout,
   useConnectMyComputerContext,
 } from 'teleterm/ui/ConnectMyComputer';
 import Logger from 'teleterm/logger';
@@ -107,31 +108,33 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
 
   const [createRoleAttempt, runCreateRoleAttempt, setCreateRoleAttempt] =
     useAsync(
-      useCallback(async () => {
-        retryWithRelogin(ctx, rootClusterUri, async () => {
-          let certsReloaded = false;
+      useCallback(
+        () =>
+          retryWithRelogin(ctx, rootClusterUri, async () => {
+            let certsReloaded = false;
 
-          try {
-            const response = await ctx.connectMyComputerService.createRole(
-              rootClusterUri
-            );
-            certsReloaded = response.certsReloaded;
-          } catch (error) {
-            if (isAccessDeniedError(error)) {
-              throw new Error(
-                'Access denied. Contact your administrator for permissions to manage users and roles.'
+            try {
+              const response = await ctx.connectMyComputerService.createRole(
+                rootClusterUri
               );
+              certsReloaded = response.certsReloaded;
+            } catch (error) {
+              if (isAccessDeniedError(error)) {
+                throw new Error(
+                  'Access denied. Contact your administrator for permissions to manage users and roles.'
+                );
+              }
+              throw error;
             }
-            throw error;
-          }
 
-          // If tshd reloaded the certs to refresh the role list, the Electron app must resync details
-          // of the cluster to also update the role list in the UI.
-          if (certsReloaded) {
-            await ctx.clustersService.syncRootCluster(rootClusterUri);
-          }
-        });
-      }, [ctx, rootClusterUri])
+            // If tshd reloaded the certs to refresh the role list, the Electron app must resync details
+            // of the cluster to also update the role list in the UI.
+            if (certsReloaded) {
+              await ctx.clustersService.syncRootCluster(rootClusterUri);
+            }
+          }),
+        [ctx, rootClusterUri]
+      )
     );
   const [
     generateConfigFileAttempt,
@@ -190,6 +193,20 @@ function AgentSetup({ rootClusterUri }: { rootClusterUri: RootClusterUri }) {
       customError: () => {
         if (joinClusterAttempt.status !== 'error') {
           return;
+        }
+
+        if (joinClusterAttempt.error instanceof NodeWaitJoinTimeout) {
+          return (
+            <>
+              <StandardError
+                error={
+                  'The agent did not join the cluster within the timeout window.'
+                }
+                mb={1}
+              />
+              <Logs logs={joinClusterAttempt.error.logs} />
+            </>
+          );
         }
 
         if (!(joinClusterAttempt.error instanceof AgentProcessError)) {

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -37,6 +37,7 @@ import Indicator from 'design/Indicator';
 import {
   AgentProcessError,
   CurrentAction,
+  NodeWaitJoinTimeout,
   useConnectMyComputerContext,
 } from 'teleterm/ui/ConnectMyComputer';
 import { assertUnreachable } from 'teleterm/ui/utils';
@@ -272,6 +273,16 @@ function prettifyCurrentAction(currentAction: CurrentAction): {
           };
         }
         case 'error': {
+          if (currentAction.attempt.error instanceof NodeWaitJoinTimeout) {
+            return {
+              Icon: StyledWarning,
+              title: 'Failed to start agent',
+              error:
+                'The agent did not join the cluster within the timeout window.',
+              logs: currentAction.attempt.error.logs,
+            };
+          }
+
           if (!(currentAction.attempt.error instanceof AgentProcessError)) {
             return {
               Icon: StyledWarning,

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -23,9 +23,6 @@ import React, {
   useMemo,
   useState,
 } from 'react';
-
-import { wait } from 'shared/utils/wait';
-
 import {
   Attempt,
   makeSuccessAttempt,
@@ -35,8 +32,8 @@ import {
 
 import { RootClusterUri } from 'teleterm/ui/uri';
 import { useAppContext } from 'teleterm/ui/appContextProvider';
-
-import { Server } from 'teleterm/services/tshd/types';
+import { Server, TshAbortSignal } from 'teleterm/services/tshd/types';
+import createAbortController from 'teleterm/services/tshd/createAbortController';
 
 import { assertUnreachable } from '../utils';
 
@@ -86,7 +83,7 @@ const ConnectMyComputerContext = createContext<ConnectMyComputerContext>(null);
 
 export const ConnectMyComputerContextProvider: FC<{
   rootClusterUri: RootClusterUri;
-}> = props => {
+}> = ({ rootClusterUri, children }) => {
   const {
     mainProcessClient,
     connectMyComputerService,
@@ -103,16 +100,15 @@ export const ConnectMyComputerContextProvider: FC<{
     setAgentConfiguredAttempt,
   ] = useAsync(
     useCallback(
-      () =>
-        connectMyComputerService.isAgentConfigFileCreated(props.rootClusterUri),
-      [connectMyComputerService, props.rootClusterUri]
+      () => connectMyComputerService.isAgentConfigFileCreated(rootClusterUri),
+      [connectMyComputerService, rootClusterUri]
     )
   );
   const isAgentConfigured =
     isAgentConfiguredAttempt.status === 'success' &&
     isAgentConfiguredAttempt.data;
 
-  const rootCluster = clustersService.findCluster(props.rootClusterUri);
+  const rootCluster = clustersService.findCluster(rootClusterUri);
   const canUse = useMemo(() => {
     const isFeatureFlagEnabled = configService.get(
       'feature.connectMyComputer'
@@ -133,7 +129,7 @@ export const ConnectMyComputerContextProvider: FC<{
   const [agentProcessState, setAgentProcessState] = useState<AgentProcessState>(
     () =>
       mainProcessClient.getAgentState({
-        rootClusterUri: props.rootClusterUri,
+        rootClusterUri,
       }) || {
         status: 'not-started',
       }
@@ -150,36 +146,33 @@ export const ConnectMyComputerContextProvider: FC<{
   const [startAgentAttempt, startAgent] = useAsync(
     useCallback(async () => {
       setCurrentActionKind('start');
-      await connectMyComputerService.runAgent(props.rootClusterUri);
 
-      const abortController = new AbortController();
+      await connectMyComputerService.runAgent(rootClusterUri);
+
+      const abortController = createAbortController();
       try {
         const server = await Promise.race([
           connectMyComputerService.waitForNodeToJoin(
-            props.rootClusterUri,
+            rootClusterUri,
             abortController.signal
           ),
           throwOnAgentProcessErrors(
             mainProcessClient,
-            props.rootClusterUri,
+            rootClusterUri,
             abortController.signal
           ),
           wait(20_000, abortController.signal).then(() => {
-            throw new Error(
-              'The agent did not manage to join the cluster within 20 seconds.'
-            );
+            const logs = mainProcessClient.getAgentLogs({ rootClusterUri });
+            throw new NodeWaitJoinTimeout(logs);
           }),
         ]);
         setCurrentActionKind('observe-process');
-        workspacesService.setConnectMyComputerAutoStart(
-          props.rootClusterUri,
-          true
-        );
-        usageService.captureConnectMyComputerAgentStart(props.rootClusterUri);
+        workspacesService.setConnectMyComputerAutoStart(rootClusterUri, true);
+        usageService.captureConnectMyComputerAgentStart(rootClusterUri);
         return server;
       } catch (error) {
         // in case of any error kill the agent
-        await connectMyComputerService.killAgent(props.rootClusterUri);
+        await connectMyComputerService.killAgent(rootClusterUri);
         throw error;
       } finally {
         abortController.abort();
@@ -187,7 +180,7 @@ export const ConnectMyComputerContextProvider: FC<{
     }, [
       connectMyComputerService,
       mainProcessClient,
-      props.rootClusterUri,
+      rootClusterUri,
       usageService,
       workspacesService,
     ])
@@ -204,13 +197,10 @@ export const ConnectMyComputerContextProvider: FC<{
   const [killAgentAttempt, killAgent] = useAsync(
     useCallback(async () => {
       setCurrentActionKind('kill');
-      await connectMyComputerService.killAgent(props.rootClusterUri);
+      await connectMyComputerService.killAgent(rootClusterUri);
       setCurrentActionKind('observe-process');
-      workspacesService.setConnectMyComputerAutoStart(
-        props.rootClusterUri,
-        false
-      );
-    }, [connectMyComputerService, props.rootClusterUri, workspacesService])
+      workspacesService.setConnectMyComputerAutoStart(rootClusterUri, false);
+    }, [connectMyComputerService, rootClusterUri, workspacesService])
   );
 
   const markAgentAsConfigured = useCallback(() => {
@@ -223,11 +213,11 @@ export const ConnectMyComputerContextProvider: FC<{
 
   useEffect(() => {
     const { cleanup } = mainProcessClient.subscribeToAgentUpdate(
-      props.rootClusterUri,
+      rootClusterUri,
       setAgentProcessState
     );
     return cleanup;
-  }, [mainProcessClient, props.rootClusterUri]);
+  }, [mainProcessClient, rootClusterUri]);
 
   let currentAction: CurrentAction;
   const kind = currentActionKind;
@@ -238,7 +228,11 @@ export const ConnectMyComputerContextProvider: FC<{
       break;
     }
     case 'start': {
-      currentAction = { kind, attempt: startAgentAttempt, agentProcessState };
+      currentAction = {
+        kind,
+        attempt: startAgentAttempt,
+        agentProcessState,
+      };
       break;
     }
     case 'observe-process': {
@@ -275,7 +269,7 @@ export const ConnectMyComputerContextProvider: FC<{
     const shouldAutoStartAgent =
       isAgentConfigured &&
       canUse &&
-      workspacesService.getConnectMyComputerAutoStart(props.rootClusterUri) &&
+      workspacesService.getConnectMyComputerAutoStart(rootClusterUri) &&
       agentIsNotStarted;
     if (shouldAutoStartAgent) {
       downloadAndStartAgent();
@@ -285,7 +279,7 @@ export const ConnectMyComputerContextProvider: FC<{
     downloadAndStartAgent,
     agentIsNotStarted,
     isAgentConfigured,
-    props.rootClusterUri,
+    rootClusterUri,
     workspacesService,
   ]);
 
@@ -306,7 +300,7 @@ export const ConnectMyComputerContextProvider: FC<{
         markAgentAsNotConfigured,
         isAgentConfiguredAttempt,
       }}
-      children={props.children}
+      children={children}
     />
   );
 };
@@ -329,7 +323,7 @@ export const useConnectMyComputerContext = () => {
 function throwOnAgentProcessErrors(
   mainProcessClient: MainProcessClient,
   rootClusterUri: RootClusterUri,
-  abortSignal: AbortSignal
+  abortSignal: TshAbortSignal
 ): Promise<never> {
   return new Promise((_, reject) => {
     const rejectOnError = (agentProcessState: AgentProcessState) => {
@@ -348,12 +342,12 @@ function throwOnAgentProcessErrors(
       rootClusterUri,
       rejectOnError
     );
-    abortSignal.onabort = () => {
+    abortSignal.addEventListener(() => {
       cleanup();
       reject(
         new DOMException('throwOnAgentProcessErrors was aborted', 'AbortError')
       );
-    };
+    });
 
     // the state may have changed before we started listening, we have to check the current state
     rejectOnError(
@@ -369,4 +363,28 @@ export class AgentProcessError extends Error {
     super('AgentProcessError');
     this.name = 'AgentProcessError';
   }
+}
+
+export class NodeWaitJoinTimeout extends Error {
+  constructor(public readonly logs: string) {
+    super('NodeWaitJoinTimeout');
+    this.name = 'NodeWaitJoinTimeout';
+  }
+}
+
+/**
+ * wait is like wait from the shared package, but it works with TshAbortSignal.
+ * TODO(ravicious): Refactor TshAbortSignal so that its interface is the same as AbortSignal.
+ * See the comment in createAbortController for more details.
+ */
+function wait(ms: number, abortSignal: TshAbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(resolve, ms);
+    if (abortSignal) {
+      abortSignal.addEventListener(() => {
+        clearTimeout(timeout);
+        reject(new DOMException('Wait was aborted.', 'AbortError'));
+      });
+    }
+  });
 }

--- a/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
+++ b/web/packages/teleterm/src/ui/services/connectMyComputer/connectMyComputerService.ts
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-import { wait } from 'shared/utils/wait';
-
 import { MainProcessClient } from 'teleterm/mainProcess/types';
 import {
   Cluster,
   CreateConnectMyComputerRoleResponse,
   Server,
+  TshAbortSignal,
   TshClient,
 } from 'teleterm/services/tshd/types';
 
@@ -83,26 +82,13 @@ export class ConnectMyComputerService {
 
   async waitForNodeToJoin(
     rootClusterUri: uri.RootClusterUri,
-    abortSignal: AbortSignal
+    abortSignal: TshAbortSignal
   ): Promise<Server> {
-    // TODO(gzdunek): Replace with waiting for the node to join.
-    await wait(1_000, abortSignal);
-    return {
-      uri: `${rootClusterUri}/servers/178ef081-259b-4aa5-a018-449b5ea7e694`,
-      tunnel: false,
-      name: '178ef081-259b-4aa5-a018-449b5ea7e694',
-      hostname: 'foo',
-      addr: '127.0.0.1:3022',
-      labelsList: [
-        {
-          name: 'hostname',
-          value: 'mbp.home',
-        },
-        {
-          name: 'teleport.dev/connect-my-computer',
-          value: 'abcd@goteleport.com',
-        },
-      ],
-    };
+    const response = await this.tshClient.waitForConnectMyComputerNodeJoin(
+      rootClusterUri,
+      abortSignal
+    );
+
+    return response.server;
   }
 }

--- a/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
+++ b/web/packages/teleterm/src/ui/services/fileTransferClient/fileTransferService.ts
@@ -34,6 +34,7 @@ export class FileTransferService {
     abortController: AbortController
   ): FileTransferListeners {
     const abortSignal = {
+      aborted: false,
       addEventListener: (cb: (...args: any[]) => void) => {
         abortController.signal.addEventListener('abort', cb);
       },
@@ -41,6 +42,13 @@ export class FileTransferService {
         abortController.signal.removeEventListener('abort', cb);
       },
     };
+    abortController.signal.addEventListener(
+      'abort',
+      () => {
+        abortSignal.aborted = true;
+      },
+      { once: true }
+    );
     const listeners = this.tshClient.transferFile(options, abortSignal);
     if (
       options.direction ===

--- a/yarn.lock
+++ b/yarn.lock
@@ -7589,12 +7589,7 @@ eventemitter3@^4.0.0:
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
 
-events@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/events/-/events-1.0.2.tgz#75849dcfe93d10fb057c30055afdbd51d06a8e24"
-  integrity sha1-dYSdz+k9EPsFfDAFWv29UdBqjiQ=
-
-events@^3.2.0, events@^3.3.0:
+events@3.3.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==


### PR DESCRIPTION
The mock implementation which simply waits and returns a bogus server is replaced with an implementation that makes a call to `WaitForConnectMyComputerNodeJoin` from #30905. The description of that PR goes into more detail as to what it is for and how to test it.