### PR TITLE
[web] init history if null

### DIFF
--- a/web/.storybook/preview.js
+++ b/web/.storybook/preview.js
@@ -31,6 +31,7 @@ import {
   lightTheme as teletermLightTheme,
 } from './../packages/teleterm/src/ui/ThemeProvider/theme';
 import { handlersTeleport } from './../packages/teleport/src/mocks/handlers';
+import history from './../packages/teleport/src/services/history/history';
 import { UserContextProvider } from 'teleport/User';
 
 // Checks we are running non-node environment (browser)
@@ -41,6 +42,8 @@ if (typeof global.process === 'undefined') {
   // So it can be accessed in stories more easily.
   window.msw = { worker, rest };
 }
+
+history.init();
 
 // wrap each story with theme provider
 const ThemeDecorator = (storyFn, meta) => {

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -34,17 +34,11 @@ const history = {
   },
 
   replace(route = '') {
-    if (!_inst) {
-      this.init();
-    }
     route = this.ensureKnownRoute(route);
     _inst.replace(route);
   },
 
   push(route, withRefresh = false) {
-    if (!_inst) {
-      this.init();
-    }
     route = this.ensureKnownRoute(route);
     if (withRefresh) {
       this._pageRefresh(route);
@@ -58,9 +52,6 @@ const history = {
   },
 
   goToLogin(rememberLocation = false) {
-    if (!_inst) {
-      this.init();
-    }
     let url = cfg.routes.login;
     if (rememberLocation) {
       const { search, pathname } = _inst.location;

--- a/web/packages/teleport/src/services/history/history.ts
+++ b/web/packages/teleport/src/services/history/history.ts
@@ -34,11 +34,17 @@ const history = {
   },
 
   replace(route = '') {
+    if (!_inst) {
+      this.init();
+    }
     route = this.ensureKnownRoute(route);
     _inst.replace(route);
   },
 
   push(route, withRefresh = false) {
+    if (!_inst) {
+      this.init();
+    }
     route = this.ensureKnownRoute(route);
     if (withRefresh) {
       this._pageRefresh(route);
@@ -52,6 +58,9 @@ const history = {
   },
 
   goToLogin(rememberLocation = false) {
+    if (!_inst) {
+      this.init();
+    }
     let url = cfg.routes.login;
     if (rememberLocation) {
       const { search, pathname } = _inst.location;


### PR DESCRIPTION
TL;DR: this will make sure that history is init before using any of it's methods. 

This fix is only to fix our broken Storybook tests. The old resources have a check to push to the Unified Resources route. this uses our `history` utility. We've never used this in Storybook tests and the old resource stories currently break because it's trying to call a method on a null instance.

I added it to the methods that called `_inst` but tbh it was only needed in `replace` for this fix. but might as well fix the others in case it come up later.

"Why is it pushing to the unified resources route?"
Well... it is and it isnt. the route doesn't matter in the storybook tests. So, this is "hacky" but I wasn't able to find a reliable way to
1. set and, more importantly, remove a localStorage variable
2. and do that PER TEST. there are decorators yes, but those don't have any "cleanup" functions. 

The storybook _tests_ themselves don't have this problem as i [set a beforeAll and afterAll](https://github.com/gravitational/teleport/commit/d9f7394194aee5b97c020fe53c25cb492c3234a0) to skip this history check, but for rendering storybook tests themselves, i haven't found a way to do this.

Happy to dive in deeper, but this seems like a simple fix that gets what we want done which is, everything still pushing around the way we want, and storybooks aren't broken anymore