### PR TITLE
Don't set additional groups on darwin

### DIFF
--- a/lib/srv/reexec.go
+++ b/lib/srv/reexec.go
@@ -1038,11 +1038,11 @@ func (o *osWrapper) newParker(ctx context.Context, credential syscall.Credential
 // getCmdCredentials parses the uid, gid, and groups of the
 // given user into a credential object for a command to use.
 func getCmdCredential(localUser *user.User) (*syscall.Credential, error) {
-	uid, err := strconv.Atoi(localUser.Uid)
+	uid, err := strconv.ParseUint(localUser.Uid, 10, 32)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	gid, err := strconv.Atoi(localUser.Gid)
+	gid, err := strconv.ParseUint(localUser.Gid, 10, 32)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -1065,7 +1065,7 @@ func getCmdCredential(localUser *user.User) (*syscall.Credential, error) {
 	}
 	groups := make([]uint32, 0)
 	for _, sgid := range userGroups {
-		igid, err := strconv.Atoi(sgid)
+		igid, err := strconv.ParseUint(sgid, 10, 32)
 		if err != nil {
 			log.Warnf("Cannot interpret user group: '%v'", sgid)
 		} else {


### PR DESCRIPTION
This PR makes it so that we don't set the list of additional groups when spawning processes as a user other than the one running the `teleport` binary on macOS; setting the list to more than 16 groups is not possible, and the call to setgroups is "highly discouraged" (as per the man page in macOS 13.5), and the system seems to pick up the correct list of additional groups just fine even without our effort.

Fixes #3167.
