### PR TITLE
[v13] helm: Use cert-manager secret or tls.existingSecretName for ingress when enabled

### DIFF
--- a/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/deployment.yaml
@@ -120,11 +120,7 @@ spec:
     {{- list $initContainer | toYaml | nindent 8 }}
     {{- /* Note: this will break if the user sets volumeMounts to its initContainer */}}
           volumeMounts:
-    {{- if $proxy.highAvailability.certManager.enabled }}
-          - mountPath: /etc/teleport-tls
-            name: "teleport-tls"
-            readOnly: true
-    {{- else if $proxy.tls.existingSecretName }}
+    {{- if or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName }}
           - mountPath: /etc/teleport-tls
             name: "teleport-tls"
             readOnly: true
@@ -236,11 +232,7 @@ spec:
         securityContext: {{- toYaml $proxy.securityContext | nindent 10 }}
 {{- end }}
         volumeMounts:
-{{- if $proxy.highAvailability.certManager.enabled }}
-        - mountPath: /etc/teleport-tls
-          name: "teleport-tls"
-          readOnly: true
-{{- else if $proxy.tls.existingSecretName }}
+{{- if or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName }}
         - mountPath: /etc/teleport-tls
           name: "teleport-tls"
           readOnly: true

--- a/examples/chart/teleport-cluster/templates/proxy/ingress.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/ingress.yaml
@@ -38,6 +38,8 @@ spec:
   {{- end }}
   {{- if $proxy.highAvailability.certManager.enabled }}
     secretName: teleport-tls
+  {{- else if $proxy.tls.existingSecretName }}
+    secretName: {{ $proxy.tls.existingSecretName }}
   {{- end }}
   rules:
    {{- range $publicAddr }}

--- a/examples/chart/teleport-cluster/templates/proxy/ingress.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/ingress.yaml
@@ -36,6 +36,9 @@ spec:
   {{- range $publicAddr }}
     - {{ quote . }}
   {{- end }}
+  {{- if $proxy.highAvailability.certManager.enabled }}
+    secretName: teleport-tls
+  {{- end }}
   rules:
    {{- range $publicAddr }}
   - host: {{ quote . }}

--- a/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
+++ b/examples/chart/teleport-cluster/templates/proxy/predeploy_job.yaml
@@ -53,11 +53,7 @@ spec:
         securityContext: {{- toYaml $proxy.securityContext | nindent 10 }}
 {{- end }}
         volumeMounts:
-{{- if $proxy.highAvailability.certManager.enabled }}
-        - mountPath: /etc/teleport-tls
-          name: "teleport-tls"
-          readOnly: true
-{{- else if $proxy.tls.existingSecretName }}
+{{- if or $proxy.highAvailability.certManager.enabled $proxy.tls.existingSecretName }}
         - mountPath: /etc/teleport-tls
           name: "teleport-tls"
           readOnly: true

--- a/examples/chart/teleport-cluster/tests/__snapshot__/ingress_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/ingress_test.yaml.snap
@@ -36,6 +36,12 @@ sets the publicAddr and wildcard of publicAddr as hostnames when Ingress is enab
     - hosts:
       - helm-lint.example.com
       - '*.helm-lint.example.com'
+sets tls.secretName the value of tls.existingSecretName when set:
+  1: |
+    - hosts:
+      - teleport.example.com
+      - '*.teleport.example.com'
+      secretName: helm-lint-tls-secret
 sets tls.secretName when cert-manager is enabled:
   1: |
     - hosts:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/ingress_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/ingress_test.yaml.snap
@@ -14,6 +14,11 @@ does not set a wildcard of clusterName as a hostname when Ingress is enabled and
 : 1: |
     - hosts:
       - helm-lint.example.com
+does not set tls.secretName by default:
+  1: |
+    - hosts:
+      - teleport.example.com
+      - '*.teleport.example.com'
 exposes all publicAddrs and wildcard publicAddrs as hostnames when Ingress is enabled and multiple publicAddrs are set:
   1: |
     - hosts:
@@ -31,6 +36,12 @@ sets the publicAddr and wildcard of publicAddr as hostnames when Ingress is enab
     - hosts:
       - helm-lint.example.com
       - '*.helm-lint.example.com'
+sets tls.secretName when cert-manager is enabled:
+  1: |
+    - hosts:
+      - teleport.example.com
+      - '*.teleport.example.com'
+      secretName: teleport-tls
 trims ports from publicAddr and uses it as the hostname when Ingress is enabled and publicAddr is set:
   1: |
     - hosts:

--- a/examples/chart/teleport-cluster/tests/ingress_test.yaml
+++ b/examples/chart/teleport-cluster/tests/ingress_test.yaml
@@ -523,3 +523,16 @@ tests:
           value: teleport-tls
       - matchSnapshot:
           path: spec.tls
+
+  - it: sets tls.secretName the value of tls.existingSecretName when set
+    values:
+      - ../.lint/ingress.yaml
+    set:
+      tls:
+        existingSecretName: helm-lint-tls-secret
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: helm-lint-tls-secret
+      - matchSnapshot:
+          path: spec.tls

--- a/examples/chart/teleport-cluster/tests/ingress_test.yaml
+++ b/examples/chart/teleport-cluster/tests/ingress_test.yaml
@@ -500,3 +500,26 @@ tests:
       - equal:
           path: spec.otherSpecStuff
           value: lint
+
+  - it: does not set tls.secretName by default
+    values:
+      - ../.lint/ingress.yaml
+    asserts:
+      - isEmpty:
+          path: spec.tls[0].secretName
+      - matchSnapshot:
+          path: spec.tls
+
+  - it: sets tls.secretName when cert-manager is enabled
+    values:
+      - ../.lint/ingress.yaml
+    set:
+      highAvailability:
+        certManager:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.tls[0].secretName
+          value: teleport-tls
+      - matchSnapshot:
+          path: spec.tls


### PR DESCRIPTION
Backport #30789 to branch/v13