### PR TITLE
[v13] Preserve query params in cross-cluster app redirect.

### DIFF
--- a/lib/web/app/transport.go
+++ b/lib/web/app/transport.go
@@ -187,12 +187,15 @@ func (t *transport) rewriteRedirect(resp *http.Response) error {
 	// We want the rewrite to happen using our own public address.
 	if host == t.c.identity.RouteToApp.PublicAddr {
 		// drop scheme and host, leaving only the relative path.
-		// since the path can be an empty string, canonicalize it as "/".
+		u.Host = ""
+		u.Scheme = ""
+
+		// since the path can be an empty string, canonicalize it to "/".
 		if u.Path == "" {
-			resp.Header.Set("Location", "/")
-		} else {
-			resp.Header.Set("Location", u.Path)
+			u.Path = "/"
 		}
+
+		resp.Header.Set("Location", u.String())
 	}
 	return nil
 }

--- a/lib/web/app/transport_test.go
+++ b/lib/web/app/transport_test.go
@@ -139,6 +139,19 @@ func Test_transport_rewriteRedirect(t *testing.T) {
 			wantLocation:   "/admin/blah",
 		},
 		{
+			name: "remote app, redirect to app public addr, preserve query params",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{
+					ClusterName: leafCluster,
+					PublicAddr:  "dumper.leaf.teleport.example.com",
+				}},
+				makeAppServer(leafCluster, "dumper")),
+			respStatusCode: 302,
+			respLocation:   "https://dumper.leaf.teleport.example.com:3080/admin/blah?foo=bar&baz=bar",
+			wantLocation:   "/admin/blah?foo=bar&baz=bar",
+		},
+		{
 			name: "canonicalize empty location to /",
 			transportConfig: makeTransportConfig(
 				rootCluster,
@@ -150,6 +163,19 @@ func Test_transport_rewriteRedirect(t *testing.T) {
 			respStatusCode: 302,
 			respLocation:   "https://dumper.leaf.teleport.example.com:3080",
 			wantLocation:   "/",
+		},
+		{
+			name: "canonicalize empty location to /, preserve query params",
+			transportConfig: makeTransportConfig(
+				rootCluster,
+				&tlsca.Identity{RouteToApp: tlsca.RouteToApp{
+					ClusterName: leafCluster,
+					PublicAddr:  "dumper.leaf.teleport.example.com",
+				}},
+				makeAppServer(leafCluster, "dumper")),
+			respStatusCode: 302,
+			respLocation:   "https://dumper.leaf.teleport.example.com:3080?foo=bar&baz=bar",
+			wantLocation:   "/?foo=bar&baz=bar",
 		},
 	}
 


### PR DESCRIPTION
Backport #31275 to branch/v13