### PR TITLE
Attempt to refactor gateway CLI command

### DIFF
--- a/integration/proxy/proxy_helpers.go
+++ b/integration/proxy/proxy_helpers.go
@@ -64,6 +64,7 @@ import (
 	alpncommon "github.com/gravitational/teleport/lib/srv/alpnproxy/common"
 	"github.com/gravitational/teleport/lib/srv/db/mysql"
 	"github.com/gravitational/teleport/lib/srv/db/postgres"
+	"github.com/gravitational/teleport/lib/teleterm/daemon"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
 	"github.com/gravitational/teleport/lib/tlsca"
 	"github.com/gravitational/teleport/lib/utils"
@@ -692,7 +693,7 @@ func mustFindKubePod(t *testing.T, tc *client.TeleportClient) {
 	require.Equal(t, types.KindKubePod, response.Resources[0].Kind)
 }
 
-func mustConnectDatabaseGateway(t *testing.T, gw gateway.Gateway) {
+func mustConnectDatabaseGateway(t *testing.T, _ *daemon.Service, gw gateway.Gateway) {
 	t.Helper()
 
 	dbGateway, err := gateway.AsDatabase(gw)

--- a/integration/proxy/teleterm_test.go
+++ b/integration/proxy/teleterm_test.go
@@ -98,7 +98,7 @@ func testDBGatewayCertRenewal(t *testing.T, pack *dbhelpers.DatabasePack, albAdd
 	)
 }
 
-type testGatewayConnectionFunc func(*testing.T, gateway.Gateway)
+type testGatewayConnectionFunc func(*testing.T, *daemon.Service, gateway.Gateway)
 
 func testGatewayCertRenewal(t *testing.T, inst *helpers.TeleInstance, username, albAddr string, params daemon.CreateGatewayParams, testConnection testGatewayConnectionFunc) {
 	t.Helper()
@@ -125,6 +125,7 @@ func testGatewayCertRenewal(t *testing.T, inst *helpers.TeleInstance, username, 
 	require.NoError(t, err)
 
 	daemonService, err := daemon.New(daemon.Config{
+		Clock:   fakeClock,
 		Storage: storage,
 		CreateTshdEventsClientCredsFunc: func() (grpc.DialOption, error) {
 			return grpc.WithTransportCredentials(insecure.NewCredentials()), nil
@@ -146,7 +147,7 @@ func testGatewayCertRenewal(t *testing.T, inst *helpers.TeleInstance, username, 
 	gateway, err := daemonService.CreateGateway(context.Background(), params)
 	require.NoError(t, err, trace.DebugReport(err))
 
-	testConnection(t, gateway)
+	testConnection(t, daemonService, gateway)
 
 	// Advance the fake clock to simulate the db cert expiry inside the middleware.
 	fakeClock.Advance(time.Hour * 48)
@@ -166,7 +167,7 @@ func testGatewayCertRenewal(t *testing.T, inst *helpers.TeleInstance, username, 
 	// and then it will attempt to reissue the user cert using an expired user cert.
 	// The mocked tshdEventsClient will issue a valid user cert, save it to disk, and the middleware
 	// will let the connection through.
-	testConnection(t, gateway)
+	testConnection(t, daemonService, gateway)
 
 	require.Equal(t, 1, tshdEventsService.callCounts["Relogin"],
 		"Unexpected number of calls to TSHDEventsClient.Relogin")
@@ -338,7 +339,7 @@ func testKubeGatewayCertRenewal(t *testing.T, suite *Suite, albAddr string, kube
 		teleportCluster = kubeURI.GetLeafClusterName()
 	}
 
-	testKubeConnection := func(t *testing.T, gw gateway.Gateway) {
+	testKubeConnection := func(t *testing.T, daemonService *daemon.Service, gw gateway.Gateway) {
 		t.Helper()
 
 		clientOnce.Do(func() {
@@ -346,7 +347,7 @@ func testKubeGatewayCertRenewal(t *testing.T, suite *Suite, albAddr string, kube
 			require.NoError(t, err)
 
 			kubeconfigPath := kubeGateway.KubeconfigPath()
-			checkKubeconfigPathInCommandEnv(t, gw, kubeconfigPath)
+			checkKubeconfigPathInCommandEnv(t, daemonService, gw, kubeconfigPath)
 
 			client = kubeClientForLocalProxy(t, kubeconfigPath, teleportCluster, kubeCluster)
 		})
@@ -366,10 +367,10 @@ func testKubeGatewayCertRenewal(t *testing.T, suite *Suite, albAddr string, kube
 	)
 }
 
-func checkKubeconfigPathInCommandEnv(t *testing.T, gw gateway.Gateway, wantKubeconfigPath string) {
+func checkKubeconfigPathInCommandEnv(t *testing.T, daemonService *daemon.Service, gw gateway.Gateway, wantKubeconfigPath string) {
 	t.Helper()
 
-	cmd, err := gw.CLICommand()
+	cmd, err := daemonService.GetGatewayCLICommand(gw)
 	require.NoError(t, err)
 	require.Equal(t, cmd.Env, []string{"KUBECONFIG=" + wantKubeconfigPath})
 }

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -599,6 +599,7 @@ func testCreatingAndDeletingConnectMyComputerToken(t *testing.T, pack *dbhelpers
 	require.NoError(t, err)
 
 	daemonService, err := daemon.New(daemon.Config{
+		Clock:          fakeClock,
 		Storage:        storage,
 		KubeconfigsDir: t.TempDir(),
 	})

--- a/lib/teleterm/apiserver/handler/handler_gateways.go
+++ b/lib/teleterm/apiserver/handler/handler_gateways.go
@@ -16,6 +16,9 @@ package handler
 
 import (
 	"context"
+	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -38,7 +41,7 @@ func (s *Handler) CreateGateway(ctx context.Context, req *api.CreateGatewayReque
 		return nil, trace.Wrap(err)
 	}
 
-	apiGateway, err := newAPIGateway(gateway)
+	apiGateway, err := s.newAPIGateway(gateway)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -52,7 +55,7 @@ func (s *Handler) ListGateways(ctx context.Context, req *api.ListGatewaysRequest
 
 	apiGws := make([]*api.Gateway, 0, len(gws))
 	for _, gw := range gws {
-		apiGateway, err := newAPIGateway(gw)
+		apiGateway, err := s.newAPIGateway(gw)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -74,8 +77,8 @@ func (s *Handler) RemoveGateway(ctx context.Context, req *api.RemoveGatewayReque
 	return &api.EmptyResponse{}, nil
 }
 
-func newAPIGateway(gateway gateway.Gateway) (*api.Gateway, error) {
-	command, err := gateway.CLICommand()
+func (s *Handler) newAPIGateway(gateway gateway.Gateway) (*api.Gateway, error) {
+	command, err := s.DaemonService.GetGatewayCLICommand(gateway)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -89,8 +92,22 @@ func newAPIGateway(gateway gateway.Gateway) (*api.Gateway, error) {
 		Protocol:              gateway.Protocol(),
 		LocalAddress:          gateway.LocalAddress(),
 		LocalPort:             gateway.LocalPort(),
-		GatewayCliCommand:     command,
+		GatewayCliCommand:     makeGatewayCLICommand(command),
 	}, nil
+}
+
+func makeGatewayCLICommand(cmd *exec.Cmd) *api.GatewayCLICommand {
+	cmdString := strings.TrimSpace(
+		fmt.Sprintf("%s %s",
+			strings.Join(cmd.Env, " "),
+			strings.Join(cmd.Args, " ")))
+
+	return &api.GatewayCLICommand{
+		Path:    cmd.Path,
+		Args:    cmd.Args,
+		Env:     cmd.Env,
+		Preview: cmdString,
+	}
 }
 
 // SetGatewayTargetSubresourceName changes the TargetSubresourceName field of gateway.Gateway
@@ -103,7 +120,7 @@ func (s *Handler) SetGatewayTargetSubresourceName(ctx context.Context, req *api.
 		return nil, trace.Wrap(err)
 	}
 
-	apiGateway, err := newAPIGateway(gateway)
+	apiGateway, err := s.newAPIGateway(gateway)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -118,7 +135,7 @@ func (s *Handler) SetGatewayLocalPort(ctx context.Context, req *api.SetGatewayLo
 		return nil, trace.Wrap(err)
 	}
 
-	apiGateway, err := newAPIGateway(gateway)
+	apiGateway, err := s.newAPIGateway(gateway)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/teleterm/apiserver/handler/handler_gateways_test.go
+++ b/lib/teleterm/apiserver/handler/handler_gateways_test.go
@@ -1,0 +1,50 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package handler
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
+)
+
+func Test_makeGatewayCLICommand(t *testing.T) {
+	absPath, err := filepath.Abs("test-binary")
+	require.NoError(t, err)
+
+	// Call exec.Command with a relative path so that cmd.Args[0] is a relative path.
+	// Then replace cmd.Path with an absolute path to simulate binary being resolved to
+	// an absolute path. This way we can later verify that gateway.CLICommand doesn't use the absolute
+	// path.
+	//
+	// This also ensures that exec.Command behaves the same way on different devices, no matter
+	// whether a command like postgres is installed on the system or not.
+	cmd := exec.Command("test-binary", "arg1", "arg2")
+	cmd.Path = absPath
+	cmd.Env = []string{"FOO=bar"}
+
+	command := makeGatewayCLICommand(cmd)
+
+	require.Equal(t, &api.GatewayCLICommand{
+		Path:    absPath,
+		Args:    []string{"test-binary", "arg1", "arg2"},
+		Env:     []string{"FOO=bar"},
+		Preview: "FOO=bar test-binary arg1 arg2",
+	}, command)
+}

--- a/lib/teleterm/clusters/cluster_gateways.go
+++ b/lib/teleterm/clusters/cluster_gateways.go
@@ -35,11 +35,10 @@ type CreateGatewayParams struct {
 	// name on a database server.
 	TargetSubresourceName string
 	// LocalPort is the gateway local port
-	LocalPort          string
-	CLICommandProvider gateway.CLICommandProvider
-	TCPPortAllocator   gateway.TCPPortAllocator
-	OnExpiredCert      gateway.OnExpiredCertFunc
-	KubeconfigsDir     string
+	LocalPort        string
+	TCPPortAllocator gateway.TCPPortAllocator
+	OnExpiredCert    gateway.OnExpiredCertFunc
+	KubeconfigsDir   string
 }
 
 // CreateGateway creates a gateway
@@ -86,7 +85,6 @@ func (c *Cluster) createDBGateway(ctx context.Context, params CreateGatewayParam
 		Insecure:                      c.clusterClient.InsecureSkipVerify,
 		WebProxyAddr:                  c.clusterClient.WebProxyAddr,
 		Log:                           c.Log,
-		CLICommandProvider:            params.CLICommandProvider,
 		TCPPortAllocator:              params.TCPPortAllocator,
 		OnExpiredCert:                 params.OnExpiredCert,
 		Clock:                         c.clock,
@@ -122,7 +120,6 @@ func (c *Cluster) createKubeGateway(ctx context.Context, params CreateGatewayPar
 		Insecure:                      c.clusterClient.InsecureSkipVerify,
 		WebProxyAddr:                  c.clusterClient.WebProxyAddr,
 		Log:                           c.Log,
-		CLICommandProvider:            params.CLICommandProvider,
 		TCPPortAllocator:              params.TCPPortAllocator,
 		OnExpiredCert:                 params.OnExpiredCert,
 		Clock:                         c.clock,

--- a/lib/teleterm/cmd/db_test.go
+++ b/lib/teleterm/cmd/db_test.go
@@ -17,20 +17,15 @@ package cmd
 import (
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"testing"
 
-	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
-	"github.com/gravitational/teleport/lib/teleterm/gatewaytest"
-	"github.com/gravitational/teleport/lib/tlsca"
 )
 
 type fakeExec struct{}
@@ -49,30 +44,6 @@ func (f fakeExec) Command(name string, arg ...string) *exec.Cmd {
 	return cmd
 }
 
-type fakeStorage struct {
-	clusters []*clusters.Cluster
-}
-
-func (f fakeStorage) GetByResourceURI(resourceURI uri.ResourceURI) (*clusters.Cluster, *client.TeleportClient, error) {
-	for _, cluster := range f.clusters {
-		if strings.HasPrefix(resourceURI.String(), cluster.URI.String()) {
-			siteName := ""
-			if cluster.URI.IsLeaf() {
-				siteName = cluster.Name
-			}
-			tc := &client.TeleportClient{
-				Config: client.Config{
-					SiteName: siteName,
-				},
-			}
-
-			return cluster, tc, nil
-		}
-	}
-
-	return nil, nil, trace.NotFound("not found")
-}
-
 type fakeDatabaseGateway struct {
 	gateway.Database
 	targetURI       uri.ResourceURI
@@ -89,7 +60,7 @@ func (m fakeDatabaseGateway) LocalAddress() string          { return "localhost"
 func (m fakeDatabaseGateway) LocalPortInt() int             { return 8888 }
 func (m fakeDatabaseGateway) LocalPort() string             { return "8888" }
 
-func TestDbcmdCLICommandProviderGetCommand(t *testing.T) {
+func TestNewDBCLICommand(t *testing.T) {
 	testCases := []struct {
 		name                  string
 		targetSubresourceName string
@@ -110,61 +81,17 @@ func TestDbcmdCLICommandProviderGetCommand(t *testing.T) {
 				URI:  uri.NewClusterURI("quux"),
 				Name: "quux",
 			}
-			fakeStorage := fakeStorage{
-				clusters: []*clusters.Cluster{&cluster},
-			}
 			mockGateway := fakeDatabaseGateway{
 				targetURI:       cluster.URI.AppendDB("foo"),
 				subresourceName: tc.targetSubresourceName,
 			}
 
-			dbcmdCLICommandProvider := NewDBCLICommandProvider(fakeStorage, fakeExec{})
-			command, err := dbcmdCLICommandProvider.GetCommand(mockGateway)
+			command, err := newDBCLICommandWithExecer(&cluster, mockGateway, fakeExec{})
 
 			require.NoError(t, err)
-			require.NotEmpty(t, command.Args)
+			require.Len(t, command.Args, 2)
 			require.Contains(t, command.Args[1], tc.targetSubresourceName)
 			require.Contains(t, command.Args[1], mockGateway.LocalPort())
 		})
 	}
-}
-
-func TestDbcmdCLICommandProviderGetCommand_ReturnsErrorIfClusterIsNotFound(t *testing.T) {
-	fakeStorage := fakeStorage{
-		clusters: []*clusters.Cluster{},
-	}
-	dbcmdCLICommandProvider := NewDBCLICommandProvider(fakeStorage, fakeExec{})
-
-	keyPairPaths := gatewaytest.MustGenAndSaveCert(t, tlsca.Identity{
-		Username: "alice",
-		Groups:   []string{"test-group"},
-		RouteToDatabase: tlsca.RouteToDatabase{
-			ServiceName: "foo",
-			Protocol:    defaults.ProtocolPostgres,
-			Username:    "alice",
-		},
-	})
-
-	gateway, err := gateway.New(
-		gateway.Config{
-			TargetURI:             uri.NewClusterURI("quux").AppendDB("foo"),
-			TargetName:            "foo",
-			TargetUser:            "alice",
-			TargetSubresourceName: "",
-			Protocol:              defaults.ProtocolPostgres,
-			LocalAddress:          "localhost",
-			WebProxyAddr:          "localhost:1337",
-			Insecure:              true,
-			CertPath:              keyPairPaths.CertPath,
-			KeyPath:               keyPairPaths.KeyPath,
-			CLICommandProvider:    dbcmdCLICommandProvider,
-			TCPPortAllocator:      gateway.NetTCPPortAllocator{},
-		},
-	)
-	require.NoError(t, err)
-	t.Cleanup(func() { gateway.Close() })
-
-	_, err = dbcmdCLICommandProvider.GetCommand(gateway)
-	require.Error(t, err)
-	require.True(t, trace.IsNotFound(err), "err is not trace.NotFound")
 }

--- a/lib/teleterm/cmd/kube.go
+++ b/lib/teleterm/cmd/kube.go
@@ -26,18 +26,8 @@ import (
 	"github.com/gravitational/teleport/lib/teleterm/gateway"
 )
 
-// KubeCLICommandProvider provides CLI commands for kube gateways.
-type KubeCLICommandProvider struct {
-}
-
-// NewKubeCLICommandProvider creates a new gateway.CLICommandBuilder for kube.
-func NewKubeCLICommandProvider() KubeCLICommandProvider {
-	return KubeCLICommandProvider{}
-}
-
-// GetCommand returns a exec.Cmd with KUBECONFIG environment variable that can
-// be used by kube clients to connect to the kube gateway.
-func (p KubeCLICommandProvider) GetCommand(g gateway.Gateway) (*exec.Cmd, error) {
+// NewKubeCLICommand creates CLI commands for kube gateways.
+func NewKubeCLICommand(g gateway.Gateway) (*exec.Cmd, error) {
 	kube, err := gateway.AsKube(g)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/teleterm/cmd/kube_test.go
+++ b/lib/teleterm/cmd/kube_test.go
@@ -30,8 +30,8 @@ type fakeKubeGateway struct {
 
 func (m fakeKubeGateway) KubeconfigPath() string { return "test.kubeconfig" }
 
-func TestKubeCLICommandProvider(t *testing.T) {
-	cmd, err := NewKubeCLICommandProvider().GetCommand(fakeKubeGateway{})
+func TestNewKubeCLICommand(t *testing.T) {
+	cmd, err := NewKubeCLICommand(fakeKubeGateway{})
 	require.NoError(t, err)
 	require.Equal(t, []string{"KUBECONFIG=test.kubeconfig"}, cmd.Env)
 }

--- a/lib/teleterm/daemon/config.go
+++ b/lib/teleterm/daemon/config.go
@@ -17,21 +17,35 @@ limitations under the License.
 package daemon
 
 import (
+	"context"
+
 	"github.com/gravitational/trace"
+	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 
-	"github.com/gravitational/teleport/lib/client/db/dbcmd"
+	"github.com/gravitational/teleport/lib/client"
+	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/teleterm/clusters"
-	"github.com/gravitational/teleport/lib/teleterm/cmd"
-	"github.com/gravitational/teleport/lib/teleterm/gateway"
 	"github.com/gravitational/teleport/lib/teleterm/services/connectmycomputer"
 )
 
+// Storage defines an interface for cluster profile storage.
+type Storage interface {
+	clusters.Resolver
+
+	ReadAll() ([]*clusters.Cluster, error)
+	Add(ctx context.Context, webProxyAddress string) (*clusters.Cluster, *client.TeleportClient, error)
+	Remove(ctx context.Context, profileName string) error
+	GetByResourceURI(resourceURI uri.ResourceURI) (*clusters.Cluster, *client.TeleportClient, error)
+}
+
 // Config is the cluster service config
 type Config struct {
+	// Clock is a clock for time-related operations
+	Clock clockwork.Clock
 	// Storage is a storage service that reads/writes to tsh profiles
-	Storage *clusters.Storage
+	Storage Storage
 	// Log is a component logger
 	Log *logrus.Entry
 	// PrehogAddr is the URL where prehog events should be submitted.
@@ -40,9 +54,7 @@ type Config struct {
 	// Acesss.
 	KubeconfigsDir string
 
-	GatewayCreator         GatewayCreator
-	DBCLICommandProvider   gateway.CLICommandProvider
-	KubeCLICommandProvider gateway.CLICommandProvider
+	GatewayCreator GatewayCreator
 	// CreateTshdEventsClientCredsFunc lazily creates creds for the tshd events server ran by the
 	// Electron app. This is to ensure that the server public key is written to the disk under the
 	// expected location by the time we get around to creating the client.
@@ -56,6 +68,10 @@ type CreateTshdEventsClientCredsFunc func() (grpc.DialOption, error)
 
 // CheckAndSetDefaults checks the configuration for its validity and sets default values if needed
 func (c *Config) CheckAndSetDefaults() error {
+	if c.Clock == nil {
+		c.Clock = clockwork.NewRealClock()
+	}
+
 	if c.Storage == nil {
 		return trace.BadParameter("missing cluster storage")
 	}
@@ -72,14 +88,6 @@ func (c *Config) CheckAndSetDefaults() error {
 		c.Log = logrus.NewEntry(logrus.StandardLogger()).WithField(trace.Component, "daemon")
 	}
 
-	if c.DBCLICommandProvider == nil {
-		c.DBCLICommandProvider = cmd.NewDBCLICommandProvider(c.Storage, dbcmd.SystemExecer{})
-	}
-
-	if c.KubeCLICommandProvider == nil {
-		c.KubeCLICommandProvider = cmd.NewKubeCLICommandProvider()
-	}
-
 	if c.ConnectMyComputerRoleSetup == nil {
 		roleSetup, err := connectmycomputer.NewRoleSetup(&connectmycomputer.RoleSetupConfig{})
 		if err != nil {
@@ -89,7 +97,7 @@ func (c *Config) CheckAndSetDefaults() error {
 	}
 
 	if c.ConnectMyComputerTokenProvisioner == nil {
-		c.ConnectMyComputerTokenProvisioner = connectmycomputer.NewTokenProvisioner(&connectmycomputer.TokenProvisionerConfig{Clock: c.Storage.Clock})
+		c.ConnectMyComputerTokenProvisioner = connectmycomputer.NewTokenProvisioner(&connectmycomputer.TokenProvisionerConfig{Clock: c.Clock})
 	}
 	return nil
 }

--- a/lib/teleterm/daemon/daemon_headless.go
+++ b/lib/teleterm/daemon/daemon_headless.go
@@ -101,7 +101,7 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 		Step:   maxBackoffDuration / 5,
 		Max:    maxBackoffDuration,
 		Jitter: retryutils.NewHalfJitter(),
-		Clock:  s.cfg.Storage.Clock,
+		Clock:  s.cfg.Clock,
 	})
 	if err != nil {
 		return trace.Wrap(err)
@@ -248,7 +248,7 @@ func (s *Service) startHeadlessWatcher(cluster *clusters.Cluster, waitInit bool)
 				return
 			}
 
-			startedWaiting := s.cfg.Storage.Clock.Now()
+			startedWaiting := s.cfg.Clock.Now()
 			select {
 			case t := <-retry.After():
 				log.WithError(err).Debugf("Restarting watch on error after waiting %v.", t.Sub(startedWaiting))

--- a/lib/teleterm/gateway/base.go
+++ b/lib/teleterm/gateway/base.go
@@ -21,15 +21,12 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
-	"os/exec"
 	"strconv"
-	"strings"
 
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
 	"github.com/gravitational/teleport/api/utils/keys"
-	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	alpn "github.com/gravitational/teleport/lib/srv/alpnproxy"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/tlsca"
@@ -187,29 +184,6 @@ func (b *base) LocalPortInt() int {
 	return port
 }
 
-// CLICommand returns a command which launches a CLI client pointed at the gateway.
-func (b *base) CLICommand() (*api.GatewayCLICommand, error) {
-	cmd, err := b.cfg.CLICommandProvider.GetCommand(b)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return makeCLICommand(cmd), nil
-}
-
-func makeCLICommand(cmd *exec.Cmd) *api.GatewayCLICommand {
-	cmdString := strings.TrimSpace(
-		fmt.Sprintf("%s %s",
-			strings.Join(cmd.Env, " "),
-			strings.Join(cmd.Args, " ")))
-
-	return &api.GatewayCLICommand{
-		Path:    cmd.Path,
-		Args:    cmd.Args,
-		Env:     cmd.Env,
-		Preview: cmdString,
-	}
-}
-
 // ReloadCert loads the key pair from cfg.CertPath & cfg.KeyPath and updates the cert of the running
 // local proxy. This is typically done after the cert is reissued and saved to disk.
 //
@@ -273,11 +247,6 @@ type base struct {
 	// that the local proxy is now closed and to release any resources.
 	closeContext context.Context
 	closeCancel  context.CancelFunc
-}
-
-// CLICommandProvider provides a CLI command for gateways which support CLI clients.
-type CLICommandProvider interface {
-	GetCommand(gateway Gateway) (*exec.Cmd, error)
 }
 
 type TCPPortAllocator interface {

--- a/lib/teleterm/gateway/config.go
+++ b/lib/teleterm/gateway/config.go
@@ -73,8 +73,6 @@ type Config struct {
 	WebProxyAddr string
 	// Log is a component logger
 	Log *logrus.Entry
-	// CLICommandProvider returns a CLI command for the gateway
-	CLICommandProvider CLICommandProvider
 	// TCPPortAllocator creates listeners on the given ports. This interface lets us avoid occupying
 	// hardcoded ports in tests.
 	TCPPortAllocator TCPPortAllocator
@@ -129,10 +127,6 @@ func (c *Config) CheckAndSetDefaults() error {
 
 	if c.TargetURI.String() == "" {
 		return trace.BadParameter("missing target URI")
-	}
-
-	if c.CLICommandProvider == nil {
-		return trace.BadParameter("missing CLICommandProvider")
 	}
 
 	if c.TCPPortAllocator == nil {

--- a/lib/teleterm/gateway/interfaces.go
+++ b/lib/teleterm/gateway/interfaces.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/sirupsen/logrus"
 
-	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/teleterm/api/uri"
 	"github.com/gravitational/teleport/lib/tlsca"
 )
@@ -35,8 +34,6 @@ type Gateway interface {
 	// ReloadCert loads the key pair from cfg.CertPath & cfg.KeyPath and
 	// updates the cert of the running local proxy.
 	ReloadCert() error
-	// CLICommand returns a command which launches a CLI client pointed at the gateway.
-	CLICommand() (*api.GatewayCLICommand, error)
 
 	URI() uri.ResourceURI
 	TargetURI() uri.ResourceURI

--- a/lib/teleterm/gateway/kube.go
+++ b/lib/teleterm/gateway/kube.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/gravitational/teleport/api/utils/keypaths"
 	"github.com/gravitational/teleport/api/utils/keys"
-	api "github.com/gravitational/teleport/gen/proto/go/teleport/lib/teleterm/v1"
 	"github.com/gravitational/teleport/lib/auth/native"
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/kube/kubeconfig"
@@ -205,16 +204,4 @@ func (k *kube) writeKubeconfig(key *keys.PrivateKey, cas map[string]tls.Certific
 		return trace.Wrap(utils.RemoveFileIfExist(k.KubeconfigPath()))
 	})
 	return nil
-}
-
-func (k *kube) CLICommand() (*api.GatewayCLICommand, error) {
-	// TODO(greedy52) currently kube must implement CLICommand in order to pass
-	// Kube to CLICommandProvider. We should revisit gateway design/flows like
-	// this. For example, one alternative is to move gateway.CLICommand to
-	// daemon.GatewayCLICommand as daemon owns all CLICommandProvider.
-	cmd, err := k.cfg.CLICommandProvider.GetCommand(k)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return makeCLICommand(cmd), nil
 }

--- a/lib/teleterm/gateway/kube_test.go
+++ b/lib/teleterm/gateway/kube_test.go
@@ -67,16 +67,15 @@ func TestKubeGateway(t *testing.T) {
 	proxy := mustStartMockProxyWithKubeAPI(t, identity)
 	gateway, err := New(
 		Config{
-			Clock:              clock,
-			TargetName:         kubeClusterName,
-			TargetURI:          uri.NewClusterURI(teleportClusterName).AppendKube(kubeClusterName),
-			CertPath:           proxy.clientCertPath(),
-			KeyPath:            proxy.clientKeyPath(),
-			WebProxyAddr:       proxy.webProxyAddr,
-			ClusterName:        teleportClusterName,
-			CLICommandProvider: mockCLICommandProvider{},
-			Username:           identity.Username,
-			KubeconfigsDir:     t.TempDir(),
+			Clock:          clock,
+			TargetName:     kubeClusterName,
+			TargetURI:      uri.NewClusterURI(teleportClusterName).AppendKube(kubeClusterName),
+			CertPath:       proxy.clientCertPath(),
+			KeyPath:        proxy.clientKeyPath(),
+			WebProxyAddr:   proxy.webProxyAddr,
+			ClusterName:    teleportClusterName,
+			Username:       identity.Username,
+			KubeconfigsDir: t.TempDir(),
 			RootClusterCACertPoolFunc: func(_ context.Context) (*x509.CertPool, error) {
 				return proxy.certPool(), nil
 			},


### PR DESCRIPTION
This is an attempt to refactor gateway CLI command is handled on the golang side. 

High-level changes:
- Moved `gateway.CLICommand()` to `daemon.GetGatewayCLICommand(gateway)`
- Moved `exec.Cmd`->`api.GatewayCLICommand` conversion to `teleterm/apiserver/handler`
- Removed `CLICommandProvider` interface, daemon now creates the `exec.Cmd` directly

Personally, I like this new version better as it reduces dependency but love to know your thoughts. I can drop this if we prefer the current implementation.