### PR TITLE
integrations/operator: Add pprof support

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -252,7 +252,7 @@ spec:
           - name: operator-http-metrics
             containerPort: 8080
             protocol: TCP
-          - name: operator-http-readiness
+          - name: operator-http-health
             containerPort: 8081
             protocol: TCP
   {{- if .Values.operator.resources }}

--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -248,6 +248,13 @@ spec:
             port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
+        ports:
+          - name: operator-http-metrics
+            containerPort: 8080
+            protocol: TCP
+          - name: operator-http-readiness
+            containerPort: 8081
+            protocol: TCP
   {{- if .Values.operator.resources }}
         resources: {{- toYaml .Values.operator.resources | nindent 10 }}
   {{- end }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -14,7 +14,7 @@ should add an operator side-car when operator is enabled:
       name: operator-http-metrics
       protocol: TCP
     - containerPort: 8081
-      name: operator-http-readiness
+      name: operator-http-health
       protocol: TCP
     readinessProbe:
       httpGet:

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -9,6 +9,13 @@ should add an operator side-car when operator is enabled:
       initialDelaySeconds: 15
       periodSeconds: 20
     name: operator
+    ports:
+    - containerPort: 8080
+      name: operator-http-metrics
+      protocol: TCP
+    - containerPort: 8081
+      name: operator-http-readiness
+      protocol: TCP
     readinessProbe:
       httpGet:
         path: /readyz

--- a/integrations/operator/main.go
+++ b/integrations/operator/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Gravitational, Inc.
+Copyright 2023 Gravitational, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -67,11 +67,14 @@ func main() {
 	var err error
 	var metricsAddr string
 	var probeAddr string
+	var pprofAddr string
 	var leaderElectionID string
 	var syncPeriodString string
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	// pprof is disabled by default
+	flag.StringVar(&pprofAddr, "pprof-bind-address", "", "The address the pprof endpoint binds to, leave empty to disable.")
 	flag.StringVar(&leaderElectionID, "leader-election-id", "431e83f4.teleport.dev", "Leader Election Id to use")
 	flag.StringVar(&syncPeriodString, "sync-period", "10h", "Operator sync period (format: https://pkg.go.dev/time#ParseDuration)")
 
@@ -104,6 +107,7 @@ func main() {
 		LeaderElectionID:       leaderElectionID,
 		Namespace:              namespace,
 		SyncPeriod:             &syncPeriod,
+		PprofBindAddress:       pprofAddr,
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")


### PR DESCRIPTION
This PR adds `pprof` support to the teleport operator so we can diagnose memory consumption.

It also declares existing operator ports (metric and health)

Part of https://github.com/gravitational/teleport/issues/24110