### PR TITLE
[v12] Recommend writing the client secret to a file

### DIFF
--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -50,8 +50,12 @@ Create a client secret to use along with the client ID in the next step:
 
 ## Step 2/3. Create a GitHub authentication connector
 
-Define a GitHub authentication connector using `tctl`. Update this example
-command with:
+In this section, you will define a GitHub authentication connector using `tctl`.
+
+On your workstation, create a file called `client-secret.txt` consisting only of
+your client secret.
+
+Update this example command with:
 
 - Your OAuth app's client ID and client secret created during the previous step.
 - The roles you want to map from your GitHub organization to Teleport roles.
@@ -64,8 +68,8 @@ for a full reference of flags for this command:
 ```code
 $ tctl sso configure github \
 --id=<Var name="GITHUB-CLIENT-ID"/> \
---secret=<Var name="GITHUB-CLIENT-SECRET"/> \
---teams-to-roles=<Var name="ORG-NAME,github-team,access,editor"/> \
+--secret=$(cat client-secret.txt) \
+--teams-to-roles=<Var name="ORG-NAME,GITHUB-TEAM,access,editor"/> \
 > github.yaml
 ```
 
@@ -109,10 +113,10 @@ file to define multiple mappings. For example:
 ```code
 $  tctl sso configure github \
 --id=<Var name="GITHUB-CLIENT-ID"/> \
---secret=<Var name="GITHUB-CLIENT-SECRET"/> \
---teams-to-roles=<Var name="ORG-NAME,github-team,access,editor"/> \
---teams-to-roles="org-name,administrators,admins \
---teams-to-roles="different-org,developers,dev \
+--secret=$(cat client-secret.txt) \
+--teams-to-roles=<Var name="ORG-NAME,GITHUB-TEAM,access,editor"/> \
+--teams-to-roles="ORG-NAME,administrators,admins \
+--teams-to-roles="DIFFERENT-ORG,developers,dev \
 > github.yaml
 ```
 
@@ -144,8 +148,8 @@ instance endpoints with the `--endpoint-url`, `--api-endpoint-url` parameters:
 ```code
 $ tctl sso configure github \
 --id=<Var name="GITHUB-CLIENT-ID"/> \
---secret=<Var name="GITHUB-CLIENT-SECRET"/> \
---teams-to-roles=<Var name="ORG-NAME,github-team,access,editor"/> \
+--secret=$(cat client-secret.txt) \
+--teams-to-roles=<Var name="ORG-NAME,GITHUB-TEAM,access,editor"/> \
 --endpoint-url=https://<Var name="github-enterprise-server-address"/>
 --api-endpoint-url=https://<Var name="api-github-enterprise-server-address"/>
 > github.yaml

--- a/docs/pages/access-controls/sso/gitlab.mdx
+++ b/docs/pages/access-controls/sso/gitlab.mdx
@@ -59,6 +59,9 @@ to each of these groups.
 
 Create an OIDC connector resource using `tctl`.
 
+On your workstation, create a file called `client-secret.txt` consisting only of
+your client secret.
+
 <Tabs>
 <TabItem label="GitLab.com">
 Replace the application ID and secret with the values from GitLab:
@@ -66,7 +69,7 @@ Replace the application ID and secret with the values from GitLab:
 ```code
 $ tctl sso configure oidc --preset gitlab \
 --id <APPLICATION-ID> \
---secret <APPLICATION-SECRET> \
+--secret $( cat client-secret.txt) \
 --claims-to-roles groups,company/admin,admin \
 --claims-to-roles groups,company/dev,dev > oidc.yaml
 ```
@@ -80,7 +83,7 @@ Replace the application ID and secret with the values from GitLab, and replace
 $ tctl sso configure oidc --preset gitlab \
 --id <APPLICATION-ID> \
 --issuer-url https://gitlab.company.com \
---secret <APPLICATION-SECRET> \
+--secret $( cat client-secret.txt) \
 --claims-to-roles groups,company/admin,admin \
 --claims-to-roles groups,company/dev,dev > oidc.yaml
 ```

