### PR TITLE
docs: include sudo for db configure create examples

### DIFF
--- a/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
+++ b/docs/pages/database-access/guides/aws-cassandra-keyspaces.mdx
@@ -51,7 +51,8 @@ Create a configuration for the Teleport Database Service, pointing the
 `--proxy` flag to the address of your Teleport Proxy Service:
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
+   -o file \
   --token=/tmp/token \
   --proxy=teleport.example.com:443 \
   --name=keyspaces \
@@ -68,7 +69,8 @@ Create a configuration for the Teleport Database Service, pointing the
 `--proxy` flag to the address of your Teleport Proxy Service:
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
+   -o file \
   --token=/tmp/token \
   --proxy=mytenant.teleport.sh:443 \
   --name=keyspaces \

--- a/docs/pages/database-access/guides/aws-opensearch.mdx
+++ b/docs/pages/database-access/guides/aws-opensearch.mdx
@@ -204,7 +204,7 @@ your terminal, and manually adjust `/etc/teleport.yaml`.
 Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
    --proxy=<Var name="proxy-address" /> \

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -56,7 +56,7 @@ Create the Database Service configuration.
   URI (e.g. `mytenant.teleport.sh:443`):
 
   ```code
-  $ teleport db configure create \
+  $ sudo teleport db configure create \
     -o file \
     --proxy=teleport.example.com:443 \
     --token=/tmp/token \
@@ -72,7 +72,7 @@ Create the Database Service configuration.
   URI (e.g. `mytenant.teleport.sh:443`):
 
   ```code
-  $ teleport db configure create \
+  $ sudo teleport db configure create \
     -o file \
     --proxy=teleport.example.com:443 \
     --token=/tmp/token \
@@ -86,7 +86,7 @@ Create the Database Service configuration.
 Run the following command on your Database Service host:
 
   ```code
-  $ teleport db configure create \
+  $ sudo teleport db configure create \
     -o file \
     --proxy=teleport.example.com:443 \
     --token=/tmp/token \

--- a/docs/pages/database-access/guides/azure-redis.mdx
+++ b/docs/pages/database-access/guides/azure-redis.mdx
@@ -45,7 +45,7 @@ Create the Database Service configuration, specifying a region like this:
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
   -o file \
   --proxy=tele.example.com:443 \
   --token=/tmp/token \
@@ -55,7 +55,7 @@ $ teleport db configure create \
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
   -o file \
   --proxy=teleport.example.com:3080 \
   --token=/tmp/token \

--- a/docs/pages/database-access/guides/azure-sql-server-ad.mdx
+++ b/docs/pages/database-access/guides/azure-sql-server-ad.mdx
@@ -189,7 +189,7 @@ Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
    --proxy=teleport.example.com \
@@ -199,7 +199,7 @@ $ teleport db configure create \
 </TabItem>
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
    --proxy=mytenant.teleport.sh:443 \

--- a/docs/pages/database-access/guides/postgres-redshift.mdx
+++ b/docs/pages/database-access/guides/postgres-redshift.mdx
@@ -47,7 +47,7 @@ On the node that is running the Database Service, create a configuration file:
 <TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --proxy=teleport.example.com:3080 \
    --token=/tmp/token \
@@ -58,7 +58,7 @@ $ teleport db configure create \
 <TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --proxy=mytenant.teleport.sh:443 \
    --token=/tmp/token \

--- a/docs/pages/database-access/guides/rds-proxy.mdx
+++ b/docs/pages/database-access/guides/rds-proxy.mdx
@@ -47,7 +47,7 @@ your Teleport Proxy address or Teleport Cloud tenant (e.g. `mytenant.teleport.sh
 and replace <Var name="us-west-1" /> with your preferred region:
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --proxy=<Var name="teleport.example.com"/>:443 \
    --token=/tmp/token \

--- a/docs/pages/database-access/guides/rds.mdx
+++ b/docs/pages/database-access/guides/rds.mdx
@@ -141,7 +141,7 @@ the region associated with the RDS databases you would like Teleport to
 discover.
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --proxy=<Var name="example.teleport.sh:443" />  \
    --token=/tmp/token \

--- a/docs/pages/database-access/guides/redis-aws.mdx
+++ b/docs/pages/database-access/guides/redis-aws.mdx
@@ -49,7 +49,7 @@ Create the Database Service configuration:
 <Tabs>
   <TabItem label="ElastiCache">
   ```code
-  $ teleport db configure create \
+  $ sudo teleport db configure create \
      -o file \
      --proxy=teleport.example.com:3080 \
      --token=/tmp/token \
@@ -58,7 +58,7 @@ Create the Database Service configuration:
   </TabItem>
   <TabItem label="MemoryDB">
   ```code
-  $ teleport db configure create \
+  $ sudo teleport db configure create \
      -o file \
      --proxy=teleport.example.com:3080 \
      --token=/tmp/token \
@@ -73,7 +73,7 @@ Create the Database Service configuration:
 <Tabs>
   <TabItem label="ElastiCache">
   ```code
-  $ teleport db configure create \
+  $ sudo teleport db configure create \
      -o file \
      --proxy=mytenant.teleport.sh:443 \
      --token=/tmp/token \
@@ -82,7 +82,7 @@ Create the Database Service configuration:
   </TabItem>
   <TabItem label="MemoryDB">
   ```
-  $ teleport db configure create \
+  $ sudo teleport db configure create \
      -o file \
      --proxy=mytenant.teleport.sh:443 \
      --token=/tmp/token \

--- a/docs/pages/database-access/guides/redshift-serverless.mdx
+++ b/docs/pages/database-access/guides/redshift-serverless.mdx
@@ -203,7 +203,7 @@ Install Teleport on the host where you will run the Teleport Database Service:
 On the same host, create a Teleport configuration file:
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --proxy=teleport.example.com:443 \
    --token=/tmp/token \


### PR DESCRIPTION
`sudo` was not consistently used for the `db configure create` examples.  Unless the user is `root` it will fail.