### PR TITLE
[docs] update TLS routing curl test with --no-alpn

### DIFF
--- a/docs/pages/architecture/tls-routing.mdx
+++ b/docs/pages/architecture/tls-routing.mdx
@@ -249,7 +249,7 @@ and long-lived connections.
 You can set up a Teleport Proxy Service behind the reverse proxy and run the
 following command to test the connection:
 ```bash
-$ curl -v https://<proxy.example.com>/webapi/connectionupgrade -H "Connection: Upgrade" -H "Upgrade: alpn-ping"
+$ curl -v https://<proxy.example.com>/webapi/connectionupgrade -H "Connection: Upgrade" -H "Upgrade: alpn-ping" --no-alpn
 ```
 
 For a successful upgrade, the server should return "101 Switching Protocols"


### PR DESCRIPTION
Related PR:
- #30499

Background:
`curl` by default sends both `h2` and `http1.1`. But that may get different results from `tsh` where no ALPN value is used on the initial upgrade call.