### PR TITLE
Add an optional PodMonitor to the teleport-kube-agent chart

### DIFF
--- a/examples/chart/teleport-cluster/.lint/podmonitor.yaml
+++ b/examples/chart/teleport-cluster/.lint/podmonitor.yaml
@@ -1,0 +1,6 @@
+clusterName: test-kube-cluster-name
+podMonitor:
+  enabled: true
+  additionalLabels:
+    prometheus: default
+  interval: 30s

--- a/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
+++ b/examples/chart/teleport-cluster/tests/podmonitor_test.yaml
@@ -3,12 +3,15 @@ templates:
   - podmonitor.yaml
 tests:
   - it: does not create a PodMonitor by default
+    set:
+      clusterName: test-kube-cluster-name
     asserts:
       - hasDocuments:
           count: 0
 
   - it: creates a PodMonitor when enabled
     set:
+      clusterName: test-kube-cluster-name
       podMonitor:
         enabled: true
     asserts:
@@ -19,6 +22,7 @@ tests:
 
   - it: configures scrape interval if provided
     set:
+      clusterName: test-kube-cluster-name
       podMonitor:
         enabled: true
         interval: 2m
@@ -28,12 +32,9 @@ tests:
           value: 2m
 
   - it: wears additional labels if provided
-    set:
-      podMonitor:
-        enabled: true
-        additionalLabels:
-          prometheus: teleport-only
     asserts:
       - equal:
           path: metadata.labels.prometheus
-          value: teleport-only
+          value: default
+    values:
+      - ../.lint/podmonitor.yaml

--- a/examples/chart/teleport-kube-agent/.lint/podmonitor.yaml
+++ b/examples/chart/teleport-kube-agent/.lint/podmonitor.yaml
@@ -1,0 +1,7 @@
+proxyAddr: proxy.example.com:3080
+kubeClusterName: test-kube-cluster-name
+podMonitor:
+  enabled: true
+  additionalLabels:
+    prometheus: default
+  interval: 30s

--- a/examples/chart/teleport-kube-agent/templates/podmonitor.yaml
+++ b/examples/chart/teleport-kube-agent/templates/podmonitor.yaml
@@ -1,0 +1,31 @@
+{{- if.Values.podMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+  {{- with .Values.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  jobLabel: {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+  podMetricsEndpoints:
+    - port: diag
+      path: /metrics
+      {{- with .Values.podMonitor.interval }}
+      interval: {{ . | quote }}
+      {{- end }}
+  podTargetLabels:
+    - "app.kubernetes.io/name"
+    - "app.kubernetes.io/instance"
+    - "app.kubernetes.io/component"
+    - "app.kubernetes.io/version"
+    - "teleport.dev/majorVersion"
+{{- end }}

--- a/examples/chart/teleport-kube-agent/tests/podmonitor_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/podmonitor_test.yaml
@@ -1,0 +1,43 @@
+suite: PodMonitor
+templates:
+  - podmonitor.yaml
+tests:
+  - it: does not create a PodMonitor by default
+    set:
+      proxyAddr: proxy.example.com:3080
+      kubeClusterName: test-kube-cluster-name
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: creates a PodMonitor when enabled
+    set:
+      proxyAddr: proxy.example.com:3080
+      kubeClusterName: test-kube-cluster-name
+      podMonitor:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodMonitor
+
+  - it: configures scrape interval if provided
+    set:
+      proxyAddr: proxy.example.com:3080
+      kubeClusterName: test-kube-cluster-name
+      podMonitor:
+        enabled: true
+        interval: 2m
+    asserts:
+      - equal:
+          path: spec.podMetricsEndpoints[0].interval
+          value: 2m
+
+  - it: wears additional labels if provided
+    asserts:
+      - equal:
+          path: metadata.labels.prometheus
+          value: default
+    values:
+      - ../.lint/podmonitor.yaml

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -23,6 +23,7 @@
         "clusterRoleBindingName",
         "roleName",
         "roleBindingName",
+        "podMonitor",
         "serviceAccountName",
         "secretName",
         "log",
@@ -365,6 +366,29 @@
                     "$id": "#/properties/highAvailability/properties/requireAntiAffinity",
                     "type": "boolean",
                     "default": false
+                }
+            }
+        },
+        "podMonitor": {
+            "$id": "#/properties/podMonitor",
+            "type": "object",
+            "required": ["enabled"],
+            "properties": {
+                "enabled": {
+                    "$id": "#/properties/podMonitor/enabled",
+                    "type": "boolean",
+                    "default": false
+                },
+                "additionalLabels": {
+                    "$id": "#/properties/podMonitor/additionalLabels",
+                    "type": "object",
+                    "default": {"prometheus": "default"},
+                    "additionalProperties": {"type": "string"}
+                },
+                "interval": {
+                    "$id": "#/properties/podMonitor/interval",
+                    "type": "string",
+                    "default": "30s"
                 }
             }
         },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -198,6 +198,21 @@ highAvailability:
     enabled: false
     minAvailable: 1
 
+# podMonitor controls the PodMonitor CR (from monitoring.coreos.com/v1)
+# This CRD is managed by the prometheus-operator and allows workload to
+# get monitored. To use this value, you need to run a `prometheus-operator`
+# in the cluster for this value to take effect.
+# See https://prometheus-operator.dev/docs/prologue/introduction/
+podMonitor:
+  # Whether the chart should deploy a PodMonitor.
+  # Disabled by default as it requires the PodMonitor CRD to be installed.
+  enabled: false
+  # additionalLabels to put on the PodMonitor.
+  # This is used to be selected by a specific prometheus instance.
+  additionalLabels: {}
+  # interval is the interval between two metrics scrapes. Defaults to 30s
+  interval: 30s
+
 ################################################################
 # Values that must be provided if using persistent storage for Teleport.
 #


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/30944

Adds in podmonitor to teleport-kube-agent helm chart 

Linting passes
Newly added tests pass, existing tests fail locally