### PR TITLE
[v14] pgbk: schema version 2, more robust change feed parsing

### DIFF
--- a/lib/backend/pgbk/background.go
+++ b/lib/backend/pgbk/background.go
@@ -150,7 +150,7 @@ func (b *Backend) runChangeFeed(ctx context.Context) error {
 	// REPLICATION attribute yet
 	// HACK(espadolini): ALTER ROLE CURRENT_USER REPLICATION just crashes postgres on Azure
 	if _, err := conn.Exec(ctx,
-		fmt.Sprintf("ALTER ROLE \"%v\" REPLICATION", poolConfig.ConnConfig.User),
+		fmt.Sprintf("ALTER ROLE %v REPLICATION", pgx.Identifier{poolConfig.ConnConfig.User}.Sanitize()),
 		pgx.QueryExecModeExec,
 	); err != nil {
 		b.log.WithError(err).Debug("Failed to enable replication for the current user.")

--- a/lib/backend/pgbk/background.go
+++ b/lib/backend/pgbk/background.go
@@ -245,7 +245,7 @@ FROM d`,
 				Item: backend.Item{
 					Key:     key,
 					Value:   value,
-					Expires: time.Time(expires),
+					Expires: time.Time(expires).UTC(),
 				},
 			})
 			return nil
@@ -264,7 +264,7 @@ FROM d`,
 				Item: backend.Item{
 					Key:     key,
 					Value:   value,
-					Expires: time.Time(expires),
+					Expires: time.Time(expires).UTC(),
 				},
 			})
 			return nil

--- a/lib/backend/pgbk/background.go
+++ b/lib/backend/pgbk/background.go
@@ -57,9 +57,9 @@ func (b *Backend) backgroundExpiry(ctx context.Context) {
 				// or skipped, and it's not necessary but it's a nice touch that
 				// we'll be deleting expired items in expiration order
 				tag, err := b.pool.Exec(ctx,
-					"DELETE FROM kv WHERE key IN (SELECT key FROM kv"+
-						" WHERE expires IS NOT NULL AND expires <= now()"+
-						" ORDER BY expires LIMIT $1 FOR UPDATE)",
+					"DELETE FROM kv WHERE kv.key IN (SELECT kv_inner.key FROM kv AS kv_inner"+
+						" WHERE kv_inner.expires IS NOT NULL AND kv_inner.expires <= now()"+
+						" ORDER BY kv_inner.expires LIMIT $1 FOR UPDATE)",
 					b.cfg.ExpiryBatchSize,
 				)
 				if err != nil {

--- a/lib/events/pgevents/pgevents.go
+++ b/lib/events/pgevents/pgevents.go
@@ -376,28 +376,28 @@ func (l *Log) searchEvents(
 
 	var qb strings.Builder
 	qb.WriteString("DECLARE cur CURSOR FOR SELECT" +
-		" event_time, event_id, event_data" +
+		" events.event_time, events.event_id, events.event_data" +
 		" FROM events" +
-		" WHERE event_time BETWEEN @from_time AND @to_time")
+		" WHERE events.event_time BETWEEN @from_time AND @to_time")
 
 	if len(eventTypes) > 0 {
-		qb.WriteString(" AND event_type = ANY(@event_types)")
+		qb.WriteString(" AND events.event_type = ANY(@event_types)")
 	}
 	if sessionID != "" {
 		// hint to the query planner, it can use the partial index on session_id
 		// no matter what the argument is
-		qb.WriteString(" AND session_id != '00000000-0000-0000-0000-000000000000' AND session_id = @session_id")
+		qb.WriteString(" AND events.session_id != '00000000-0000-0000-0000-000000000000' AND events.session_id = @session_id")
 	}
 	if order != types.EventOrderDescending {
 		if startKey != "" {
-			qb.WriteString(" AND (event_time, event_id) > (@start_time, @start_id)")
+			qb.WriteString(" AND (events.event_time, events.event_id) > (@start_time, @start_id)")
 		}
-		qb.WriteString(" ORDER BY event_time, event_id")
+		qb.WriteString(" ORDER BY events.event_time, events.event_id")
 	} else {
 		if startKey != "" {
-			qb.WriteString(" AND (event_time, event_id) < (@start_time, @start_id)")
+			qb.WriteString(" AND (events.event_time, events.event_id) < (@start_time, @start_id)")
 		}
-		qb.WriteString(" ORDER BY event_time DESC, event_id DESC")
+		qb.WriteString(" ORDER BY events.event_time DESC, events.event_id DESC")
 	}
 
 	queryString := qb.String()


### PR DESCRIPTION
Backport #31358 to branch/v14

changelog: To improve robustness and performance, this version of Teleport includes a schema migration for the PostgreSQL backend; the migration will be applied automatically, but it will prevent older versions of Teleport from starting up against the same PostgreSQL database without manual intervention.