### PR TITLE
Refactor IsOwner/IsMember and use AccessListMember object.

### DIFF
--- a/lib/auth/userloginstate/generator.go
+++ b/lib/auth/userloginstate/generator.go
@@ -139,7 +139,8 @@ func (g *Generator) addAccessListsToState(ctx context.Context, user types.User, 
 	}
 
 	for _, accessList := range accessLists {
-		if err := services.IsMember(identity, g.clock, accessList); err != nil {
+		// Check that the user meets the access list requirements.
+		if err := services.IsAccessListMember(ctx, identity, g.clock, accessList, g.accessLists); err != nil {
 			continue
 		}
 

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -238,7 +238,8 @@ func newAccessList(t *testing.T, name string, roles []string, traits trait.Trait
 	}, accesslist.Spec{
 		Title: "title",
 		Audit: accesslist.Audit{
-			Frequency: time.Hour,
+			Frequency:     time.Hour,
+			NextAuditDate: time.Now().Add(time.Hour * 48),
 		},
 		Owners: []accesslist.Owner{
 			{

--- a/lib/auth/userloginstate/generator_test.go
+++ b/lib/auth/userloginstate/generator_test.go
@@ -48,6 +48,7 @@ func TestAccessLists(t *testing.T) {
 	tests := []struct {
 		name        string
 		accessLists []*accesslist.AccessList
+		members     []*accesslist.AccessListMember
 		roles       []string
 		expected    *userloginstate.UserLoginState
 	}{
@@ -63,15 +64,16 @@ func TestAccessLists(t *testing.T) {
 		{
 			name: "access lists add roles and traits",
 			accessLists: []*accesslist.AccessList{
-				newAccessList(t, "1", []string{"user"}, []string{"role1"}, trait.Traits{
+				newAccessList(t, "1", []string{"role1"}, trait.Traits{
 					"trait1": []string{"value1"},
 				}),
-				newAccessList(t, "2", []string{"user"}, []string{"role2"}, trait.Traits{
+				newAccessList(t, "2", []string{"role2"}, trait.Traits{
 					"trait1": []string{"value2"},
 					"trait2": []string{"value3"},
 				}),
 			},
-			roles: []string{"orole1", "role1", "role2"},
+			members: append(newAccessListMembers(t, "1", "user"), newAccessListMembers(t, "2", "user")...),
+			roles:   []string{"orole1", "role1", "role2"},
 			expected: newUserLoginState(t, "user",
 				[]string{
 					"orole1",
@@ -86,15 +88,16 @@ func TestAccessLists(t *testing.T) {
 		{
 			name: "access lists add roles and traits, roles missing from backend",
 			accessLists: []*accesslist.AccessList{
-				newAccessList(t, "1", []string{"user"}, []string{"role1"}, trait.Traits{
+				newAccessList(t, "1", []string{"role1"}, trait.Traits{
 					"trait1": []string{"value1"},
 				}),
-				newAccessList(t, "2", []string{"user"}, []string{"role2"}, trait.Traits{
+				newAccessList(t, "2", []string{"role2"}, trait.Traits{
 					"trait1": []string{"value2"},
 					"trait2": []string{"value3"},
 				}),
 			},
-			roles: []string{"orole1"},
+			members: append(newAccessListMembers(t, "1", "user"), newAccessListMembers(t, "2", "user")...),
+			roles:   []string{"orole1"},
 			expected: newUserLoginState(t, "user",
 				[]string{"orole1"}, trait.Traits{
 					"otrait1": []string{"value1", "value2"},
@@ -105,15 +108,16 @@ func TestAccessLists(t *testing.T) {
 		{
 			name: "access lists only a member of some lists",
 			accessLists: []*accesslist.AccessList{
-				newAccessList(t, "1", []string{"user"}, []string{"role1"}, trait.Traits{
+				newAccessList(t, "1", []string{"role1"}, trait.Traits{
 					"trait1": []string{"value1"},
 				}),
-				newAccessList(t, "2", []string{"not-user"}, []string{"role2"}, trait.Traits{
+				newAccessList(t, "2", []string{"role2"}, trait.Traits{
 					"trait1": []string{"value2"},
 					"trait2": []string{"value3"},
 				}),
 			},
-			roles: []string{"orole1", "role1", "role2"},
+			members: append(newAccessListMembers(t, "1", "user"), newAccessListMembers(t, "2", "not-user")...),
+			roles:   []string{"orole1", "role1", "role2"},
 			expected: newUserLoginState(t, "user",
 				[]string{
 					"orole1",
@@ -126,10 +130,11 @@ func TestAccessLists(t *testing.T) {
 		{
 			name: "access lists add roles with duplicates",
 			accessLists: []*accesslist.AccessList{
-				newAccessList(t, "1", []string{"user"}, []string{"role1", "role2"}, trait.Traits{}),
-				newAccessList(t, "2", []string{"user"}, []string{"role2", "role3"}, trait.Traits{}),
+				newAccessList(t, "1", []string{"role1", "role2"}, trait.Traits{}),
+				newAccessList(t, "2", []string{"role2", "role3"}, trait.Traits{}),
 			},
-			roles: []string{"orole1", "role1", "role2", "role3"},
+			members: append(newAccessListMembers(t, "1", "user"), newAccessListMembers(t, "2", "user")...),
+			roles:   []string{"orole1", "role1", "role2", "role3"},
 			expected: newUserLoginState(t, "user",
 				[]string{
 					"orole1",
@@ -143,20 +148,21 @@ func TestAccessLists(t *testing.T) {
 		{
 			name: "access lists add traits with duplicates",
 			accessLists: []*accesslist.AccessList{
-				newAccessList(t, "1", []string{"user"}, []string{},
+				newAccessList(t, "1", []string{},
 					trait.Traits{
 						"trait1": []string{"value1", "value2"},
 						"trait2": []string{"value3", "value4"},
 					},
 				),
-				newAccessList(t, "2", []string{"user"}, []string{},
+				newAccessList(t, "2", []string{},
 					trait.Traits{
 						"trait2": []string{"value3", "value1"},
 						"trait3": []string{"value5", "value6"},
 					},
 				),
 			},
-			roles: []string{"orole1"},
+			members: append(newAccessListMembers(t, "1", "user"), newAccessListMembers(t, "2", "user")...),
+			roles:   []string{"orole1"},
 			expected: newUserLoginState(t, "user",
 				[]string{
 					"orole1",
@@ -177,6 +183,11 @@ func TestAccessLists(t *testing.T) {
 
 			for _, accessList := range test.accessLists {
 				_, err = backendSvc.UpsertAccessList(ctx, accessList)
+				require.NoError(t, err)
+			}
+
+			for _, member := range test.members {
+				_, err = backendSvc.UpsertAccessListMember(ctx, member)
 				require.NoError(t, err)
 			}
 
@@ -219,19 +230,8 @@ func initGeneratorSvc(t *testing.T) (*Generator, *svc) {
 		&svc{AccessLists: accessListsSvc, Access: accessSvc}
 }
 
-func newAccessList(t *testing.T, name string, members []string, roles []string, traits trait.Traits) *accesslist.AccessList {
+func newAccessList(t *testing.T, name string, roles []string, traits trait.Traits) *accesslist.AccessList {
 	t.Helper()
-
-	alMembers := make([]accesslist.Member, len(members))
-	for i, member := range members {
-		alMembers[i] = accesslist.Member{
-			Name:    member,
-			Joined:  time.Now(),
-			Expires: time.Now().Add(24 * time.Hour),
-			Reason:  "added",
-			AddedBy: "owner",
-		}
-	}
 
 	accessList, err := accesslist.NewAccessList(header.Metadata{
 		Name: name,
@@ -258,11 +258,30 @@ func newAccessList(t *testing.T, name string, members []string, roles []string, 
 			Roles:  roles,
 			Traits: traits,
 		},
-		Members: alMembers,
 	})
 	require.NoError(t, err)
 
 	return accessList
+}
+
+func newAccessListMembers(t *testing.T, accessList string, members ...string) []*accesslist.AccessListMember {
+	alMembers := make([]*accesslist.AccessListMember, len(members))
+	for i, member := range members {
+		var err error
+		alMembers[i], err = accesslist.NewAccessListMember(header.Metadata{
+			Name: member,
+		}, accesslist.AccessListMemberSpec{
+			AccessList: accessList,
+			Name:       member,
+			Joined:     time.Now(),
+			Expires:    time.Now().Add(24 * time.Hour),
+			Reason:     "added",
+			AddedBy:    "owner",
+		})
+		require.NoError(t, err)
+	}
+
+	return alMembers
 }
 
 func newUserLoginState(t *testing.T, name string, roles []string, traits map[string][]string) *userloginstate.UserLoginState {

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -166,7 +166,7 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 }
 
 // IsOwner will return true if the user is an owner for the current list.
-// TODO(mdwn): Remove this.
+// TODO(mdwn): Remove this once references to this function call are removed from enterprise.
 func IsOwner(identity tlsca.Identity, accessList *accesslist.AccessList) error {
 	return IsAccessListOwner(identity, accessList)
 }
@@ -198,7 +198,7 @@ func IsAccessListOwner(identity tlsca.Identity, accessList *accesslist.AccessLis
 }
 
 // IsMember will return true if the user is a member for the current list.
-// TODO(mdwn): Remove this.
+// TODO(mdwn): Remove this once references to this function call are removed from enterprise.
 func IsMember(identity tlsca.Identity, clock clockwork.Clock, accessList *accesslist.AccessList) error {
 	username := identity.Username
 	for _, member := range accessList.Spec.Members {
@@ -236,7 +236,7 @@ func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock cloc
 	}
 
 	if !userMeetsRequirements(identity, accessList.Spec.MembershipRequires) {
-		return trace.AccessDenied("user %s does not meet membership requirements", username)
+		return trace.AccessDenied("user %s is a member, but does not have the roles or traits required to be a member of this list", username)
 	}
 	return nil
 }

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -232,7 +232,7 @@ func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock cloc
 	}
 
 	if !clock.Now().Before(expires) {
-		return trace.NotFound("user %s's membership has expired in the access list", username)
+		return trace.AccessDenied("user %s's membership has expired in the access list", username)
 	}
 
 	if !userMeetsRequirements(identity, accessList.Spec.MembershipRequires) {

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -227,7 +227,7 @@ func IsAccessListMember(ctx context.Context, identity tlsca.Identity, clock cloc
 	}
 
 	expires := member.Spec.Expires
-	if expires.IsZero() {
+	if expires.IsZero() || accessList.Spec.Audit.NextAuditDate.Before(expires) {
 		expires = accessList.Spec.Audit.NextAuditDate
 	}
 

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -252,7 +252,7 @@ func TestIsAccessListOwner(t *testing.T) {
 					"otrait2": {"ovalue3", "ovalue4"},
 				},
 			},
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+			errAssertionFunc: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsAccessDenied(err))
 			},
 		},
@@ -266,7 +266,7 @@ func TestIsAccessListOwner(t *testing.T) {
 					"otrait2": {"ovalue3", "ovalue4"},
 				},
 			},
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+			errAssertionFunc: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsAccessDenied(err))
 			},
 		},
@@ -280,7 +280,7 @@ func TestIsAccessListOwner(t *testing.T) {
 					"otrait2": {"ovalue3"},
 				},
 			},
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+			errAssertionFunc: func(t require.TestingT, err error, i ...any) {
 				require.True(t, trace.IsAccessDenied(err))
 			},
 		},

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -460,6 +460,21 @@ func TestIsAccessListMember(t *testing.T) {
 		{
 			name: "is expired member",
 			identity: tlsca.Identity{
+				Username: member2,
+				Groups:   []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			currentTime: time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+		{
+			name: "is expired member (overridden next audit date)",
+			identity: tlsca.Identity{
 				Username: member1,
 				Groups:   []string{"mrole1", "mrole2"},
 				Traits: map[string][]string{
@@ -467,7 +482,7 @@ func TestIsAccessListMember(t *testing.T) {
 					"mtrait2": {"mvalue3", "mvalue4"},
 				},
 			},
-			currentTime: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+			currentTime: time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC),
 			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
 				require.True(t, trace.IsNotFound(err))
 			},
@@ -550,7 +565,8 @@ func newAccessList(t *testing.T) *accesslist.AccessList {
 				},
 			},
 			Audit: accesslist.Audit{
-				Frequency: time.Hour,
+				Frequency:     time.Hour,
+				NextAuditDate: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC),
 			},
 			MembershipRequires: accesslist.Requires{
 				Roles: []string{"mrole1", "mrole2"},

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -224,7 +224,7 @@ func TestAccessListMemberMarshal(t *testing.T) {
 	require.Equal(t, expected, actual)
 }
 
-func TestIsOwner(t *testing.T) {
+func TestIsAccessListOwner(t *testing.T) {
 	tests := []struct {
 		name             string
 		identity         tlsca.Identity
@@ -292,11 +292,12 @@ func TestIsOwner(t *testing.T) {
 			t.Parallel()
 
 			accessList := newAccessList(t)
-			test.errAssertionFunc(t, IsOwner(test.identity, accessList))
+			test.errAssertionFunc(t, IsAccessListOwner(test.identity, accessList))
 		})
 	}
 }
 
+// TODO(mdwn): Remove this.
 func TestIsMember(t *testing.T) {
 	tests := []struct {
 		name             string
@@ -392,6 +393,142 @@ func TestIsMember(t *testing.T) {
 	}
 }
 
+// testMembersGetter implements AccessListMembersGetter for testing.
+type testMembersGetter struct {
+	members map[string]map[string]*accesslist.AccessListMember
+}
+
+// ListAccessListMembers returns a paginated list of all access list members.
+func (t *testMembersGetter) ListAccessListMembers(ctx context.Context, accessList string, _ int, _ string) (members []*accesslist.AccessListMember, nextToken string, err error) {
+	for _, member := range t.members[accessList] {
+		members = append(members, member)
+	}
+	return members, "", nil
+}
+
+// GetAccessListMember returns the specified access list member resource.
+func (t *testMembersGetter) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
+	members, ok := t.members[accessList]
+	if !ok {
+		return nil, trace.NotFound("not found")
+	}
+
+	member, ok := members[memberName]
+	if !ok {
+		return nil, trace.NotFound("not found")
+	}
+
+	return member, nil
+}
+
+func TestIsAccessListMember(t *testing.T) {
+	tests := []struct {
+		name             string
+		identity         tlsca.Identity
+		memberCtx        context.Context
+		currentTime      time.Time
+		errAssertionFunc require.ErrorAssertionFunc
+	}{
+		{
+			name: "is member",
+			identity: tlsca.Identity{
+				Username: member1,
+				Groups:   []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: require.NoError,
+		},
+		{
+			name: "is not a member",
+			identity: tlsca.Identity{
+				Username: member3,
+				Groups:   []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+		{
+			name: "is expired member",
+			identity: tlsca.Identity{
+				Username: member1,
+				Groups:   []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			currentTime: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsNotFound(err))
+			},
+		},
+		{
+			name: "is member with missing roles",
+			identity: tlsca.Identity{
+				Username: member1,
+				Groups:   []string{"mrole1"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1", "mvalue2"},
+					"mtrait2": {"mvalue3", "mvalue4"},
+				},
+			},
+			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+		{
+			name: "is member with missing traits",
+			identity: tlsca.Identity{
+				Username: member1,
+				Groups:   []string{"mrole1", "mrole2"},
+				Traits: map[string][]string{
+					"mtrait1": {"mvalue1"},
+					"mtrait2": {"mvalue3"},
+				},
+			},
+			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
+			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
+				require.True(t, trace.IsAccessDenied(err))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			accessList := newAccessList(t)
+			members := newAccessListMembers(t)
+
+			memberMap := map[string]map[string]*accesslist.AccessListMember{}
+			for _, member := range members {
+				accessListName := member.Spec.AccessList
+				if _, ok := memberMap[accessListName]; !ok {
+					memberMap[accessListName] = map[string]*accesslist.AccessListMember{}
+				}
+				memberMap[accessListName][member.Spec.Name] = member
+			}
+			getter := &testMembersGetter{members: memberMap}
+
+			test.errAssertionFunc(t, IsAccessListMember(ctx, test.identity, clockwork.NewFakeClockAt(test.currentTime), accessList, getter))
+		})
+	}
+}
+
 func newAccessList(t *testing.T) *accesslist.AccessList {
 	t.Helper()
 
@@ -457,6 +594,36 @@ func newAccessList(t *testing.T) *accesslist.AccessList {
 	require.NoError(t, err)
 
 	return accessList
+}
+
+func newAccessListMembers(t *testing.T) []*accesslist.AccessListMember {
+	t.Helper()
+
+	member1, err := accesslist.NewAccessListMember(header.Metadata{
+		Name: member1,
+	}, accesslist.AccessListMemberSpec{
+		AccessList: "test",
+		Name:       member1,
+		Joined:     time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
+		Expires:    time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		Reason:     "because",
+		AddedBy:    ownerUser,
+	})
+	require.NoError(t, err)
+
+	member2, err := accesslist.NewAccessListMember(header.Metadata{
+		Name: member2,
+	}, accesslist.AccessListMemberSpec{
+		AccessList: "test",
+		Name:       member2,
+		Joined:     time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
+		Expires:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		Reason:     "because again",
+		AddedBy:    ownerUser,
+	})
+	require.NoError(t, err)
+
+	return []*accesslist.AccessListMember{member1, member2}
 }
 
 var accessListYAML = `---

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -469,7 +469,7 @@ func TestIsAccessListMember(t *testing.T) {
 			},
 			currentTime: time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC),
 			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsNotFound(err))
+				require.True(t, trace.IsAccessDenied(err))
 			},
 		},
 		{
@@ -484,7 +484,7 @@ func TestIsAccessListMember(t *testing.T) {
 			},
 			currentTime: time.Date(2024, 7, 1, 0, 0, 0, 0, time.UTC),
 			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsNotFound(err))
+				require.True(t, trace.IsAccessDenied(err))
 			},
 		},
 		{


### PR DESCRIPTION
IsOwner/IsMember have been renamed to IsAccessListOwner and IsAccessListMember for better clarity, and IsAccessListMember uses the new AccessListMember object now. References to IsMember in the OSS codebase have been replaced with IsAccessListMember, and tests have been updated.