### PR TITLE
Make the WebAuthn error message a bit more explicit

### DIFF
--- a/web/packages/teleport/src/services/auth/makeMfa.ts
+++ b/web/packages/teleport/src/services/auth/makeMfa.ts
@@ -110,7 +110,9 @@ export function makeWebauthnCreationResponse(res) {
 export function makeWebauthnAssertionResponse(res) {
   // Response can be null if Credential cannot be unambiguously obtained.
   if (!res) {
-    throw new Error('error obtaining credential, please try again');
+    throw new Error(
+      'error obtaining credential from the hardware key, please try again'
+    );
   }
 
   const clientExtentions = res.getClientExtensionResults();


### PR DESCRIPTION
Fixes #28351 