### PR TITLE
improve handling of dynamic system roles and fix shared client closure

### DIFF
--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -963,6 +963,25 @@ type Identity struct {
 	XCert *x509.Certificate
 	// ClusterName is a name of host's cluster
 	ClusterName string
+	// SystemRoles is a list of additional system roles.
+	SystemRoles []string
+}
+
+// HasSystemRole checks if this identity encompases the supplied system role.
+func (i *Identity) HasSystemRole(role types.SystemRole) bool {
+	// check identity's primary system role
+	if i.ID.Role == role {
+		return true
+	}
+
+	// check any additional system roles the cert might have
+	for _, r := range i.SystemRoles {
+		if types.SystemRole(r) == role {
+			return true
+		}
+	}
+
+	return false
 }
 
 // String returns user-friendly representation of the identity.
@@ -1137,6 +1156,7 @@ func ReadIdentityFromKeyPair(privateKey []byte, certs *proto.Certs) (*Identity, 
 		identity.XCert = i.XCert
 		identity.TLSCertBytes = certs.TLS
 		identity.TLSCACertsBytes = certs.TLSCACerts
+		identity.SystemRoles = i.SystemRoles
 	}
 
 	return identity, nil
@@ -1177,6 +1197,7 @@ func ReadTLSIdentityFromKeyPair(keyBytes, certBytes []byte, caCertsBytes [][]byt
 		TLSCertBytes:    certBytes,
 		TLSCACertsBytes: caCertsBytes,
 		XCert:           cert,
+		SystemRoles:     id.SystemRoles,
 	}
 	// The passed in ciphersuites don't appear to matter here since the returned
 	// *tls.Config is never actually used?

--- a/lib/auth/init.go
+++ b/lib/auth/init.go
@@ -32,6 +32,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/crypto/ssh"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gravitational/teleport"
@@ -967,21 +968,14 @@ type Identity struct {
 	SystemRoles []string
 }
 
-// HasSystemRole checks if this identity encompases the supplied system role.
+// HasSystemRole checks if this identity encompasses the supplied system role.
 func (i *Identity) HasSystemRole(role types.SystemRole) bool {
 	// check identity's primary system role
 	if i.ID.Role == role {
 		return true
 	}
 
-	// check any additional system roles the cert might have
-	for _, r := range i.SystemRoles {
-		if types.SystemRole(r) == role {
-			return true
-		}
-	}
-
-	return false
+	return slices.Contains(i.SystemRoles, string(role))
 }
 
 // String returns user-friendly representation of the identity.

--- a/lib/auth/join.go
+++ b/lib/auth/join.go
@@ -295,7 +295,11 @@ func (a *Server) generateCerts(
 	}
 
 	// Emit audit event
-	log.Infof("Node %q [%v] has joined the cluster.", req.NodeName, req.HostID)
+	if req.Role == types.RoleInstance {
+		log.Infof("Instance %q [%v] has joined the cluster. role=%s, systemRoles=%+v", req.NodeName, req.HostID, req.Role, systemRoles)
+	} else {
+		log.Infof("Instance %q [%v] has joined the cluster. role=%s", req.NodeName, req.HostID, req.Role)
+	}
 	joinEvent := &apievents.InstanceJoin{
 		Metadata: apievents.Metadata{
 			Type: events.InstanceJoinEvent,

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -206,7 +206,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 			}, nil
 		}
 		process.log.Infof("Connecting to the cluster %v with TLS client certificate.", identity.ClusterName)
-		clt, err := process.newClient(identity)
+		clt, reused, err := process.getClient(identity)
 		if err != nil {
 			// In the event that a user is attempting to connect a machine to
 			// a different cluster it will give a cryptic warning about an
@@ -221,6 +221,7 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 		}
 		return &Connector{
 			Client:         clt,
+			ReusedClient:   reused,
 			ClientIdentity: identity,
 			ServerIdentity: identity,
 		}, nil
@@ -235,12 +236,13 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: identity,
 				}, nil
 			}
