### PR TITLE
Fix the 'more labels' link hover state

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
@@ -361,7 +361,7 @@ const MoreLabelsButton = styled(ButtonLink)`
   transition: visibility 0s;
   transition: background 150ms;
 
-  .grv-unified-resource-card:hover & {
+  ${CardContainer}:hover & {
     background-color: ${props => props.theme.colors.levels.elevated};
   }
 `;


### PR DESCRIPTION
Fixes #30828.

Before: 
![Aug-30-2023 12-20-09](https://github.com/gravitational/teleport/assets/9391503/b4603c8b-a107-4f94-838c-3a407b2f702b)

After: 
![Aug-30-2023 12-18-51](https://github.com/gravitational/teleport/assets/9391503/34871351-c5a5-46c8-8d35-9e8f9fcbe4c9)
