### PR TITLE
[web] Add textTransform override for resource launch buttons

### DIFF
--- a/web/packages/design/src/Button/Button.jsx
+++ b/web/packages/design/src/Button/Button.jsx
@@ -16,7 +16,7 @@ limitations under the License.
 
 import React from 'react';
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
+import { bool, string } from 'prop-types';
 
 import { space, width, height } from 'design/system';
 
@@ -84,6 +84,7 @@ const themedStyles = props => {
     ...width(props),
     ...block(props),
     ...height(props),
+    ...textTransform(props),
   };
 };
 
@@ -156,6 +157,9 @@ const block = props =>
       }
     : null;
 
+const textTransform = props =>
+  props.textTransform ? { textTransform: props.textTransform } : null;
+
 const StyledButton = styled.button`
   line-height: 1.5;
   margin: 0;
@@ -184,19 +188,29 @@ Button.propTypes = {
    * block specifies if an element's display is set to block or not.
    * Set to true to set display to block.
    */
-  block: PropTypes.bool,
+  block: bool,
 
   /**
    * kind specifies the styling a button takes.
    * Select from primary (default), secondary, warning.
    */
-  kind: PropTypes.string,
+  kind: string,
 
   /**
    * size specifies the size of button.
    * Select from small, medium (default), large
    */
-  size: PropTypes.string,
+  size: string,
+
+  /**
+   * textTransform specifies the case transform of the button text.
+   * default is UPPERCASE
+   *
+   * TODO (avatus): eventually, we will move away from every button being
+   * uppercase and this probably won't be needed anymore. This is a temporary
+   * fix before we audit the whole site and migrate
+   */
+  textTransform: string,
 
   /**
    * styled-system

--- a/web/packages/shared/components/MenuLogin/MenuLogin.test.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.test.tsx
@@ -30,7 +30,7 @@ test('does not accept an empty value when required is set to true', async () => 
     />
   );
 
-  fireEvent.click(await screen.findByText('CONNECT'));
+  fireEvent.click(await screen.findByText(/connect/i));
   fireEvent.keyPress(await screen.findByPlaceholderText('MenuLogin input'), {
     key: 'Enter',
     keyCode: 13,
@@ -50,7 +50,7 @@ test('accepts an empty value when required is set to false', async () => {
     />
   );
 
-  fireEvent.click(await screen.findByText('CONNECT'));
+  fireEvent.click(await screen.findByText(/connect/i));
   fireEvent.keyPress(await screen.findByPlaceholderText('MenuLogin input'), {
     key: 'Enter',
     keyCode: 13,

--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -33,6 +33,7 @@ export const MenuLogin = React.forwardRef<MenuLoginHandle, MenuLoginProps>(
       onSelect,
       anchorOrigin,
       transformOrigin,
+      alignButtonWidthToMenu = false,
       required = true,
       width,
     } = props;
@@ -75,12 +76,14 @@ export const MenuLogin = React.forwardRef<MenuLoginHandle, MenuLoginProps>(
     return (
       <React.Fragment>
         <ButtonBorder
+          width={alignButtonWidthToMenu ? width : null}
+          textTransform={props.textTransform}
           height="24px"
           size="small"
           setRef={anchorRef}
           onClick={onOpen}
         >
-          CONNECT
+          Connect
           <ChevronDown ml={1} mr={-2} size="small" color="text.slightlyMuted" />
         </ButtonBorder>
         <Menu

--- a/web/packages/shared/components/MenuLogin/types.ts
+++ b/web/packages/shared/components/MenuLogin/types.ts
@@ -23,7 +23,9 @@ export type MenuLoginProps = {
   getLoginItems: () => LoginItem[] | Promise<LoginItem[]>;
   onSelect: (e: React.SyntheticEvent, login: string) => void;
   anchorOrigin?: any;
+  alignButtonWidthToMenu?: boolean;
   transformOrigin?: any;
+  textTransform?: string;
   placeholder?: string;
   required?: boolean;
   width?: string;

--- a/web/packages/teleport/src/Apps/AppList/AwsLaunchButton/AwsLaunchButton.tsx
+++ b/web/packages/teleport/src/Apps/AppList/AwsLaunchButton/AwsLaunchButton.tsx
@@ -45,7 +45,8 @@ export default class AwsLaunchButton extends React.Component<Props> {
     return (
       <>
         <ButtonBorder
-          width="88px"
+          textTransform="none"
+          width="90px"
           size="small"
           setRef={e => (this.anchorEl = e)}
           onClick={this.onOpen}

--- a/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`empty state for enterprise, can create 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c11:hover,
@@ -95,6 +96,7 @@ exports[`empty state for enterprise, can create 1`] = `
   padding: 0px 24px;
   margin-left: 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c12:hover,
@@ -340,7 +342,51 @@ exports[`failed state 1`] = `
   cursor: auto;
 }
 
