### PR TITLE
[web] Add empty resource screen to Resources page

### DIFF
--- a/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -249,8 +249,7 @@ exports[`empty state for enterprise, can create 1`] = `
               kind="primary"
               width="224px"
             >
-              Add 
-              application
+              Add Resource
             </button>
           </a>
           <a

--- a/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
+++ b/web/packages/teleport/src/Databases/__snapshots__/Databases.story.test.tsx.snap
@@ -249,8 +249,7 @@ exports[`empty state for enterprise, can create 1`] = `
               kind="primary"
               width="224px"
             >
-              Add 
-              database
+              Add Resource
             </button>
           </a>
           <a

--- a/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Kubes/__snapshots__/Kubes.story.test.tsx.snap
@@ -249,8 +249,7 @@ exports[`empty state 1`] = `
               kind="primary"
               width="224px"
             >
-              Add 
-              kubernetes
+              Add Resource
             </button>
           </a>
           <a

--- a/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
+++ b/web/packages/teleport/src/Nodes/__snapshots__/Nodes.story.test.tsx.snap
@@ -249,8 +249,7 @@ exports[`empty state 1`] = `
               kind="primary"
               width="224px"
             >
-              Add 
-              server
+              Add Resource
             </button>
           </a>
           <a

--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -168,7 +168,6 @@ const emptyStateInfo: EmptyStateInfo = {
   title: 'Add your first resource to Teleport',
   byline:
     'Connect SSH servers, Kubernetes clusters, Windows Desktops, Databases, Web apps and more from our integrations catalog.',
-  resourceType: SearchResource.UNIFIED_RESOURCE,
   readOnly: {
     title: 'No Resources Found',
     resource: 'resources',

--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -25,6 +25,7 @@ import {
   FeatureHeaderTitle,
 } from 'teleport/components/Layout';
 import ErrorMessage from 'teleport/components/AgentErrorMessage';
+import Empty, { EmptyStateInfo } from 'teleport/components/Empty';
 import useTeleport from 'teleport/useTeleport';
 import cfg from 'teleport/config';
 import history from 'teleport/services/history/history';
@@ -147,6 +148,13 @@ export function Resources() {
           </Box>
         )}
       </div>
+      {attempt.status === 'success' && fetchedData.agents.length === 0 && (
+        <Empty
+          clusterId={clusterId}
+          canCreate={canCreate && !isLeafCluster}
+          emptyStateInfo={emptyStateInfo}
+        />
+      )}
     </FeatureBox>
   );
 }
@@ -155,3 +163,14 @@ const ResourcesContainer = styled(Flex)`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
 `;
+
+const emptyStateInfo: EmptyStateInfo = {
+  title: 'Add your first resource to Teleport',
+  byline:
+    'Connect SSH servers, Kubernetes clusters, Windows Desktops, Databases, Web apps and more from our integrations catalog.',
+  resourceType: SearchResource.UNIFIED_RESOURCE,
+  readOnly: {
+    title: 'No Resources Found',
+    resource: 'resources',
+  },
+};

--- a/web/packages/teleport/src/components/Empty/Empty.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.tsx
@@ -32,6 +32,7 @@ type ResourceType =
   | 'database'
   | 'desktop'
   | 'kubernetes'
+  | 'unified_resource'
   | 'server';
 
 function getAccentImage(resourceType: ResourceType): string {
@@ -41,6 +42,8 @@ function getAccentImage(resourceType: ResourceType): string {
     desktop: desktop,
     kubernetes: stack,
     server: stack,
+    // TODO (avatus) update once we have a dedicated image for unified resources
+    unified_resource: stack,
   };
   return accentImages[resourceType];
 }
@@ -105,23 +108,31 @@ export default function Empty(props: Props) {
           <Link
             to={{
               pathname: `${cfg.routes.root}/discover`,
-              state: { entity: resourceType },
+              state: {
+                entity:
+                  resourceType !== 'unified_resource' ? resourceType : null,
+              },
             }}
             style={{ textDecoration: 'none' }}
           >
-            <ButtonPrimary width="224px">Add {resourceType}</ButtonPrimary>
+            <ButtonPrimary width="224px" textTransform="none">
+              Add Resource
+            </ButtonPrimary>
           </Link>
-          <ButtonBorder
-            size="medium"
-            as="a"
-            href={docsURL}
-            target="_blank"
-            width="224px"
-            ml={4}
-            rel="noreferrer"
-          >
-            View Documentation
-          </ButtonBorder>
+          {docsURL && (
+            <ButtonBorder
+              textTransform="none"
+              size="medium"
+              as="a"
+              href={docsURL}
+              target="_blank"
+              width="224px"
+              ml={4}
+              rel="noreferrer"
+            >
+              View Documentation
+            </ButtonBorder>
+          )}
         </Box>
       </Box>
     </Box>
@@ -130,7 +141,7 @@ export default function Empty(props: Props) {
 
 export type EmptyStateInfo = {
   byline: string;
-  docsURL: string;
+  docsURL?: string;
   resourceType: ResourceType;
   readOnly: {
     title: string;

--- a/web/packages/teleport/src/components/Empty/Empty.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.tsx
@@ -32,7 +32,6 @@ type ResourceType =
   | 'database'
   | 'desktop'
   | 'kubernetes'
-  | 'unified_resource'
   | 'server';
 
 function getAccentImage(resourceType: ResourceType): string {
@@ -109,8 +108,7 @@ export default function Empty(props: Props) {
             to={{
               pathname: `${cfg.routes.root}/discover`,
               state: {
-                entity:
-                  resourceType !== 'unified_resource' ? resourceType : null,
+                entity: resourceType,
               },
             }}
             style={{ textDecoration: 'none' }}
@@ -142,7 +140,7 @@ export default function Empty(props: Props) {
 export type EmptyStateInfo = {
   byline: string;
   docsURL?: string;
-  resourceType: ResourceType;
+  resourceType?: ResourceType;
   readOnly: {
     title: string;
     resource: string;


### PR DESCRIPTION
Adds a "no resource" state to the Unified Resources page. This is copied over from the empty Nodes state with a few caveats

no documentation link since there isn't really a documentation link for unified resources. Discussion about this in #dev-frontend 
"Add Resource" does the same thing as "Enroll New Resource" now which links to the discover page with no state. 

Instead of having a conditional for `Add X` where x is the resource, I just changed to `Resource` by default. The other views are legacy now and them having 'Add Resource' still makes sense so... no biggie imo.

![Screenshot 2023-08-23 at 4 48 08 PM](https://github.com/gravitational/teleport/assets/5201977/a2ed677a-42eb-41f4-8ba8-074b1221695a)
![Screenshot 2023-08-23 at 4 49 03 PM](https://github.com/gravitational/teleport/assets/5201977/6f7b8662-db03-416c-95fe-bc292e5e6139)
