### PR TITLE
Reduce latency establishing desktop connections

### DIFF
--- a/lib/service/service.go
+++ b/lib/service/service.go
@@ -4000,9 +4000,10 @@ func (process *TeleportProcess) initProxyEndpoint(conn *Connector) error {
 				ctx, err := controller(ctx, sctx, login, localAddr, remoteAddr)
 				return ctx, trace.Wrap(err)
 			}),
-			PROXYSigner:  proxySigner,
-			OpenAIConfig: cfg.OpenAIConfig,
-			NodeWatcher:  nodeWatcher,
+			PROXYSigner:    proxySigner,
+			OpenAIConfig:   cfg.OpenAIConfig,
+			NodeWatcher:    nodeWatcher,
+			TracerProvider: process.TracingProvider,
 		}
 		webHandler, err := web.NewHandler(webConfig)
 		if err != nil {

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -78,6 +78,7 @@ import (
 	"github.com/gravitational/teleport/lib/limiter"
 	"github.com/gravitational/teleport/lib/modules"
 	"github.com/gravitational/teleport/lib/multiplexer"
+	"github.com/gravitational/teleport/lib/observability/tracing"
 	"github.com/gravitational/teleport/lib/plugin"
 	"github.com/gravitational/teleport/lib/proxy"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -141,6 +142,9 @@ type Handler struct {
 	// nodeWatcher is a services.NodeWatcher used by Assist to lookup nodes from
 	// the proxy's cache and get nodes in real time.
 	nodeWatcher *services.NodeWatcher
+
+	// tracer is used to create spans.
+	tracer oteltrace.Tracer
 }
 
 // HandlerOption is a functional argument - an option that can be passed
@@ -269,6 +273,16 @@ type Config struct {
 	NodeWatcher *services.NodeWatcher
 }
 
+// SetDefaults ensures proper default values are set if
+// not provided.
+func (c *Config) SetDefaults() {
+	c.ProxyClient = auth.WithGithubConnectorConversions(c.ProxyClient)
+
+	if c.TracerProvider == nil {
+		c.TracerProvider = tracing.NoopProvider()
+	}
+}
+
 type APIHandler struct {
 	handler *Handler
 
@@ -315,13 +329,16 @@ func (h *APIHandler) Close() error {
 // NewHandler returns a new instance of web proxy handler
 func NewHandler(cfg Config, opts ...HandlerOption) (*APIHandler, error) {
 	const apiPrefix = "/" + teleport.WebAPIVersion
-	cfg.ProxyClient = auth.WithGithubConnectorConversions(cfg.ProxyClient)
+
+	cfg.SetDefaults()
+
 	h := &Handler{
 		cfg:                  cfg,
 		log:                  newPackageLogger(),
 		clock:                clockwork.NewRealClock(),
 		ClusterFeatures:      cfg.ClusterFeatures,
 		healthCheckAppServer: cfg.HealthCheckAppServer,
+		tracer:               cfg.TracerProvider.Tracer(teleport.ComponentWeb),
 	}
 
 	// Check for self-hosted vs Cloud.

--- a/lib/web/desktop.go
+++ b/lib/web/desktop.go
@@ -36,6 +36,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/gravitational/trace"
+	"github.com/gravitational/trace/trail"
 	"github.com/julienschmidt/httprouter"
 	"github.com/sirupsen/logrus"
 
@@ -48,7 +49,6 @@ import (
 	"github.com/gravitational/teleport/lib/client"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/httplib"
-	"github.com/gravitational/teleport/lib/multiplexer"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
 	"github.com/gravitational/teleport/lib/srv/desktop/tdp"
 	"github.com/gravitational/teleport/lib/utils"
@@ -168,14 +168,8 @@ func (h *Handler) createDesktopConnection(
 		validServiceIDs[i], validServiceIDs[j] = validServiceIDs[j], validServiceIDs[i]
 	})
 
-	pc, err := proxyClient(r.Context(), sctx, h.ProxyHostPort(), username, h.cfg.PROXYSigner)
-	if err != nil {
-		return sendTDPError(trace.Wrap(err))
-	}
-	defer pc.Close()
-
 	// Issue certificate for TLS config and pass MFA check if required.
-	tlsConfig, err := desktopTLSConfig(r.Context(), ws, pc, sctx, desktopName, username, site.GetName())
+	tlsConfig, err := h.desktopTLSConfig(r.Context(), ws, clt, sctx, desktopName, username, site.GetName())
 	if err != nil {
 		return sendTDPError(err)
 	}
@@ -219,33 +213,6 @@ func (h *Handler) createDesktopConnection(
 	return nil
 }
 
-func proxyClient(ctx context.Context, sessCtx *SessionContext, addr, windowsUser string, proxySigner multiplexer.PROXYHeaderSigner) (*client.ProxyClient, error) {
-	cfg, err := makeTeleportClientConfig(ctx, sessCtx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-
-	// Set HostLogin to avoid the default behavior of looking up the
-	// Unix user Teleport is running as (which doesn't work in containerized
-	// environments where we're running as an arbitrary UID)
-	cfg.HostLogin = windowsUser
-
-	cfg.PROXYSigner = proxySigner
-
-	if err := cfg.ParseProxyHost(addr); err != nil {
-		return nil, trace.Wrap(err)
-	}
-	tc, err := client.NewClient(cfg)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	pc, err := tc.ConnectToProxy(ctx)
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
-	return pc, nil
-}
-
 const (
 	// SNISuffix is the server name suffix used during SNI to specify the
 	// target desktop to connect to. The client (proxy_service) will use SNI
@@ -256,72 +223,176 @@ const (
 	SNISuffix = ".desktop." + constants.APIDomain
 )
 
-func desktopTLSConfig(ctx context.Context, ws *websocket.Conn, pc *client.ProxyClient, sessCtx *SessionContext, desktopName, username, siteName string) (*tls.Config, error) {
+func (h *Handler) desktopTLSConfig(ctx context.Context, ws *websocket.Conn, clusterClient auth.ClientI, sessCtx *SessionContext, desktopName, username, siteName string) (_ *tls.Config, err error) {
+	ctx, span := h.tracer.Start(ctx, "desktop/TLSConfig")
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+
 	pk, err := keys.ParsePrivateKey(sessCtx.cfg.Session.GetPriv())
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
 
-	codec := tdpMFACodec{}
-
-	key, err := pc.IssueUserCertsWithMFA(ctx, client.ReissueParams{
-		RouteToWindowsDesktop: proto.RouteToWindowsDesktop{
-			WindowsDesktop: desktopName,
-			Login:          username,
+	mfaRequiredResp, err := clusterClient.IsMFARequired(ctx, &proto.IsMFARequiredRequest{
+		Target: &proto.IsMFARequiredRequest_WindowsDesktop{
+			WindowsDesktop: &proto.RouteToWindowsDesktop{
+				WindowsDesktop: desktopName,
+				Login:          username,
+			},
 		},
-		RouteToCluster: siteName,
-		ExistingCreds: &client.Key{
-			PrivateKey:          pk,
-			Cert:                sessCtx.cfg.Session.GetPub(),
-			TLSCert:             sessCtx.cfg.Session.GetTLSCert(),
-			WindowsDesktopCerts: make(map[string][]byte),
-		},
-	}, func(ctx context.Context, c *proto.MFAAuthenticateChallenge) (*proto.MFAAuthenticateResponse, error) {
-		challenge := &client.MFAAuthenticateChallenge{
-			WebauthnChallenge: wantypes.CredentialAssertionFromProto(c.WebauthnChallenge),
-		}
-
-		// Send the challenge over the socket.
-		msg, err := codec.encode(challenge, defaults.WebsocketWebauthnChallenge)
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		if err := ws.WriteMessage(websocket.BinaryMessage, msg); err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		ty, buf, err := ws.ReadMessage()
-		if err != nil {
-			return nil, trace.Wrap(err)
-		}
-
-		if ty != websocket.BinaryMessage {
-			return nil, trace.BadParameter("received unexpected web socket message type %d", ty)
-		}
-
-		resp, err := codec.decodeResponse(buf, defaults.WebsocketWebauthnChallenge)
-		return resp, trace.Wrap(err)
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	windowsDesktopCerts, ok := key.WindowsDesktopCerts[desktopName]
-	if !ok {
-		return nil, trace.NotFound("failed to find windows desktop certificates for %q", desktopName)
+
+	key := &client.Key{
+		PrivateKey: pk,
+		Cert:       sessCtx.cfg.Session.GetPub(),
+		TLSCert:    sessCtx.cfg.Session.GetTLSCert(),
 	}
-	certConf, err := pk.TLSCertificate(windowsDesktopCerts)
+
+	tlsCert, err := key.TeleportTLSCertificate()
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	certsReq := proto.UserCertsRequest{
+		PublicKey:      key.MarshalSSHPublicKey(),
+		Username:       tlsCert.Subject.CommonName,
+		Expires:        tlsCert.NotAfter,
+		RouteToCluster: siteName,
+		Usage:          proto.UserCertsRequest_WindowsDesktop,
+		RouteToWindowsDesktop: proto.RouteToWindowsDesktop{
+			WindowsDesktop: desktopName,
+			Login:          username,
+		},
+	}
+
+	var certPEMBlock []byte
+	if mfaRequiredResp.Required {
+		certPEMBlock, err = h.performMFACeremony(ctx, sessCtx.cfg.RootClient, ws, &certsReq)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+	} else {
+		certs, err := sessCtx.cfg.RootClient.GenerateUserCerts(ctx, certsReq)
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		certPEMBlock = certs.TLS
+	}
+
+	certConf, err := pk.TLSCertificate(certPEMBlock)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
 	tlsConfig, err := sessCtx.ClientTLSConfig(ctx)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	tlsConfig.Certificates = []tls.Certificate{certConf}
 	// Pass target desktop name via SNI.
 	tlsConfig.ServerName = desktopName + SNISuffix
 	return tlsConfig, nil
+}
+
+// performMFACeremony completes the mfa ceremony and returns the raw TLS certificate
+// on success. The user will be prompted to tap their security key by the UI
+// in order to perform the assertion.
+func (h *Handler) performMFACeremony(ctx context.Context, authClient auth.ClientI, ws *websocket.Conn, certsReq *proto.UserCertsRequest) (_ []byte, err error) {
+	ctx, span := h.tracer.Start(ctx, "desktop/performMFACeremony")
+	defer func() {
+		span.RecordError(err)
+		span.End()
+	}()
+
+	stream, err := authClient.GenerateUserSingleUseCerts(ctx)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	defer func() {
+		stream.CloseSend()
+		stream.Recv()
+	}()
+
+	if err := stream.Send(
+		&proto.UserSingleUseCertsRequest{
+			Request: &proto.UserSingleUseCertsRequest_Init{
+				Init: certsReq,
+			},
+		}); err != nil {
+		return nil, trail.FromGRPC(err)
+	}
+
+	challengeResp, err := stream.Recv()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	c := challengeResp.GetMFAChallenge()
+	if c == nil {
+		return nil, trace.BadParameter("server sent a %T on GenerateUserSingleUseCerts, expected MFAChallenge", challengeResp.Response)
+	}
+
+	codec := tdpMFACodec{}
+
+	// Send the challenge over the socket.
+	msg, err := codec.encode(
+		&client.MFAAuthenticateChallenge{
+			WebauthnChallenge: wantypes.CredentialAssertionFromProto(c.WebauthnChallenge),
+		},
+		defaults.WebsocketWebauthnChallenge,
+	)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if err := ws.WriteMessage(websocket.BinaryMessage, msg); err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	span.AddEvent("waiting for user to complete mfa ceremony")
+	ty, buf, err := ws.ReadMessage()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if ty != websocket.BinaryMessage {
+		return nil, trace.BadParameter("received unexpected web socket message type %d", ty)
+	}
+
+	assertion, err := codec.decodeResponse(buf, defaults.WebsocketWebauthnChallenge)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+	span.AddEvent("mfa ceremony completed")
+
+	err = stream.Send(&proto.UserSingleUseCertsRequest{Request: &proto.UserSingleUseCertsRequest_MFAResponse{MFAResponse: assertion}})
+	if err != nil {
+		return nil, trail.FromGRPC(err)
+	}
+
+	userCertResp, err := stream.Recv()
+	if err != nil {
+		return nil, trail.FromGRPC(err)
+	}
+
+	certResp := userCertResp.GetCert()
+	if certResp == nil {
+		return nil, trace.BadParameter("server sent a %T on GenerateUserSingleUseCerts, expected SingleUseUserCert", userCertResp.Response)
+	}
+
+	switch crt := certResp.Cert.(type) {
+	case *proto.SingleUseUserCert_TLS:
+		return crt.TLS, nil
+	default:
+		return nil, trace.BadParameter("server sent a %T SingleUseUserCert in response", certResp.Cert)
+	}
 }
 
 type connector struct {


### PR DESCRIPTION
Eliminates the Proxy communicating with itself via SSH to generate user TLS certificates when connecting to desktops. The web api already has an establish auth client to the root and leaf cluster and is capable of issuing certificates directly with them.