### PR TITLE
stream audit query responses

### DIFF
--- a/lib/ai/chat.go
+++ b/lib/ai/chat.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/sashabaranov/go-openai"
-	"github.com/tiktoken-go/tokenizer"
 
 	"github.com/gravitational/teleport/lib/ai/model"
 	"github.com/gravitational/teleport/lib/ai/model/output"
@@ -30,10 +29,9 @@ import (
 
 // Chat represents a conversation between a user and an assistant with context memory.
 type Chat struct {
-	client    *Client
-	messages  []openai.ChatCompletionMessage
-	tokenizer tokenizer.Codec
-	agent     *model.Agent
+	client   *Client
+	messages []openai.ChatCompletionMessage
+	agent    *model.Agent
 }
 
 // Insert inserts a message into the conversation. Returns the index of the message.

--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -358,5 +358,5 @@ func TestChat_Complete_AuditQuery(t *testing.T) {
 	// We check that the agent returns the expected response
 	message, ok := result.(*output.StreamingMessage)
 	require.True(t, ok)
-	require.Equal(t, generatedQuery, message.String())
+	require.Equal(t, generatedQuery, message.WaitAndConsume())
 }

--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -356,7 +356,7 @@ func TestChat_Complete_AuditQuery(t *testing.T) {
 	require.NoError(t, err)
 
 	// We check that the agent returns the expected response
-	message, ok := result.(*output.Message)
+	message, ok := result.(*output.StreamingMessage)
 	require.True(t, ok)
-	require.Equal(t, generatedQuery, message.Content)
+	require.Equal(t, generatedQuery, message.String())
 }

--- a/lib/ai/client.go
+++ b/lib/ai/client.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gravitational/trace"
 	"github.com/sashabaranov/go-openai"
-	"github.com/tiktoken-go/tokenizer/codec"
 
 	"github.com/gravitational/teleport/lib/ai/embedding"
 	"github.com/gravitational/teleport/lib/ai/model"
@@ -75,10 +74,7 @@ func (client *Client) NewChat(toolContext *modeltools.ToolContext) *Chat {
 				Content: model.PromptCharacter(toolContext.User),
 			},
 		},
-		// Initialize a tokenizer for prompt token accounting.
-		// Cl100k is used by GPT-3 and GPT-4.
-		tokenizer: codec.NewCl100kBase(),
-		agent:     model.NewAgent(toolContext, tools...),
+		agent: model.NewAgent(toolContext, tools...),
 	}
 }
 
@@ -92,10 +88,7 @@ func (client *Client) NewCommand(username string) *Chat {
 				Content: model.PromptCharacter(username),
 			},
 		},
-		// Initialize a tokenizer for prompt token accounting.
-		// Cl100k is used by GPT-3 and GPT-4.
-		tokenizer: codec.NewCl100kBase(),
-		agent:     model.NewAgent(toolContext, &modeltools.CommandGenerationTool{}),
+		agent: model.NewAgent(toolContext, &modeltools.CommandGenerationTool{}),
 	}
 }
 

--- a/lib/ai/model/output/messages.go
+++ b/lib/ai/model/output/messages.go
@@ -28,9 +28,9 @@ type StreamingMessage struct {
 	Parts <-chan string
 }
 
-// String implements the Stringer interface. It waits until the message stream
-// is over and returns the full message.
-func (msg *StreamingMessage) String() string {
+// WaitAndConsume waits until the message stream is over and returns the full message.
+// This can only be called once on a message as it empties its Parts channel.
+func (msg *StreamingMessage) WaitAndConsume() string {
 	sb := strings.Builder{}
 	for part := range msg.Parts {
 		sb.WriteString(part)

--- a/lib/ai/model/output/messages.go
+++ b/lib/ai/model/output/messages.go
@@ -16,6 +16,8 @@
 
 package output
 
+import "strings"
+
 // Message represents a new message within a live conversation.
 type Message struct {
 	Content string
@@ -24,6 +26,16 @@ type Message struct {
 // StreamingMessage represents a new message that is being streamed from the LLM.
 type StreamingMessage struct {
 	Parts <-chan string
+}
+
+// String implements the Stringer interface. It waits until the message stream
+// is over and returns the full message.
+func (msg *StreamingMessage) String() string {
+	sb := strings.Builder{}
+	for part := range msg.Parts {
+		sb.WriteString(part)
+	}
+	return sb.String()
 }
 
 // Label represents a label returned by OpenAI's completion API.

--- a/lib/ai/model/output/streaming.go
+++ b/lib/ai/model/output/streaming.go
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package output
 
 import (

--- a/lib/ai/model/output/streaming.go
+++ b/lib/ai/model/output/streaming.go
@@ -1,0 +1,65 @@
+package output
+
+import (
+	"errors"
+	"io"
+	"strings"
+
+	"github.com/gravitational/trace"
+	"github.com/sashabaranov/go-openai"
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gravitational/teleport/lib/ai/tokens"
+)
+
+// StreamToDeltas converts an openai.CompletionStream into a channel of strings.
+// This channel can then be consumed manually to search for specific markers,
+// or directly converted into a StreamingMessage with NewStreamingMessage.
+func StreamToDeltas(stream *openai.ChatCompletionStream) chan string {
+	deltas := make(chan string)
+	go func() {
+		defer close(deltas)
+
+		for {
+			response, err := stream.Recv()
+			if errors.Is(err, io.EOF) {
+				return
+			} else if err != nil {
+				log.Tracef("agent encountered an error while streaming: %v", err)
+				return
+			}
+
+			delta := response.Choices[0].Delta.Content
+			deltas <- delta
+		}
+	}()
+	return deltas
+}
+
+// NewStreamingMessage takes a string channel and converts it to
+// a StreamingMessage.
+// If content was already streamed, it must be passed through the alreadyStreamed parameter.
+// If the already streamed content contains a prefix that must be stripped
+// (like a marker to identify the kind of response the model is providing),
+// the prefix can be passed through the prefix parameter. It will be stripped
+// but will still be reflected in the token count.
+func NewStreamingMessage(deltas <-chan string, alreadyStreamed, prefix string) (*StreamingMessage, *tokens.AsynchronousTokenCounter, error) {
+	parts := make(chan string)
+	streamingTokenCounter, err := tokens.NewAsynchronousTokenCounter(alreadyStreamed)
+	if err != nil {
+		return nil, nil, trace.Wrap(err)
+	}
+	go func() {
+		defer close(parts)
+
+		parts <- strings.TrimPrefix(alreadyStreamed, prefix)
+		for delta := range deltas {
+			parts <- delta
+			errCount := streamingTokenCounter.Add()
+			if errCount != nil {
+				log.WithError(errCount).Debug("Failed to add streamed completion text to the token counter")
+			}
+		}
+	}()
+	return &StreamingMessage{Parts: parts}, streamingTokenCounter, nil
+}


### PR DESCRIPTION
This PR makes the audit query generation tool return streaming messages.

It extracts the existing streaming logic in `lib/ai/model/output/streaming.go` so it can be used both by the main agent and by the tools. It also removes the stale tokenizer field from the `ai.Chat` struct.