### PR TITLE
Add default GitHub API URLs to SSO connector

### DIFF
--- a/api/types/github.go
+++ b/api/types/github.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	githubURL    = "https://github.com"
-	githubAPIURL = "https://api.github.com"
+	GithubURL    = "https://github.com"
+	GithubAPIURL = "https://api.github.com"
 )
 
 // GithubConnector defines an interface for a Github OAuth2 connector
@@ -279,12 +279,12 @@ func (c *GithubConnectorV3) SetDisplay(display string) {
 
 // GetEndpointURL returns the endpoint URL
 func (c *GithubConnectorV3) GetEndpointURL() string {
-	return githubURL
+	return GithubURL
 }
 
 // GetEndpointURL returns the API endpoint URL
 func (c *GithubConnectorV3) GetAPIEndpointURL() string {
-	return githubAPIURL
+	return GithubAPIURL
 }
 
 // MapClaims returns a list of logins based on the provided claims,

--- a/docs/pages/access-controls/sso/github-sso.mdx
+++ b/docs/pages/access-controls/sso/github-sso.mdx
@@ -91,11 +91,11 @@ kind: github
 metadata:
   name: github
 spec:
-  api_endpoint_url: ""
+  api_endpoint_url: https://api.github.com
   client_id: <client-id>
   client_secret: <client-secret>
   display: GitHub
-  endpoint_url: ""
+  endpoint_url: https://github.com
   redirect_url: https://<proxy-address>/v1/webapi/github/callback
   teams_to_logins: null
   teams_to_roles:

--- a/tool/tctl/sso/configure/github.go
+++ b/tool/tctl/sso/configure/github.go
@@ -49,8 +49,15 @@ func addGithubCommand(cmd *SSOConfigureCommand) *AuthKindCommand {
 	sub.Flag("display", "Sets the connector display name.").StringVar(&spec.Display)
 	sub.Flag("id", "GitHub app client ID.").PlaceHolder("ID").Required().StringVar(&spec.ClientID)
 	sub.Flag("secret", "GitHub app client secret.").Required().PlaceHolder("SECRET").StringVar(&spec.ClientSecret)
-	sub.Flag("endpoint-url", "Endpoint URL for GitHub instance.").StringVar(&spec.EndpointURL)
-	sub.Flag("api-endpoint-url", "API endpoint URL for GitHub instance.").StringVar(&spec.APIEndpointURL)
+	sub.Flag("endpoint-url", "Endpoint URL for GitHub instance.").
+		PlaceHolder("URL").
+		Default(types.GithubURL).
+		StringVar(&spec.EndpointURL)
+
+	sub.Flag("api-endpoint-url", "API endpoint URL for GitHub instance.").
+		PlaceHolder("URL").
+		Default(types.GithubAPIURL).
+		StringVar(&spec.APIEndpointURL)
 
 	// auto
 	sub.Flag("redirect-url", "Authorization callback URL.").PlaceHolder("URL").StringVar(&spec.RedirectURL)


### PR DESCRIPTION
`tctl sso configure github` was producing an untestable connector spec, or at least a spec that would _always fail_ when tested with `tctl sso test`, due to missing GitHub endpoints in the generated spec.

This change adds the default GitHub endpoint URLs as default values for the endpoint flags in `tctl sso configure github` so that the produces spec is valis and testable.

Note: Our WebUI appears to magically add these values when saving
      a connector, so this issue only really effects `tctl sso test`

Includes doc update to match new output.

Fixes: #31396
Changelog: `tctl sso configure github` now includes default Github endpoints