### PR TITLE
Clarify the docs test plan

### DIFF
--- a/.github/ISSUE_TEMPLATE/test-plan-docs.md
+++ b/.github/ISSUE_TEMPLATE/test-plan-docs.md
@@ -15,8 +15,14 @@ new major version of Teleport:
 - [ ] Verify that `gravitational/docs/.gitmodules` contains the latest release
 
 - [ ] Ensure that submodule directories in `gravitational/docs` correspond to
-    those in `.gitmodules` (remove the directory of the EOL release and create
-    one for the next release)
+    those in `.gitmodules`.
+
+    Remove the directory of the EOL release and create one for the next release
+    using a command similar to the following:
+    
+    ```bash 
+    git submodule add https://github.com/gravitational/teleport content/<VERSION>.x 
+    ```
 
 ## Is the docs site up to date with the new release?
 
@@ -85,4 +91,6 @@ to select "Version 12.0" in the documentation version switcher.
 ### New feature docs
 
 - [ ] Review the roadmap for the major version we are releasing and verify that
-  you can complete all how-to guides for new features successfully.
+  you can complete all how-to guides for new features successfully. Consult the
+  [Upcoming Releases Page](../../docs/pages/upcoming-releases.mdx) for a list of
+  features in the next major release.


### PR DESCRIPTION
This change edits the documentation test plan to clarify some points of friction:

- Includes a sample command for adding a new submodule to the docs site so the person updating the docs site config doesn't need to figure this out.
- Notes the source of features in the upcoming major version so we can test the docs for those features.