### PR TITLE
chore: Bump devbox go to 1.21.0.

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -16,7 +16,7 @@
     "yamllint@latest",
     "zlib@latest",
 
-    "go@1.20.6",
+    "go@1.21.0",
     "libfido2@1.13.0",
     "llvmPackages_14.clangUseLLVM@14.0.6",
     "nodejs@18.16.1",

--- a/devbox.lock
+++ b/devbox.lock
@@ -37,11 +37,11 @@
       "source": "devbox-search",
       "version": "2.41.0"
     },
-    "go@1.20.6": {
-      "last_modified": "2023-07-30T12:29:02Z",
-      "resolved": "github:NixOS/nixpkgs/3acb5c4264c490e7714d503c7166a3fde0c51324#go",
+    "go@1.21.0": {
+      "last_modified": "2023-08-22T06:04:29Z",
+      "resolved": "github:NixOS/nixpkgs/9d757ec498666cc1dcc6f2be26db4fd3e1e9ab37#go_1_21",
       "source": "devbox-search",
-      "version": "1.20.6"
+      "version": "1.21.0"
     },
     "golangci-lint@latest": {
       "last_modified": "2023-06-30T04:44:22Z",


### PR DESCRIPTION
go on the devbox has been bumped to 1.21.0.