### PR TITLE
AWS OIDC - DeployService: add optional Security Groups

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -49,6 +49,9 @@ func StatementForECSManageService() *Statement {
 			"ecs:DescribeClusters", "ecs:CreateCluster", "ecs:PutClusterCapacityProviders",
 			"ecs:DescribeServices", "ecs:CreateService", "ecs:UpdateService",
 			"ecs:RegisterTaskDefinition",
+
+			// EC2 DescribeSecurityGroups is required so that the user can list the SG and then pick which ones they want to apply to the ECS Service.
+			"ec2:DescribeSecurityGroups",
 		},
 		Resources: allResources,
 	}

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -162,6 +162,7 @@ func (h *Handler) awsOIDCDeployService(w http.ResponseWriter, r *http.Request, p
 		Region:                        req.Region,
 		AccountID:                     req.AccountID,
 		SubnetIDs:                     req.SubnetIDs,
+		SecurityGroups:                req.SecurityGroups,
 		ClusterName:                   req.ClusterName,
 		ServiceName:                   req.ServiceName,
 		TaskName:                      req.TaskName,

--- a/lib/web/ui/integration.go
+++ b/lib/web/ui/integration.go
@@ -141,6 +141,10 @@ type AWSOIDCDeployServiceRequest struct {
 	// If deploying a Database Service, you should use the SubnetIDs returned by the List Database API call.
 	SubnetIDs []string `json:"subnetIds"`
 
+	// SecurityGroups to apply to the service's network configuration.
+	// If empty, the default security group for the VPC is going to be used.
+	SecurityGroups []string `json:"securityGroups"`
+
 	// ClusterName is the ECS Cluster to be used.
 	// Optional.
 	// Defaults to <teleport-cluster-name>-teleport, eg. acme-teleport


### PR DESCRIPTION
When deploying a Teleport service using the AWS OIDC DeployService, we can provide the SecurityGroups to be applied to the network configuration of the service.

Using the default SG for the VPC (vpc is inferred from the used subnets) might not always be the best one (it is usually locked down).

This PR adds an optional new field that clients can use to be explicit about the SGs they want.

We also added a new permission when configuring the IAM Permissions for the DeployService, to allow the usage of the ListSecurityGroups action. Users can see the list of SG and then pick which ones they want.

Without SecurityGroups
![image](https://github.com/gravitational/teleport/assets/689271/ec39fbc9-2037-4097-b73d-8e0be15bf423)

Setting a custom Security Group
![image](https://github.com/gravitational/teleport/assets/689271/41746e86-f0f8-4b9c-bfa3-710fc65a5d46)