-			clt, err := process.newClient(identity)
+			clt, reused, err := process.getClient(identity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &Connector{
 				Client:         clt,
+				ReusedClient:   reused,
 				ClientIdentity: identity,
 				ServerIdentity: identity,
 			}, nil
@@ -257,12 +259,13 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: identity,
 				}, nil
 			}
-			clt, err := process.newClient(newIdentity)
+			clt, reused, err := process.getClient(newIdentity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &Connector{
 				Client:         clt,
+				ReusedClient:   reused,
 				ClientIdentity: newIdentity,
 				ServerIdentity: identity,
 			}, nil
@@ -279,12 +282,13 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: newIdentity,
 				}, nil
 			}
-			clt, err := process.newClient(newIdentity)
+			clt, reused, err := process.getClient(newIdentity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &Connector{
 				Client:         clt,
+				ReusedClient:   reused,
 				ClientIdentity: newIdentity,
 				ServerIdentity: newIdentity,
 			}, nil
@@ -299,12 +303,13 @@ func (process *TeleportProcess) connect(role types.SystemRole, opts ...certOptio
 					ServerIdentity: identity,
 				}, nil
 			}
-			clt, err := process.newClient(identity)
+			clt, reused, err := process.getClient(identity)
 			if err != nil {
 				return nil, trace.Wrap(err)
 			}
 			return &Connector{
 				Client:         clt,
+				ReusedClient:   reused,
 				ClientIdentity: identity,
 				ServerIdentity: identity,
 			}, nil
@@ -517,7 +522,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			ServerIdentity: identity,
 		}
 	} else {
-		clt, err := process.newClient(identity)
+		clt, reused, err := process.getClient(identity)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -525,6 +530,7 @@ func (process *TeleportProcess) firstTimeConnect(role types.SystemRole) (*Connec
 			ClientIdentity: identity,
 			ServerIdentity: identity,
 			Client:         clt,
+			ReusedClient:   reused,
 		}
 	}
 
@@ -1041,20 +1047,34 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 	}
 }
 
