### PR TITLE
Improve agent log processing (no cut off logs + close event instead of exit)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@ const config = require('@gravitational/build/jest/config');
 
 process.env.TZ = 'UTC';
 
-const esModules = ['strip-ansi-stream', 'ansi-regex'].join('|');
+const esModules = ['strip-ansi', 'ansi-regex'].join('|');
 
 /** @type {import('@jest/types').Config.InitialOptions} */
 module.exports = {

--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -31,7 +31,7 @@
     "@types/tar-fs": "^2.0.1",
     "emittery": "^1.0.1",
     "node-pty": "0.11.0-beta29",
-    "strip-ansi-stream": "^2.0.1",
+    "strip-ansi": "^7.1.0",
     "tar-fs": "^3.0.3"
   },
   "devDependencies": {

--- a/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.test.ts
+++ b/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.test.ts
@@ -141,6 +141,16 @@ test('status updates are sent on a successful start', async () => {
     expect(updateSender).toHaveBeenCalledWith(rootClusterUri, runningState);
 
     await agentRunner.kill(rootClusterUri);
+
+    // Since the agent changes status on the close event and not the exit event, we must wait for
+    // this to occur.
+    await expect(
+      () => agentRunner.getState(rootClusterUri).status === 'exited'
+    ).toEventuallyBeTrue({
+      waitFor: 2000,
+      tick: 10,
+    });
+
     const exitedState: AgentProcessState = {
       status: 'exited',
       code: null,

--- a/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
+++ b/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
@@ -216,8 +216,13 @@ export class AgentRunner {
     rootClusterUri: RootClusterUri,
     state: AgentProcessState
   ): void {
+    let loggedState = state;
+    if (state.status === 'exited') {
+      const { logs, ...rest } = state; // eslint-disable-line @typescript-eslint/no-unused-vars
+      loggedState = rest;
+    }
     this.logger.info(
-      `Updating agent state ${rootClusterUri}: ${JSON.stringify(state)}`
+      `Updating agent state ${rootClusterUri}: ${JSON.stringify(loggedState)}`
     );
 
     const agent = this.agentProcesses.get(rootClusterUri);

--- a/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
+++ b/web/packages/teleterm/src/mainProcess/agentRunner/agentRunner.ts
@@ -98,8 +98,8 @@ export class AgentRunner {
       this.logger.warn(`Cannot get an agent to kill for ${rootClusterUri}`);
       return;
     }
+    this.logger.info(`Killing agent for ${rootClusterUri}`);
     await terminateWithTimeout(agent.process);
-    this.logger.info(`Killed agent for ${rootClusterUri}`);
   }
 
   async killAll(): Promise<void> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7269,7 +7269,7 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-string-regexp@^1.0.3, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
@@ -13154,19 +13154,6 @@ readable-stream@^2.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
-readable-stream@^2.0.2:
-  version "2.3.8"
-  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.8.tgz#91125e8042bba1b9887f49345f6277027ce8be9b"
-  integrity sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.3"
-    isarray "~1.0.0"
-    process-nextick-args "~2.0.0"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.1.1"
-    util-deprecate "~1.0.1"
-
 readable-stream@^3.0.6, readable-stream@^3.4.0, readable-stream@^3.6.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
@@ -13388,15 +13375,6 @@ repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
-
-replacestream@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/replacestream/-/replacestream-4.0.3.tgz#3ee5798092be364b1cdb1484308492cb3dff2f36"
-  integrity sha512-AC0FiLS352pBBiZhd4VXB1Ab/lh0lEgpP+GGvZqbQh8a5cmXVoTe5EX/YeTFArnp4SRGTHh1qCHu9lGs1qG8sA==
-  dependencies:
-    escape-string-regexp "^1.0.3"
-    object-assign "^4.0.1"
-    readable-stream "^2.0.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -14404,14 +14382,6 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi-stream@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi-stream/-/strip-ansi-stream-2.0.1.tgz#9a5f4ef2f29a6e22e685bf69bf106df118230b46"
-  integrity sha512-8obaZwnoFRHCgxzrqil2435OBiCcJBOtcPkmCpgHCIJ6Rb3/Ewfob9HOkyhgxVAAaXnKGIWDiV8X4XJSOdKMkg==
-  dependencies:
-    ansi-regex "^6.0.1"
-    replacestream "^4.0.3"
-
 strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
@@ -14432,6 +14402,13 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
   dependencies:
     ansi-regex "^5.0.1"
+
+strip-ansi@^7.1.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.1.0.tgz#d5b6568ca689d8561370b0707685d22434faff45"
+  integrity sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==
+  dependencies:
+    ansi-regex "^6.0.1"
 
 strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This PR fixes the issue with cut off logs I talked about in https://github.com/gravitational/teleport/pull/30910#issuecomment-1691223910.

## Cut off logs

During node join timeout, we ask the main process for the agent logs and I noticed they'd be cut off. This seemed suspicious – the logs are not huge so there wasn't really a reason for them to get cut off like this.

I found that the reason for this was [`stripAnsiStream`](https://www.npmjs.com/package/strip-ansi-stream) that we used to strip color codes from the teleport process output. We piped the agent stderr into that stream and used the output of `stripAnsiStream` to further process logs.

The problem is that underneath, `stripAnsiStream` uses `replacestream` which [by default splits the readable stream into 100 characters long chunks](https://www.npmjs.com/package/replacestream#list-of-options). `stripAnsiStream` offers no way to modify this behavior. So we'd have a race condition where the agent outputs a line of logs and the event loop in JS first processes the first chunk, then the node join timeout and then the second chunk. Thus, when asking to caputer current logs in the handler for the node join timeout, we'd get only part of the logs.

This PR fixes this by not using `stripAnsiStream` and instead stripping the ANSI codes directly with `stripAnsi`.

The easiest way to test it is to rebase this branch on `ravicious/launch-js`, open `connectMyComputer` context and reduce the timeout from `20_000` to something like `2_000`. I also usually modified my local agent config (`~/Library/Application\ Support/Electron/agents/<profile name>/config.yaml`) to point at an incorrect `proxy_server` to cause the agent to repeatedly output logs.

## Using `close` event instead of `exit`

This PR also makes it so that we're using [the `close` event](https://nodejs.org/docs/latest-v18.x/api/child_process.html#event-close) to signal process exit rather than [the `exit` event](https://nodejs.org/docs/latest-v18.x/api/child_process.html#event-exit). I'll explain why in code comments.