### PR TITLE
[v11] Recommend writing the client secret to a file

### DIFF
--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -47,8 +47,12 @@ Create a client secret to use along with the client ID in the next step:
 
 ## Step 2/3. Create a GitHub authentication connector
 
-Define a GitHub authentication connector using `tctl`. Update this example
-command with:
+In this section, you will define a GitHub authentication connector using `tctl`.
+
+On your workstation, create a file called `client-secret.txt` consisting only of
+your client secret.
+
+Update this example command with:
 
 - Your OAuth app's client ID and client secret created during the previous step.
 - The roles you want to map from your GitHub organization to Teleport roles.
@@ -60,8 +64,8 @@ for a full reference of flags for this command:
 
 ```code
 $ tctl sso configure github \
---id=<Var name="GITHUB-CLIENT-ID"/>\
---secret=<Var name="GITHUB-CLIENT-SECRET"/> \
+--id=<Var name="GITHUB-CLIENT-ID"/> \
+--secret=$(cat client-secret.txt) \
 --teams-to-roles=<Var name="ORG-NAME,GITHUB-TEAM,access,editor"/> \
 > github.yaml
 ```
@@ -95,8 +99,8 @@ file to define multiple mappings. For example:
 
 ```code
 $  tctl sso configure github \
---id=<Var name="GITHUB-CLIENT-ID"/>\
---secret=<Var name="GITHUB-CLIENT-SECRET"/> \
+--id=<Var name="GITHUB-CLIENT-ID"/> \
+--secret=$(cat client-secret.txt) \
 --teams-to-roles=<Var name="ORG-NAME,GITHUB-TEAM,access,editor"/> \
 --teams-to-roles="ORG-NAME,administrators,admins \
 --teams-to-roles="DIFFERENT-ORG,developers,dev \


### PR DESCRIPTION
Backports #29919

* Recommend writing the client secret to a file

Fixes #29278

Edit OIDC guides to recommmend writing the user's client secret to a file before running `tctl sso configure oidc`. This way, the client secret does not appear in the user's shell history.

* Respond to feedback