### PR TITLE
[web] Update max width for resources page

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/teleport/src/UnifiedResources/FilterPanel.tsx
@@ -89,7 +89,7 @@ export function FilterPanel({
   };
 
   return (
-    <Flex justifyContent="space-between" mb={2}>
+    <Flex justifyContent="space-between" mb={3}>
       <Box width="300px">
         <FilterSelect
           isMulti={true}

--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -162,6 +162,11 @@ export function Resources() {
 const ResourcesContainer = styled(Flex)`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
+  @media (min-width: 1800px) {
+    max-width: 1800px;
+    grid-template-columns: repeat(4, minmax(400px, 1fr));
+    margin: auto;
+  }
 `;
 
 const emptyStateInfo: EmptyStateInfo = {

--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -40,6 +40,8 @@ import { ResourceCard } from './ResourceCard';
 import SearchPanel from './SearchPanel';
 import { FilterPanel } from './FilterPanel';
 
+const RESOURCES_MAX_WIDTH = '1800px';
+
 export function Resources() {
   const { isLeafCluster } = useStickyClusterId();
   const enabled = localStorage.areUnifiedResourcesEnabled();
@@ -100,8 +102,20 @@ export function Resources() {
   }
 
   return (
-    <FeatureBox>
-      <FeatureHeader alignItems="center" justifyContent="space-between">
+    <FeatureBox
+      css={`
+        max-width: ${RESOURCES_MAX_WIDTH};
+        margin: auto;
+      `}
+    >
+      <FeatureHeader
+        css={`
+          border-bottom: none;
+        `}
+        mb={1}
+        alignItems="center"
+        justifyContent="space-between"
+      >
         <FeatureHeaderTitle>Resources</FeatureHeaderTitle>
         <Flex alignItems="center">
           <AgentButtonAdd
@@ -162,10 +176,8 @@ export function Resources() {
 const ResourcesContainer = styled(Flex)`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  @media (min-width: 1800px) {
-    max-width: 1800px;
+  @media (min-width: ${RESOURCES_MAX_WIDTH}) {
     grid-template-columns: repeat(4, minmax(400px, 1fr));
-    margin: auto;
   }
 `;
 


### PR DESCRIPTION
This will set the max-width of the resources container to be 1800px as per the design. Also, maxing the columns to 4.

![Screenshot 2023-08-24 at 4 11 43 PM](https://github.com/gravitational/teleport/assets/5201977/110cd845-30ad-4183-a54b-c912bd57fbcb)
