### PR TITLE
Add server type to resource card, fix windows/app launch buttons

### DIFF
--- a/lib/web/apiserver_test.go
+++ b/lib/web/apiserver_test.go
@@ -1107,6 +1107,7 @@ func TestClusterNodesGet(t *testing.T) {
 	require.ElementsMatch(t, res.Items, []ui.Server{
 		{
 			Kind:        types.KindNode,
+			SubKind:     types.SubKindTeleportNode,
 			ClusterName: clusterName,
 			Name:        server1.GetName(),
 			Hostname:    server1.GetHostname(),
@@ -1117,6 +1118,7 @@ func TestClusterNodesGet(t *testing.T) {
 		},
 		{
 			Kind:        types.KindNode,
+			SubKind:     types.SubKindTeleportNode,
 			ClusterName: clusterName,
 			Name:        "server2",
 			Labels:      []ui.Label{{Name: "test-field", Value: "test-value"}},

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -42,8 +42,8 @@ type Server struct {
 	Kind string `json:"kind"`
 	// Tunnel indicates of this server is connected over a reverse tunnel.
 	Tunnel bool `json:"tunnel"`
-	// OpenSSh returns true for OpenSSHNode and OpenSSHEICENodes
-	OpenSSH bool `json:"openssh,omitempty"`
+	// SubKind is an optional subkind such as OpenSSH
+	SubKind string `json:"subKind,omitempty"`
 	// Name is this server name
 	Name string `json:"id"`
 	// ClusterName is this server cluster name
@@ -86,7 +86,7 @@ func MakeServer(clusterName string, server types.Server, accessChecker services.
 		return Server{}, trace.Wrap(err)
 	}
 
-	return Server{
+	uiServer := Server{
 		Kind:        server.GetKind(),
 		ClusterName: clusterName,
 		Labels:      uiLabels,
@@ -94,9 +94,11 @@ func MakeServer(clusterName string, server types.Server, accessChecker services.
 		Hostname:    server.GetHostname(),
 		Addr:        server.GetAddr(),
 		Tunnel:      server.GetUseTunnel(),
-		OpenSSH:     server.IsOpenSSHNode(),
+		SubKind:     server.GetSubKind(),
 		SSHLogins:   serverLogins,
-	}, nil
+	}
+
+	return uiServer, nil
 }
 
 // MakeServers creates server objects for webapp

--- a/lib/web/ui/server.go
+++ b/lib/web/ui/server.go
@@ -42,6 +42,8 @@ type Server struct {
 	Kind string `json:"kind"`
 	// Tunnel indicates of this server is connected over a reverse tunnel.
 	Tunnel bool `json:"tunnel"`
+	// OpenSSh returns true for OpenSSHNode and OpenSSHEICENodes
+	OpenSSH bool `json:"openssh,omitempty"`
 	// Name is this server name
 	Name string `json:"id"`
 	// ClusterName is this server cluster name
@@ -92,6 +94,7 @@ func MakeServer(clusterName string, server types.Server, accessChecker services.
 		Hostname:    server.GetHostname(),
 		Addr:        server.GetAddr(),
 		Tunnel:      server.GetUseTunnel(),
+		OpenSSH:     server.IsOpenSSHNode(),
 		SSHLogins:   serverLogins,
 	}, nil
 }

--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -123,7 +123,7 @@ const LoginItemList = ({
   const content = getLoginItemListContent(getLoginItemsAttempt, onClick);
 
   return (
-    <Flex flexDirection="column" width={width}>
+    <Flex flexDirection="column" minWidth={width}>
       <Input
         p="2"
         m="2"

--- a/web/packages/teleport/src/Apps/AppList/AwsLaunchButton/AwsLaunchButton.tsx
+++ b/web/packages/teleport/src/Apps/AppList/AwsLaunchButton/AwsLaunchButton.tsx
@@ -51,7 +51,7 @@ export default class AwsLaunchButton extends React.Component<Props> {
           setRef={e => (this.anchorEl = e)}
           onClick={this.onOpen}
         >
-          LAUNCH
+          Launch
           <ChevronDown ml={1} size="small" color="text.slightlyMuted" />
         </ButtonBorder>
         <Menu

--- a/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
+++ b/web/packages/teleport/src/Apps/__snapshots__/Apps.story.test.tsx.snap
@@ -1383,7 +1383,7 @@ exports[`failed state 1`] = `
                 kind="border"
                 width="90px"
               >
-                LAUNCH
+                Launch
                 <span
                   class="c33 icon icon-chevrondown"
                   color="text.slightlyMuted"
@@ -2667,7 +2667,7 @@ exports[`loaded state 1`] = `
                 kind="border"
                 width="90px"
               >
-                LAUNCH
+                Launch
                 <span
                   class="c33 icon icon-chevrondown"
                   color="text.slightlyMuted"

--- a/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceActionButton.tsx
@@ -244,6 +244,7 @@ const KubeConnect = ({ kube }: { kube: Kube }) => {
   return (
     <>
       <ButtonBorder
+        width="90px"
         textTransform="none"
         size="small"
         onClick={() => setOpen(true)}

--- a/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
@@ -209,9 +209,10 @@ function resourceDescription(resource: UnifiedResource) {
     case 'kube_cluster':
       return { primary: 'Kubernetes' };
     case 'node':
-      // TODO(bl-nero): Pass the subkind to display as the primary and push addr
-      // to secondary.
-      return { primary: resource.addr };
+      return {
+        primary: resource.openssh ? 'OpenSSH Server' : 'SSH Server',
+        secondary: resource.tunnel ? '← tunnel' : resource.addr,
+      };
     case 'windows_desktop':
       return { primary: 'Windows', secondary: resource.addr };
 

--- a/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
@@ -210,7 +210,7 @@ function resourceDescription(resource: UnifiedResource) {
       return { primary: 'Kubernetes' };
     case 'node':
       return {
-        primary: resource.openssh ? 'OpenSSH Server' : 'SSH Server',
+        primary: resource.subKind || 'SSH Server',
         secondary: resource.tunnel ? '← tunnel' : resource.addr,
       };
     case 'windows_desktop':

--- a/web/packages/teleport/src/services/nodes/makeNode.ts
+++ b/web/packages/teleport/src/services/nodes/makeNode.ts
@@ -18,11 +18,12 @@ import { Node } from './types';
 
 export default function makeNode(json: any): Node {
   json = json ?? {};
-  const { id, siteId, hostname, addr, tunnel, tags, sshLogins } = json;
+  const { id, siteId, subKind, hostname, addr, tunnel, tags, sshLogins } = json;
 
   return {
     kind: 'node',
     id,
+    subKind: formatSubKindInfo(subKind),
     clusterId: siteId,
     hostname,
     labels: tags ?? [],
@@ -30,4 +31,15 @@ export default function makeNode(json: any): Node {
     tunnel,
     sshLogins: sshLogins ?? [],
   };
+}
+
+function formatSubKindInfo(subKind: string) {
+  switch (subKind) {
+    case 'openssh-ec2-ice':
+    case 'openssh':
+      return 'OpenSSH Server';
+
+    default:
+      return 'SSH Server';
+  }
 }

--- a/web/packages/teleport/src/services/nodes/nodes.test.ts
+++ b/web/packages/teleport/src/services/nodes/nodes.test.ts
@@ -31,6 +31,7 @@ test('correct formatting of nodes fetch response', async () => {
         hostname: 'im-a-nodename',
         labels: [{ name: 'env', value: 'dev' }],
         addr: '192.168.86.132:3022',
+        subKind: 'SSH Server',
         tunnel: false,
         sshLogins: ['root'],
       },

--- a/web/packages/teleport/src/services/nodes/types.ts
+++ b/web/packages/teleport/src/services/nodes/types.ts
@@ -23,7 +23,7 @@ export interface Node {
   labels: ResourceLabel[];
   addr: string;
   tunnel: boolean;
-  openssh: boolean;
+  subKind?: string;
   sshLogins: string[];
 }
 

--- a/web/packages/teleport/src/services/nodes/types.ts
+++ b/web/packages/teleport/src/services/nodes/types.ts
@@ -23,6 +23,7 @@ export interface Node {
   labels: ResourceLabel[];
   addr: string;
   tunnel: boolean;
+  openssh: boolean;
   sshLogins: string[];
 }
 


### PR DESCRIPTION
A couple small fixes.
First, adding the addr/tunnel distinction back to servers in the Unified Resource cards. 
Example:
<img width="559" alt="Screenshot 2023-08-28 at 2 55 42 PM" src="https://github.com/gravitational/teleport/assets/5201977/f696be1e-fdd3-446e-8159-7ac427983c78">
If not a tunnel, we show the addr like before. Also, if its an openssh server, the text will be `OpenSSH Server`

Fixes a bug for longer login launch names in the MenuLogin and the uppercase LAUNCH
Bug:
![image (2)](https://github.com/gravitational/teleport/assets/5201977/3b62fe3f-401f-46c4-b156-2b9cae07a433)

Fix:
<img width="413" alt="Screenshot 2023-08-28 at 3 24 05 PM" src="https://github.com/gravitational/teleport/assets/5201977/c7357daa-057a-4bbb-b212-039ea9d762b2">
