### PR TITLE
Upgrade Node.js to v18

### DIFF
--- a/.github/workflows/lint-ui.yaml
+++ b/.github/workflows/lint-ui.yaml
@@ -17,10 +17,18 @@ jobs:
       - name: Checkout OSS Teleport
         uses: actions/checkout@v3
 
+      - name: Determine Toolchain Versions
+        run: |
+          echo NODE_VERSION=$(make -s -C build.assets print-node-version) >> $GITHUB_ENV
+
+      - name: Print versions
+        run: |
+          echo "node: ${NODE_VERSION}"
+
       - name: Setup Node Toolchain
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Yarn dependencies
         run: yarn --frozen-lockfile

--- a/.github/workflows/unit-tests-ui.yaml
+++ b/.github/workflows/unit-tests-ui.yaml
@@ -19,10 +19,18 @@ jobs:
       - name: Checkout OSS Teleport
         uses: actions/checkout@v3
 
+      - name: Determine Toolchain Versions
+        run: |
+          echo NODE_VERSION=$(make -s -C build.assets print-node-version) >> $GITHUB_ENV
+
+      - name: Print versions
+        run: |
+          echo "node: ${NODE_VERSION}"
+
       - name: Setup Node Toolchain
         uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Install Yarn dependencies
         run: yarn --frozen-lockfile

--- a/build.assets/Dockerfile-centos7
+++ b/build.assets/Dockerfile-centos7
@@ -214,20 +214,6 @@ ENV GOPATH="/go" \
     GOROOT="/opt/go" \
     PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-# Install node.
-RUN yum install -y python3
-ARG NODE_VERSION
-ENV NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${BUILDARCH}.tar.xz"
-ENV NODE_PATH="/usr/local/lib/nodejs-linux"
-ENV PATH="$PATH:${NODE_PATH}/bin"
-RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
-     export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz" && \
-     mkdir -p ${NODE_PATH} && \
-     curl -o /tmp/nodejs.tar.xz -fsSL ${NODE_URL} && \
-     tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
-RUN node --version
-RUN corepack enable yarn
-
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install

--- a/build.assets/Dockerfile-centos7-fips
+++ b/build.assets/Dockerfile-centos7-fips
@@ -121,19 +121,6 @@ ENV GOEXPERIMENT=boringcrypto \
     GOROOT="/opt/go" \
     PATH="/opt/llvm/bin:$PATH:/opt/go/bin:/go/bin:/go/src/github.com/gravitational/teleport/build"
 
-# Install node.
-RUN yum install -y python3
-ARG NODE_VERSION
-ENV NODE_PATH="/usr/local/lib/nodejs-linux"
-ENV PATH="$PATH:${NODE_PATH}/bin"
-RUN export NODE_ARCH=$(if [ "$BUILDARCH" = "amd64" ]; then echo "x64"; else echo "arm64"; fi) && \
-    export NODE_URL="https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" && \
-    mkdir -p ${NODE_PATH} && \
-    curl -o /tmp/nodejs.tar.xz -fsSL ${NODE_URL} && \
-    tar -xJf /tmp/nodejs.tar.xz -C /usr/local/lib/nodejs-linux --strip-components=1
-RUN node --version
-RUN corepack enable yarn
-
 # Install PAM module and policies for testing.
 COPY pam/ /opt/pam_teleport/
 RUN make -C /opt/pam_teleport install

--- a/build.assets/Makefile
+++ b/build.assets/Makefile
@@ -155,7 +155,6 @@ buildbox-centos7:
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg DEVTOOLSET=$(DEVTOOLSET) \
@@ -175,7 +174,6 @@ buildbox-centos7-fips:
 		--build-arg GID=$(GID) \
 		--build-arg BUILDARCH=$(RUNTIME_ARCH) \
 		--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
-		--build-arg NODE_VERSION=$(NODE_VERSION) \
 		--build-arg RUST_VERSION=$(RUST_VERSION) \
 		--build-arg WASM_PACK_VERSION=$(WASM_PACK_VERSION) \
 		--build-arg LIBBPF_VERSION=$(LIBBPF_VERSION) \

