### PR TITLE
Use `127.0.0.1:3080` as Vite default proxy target

### DIFF
--- a/web/packages/build/vite/config.ts
+++ b/web/packages/build/vite/config.ts
@@ -28,6 +28,8 @@ import { getStyledComponentsConfig } from './styled';
 
 import type { UserConfig } from 'vite';
 
+const DEFAULT_PROXY_TARGET = '127.0.0.1:3080';
+
 export function createViteConfig(
   rootDirectory: string,
   outputDirectory: string
@@ -42,10 +44,10 @@ export function createViteConfig(
         );
       } else {
         console.warn(
-          '  \x1b[33m⚠ PROXY_TARGET was not set, defaulting to localhost:3080\x1b[0m'
+          `  \x1b[33m⚠ PROXY_TARGET was not set, defaulting to ${DEFAULT_PROXY_TARGET}\x1b[0m`
         );
 
-        target = 'localhost:3080';
+        target = DEFAULT_PROXY_TARGET;
       }
     }
 


### PR DESCRIPTION
Node.js >= 17 returns an IPv6 address (::1) when resolving `localhost` instead of an IPv4 address (127.0.0.1).
This causes the following errors:
```
10:02:25 AM [vite] Internal server error: connect ECONNREFUSED ::1:3080
      at TCPConnectWrap.afterConnect [as oncomplete] (node:net:1495:16)
```

More details: https://github.com/nodejs/node/issues/40702#issuecomment-1103623246