### PR TITLE
Ensure access list data integrity.

### DIFF
--- a/api/client/accesslist/accesslist.go
+++ b/api/client/accesslist/accesslist.go
@@ -113,8 +113,7 @@ func (c *Client) DeleteAccessList(ctx context.Context, name string) error {
 
 // DeleteAllAccessLists removes all access lists.
 func (c *Client) DeleteAllAccessLists(ctx context.Context) error {
-	_, err := c.grpcClient.DeleteAllAccessLists(ctx, &accesslistv1.DeleteAllAccessListsRequest{})
-	return trace.Wrap(err)
+	return trace.NotImplemented("DeleteAllAccessLists not supported in the gRPC client")
 }
 
 // ListAccessListMembers returns a paginated list of all access list members for an access list.
@@ -185,6 +184,5 @@ func (c *Client) DeleteAllAccessListMembersForAccessList(ctx context.Context, ac
 
 // DeleteAllAccessListMembers hard deletes all access list members.
 func (c *Client) DeleteAllAccessListMembers(ctx context.Context) error {
-	_, err := c.grpcClient.DeleteAllAccessListMembers(ctx, &accesslistv1.DeleteAllAccessListMembersRequest{})
-	return trace.Wrap(err)
+	return trace.NotImplemented("DeleteAllAccessListMembers is not supported in the gRPC client")
 }

--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"time"
 
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
@@ -36,6 +37,10 @@ const (
 
 	accessListMemberPrefix      = "access_list_member"
 	accessListMemberMaxPageSize = 200
+
+	// This lock is necessary to prevent a race condition between access lists and members and to ensure
+	// consistency of the one-to-many relationship between them.
+	accessListLockTTL = 5 * time.Second
 )
 
 // AccessListService manages Access List resources in the Backend.
@@ -93,13 +98,21 @@ func (a *AccessListService) ListAccessLists(ctx context.Context, pageSize int, n
 
 // GetAccessList returns the specified access list resource.
 func (a *AccessListService) GetAccessList(ctx context.Context, name string) (*accesslist.AccessList, error) {
-	accessList, err := a.service.GetResource(ctx, name)
+	var accessList *accesslist.AccessList
+	err := a.service.RunWhileLocked(ctx, lockName(name), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		var err error
+		accessList, err = a.service.GetResource(ctx, name)
+		return trace.Wrap(err)
+	})
 	return accessList, trace.Wrap(err)
 }
 
 // UpsertAccessList creates or updates an access list resource.
 func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *accesslist.AccessList) (*accesslist.AccessList, error) {
-	if err := a.service.UpsertResource(ctx, accessList); err != nil {
+	err := a.service.RunWhileLocked(ctx, lockName(accessList.GetName()), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		return trace.Wrap(a.service.UpsertResource(ctx, accessList))
+	})
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return accessList, nil
@@ -107,19 +120,24 @@ func (a *AccessListService) UpsertAccessList(ctx context.Context, accessList *ac
 
 // DeleteAccessList removes the specified access list resource.
 func (a *AccessListService) DeleteAccessList(ctx context.Context, name string) error {
-	// Delete all associated members.
-	err := a.DeleteAllAccessListMembersForAccessList(ctx, name)
-	if err != nil {
-		return trace.Wrap(err)
-	}
+	err := a.service.RunWhileLocked(ctx, lockName(name), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		// Delete all associated members.
+		err := a.memberService.WithPrefix(name).DeleteAllResources(ctx)
+		if err != nil {
+			return trace.Wrap(err)
+		}
 
-	return trace.Wrap(a.service.DeleteResource(ctx, name))
+		return trace.Wrap(a.service.DeleteResource(ctx, name))
+	})
+
+	return trace.Wrap(err)
 }
 
 // DeleteAllAccessLists removes all access lists.
 func (a *AccessListService) DeleteAllAccessLists(ctx context.Context) error {
+	// Locks are not used here as these operations are more likely to be used by the cache.
 	// Delete all members for all access lists.
-	err := a.DeleteAllAccessListMembers(ctx)
+	err := a.memberService.DeleteAllResources(ctx)
 	if err != nil {
 		return trace.Wrap(err)
 	}
@@ -129,18 +147,45 @@ func (a *AccessListService) DeleteAllAccessLists(ctx context.Context) error {
 
 // ListAccessListMembers returns a paginated list of all access list members.
 func (a *AccessListService) ListAccessListMembers(ctx context.Context, accessList string, pageSize int, nextToken string) ([]*accesslist.AccessListMember, string, error) {
-	return a.memberService.WithPrefix(accessList).ListResources(ctx, pageSize, nextToken)
+	var members []*accesslist.AccessListMember
+	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		_, err := a.service.GetResource(ctx, accessList)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		members, nextToken, err = a.memberService.WithPrefix(accessList).ListResources(ctx, pageSize, nextToken)
+		return trace.Wrap(err)
+	})
+	if err != nil {
+		return nil, "", trace.Wrap(err)
+	}
+	return members, nextToken, nil
 }
 
 // GetAccessListMember returns the specified access list member resource.
 func (a *AccessListService) GetAccessListMember(ctx context.Context, accessList string, memberName string) (*accesslist.AccessListMember, error) {
-	member, err := a.memberService.WithPrefix(accessList).GetResource(ctx, memberName)
+	var member *accesslist.AccessListMember
+	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		_, err := a.service.GetResource(ctx, accessList)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		member, err = a.memberService.WithPrefix(accessList).GetResource(ctx, memberName)
+		return trace.Wrap(err)
+	})
 	return member, trace.Wrap(err)
 }
 
 // UpsertAccessListMember creates or updates an access list member resource.
 func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *accesslist.AccessListMember) (*accesslist.AccessListMember, error) {
-	if err := trace.Wrap(a.memberService.WithPrefix(member.Spec.AccessList).UpsertResource(ctx, member)); err != nil {
+	err := a.service.RunWhileLocked(ctx, lockName(member.Spec.AccessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		_, err := a.service.GetResource(ctx, member.Spec.AccessList)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return trace.Wrap(a.memberService.WithPrefix(member.Spec.AccessList).UpsertResource(ctx, member))
+	})
+	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 	return member, nil
@@ -148,15 +193,35 @@ func (a *AccessListService) UpsertAccessListMember(ctx context.Context, member *
 
 // DeleteAccessListMember hard deletes the specified access list member resource.
 func (a *AccessListService) DeleteAccessListMember(ctx context.Context, accessList string, memberName string) error {
-	return trace.Wrap(a.memberService.WithPrefix(accessList).DeleteResource(ctx, memberName))
+	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		_, err := a.service.GetResource(ctx, accessList)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return trace.Wrap(a.memberService.WithPrefix(accessList).DeleteResource(ctx, memberName))
+	})
+	return trace.Wrap(err)
 }
 
 // DeleteAllAccessListMembersForAccessList hard deletes all access list members for an access list.
 func (a *AccessListService) DeleteAllAccessListMembersForAccessList(ctx context.Context, accessList string) error {
-	return trace.Wrap(a.memberService.WithPrefix(accessList).DeleteAllResources(ctx))
+	err := a.service.RunWhileLocked(ctx, lockName(accessList), accessListLockTTL, func(ctx context.Context, _ backend.Backend) error {
+		_, err := a.service.GetResource(ctx, accessList)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		return trace.Wrap(a.memberService.WithPrefix(accessList).DeleteAllResources(ctx))
+	})
+	return trace.Wrap(err)
 }
 
 // DeleteAllAccessListMembers hard deletes all access list members.
 func (a *AccessListService) DeleteAllAccessListMembers(ctx context.Context) error {
+
+	// Locks are not used here as this operation is more likely to be used by the cache.
 	return trace.Wrap(a.memberService.DeleteAllResources(ctx))
+}
+
+func lockName(accessListName string) string {
+	return string(backend.Key("access_list", accessListName))
 }

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -163,6 +163,10 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, members)
 