--- a/docs/pages/access-controls/sso/google-workspace.mdx
+++ b/docs/pages/access-controls/sso/google-workspace.mdx
@@ -298,6 +298,9 @@ The alternative to creating the OIDC connector with embedded JSON is to upload t
 If you have a self-hosted Teleport cluster, you can upload the service account JSON file to all hosts 
 running the Teleport Auth Service.
 
+On your workstation, create a file called `client-secret.txt` consisting only of
+your client secret.
+
 <Tabs>
 <TabItem label="Embed JSON">
 
@@ -306,7 +309,7 @@ With this method, you don't have to provide the JSON file to all of the hosts ru
 
 ```code
 $ tctl sso configure oidc --preset google --id <CLIENT-ID> \
---secret <CLIENT-SECRET> \
+--secret $( cat client-secret.txt) \
 --claims-to-roles groups,auditor@example.com,auditor \
 --claims-to-roles groups,teleport-developers@example.com,access \
 --google-admin=<GOOGLE-WORKSPACE-ADMIN-EMAIL> \
@@ -379,8 +382,8 @@ make the JSON file available to all hosts running the Teleport Auth Service.
 
 ```code
 $ tctl sso configure oidc --preset google --id <CLIENT-ID> \
---secret <CLIENT-SECRET> \
---google-acc-uri <PATH-TO-SERVICE-ACCOUNT-KEY>.json \
+--secret $( cat client-secret.txt) \
+--google-acc-uri <PATH/TO/SERVICE-ACCOUNT-KEY>.json \
 --claims-to-roles groups,auditor@example.com,auditor \
 --claims-to-roles groups,teleport-developers@example.com,access \
 --google-admin=<GOOGLE-WORKSPACE-ADMIN-EMAIL> > gworkspace-connector.yaml

--- a/docs/pages/access-controls/sso/oidc.mdx
+++ b/docs/pages/access-controls/sso/oidc.mdx
@@ -37,11 +37,11 @@ For Google Workspace, see [Teleport Authentication with Google Workspace](google
 </Admonition>
 
 Save the relevant information from your identity provider. To make following
-this guide easier, you can add the values here and they will be included in the
+this guide easier, you can add the Client ID here and it will be included in the
 example commands below:
 
-- Client ID: <Var name="<CLIENT-ID>" description="The Client ID for your Teleport application, provided by your IdP"/>
-- Client secret: <Var name="<CLIENT-SECRET>" description="The Client secret for your Teleport application, provided by your IdP"/>
+Client ID: <Var name="<CLIENT-ID>" description="The Client ID for your Teleport
+application, provided by your IdP"/>
 
 ## OIDC Redirect URL
 
@@ -57,8 +57,11 @@ with your Teleport Cloud tenant or Proxy Service address.
 ## OIDC connector configuration
 
 The next step is to add an OIDC connector to Teleport. The connectors are
-created, tested, and added or removed using `tctl` [resource commands](../../reference/resources.mdx)
-or the Teleport Web UI.
+created, tested, and added or removed using `tctl` [resource
+commands](../../reference/resources.mdx) or the Teleport Web UI.
+
+On your workstation, create a file called `client-secret.txt` consisting only of
+your client secret.
 
 To create a new connector, use `tctl sso configure`. The following example creates a
 connector resource file in YAML format named `oidc-connector.yaml`:
@@ -66,7 +69,8 @@ connector resource file in YAML format named `oidc-connector.yaml`:
 ```code
 $ tctl sso configure oidc --name <CONNECTOR-NAME> \
   --issuer-url <PATH-TO-PROVIDER> \
-  --id <CLIENT-ID> --secret <CLIENT-SECRET> \
+  --id <CLIENT-ID> \
+  --secret $(cat client-secret.txt) \
   --claims-to-roles <CLAIM-KEY>,<CLAIM-VALUE>,access \
   --claims-to-roles <CLAIM-KEY>,<CLAIM-VALUE>,editor > oidc-connector.yaml
 ```


### PR DESCRIPTION
Backports #29919

* Recommend writing the client secret to a file

Fixes #29278

Edit OIDC guides to recommmend writing the user's client secret to a file before running `tctl sso configure oidc`. This way, the client secret does not appear in the user's shell history.

* Respond to feedback