### PR TITLE
[Docs] Update documentation for max duration feature in access requests

### DIFF
--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -218,3 +218,33 @@ Users can also create Access Requests with the `tsh request create` command.
 elevated access. See the [CLI
 Reference](../../reference/cli/tsh.mdx#tsh-request-create) for more
 details.
+
+### Max duration for Access Requests
+
+By default, Teleport will allow users to request access to a role until the
+current session expires. This can be overridden by setting the `max_duration`
+when requesting access to a role. The `max_duration` allows to extend the
+access up to 7 days. The `max_duration` can be set in the web UI or via the
+`--max-duration` flag when using the `tsh` CLI.
+
+To enable the `max_duration` feature, the `max_duration` option must be set in
+the role definition.
+```yaml
+kind: role
+version: v5
+metadata:
+  name: contractor
+spec:
+  allow:
+    request:
+      # Allow access to role `dba` for up to 4 days.
+      roles: ['dba']
+      max_duration: 4d
+```
+
+Max duration extends access to a role for the specified duration, but each
+session is still limited by the `max_session_ttl` option in the role definition.
+For example, if the `max_session_ttl` is set to 1 hour, the user will be able
+to request access to the role for up to 4 days, but each session will expire
+after 1 hour. The user will need to assume the role again to continue using it.
+If the `max_session_ttl` is not set, the session will expire after 12 hours.

--- a/docs/pages/access-controls/access-requests/role-requests.mdx
+++ b/docs/pages/access-controls/access-requests/role-requests.mdx
@@ -223,12 +223,12 @@ details.
 
 By default, Teleport will allow users to request access to a role until the
 current session expires. This can be overridden by setting the `max_duration`
-when requesting access to a role. The `max_duration` allows to extend the
-access up to 7 days. The `max_duration` can be set in the web UI or via the
-`--max-duration` flag when using the `tsh` CLI.
+when requesting access to a role. The `max_duration` option allows users to
+extend their access up to 7 days. The `max_duration` can be set in the Web UI
+or via the `--max-duration` flag when using the `tsh` CLI.
 
 To enable the `max_duration` feature, the `max_duration` option must be set in
-the role definition.
+a user's role definition:
 ```yaml
 kind: role
 version: v5


### PR DESCRIPTION
Documentation for the access request feature has been expanded to describe the 'max_duration' property in role requests. The change explains how to override the default behaviour (where a user can request access to a role until the session expires) by setting a 'max_duration'. Details include how to set this in the web UI or CLI, the need to define the setting in the role definition, and its interaction with the 'max_session_ttl'. The update provides necessary guidance for users requiring elevated access beyond their current session.