### PR TITLE
Remove use of require assertions inside Eventually calls

### DIFF
--- a/e2e/aws/rds_test.go
+++ b/e2e/aws/rds_test.go
@@ -190,7 +190,7 @@ func postgresConnTestFn(cluster *helpers.TeleInstance) dbConnectionTestFunc {
 		var pgConn *pgconn.PgConn
 		// retry for a while, the database service might need time to give
 		// itself IAM rds:connect permissions.
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			var err error
 			pgConn, err = postgres.MakeTestClient(ctx, common.TestClientConfig{
 				AuthClient:      cluster.GetSiteAPI(cluster.Secrets.SiteName),
@@ -200,8 +200,8 @@ func postgresConnTestFn(cluster *helpers.TeleInstance) dbConnectionTestFunc {
 				Username:        username,
 				RouteToDatabase: route,
 			})
-			assert.NoError(c, err)
-			assert.NotNil(c, pgConn)
+			assert.NoError(t, err)
+			assert.NotNil(t, pgConn)
 		}, time.Second*10, time.Second, "connecting to postgres")
 
 		// Execute a query.
@@ -229,11 +229,11 @@ func postgresLocalProxyConnTestFn(cluster *helpers.TeleInstance) dbConnectionTes
 		var pgConn *pgconn.PgConn
 		// retry for a while, the database service might need time to give
 		// itself IAM rds:connect permissions.
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			var err error
 			pgConn, err = pgconn.Connect(ctx, connString)
-			assert.NoError(c, err)
-			assert.NotNil(c, pgConn)
+			assert.NoError(t, err)
+			assert.NotNil(t, pgConn)
 		}, time.Second*10, time.Second, "connecting to postgres")
 
 		// Execute a query.
@@ -259,11 +259,11 @@ func mySQLLocalProxyConnTestFn(cluster *helpers.TeleInstance) dbConnectionTestFu
 		var conn *mysqlclient.Conn
 		// retry for a while, the database service might need time to give
 		// itself IAM rds:connect permissions.
-		require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
 			var err error
 			conn, err = mysqlclient.Connect(lp.GetAddr(), route.Username, "" /*no password*/, route.Database)
-			assert.NoError(c, err)
-			assert.NotNil(c, conn)
+			assert.NoError(t, err)
+			assert.NotNil(t, conn)
 		}, time.Second*10, time.Second, "connecting to mysql")
 
 		// Execute a query.
@@ -329,11 +329,12 @@ func generateClientDBCert(t *testing.T, authSrv *auth.Server, user string, route
 }
 
 func waitForDatabases(t *testing.T, auth *service.TeleportProcess, wantNames ...string) {
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+
 		databases, err := auth.GetAuthServer().GetDatabases(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		// map the registered "db" resource names.
 		seen := map[string]struct{}{}
@@ -347,11 +348,12 @@ func waitForDatabases(t *testing.T, auth *service.TeleportProcess, wantNames ...
 }
 
 func waitForDatabaseServers(t *testing.T, auth *service.TeleportProcess, wantNames ...string) {
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+
 		servers, err := auth.GetAuthServer().GetDatabaseServers(ctx, apidefaults.Namespace)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		// map the registered "db_server" resource names.
 		seen := map[string]struct{}{}

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -894,11 +894,22 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 func waitForAppRegInRemoteSiteCache(t *testing.T, tunnel reversetunnelclient.Server, clusterName string, cfgApps []servicecfg.App, hostUUID string) {
 	require.Eventually(t, func() bool {
 		site, err := tunnel.GetSite(clusterName)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("error getting site from tunnel: %v", err)
+			return false
+		}
+
 		ap, err := site.CachingAccessPoint()
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("error getting caching access point from site: %v", err)
+			return false
+		}
+
 		apps, err := ap.GetApplicationServers(context.Background(), apidefaults.Namespace)
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("error getting application servers from access point: %v", err)
+			return false
+		}
 
 		counter := 0
 		for _, v := range apps {

--- a/integration/appaccess/pack.go
+++ b/integration/appaccess/pack.go
@@ -31,6 +31,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport"
@@ -892,24 +893,15 @@ func (p *Pack) startLeafAppServers(t *testing.T, count int, opts AppTestOptions)
 }
 
 func waitForAppRegInRemoteSiteCache(t *testing.T, tunnel reversetunnelclient.Server, clusterName string, cfgApps []servicecfg.App, hostUUID string) {
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		site, err := tunnel.GetSite(clusterName)
-		if err != nil {
-			t.Logf("error getting site from tunnel: %v", err)
-			return false
-		}
+		assert.NoError(t, err)
 
 		ap, err := site.CachingAccessPoint()
-		if err != nil {
-			t.Logf("error getting caching access point from site: %v", err)
-			return false
-		}
+		assert.NoError(t, err)
 
 		apps, err := ap.GetApplicationServers(context.Background(), apidefaults.Namespace)
-		if err != nil {
-			t.Logf("error getting application servers from access point: %v", err)
-			return false
-		}
+		assert.NoError(t, err)
 
 		counter := 0
 		for _, v := range apps {
@@ -917,6 +909,6 @@ func waitForAppRegInRemoteSiteCache(t *testing.T, tunnel reversetunnelclient.Ser
 				counter++
 			}
 		}
-		return len(cfgApps) == counter
+		assert.Len(t, cfgApps, counter)
 	}, time.Minute*2, time.Millisecond*200)
 }

--- a/integration/ec2_test.go
+++ b/integration/ec2_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/api/breaker"
+	apiclient "github.com/gravitational/teleport/api/client"
+	"github.com/gravitational/teleport/api/client/proto"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/integration/helpers"
@@ -209,8 +211,7 @@ func TestEC2NodeJoin(t *testing.T) {
 
 	// the node should eventually join the cluster and heartbeat
 	require.Eventually(t, func() bool {
-		nodes, err := authServer.GetNodes(ctx, apidefaults.Namespace)
-		assert.NoError(t, err)
+		nodes, _ := authServer.GetNodes(ctx, apidefaults.Namespace)
 		return len(nodes) > 0
 	}, time.Minute, time.Second, "waiting for node to join cluster")
 }
@@ -268,12 +269,11 @@ func TestIAMNodeJoin(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, proxySvc.Close()) })
 
 	// the proxy should eventually join the cluster and heartbeat
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		proxies, err := authServer.GetProxies()
 		assert.NoError(t, err)