--- a/build.assets/versions.mk
+++ b/build.assets/versions.mk
@@ -5,7 +5,7 @@
 # Sync with devbox.json.
 GOLANG_VERSION ?= go1.20.7
 
-NODE_VERSION ?= 16.18.1
+NODE_VERSION ?= 18.17.1
 
 # Run lint-rust check locally before merging code after you bump this.
 RUST_VERSION ?= 1.71.1

--- a/devbox.json
+++ b/devbox.json
@@ -19,7 +19,7 @@
     "go@1.20.6",
     "libfido2@1.13.0",
     "llvmPackages_14.clangUseLLVM@14.0.6",
-    "nodejs@16.18.1",
+    "nodejs@18.16.1",
     "protobuf3_20@3.20.3",
     "rustc@1.70.0",
     "yarn@1.22.19",

--- a/devbox.lock
+++ b/devbox.lock
@@ -72,10 +72,11 @@
       "source": "devbox-search",
       "version": "14.0.6"
     },
-    "nodejs@16.18.1": {
-      "last_modified": "2023-01-02T04:31:48Z",
-      "resolved": "github:NixOS/nixpkgs/a4379d2b0deefedc8dba360897557707ea9ee9a7#nodejs-16_x",
-      "version": "16.18.1"
+    "nodejs@18.16.1": {
+      "last_modified": "2023-06-30T04:44:22Z",
+      "resolved": "github:NixOS/nixpkgs/3c614fbc76fc152f3e1bc4b2263da6d90adf80fb#nodejs_18",
+      "source": "devbox-search",
+      "version": "18.16.1"
     },
     "openssl@latest": {
       "last_modified": "2023-07-23T03:35:12Z",

--- a/web/packages/build/package.json
+++ b/web/packages/build/package.json
@@ -49,7 +49,7 @@
     "@testing-library/user-event": "^14.4.3",
     "@types/jest": "^27.3.1",
     "@types/jsdom": "^21.1.0",
-    "@types/node": "^16.11.10",
+    "@types/node": "^18.17.1",
     "@types/react": "^16.8.19",
     "@types/react-router-dom": "^5.1.1",
     "@types/react-transition-group": "^4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3856,10 +3856,15 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.16.7.tgz#86d0ba2541f808cb78d4dc5d3e40242a349d6db8"
   integrity sha512-MFg7ua/bRtnA1hYE3pVyWxGd/r7aMqjNOdHvlSsXV3n8iaeGKkOaPzpJh6/ovf4bEXWcojkeMJpTsq3mzXW4IQ==
 
-"@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0", "@types/node@^16.11.10":
+"@types/node@^14.0.10 || ^16.0.0", "@types/node@^14.14.20 || ^16.0.0":
   version "16.18.16"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.16.tgz#09ff98b144abae2d7cce3e9fe9040ab2bf73222c"
   integrity sha512-ZOzvDRWp8dCVBmgnkIqYCArgdFOO9YzocZp8Ra25N/RStKiWvMOXHMz+GjSeVNe5TstaTmTWPucGJkDw0XXJWA==
+
+"@types/node@^18.17.1":
+  version "18.17.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.17.5.tgz#c58b12bca8c2a437b38c15270615627e96dd0bc5"
+  integrity sha512-xNbS75FxH6P4UXTPUJp/zNPq6/xsfdJKussCWNOnz4aULWIRwMgP1LgaB5RiBnMX1DPCYenuqGZfnIAx5mbFLA==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/21724

Depends on https://github.com/gravitational/teleport/pull/30322

I removed Node.js from the CentOS Dockerfiles as webassets are now built with a different buildbox. 
I'm wondering if we should we also remove it from `Dockerfile-multiarch`, AFAIK it is not used there. 

[I ran a build](https://drone.platform.teleport.sh/gravitational/teleport/27614) that includes changes from the linked PR.