### PR TITLE
[v13] Use the most recent user object for the bot generation label.

### DIFF
--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -3125,7 +3125,7 @@ func (a *ServerWithRoles) generateUserCerts(ctx context.Context, req proto.UserC
 	// If the cert is renewable, process any certificate generation counter.
 	if certReq.renewable {
 		currentIdentityGeneration := a.context.Identity.GetIdentity().Generation
-		if err := a.authServer.validateGenerationLabel(ctx, user, &certReq, currentIdentityGeneration); err != nil {
+		if err := a.authServer.validateGenerationLabel(ctx, user.GetName(), &certReq, currentIdentityGeneration); err != nil {
 			return nil, trace.Wrap(err)
 		}
 	}

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -371,10 +371,10 @@ func (s *Server) checkOrCreateBotToken(ctx context.Context, req *proto.CreateBot
 }
 
 // validateGenerationLabel validates and updates a generation label.
-func (s *Server) validateGenerationLabel(ctx context.Context, userState services.UserState, certReq *certRequest, currentIdentityGeneration uint64) error {
+func (s *Server) validateGenerationLabel(ctx context.Context, username string, certReq *certRequest, currentIdentityGeneration uint64) error {
 	// Fetch the user, bypassing the cache. We might otherwise fetch a stale
 	// value in case of a rapid certificate renewal.
-	user, err := s.Services.GetUser(userState.GetName(), false)
+	user, err := s.Services.GetUser(username, false)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -579,7 +579,7 @@ func (s *Server) generateInitialBotCerts(ctx context.Context, username string, p
 		generation:    generation,
 	}
 
-	if err := s.validateGenerationLabel(ctx, userState, &certReq, 0); err != nil {
+	if err := s.validateGenerationLabel(ctx, userState.GetName(), &certReq, 0); err != nil {
 		return nil, trace.Wrap(err)
 	}
 

--- a/lib/auth/bot.go
+++ b/lib/auth/bot.go
@@ -380,7 +380,7 @@ func (s *Server) validateGenerationLabel(ctx context.Context, userState services
 	}
 
 	var currentUserGeneration uint64
-	label := userState.BotGenerationLabel()
+	label := user.BotGenerationLabel()
 	if label != "" {
 		currentUserGeneration, err = strconv.ParseUint(label, 10, 64)
 		if err != nil {


### PR DESCRIPTION
Backport #30978 to branch/v13

Changelog: Fixes a bug in 13.3.5 causing bot locking and bringing down clusters using the Teleport Kubernetes Operator.