### PR TITLE
[web] Remove extra err check

### DIFF
--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -2582,9 +2582,6 @@ func (h *Handler) clusterUnifiedResourcesGet(w http.ResponseWriter, r *http.Requ
 			unifiedResources = append(unifiedResources, desktop)
 		case types.KubeCluster:
 			kube := ui.MakeKubeCluster(r, accessChecker)
-			if err != nil {
-				return nil, trace.Wrap(err)
-			}
 			unifiedResources = append(unifiedResources, kube)
 		default:
 			return nil, trace.Errorf("UI Resource has unknown type: %T", resource)


### PR DESCRIPTION
For context: https://github.com/gravitational/teleport/pull/30935#discussion_r1304307398

When kubes were included in the page, and the user didn't have access to list/read `user_group`, it would properly log and get ignored in the process of `MakeApp`... but then I was accidentally checking for an err lower in the loop when `MakeKube` (that doesnt return an error) and so it would throw in the UI. 