### PR TITLE
AWS OIDC - List EC2: add AWS EC2 Instance ID as label

### DIFF
--- a/lib/integrations/awsoidc/listec2_test.go
+++ b/lib/integrations/awsoidc/listec2_test.go
@@ -178,8 +178,9 @@ func TestListEC2(t *testing.T) {
 					SubKind: "openssh-ec2-ice",
 					Metadata: types.Metadata{
 						Labels: map[string]string{
-							"account-id": "123456789012",
-							"region":     "us-east-1",
+							"account-id":               "123456789012",
+							"region":                   "us-east-1",
+							"teleport.dev/instance-id": "i-123456789abcedf",
 						},
 						Namespace: "default",
 					},

--- a/lib/services/server.go
+++ b/lib/services/server.go
@@ -443,7 +443,10 @@ func NewAWSNodeFromEC2Instance(instance ec2Types.Instance, awsCloudMetadata *typ
 	}
 	libaws.AddMetadataLabels(labels, awsCloudMetadata.AccountID, awsCloudMetadata.Region)
 
-	awsCloudMetadata.InstanceID = aws.ToString(instance.InstanceId)
+	instanceID := aws.ToString(instance.InstanceId)
+	labels[types.AWSInstanceIDLabel] = instanceID
+
+	awsCloudMetadata.InstanceID = instanceID
 	awsCloudMetadata.VPCID = aws.ToString(instance.VpcId)
 	awsCloudMetadata.SubnetID = aws.ToString(instance.SubnetId)
 

--- a/lib/services/server_test.go
+++ b/lib/services/server_test.go
@@ -74,9 +74,10 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				SubKind: "openssh-ec2-ice",
 				Metadata: types.Metadata{
 					Labels: map[string]string{
-						"account-id": "1234567889012",
-						"region":     "us-east-1",
-						"MyTag":      "MyTagValue",
+						"account-id":               "1234567889012",
+						"region":                   "us-east-1",
+						"MyTag":                    "MyTagValue",
+						"teleport.dev/instance-id": "i-123456789abcedf",
 					},
 					Namespace: "default",
 				},
@@ -120,9 +121,10 @@ func TestNewAWSNodeFromEC2Instance(t *testing.T) {
 				SubKind: "openssh-ec2-ice",
 				Metadata: types.Metadata{
 					Labels: map[string]string{
-						"account-id": "1234567889012",
-						"region":     "us-east-1",
-						"MyTag":      "MyTagValue",
+						"account-id":               "1234567889012",
+						"region":                   "us-east-1",
+						"MyTag":                    "MyTagValue",
+						"teleport.dev/instance-id": "i-123456789abcedf",
 					},
 					Namespace: "default",
 				},


### PR DESCRIPTION
Context: https://github.com/gravitational/teleport/issues/29317

When listing EC2 instances we should be able to tell which ones were already added.
To do so, we should use the instance-id which is unique. We can't use the Spec.CloudMetadata.AWS.InstanceID because predicate can't use fields that are optional.

This PR adds the InstanceID as label.
It uses `teleport.dev/instance-id` label key.

When creating a Node from WebUI, it will send the same set of labels that was received.
So, WebUI will send this same label.

When listing EC2 instances, WebUI queries the backend for a list of Nodes of type EC2 EICE and the same `instance-id` and uses the result to show which ones were already added.


Demo
```
dinis@lenix ~> curl 'https://<cluster>/v1/webapi/sites/lenix/integrations/aws-oidc/teleportdev/ec2' \
                    ....
                     --data-raw '{"region":"eu-west-2"}' | jq

{
  "servers": [
    {
      "kind": "node",
      "tunnel": false,
      "subKind": "openssh-ec2-ice",
      "id": "e822c9bf-bd2a-49e2-a9d3-ff544d000aed",
      "siteId": "lenix",
      "hostname": "ip-172-31-39-120.eu-west-2.compute.internal",
      "addr": "172.31.39.120:22",
      "tags": [
        {
          "name": "Name",
          "value": "MarcoDevTeleport"
        },
        {
          "name": "account-id",
          "value": "278576220453"
        },
        {
          "name": "region",
          "value": "eu-west-2"
        },
        {
          "name": "teleport.dev/instance-id",
          "value": "i-0b1751688b2e4aedf"
        }
      ],
      "sshLogins": [
        "dinis",
        "ubuntu",
        "root"
      ]
    }
  ]
}
```