### PR TITLE
Get accessInfo based on user on access request drop

### DIFF
--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -485,18 +485,13 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			_, err = auth.CreateUser(authServer, userName, userRoles...)
 			require.NoError(t, err)
 
-			// Log in as the new user.
-			creds, err := helpers.GenerateUserCreds(helpers.UserCredsRequest{
-				Process:  pack.Root.Cluster.Process,
-				Username: userName,
-			})
-			require.NoError(t, err)
-			tc := mustLogin(t, userName, pack, creds)
+			userPassword := uuid
+			require.NoError(t, authServer.UpsertPassword(userName, []byte(userPassword)))
 
 			// Prepare daemon.Service.
 			storage, err := clusters.NewStorage(clusters.Config{
-				Dir:                tc.KeysDir,
-				InsecureSkipVerify: tc.InsecureSkipVerify,
+				Dir:                t.TempDir(),
+				InsecureSkipVerify: true,
 			})
 			require.NoError(t, err)
 
@@ -515,10 +510,26 @@ func testCreateConnectMyComputerRole(t *testing.T, pack *dbhelpers.DatabasePack)
 			)
 			require.NoError(t, err)
 
-			// Call CreateConnectMyComputerRole.
 			rootClusterName, _, err := net.SplitHostPort(pack.Root.Cluster.Web)
 			require.NoError(t, err)
 			rootClusterURI := uri.NewClusterURI(rootClusterName).String()
+
+			// Log in as the new user.
+			// It's important to use the actual login handler rather than mustLogin. mustLogin completely
+			// skips the actual login flow and saves valid certs to disk. We already had a regression that
+			// was not caught by this test because the test did not trigger certain code paths because it
+			// was using mustLogin as a shortcut.
+			_, err = handler.AddCluster(ctx, &api.AddClusterRequest{Name: pack.Root.Cluster.Web})
+			require.NoError(t, err)
+			_, err = handler.Login(ctx, &api.LoginRequest{
+				ClusterUri: rootClusterURI,
+				Params: &api.LoginRequest_Local{
+					Local: &api.LoginRequest_LocalParams{User: userName, Password: userPassword},
+				},
+			})
+			require.NoError(t, err)
+
+			// Call CreateConnectMyComputerRole.
 			response, err := handler.CreateConnectMyComputerRole(ctx, &api.CreateConnectMyComputerRoleRequest{
 				RootClusterUri: rootClusterURI,
 			})
@@ -672,6 +683,13 @@ func testCreatingAndDeletingConnectMyComputerToken(t *testing.T, pack *dbhelpers
 	require.True(t, trace.IsNotFound(err))
 }
 
+// mustLogin logs in as the given user by completely skipping the actual login flow and saving valid
+// certs to disk. clusters.Storage can then be pointed to tc.KeysDir and daemon.Service can act as
+// if the user was succesfully logged in.
+//
+// This is faster than going through the actual process, but keep in mind that it might skip some
+// vital steps. It should be used only for tests which don't depend on complex user setup and do not
+// reissue certs or modify them in some other way.
 func mustLogin(t *testing.T, userName string, pack *dbhelpers.DatabasePack, creds *helpers.UserCreds) *client.TeleportClient {
 	tc, err := pack.Root.Cluster.NewClientWithCreds(helpers.ClientConfig{
 		Login:   userName,

--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -685,7 +685,7 @@ func testCreatingAndDeletingConnectMyComputerToken(t *testing.T, pack *dbhelpers
 
 // mustLogin logs in as the given user by completely skipping the actual login flow and saving valid
 // certs to disk. clusters.Storage can then be pointed to tc.KeysDir and daemon.Service can act as
-// if the user was succesfully logged in.
+// if the user was successfully logged in.
 //
 // This is faster than going through the actual process, but keep in mind that it might skip some
 // vital steps. It should be used only for tests which don't depend on complex user setup and do not

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2994,11 +2994,7 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 		// Reset to the base roles and traits stored in the backend user,
 		// currently active requests (not being dropped) and new access requests
 		// will be filled in below.
-		userState, err := a.authServer.getUserOrLoginState(ctx, user.GetName())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		accessInfo = services.AccessInfoFromUserState(userState)
+		accessInfo = services.AccessInfoFromUser(user)
 
 		// Check for ["*"] as special case to drop all requests.
 		if len(req.DropAccessRequests) == 1 && req.DropAccessRequests[0] == "*" {


### PR DESCRIPTION
That's how it used to be before user login state was introduced (#29364). When dropping a resource access request, we want to restore certs back to the state before the access request was assumed, so that the user access is not limited only to select resources. In the past, this was done by calculating accessInfo from a plain user object.

This approach had the side effect of refreshing the role list of the user based on the current backend state, without the need to provide credentials again. Teleport Connect used this side effect to make the setup of Connect My Computer interaction-free.

Theoretically, it'd be beneficial for `tsh request drop` to use login state rather than the current backend state, as it'd make it impossible to "escalate" privileges by refreshing the list of roles without authenticating again. However, this brakes the setup of Connect My Computer as it expects GenerateUserCerts to return a role list based on a current user role list.

This commit reverts that change. [Mike says](https://github.com/gravitational/teleport/pull/29364#discussion_r1305787278) this behavior change wasn't intentional and that we should revert it. It's also beneficial for Connect, as an alternative would be to change Connect My Computer setup to require a one-time relogin midway through.

See [the discussion under #29364](https://github.com/gravitational/teleport/pull/29364#discussion_r1304569736) for even more context.