-		return len(proxies) > 0
+		assert.NotEmpty(t, proxies)
 	}, time.Minute, time.Second, "waiting for proxy to join cluster")
-
 	// InsecureDevMode needed for node to trust proxy
 	wasInsecureDevMode := lib.IsInsecureDevMode()
 	t.Cleanup(func() { lib.SetInsecureDevMode(wasInsecureDevMode) })
@@ -293,10 +293,10 @@ func TestIAMNodeJoin(t *testing.T) {
 	t.Cleanup(func() { require.NoError(t, nodeSvc.Close()) })
 
 	// the node should eventually join the cluster and heartbeat
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		nodes, err := authServer.GetNodes(context.Background(), apidefaults.Namespace)
 		assert.NoError(t, err)
-		return len(nodes) > 0
+		assert.NotEmpty(t, nodes)
 	}, time.Minute, time.Second, "waiting for node to join cluster")
 }
 
@@ -390,8 +390,9 @@ func TestEC2Labels(t *testing.T) {
 	var apps []types.AppServer
 	var databases []types.DatabaseServer
 	var kubes []types.KubeServer
+
 	// Wait for everything to come online.
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		var err error
 		nodes, err = authServer.GetNodes(ctx, tconf.SSH.Namespace)
 		assert.NoError(t, err)
@@ -405,7 +406,7 @@ func TestEC2Labels(t *testing.T) {
 		// dedupClusters is required because GetKubernetesServers returns duplicated servers
 		// because it lists the KindKubeServer and KindKubeService.
 		// We must remove this once legacy heartbeat is removed.
-		// DELETE IN 13.0.0
+		// DELETE IN 13.0.0 (tigrato)
 		var dedupClusters []types.KubeServer
 		dedup := map[string]struct{}{}
 		for _, kube := range kubes {
@@ -416,49 +417,51 @@ func TestEC2Labels(t *testing.T) {
 			dedupClusters = append(dedupClusters, kube)
 		}
 
-		return len(nodes) == 1 && len(apps) == 1 && len(databases) == 1 && len(dedupClusters) == 1
+		assert.Len(t, nodes, 1)
+		assert.Len(t, apps, 1)
+		assert.Len(t, databases, 1)
+		assert.Len(t, dedupClusters, 1)
 	}, 10*time.Second, time.Second)
 
 	tagName := fmt.Sprintf("%s/Name", labels.AWSLabelNamespace)
 
 	// Check that EC2 labels were applied.
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		node, err := authServer.GetNode(ctx, tconf.SSH.Namespace, nodes[0].GetName())
-		if err != nil {
-			t.Logf("error getting node: %v", err)
-			return false
-		}
+		assert.NoError(t, err)
 
 		_, nodeHasLabel := node.GetAllLabels()[tagName]
+		assert.True(t, nodeHasLabel)
+
 		apps, err := authServer.GetApplicationServers(ctx, tconf.SSH.Namespace)
 		assert.NoError(t, err)
-		if len(apps) != 1 {
-			t.Logf("want 1 app, got %d", len(apps))
-			return false
-		}
+		assert.Len(t, apps, 1)
 
 		app := apps[0].GetApp()
 		_, appHasLabel := app.GetAllLabels()[tagName]
+		assert.True(t, appHasLabel)
 
 		databases, err := authServer.GetDatabaseServers(ctx, tconf.SSH.Namespace)
 		assert.NoError(t, err)
-		if len(databases) != 1 {
-			t.Logf("want 1 database, got %d", len(databases))
-			return false
-		}
+		assert.Len(t, databases, 1)
 
 		database := databases[0].GetDatabase()
 		_, dbHasLabel := database.GetAllLabels()[tagName]
+		assert.True(t, dbHasLabel)
 
-		kubeClusters := helpers.GetKubeClusters(t, authServer)
-		if len(kubeClusters) != 1 {
-			t.Logf("want 1 kube cluster, got %d", len(kubeClusters))
-			return false
-		}
+		kubeResources, err := apiclient.GetResourcesWithFilters(
+			context.Background(), authServer,
+			proto.ListResourcesRequest{ResourceType: types.KindKubeServer},
+		)
+		assert.NoError(t, err)
+		assert.Len(t, kubeResources, 1)
 
-		kube := kubeClusters[0]
+		kubeServers, err := types.ResourcesWithLabels(kubeResources).AsKubeServers()
+		assert.NoError(t, err)
+
+		kube := kubeServers[0].GetCluster()
 		_, kubeHasLabel := kube.GetStaticLabels()[tagName]
-		return nodeHasLabel && appHasLabel && dbHasLabel && kubeHasLabel
+		assert.True(t, kubeHasLabel)
 	}, 10*time.Second, time.Second)
 }
 

