### PR TITLE
PoC: sane CRD creation logic

### DIFF
--- a/examples/chart/teleport-cluster/Chart.yaml
+++ b/examples/chart/teleport-cluster/Chart.yaml
@@ -12,4 +12,4 @@ keywords:
 dependencies:
   - name: teleport-operator
     version: *version
-    condition: installCRDs,operator.enabled
+    alias: operator

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_githubconnectors.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/resources.teleport.dev_githubconnectors.yaml
@@ -1,3 +1,17 @@
+{{/*
+  Deploy the CRD if `installCRDs` is set to "always", or if `installCRD` is set
+  to "dynamic" and either `enabled` is true or the CRD is already present.
+*/}}
+{{- if or
+  (eq .Values.installCRDs "always")
+  (and
+    (eq .Values.installCRDs "dynamic")
+    (or
+      .Values.enabled
+      (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "teleportgithubconnectors.resources.teleport.dev")
+    )
+  )
+}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -166,3 +180,4 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
+{{- end }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/templates/test.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/templates/test.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+data:
+  foo: |2
+    {{- lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "teleportgithubconnectors.resources.teleport.dev" | printf "#%v" | nindent 4}}
+  {{ if (lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" "teleportgithubconnectors.resources.teleport.dev")}}
+  bar: lookup true
+  {{- end }}

--- a/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
+++ b/examples/chart/teleport-cluster/charts/teleport-operator/values.yaml
@@ -1,0 +1,9 @@
+enabled: true
+
+# Can take 3 values: dynamic, always, never
+# - "dynamic" means the CRD will be installed if the operator is enabled or if
+#   the CRD was already present in the cluster. The presence check is here to
+#   avoid massive deletion issue when disabling the operator.
+# - "always" means the CRD is always installed
+# - "never" means the CRD is never installed
+installCRDs: "dynamic"


### PR DESCRIPTION
This is a Proof of concept of one potential solution for https://github.com/gravitational/teleport/issues/31059

This is a small breaking change: `installCRDs` will now be ignored and `operator.installCRDs` is a string with 3 values:
- `always`
- `never`
- `dynamic`

We could use v14 to make this breaking change.