### PR TITLE
docs: remove reference statement on web ui connect

### DIFF
--- a/docs/pages/connect-your-client/web-ui.mdx
+++ b/docs/pages/connect-your-client/web-ui.mdx
@@ -6,8 +6,6 @@ The Teleport Web UI is a web-based visual interface from which you can access re
 view active sessions and recordings, create and review Access Requests, 
 manage users and roles, and more.
 
-This page serves a reference on Web UI features and their usage.
-
 ## Joining an active session
 
 The Web UI allows you to list and join active SSH sessions via a web-based terminal.


### PR DESCRIPTION
Removing "this serves as a reference" as we do not yet have a comprehensive reference here yet. That can cause confusion. https://github.com/gravitational/teleport/issues/31369 has been opened to track having a fleshed out web ui reference.