### PR TITLE
integrations/updater: add support for private registries

### DIFF
--- a/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
+++ b/docs/pages/reference/helm-reference/includes/zz_generated.teleport-kube-agent.mdx
@@ -675,6 +675,20 @@ than a Teleport-published image.
 `updater.serviceAccount.name` is the updater Kubernetes Service
 Account name. When unset, it defaults to `<kube agent sa name>-updater`
 
+### `updater.pullCredentials`
+
+| Type | Default |
+|------|---------|
+| `string` | `""` |
+
+`updater.pullCredentials` configures how the updater attempts to
+get the image pull credentials used to validate the image signature.
+
+This is not required when pulling images from official public Teleport
+registries (chart's default).
+
+Supported values are `amazon`, `google`, `docker` and `none`.
+
 ### `updater.extraArgs`
 
 | Type | Default |

--- a/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
+++ b/examples/chart/teleport-kube-agent/templates/updater/deployment.yaml
@@ -67,9 +67,12 @@ spec:
           - "--base-image={{ include "teleport-kube-agent.baseImage" . }}"
           - "--version-server={{ tpl $updater.versionServer . }}"
           - "--version-channel={{ $updater.releaseChannel }}"
-          {{- if .Values.updater.extraArgs }}
-            {{- toYaml .Values.updater.extraArgs | nindent 10 }}
-          {{- end }}
+{{- if $updater.pullCredentials }}
+          - "--pull-credentials={{ $updater.pullCredentials }}"
+{{- end }}
+{{- if .Values.updater.extraArgs }}
+          {{- toYaml .Values.updater.extraArgs | nindent 10 }}
+{{- end }}
 {{- if $updater.securityContext }}
         securityContext: {{- toYaml $updater.securityContext | nindent 10 }}
 {{- end }}

--- a/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_deployment_test.yaml
@@ -235,6 +235,7 @@ tests:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: distinct-updater-sa
+
   - it: sets extraArgs when set
     values:
       - ../.lint/updater.yaml
@@ -246,3 +247,14 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].args
           content: "--foo=bar"
+
+  - it: sets the pull credentials when specified
+    values:
+      - ../.lint/updater.yaml
+    set:
+      updater:
+        pullCredentials: "amazon"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--pull-credentials=amazon"

--- a/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
+++ b/examples/chart/teleport-kube-agent/tests/updater_rolebinding_test.yaml
@@ -1,4 +1,4 @@
-suite: Updater Role
+suite: Updater RoleBinding
 templates:
   - updater/rolebinding.yaml
 tests:

--- a/examples/chart/teleport-kube-agent/values.schema.json
+++ b/examples/chart/teleport-kube-agent/values.schema.json
@@ -15,6 +15,7 @@
         "teleportVersionOverride",
         "insecureSkipProxyTLSVerify",
         "teleportConfig",
+        "updater",
         "existingDataVolume",
         "podSecurityPolicy",
         "labels",
@@ -262,6 +263,56 @@
                     "$id": "#/properties/tls/properties/existingCASecretName",
                     "type": "string",
                     "default": ""
+                }
+            }
+        },
+        "updater": {
+            "$id": "#/properties/updater",
+            "type": "object",
+            "required": [
+                "enabled"
+            ],
+            "properties": {
+                "enabled": {
+                    "$id": "#/properties/updater/properties/enabled",
+                    "type": "boolean",
+                    "default": false
+                },
+                "versionServer": {
+                    "$id": "#/properties/updater/properties/versionServer",
+                    "type": "string",
+                    "default": "https://updates.releases.teleport.dev/v1/"
+                },
+                "releaseChannel": {
+                    "$id": "#/properties/updater/properties/releaseChannel",
+                    "type": "string",
+                    "default": "stable/cloud"
+                },
+                "image": {
+                    "$id": "#/properties/updater/properties/image",
+                    "type": "string",
+                    "default": "public.ecr.aws/gravitational/teleport-kube-agent-updater"
+                },
+                "serviceAccount": {
+                    "$id": "#/properties/updater/properties/serviceAccount",
+                    "type": "object",
+                    "properties": {
+                        "name": {
+                            "$id": "#/properties/updater/properties/serviceAccount/properties/name",
+                            "type": "string",
+                            "default": ""
+                        }
+                    }
+                },
+                "pullCredentials": {
+                    "$id": "#/properties/updater/properties/pullCredentials",
+                    "type": "string",
+                    "default": ""
+                },
+                "extraArgs": {
+                    "$id": "#/properties/updater/properties/extraArgs",
+                    "type": "array",
+                    "default": []
                 }
             }
         },

