### PR TITLE
[v13] post-release: pass GITHUB_TOKEN for gh CLI use

### DIFF
--- a/.github/workflows/post-release.yaml
+++ b/.github/workflows/post-release.yaml
@@ -67,7 +67,7 @@ jobs:
           echo "major=$MAJOR" >> "$GITHUB_OUTPUT"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Generate Github token
+      - name: Generate GitHub token
         id: generate_token
         uses: tibdex/github-app-token@v1
         with:
@@ -100,3 +100,5 @@ jobs:
           git commit -am "[auto] docs: Update version to ${{ github.event.release.tag_name }}"
           git push --set-upstream origin $BRANCH_NAME
           gh pr create --fill --label=automated --label=documentation
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}


### PR DESCRIPTION
Backports #31225