### PR TITLE
skip motd in UI if request initiated from tsh headless auth

### DIFF
--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -114,64 +114,66 @@ test('login with private key policy enabled through role setting', async () => {
   expect(screen.getByText(/login disabled/i)).toBeInTheDocument();
 });
 
-test('show motd only if motd is set', async () => {
-  // default login form
-  const { unmount } = render(<Login />);
-  expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
-  expect(
-    screen.queryByText('Welcome to cluster, your activity will be recorded.')
-  ).not.toBeInTheDocument();
-  unmount();
+describe('test MOTD', () => {
+  test('show motd only if motd is set', async () => {
+    // default login form
+    const { unmount } = render(<Login />);
+    expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText('Welcome to cluster, your activity will be recorded.')
+    ).not.toBeInTheDocument();
+    unmount();
 
-  // now set motd
-  jest
-    .spyOn(cfg, 'getMotd')
-    .mockImplementation(
-      () => 'Welcome to cluster, your activity will be recorded.'
-    );
+    // now set motd
+    jest
+      .spyOn(cfg, 'getMotd')
+      .mockImplementation(
+        () => 'Welcome to cluster, your activity will be recorded.'
+      );
 
-  render(<Login />);
+    render(<Login />);
 
-  expect(
-    screen.getByText('Welcome to cluster, your activity will be recorded.')
-  ).toBeInTheDocument();
-  expect(screen.queryByPlaceholderText(/username/i)).not.toBeInTheDocument();
-});
-
-test('show login form after modt acknowledge', async () => {
-  jest
-    .spyOn(cfg, 'getMotd')
-    .mockImplementation(
-      () => 'Welcome to cluster, your activity will be recorded.'
-    );
-  render(<Login />);
-  expect(
-    screen.getByText('Welcome to cluster, your activity will be recorded.')
-  ).toBeInTheDocument();
-
-  fireEvent.click(screen.getByText('Acknowledge'));
-  expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
-});
-
-test('skip motd if login initiated from headless auth', async () => {
-  // set global window.location with redirect url.
-  global.window = Object.create(window);
-  const url =
-    'https://teleport.example.com/web/login?redirect_uri=https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a';
-  Object.defineProperty(window, 'location', {
-    value: {
-      href: url,
-    },
+    expect(
+      screen.getByText('Welcome to cluster, your activity will be recorded.')
+    ).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/username/i)).not.toBeInTheDocument();
   });
 
-  jest
-    .spyOn(cfg, 'getMotd')
-    .mockImplementation(
-      () => 'Welcome to cluster, your activity will be recorded.'
-    );
-  render(<Login />);
+  test('show login form after modt acknowledge', async () => {
+    jest
+      .spyOn(cfg, 'getMotd')
+      .mockImplementation(
+        () => 'Welcome to cluster, your activity will be recorded.'
+      );
+    render(<Login />);
+    expect(
+      screen.getByText('Welcome to cluster, your activity will be recorded.')
+    ).toBeInTheDocument();
 
-  expect(
-    screen.queryByText('Welcome to cluster, your activity will be recorded.')
-  ).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Acknowledge'));
+    expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
+  });
+
+  test('skip motd if login initiated from headless auth', async () => {
+    // set global window.location with redirect url.
+    global.window = Object.create(window);
+    const url =
+      'https://teleport.example.com/web/login?redirect_uri=https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a';
+    Object.defineProperty(window, 'location', {
+      value: {
+        href: url,
+      },
+    });
+
+    jest
+      .spyOn(cfg, 'getMotd')
+      .mockImplementation(
+        () => 'Welcome to cluster, your activity will be recorded.'
+      );
+    render(<Login />);
+
+    expect(
+      screen.queryByText('Welcome to cluster, your activity will be recorded.')
+    ).not.toBeInTheDocument();
+  });
 });

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -15,7 +15,6 @@
  */
 
 import React from 'react';
-import { MemoryRouter, Route } from 'react-router';
 import { render, fireEvent, screen, waitFor } from 'design/utils/testing';
 import { privateKeyEnablingPolicies } from 'shared/services/consts';
 
@@ -161,16 +160,13 @@ describe('test MOTD', () => {
       .mockImplementation(
         () => 'Welcome to cluster, your activity will be recorded.'
       );
+    jest
+      .spyOn(history, 'getRedirectParam')
+      .mockReturnValue(
+        'https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a'
+      );
 
-    const url =
-      'https://teleport.example.com/web/login?redirect_uri=https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a';
-    render(
-      <MemoryRouter>
-        <Route path={url}>
-          <Login />
-        </Route>
-      </MemoryRouter>
-    );
+    render(<Login />);
 
     expect(
       screen.queryByText('Welcome to cluster, your activity will be recorded.')

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -15,6 +15,7 @@
  */
 
 import React from 'react';
+import { MemoryRouter, Route } from 'react-router';
 import { render, fireEvent, screen, waitFor } from 'design/utils/testing';
 import { privateKeyEnablingPolicies } from 'shared/services/consts';
 
@@ -155,22 +156,21 @@ describe('test MOTD', () => {
   });
 
   test('skip motd if login initiated from headless auth', async () => {
-    // set global window.location with redirect url.
-    global.window = Object.create(window);
-    const url =
-      'https://teleport.example.com/web/login?redirect_uri=https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a';
-    Object.defineProperty(window, 'location', {
-      value: {
-        href: url,
-      },
-    });
-
     jest
       .spyOn(cfg, 'getMotd')
       .mockImplementation(
         () => 'Welcome to cluster, your activity will be recorded.'
       );
-    render(<Login />);
+
+    const url =
+      'https://teleport.example.com/web/login?redirect_uri=https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a';
+    render(
+      <MemoryRouter>
+        <Route path={url}>
+          <Login />
+        </Route>
+      </MemoryRouter>
+    );
 
     expect(
       screen.queryByText('Welcome to cluster, your activity will be recorded.')

--- a/web/packages/teleport/src/Login/Login.test.tsx
+++ b/web/packages/teleport/src/Login/Login.test.tsx
@@ -152,3 +152,26 @@ test('show login form after modt acknowledge', async () => {
   fireEvent.click(screen.getByText('Acknowledge'));
   expect(screen.getByPlaceholderText(/username/i)).toBeInTheDocument();
 });
+
+test('skip motd if login initiated from headless auth', async () => {
+  // set global window.location with redirect url.
+  global.window = Object.create(window);
+  const url =
+    'https://teleport.example.com/web/login?redirect_uri=https://teleport.example.com/web/headless/5c5c1f73-ac5c-52ee-bc9e-0353094dcb4a';
+  Object.defineProperty(window, 'location', {
+    value: {
+      href: url,
+    },
+  });
+
+  jest
+    .spyOn(cfg, 'getMotd')
+    .mockImplementation(
+      () => 'Welcome to cluster, your activity will be recorded.'
+    );
+  render(<Login />);
+
+  expect(
+    screen.queryByText('Welcome to cluster, your activity will be recorded.')
+  ).not.toBeInTheDocument();
+});

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -44,11 +44,8 @@ export default function useLogin() {
 
     if (redirectUri?.includes('headless')) {
       return false;
-    } else if (cfg.getMotd()) {
-      return true;
-    } else {
-      return false;
     }
+    return !!cfg.getMotd();
   });
 
   function acknowledgeMotd() {

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -39,7 +39,16 @@ export default function useLogin() {
   const auth2faType = cfg.getAuth2faType();
   const isLocalAuthEnabled = cfg.getLocalAuthFlag();
   const motd = cfg.getMotd();
-  const [showMotd, setShowMotd] = useState(!!motd);
+  const [showMotd, setShowMotd] = useState(() => {
+    const url = new URL(window.location.href);
+    const redirect_uri = url.searchParams.get('redirect_uri');
+
+    if (redirect_uri?.includes('headless')) {
+      return false;
+    } else if (cfg.getMotd()) {
+      return true;
+    }
+  });
 
   function acknowledgeMotd() {
     setShowMotd(false);

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -39,14 +39,16 @@ export default function useLogin() {
   const auth2faType = cfg.getAuth2faType();
   const isLocalAuthEnabled = cfg.getLocalAuthFlag();
   const motd = cfg.getMotd();
-  const [showMotd, setShowMotd] = useState(() => {
+  const [showMotd, setShowMotd] = useState<boolean>(() => {
     const url = new URL(window.location.href);
-    const redirect_uri = url.searchParams.get('redirect_uri');
+    const redirectUri = url.searchParams.get('redirect_uri');
 
-    if (redirect_uri?.includes('headless')) {
+    if (redirectUri?.includes('headless')) {
       return false;
     } else if (cfg.getMotd()) {
       return true;
+    } else {
+      return false;
     }
   });
 

--- a/web/packages/teleport/src/Login/useLogin.ts
+++ b/web/packages/teleport/src/Login/useLogin.ts
@@ -40,8 +40,7 @@ export default function useLogin() {
   const isLocalAuthEnabled = cfg.getLocalAuthFlag();
   const motd = cfg.getMotd();
   const [showMotd, setShowMotd] = useState<boolean>(() => {
-    const url = new URL(window.location.href);
-    const redirectUri = url.searchParams.get('redirect_uri');
+    const redirectUri = history.getRedirectParam();
 
     if (redirectUri?.includes('headless')) {
       return false;


### PR DESCRIPTION
When login in Web UI is initiated for headless auth, for example with authentication link generated by `tsh --headless` command: 
```
Complete headless authentication in your local web browser:

https://<proxy>/web/headless/c7bd5f24-d487-5dd4-b30e-371a80bd5993
```
opening the link in browser redirects to login page with the following redirect format:
`https://<proxy>/web/login?redirect_uri=https://<proxy>/web/headless/c7bd5f24-d487-5dd4-b30e-371a80bd5993`

To disable MOTD when auth is initiated from headless auth, now we set `showMotd = false` if login url includes `redirect_uri` and the `redirect_uri` includes `headless`.

Tested with both local user and Github user configured with Github auth.

closes https://github.com/gravitational/teleport/issues/28746