### PR TITLE
[v13] Set cloud version to v13.3.4

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1612,7 +1612,7 @@
     },
     "teleport": {
       "major_version": "13",
-      "version": "13.3.2",
+      "version": "13.3.4",
       "golang": "1.20",
       "plugin": {
         "version": "13.3.2"


### PR DESCRIPTION
Teleport Cloud tenants will be upgraded to v13.3.4 on Wednesday 8/23.

Backport: https://github.com/gravitational/teleport/pull/30883
See: https://github.com/gravitational/cloud/issues/5742