### PR TITLE
[v14] [docs] update TLS routing curl test with --no-alpn

### DIFF
--- a/docs/pages/architecture/tls-routing.mdx
+++ b/docs/pages/architecture/tls-routing.mdx
@@ -249,7 +249,7 @@ and long-lived connections.
 You can set up a Teleport Proxy Service behind the reverse proxy and run the
 following command to test the connection:
 ```bash
-$ curl -v https://<proxy.example.com>/webapi/connectionupgrade -H "Connection: Upgrade" -H "Upgrade: alpn-ping"
+$ curl -v https://<proxy.example.com>/webapi/connectionupgrade -H "Connection: Upgrade" -H "Upgrade: alpn-ping" --no-alpn
 ```
 
 For a successful upgrade, the server should return "101 Switching Protocols"


### PR DESCRIPTION
Backport #31088 to branch/v14