### PR TITLE
Additional safety with `X-Forwarded-Host` handling

### DIFF
--- a/lib/srv/alpnproxy/local_proxy.go
+++ b/lib/srv/alpnproxy/local_proxy.go
@@ -333,6 +333,8 @@ func (l *LocalProxy) StartHTTPAccessProxy(ctx context.Context) error {
 			// localhost. Set appropriate header to keep this information.
 			if addr, err := utils.ParseAddr(req.Host); err == nil && !addr.IsLocal() {
 				req.Header.Set("X-Forwarded-Host", req.Host)
+			} else { // ensure that there is no client provided X-Forwarded-Host
+				req.Header.Del("X-Forwarded-Host")
 			}
 
 			proxy, err := l.getHTTPReverseProxyForReq(req, defaultProxy)

--- a/lib/srv/app/aws/endpoints.go
+++ b/lib/srv/app/aws/endpoints.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gravitational/trace"
 
 	awsapiutils "github.com/gravitational/teleport/api/utils/aws"
+	libutils "github.com/gravitational/teleport/lib/utils"
 	awsutils "github.com/gravitational/teleport/lib/utils/aws"
 )
 
@@ -61,7 +62,8 @@ import (
 // endpoint.
 func resolveEndpoint(r *http.Request) (*endpoints.ResolvedEndpoint, error) {
 	// Use X-Forwarded-Host header if it is a valid AWS endpoint.
-	if awsapiutils.IsAWSEndpoint(r.Header.Get("X-Forwarded-Host")) {
+	forwardedHost, headErr := libutils.GetSingleHeader(r.Header, "X-Forwarded-Host")
+	if headErr == nil && awsapiutils.IsAWSEndpoint(forwardedHost) {
 		re, err := resolveEndpointByXForwardedHost(r, awsutils.AuthorizationHeader)
 		return re, trace.Wrap(err)
 	}

--- a/lib/srv/app/azure/handler.go
+++ b/lib/srv/app/azure/handler.go
@@ -161,8 +161,10 @@ func (s *handler) formatForwardResponseError(rw http.ResponseWriter, r *http.Req
 
 // prepareForwardRequest prepares a request for forwarding, updating headers and target host. Several checks are made along the way.
 func (s *handler) prepareForwardRequest(r *http.Request, sessionCtx *common.SessionContext) (*http.Request, error) {
-	forwardedHost := r.Header.Get("X-Forwarded-Host")
-	if !azure.IsAzureEndpoint(forwardedHost) {
+	forwardedHost, err := utils.GetSingleHeader(r.Header, "X-Forwarded-Host")
+	if err != nil {
+		return nil, trace.AccessDenied(err.Error())
+	} else if !azure.IsAzureEndpoint(forwardedHost) {
 		return nil, trace.AccessDenied("%q is not an Azure endpoint", forwardedHost)
 	}
 

--- a/lib/srv/app/gcp/handler.go
+++ b/lib/srv/app/gcp/handler.go
@@ -184,8 +184,10 @@ func (s *handler) formatForwardResponseError(rw http.ResponseWriter, r *http.Req
 
 // prepareForwardRequest prepares a request for forwarding, updating headers and target host. Several checks are made along the way.
 func (s *handler) prepareForwardRequest(r *http.Request, sessionCtx *common.SessionContext) (*http.Request, error) {
-	forwardedHost := r.Header.Get("X-Forwarded-Host")
-	if !gcp.IsGCPEndpoint(forwardedHost) {
+	forwardedHost, err := utils.GetSingleHeader(r.Header, "X-Forwarded-Host")
+	if err != nil {
+		return nil, trace.AccessDenied(err.Error())
+	} else if !gcp.IsGCPEndpoint(forwardedHost) {
 		return nil, trace.AccessDenied("%q is not a GCP endpoint", forwardedHost)
 	}
 

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -117,6 +117,19 @@ func GetAnyHeader(header http.Header, keys ...string) string {
 	return ""
 }
 
+// GetSingleHeader will return the header value for the key if there is exactly one value present.  If the header is
+// missing or specified multiple times, an error will be returned.
+func GetSingleHeader(headers http.Header, key string) (string, error) {
+	values := headers.Values(key)
+	if len(values) > 1 {
+		return "", trace.BadParameter("multiple %q headers", key)
+	} else if len(values) == 0 {
+		return "", trace.Errorf("missing %q headers", key)
+	} else {
+		return values[0], nil
+	}
+}
+
 // HTTPDoClient is an interface that defines the Do function of http.Client.
 type HTTPDoClient interface {
 	Do(req *http.Request) (*http.Response, error)

--- a/lib/utils/http.go
+++ b/lib/utils/http.go
@@ -124,7 +124,7 @@ func GetSingleHeader(headers http.Header, key string) (string, error) {
 	if len(values) > 1 {
 		return "", trace.BadParameter("multiple %q headers", key)
 	} else if len(values) == 0 {
-		return "", trace.Errorf("missing %q headers", key)
+		return "", trace.NotFound("missing %q headers", key)
 	} else {
 		return values[0], nil
 	}


### PR DESCRIPTION
This adds `utils.GetSingleHeader` as a common way to make sure that additional headers are not being inserted into the request. We use this in the `aws`, `azure`, and `gcp` handler as part of verifying the source of the request.

In addition `alpnproxy/local_proxy.go` contains a fix where an invalid `Host` header can allow an arbitrary `X-Forwarded-Host` value to pass through unchanged.

This PR fixes low severity issue: https://github.com/gravitational/teleport-private/issues/922