+	// Listing members of a non existent list should produce an error.
+	_, _, err = service.ListAccessListMembers(ctx, "non-existent", 0, "")
+	require.ErrorIs(t, err, trace.NotFound("access_list \"non-existent\" doesn't exist"))
+
 	// Verify access list members are not present.
 	accessList1Member1 := newAccessListMember(t, accessList1.GetName(), "alice")
 	accessList1Member2 := newAccessListMember(t, accessList1.GetName(), "bob")
@@ -186,6 +190,10 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	member, err = service.GetAccessListMember(ctx, accessList1.GetName(), accessList1Member2.GetName())
 	require.NoError(t, err)
 	require.Empty(t, cmp.Diff(accessList1Member2, member, cmpOpts...))
+
+	// Add access list member for non existent list should produce an error.
+	_, err = service.UpsertAccessListMember(ctx, newAccessListMember(t, "non-existent-list", "nobody"))
+	require.ErrorIs(t, err, trace.NotFound("access_list \"non-existent-list\" doesn't exist"))
 
 	accessList2Member1 := newAccessListMember(t, accessList2.GetName(), "bob")
 	accessList2Member2 := newAccessListMember(t, accessList2.GetName(), "jim")
@@ -220,14 +228,18 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	_, err = service.GetAccessListMember(ctx, accessList2.GetName(), accessList2Member1.GetName())
 	require.True(t, trace.IsNotFound(err))
 