-.c36 {
+.c32 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  color: #FFFFFF;
+  background: rgba(255,255,255,0);
+  border: 1px solid rgba(255,255,255,0.36);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  width: 90px;
+  text-transform: none;
+}
+
+.c32:hover,
+.c32:focus {
+  background: rgba(255,255,255,0.07);
+}
+
+.c32:active {
+  background: rgba(255,255,255,0.13);
+}
+
+.c32:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+  cursor: auto;
+}
+
+.c37 {
   align-items: center;
   border: none;
   cursor: pointer;
@@ -362,25 +408,25 @@ exports[`failed state 1`] = `
   margin-right: 0px;
 }
 
-.c36:disabled {
+.c37:disabled {
   color: rgba(255,255,255,0.36);
 }
 
-.c36:disabled {
+.c37:disabled {
   color: rgba(255,255,255,0.36);
   cursor: default;
 }
 
-.c36:hover:enabled,
-.c36:focus:enabled {
+.c37:hover:enabled,
+.c37:focus:enabled {
   background: rgba(255,255,255,0.13);
 }
 
-.c36:active:enabled {
+.c37:active:enabled {
   background: rgba(255,255,255,0.18);
 }
 
-.c38 {
+.c39 {
   align-items: center;
   border: none;
   cursor: pointer;
@@ -401,21 +447,21 @@ exports[`failed state 1`] = `
   margin-left: 0px;
 }
 