+// getClient gets an appropriate client for the given identity. The instance client is reused if appropriate, otherwise
+// a new client is created.
+func (process *TeleportProcess) getClient(identity *auth.Identity) (clt *auth.Client, reused bool, err error) {
+	if identity.ID.Role != types.RoleInstance {
+		// non-instance roles should wait to see if the instance client can be reused
+		// before acquiring their own client.
+		if conn := process.waitForInstanceConnector(); conn != nil && conn.Client != nil {
+			if conn.ClientIdentity.HasSystemRole(identity.ID.Role) {
+				process.log.Infof("Reusing Instance client for %s. additionalSystemRoles=%+v", identity.ID.Role, conn.ClientIdentity.SystemRoles)
+				return conn.Client, true, nil
+			} else {
+				process.log.Warnf("Unable to reuse Instance client for %s. additionalSystemRoles=%+v", identity.ID.Role, conn.ClientIdentity.SystemRoles)
+			}
+		} else {
+			process.log.Warnf("Unable to reuse Instance client for %s. (not available)", identity.ID.Role)
+		}
+	}
+
+	clt, err = process.newClient(identity)
+	return clt, false, err
+}
+
 // newClient attempts to connect to either the proxy server or auth server
 // For config v3 and onwards, it will only connect to either the proxy (via tunnel) or the auth server (direct),
 // depending on what was specified in the config.
 // For config v1 and v2, it will attempt to direct dial the auth server, and fallback to trying to tunnel
 // to the Auth Server through the proxy.
 func (process *TeleportProcess) newClient(identity *auth.Identity) (*auth.Client, error) {
-	if identity.ID.Role != types.RoleInstance && identity.ID.Role != types.RoleMDM {
-		clt, ok := process.waitForInstanceClient()
-		if !ok {
-			return nil, trace.Errorf("failed to get instance client for identity %q", identity.ID.Role)
-		}
-		return clt, nil
-	}
-
 	tlsConfig, err := identity.TLSConfig(process.Config.CipherSuites)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -1048,7 +1048,9 @@ func (process *TeleportProcess) rotate(conn *Connector, localState auth.StateV2,
 }
 
 // getClient gets an appropriate client for the given identity. The instance client is reused if appropriate, otherwise
-// a new client is created.
+// a new client is created. Reused clients should not be closed since they are owned by another service. In practice, the value
+// of 'reused' should just be passed directly to Connector.ReusedClient when building the connector of this client. Connector.Close
+// will handle closure correctly as long as this value is set.
 func (process *TeleportProcess) getClient(identity *auth.Identity) (clt *auth.Client, reused bool, err error) {
 	if identity.ID.Role != types.RoleInstance {
 		// non-instance roles should wait to see if the instance client can be reused

--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -287,6 +287,10 @@ type Connector struct {
 
 	// Client is authenticated client with credentials from ClientIdentity.
 	Client *auth.Client
+
+	// ReusedClient, if true, indicates that the client reference is owned by
+	// a different connector and should not be closed.
+	ReusedClient bool
 }
 
 // TunnelProxyResolver if non-nil, indicates that the client is connected to the Auth Server
@@ -312,7 +316,7 @@ func (c *Connector) UseTunnel() bool {
 
 // Close closes resources associated with connector
 func (c *Connector) Close() error {
-	if c.Client != nil {
+	if c.Client != nil && !c.ReusedClient {
 		return c.Client.Close()
 	}
 	return nil
@@ -344,15 +348,15 @@ type TeleportProcess struct {
 	// inventoryHandle is the downstream inventory control handle for this instance.
 	inventoryHandle inventory.DownstreamHandle
 
-	// instanceClient is the instance-level auth client. this is created asynchronously
+	// instanceConnector contains the instance-level connector. this is created asynchronously
 	// and may not exist for some time if cert migrations are necessary.
-	instanceClient *auth.Client
+	instanceConnector *Connector
 
-	// instanceClientReady is closed when the isntance client becomes available.
-	instanceClientReady chan struct{}
+	// instanceConnectorReady is closed when the isntance client becomes available.
+	instanceConnectorReady chan struct{}
 
-	// instanceClientReadyOnce protects instanceClientReady from double-close.
-	instanceClientReadyOnce sync.Once
+	// instanceConnectorReadyOnce protects instanceConnectorReady from double-close.
+	instanceConnectorReadyOnce sync.Once
 
 	// instanceRoles is the collection of enabled service roles (excludes things like "admin"
 	// and "instance" which aren't true user-facing services). The values in this mapping are
@@ -923,21 +927,21 @@ func NewTeleport(cfg *servicecfg.Config) (*TeleportProcess, error) {
 	}
 
 	process := &TeleportProcess{
-		PluginRegistry:      cfg.PluginRegistry,
-		Clock:               cfg.Clock,
-		Supervisor:          supervisor,
-		Config:              cfg,
-		instanceClientReady: make(chan struct{}),
-		instanceRoles:       make(map[types.SystemRole]string),
-		Identities:          make(map[types.SystemRole]*auth.Identity),
-		connectors:          make(map[types.SystemRole]*Connector),
-		importedDescriptors: cfg.FileDescriptors,
-		storage:             storage,
-		id:                  processID,
-		log:                 cfg.Log,
-		keyPairs:            make(map[keyPairKey]KeyPair),
-		cloudLabels:         cloudLabels,
-		TracingProvider:     tracing.NoopProvider(),
+		PluginRegistry:         cfg.PluginRegistry,
+		Clock:                  cfg.Clock,
+		Supervisor:             supervisor,
+		Config:                 cfg,
+		instanceConnectorReady: make(chan struct{}),
+		instanceRoles:          make(map[types.SystemRole]string),
+		Identities:             make(map[types.SystemRole]*auth.Identity),
+		connectors:             make(map[types.SystemRole]*Connector),
+		importedDescriptors:    cfg.FileDescriptors,
+		storage:                storage,
+		id:                     processID,
+		log:                    cfg.Log,
+		keyPairs:               make(map[keyPairKey]KeyPair),
+		cloudLabels:            cloudLabels,
+		TracingProvider:        tracing.NoopProvider(),
 	}
 
 	process.registerExpectedServices(cfg)
@@ -1252,31 +1256,37 @@ func (process *TeleportProcess) getLocalAuth() *auth.Server {
 	return process.localAuth
 }
 
-func (process *TeleportProcess) setInstanceClient(clt *auth.Client) {
+func (process *TeleportProcess) setInstanceConnector(conn *Connector) {
 	process.Lock()
-	process.instanceClient = clt
+	process.instanceConnector = conn
 	process.Unlock()
-	process.instanceClientReadyOnce.Do(func() {
-		close(process.instanceClientReady)
+	process.instanceConnectorReadyOnce.Do(func() {
+		close(process.instanceConnectorReady)
 	})
 }
 
-func (process *TeleportProcess) getInstanceClient() *auth.Client {
+func (process *TeleportProcess) getInstanceConnector() *Connector {
 	process.Lock()
 	defer process.Unlock()
-	return process.instanceClient
+	return process.instanceConnector
 }
 
-// waitForInstanceClient waits for the instance client to become available. Instance client is only available if at least
-// one non-auth service is registered.  Auth-only instances cannot use the instance client because auth servers need to
-// be able to fully initialize without a valid CA in order to support HSMs.
-func (process *TeleportProcess) waitForInstanceClient() (clt *auth.Client, ok bool) {
+func (process *TeleportProcess) getInstanceClient() *auth.Client {
+	conn := process.getInstanceConnector()
+	if conn == nil {
+		return nil
+	}
+	return conn.Client
+}
+
+// waitForInstanceConnector waits for the instance connector to become available. returns nil if
+// process shutdown is triggered or if this is an auth-only instance.
+func (process *TeleportProcess) waitForInstanceConnector() *Connector {
 	select {
-	case <-process.instanceClientReady:
-		clt = process.getInstanceClient()
-		return clt, clt != nil
+	case <-process.instanceConnectorReady:
+		return process.getInstanceConnector()
 	case <-process.ExitContext().Done():
-		return nil, false
+		return nil
 	}
 }
 
@@ -2373,6 +2383,7 @@ func (process *TeleportProcess) initInstance() error {
 		// for purposes other than the control stream.
 		// TODO(fspmarshall): implement one of the two potential solutions listed above.
 		process.BroadcastEvent(Event{Name: InstanceReady, Payload: nil})
+		process.setInstanceConnector(nil)
 		return nil
 	}
 	process.RegisterWithAuthServer(types.RoleInstance, InstanceIdentityEvent)
@@ -2387,7 +2398,7 @@ func (process *TeleportProcess) initInstance() error {
 			return trace.Wrap(err)
 		}
 
-		process.setInstanceClient(conn.Client)
+		process.setInstanceConnector(conn)
 		log.Infof("Successfully registered instance client.")
 		process.BroadcastEvent(Event{Name: InstanceReady, Payload: nil})
 		return nil


### PR DESCRIPTION
More complete fix for https://github.com/gravitational/teleport.e/issues/2022 (was previously partially addressed by https://github.com/gravitational/teleport/pull/30701).

This PR fixes two separate but related issues:

First, the instance cert system was designed before plugins existed and is built on the assumption that the certificate permissions required are static.  This caused plugins to have incorrect permissions when using the Instance client (or, rather, they _could_ have incorrect permissions depending on the other services they shared the instance with).  This is fixed by detecting when a system role is not covered by the instance cert and generating a new client in that case.

Second, plugins that exit before process exit were causing the shared client to be terminated early.  This has been addressed by having connectors track wether or not they are using a shared client, so that shared clients are not closed.

Related: https://github.com/gravitational/teleport.e/pull/2045

Supersedes: https://github.com/gravitational/teleport/pull/30810