### PR TITLE
Fix access list enterprise tests.

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -18,6 +18,7 @@ package accesslist
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -235,17 +236,17 @@ func (a *AccessList) MatchSearch(values []string) bool {
 }
 
 func (a *Audit) UnmarshalJSON(data []byte) error {
-	var audit map[string]string
+	var audit map[string]interface{}
 	if err := json.Unmarshal(data, &audit); err != nil {
 		return trace.Wrap(err)
 	}
 
 	var err error
-	a.Frequency, err = time.ParseDuration(audit["frequency"])
+	a.Frequency, err = time.ParseDuration(fmt.Sprintf("%v", audit["frequency"]))
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	a.NextAuditDate, err = time.Parse(time.RFC3339Nano, audit["next_audit_date"])
+	a.NextAuditDate, err = time.Parse(time.RFC3339Nano, fmt.Sprintf("%v", audit["next_audit_date"]))
 	if err != nil {
 		return trace.Wrap(err)
 	}


### PR DESCRIPTION
The access list enterprise tests were broken by changing the custom JSON marshaling of the access list audit from `map[string]interface{}` to `map[string]string`. This change restores the old behavior.