### PR TITLE
post-release: pass GITHUB_TOKEN for gh CLI use

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -67,7 +67,7 @@ jobs:
           echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Generate Github token
+      - name: Generate GitHub token
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92 # v1.8.0
         with:
@@ -100,3 +100,5 @@ jobs:
           git commit -am "[auto] docs: Update version to ${{ github.event.release.tag_name }}"
           git push --set-upstream origin $BRANCH_NAME
           gh pr create --fill --label=automated --label=documentation
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Fixes the error encountered here: https://github.com/gravitational/teleport/actions/runs/6018662804/job/16327233723#step:5:3010