+	// Delete from a non-existent access list should return an error.
+	err = service.DeleteAccessListMember(ctx, "non-existent-list", "nobody")
+	require.ErrorIs(t, err, trace.NotFound("access_list \"non-existent-list\" doesn't exist"))
+
 	// Delete an access list.
 	err = service.DeleteAccessList(ctx, accessList1.GetName())
 	require.NoError(t, err)
 
 	// Verify that the access list's members have been removed and that the other has not been affected.
-	members, _, err = service.ListAccessListMembers(ctx, accessList1.GetName(), 0, "")
-	require.NoError(t, err)
-	require.Empty(t, members)
+	_, _, err = service.ListAccessListMembers(ctx, accessList1.GetName(), 0, "")
+	require.True(t, trace.IsNotFound(err), "missing access list should produce not found error during list")
+	require.ErrorIs(t, err, trace.NotFound("access_list %q doesn't exist", accessList1.GetName()))
 
 	members, _, err = service.ListAccessListMembers(ctx, accessList2.GetName(), 0, "")
 	require.NoError(t, err)
@@ -236,6 +248,11 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	// Re-add access list 1 with its members.
 	_, err = service.UpsertAccessList(ctx, accessList1)
 	require.NoError(t, err)
+
+	// Verify that the members were previously removed.
+	members, _, err = service.ListAccessListMembers(ctx, accessList1.GetName(), 0, "")
+	require.NoError(t, err)
+	require.Empty(t, members)
 
 	_, err = service.UpsertAccessListMember(ctx, accessList1Member1)
 	require.NoError(t, err)
@@ -249,6 +266,10 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, members)
 
+	// Try to delete all members from a non-existent list.
+	err = service.DeleteAllAccessListMembersForAccessList(ctx, "non-existent-list")
+	require.ErrorIs(t, err, trace.NotFound("access_list \"non-existent-list\" doesn't exist"))
+
 	members, _, err = service.ListAccessListMembers(ctx, accessList2.GetName(), 0, "")
 	require.NoError(t, err)
 	require.NotEmpty(t, members)
@@ -261,14 +282,12 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	err = service.DeleteAllAccessLists(ctx)
 	require.NoError(t, err)
 
-	// Verify all members are gone.
-	members, _, err = service.ListAccessListMembers(ctx, accessList1.GetName(), 0, "")
-	require.NoError(t, err)
-	require.Empty(t, members)
+	// Verify that access lists are gone.
+	_, _, err = service.ListAccessListMembers(ctx, accessList1.GetName(), 0, "")
+	require.ErrorIs(t, err, trace.NotFound("access_list %q doesn't exist", accessList1.GetName()))
 
-	members, _, err = service.ListAccessListMembers(ctx, accessList2.GetName(), 0, "")
-	require.NoError(t, err)
-	require.Empty(t, members)
+	_, _, err = service.ListAccessListMembers(ctx, accessList2.GetName(), 0, "")
+	require.ErrorIs(t, err, trace.NotFound("access_list %q doesn't exist", accessList2.GetName()))
 }
 
 func newAccessList(t *testing.T, name string) *accesslist.AccessList {


### PR DESCRIPTION
This commit adds locking to the access list service. The concern here is that, without this locking and the additional logic here, it's possible to add members to access lists that don't exist. Furthermore, if a user then creates an access list with the same name as the access list being used for creating these members, then the access list will have members added to it.

The locks and logic here should ensure that members are only added to lists that exist and that users are properly cleaned up after removing a list without the possibility of orphaned members.