### PR TITLE
Add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -169,3 +169,16 @@ updates:
       - jentfoo
       - rosstimothy
       - zmb3
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: "America/Los_Angeles"
+    reviewers:
+      - wadells
+      - jentfoo
+      - fheinecke
+      - camscale


### PR DESCRIPTION
We have some 3rd party GitHub Actions we're pinning for determinism and security, however we'd also like these pinned actions to stay up to date in a controlled fashion.  This PR adds Dependabot for Github actions.

For example of recent pinnings, see:
* https://github.com/gravitational/teleport/pull/31045
* https://github.com/gravitational/teleport/pull/31115

Initial reviewers are a mix of security and internal tools folks, chosen to triage the first couple rounds of updates.  I plan on handling these mostly myself, but I'd like to keep the other folks aware.

I chose not to add a language group for these yet, as I'd rather deal with each update individually while we get GHA dependency management ship-shape.

Contributes to https://github.com/gravitational/SecOps/issues/403

### Testing Done

I added a version of this in https://github.com/wadells/teleport.  You can see an example PR it opened here:

https://github.com/wadells/teleport/pull/15