### PR TITLE
Add the ability to run a specific tool to Assist.

### DIFF
--- a/lib/ai/chat_test.go
+++ b/lib/ai/chat_test.go
@@ -321,13 +321,13 @@ func generateAccessRequestResponse(t *testing.T) string {
 func TestChat_Complete_AuditQuery(t *testing.T) {
 	// Test setup: generate the responses that will be served by our OpenAI mock
 	action := model.PlanOutput{
-		Action:      "Audit Query Generation",
+		Action:      tools.AuditQueryGenerationToolName,
 		ActionInput: "Lists user who connected to a server as root.",
 		Reasoning:   "foo",
 	}
 	selectedAction, err := json.Marshal(action)
 	require.NoError(t, err)
-	generatedQuery := "SELECT user FROM session_start WHERE login='root'"
+	const generatedQuery = "SELECT user FROM session_start WHERE login='root'"
 
 	responses := []string{
 		// The model must select the audit query tool

--- a/lib/ai/client.go
+++ b/lib/ai/client.go
@@ -92,6 +92,30 @@ func (client *Client) NewCommand(username string) *Chat {
 	}
 }
 
+func (client *Client) RunTool(ctx context.Context, toolContext *modeltools.ToolContext, toolName, toolInput string) (any, *tokens.TokenCount, error) {
+	tools := []modeltools.Tool{
+		&modeltools.CommandExecutionTool{},
+		&modeltools.EmbeddingRetrievalTool{},
+		&modeltools.AuditQueryGenerationTool{LLM: client.svc},
+	}
+	// The following tools are only available in the enterprise build. They will fail
+	// if included in OSS due to the lack of the required backend APIs.
+	if modules.GetModules().BuildType() == modules.BuildEnterprise {
+		tools = append(tools, &modeltools.AccessRequestCreateTool{},
+			&modeltools.AccessRequestsListTool{},
+			&modeltools.AccessRequestListRequestableRolesTool{},
+			&modeltools.AccessRequestListRequestableResourcesTool{})
+	}
+	agent := model.NewAgent(toolContext, tools...)
+	action := &model.AgentAction{
+		Action:    toolName,
+		Input:     toolInput,
+		Reasoning: "Tool invoked directly",
+	}
+
+	return agent.DoAction(ctx, client.svc, action)
+}
+
 func (client *Client) NewAuditQuery(username string) *Chat {
 	toolContext := &modeltools.ToolContext{User: username}
 	return &Chat{

--- a/lib/ai/client_test.go
+++ b/lib/ai/client_test.go
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 Gravitational, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sashabaranov/go-openai"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	assistpb "github.com/gravitational/teleport/api/gen/proto/go/assist/v1"
+	"github.com/gravitational/teleport/lib/ai/model/output"
+	"github.com/gravitational/teleport/lib/ai/model/tools"
+	"github.com/gravitational/teleport/lib/ai/testutils"
+)
+
+func TestRunTool_AuditQueryGeneration(t *testing.T) {
+	// Test setup: starting a mock openai server and creating the client
+	const generatedQuery = "SELECT user FROM session_start WHERE login='root'"
+
+	responses := []string{
+		// Then the audit query tool chooses to request session.start events
+		"session.start",
+		// Finally the tool builds a query based on the provided schemas
+		generatedQuery,
+	}
+	server := httptest.NewServer(testutils.GetTestHandlerFn(t, responses))
+	t.Cleanup(server.Close)
+
+	cfg := openai.DefaultConfig("secret-test-token")
+	cfg.BaseURL = server.URL
+
+	client := NewClientFromConfig(cfg)
+
+	// Doing the test: Check that the AuditQueryGeneration tool can be invoked
+	// through client.RunTool and validate its response.
+	ctx := context.Background()
+	toolCtx := &tools.ToolContext{User: "alice"}
+	response, _, err := client.RunTool(ctx, toolCtx, tools.AuditQueryGenerationToolName, "List users who connected to a server as root")
+	require.NoError(t, err)
+	message, ok := response.(*output.StreamingMessage)
+	require.True(t, ok)
+	require.Equal(t, generatedQuery, message.WaitAndConsume())
+}
+
+type mockEmbeddingGetter struct {
+	response []*assistpb.EmbeddedDocument
+}
+
+func (m *mockEmbeddingGetter) GetAssistantEmbeddings(ctx context.Context, in *assistpb.GetAssistantEmbeddingsRequest, opts ...grpc.CallOption) (*assistpb.GetAssistantEmbeddingsResponse, error) {
+	return &assistpb.GetAssistantEmbeddingsResponse{Embeddings: m.response}, nil
+}
+
+func TestRunTool_EmbeddingRetrieval(t *testing.T) {
+	// Test setup: starting a mock openai server and embedding getter,
+	// then create the client.
+	mock := &mockEmbeddingGetter{
+		[]*assistpb.EmbeddedDocument{
+			{
+				Id:              "1",
+				Content:         "foo",
+				SimilarityScore: 1,
+			},
+			{
+				Id:              "2",
+				Content:         "bar",
+				SimilarityScore: 0.9,
+			},
+		},
+	}
+	ctx := context.Background()
+	toolCtx := &tools.ToolContext{AssistEmbeddingServiceClient: mock}
+
+	responses := make([]string, 0)
+	server := httptest.NewServer(testutils.GetTestHandlerFn(t, responses))
+	t.Cleanup(server.Close)
+
+	cfg := openai.DefaultConfig("secret-test-token")
+	cfg.BaseURL = server.URL
+	client := NewClientFromConfig(cfg)
+
+	// Doing the test: Check that the EmbeddingRetrieval tool can be invoked
+	// through client.RunTool and validate its response.
+	input := tools.EmbeddingRetrievalToolInput{Question: "Find foobar"}
+	inputText, err := json.Marshal(input)
+	require.NoError(t, err)
+	response, _, err := client.RunTool(ctx, toolCtx, "Nodes names and labels retrieval", string(inputText))
+	require.NoError(t, err)
+	message, ok := response.(*output.Message)
+	require.True(t, ok)
+	require.Equal(t, "foo\nbar\n", message.Content)
+}

--- a/lib/ai/model/tools/auditquery.go
+++ b/lib/ai/model/tools/auditquery.go
@@ -30,12 +30,14 @@ import (
 	"github.com/gravitational/teleport/lib/ai/tokens"
 )
 
+const AuditQueryGenerationToolName = "Audit Query Generation"
+
 type AuditQueryGenerationTool struct {
 	LLM *openai.Client
 }
 
 func (t *AuditQueryGenerationTool) Name() string {
-	return "Audit Query Generation"
+	return AuditQueryGenerationToolName
 }
 
 func (t *AuditQueryGenerationTool) Description() string {


### PR DESCRIPTION
This PR contains:
- a refactoring of the model action logic to be exposed through the `DoAction` function
- A `RunTool()` capability exposed by ai.Client and assist.Assist
- a new "audit-query" action that directly invokes the audit generation tool

The DoAction/RunTool invocation method, as opposed to regular Chat invocation, is motivated by response time. On a chat invocation, it takes 6 seconds to start streaming the tool response. Of those 6 seconds, 5 are spent on the action planning and 1 on the actual tool. In cases where we know which tool we want to use, invoking the tool directly removes those 5 extra seconds and dramatically improves the UX.