--- a/examples/chart/teleport-kube-agent/values.yaml
+++ b/examples/chart/teleport-kube-agent/values.yaml
@@ -579,6 +579,15 @@ updater:
     # Account name. When unset, it defaults to `<kube agent sa name>-updater`
     name: ""
 
+  # updater.pullCredentials(string) -- configures how the updater attempts to
+  # get the image pull credentials used to validate the image signature.
+  #
+  # This is not required when pulling images from official public Teleport
+  # registries (chart's default).
+  #
+  # Supported values are `amazon`, `google`, `docker` and `none`.
+  pullCredentials: ""
+
   # updater.extraArgs(list) -- contains additional arguments to pass to the updater
   # binary.
   extraArgs: []

--- a/go.mod
+++ b/go.mod
@@ -59,6 +59,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/sts v1.26.7
 	github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin v1.1.0
 	github.com/aws/smithy-go v1.19.0
+	github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8
 	github.com/beevik/etree v1.3.0
 	github.com/bufbuild/connect-go v1.10.0
 	github.com/buildkite/bintest/v3 v3.2.0
@@ -243,6 +244,8 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.7.2 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.2.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.18.7 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecr v1.20.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.18.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.10.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.2.10 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.8.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -201,6 +201,7 @@ github.com/aws/aws-sdk-go v1.49.21 h1:Rl8KW6HqkwzhATwvXhyr7vD4JFUMi7oXGAw9SrxxIF
 github.com/aws/aws-sdk-go v1.49.21/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.18.0/go.mod h1:uzbQtefpm44goOPmdKyAlXSNcwlRgF3ePWVW6EtJvvw=
+github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
 github.com/aws/aws-sdk-go-v2 v1.24.1 h1:xAojnj+ktS95YZlDf0zxWBkbFtymPeDP+rvUQIH3uAU=
 github.com/aws/aws-sdk-go-v2 v1.24.1/go.mod h1:LNh45Br1YAkEKaAqvmE1m8FUx6a5b/V0oAKV7of29b4=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.5.4 h1:OCs21ST2LrepDfD3lwlQiOqIGp6JiEUqG84GzTDoyJs=
