### PR TITLE
[v13] Get accessInfo based on user on access request drop

### DIFF
--- a/integration/teleterm_test.go
+++ b/integration/teleterm_test.go
@@ -302,6 +302,13 @@ func testHeadlessWatcher(t *testing.T, pack *dbhelpers.DatabasePack, creds *help
 	}, time.Second, 100*time.Millisecond)
 }
 
+// mustLogin logs in as the given user by completely skipping the actual login flow and saving valid
+// certs to disk. clusters.Storage can then be pointed to tc.KeysDir and daemon.Service can act as
+// if the user was successfully logged in.
+//
+// This is faster than going through the actual process, but keep in mind that it might skip some
+// vital steps. It should be used only for tests which don't depend on complex user setup and do not
+// reissue certs or modify them in some other way.
 func mustLogin(t *testing.T, userName string, pack *dbhelpers.DatabasePack, creds *helpers.UserCreds) *client.TeleportClient {
 	tc, err := pack.Root.Cluster.NewClientWithCreds(helpers.ClientConfig{
 		Login:   userName,

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -2766,11 +2766,7 @@ func (a *ServerWithRoles) desiredAccessInfoForUser(ctx context.Context, req *pro
 		// Reset to the base roles and traits stored in the backend user,
 		// currently active requests (not being dropped) and new access requests
 		// will be filled in below.
-		userState, err := a.authServer.getUserOrLoginState(ctx, user.GetName())
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-		accessInfo = services.AccessInfoFromUserState(userState)
+		accessInfo = services.AccessInfoFromUser(user)
 
 		// Check for ["*"] as special case to drop all requests.
 		if len(req.DropAccessRequests) == 1 && req.DropAccessRequests[0] == "*" {


### PR DESCRIPTION
Backport #31068.

Changelog: `tsh request drop` behavior was restored to pre-v13.3.5 state where after dropping an access request, the role list will be based on the current role list of the user on the backend, not on the login state (as introduced in #30628).

---

The backport doesn't include the integration test because the test was for a feature that's not included in v13.