### PR TITLE
Use the Go 1.21.0 toolchain to build modules

### DIFF
--- a/.github/workflows/build-api.yaml
+++ b/.github/workflows/build-api.yaml
@@ -38,8 +38,5 @@ jobs:
           go-version-file: api/go.mod
           cache-dependency-path: api/go.sum
 
-      - name: Init workspace
-        run: go work init . ./api/
-        
       - name: Build
-        run: go build ./api/...
+        run: cd api; go build ./...

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/gravitational/teleport
 
 go 1.20
 
+toolchain go1.21.0
+
 require (
 	cloud.google.com/go/compute v1.23.0
 	cloud.google.com/go/compute/metadata v0.2.3


### PR DESCRIPTION
This has (mostly) no practical effect as of right now, but it's a convenient way to bump the Go version for future patches/releases.

Done using `go get toolchain@go1.21`.

* https://go.dev/blog/toolchain