### PR TITLE
[Web] Fix Unified Resources Empty States

### DIFF
--- a/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
+++ b/web/packages/teleport/src/Discover/SelectResource/SelectResource.tsx
@@ -106,8 +106,14 @@ export function SelectResource({ onSelect }: SelectResourceProps) {
     // We sort the list by the specified resource type,
     // and then apply a search filter to it to reduce
     // the amount of results.
+    // We don't do this if the resource type is `unified_resource`,
+    // since we want to show all resources.
+    // TODO(bl-nero): remove this once the localstorage setting to disable unified resources is removed.
     const resourceKindSpecifiedByUrlLoc = location.state?.entity;
-    if (resourceKindSpecifiedByUrlLoc) {
+    if (
+      resourceKindSpecifiedByUrlLoc &&
+      resourceKindSpecifiedByUrlLoc !== SearchResource.UNIFIED_RESOURCE
+    ) {
       const sortedResourcesByKind = sortResourcesByKind(
         resourceKindSpecifiedByUrlLoc,
         sortedResources

--- a/web/packages/teleport/src/UnifiedResources/FilterPanel.tsx
+++ b/web/packages/teleport/src/UnifiedResources/FilterPanel.tsx
@@ -136,6 +136,7 @@ const SortOrderButton = styled(ButtonBorder)`
   border-bottom-left-radius: 0;
   border-color: ${props => props.theme.colors.spotBackground[1]};
   border-left: none;
+  height: 40px;
 `;
 
 const FilterSelect = styled(Select)`
@@ -150,6 +151,7 @@ const SortSelect = styled(Select)`
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
     border: 1px solid ${props => props.theme.colors.spotBackground[1]};
+    height: 40px;
   }
   .react-select__dropdown-indicator {
     display: none;

--- a/web/packages/teleport/src/components/Empty/Empty.tsx
+++ b/web/packages/teleport/src/components/Empty/Empty.tsx
@@ -32,7 +32,8 @@ type ResourceType =
   | 'database'
   | 'desktop'
   | 'kubernetes'
-  | 'server';
+  | 'server'
+  | 'unified_resource';
 
 function getAccentImage(resourceType: ResourceType): string {
   const accentImages = {

--- a/web/packages/teleport/src/services/localStorage/localStorage.ts
+++ b/web/packages/teleport/src/services/localStorage/localStorage.ts
@@ -179,7 +179,7 @@ const storage = {
    * Returns `true` if the unified resources feature should be visible in the
    * navigation.
    *
-   * TODO(bl-nero): remove this setting once unified resources are released.
+   * TODO(bl-nero): remove this setting once unified resources are released. Please also see TODO item in `SelectResource.tsx`.
    */
   areUnifiedResourcesEnabled(): boolean {
     const disabled = window.localStorage.getItem(


### PR DESCRIPTION
## Purpose

This PR fixes the graphic for the empty `"Add your first resource"` screen and also adds a `"No resources found"` state. Previously, if you made a search that yielded no results, it would show the `"Add your first resource"` screen.

Also fixes a minor re-sizing bug with the sorting indicator button on the right.

## Implementation

- The graphic for the `"Add your first resource"` component wasn't working because the `resourceType` field in `emptyStateInfo` provided by the `Resources.tsx` component wasn't defined. When a user clicks the `"Add resource"` button, we use that `resourceType` to pre-populate the search on the Discover page, I disabled this functionality for the `unified_resource` type to avoid it being pre-populated with the string `"unified_resource"` (and yielding no results).
- The `"No resources found"` design is not based on any Figma designs as I couldn't find any.

## Demo

### Empty state with no search

#### Before

![image](https://github.com/gravitational/teleport/assets/56373201/c43e3571-eab4-4829-9a38-3997ed05267a)

#### After

![image](https://github.com/gravitational/teleport/assets/56373201/89ca5794-bfad-4b82-a339-97ef594dc141)

### Empty state with search

#### Before

![image](https://github.com/gravitational/teleport/assets/56373201/537af112-e793-4f62-9955-7fc0bbbcbb1c)

#### After

![image](https://github.com/gravitational/teleport/assets/56373201/06ecb5a2-df0c-4458-bc0d-c9bc5bc4a4cb)

![image](https://github.com/gravitational/teleport/assets/56373201/8a662120-5b94-48f5-a255-75f59e9525c0)


### Selectors

#### Before

![image](https://github.com/gravitational/teleport/assets/56373201/8be20de4-9b24-4380-8d70-2e883d95fb28)

#### After

![image](https://github.com/gravitational/teleport/assets/56373201/a8a3c76f-8e48-4ba9-b1e4-28127579a9c4)





 