### PR TITLE
[v13] ci: Use "post-release" environment in update-docs post-release workflow

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -54,6 +54,7 @@ jobs:
   update-docs-version:
     name: Update docs version
     runs-on: ubuntu-latest
+    environment: post-release
     steps:
       - name: Get Release Branch
         id: get-branch


### PR DESCRIPTION
Add an `environment: post-release` clause to the `update-docs-version`
job in the `post-release.yaml` workflow so it can access the `APP_ID`
var and the `PRIVATE_KEY` secret. This allows it to generate a github
token with the permissions of the installed application referenced by
`APP_ID`.

App: https://github.com/organizations/gravitational/settings/apps/teleport-post-release-automation
Backport: https://github.com/gravitational/teleport/pull/30890
Changelog: none