### PR TITLE
[v12] Reduce memory leakage in API client caused by `otelgrpc` interceptors

### DIFF
--- a/api/client/client.go
+++ b/api/client/client.go
@@ -469,6 +469,7 @@ func onceValue[T any](f func() T) func() T {
 // then this leads to a memory leak since the underlying metric is not cleaned
 // up.
 // See https://github.com/gravitational/teleport/issues/30759
+// See https://github.com/open-telemetry/opentelemetry-go-contrib/issues/4226
 var otelStreamClientInterceptor = onceValue(func() grpc.StreamClientInterceptor {
 	return otelgrpc.StreamClientInterceptor()
 })


### PR DESCRIPTION
Backport #30767 to branch/v12