### PR TITLE
docs: update agent joining when to use

### DIFF
--- a/docs/pages/agents/join-services-to-your-cluster.mdx
+++ b/docs/pages/agents/join-services-to-your-cluster.mdx
@@ -13,8 +13,8 @@ Service. Choose the method that best suits your infrastructure:
 
 |Method|Description|When to use|
 |------|-----------|-----------|
-|[EC2 Identity Document](./join-services-to-your-cluster/aws-ec2.mdx)|A Teleport process running on an EC2 instance authenticates to your cluster via a signed EC2 instance identity document.|Your Teleport process will run on EC2.|
-|[AWS IAM](./join-services-to-your-cluster/aws-iam.mdx)|A Teleport process uses AWS credentials to join the cluster, whether running on EC2 or not.|At least some of your infrastructure runs on AWS and your Teleport cluster is self hosted.|
+|[EC2 Identity Document](./join-services-to-your-cluster/aws-ec2.mdx)|A Teleport process running on an EC2 instance authenticates to your cluster via a signed EC2 instance identity document.|Your Teleport process will run on EC2 and your Teleport cluster is self hosted.|
+|[AWS IAM](./join-services-to-your-cluster/aws-iam.mdx)|A Teleport process uses AWS credentials to join the cluster, whether running on EC2 or not.|At least some of your infrastructure runs on AWS.|
 |[Azure Managed Identity](./join-services-to-your-cluster/azure.mdx)|A Teleport process demonstrates that it runs in your Azure subscription by sending a signed attested data document and access token to the Teleport Auth Service.|Your Teleport process will run on Azure.|
 |[Kubernetes ServiceAccount](./join-services-to-your-cluster/kubernetes.mdx)|A Teleport process uses a Kubernetes-signed proof to establish a trust relationship with your Teleport cluster.|Your Teleport process will run on Kubernetes.|
 |[GCP IAM](./join-services-to-your-cluster/gcp.mdx)|A Teleport process uses a GCP-signed token to establish a trust relationship with your Teleport cluster.|Your Teleport process will run on a GCP VM.|


### PR DESCRIPTION
The AWS IAM description is incorrect that it's not only for self-hosted. Moved that to EC2 which does apply.