### PR TITLE
Fix JSON marshalling for Audit struct

### DIFF
--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -18,7 +18,6 @@ package accesslist
 
 import (
 	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -236,24 +235,27 @@ func (a *AccessList) MatchSearch(values []string) bool {
 }
 
 func (a *Audit) UnmarshalJSON(data []byte) error {
-	var audit map[string]interface{}
+	var audit struct {
+		Frequency     string `json:"frequency"`
+		NextAuditDate string `json:"next_audit_date"`
+	}
 	if err := json.Unmarshal(data, &audit); err != nil {
 		return trace.Wrap(err)
 	}
 
 	var err error
-	a.Frequency, err = time.ParseDuration(fmt.Sprintf("%v", audit["frequency"]))
+	a.Frequency, err = time.ParseDuration(audit.Frequency)
 	if err != nil {
 		return trace.Wrap(err)
 	}
-	a.NextAuditDate, err = time.Parse(time.RFC3339Nano, fmt.Sprintf("%v", audit["next_audit_date"]))
+	a.NextAuditDate, err = time.Parse(time.RFC3339Nano, audit.NextAuditDate)
 	if err != nil {
 		return trace.Wrap(err)
 	}
 	return nil
 }
 
-func (a *Audit) MarshalJSON() ([]byte, error) {
+func (a Audit) MarshalJSON() ([]byte, error) {
 	audit := map[string]interface{}{}
 	audit["frequency"] = a.Frequency.String()
 	audit["next_audit_date"] = a.NextAuditDate.Format(time.RFC3339Nano)

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -235,9 +235,13 @@ func (a *AccessList) MatchSearch(values []string) bool {
 }
 
 func (a *Audit) UnmarshalJSON(data []byte) error {
-	var audit struct {
+	type Alias Audit
+	audit := struct {
 		Frequency     string `json:"frequency"`
 		NextAuditDate string `json:"next_audit_date"`
+		*Alias
+	}{
+		Alias: (*Alias)(a),
 	}
 	if err := json.Unmarshal(data, &audit); err != nil {
 		return trace.Wrap(err)
@@ -256,9 +260,14 @@ func (a *Audit) UnmarshalJSON(data []byte) error {
 }
 
 func (a Audit) MarshalJSON() ([]byte, error) {
-	audit := map[string]interface{}{}
-	audit["frequency"] = a.Frequency.String()
-	audit["next_audit_date"] = a.NextAuditDate.Format(time.RFC3339Nano)
-	data, err := json.Marshal(audit)
-	return data, trace.Wrap(err)
+	type Alias Audit
+	return json.Marshal(&struct {
+		Frequency     string `json:"frequency"`
+		NextAuditDate string `json:"next_audit_date"`
+		Alias
+	}{
+		Alias:         (Alias)(a),
+		Frequency:     a.Frequency.String(),
+		NextAuditDate: a.NextAuditDate.Format(time.RFC3339Nano),
+	})
 }

--- a/api/types/accesslist/accesslist_test.go
+++ b/api/types/accesslist/accesslist_test.go
@@ -33,6 +33,8 @@ func TestAuditMarshaling(t *testing.T) {
 	data, err := json.Marshal(&audit)
 	require.NoError(t, err)
 
+	require.Equal(t, `{"frequency":"1h0m0s","next_audit_date":"2023-02-02T00:00:00Z"}`, string(data))
+
 	raw := map[string]interface{}{}
 	require.NoError(t, json.Unmarshal(data, &raw))
 


### PR DESCRIPTION
This PR changes the `MarshalJSON()` receiver to fix the issue when the marshaler is not called when marshaling Audit fields.