### PR TITLE
Wraps go-redis internal logger and logs at TRACE level.

### DIFF
--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -492,7 +492,7 @@ type driverLogger struct {
 	*logrus.Entry
 }
 
-func (l *driverLogger) Printf(_ context.Context, format string, v ...interface{}) {
+func (l *driverLogger) Printf(_ context.Context, format string, v ...any) {
 	l.Entry.Tracef(format, v...)
 }
 


### PR DESCRIPTION
Fixes #31303

Will backport together will the new driver to older branches.