--- a/integrations/lib/testing/integration/setup.go
+++ b/integrations/lib/testing/integration/setup.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/gravitational/teleport/integrations/lib/logger"
@@ -122,7 +123,7 @@ func (s *SSHSetup) SetupService() {
 	// Wait for node to show up on the server.
 	require.Eventually(t, func() bool {
 		resources, err := s.Integration.tctl(s.Auth).GetAll(s.Context(), "nodes")
-		require.NoError(t, err)
+		assert.NoError(t, err)
 
 		return len(resources) != 0
 	}, 5*time.Second, time.Second)

--- a/integrations/lib/testing/integration/setup.go
+++ b/integrations/lib/testing/integration/setup.go
@@ -121,10 +121,9 @@ func (s *SSHSetup) SetupService() {
 	require.True(t, ready, "ssh is not ready")
 
 	// Wait for node to show up on the server.
-	require.Eventually(t, func() bool {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		resources, err := s.Integration.tctl(s.Auth).GetAll(s.Context(), "nodes")
 		assert.NoError(t, err)
-
-		return len(resources) != 0
+		assert.NotEmpty(t, resources)
 	}, 5*time.Second, time.Second)
 }

--- a/lib/cache/cache_test.go
+++ b/lib/cache/cache_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/slices"
 
@@ -976,7 +977,11 @@ func TestListResources_NodesTTLVariant(t *testing.T) {
 			Limit:        int32(pageSize),
 			SortBy:       sortBy,
 		})
-		require.NoError(t, err)
+		if err != nil {
+			t.Logf("error listing resources: %v", err)
+			return false
+		}
+
 		resources = append(resources, resp.Resources...)
 		listResourcesStartKey = resp.NextKey
 		return len(resources) == nodeCount
@@ -2213,7 +2218,7 @@ func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[
 	require.Eventually(t, func() bool {
 		// Make sure the cache has a single resource in it.
 		out, err = funcs.cacheList(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		return len(cmp.Diff([]T{r}, out, cmpOpts...)) == 0
 	}, time.Second*2, time.Millisecond*250)
 
@@ -2240,7 +2245,7 @@ func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[
 	require.Eventually(t, func() bool {
 		// Make sure the cache has a single resource in it.
 		out, err = funcs.cacheList(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		return len(cmp.Diff([]T{r}, out, cmpOpts...)) == 0
 	}, time.Second*2, time.Millisecond*250)
 
@@ -2252,7 +2257,7 @@ func testResources[T types.Resource](t *testing.T, p *testPack, funcs testFuncs[
 	require.Eventually(t, func() bool {
 		// Check that the cache is now empty.
 		out, err = funcs.cacheList(ctx)
-		require.NoError(t, err)
+		assert.NoError(t, err)
 		return len(out) == 0
 	}, time.Second*2, time.Millisecond*250)
 }

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -409,10 +409,10 @@ func TestCloseWithActiveConnections(t *testing.T) {
 	server, connErrCh, _ := databaseServerWithActiveConnection(t, ctx)
 
 	require.NoError(t, server.Close())
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		select {
 		case err := <-connErrCh:
-			assert.ErrorIs(c, err, io.ErrUnexpectedEOF)
+			assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 		default:
 		}
 	}, time.Second, 100*time.Millisecond)


### PR DESCRIPTION
require.Eventually runs the predicate function in a background goroutine. It is invalid to use require to make assertions inside the eventually, because require will fail the test if the assertion fails, and tests can only be failed from the test's main goroutine.