### PR TITLE
Fix undefined name in test-only package

### DIFF
--- a/e2e/aws/doc.go
+++ b/e2e/aws/doc.go
@@ -12,4 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package e2e contains end-to-end tests for Teleport's AWS integrations.
 package e2e

--- a/e2e/aws/doc.go
+++ b/e2e/aws/doc.go
@@ -1,0 +1,15 @@
+// Copyright 2023 Gravitational, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package e2e

--- a/e2e/aws/fixtures_test.go
+++ b/e2e/aws/fixtures_test.go
@@ -32,10 +32,8 @@ import (
 	"github.com/gravitational/teleport/lib/utils"
 )
 
-var (
-	// Username used for tests.
-	username string
-)
+// username is the name of the host user used for tests.
+var username string
 
 func init() {
 	me, err := user.Current()


### PR DESCRIPTION
This PR moves `e2e/aws/fixtures.go` to `fixtures_test.go`; the file doesn't export anything, and the rest of the package is test-only, but it refers to the `discoveryMatcherLabelsEnv` which is a const defined in a test-only file.