### PR TITLE
improve ControlMaster error reporting 2

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -4564,15 +4564,13 @@ func testControlMaster(t *testing.T, suite *integrationTestSuite) {
 
 				// Execute SSH command and check the output is what we expect.
 				output, err := execCmd.Output()
-				if err != nil {
-					// If an *exec.ExitError is returned, parse it and return stderr. If this
-					// is not done then c.Assert will just print a byte array for the error.
-					er, ok := err.(*exec.ExitError)
-					if ok {
-						t.Fatalf("Unexpected error: %v", string(er.Stderr))
-					}
+
+				// ensure stderr is printed as a string rather than bytes
+				var stderr string
+				if e, ok := err.(*exec.ExitError); ok {
+					stderr = string(e.Stderr)
 				}
-				require.NoError(t, err)
+				require.NoError(t, err, "stderr=%q", stderr)
 				require.True(t, strings.HasSuffix(strings.TrimSpace(string(output)), "hello"))
 			}
 		})


### PR DESCRIPTION
Improve error output of `ControlMaster` test coverage.

note: this does what https://github.com/gravitational/teleport/pull/30631 was *supposed* to do. That PR also improved the handling of `exec.ExitError`, but did it in the wrong place.