### PR TITLE
Fix the access list lockName in the backend service.

### DIFF
--- a/lib/services/local/access_list.go
+++ b/lib/services/local/access_list.go
@@ -18,6 +18,7 @@ package local
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/gravitational/trace"
@@ -223,5 +224,5 @@ func (a *AccessListService) DeleteAllAccessListMembers(ctx context.Context) erro
 }
 
 func lockName(accessListName string) string {
-	return string(backend.Key("access_list", accessListName))
+	return strings.Join([]string{"access_list", accessListName}, string(backend.Separator))
 }

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/gravitational/teleport/api/types/accesslist"
 	"github.com/gravitational/teleport/api/types/header"
+	"github.com/gravitational/teleport/lib/backend"
 	"github.com/gravitational/teleport/lib/backend/memory"
 )
 
@@ -37,13 +38,13 @@ func TestAccessListCRUD(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	backend, err := memory.New(memory.Config{
+	mem, err := memory.New(memory.Config{
 		Context: ctx,
 		Clock:   clock,
 	})
 	require.NoError(t, err)
 
-	service, err := NewAccessListService(backend, clock)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
 	require.NoError(t, err)
 
 	// Create a couple access lists.
@@ -129,13 +130,13 @@ func TestAccessListMembersCRUD(t *testing.T) {
 	ctx := context.Background()
 	clock := clockwork.NewFakeClock()
 
-	backend, err := memory.New(memory.Config{
+	mem, err := memory.New(memory.Config{
 		Context: ctx,
 		Clock:   clock,
 	})
 	require.NoError(t, err)
 
-	service, err := NewAccessListService(backend, clock)
+	service, err := NewAccessListService(backend.NewSanitizer(mem), clock)
 	require.NoError(t, err)
 
 	// Create a couple access lists.


### PR DESCRIPTION
In the backend service, using slashes in the lock name seems to make the sqlite backend (and possibly others) error with the following message:

```
special characters are not allowed in resource names, please use name
composed only from characters, hyphens, dots, and plus signs:
".locks//access_list/test-access-list"
```

It looks like this is due to the fact that the `backend.Key` that was previously being used was inserting a forward slash in the front of the string for generating the lock name. It has been replaced by `path.Join`, which does not prepend a forward slash in the generated string.