### PR TITLE
[v12] Fixed typo in error message for terminal params

### DIFF
--- a/lib/session/session.go
+++ b/lib/session/session.go
@@ -221,7 +221,7 @@ func NewTerminalParamsFromUint32(w uint32, h uint32) (*TerminalParams, error) {
 // NewTerminalParamsFromInt returns new terminal parameters from int width and height
 func NewTerminalParamsFromInt(w int, h int) (*TerminalParams, error) {
 	if w > maxSize || w < minSize {
-		return nil, trace.BadParameter("bad witdth")
+		return nil, trace.BadParameter("bad width")
 	}
 	if h > maxSize || h < minSize {
 		return nil, trace.BadParameter("bad height")


### PR DESCRIPTION
Backport #31219 to branch/v12