### PR TITLE
wait for disconnect in tests

### DIFF
--- a/lib/srv/db/proxy_test.go
+++ b/lib/srv/db/proxy_test.go
@@ -403,8 +403,10 @@ func TestProxyClientDisconnectDueToIdleConnection(t *testing.T) {
 	testCtx.clock.Advance(idleClientTimeout + connMonitorDisconnectTimeBuff)
 
 	waitForEvent(t, testCtx, events.ClientDisconnectCode)
-	err = mysql.Ping()
-	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		err := mysql.Ping()
+		return err != nil
+	}, time.Second, 100*time.Millisecond, "failed to disconnect client conn")
 }
 
 // TestProxyClientDisconnectDueToCertExpiration ensures that if the DisconnectExpiredCert cluster flag is enabled
@@ -431,8 +433,10 @@ func TestProxyClientDisconnectDueToCertExpiration(t *testing.T) {
 	testCtx.clock.Advance(ttlClientCert)
 
 	waitForEvent(t, testCtx, events.ClientDisconnectCode)
-	err = mysql.Ping()
-	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		err := mysql.Ping()
+		return err != nil
+	}, time.Second, 100*time.Millisecond, "failed to disconnect client conn")
 }
 
 // TestProxyClientDisconnectDueToLockInForce ensures that clients will be
@@ -460,8 +464,10 @@ func TestProxyClientDisconnectDueToLockInForce(t *testing.T) {
 	require.NoError(t, err)
 
 	waitForEvent(t, testCtx, events.ClientDisconnectCode)
-	err = mysql.Ping()
-	require.Error(t, err)
+	require.Eventually(t, func() bool {
+		err := mysql.Ping()
+		return err != nil
+	}, time.Second, 100*time.Millisecond, "failed to disconnect client conn")
 }
 
 func setConfigClientIdleTimoutAndDisconnectExpiredCert(ctx context.Context, t *testing.T, auth *auth.Server, timeout time.Duration) {

--- a/lib/srv/db/proxy_test.go
+++ b/lib/srv/db/proxy_test.go
@@ -406,7 +406,7 @@ func TestProxyClientDisconnectDueToIdleConnection(t *testing.T) {
 	require.Eventually(t, func() bool {
 		err := mysql.Ping()
 		return err != nil
-	}, time.Second, 100*time.Millisecond, "failed to disconnect client conn")
+	}, 5*time.Second, 100*time.Millisecond, "failed to disconnect client conn")
 }
 
 // TestProxyClientDisconnectDueToCertExpiration ensures that if the DisconnectExpiredCert cluster flag is enabled
@@ -436,7 +436,7 @@ func TestProxyClientDisconnectDueToCertExpiration(t *testing.T) {
 	require.Eventually(t, func() bool {
 		err := mysql.Ping()
 		return err != nil
-	}, time.Second, 100*time.Millisecond, "failed to disconnect client conn")
+	}, 5*time.Second, 100*time.Millisecond, "failed to disconnect client conn")
 }
 
 // TestProxyClientDisconnectDueToLockInForce ensures that clients will be
@@ -467,7 +467,7 @@ func TestProxyClientDisconnectDueToLockInForce(t *testing.T) {
 	require.Eventually(t, func() bool {
 		err := mysql.Ping()
 		return err != nil
-	}, time.Second, 100*time.Millisecond, "failed to disconnect client conn")
+	}, 5*time.Second, 100*time.Millisecond, "failed to disconnect client conn")
 }
 
 func setConfigClientIdleTimoutAndDisconnectExpiredCert(ctx context.Context, t *testing.T, auth *auth.Server, timeout time.Duration) {


### PR DESCRIPTION
Fixes flaky tests https://github.com/gravitational/teleport/issues/31117 by waiting for client disconnect, since we changed the disconnect event to be emitted before the disconnect in https://github.com/gravitational/teleport/pull/31066