### PR TITLE
Remove unsafe usage of resource id

### DIFF
--- a/lib/web/app/handler_test.go
+++ b/lib/web/app/handler_test.go
@@ -330,7 +330,7 @@ func TestMatchApplicationServers(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	fakeClock := clockwork.NewFakeClockAt(time.Date(2017, 05, 10, 18, 53, 0, 0, time.UTC))
+	fakeClock := clockwork.NewFakeClock()
 	authClient := &mockAuthClient{
 		clusterName: clusterName,
 		appSession:  createAppSession(t, fakeClock, key, cert, clusterName, publicAddr),

--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -49,7 +49,7 @@ type transportConfig struct {
 	servers      []types.AppServer
 	ws           types.WebSession
 	clusterName  string
-	log          *logrus.Entry
+	log          logrus.FieldLogger
 }
 
 // Check validates configuration.
@@ -95,10 +95,8 @@ type transport struct {
 	// clientTLSConfig is the TLS config used for mutual authentication.
 	clientTLSConfig *tls.Config
 
-	// servers is the list of servers that the transport can connect to
-	// organized in a map where the key is the server ID, and the value is the
-	// `types.AppServer`.
-	servers *sync.Map
+	// mu protects access to servers in the transportConfig
+	mu sync.Mutex
 }
 
 // newTransport creates a new transport.
@@ -108,7 +106,7 @@ func newTransport(c *transportConfig) (*transport, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	t := &transport{c: c, servers: &sync.Map{}}
+	t := &transport{c: c}
 
 	t.clientTLSConfig, err = configureTLS(c)
 	if err != nil {
@@ -122,10 +120,6 @@ func newTransport(c *transportConfig) (*transport, error) {
 	}
 	tr.DialContext = t.DialContext
 	tr.TLSClientConfig = t.clientTLSConfig
-
-	for _, server := range t.c.servers {
-		t.servers.Store(server.GetResourceID(), server)
-	}
 
 	t.tr = tr
 	return t, nil
@@ -234,41 +228,36 @@ func (t *transport) rewriteRequest(r *http.Request) error {
 
 // DialContext dials and connect to the application service over the reverse
 // tunnel subsystem.
-func (t *transport) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
-	var err error
-	var conn net.Conn
+func (t *transport) DialContext(ctx context.Context, _, _ string) (conn net.Conn, err error) {
+	t.mu.Lock()
+	servers := make([]types.AppServer, len(t.c.servers))
+	copy(servers, t.c.servers)
+	t.mu.Unlock()
 
-	t.servers.Range(func(serverID, appServerInterface interface{}) bool {
-		appServer, ok := appServerInterface.(types.AppServer)
-		if !ok {
-			t.c.log.Warnf("Failed to load AppServer, invalid type %T", appServerInterface)
-			return true
+	var i int
+	for ; i < len(servers); i++ {
+		appServer := servers[i]
+		conn, err = dialAppServer(ctx, t.c.proxyClient, t.c.identity.RouteToApp.ClusterName, appServer)
+		if err != nil && isReverseTunnelDownError(err) {
+			t.c.log.Warnf("Failed to connect to application server %q: %v.", appServer, err)
+			// Continue to the next server if there is an issue
+			// establishing a connection because the tunnel is not
+			// healthy. Reset the error to avoid returning it if
+			// this is the last server.
+			err = nil
+			continue
 		}
 
-		var dialErr error
-		conn, dialErr = dialAppServer(ctx, t.c.proxyClient, t.c.identity.RouteToApp.ClusterName, appServer)
-		if dialErr != nil {
-			if isReverseTunnelDownError(dialErr) {
-				t.c.log.Warnf("Failed to connect to application server %q: %v.", serverID, dialErr)
-				t.servers.Delete(serverID)
-				// Only goes for the next server if the error returned is a
-				// connection problem. Otherwise, stop iterating over the
-				// servers and return the error.
-				return true
-			}
-		}
-
-		// "save" dial error to return as the function error.
-		err = dialErr
-		return false
-	})
-
-	if err != nil {
-		return nil, trace.Wrap(err)
+		break
 	}
 
-	if conn != nil {
-		return conn, nil
+	// eliminate any servers from the head of the list that were unreachable
+	t.mu.Lock()
+	t.c.servers = t.c.servers[i:]
+	t.mu.Unlock()
+
+	if conn != nil || err != nil {
+		return conn, trace.Wrap(err)
 	}
 
 	return nil, trace.ConnectionProblem(nil, "no application servers remaining to connect")


### PR DESCRIPTION
The transport used by app service was using a sync.Map keyed by the resource id to store app servers. However, the id of a resource is not guaranteed to be unique which could cause apps to be missed. The sync.Map was removed in favor of a mutex and iterating over the configured servers slice directly.