### PR TITLE
Add support for fake `exec` and `portforward` verbs

### DIFF
--- a/api/types/constants.go
+++ b/api/types/constants.go
@@ -1054,6 +1054,10 @@ const (
 	KubeVerbWatch = "watch"
 	// KubeVerbDeleteCollection is the Kubernetes verb for "deletecollection".
 	KubeVerbDeleteCollection = "deletecollection"
+	// KubeVerbExec is the Kubernetes verb for "pod/exec".
+	KubeVerbExec = "exec"
+	// KubeVerbPortForward is the Kubernetes verb for "pod/portforward".
+	KubeVerbPortForward = "portforward"
 )
 
 // KubernetesVerbs lists the supported Kubernetes verbs.
@@ -1067,6 +1071,8 @@ var KubernetesVerbs = []string{
 	KubeVerbList,
 	KubeVerbWatch,
 	KubeVerbDeleteCollection,
+	KubeVerbExec,
+	KubeVerbPortForward,
 }
 
 // KubernetesClusterWideResourceKinds is the list of supported Kubernetes cluster resource kinds

--- a/lib/kube/proxy/url.go
+++ b/lib/kube/proxy/url.go
@@ -309,31 +309,38 @@ func isKubeWatchRequest(req *http.Request, r apiResource) bool {
 func (r apiResource) getVerb(req *http.Request) string {
 	verb := ""
 	isWatch := isKubeWatchRequest(req, r)
-	switch req.Method {
-	case http.MethodPost:
-		verb = types.KubeVerbCreate
-	case http.MethodGet, http.MethodHead, http.MethodOptions:
-		switch {
-		case isWatch:
-			return types.KubeVerbWatch
-		case r.resourceName == "":
-			return types.KubeVerbList
-		default:
-			return types.KubeVerbGet
-		}
-	case http.MethodPut:
-		verb = types.KubeVerbUpdate
-	case http.MethodPatch:
-		verb = types.KubeVerbPatch
-	case http.MethodDelete:
-		switch {
-		case r.resourceName != "":
-			verb = types.KubeVerbDelete
-		default:
-			verb = types.KubeVerbDeleteCollection
-		}
+	switch r.resourceKind {
+	case "pods/exec", "pods/attach":
+		verb = types.KubeVerbExec
+	case "pods/portforward":
+		verb = types.KubeVerbPortForward
 	default:
-		verb = ""
+		switch req.Method {
+		case http.MethodPost:
+			verb = types.KubeVerbCreate
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			switch {
+			case isWatch:
+				return types.KubeVerbWatch
+			case r.resourceName == "":
+				return types.KubeVerbList
+			default:
+				return types.KubeVerbGet
+			}
+		case http.MethodPut:
+			verb = types.KubeVerbUpdate
+		case http.MethodPatch:
+			verb = types.KubeVerbPatch
+		case http.MethodDelete:
+			switch {
+			case r.resourceName != "":
+				verb = types.KubeVerbDelete
+			default:
+				verb = types.KubeVerbDeleteCollection
+			}
+		default:
+			verb = ""
+		}
 	}
 
 	return verb

--- a/lib/kube/proxy/url_test.go
+++ b/lib/kube/proxy/url_test.go
@@ -110,7 +110,9 @@ func Test_getResourceFromRequest(t *testing.T) {
 		{path: "/api/v1/namespaces/default/pods", want: nil},
 		{path: "/api/v1/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "default", Name: "foo", Verbs: []string{"get"}}},
 		{path: "/api/v1/watch/namespaces/default/pods/foo", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "default", Name: "foo", Verbs: []string{"watch"}}},
-		{path: "/api/v1/namespaces/kube-system/pods/foo/exec", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"get"}}},
+		{path: "/api/v1/namespaces/kube-system/pods/foo/exec", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"exec"}}},
+		{path: "/api/v1/namespaces/kube-system/pods/foo/attach", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"exec"}}},
+		{path: "/api/v1/namespaces/kube-system/pods/foo/portforward", want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "kube-system", Name: "foo", Verbs: []string{"portforward"}}},
 		{path: "/api/v1/namespaces/default/pods", body: bodyFunc("Pod", "v1"), want: &types.KubernetesResource{Kind: types.KindKubePod, Namespace: "default", Name: "foo-create", Verbs: []string{"create"}}},
 
 		// Secrets


### PR DESCRIPTION
This PR adds support for fake Kubernetes verbs to restrict access to exec and portforward endpoints.

`exec` and `portforward` aren't valid Kubernetes verbs but we extend our definition of verbs to easily restrict exec and port forward directly on Teleport roles.