@@ -219,9 +220,11 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.14.11/go.mod h1:cRrYDYAMUohBJUt
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.11 h1:I6lAa3wBWfCz/cKkOpAcumsETRkFAl70sWi8ItcMEsM=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.15.11/go.mod h1:be1NIO30kJA23ORBLqPo1LttEM6tPNSEcjkd1eKzNW0=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.33/go.mod h1:7i0PF1ME/2eUPFcjkVIwq+DOygHEoK92t5cDqNgYbIw=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43/go.mod h1:auo+PiyLl0n1l8A0e8RIeR8tOzYPfZZH/JNlrJ8igTQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.10 h1:vF+Zgd9s+H4vOXd5BMaPWykta2a6Ih0AKLq/X6NYKn4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.10/go.mod h1:6BkRjejp/GR4411UGqkX8+wFMbFbqsUIimfK4XjOKR4=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.27/go.mod h1:UrHnn3QV/d0pBZ6QBAEQcqFLf8FAzLmoUfPVIueOvoM=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37/go.mod h1:Qe+2KtKml+FEsQF/DHmDV+xjtche/hwoF75EG4UlHW8=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.10 h1:nYPe006ktcqUji8S2mqXf9c/7NdiKriOwMvWQHgYztw=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.10/go.mod h1:6UV4SZkVvmODfXKql4LCbaZUpF7HO2BX38FgBf9ZOLw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.34/go.mod h1:Etz2dj6UHYuw+Xw830KfzCfWGMzqvUTCjUj5b76GVDc=
@@ -239,6 +242,10 @@ github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0 h1:1KE7EgE5xiPZ6H19hdF27B/p/CG
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.144.0/go.mod h1:hIsHE0PaWAQakLCshKS7VKWMGXaqrAFp4m95s2W9E6c=
 github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.20.6 h1:Y0pqdpafA8TdG6AalCMFbbQ5SlO99MAybU0BDPLHbwo=
 github.com/aws/aws-sdk-go-v2/service/ec2instanceconnect v1.20.6/go.mod h1:y6fUhf01cjz+VUz+zrmJh3KfIXhefV7dS4STCxgHx7g=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.20.2 h1:y6LX9GUoEA3mO0qpFl1ZQHj1rFyPWVphlzebiSt2tKE=
+github.com/aws/aws-sdk-go-v2/service/ecr v1.20.2/go.mod h1:Q0LcmaN/Qr8+4aSBrdrXXePqoX0eOuYpJLbYpilmWnA=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.18.2 h1:PpbXaecV3sLAS6rjQiaKw4/jyq3Z8gNzmoJupHAoBp0=
+github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.18.2/go.mod h1:fUHpGXr4DrXkEDpGAjClPsviWf+Bszeb0daKE0blxv8=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.37.0 h1:7jZWcv19M7jGHmrQqEFbCqNRXa6LZV4ot4nT7fsIG9U=
 github.com/aws/aws-sdk-go-v2/service/ecs v1.37.0/go.mod h1:kt+L4lMA2nvv9evq9S6TOH1up95/2RsQG4GXfxoPRfM=
 github.com/aws/aws-sdk-go-v2/service/eks v1.37.1 h1:5eFw5vlZI2KOChY0DOWxsnuC6N01WC3ZUo5+lco9mN8=
@@ -280,8 +287,11 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.26.7/go.mod h1:6h2YuIoxaMSCFf5fi1EgZ
 github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin v1.1.0 h1:EJsHUYgFBV7/N1YtL73lsfZODAOU+CnNSZfEAlqqQaA=
 github.com/aws/aws-sigv4-auth-cassandra-gocql-driver-plugin v1.1.0/go.mod h1:AxKuXHc0zv2yYaeueUG7R3ONbcnQIuDj0bkdFmPVRzU=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.15.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.19.0 h1:KWFKQV80DpP3vJrrA9sVAHQ5gc2z8i4EzrLhLlWXcBM=
 github.com/aws/smithy-go v1.19.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
+github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8 h1:SoFYaT9UyGkR0+nogNyD/Lj+bsixB+SNuAS4ABlEs6M=
+github.com/awslabs/amazon-ecr-credential-helper/ecr-login v0.0.0-20231024185945-8841054dbdb8/go.mod h1:2JF49jcDOrLStIXN/j/K1EKRq8a8R2qRnlZA6/o/c7c=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1/go.mod h1:uYgXzlJ7ZpABp8OJ+exZzJJhRNQ2ASbcXHWsFqH8hp8=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=

