### PR TITLE
AWS OIDC: Add StateMessage and DashboardLink to List EICE

### DIFF
--- a/lib/integrations/awsoidc/list_ec2ice.go
+++ b/lib/integrations/awsoidc/list_ec2ice.go
@@ -19,6 +19,7 @@ package awsoidc
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
@@ -142,8 +143,10 @@ func ListEC2ICE(ctx context.Context, clt ListEC2ICEClient, req ListEC2ICERequest
 		subnetID := aws.ToString(ice.SubnetId)
 		state := ice.State
 		stateMessage := aws.ToString(ice.StateMessage)
+
+		idURLSafe := url.QueryEscape(name)
 		dashboardLink := fmt.Sprintf("https://%s.console.aws.amazon.com/vpc/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=%s",
-			req.Region, aws.ToString(ice.InstanceConnectEndpointId),
+			req.Region, idURLSafe,
 		)
 
 		ret.EC2ICEs = append(ret.EC2ICEs, EC2InstanceConnectEndpoint{

--- a/lib/integrations/awsoidc/list_ec2ice_test.go
+++ b/lib/integrations/awsoidc/list_ec2ice_test.go
@@ -98,6 +98,7 @@ func TestListEC2ICE(t *testing.T) {
 		// First page must return pageSize number of Endpoints
 		resp, err := ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
 			VPCID:     "vpc-123",
+			Region:    "us-east-1",
 			NextToken: "",
 		})
 		require.NoError(t, err)
@@ -109,6 +110,7 @@ func TestListEC2ICE(t *testing.T) {
 		// Second page must return pageSize number of Endpoints
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
 			VPCID:     "vpc-abc",
+			Region:    "us-east-1",
 			NextToken: nextPageToken,
 		})
 		require.NoError(t, err)
@@ -120,6 +122,7 @@ func TestListEC2ICE(t *testing.T) {
 		// Third page must return only the remaining Endpoints and an empty nextToken
 		resp, err = ListEC2ICE(ctx, mockListClient, ListEC2ICERequest{
 			VPCID:     "vpc-abc",
+			Region:    "us-east-1",
 			NextToken: nextPageToken,
 		})
 		require.NoError(t, err)
@@ -139,12 +142,14 @@ func TestListEC2ICE(t *testing.T) {
 			name: "valid for listing instances",
 			req: ListEC2ICERequest{
 				VPCID:     "vpc-abcd",
+				Region:    "us-east-1",
 				NextToken: "",
 			},
 			mockEndpoints: []ec2Types.Ec2InstanceConnectEndpoint{{
 				SubnetId:                  aws.String("subnet-123"),
 				InstanceConnectEndpointId: aws.String("ice-name"),
 				State:                     "create-complete",
+				StateMessage:              aws.String("success message"),
 			},
 			},
 			respCheck: func(t *testing.T, ldr *ListEC2ICEResponse) {
@@ -152,17 +157,28 @@ func TestListEC2ICE(t *testing.T) {
 				require.Empty(t, ldr.NextToken, "expected an empty NextToken")
 
 				endpoint := EC2InstanceConnectEndpoint{
-					Name:     "ice-name",
-					State:    "create-complete",
-					SubnetID: "subnet-123",
+					Name:          "ice-name",
+					State:         "create-complete",
+					SubnetID:      "subnet-123",
+					StateMessage:  "success message",
+					DashboardLink: "https://us-east-1.console.aws.amazon.com/vpc/home?#InstanceConnectEndpointDetails:instanceConnectEndpointId=ice-name",
 				}
 				require.Empty(t, cmp.Diff(endpoint, ldr.EC2ICEs[0]))
 			},
 			errCheck: noErrorFunc,
 		},
 		{
-			name:     "no vpc id",
-			req:      ListEC2ICERequest{},
+			name: "no vpc id",
+			req: ListEC2ICERequest{
+				Region: "us-east-1",
+			},
+			errCheck: trace.IsBadParameter,
+		},
+		{
+			name: "no region id",
+			req: ListEC2ICERequest{
+				VPCID: "vpc-123",
+			},
 			errCheck: trace.IsBadParameter,
 		},
 	} {

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -316,6 +316,7 @@ func (h *Handler) awsOIDCListEC2ICE(w http.ResponseWriter, r *http.Request, p ht
 	resp, err := awsoidc.ListEC2ICE(ctx,
 		listEC2ICEClient,
 		awsoidc.ListEC2ICERequest{
+			Region:    req.Region,
 			VPCID:     req.VPCID,
 			NextToken: req.NextToken,
 		},


### PR DESCRIPTION
Context: https://github.com/gravitational/teleport/issues/29317
When listing EC2 Instance Connect Endpoint it is useful to return the state message and dashboard link so that the user knows what went wrong and how to access the EC2 Instance Connect Endpoint.

This is useful when creating an EC2 Instance Connect Endpoint didn't work.