### PR TITLE
docs: include sudo for example commands

### DIFF
--- a/docs/pages/access-controls/device-trust/jamf-integration.mdx
+++ b/docs/pages/access-controls/device-trust/jamf-integration.mdx
@@ -101,11 +101,11 @@ Change the following settings, as appropriate:
 Finally, write your Jamf password to the `/var/lib/teleport/jamf_password` file:
 
 ```code
-$ nano /var/lib/teleport/jamf_password # or use your favorite editor
+$ sudo nano /var/lib/teleport/jamf_password # or use your favorite editor
 
 # Only the OS user that runs `teleport` should have access to the password file.
-$ chmod 400 /var/lib/teleport/jamf_password
-$ chown teleport /var/lib/teleport/jamf_password
+$ sudo chmod 400 /var/lib/teleport/jamf_password
+$ sudo chown teleport /var/lib/teleport/jamf_password
 ```
 
 ## Step 3/4. Create a join token
@@ -115,7 +115,7 @@ On your local workstation, create the token as shown below:
 
 ```code
 $ tctl tokens add --type=mdm
-The invite token: 07c0565aa280595d7645b2964c36ebd1
+The invite token: (=presets.tokens.second=)
 This token will expire in 30 minutes.
 
 From the Jamf service host, use this token to add an MDM service to Teleport.
@@ -131,9 +131,9 @@ From the Jamf service host, use this token to add an MDM service to Teleport.
 Using the token created above, start the service:
 
 ```code
-$ teleport start --config=/var/lib/teleport.yaml \
-   --token=07c0565aa280595d7645b2964c36ebd1 \
-   --ca-pin=sha256:4b32d9c54b2b3332019d5f0720b8f9a603de03ace07d308bcd743465eee1f200
+$ sudo teleport start --config=/var/lib/teleport.yaml \
+   --token=(=presets.tokens.second=) \
+   --ca-pin=(=presets.ca_pin=)
 ```
 
 The initial sync should happen in a few minutes. You can confirm from the Teleport service logs:

--- a/docs/pages/deploy-a-cluster/deployments/ibm.mdx
+++ b/docs/pages/deploy-a-cluster/deployments/ibm.mdx
@@ -166,7 +166,7 @@ storage:
 </Admonition>
 
 ```code
-$ teleport start --config=/etc/teleport.yaml -d
+$ sudo teleport start --config=/etc/teleport.yaml -d
 # DEBU [SQLITE]    Connected to: file:/var/lib/teleport/proc/sqlite.db?_busy_timeout=10000&_sync=OFF, poll stream period: 1s lite/lite.go:173
 # DEBU [SQLITE]    Synchronous: 0, busy timeout: 10000 lite/lite.go:220
 # DEBU [KEYGEN]    SSH cert authority is going to pre-compute 25 keys. native/native.go:104

--- a/docs/pages/includes/database-access/db-configure-start.mdx
+++ b/docs/pages/includes/database-access/db-configure-start.mdx
@@ -14,7 +14,7 @@ Generate a configuration file at `/etc/teleport.yaml` for the Database Service:
 <TabItem scope={["oss", "enterprise"]} label="Teleport Enterprise/Enterprise Cloud">
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
    --proxy=teleport.example.com:443 \
@@ -28,7 +28,7 @@ $ teleport db configure create \
 <TabItem scope={["cloud","team"]} label="Teleport Team/Community Edition">
 
 ```code
-$ teleport db configure create \
+$ sudo teleport db configure create \
    -o file \
    --token=/tmp/token \
    --proxy=mytenant.teleport.sh:443 \

--- a/docs/pages/management/admin/self-signed-certs.mdx
+++ b/docs/pages/management/admin/self-signed-certs.mdx
@@ -99,9 +99,9 @@ running Teleport: via the `teleport` CLI, using a Helm chart, or via systemd:
     When running `teleport` from the command line, pass the `--insecure` flag to disable
     TLS certificate validation. For example:
     ```sh
-    $ teleport start -c /etc/teleport.yaml --insecure
-    $ teleport app start -c /etc/teleport.yaml --insecure
-    $ teleport db start -c /etc/teleport.yaml --insecure
+    $ sudo teleport start -c /etc/teleport.yaml --insecure
+    $ sudo teleport app start -c /etc/teleport.yaml --insecure
+    $ sudo teleport db start -c /etc/teleport.yaml --insecure
     ```
     Without the `--insecure` flag, you will see an error message that looks like
     `x509: “tele.example.com” certificate is not trusted`.

--- a/docs/pages/server-access/guides/bpf-session-recording.mdx
+++ b/docs/pages/server-access/guides/bpf-session-recording.mdx
@@ -167,9 +167,7 @@ ssh_service:
 
 ### Start Teleport on your Node
 
-```code
-$ teleport start
-```
+(!docs/pages/includes/start-teleport.mdx service="the Teleport SSH Service"!)
 
 ## Step 2/2. Inspect the audit log
 


### PR DESCRIPTION
- example commands were missing `sudo` which would have resulted in error in cases where the user was not running as `root`
- minor update to jamf to use configured values instead of hard-coded