### PR TITLE
Fix flaky tests

### DIFF
--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -829,7 +829,7 @@ func (s *Server) Close() error {
 
 // Shutdown performs a graceful shutdown.
 func (s *Server) Shutdown(ctx context.Context) (err error) {
-	err = s.close(ctx)
+	err = trace.Wrap(s.close(ctx))
 	defer s.closeConnFunc()
 
 	activeConnections := s.activeConnections.Load()
@@ -838,7 +838,7 @@ func (s *Server) Shutdown(ctx context.Context) (err error) {
 	}
 
 	s.log.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
-	lastReport := time.Time{}
+	lastReport := time.Now()
 	ticker := time.NewTicker(s.cfg.ShutdownPollPeriod)
 	defer ticker.Stop()
 

--- a/lib/srv/db/server.go
+++ b/lib/srv/db/server.go
@@ -828,13 +828,13 @@ func (s *Server) Close() error {
 }
 
 // Shutdown performs a graceful shutdown.
-func (s *Server) Shutdown(ctx context.Context) (err error) {
-	err = trace.Wrap(s.close(ctx))
+func (s *Server) Shutdown(ctx context.Context) error {
+	err := s.close(ctx)
 	defer s.closeConnFunc()
 
 	activeConnections := s.activeConnections.Load()
 	if activeConnections == 0 {
-		return
+		return trace.Wrap(err)
 	}
 
 	s.log.Infof("Shutdown: waiting for %v connections to finish.", activeConnections)
@@ -847,7 +847,7 @@ func (s *Server) Shutdown(ctx context.Context) (err error) {
 		case <-ticker.C:
 			activeConnections = s.activeConnections.Load()
 			if activeConnections == 0 {
-				return
+				return trace.Wrap(err)
 			}
 
 			if time.Since(lastReport) > 10*s.cfg.ShutdownPollPeriod {
@@ -856,7 +856,7 @@ func (s *Server) Shutdown(ctx context.Context) (err error) {
 			}
 		case <-ctx.Done():
 			s.log.Infof("Context canceled wait, returning.")
-			return
+			return trace.Wrap(err)
 		}
 	}
 }

--- a/lib/srv/db/server_test.go
+++ b/lib/srv/db/server_test.go
@@ -394,25 +394,9 @@ func TestShutdownWithActiveConnections(t *testing.T) {
 	}
 
 	cancelConn()
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		select {
-		case err := <-connErrCh:
-			assert.NoError(c, err, "unexpected connection error")
-		default:
-		}
-	}, time.Second, 100*time.Millisecond)
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		select {
-		case err := <-shutdownErrCh:
-			assert.NoError(c, err, "unexpected server shutdown error")
-		default:
-		}
-	}, time.Second, 100*time.Millisecond)
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.NoError(c, server.Wait(), "unexpected server Wait error")
-	}, time.Second, 100*time.Millisecond)
+	require.NoError(t, <-connErrCh, "unexpected connection close error")
+	require.NoError(t, <-shutdownErrCh, "unexpected server shutdown error")
+	require.NoError(t, server.Wait(), "unexpected server Wait error")
 }
 
 // TestShutdownWithActiveConnections given that a running database server with
@@ -432,10 +416,7 @@ func TestCloseWithActiveConnections(t *testing.T) {
 		default:
 		}
 	}, time.Second, 100*time.Millisecond)
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.NoError(t, server.Wait(), "unexpected error from server Wait")
-	}, time.Second, 100*time.Millisecond)
+	require.NoError(t, server.Wait(), "unexpected server Wait error")
 }
 
 // serverWithActiveConnection starts a server with one active connection that
@@ -451,7 +432,7 @@ func databaseServerWithActiveConnection(t *testing.T, ctx context.Context) (*Ser
 	require.True(t, ok)
 
 	connCtx, cancelConn := context.WithCancel(ctx)
-	t.Cleanup(func() { cancelConn() })
+	t.Cleanup(cancelConn)
 	connErrCh := make(chan error)
 
 	go func() {
@@ -481,12 +462,22 @@ func databaseServerWithActiveConnection(t *testing.T, ctx context.Context) (*Ser
 	}()
 
 	require.Eventually(t, func() bool {
+		select {
+		case err := <-connErrCh:
+			assert.Failf(t, "unexpected connection close", "conn error: %v", err)
+		default:
+		}
 		return testCtx.server.activeConnections.Load() == int32(1)
 	}, time.Second, 100*time.Millisecond, "expected one active connection, but got none")
 
 	// Ensures the first query has been received.
 	require.Eventually(t, func() bool {
-		return dbTestServer.db.QueryCount() > uint32(1)
+		select {
+		case err := <-connErrCh:
+			assert.Failf(t, "unexpected connection close", "conn error: %v", err)
+		default:
+		}
+		return dbTestServer.db.QueryCount() >= uint32(1)
 	}, time.Second, 100*time.Millisecond, "database test server hasn't received queries")
 
 	return testCtx.server, connErrCh, cancelConn


### PR DESCRIPTION
This PR attempts to fix flakiness in a couple of tests, and reports better failure messages if they continue to flake:
* TestCloseWithActiveConnections
* TestShutdownWithActiveConnections

I got a local test failure on these while running the test suite to investigate another test, but I'm not aware of it actually failing in CI.

The test failure was caused by not getting a db query server-side, although we were checking for at least 2 queries instead of 1, and the error message didn't indicate what caused the missing queries.

In any case, if these tests fail in CI, we'll at least get a more useful error message about why it failed