-.c38:disabled {
+.c39:disabled {
   color: rgba(255,255,255,0.36);
 }
 
-.c38:disabled {
+.c39:disabled {
   color: rgba(255,255,255,0.36);
   cursor: default;
 }
 
-.c38:hover:enabled,
-.c38:focus:enabled {
+.c39:hover:enabled,
+.c39:focus:enabled {
   background: rgba(255,255,255,0.13);
 }
 
-.c38:active:enabled {
+.c39:active:enabled {
   background: rgba(255,255,255,0.18);
 }
 
@@ -455,7 +501,7 @@ exports[`failed state 1`] = `
   justify-content: center;
 }
 
-.c32 {
+.c33 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -521,7 +567,7 @@ exports[`failed state 1`] = `
   justify-content: center;
 }
 
-.c33 {
+.c34 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -532,7 +578,7 @@ exports[`failed state 1`] = `
   justify-content: center;
 }
 
-.c35 {
+.c36 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
@@ -663,7 +709,7 @@ exports[`failed state 1`] = `
   border-top-right-radius: 8px;
 }
 
-.c34 {
+.c35 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -700,11 +746,11 @@ exports[`failed state 1`] = `
   background-color: rgba(255,255,255,0.13);
 }
 
-.c37 svg {
+.c38 svg {
   font-size: 20px;
 }
 
-.c37 svg:before {
+.c38 svg:before {
   padding-left: 1px;
 }
 
@@ -1333,13 +1379,13 @@ exports[`failed state 1`] = `
               align="right"
             >
               <button
-                class="c29"
+                class="c32"
                 kind="border"
-                width="88px"
+                width="90px"
               >
                 LAUNCH
                 <span
-                  class="c32 icon icon-chevrondown"
+                  class="c33 icon icon-chevrondown"
                   color="text.slightlyMuted"
                 >
                   <svg
@@ -1363,7 +1409,7 @@ exports[`failed state 1`] = `
               style="user-select: none;"
             >
               <div
-                class="c33"
+                class="c34"
                 height="32px"
                 width="32px"
               >
@@ -1420,17 +1466,17 @@ exports[`failed state 1`] = `
         </tbody>
       </table>
       <nav
-        class="c34"
+        class="c35"
       >
         <div
-          class="c35"
+          class="c36"
           width="100%"
         >
           <div
             class="c21"
           >
             <button
-              class="c36 c37"
+              class="c37 c38"
               title="Previous page"
             >
               <span
@@ -1454,7 +1500,7 @@ exports[`failed state 1`] = `
               </span>
             </button>
             <button
-              class="c38 c37"
+              class="c39 c38"
               title="Next page"
             >
               <span
@@ -1514,6 +1560,7 @@ exports[`loaded state 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c3:hover,
@@ -1574,7 +1621,51 @@ exports[`loaded state 1`] = `
   cursor: auto;
 }
 
-.c36 {
+.c32 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  color: #FFFFFF;
+  background: rgba(255,255,255,0);
+  border: 1px solid rgba(255,255,255,0.36);
+  font-size: 10px;
+  min-height: 24px;
+  padding: 0px 16px;
+  width: 90px;
+  text-transform: none;
+}
+
+.c32:hover,
+.c32:focus {
+  background: rgba(255,255,255,0.07);
+}
+
+.c32:active {
+  background: rgba(255,255,255,0.13);
+}
+
+.c32:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+  cursor: auto;
+}
+
+.c37 {
   align-items: center;
   border: none;
   cursor: pointer;
@@ -1596,25 +1687,25 @@ exports[`loaded state 1`] = `
   margin-right: 0px;
 }
 
-.c36:disabled {
+.c37:disabled {
   color: rgba(255,255,255,0.36);
 }
 
-.c36:disabled {
+.c37:disabled {
   color: rgba(255,255,255,0.36);
   cursor: default;
 }
 
-.c36:hover:enabled,
-.c36:focus:enabled {
+.c37:hover:enabled,
+.c37:focus:enabled {
   background: rgba(255,255,255,0.13);
 }
 
-.c36:active:enabled {
+.c37:active:enabled {
   background: rgba(255,255,255,0.18);
 }
 
-.c38 {
+.c39 {
   align-items: center;
   border: none;
   cursor: pointer;
@@ -1635,21 +1726,21 @@ exports[`loaded state 1`] = `
   margin-left: 0px;
 }
 
-.c38:disabled {
+.c39:disabled {
   color: rgba(255,255,255,0.36);
 }
 
-.c38:disabled {
+.c39:disabled {
   color: rgba(255,255,255,0.36);
   cursor: default;
 }
 
-.c38:hover:enabled,
-.c38:focus:enabled {
+.c39:hover:enabled,
+.c39:focus:enabled {
   background: rgba(255,255,255,0.13);
 }
 
-.c38:active:enabled {
+.c39:active:enabled {
   background: rgba(255,255,255,0.18);
 }
 
@@ -1689,7 +1780,7 @@ exports[`loaded state 1`] = `
   justify-content: center;
 }
 
-.c32 {
+.c33 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1755,7 +1846,7 @@ exports[`loaded state 1`] = `
   justify-content: center;
 }
 
-.c33 {
+.c34 {
   box-sizing: border-box;
   height: 32px;
   width: 32px;
@@ -1766,7 +1857,7 @@ exports[`loaded state 1`] = `
   justify-content: center;
 }
 
-.c35 {
+.c36 {
   box-sizing: border-box;
   width: 100%;
   display: flex;
@@ -1897,7 +1988,7 @@ exports[`loaded state 1`] = `
   border-top-right-radius: 8px;
 }
 
-.c34 {
+.c35 {
   padding: 16px 24px;
   display: flex;
   height: 24px;
@@ -1934,11 +2025,11 @@ exports[`loaded state 1`] = `
   background-color: rgba(255,255,255,0.13);
 }
 
-.c37 svg {
+.c38 svg {
   font-size: 20px;
 }
 
-.c37 svg:before {
+.c38 svg:before {
   padding-left: 1px;
 }
 
@@ -2572,13 +2663,13 @@ exports[`loaded state 1`] = `
               align="right"
             >
               <button
-                class="c29"
+                class="c32"
                 kind="border"
-                width="88px"
+                width="90px"
               >
                 LAUNCH
                 <span
-                  class="c32 icon icon-chevrondown"
+                  class="c33 icon icon-chevrondown"
                   color="text.slightlyMuted"
                 >
                   <svg
@@ -2602,7 +2693,7 @@ exports[`loaded state 1`] = `
               style="user-select: none;"
             >
               <div
-                class="c33"
+                class="c34"
                 height="32px"
                 width="32px"
               >
@@ -2659,17 +2750,17 @@ exports[`loaded state 1`] = `
         </tbody>
       </table>
       <nav
-        class="c34"
+        class="c35"
       >
         <div
-          class="c35"
+          class="c36"
           width="100%"
         >
           <div
             class="c21"
           >
             <button
-              class="c36 c37"
+              class="c37 c38"
               title="Previous page"
             >
               <span
@@ -2693,7 +2784,7 @@ exports[`loaded state 1`] = `
               </span>
             </button>
             <button
-              class="c38 c37"
+              class="c39 c38"
               title="Next page"
             >
               <span

--- a/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Console/DocumentNodes/__snapshots__/DocumentNodes.story.test.tsx.snap
@@ -960,7 +960,7 @@ exports[`render DocumentNodes 1`] = `
                   height="24px"
                   kind="border"
                 >
-                  CONNECT
+                  Connect
                   <span
                     class="c30 icon icon-chevrondown"
                     color="text.slightlyMuted"
@@ -1014,7 +1014,7 @@ exports[`render DocumentNodes 1`] = `
                   height="24px"
                   kind="border"
                 >
-                  CONNECT
+                  Connect
                   <span
                     class="c30 icon icon-chevrondown"
                     color="text.slightlyMuted"
@@ -1073,7 +1073,7 @@ exports[`render DocumentNodes 1`] = `
                   height="24px"
                   kind="border"
                 >
-                  CONNECT
+                  Connect
                   <span
                     class="c30 icon icon-chevrondown"
                     color="text.slightlyMuted"
@@ -1132,7 +1132,7 @@ exports[`render DocumentNodes 1`] = `
                   height="24px"
                   kind="border"
                 >
-                  CONNECT
+                  Connect
                   <span
                     class="c30 icon icon-chevrondown"
                     color="text.slightlyMuted"
@@ -1210,7 +1210,7 @@ exports[`render DocumentNodes 1`] = `
                   height="24px"
                   kind="border"
                 >
-                  CONNECT
+                  Connect
                   <span
                     class="c30 icon icon-chevrondown"
                     color="text.slightlyMuted"

--- a/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`empty state for enterprise, can create 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c11:hover,
@@ -95,6 +96,7 @@ exports[`empty state for enterprise, can create 1`] = `
   padding: 0px 24px;
   margin-left: 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c12:hover,
@@ -1209,6 +1211,7 @@ exports[`open source loaded 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c3:hover,

--- a/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`empty state 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c11:hover,
@@ -95,6 +96,7 @@ exports[`empty state 1`] = `
   padding: 0px 24px;
   margin-left: 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c12:hover,
@@ -1136,6 +1138,7 @@ exports[`loaded 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c3:hover,

--- a/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -51,6 +51,7 @@ exports[`empty state 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c11:hover,
@@ -95,6 +96,7 @@ exports[`empty state 1`] = `
   padding: 0px 24px;
   margin-left: 24px;
   width: 224px;
+  text-transform: none;
 }
 
 .c12:hover,
@@ -994,7 +996,7 @@ exports[`failed 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -1048,7 +1050,7 @@ exports[`failed 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -1102,7 +1104,7 @@ exports[`failed 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -1156,7 +1158,7 @@ exports[`failed 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -1210,7 +1212,7 @@ exports[`failed 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -1269,7 +1271,7 @@ exports[`failed 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -1328,7 +1330,7 @@ exports[`failed 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -1445,6 +1447,7 @@ exports[`loaded 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c3:hover,
@@ -2164,7 +2167,7 @@ exports[`loaded 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -2218,7 +2221,7 @@ exports[`loaded 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -2272,7 +2275,7 @@ exports[`loaded 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -2326,7 +2329,7 @@ exports[`loaded 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -2380,7 +2383,7 @@ exports[`loaded 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -2439,7 +2442,7 @@ exports[`loaded 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"
@@ -2498,7 +2501,7 @@ exports[`loaded 1`] = `
               height="24px"
               kind="border"
             >
-              CONNECT
+              Connect
               <span
                 class="c27 icon icon-chevrondown"
                 color="text.slightlyMuted"

--- a/web/packages/teleport/src/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/teleport/src/UnifiedResources/FilterPanel.tsx
@@ -102,6 +102,7 @@ export function FilterPanel({
       <Flex>
         <Box width="100px">
           <SortSelect
+            size="small"
             options={sortFieldOptions}
             value={activeSortFieldOption}
             isSearchable={false}

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -77,6 +77,9 @@ const NodeConnect = ({ node }: { node: Node }) => {
 
   return (
     <MenuLogin
+      width="90px"
+      textTransform="none"
+      alignButtonWidthToMenu
       getLoginItems={handleOnOpen}
       onSelect={handleOnSelect}
       transformOrigin={{
@@ -114,6 +117,9 @@ const DesktopConnect = ({ desktop }: { desktop: Desktop }) => {
 
   return (
     <MenuLogin
+      width="90px"
+      textTransform="none"
+      alignButtonWidthToMenu
       getLoginItems={handleOnOpen}
       onSelect={handleOnSelect}
       transformOrigin={{
@@ -157,6 +163,7 @@ const AppLaunch = ({ app }: { app: App }) => {
         width="90px"
         size="small"
         title="Cloud or TCP applications cannot be launched by the browser"
+        textTransform="none"
       >
         Launch
       </ButtonBorder>
@@ -171,6 +178,7 @@ const AppLaunch = ({ app }: { app: App }) => {
         target="_blank"
         href={samlAppSsoUrl}
         rel="noreferrer"
+        textTransform="none"
       >
         Login
       </ButtonBorder>
@@ -184,6 +192,7 @@ const AppLaunch = ({ app }: { app: App }) => {
       target="_blank"
       href={launchUrl}
       rel="noreferrer"
+      textTransform="none"
     >
       Launch
     </ButtonBorder>
@@ -201,6 +210,8 @@ function DatabaseConnect({ database }: { database: Database }) {
   return (
     <>
       <ButtonBorder
+        textTransform="none"
+        width="90px"
         size="small"
         onClick={() => {
           setOpen(true);
@@ -232,7 +243,11 @@ const KubeConnect = ({ kube }: { kube: Kube }) => {
   const accessRequestId = ctx.storeUser.getAccessRequestId();
   return (
     <>
-      <ButtonBorder size="small" onClick={() => setOpen(true)}>
+      <ButtonBorder
+        textTransform="none"
+        size="small"
+        onClick={() => setOpen(true)}
+      >
         Connect
       </ButtonBorder>
       {open && (

--- a/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
+++ b/web/packages/teleport/src/components/AgentButtonAdd/AgentButtonAdd.tsx
@@ -55,6 +55,7 @@ export default function AgentButtonAdd(props: Props) {
       style={{ textDecoration: 'none' }}
     >
       <ButtonPrimary
+        textTransform="none"
         title={title}
         disabled={disabled}
         width="240px"

--- a/web/packages/teleport/src/components/AgentButtonAdd/__snapshots__/AgentButtonAdd.story.test.tsx.snap
+++ b/web/packages/teleport/src/components/AgentButtonAdd/__snapshots__/AgentButtonAdd.story.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`can create 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c0:hover,
@@ -86,6 +87,7 @@ exports[`cannot create 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c0:hover,
@@ -147,6 +149,7 @@ exports[`cannot create when resource starts with vowel 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c0:hover,
@@ -208,6 +211,7 @@ exports[`on leaf cluster 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c0:hover,
@@ -269,6 +273,7 @@ exports[`on leaf cluster when resource starts with vowel 1`] = `
   font-size: 12px;
   padding: 0px 24px;
   width: 240px;
+  text-transform: none;
 }
 
 .c0:hover,


### PR DESCRIPTION
This is a temporary fix to migrate only the Unified Resources page to proper casing on buttons. Eventually, we want to move every button to this because, and to quote Kenny
> we’re trying to move away from SHOUTING AT EVERYONE FROM EVERY BUTTON 
![Screenshot 2023-08-23 at 2 59 41 PM](https://github.com/gravitational/teleport/assets/5201977/535fe7cd-1be6-42c4-b5db-3c7616aa1423)

I've added it as an optional prop as to not mess with Connect's styling. Although, it'll change when we switch to unified resources anyway so, you let me know.

It also fixes some mismatched width's on the buttons now that they are all seen together on one page.

Added a `TODO` to remove once we do a larger migrate