### PR TITLE
[v13] docs: use variables for proxy addresses in Kube access

### DIFF
--- a/docs/pages/kubernetes-access/discovery/aws.mdx
+++ b/docs/pages/kubernetes-access/discovery/aws.mdx
@@ -256,13 +256,12 @@ the Kubernetes Service listen to the dynamic resources created by the Discovery
 Service.
 
 ```yaml
-version: v2
+version: v3
 teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  auth_servers:
-  - "teleport.example.com:3080"
+  proxy_server: <Var name="teleport.example.com" />:443
 auth_service:
   enabled: off
 proxy_service:

--- a/docs/pages/kubernetes-access/discovery/azure.mdx
+++ b/docs/pages/kubernetes-access/discovery/azure.mdx
@@ -227,13 +227,12 @@ Service.
 (!docs/pages/kubernetes-access/discovery/includes/discovery-group.mdx!)
 
 ```yaml
-version: v2
+version: v3
 teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  auth_servers:
-  - "teleport.example.com:3080"
+  proxy_server: <Var name="teleport.example.com" />:443    
 auth_service:
   enabled: off
 proxy_service:

--- a/docs/pages/kubernetes-access/discovery/google-cloud.mdx
+++ b/docs/pages/kubernetes-access/discovery/google-cloud.mdx
@@ -363,7 +363,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: "teleport.example.com:443"
+  proxy_server: <Var name="teleport.example.com" />:443    
 auth_service:
   enabled: off
 proxy_service:
@@ -385,7 +385,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: "teleport.example.com:443"
+  proxy_server: <Var name="teleport.example.com" />:443    
 auth_service:
   enabled: off
 proxy_service:

--- a/docs/pages/kubernetes-access/getting-started.mdx
+++ b/docs/pages/kubernetes-access/getting-started.mdx
@@ -84,8 +84,8 @@ commands, assigning `PROXY_ADDR` to the address of your Auth Service or Proxy
 Service.
 
 ```code
-$ PROXY_ADDR=teleport.example.com:443
-$ CLUSTER=cookie
+$ PROXY_ADDR=<Var name="teleport.example.com" />:443
+$ CLUSTER=<Var name="cookie" />
 # Create the values.yaml file
 $ cat > values.yaml << EOF
 authToken: "${TOKEN}"
@@ -112,8 +112,8 @@ commands, assigning `PROXY_ADDR` to the address of your Auth Service or Proxy
 Service.
 
 ```code
-$ PROXY_ADDR=teleport.example.com:443
-$ CLUSTER=cookie
+$ PROXY_ADDR=<Var name="teleport.example.com" />:443
+$ CLUSTER=<Var name="cookie" />
 # Create the values.yaml file
 $ cat > values.yaml << EOF
 authToken: "${TOKEN}"
@@ -140,10 +140,10 @@ Switch `kubectl` to the Kubernetes cluster `cookie` and run the following
 commands, assigning `PROXY_ADDR` to the address of your Teleport Cloud tenant.
 
 ```code
-$ PROXY_ADDR=mytenant.teleport.sh:443
+$ PROXY_ADDR=<Var name="mytenant.teleport.sh" />:443
 
 # Install Kubernetes agent. It dials back to the Teleport cluster at $PROXY_ADDR
-$ CLUSTER=cookie
+$ CLUSTER=<Var name="cookie" />
 # Create the values.yaml file
 $ cat > values.yaml << EOF
 authToken: "${TOKEN}"

--- a/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
+++ b/docs/pages/kubernetes-access/register-clusters/static-kubeconfig.mdx
@@ -139,7 +139,7 @@ teleport:
   join_params:
     token_name: "/tmp/token"
     method: token
-  proxy_server: "teleport.example.com:3080"
+  proxy_server: <Var name="teleport.example.com" />:443
 auth_service:
   enabled: off
 proxy_service:
@@ -153,7 +153,7 @@ kubernetes_service:
     "region": "us-east1"
 ```
 
-Edit `/etc/teleport.yaml` to replace `teleport.example.com:3080` with the host
+Edit `/etc/teleport.yaml` to replace `teleport.example.com:443` with the host
 and port of your Teleport Proxy Service or Teleport Cloud tenant, e.g.,
 `mytenant.teleport.sh:443`.
 


### PR DESCRIPTION
Backport #31054 to branch/v13