--- a/integrations/kube-agent-updater/pkg/img/cosign.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign.go
@@ -24,7 +24,9 @@ import (
 	"encoding/hex"
 
 	"github.com/distribution/reference"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/gravitational/trace"
 	"github.com/opencontainers/go-digest"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
@@ -99,7 +101,7 @@ func (v *cosignKeyValidator) ValidateAndResolveDigest(ctx context.Context, image
 // NewCosignSingleKeyValidator takes a PEM-encoded public key and returns an
 // img.Validator that checks the image was signed with cosign by the
 // corresponding private key.
-func NewCosignSingleKeyValidator(pem []byte, name string) (Validator, error) {
+func NewCosignSingleKeyValidator(pem []byte, name string, keyChain authn.Keychain) (Validator, error) {
 	pubKey, err := cryptoutils.UnmarshalPEMToPublicKey(pem)
 	if err != nil {
 		return nil, trace.Wrap(err)
@@ -112,10 +114,12 @@ func NewCosignSingleKeyValidator(pem []byte, name string) (Validator, error) {
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
 	return &cosignKeyValidator{
-		verifier: verifier,
-		skid:     skid,
-		name:     name,
+		registryOptions: []ociremote.Option{ociremote.WithRemoteOptions(remote.WithAuthFromKeychain(keyChain))},
+		verifier:        verifier,
+		skid:            skid,
+		name:            name,
 	}, nil
 }
 

--- a/integrations/kube-agent-updater/pkg/img/cosign_test.go
+++ b/integrations/kube-agent-updater/pkg/img/cosign_test.go
@@ -37,8 +37,8 @@ import (
 
 var distrolessKey = []byte("-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWZzVzkb8A+DbgDpaJId/bOmV8n7Q\nOqxYbK0Iro6GzSmOzxkn+N2AKawLyXi84WSwJQBK//psATakCgAQKkNTAA==\n-----END PUBLIC KEY-----")
 
-func Test_NewCosignSingleKeyValidator(t *testing.T) {
-	a, err := NewCosignSingleKeyValidator(distrolessKey, "distroless")
+func Test_NewCosignSignleKeyValidator(t *testing.T) {
+	a, err := NewCosignSingleKeyValidator(distrolessKey, "distroless", nil)
 	require.NoError(t, err)
 	require.Equal(t, "distroless-799a5c21a7f8c39707274cbd065ba2e1969d8d29", a.Name())
 }

--- a/integrations/kube-agent-updater/pkg/img/keychains.go
+++ b/integrations/kube-agent-updater/pkg/img/keychains.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package img
+
+import (
+	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login"
+	"github.com/awslabs/amazon-ecr-credential-helper/ecr-login/api"
+	"github.com/google/go-containerregistry/pkg/authn"
+	"github.com/google/go-containerregistry/pkg/v1/google"
+	"github.com/gravitational/trace"
+)
+
+type CredentialSource string
+
+const (
+	DockerCredentialSource = "docker"
+	AmazonCredentialSource = "aws"
+	GoogleCredentialSource = "google"
+	NoCredentialSource     = "none"
+)
+
+// GetKeychain builds a ggcr keychain for image pulling and returns it.
+// We could attempt to autodetect or build a multi-keychain but ECR login
+// attempts take a lot of time and log errors. As most users don't need registry
+// auth, it's acceptable to have them do an extra step and specify which auth
+// they need.
+func GetKeychain(credSource string) (authn.Keychain, error) {
+	switch credSource {
+	case DockerCredentialSource:
+		return authn.DefaultKeychain, nil
+	case AmazonCredentialSource:
+		return authn.NewKeychainFromHelper(ecr.NewECRHelper(ecr.WithClientFactory(api.DefaultClientFactory{}))), nil
+	case GoogleCredentialSource:
+		return google.Keychain, nil
+	case NoCredentialSource:
+		return nil, nil
+	default:
+		return nil, trace.BadParameter("credential source '%s' not recognized", credSource)
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/gravitational/teleport/issues/30587

This PR adds common authentication mechanism support. 

It doesn't add auto-detection because Amazon creds helper retries a lot. This slows down the signature check and logs errors if it can not find AWS creds (expected when running out of AWS). We'll be able to add this in the future if needed, but this requires extra work, and this PR would not be a low-hanging fruit anymore.

Changelog: The `teleport-kube-agent-updater` can now be configured to pull images from private registries using `aws`, `gcp`, or docker's `config.json` credentials.