### PR TITLE
Fix an issue `context canceled` spams Proxy log for database connections

### DIFF
--- a/lib/srv/app/server.go
+++ b/lib/srv/app/server.go
@@ -702,7 +702,7 @@ func (s *Server) HandleConnection(conn net.Conn) {
 }
 
 func (s *Server) handleConnection(conn net.Conn) (func(), error) {
-	ctx, cancel := context.WithCancel(s.closeContext)
+	ctx, cancel := context.WithCancelCause(s.closeContext)
 	tc, err := srv.NewTrackingReadConn(srv.TrackingReadConnConfig{
 		Conn:    conn,
 		Clock:   s.c.Clock,

--- a/lib/srv/db/proxyserver.go
+++ b/lib/srv/db/proxyserver.go
@@ -534,7 +534,7 @@ func (s *ProxyServer) Proxy(ctx context.Context, proxyCtx *common.ProxyContext, 
 
 	// Ignore context.Canceled errors from monitoring.
 	//
-	// The clientConn is closed by utils.ProxyConn on succesful io.Copy thus
+	// The clientConn is closed by utils.ProxyConn on successful io.Copy thus
 	// possibly causing utils.ProxyConn to return context.Canceled (as monitor
 	// context is closed when TrackingReadConn.Close() is called).
 	//

--- a/lib/srv/monitor.go
+++ b/lib/srv/monitor.go
@@ -492,7 +492,7 @@ type TrackingReadConnConfig struct {
 	Clock clockwork.Clock
 	// Context is an external context to cancel the operation.
 	Context context.Context
-	/// Cancel is called whenever client context is closed.
+	// Cancel is called whenever client context is closed.
 	Cancel context.CancelCauseFunc
 }
 
@@ -547,11 +547,14 @@ func (t *TrackingReadConn) Read(b []byte) (int, error) {
 	return n, err
 }
 
+// Close cancels the context with io.EOF and closes the underlying connection.
 func (t *TrackingReadConn) Close() error {
 	t.cfg.Cancel(io.EOF)
 	return t.Conn.Close()
 }
 
+// CloseWithCause cancels the context with provided cause and closes the
+// underlying connection.
 func (t *TrackingReadConn) CloseWithCause(cause error) error {
 	t.cfg.Cancel(cause)
 	return t.Conn.Close()

--- a/lib/srv/monitor_test.go
+++ b/lib/srv/monitor_test.go
@@ -23,11 +23,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gravitational/trace"
 	"github.com/jonboulle/clockwork"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-
-	"github.com/gravitational/trace"
 
 	"github.com/gravitational/teleport/api/constants"
 	"github.com/gravitational/teleport/api/types"

--- a/lib/utils/proxyconn.go
+++ b/lib/utils/proxyconn.go
@@ -86,7 +86,8 @@ func ProxyConn(ctx context.Context, client, server io.ReadWriteCloser) error {
 				errors = append(errors, err)
 			}
 		case <-ctx.Done():
-			return ctx.Err()
+			// Cause(ctx) returns ctx.Err() if no cause is provided.
+			return trace.Wrap(context.Cause(ctx))
 		}
 	}
 


### PR DESCRIPTION
Fixes #31367

Caused by:
- monitored context is passed to `utils.ProxyConn`
- `utils.ProxyConn` finishes `io.Copy` and calls `clientConn.Close`
- `clientConn.Close` (in this case `TrackingReadConn.Close`) cancels the context
- `utils.ProxyConn` returns `context.Canceled`

The simple fix is to ignore `context.Canceled`. However, in case the connection is killed for a legit reason by the monitor (e.g. expired cert), the proxyserver should still launch an error. Thus the main change of this PR is to cancel and propagate the context with a proper `Cause`, when the monitor kills the connection:

```
2023-09-05T17:00:04Z ERRO [DB:PROXY]  Failed to handle database TLS connection. error:[
ERROR REPORT:
Original Error: *trace.AccessDeniedError client certificate expired at 2023-09-05 17:00:04.000143482 &#43;0000 UTC
Stack Trace:
github.com/gravitational/teleport/lib/srv/monitor.go:424 github.com/gravitational/teleport/lib/srv.(*Monitor).disconnectClient
github.com/gravitational/teleport/lib/srv/monitor.go:408 github.com/gravitational/teleport/lib/srv.(*Monitor).disconnectClientOnExpiredCert
github.com/gravitational/teleport/lib/srv/monitor.go:341 github.com/gravitational/teleport/lib/srv.(*Monitor).start
github.com/gravitational/teleport/lib/srv/monitor.go:289 github.com/gravitational/teleport/lib/srv.StartMonitor.func1
runtime/asm_amd64.s:1650 runtime.goexit

```