### PR TITLE
[v12] Update device trust docs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -346,12 +346,38 @@
         {
           "title": "Device Trust",
           "slug": "/access-controls/device-trust/",
-          "forScopes": ["enterprise", "cloud"],
+          "forScopes": [
+            "enterprise",
+            "cloud",
+            "team"
+          ],
           "entries": [
             {
-              "title": "Set Up Device Trust",
+              "title": "Getting Started",
               "slug": "/access-controls/device-trust/guide/",
-              "forScopes": ["enterprise","cloud"]
+              "forScopes": [
+                "enterprise",
+                "cloud",
+                "team"
+              ]
+            },
+            {
+              "title": "Manage Trusted Devices",
+              "slug": "/access-controls/device-trust/device-management/",
+              "forScopes": [
+                "enterprise",
+                "cloud",
+                "team"
+              ]
+            },
+            {
+              "title": "Enforce Device Trust",
+              "slug": "/access-controls/device-trust/enforcing-device-trust/",
+              "forScopes": [
+                "enterprise",
+                "cloud",
+                "team"
+              ]
             }
           ]
         },
@@ -1433,12 +1459,17 @@
     "ansible": {
       "min_version": "2.9.6"
     },
+    "clusterDefaults": {
+      "clusterName": "teleport.example.com",
+      "username": "myuser",
+      "nodeIP": "ip-172-31-35-170"
+    },
     "aws": {
       "aws_access_key": "abcd1234-this-is-an-example",
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.3.4",
+      "version": "13.2.3",
       "major_version": "13",
       "sla": {
         "monthly_percentage": "99.9%",
@@ -1482,16 +1513,16 @@
     },
     "teleport": {
       "major_version": "12",
-      "version": "12.4.15",
+      "version": "12.4.14",
       "golang": "1.20",
       "plugin": {
         "version": "12.3.1"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
-      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:12.4.15",
-      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.15",
-      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:12.4.15",
-      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.15"
+      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:12.4.14",
+      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.14",
+      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:12.4.14",
+      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.14"
     },
     "terraform": {
       "version": "1.0.0"

--- a/docs/config.json
+++ b/docs/config.json
@@ -1469,7 +1469,7 @@
       "aws_secret_access_key": "zyxw9876-this-is-an-example"
     },
     "cloud": {
-      "version": "13.2.3",
+      "version": "13.3.4",
       "major_version": "13",
       "sla": {
         "monthly_percentage": "99.9%",
@@ -1513,16 +1513,16 @@
     },
     "teleport": {
       "major_version": "12",
-      "version": "12.4.14",
+      "version": "12.4.15",
       "golang": "1.20",
       "plugin": {
         "version": "12.3.1"
       },
       "helm_repo_url": "https://charts.releases.teleport.dev",
-      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:12.4.14",
-      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.14",
-      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:12.4.14",
-      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.14"
+      "latest_oss_docker_image": "public.ecr.aws/gravitational/teleport-distroless:12.4.15",
+      "latest_oss_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.15",
+      "latest_ent_docker_image": "public.ecr.aws/gravitational/teleport-ent-distroless:12.4.15",
+      "latest_ent_debug_docker_image": "public.ecr.aws/gravitational/teleport-distroless-debug:12.4.15"
     },
     "terraform": {
       "version": "1.0.0"

--- a/docs/pages/access-controls/device-trust.mdx
+++ b/docs/pages/access-controls/device-trust.mdx
@@ -12,7 +12,7 @@ videoBanner: gBQyj_X1LVw
   - Teleport client: `tsh` and Teleport connect.
   - Resources: SSH, Database and Kubernetes.
 
-  Support for Windows device is available in version 13.0 and above.
+  Support for Windows devices with a TPM is available in version 13.0 and above.
 
   Support for other operating systems, access from Web UI and application
   access is planned for upcoming Teleport versions.

--- a/docs/pages/access-controls/device-trust.mdx
+++ b/docs/pages/access-controls/device-trust.mdx
@@ -1,14 +1,24 @@
 ---
 title: Device Trust (Preview)
-description: Use and enforce trusted devices with Teleport
+description: Teleport Device Trust Concepts
 layout: tocless-doc
+videoBanner: gBQyj_X1LVw
 ---
 
 <Admonition type="warning">
-Device Trust is currently in Preview mode.
+  Device Trust is currently in Preview mode and supports following components:
 
-Device Trust requires Teleport Enterprise v12+.
+  - User devices: macOS.
+  - Teleport client: `tsh` and Teleport connect.
+  - Resources: SSH, Database and Kubernetes.
+
+  Support for Windows device is available in version 13.0 and above.
+
+  Support for other operating systems, access from Web UI and application
+  access is planned for upcoming Teleport versions.
 </Admonition>
+
+## Concepts
 
 Device Trust allows Teleport admins to enforce the use of trusted devices.
 Resources protected by the device mode "required" will enforce the use of a
@@ -16,16 +26,69 @@ trusted device, in addition to establishing the user's identity and enforcing
 the necessary roles. Furthermore, users using a trusted device leave audit
 trails that include the device's information.
 
-The device trust preview works only with macOS devices and supports the
-following Teleport features:
+Device Trust requires two of the following steps to have been configured:
 
-- SSH access enforcement
-- Database access enforcement
-- Kubernetes access enforcement
+- Trusted device registered and enrolled with Teleport.
+- Device enforcement mode configured via either a role or a cluster-wide config.
 
-Support for other operating systems and access features is planned for upcoming
-Teleport versions.
+Categorically, we define these two requirements as Trusted Device management
+and Device Trust enforcement.
+
+## Trusted Device management
+
+Device management is divided into two separate phases: inventory management and
+device enrollment.
+
+**Inventory management** is performed by a device admin. In this step, devices
+are registered or removed from Teleport. For example, this happens when the IT
+department of your company acquires new devices, or retires devices from use.
+
+Inventory management can be manually operated using `tctl` or automatically synced
+with a Mobile Device Management (MDM) solution such as Jamf Pro.
+
+**Device enrollment** is performed either by a device admin or by the end-user,
+at your discretion. This is the step that creates the Secure Enclave private key
+in the device and registers its public key counterpart with the Teleport Auth
+Server. Enrollment has to run on the actual device that you want to enroll. For
+example, this happens when a user gets a new device for the first time, or when
+IT prepares a new device for a user. Enrollment only needs to happen once per
+user/device combination.
+
+Enrollment exchanges an enrollment token, created by a
+device admin, for the opportunity to enroll the corresponding device.
+
+### How trust is established with the device
+
+Device Trust leverages dedicated secure hardware in devices to store device credentials
+and perform device challenges. The specific implementation varies between types of devices.
+
+On macOS devices, Device Trust uses the Secure Enclave in order to store a
+device private key. That key is used to solve device challenges issued by the
+Teleport Auth Service, proving the identity of the trusted device.
+
+The signed attestation ensures that the Teleport Auth Service knows both the state
+of the device and that the request has come from the device.
+
+That said, a device is as "trustworthy" as the enrollment process. If enrollment operator
+enrolls a malicious device to Teleport, establishing trust with Secure Enclave or TPM is
+already defeated at this point. The more trusted the enrollment environment and operator,
+the better the ongoing guarantees that the device itself is trustworthy.
+
+## Device Trust enforcement
+
+Enforcing Device Trust means configuring Teleport with device trust mode, i.e. applying
+`device_trust_mode: required` rule, which tells Teleport Auth Service to only allow access
+with a trusted and an authenticated device, in addition to establishing the user's identity and enforcing
+the necessary roles.
+
+Teleport supports two methods for device enforcement: Role-based
+enforcement and Cluster-wide enforcement.
+
+- **Role-based enforcement** can be used to enforce Device Trust at role level, using RBAC.
+- **Cluster-wide enforcement** can be used to enforce Device Trust at cluster level.
 
 ## Guides
 
-- [Set Up Device Trust](./device-trust/guide.mdx)
+- [Getting Started with Device Trust](./device-trust/guide.mdx)
+- [Device Management](./device-trust/device-management.mdx)
+- [Enforcing Device Trust](./device-trust/enforcing-device-trust.mdx)

--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -49,8 +49,6 @@ Asset Tag    OS    Enroll Status Device ID
 ```
 
 <Admonition type="warning" title="Device Role">
-  For clusters created after v13.3.6, Teleport supports preset `device-admin` role to manage devices.
-
   For clusters created using Teleport v12 or newer, the preset `editor` role has
   the necessary permissions to manage devices. For clusters created before v12, you may want
   to create a dedicated [`device-admin`](#dedicated-device-admin-role) role.

--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -1,0 +1,174 @@
+---
+title: Manage Trusted Devices (Preview)
+description: Learn how to manage Trusted Devices
+---
+
+<Admonition type="warning" title="Preview Note: Supported Device Type">
+The device trust preview works on macOS devices. Support for other operating
+systems and access features is planned for upcoming Teleport versions.
+</Admonition>
+
+### Prerequisites
+
+(!docs/pages/includes/no-oss-prereqs-tabs.mdx!)
+
+(!docs/pages/includes/device-trust/prereqs.mdx!)
+
+## Register a trusted device
+
+The `tctl` tool is used to manage the device inventory. A device admin is
+responsible for managing devices, adding new devices to the inventory and
+removing devices that are no longer in use.
+
+<Admonition type="tip" title="Self enrollment: v13.3.5+">
+  Users with the preset `editor` or `device-admin` role (since v13.3.6)
+  can register and enroll their device in a single step with the following command:
+  ```code
+  $ tsh device enroll --current-device
+  ```
+</Admonition>
+
+To register a device, you first need to determine its serial number.
+
+Replace the `$SERIAL` below with your macOS device serial number (visible under Apple ->
+"About This Mac" -> "Serial number", or use the command below).
+
+```code
+$ SERIAL="$(ioreg -c IOPlatformExpertDevice -d 2 | grep -i IOPlatformSerialNumber | awk -F'"' '{print $4}')"
+$ tctl devices add --os=macos --asset-tag="$SERIAL"
+Device (=devicetrust.asset_tag=)/macOS added to the inventory
+```
+
+View registered devices:
+
+```code
+$ tctl devices ls
+Asset Tag    OS    Enroll Status Device ID
+------------ ----- ------------- ------------------------------------
+(=devicetrust.asset_tag=) macOS not enrolled  (=devicetrust.device_id=)
+```
+
+<Admonition type="warning" title="Device Role">
+  For clusters created after v13.3.6, Teleport supports preset `device-admin` role to manage devices.
+
+  For clusters created using Teleport v12 or newer, the preset `editor` role has
+  the necessary permissions to manage devices. For clusters created before v12, you may want
+  to create a dedicated [`device-admin`](#dedicated-device-admin-role) role.
+</Admonition>
+
+## Create a device enrollment token
+
+A registered device becomes a trusted device after it goes through the
+enrollment ceremony. To enroll the device, a device enrollment token is
+necessary. The token is created by a device admin and sent to the person
+performing the enrollment off-band (for example, via a corporate chat).
+
+To create an enrollment token run the command below, where `--asset-tag` is
+the serial number of the device we want to enroll:
+
+```code
+$ tctl devices enroll --asset-tag="(=devicetrust.asset_tag=)"
+Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
+tsh device enroll --token=(=devicetrust.enroll_token=)
+```
+
+## Enroll a trusted device
+
+To perform the enrollment ceremony, using the device specified above, type the
+command printed by `tctl devices enroll`:
+
+```code
+$ tsh device enroll --token=(=devicetrust.enroll_token=)
+Device "(=devicetrust.asset_tag=)"/macOS enrolled
+
+$ tsh logout
+$ tsh login --proxy=(=clusterDefaults.clusterName=) --user=(=clusterDefaults.username=) # fetch new certificates
+Enter password for Teleport user (=clusterDefaults.username=):
+Tap any security key
+Detected security key tap
+> Profile URL:        (=clusterDefaults.clusterName=):443
+  Logged in as:       (=clusterDefaults.username=)
+  Cluster:            (=clusterDefaults.clusterName=)
+  Roles:              access, editor
+  Logins:             (=clusterDefaults.username=)
+  Kubernetes:         enabled
+  Valid until:        2023-06-23 02:47:05 -0300 -03 [valid for 12h0m0s]
+  Extensions:         teleport-device-asset-tag, teleport-device-credential-id, teleport-device-id
+```
+The presence of the `teleport-device-*` extensions shows that the device was
+successfully enrolled and authenticated. The device above is now a trusted device.
+
+## Remove a trusted device
+
+A device that is no longer in use may be removed using `tctl devices rm
+--device-id=<ID>` or `tctl devices rm --asset-tag=<SERIAL>`
+
+First, find a device to delete:
+```code
+$ tctl devices ls
+Asset Tag    OS    Enroll Status Device ID
+------------ ----- ------------- ------------------------------------
+C00AA0AAAA0A macOS enrolled      c9cbb327-68a8-497e-b820-6a4b2bf58269
+```
+
+Now use asset-tag or device id to delete a device:
+```code
+# Delete using asset tag:
+$ tctl devices rm --asset-tag=C00AA0AAAA0A
+Device "C00AA0AAAA0A" removed
+
+# Delete using device id:
+$ tctl devices rm --device-id=c9cbb327-68a8-497e-b820-6a4b2bf58269
+Device "c9cbb327-68a8-497e-b820-6a4b2bf58269" removed
+```
+
+## Dedicated device admin role
+
+We recommend creating a dedicated `device-admin` role for device inventory
+management.
+
+<Admonition type="tip" title="v13.3.6+">
+  Teleport version 13.3.6 and above has the preset `device-admin` role, which
+  is a substitute for the role described below.
+</Admonition>
+
+Following is an example of a role that grants permissions for the `device` resource is necessary to manage
+the inventory. Save the yaml below as `device-admin.yaml` and create it in your
+cluster:
+
+```yaml
+version: v6
+kind: role
+metadata:
+  name: device-admin
+spec:
+  allow:
+    rules:
+    - resources: ["device"]
+      verbs:
+      - create
+      - read
+      - list
+      - update
+      - delete
+      - create_enroll_token
+      - enroll
+```
+
+```code
+$ tctl create -f device-admin.yaml
+role 'device-admin' has been created
+```
+
+Note that in addition to the usual CRUD verbs (create, read, list, update and
+delete), we have also included `create_enroll_token` and `enroll`. The
+`create_enroll_token` verb is necessary to execute the `tctl devices enroll`
+command; `enroll` is necessary to execute `tsh device enroll`.
+
+## Troubleshooting
+
+(!docs/pages/includes/device-trust/enroll-troubleshooting.mdx!)
+
+## Next steps
+
+- [Device Trust Enforcement](./enforcing-device-trust.mdx)

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -1,0 +1,190 @@
+---
+title: Enforce Device Trust (Preview)
+description: Learn how to enforce trusted devices with Teleport
+videoBanner: gBQyj_X1LVw
+---
+
+<Admonition type="warning" title="Preview Note: Supported Resources">
+The device trust preview only supports SSH, Database and Kubernetes resources.
+Support for other resources is planned for upcoming Teleport versions.
+</Admonition>
+
+Resources protected by the device mode "required" will enforce the use of a
+trusted device, in addition to establishing the user's identity and enforcing
+the necessary roles. Furthermore, users using a trusted device leave audit
+trails that include the device's information.
+
+Device Trust enforcement can be configured with the following three modes of operation, represented
+by the `device_trust_mode` authentication setting:
+
+- `off` - disables device trust. Device authentication is not performed and
+  device-aware audit logs are absent.
+- `optional` - enables device authentication and device-aware audit, but does
+  not require a trusted device to access resources.
+- `required` - enables device authentication and device-aware audit.
+  Additionally, it requires a trusted device for all SSH, Database and
+  Kubernetes connections.
+
+### Prerequisites
+(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
+
+(!docs/pages/includes/device-trust/prereqs.mdx!)
+
+## Role-based trusted device enforcement
+
+Role-based configuration enforces trusted device access at the role level. It
+can be configured with the `spec.options.device_trust_mode` option and
+applies to the resources in its `allow` rules. It
+works similarly to [`require_session_mfa`](../guides/per-session-mfa.mdx).
+
+<Admonition type="tip" title="v13.3.6+">
+  Teleport version 13.3.6 and above has the preset `require-trusted-device` role.
+  Make sure you update the "allow" rules in the role according to your requirements.
+</Admonition>
+
+To enforce authenticated device checks for a specific role, update the role with
+the following:
+
+```diff
+kind: role
+version: v6
+metadata:
+  name: require-trusted-device
+spec:
+  options:
+    # require authenticated device check for this role
++   device_trust_mode: "required" # add this line
+  allow:
+    logins: ['admin']
+    kubernetes_groups: ['edit']
+    node_labels:
+      '*': '*'
+    ...
+
+```
+
+```code
+$ tctl create -f device-enforcement.yaml
+```
+
+## Cluster-wide trusted device enforcement
+
+Cluster-wide configuration enforces trusted device access at the cluster level.
+Enterprise clusters run in `optional` mode by default. Changing the mode to
+`required` will enforce a trusted device for all SSH, Database and Kubernetes
+accesses.
+
+<Admonition type="warning" title="Web UI">
+The Web UI is not capable of trusted device access during the device trust
+preview. Only `tsh` and Teleport Connect are able to fulfill device mode
+`required`.
+</Admonition>
+
+To enable device mode `required` update your configuration as follows:
+
+<Tabs dropDownCaption="Teleport Deployment">
+<TabItem label="Dynamic Resources" options="Self-Hosted,Teleport Enterprise Cloud" >
+Create a `cap.yaml` file or get the existing configuration using
+`tctl get cluster_auth_preference`:
+
+```diff
+kind: cluster_auth_preference
+version: v2
+metadata:
+  name: cluster-auth-preference
+spec:
+  type: local
+  second_factor: "on"
+  webauthn:
+    rp_id: (=clusterDefaults.clusterName=)
+  device_trust:
++   mode: "required" # add this line
+```
+
+Update the configuration:
+
+```code
+$ tctl create -f cap.yaml
+cluster auth preference has been updated
+```
+
+You can also edit this configuration directly:
+
+```code
+$ tctl edit cluster_auth_preference
+```
+
+</TabItem>
+<TabItem label="Static Config" options="Self-Hosted">
+Edit the Auth Server's `teleport.yaml` file and restart all Auth Services:
+
+```diff
+auth_service:
+  authentication:
+    type: local
+    second_factor: "on"
+    webauthn:
+      rp_id: (=clusterDefaults.clusterName=)
+    device_trust:
++     mode: "required" # add this line
+```
+
+</TabItem>
+</Tabs>
+
+Once the config is updated, SSH, Database and Kubernetes access without a trusted device will be forbidden.
+For example, SSH access without a trusted device fails with the following error:
+
+```code
+$ tsh ssh (=clusterDefaults.nodeIP=)
+ERROR: ssh: rejected: administratively prohibited (unauthorized device)
+```
+
+<Admonition type="tip" title="Trusted Clusters">
+It is possible to use [trusted
+clusters](../../management/admin/trustedclusters.mdx) to limit the impact of
+device mode `required`. A leaf cluster in mode `required` will enforce access to
+all of its resources, without imposing the same restrictions to the root
+cluster. Likewise, a root cluster will not enforce device trust on resources in
+leaf clusters.
+</Admonition>
+
+## Locking a device
+
+Similar to [session and identity locking](../guides/locking.mdx), a device can
+be locked using `tctl lock`.
+
+Locking blocks certificate issuance and ongoing or future accesses originating
+from a locked device. Locking a device only works if device trust is enabled and
+if the device is enrolled to Teleport.
+
+Find a device ID to lock:
+
+```code
+$ tctl devices ls
+Asset Tag     OS    Enroll Status   Device ID
+------------ -----  ------------- ------------------------------------
+(=devicetrust.asset_tag=)  macOS  enrolled     (=devicetrust.device_id=)
+```
+
+Lock a device:
+
+```code
+$ tctl lock --device=(=devicetrust.device_id=) --ttl=12h
+Created a lock with name "5444970a-39a0-4814-968d-e58b4a8fa686".
+```
+
+Now, if a user on that device tries to access an SSH server for example,
+Teleport will deny access:
+
+```code
+$ tsh ssh (=clusterDefaults.nodeIP=)
+ERROR: ssh: rejected: administratively prohibited (lock targeting Device:"(=devicetrust.device_id=)" is in force)
+```
+
+## Troubleshooting
+
+(!docs/pages/includes/device-trust/enroll-troubleshooting.mdx!)
+
+## Next steps
+- [Device Management](./device-management.mdx)

--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -1,128 +1,123 @@
 ---
-title: Set Up Device Trust (Preview)
-description: Learn how to use and enforce trusted devices with Teleport
+title: Getting Started with Device Trust (Preview)
+description: Get started with Teleport Device Trust
 videoBanner: gBQyj_X1LVw
 ---
 
 <Admonition type="warning">
-Device Trust is currently in Preview mode.
+  Device Trust is currently in Preview mode and supports following components:
 
-Device Trust requires Teleport Enterprise v12+.
+  - User devices: macOS.
+  - Teleport client: `tsh` and Teleport connect.
+  - Resources: SSH, Database and Kubernetes.
+
+  Support for Windows device is available in version 13.0 and above.
+
+  Support for other operating systems, access from Web UI and application
+  access is planned for upcoming Teleport versions.
 </Admonition>
 
-## Concepts
+Device Trust requires two of the following steps to have been configured:
 
-Device Trust uses the Secure Enclave in macOS devices to store a device private
-key. That key is used to solve device challenges issued by the Teleport Auth
-Server, proving the identity of the trusted device.
+- Device enforcement mode configured via either a role or a cluster-wide config.
+- Trusted device registered and enrolled with Teleport.
 
-Device management is divided into two separate phases: inventory management and
-device enrollment.
+In this guide, you will update the preset `access` role to enforce Device Trust
+and then enroll a trusted device into Teleport to access a resource (a test linux server)
+protected with Teleport.
 
-**Inventory management** is performed by a device admin. In this step, devices
-are registered or removed from Teleport. For example, this happens when the IT
-department of your company acquires new devices, or retires devices from use.
+### Prerequisites
 
-**Device enrollment** is performed either by a device admin or by the end-user,
-at your discretion. This is the step that creates the Secure Enclave private key
-in the device and register its public key counterpart with the Teleport Auth
-Server. Enrollment has to run in the actual device that you want to enroll. For
-example, this happens when a user gets a new device for the first time, or when
-IT prepares a new device for a user. Enrollment only needs to happen once per
-user/device combination.
+(!docs/pages/includes/no-oss-prereqs-tabs.mdx!)
 
-<Admonition type="tip" title="Enrollment">
-Device enrollment is key in correctly identifying a device throughout its
-lifetime. The more trusted the enrollment operator, the better the ongoing
-guarantees that the device itself is trustworthy.
+(!docs/pages/includes/device-trust/prereqs.mdx!)
+
+- User with `editor` role.
+  ```code
+  $ tsh status
+  > Profile URL:      (=clusterDefaults.clusterName=):443
+  Logged in as:       (=clusterDefaults.username=)
+  Cluster:            (=clusterDefaults.clusterName=)
+  Roles:              access, auditor, editor
+  Logins:             root, ubuntu, ec2-user
+  Kubernetes:         disabled
+  Valid until:        2023-08-22 03:30:24 -0400 EDT [valid for 11h52m0s]
+  Extensions:         login-ip, permit-agent-forwarding, permit-port-forwarding, permit-pty, private-key-policy
+  ```
+- Access to a linux server (any Linux server you can access via `tsh ssh` will do).
+  ```code
+  $ tsh ls
+  Node Name        Address        Labels
+  ---------------- -------------- --------------------------------------
+  (=clusterDefaults.nodeIP=) ⟵ Tunnel
+
+  # test connection to (=clusterDefaults.nodeIP=)
+  $ tsh ssh root@(=clusterDefaults.nodeIP=)
+  root@(=clusterDefaults.nodeIP=):~#
+  ```
+
+Once the above prerequisites are met, begin with the following step.
+
+## Step 1/2. Update role to enforce Device Trust
+
+To enforce Device Trust, a user must be assigned with a role with Device Trust mode "required".
+
+For simplicity, the example below updates the preset `access` role but you can update
+any existing access granting role which the user is assigned with to enforce Device Trust.
+
+<Admonition type="warning" title="Device Role">
+  To avoid access disruption for other users assigned with preset `access` role, you can
+  create a separate `require-trusted-device` role and use that role for this guide.
 </Admonition>
 
-The tie between the device inventory and enrollment is a device enrollment
-token. A device enrollment token needs to be created by a device admin and sent
-to the person performing the enrollment ceremony. The token ties the actual
-device being enrolled to the expected device in the inventory, adding an extra
-layer of protection.
+First, using `tctl`, open the `access` role to edit it locally:
+```code
+$ tctl edit role/access
+```
 
-## Prerequisites
-
-(!docs/pages/includes/commercial-prereqs-tabs.mdx!)
-
-- A signed and notarized `tsh` binary for enrollment.
-  [Download the macOS tsh installer](../../installation.mdx#macos).
-- A macOS device to register and enroll.
-
-## Step 1/2. Register a trusted device
-
-The `tctl` tool is used to manage the device inventory. A device admin is
-responsible for managing devices, adding new devices to the inventory and
-removing devices that are no longer in use.
-
-A role that grants permissions for the `device` resource is necessary to manage
-the inventory. Save the yaml below as `device-admin.yaml` and create it in your
-cluster:
-
-```yaml
-version: v6
+Edit the role with device trust mode:
+```diff
 kind: role
 metadata:
-  name: device-admin
+  labels:
+    teleport.internal/resource-type: preset
+  name: access
 spec:
   allow:
-    rules:
-    - resources: ["device"]
-      verbs:
-      - create
-      - read
-      - list
-      - update
-      - delete
-      - create_enroll_token
-      - enroll
+    logins:
+    - '{{internal.logins}}'
+    ...
+  options:
+    # require authenticated device check for this role
++   device_trust_mode: "required" # add this line
+    ...
+  deny:
+    ...
+
 ```
+
+Save your edits.
+
+Now that the `access` role is configured with device mode "required", users with
+this role will be enforced with Device Trust.
 
 ```code
-$ tctl create -f device-admin.yaml
-role 'device-admin' has been created
+$ tsh logout; tsh login --proxy=(=clusterDefaults.clusterName=) --user=(=clusterDefaults.username=)
+$ tsh ssh root@(=clusterDefaults.nodeIP=)
+ERROR: access denied to root connecting to (=clusterDefaults.nodeIP=):0
 ```
 
-<Admonition type="tip" title="Editor Role">
-For clusters created using Teleport v12 or newer, the builtin role `editor` has
-the necessary permissions to manage devices. For production setups a separate
-role is still recommended.
-</Admonition>
+As you can verify from the above step, access to `(=clusterDefaults.nodeIP=)` ssh server,
+which was previously accessible, is now forbidden.
 
-Note that in addition to the usual CRUD verbs (create, read, list, update and
-delete), we have also included `create_enroll_token` and `enroll`. The
-`create_enroll_token` verb is necessary to execute the `tctl devices enroll`
-command; `enroll` is necessary to execute `tsh device enroll`. Both are
-demonstrated in the following section.
+## Step 2/2. Enroll device
 
-Make sure your user has the `device-admin` role:
+To access `(=clusterDefaults.nodeIP=)` server again, you will have to enroll your device.
 
-```code
-$ tctl edit users/alice
-```
+First, register your device:
 
-```diff
-kind: user
-metadata:
-  name: alice
-  # unrelated fields omitted.
-spec:
-  roles:
-  - access
-+ - device-admin # add this line
-version: v2
-```
-
-Relogin to fetch updated certificates:
-
-```code
-$ tsh logout; tsh login --proxy=example.com --user=alice
-```
-
-Having the necessary permissions, let's add a device to the inventory. Replace
-the `$SERIAL` below with your macOS device serial number (visible under Apple ->
+Replace the `$SERIAL` below with your macOS
+device serial number (visible under Apple ->
 "About This Mac" -> "Serial number", or use the command below).
 
 ```code
@@ -140,25 +135,7 @@ Asset Tag    OS    Enroll Status Device ID
 (=devicetrust.asset_tag=) macOS not enrolled  (=devicetrust.device_id=)
 ```
 
-A registered device is a device that Teleport knows about. Once a registered
-device is enrolled, it becomes a trusted device.
-
-<Admonition type="tip" title="Removing Devices">
-A device that is no longer in use may be removed using `tctl devices rm
---device-id=<ID>` or `tctl devices rm --asset-tag=<SERIAL>`.
-</Admonition>
-
-## Step 2/2. Enroll a trusted device
-
-A registered device becomes a trusted device after it goes through the
-enrollment ceremony. Enrollment exchanges an enrollment token, created by a
-device admin, for the opportunity to enroll the corresponding device.
-
-macOS enrollments are tied to the current user in the device. If the same device
-is handed to a new user, they will need to perform enrollment again.
-
-To create an enrollment token run the following command, where `--asset-tag` is
-the serial number of the device we want to enroll.
+Create enrollment token for your device:
 
 ```code
 $ tctl devices enroll --asset-tag="(=devicetrust.asset_tag=)"
@@ -166,194 +143,48 @@ Run the command below on device "(=devicetrust.asset_tag=)" to enroll it:
 tsh device enroll --token=(=devicetrust.enroll_token=)
 ```
 
-To perform the enrollment ceremony, using the device specified above, type the
-command printed by `tctl devices enroll`:
+Now using `tsh`, enroll your device (use token printed above with `tctl devices enroll` command) :
 
 ```code
 $ tsh device enroll --token=(=devicetrust.enroll_token=)
 Device "(=devicetrust.asset_tag=)"/macOS enrolled
-
-$ tsh logout; tsh login --proxy=example.com --user=alice # fetch new certificates
 ```
 
 The device above is now a trusted device.
 
-## Optional: Cluster-wide trusted device enforcement
-
-Cluster-wide configuration enforces trusted device access at the cluster level.
-It can be configured with the following three modes of operation, represented
-by the `device_trust.mode` authentication setting:
-
-- `off` - disables device trust. Device authentication is not performed and
-  device-aware audit logs are absent.
-- `optional` - enables device authentication and device-aware audit, but does not
-  require a trusted device to access resources.
-- `required` - enables device authentication and device-aware audit.
-  Additionally, it requires a trusted device for all SSH, Database and
-  Kubernetes connections.
-
-Enterprise clusters run in `optional` mode by default. Changing the mode to
-`required` will enforce a trusted device for all SSH, Database and Kubernetes
-accesses.
-
-<Admonition type="warning" title="Web UI">
-The Web UI is not capable of trusted device access during the device trust
-preview. Only `tsh` and Teleport Connect are able to fulfill device mode
-`required`.
-</Admonition>
-
-To enable device mode `required` update your configuration as follows:
-
-<Tabs dropDownCaption="Teleport Deployment">
-<TabItem label="Dynamic Resources" options="Self-Hosted,Teleport Enterprise Cloud" >
-Create a `cap.yaml` file or get the existing configuration using
-`tctl get cluster_auth_preference`:
-
-```diff
-kind: cluster_auth_preference
-version: v2
-metadata:
-  name: cluster-auth-preference
-spec:
-  type: local
-  second_factor: "on"
-  webauthn:
-    rp_id: example.com
-  device_trust:
-+   mode: "required" # add this line
-```
-
-Update the configuration:
+Relogin to fetch updated certificate with device extension:
 
 ```code
-$ tctl create -f cap.yaml
-cluster auth preference has been updated
+$ tsh logout; tsh login --proxy=(=clusterDefaults.clusterName=) --user=(=clusterDefaults.username=)
+
+$ tsh status
+> Profile URL:        (=clusterDefaults.clusterName=):443
+  Logged in as:       (=clusterDefaults.username=)
+  Cluster:            (=clusterDefaults.clusterName=):443
+  Roles:              access, auditor, editor
+  Logins:             root
+  Kubernetes:         enabled
+  Valid until:        2023-08-22 04:06:53 -0400 EDT [valid for 12h0m0s]
+  Extensions:         login-ip, ... teleport-device-asset-tag, teleport-device-credential-id, teleport-device-id
 ```
 
-You can also edit this configuration directly:
+The presence of the `teleport-device-*` extensions shows that the device was successfully authenticated.
 
-```code
-$ tctl edit cluster_auth_preference
+Now, let's try to access server (`(=clusterDefaults.nodeIP=)`) again:
+
+```bash
+$ tsh ssh root@(=clusterDefaults.nodeIP=)
+root@(=clusterDefaults.nodeIP=):~#
 ```
 
-</TabItem>
-<TabItem label="Static Config" options="Self-Hosted">
-Edit the Auth Server's `teleport.yaml` file and restart all Auth Services:
-
-```diff
-auth_service:
-  authentication:
-    type: local
-    second_factor: "on"
-    webauthn:
-      rp_id: example.com
-    device_trust:
-+     mode: "required" # add this line
-```
-
-</TabItem>
-</Tabs>
-
-SSH, Database and Kubernetes access without a trusted device is now forbidden.
-For example, SSH access without a trusted device fails with the following error:
-
-```code
-$ tsh ssh server1
-ERROR: ssh: rejected: administratively prohibited (unauthorized device)
-```
-
-<Admonition type="tip" title="Trusted Clusters">
-It is possible to use [trusted
-clusters](../../management/admin/trustedclusters.mdx) to limit the impact of
-device mode `required`. A leaf cluster in mode `required` will enforce access to
-all of its resources, without imposing the same restrictions to the root
-cluster. Likewise, a root cluster will not enforce device trust on resources in
-leaf clusters.
-</Admonition>
-
-## Optional: Role-based trusted device enforcement
-
-Role-based configuration enforces trusted device access at the role level. It
-can be configured with the `spec.options.device_trust_mode` (`required`,
-`optional`, `off`) option and applies to the resources in its `allow` rules. It
-works similar to [`require_session_mfa`](../guides/per-session-mfa.mdx).
-
-To enforce authenticated device checks for a specific role, update the role with the following:
-
-```diff
-kind: role
-version: v6
-metadata:
-  name: example-role
-spec:
-  options:
-    # require authenticated device check for this role
-+   device_trust_mode: "required" # add this line
-  allow:
-    logins: ['admin']
-    kubernetes_groups: ['edit']
-    node_labels:
-      '*': '*'
-    ...
-
-```
-
-<Admonition type="tip" title="Per-role vs. Cluster-wide">
-Per-role configuration let's you progressively block unauthorized device access,
-and is useful for getting started with Teleport Device Trust.
-
-Once all the devices used are enrolled in Teleport, cluster-wide
-configuration will ensure every resources can only ever be accessed with a
-trusted device.
-</Admonition>
-
-## Optional: Locking a device
-
-Similar to [session and identity locking](../guides/locking.mdx), a device can
-be locked using `tctl lock`.
-
-Locking blocks certificate issuance and ongoing or future accesses originating
-from a locked device. Locking a device only works if device trust is enabled and
-if the device is enrolled to Teleport.
-
-Find a device ID to lock:
-
-```code
-$ tctl devices ls
-Asset Tag     OS    Enroll Status   Device ID
------------- -----  ------------- ------------------------------------
-(=devicetrust.asset_tag=)  macOS  enrolled     (=devicetrust.device_id=)
-```
-
-Lock a device:
-
-```code
-$ tctl lock --device (=devicetrust.device_id=) --ttl=12h
-Created a lock with name "5444970a-39a0-4814-968d-e58b4a8fa686".
-```
-
-Now, if a user on that device tries to access an SSH server for example, Teleport will deny access:
-
-```code
-$ tsh ssh server1
-ERROR: ssh: rejected: administratively prohibited (lock targeting Device:"(=devicetrust.device_id=)" is in force)
-```
+Congratulations! You have successfully configured a Trusted Device and accessed a resource protected with
+Device Trust enforcement.
 
 ## Troubleshooting
 
-### "binary missing signature or entitlements" on `tsh device enroll`
+(!docs/pages/includes/device-trust/enroll-troubleshooting.mdx!)
 
-A signed and notarized `tsh` binary is necessary to enroll and use a a trusted
-device. [Download the macOS tsh installer](../../installation.mdx#macos) to fix
-the problem.
+## Next steps
 
-### "unauthorized device" errors using a trusted device
-
-A signed and notarized `tsh` binary is necessary to use a trusted device. Make
-sure to download and use the
-[macOS tsh installer](../../installation.mdx#macos).
-
-A trusted device needs to be registered and enrolled before it is recognized by
-Teleport as such. Follow the [registration](#step-12-register-a-trusted-device)
-and [enrollment steps](#step-22-enroll-a-trusted-device) and make sure to `tsh
-logout` and `tsh login` after enrollment is done.
+- [Device Management](./device-management.mdx)
+- [Enforcing Device Trust](./enforcing-device-trust.mdx)

--- a/docs/pages/access-controls/guides/locking.mdx
+++ b/docs/pages/access-controls/guides/locking.mdx
@@ -28,7 +28,7 @@ A lock can target the following objects or attributes:
 - a Teleport user by the user's name
 - a Teleport [RBAC](../reference.mdx) role by the role's name
 - a Teleport [trusted device](
-  ../device-trust/guide.mdx#optional-locking-a-device) by the device ID
+  ../device-trust/enforcing-device-trust.mdx#locking-a-device) by the device ID
 - an MFA device by the device's UUID
 - an OS/UNIX login
 - a Teleport agent by the agent's server UUID (effectively unregistering it from the
@@ -199,8 +199,7 @@ the last known locks. This decision strategy is encoded as one of the two modes:
   guaranteed to be up to date
 - `best_effort` mode keeps relying on the most recent locks
 
-<Tabs>
-<TabItem scope={["oss", "enterprise"]} label="Self-Hosted">
+<ScopedBlock scope={["oss", "enterprise"]}>
 
 The cluster-wide mode defaults to `best_effort`. You can set up the default
 locking mode via API or CLI using a `cluster_auth_preference` resource or static
@@ -241,8 +240,8 @@ configuration file:
   </TabItem>
 </Tabs>
 
-</TabItem>
-<TabItem scope={["cloud"]} label="Teleport Enterprise Cloud">
+</ScopedBlock>
+<ScopedBlock scope={["cloud"]}>
 
 The cluster-wide mode defaults to `best_effort`. You can set up the default
 locking mode via API or CLI using a `cluster_auth_preference` resource:
@@ -266,9 +265,7 @@ $ tctl create -f cap.yaml
 # cluster auth preference has been updated
 ```
 
-</TabItem>
-
-</Tabs>
+</ScopedBlock>
 
 It is also possible to configure the locking mode for a particular role:
 
@@ -288,4 +285,3 @@ there is no user involved, the mode is taken from the cluster-wide setting.
 With multiple potentially conflicting locking modes (the cluster-wide default
 and the individual per-role settings) a single occurrence of `strict` suffices
 for the local lock view to become evaluated strictly.
-

--- a/docs/pages/includes/device-trust/enroll-troubleshooting.mdx
+++ b/docs/pages/includes/device-trust/enroll-troubleshooting.mdx
@@ -1,0 +1,14 @@
+### "binary missing signature or entitlements" on `tsh device enroll`
+
+A signed and notarized `tsh` binary is necessary to enroll and use a a trusted
+device. [Download the macOS tsh installer](../../installation.mdx#macos) to fix
+the problem.
+
+### "unauthorized device" errors using a trusted device
+
+A trusted device needs to be registered and enrolled before it is recognized by
+Teleport as such. Follow the [registration](
+../../access-controls/device-trust/device-management.mdx#register-a-trusted-device) and
+[enrollment](
+../../access-controls/device-trust/device-management.mdx#enroll-a-trusted-device) steps
+and make sure to `tsh logout` and `tsh login` after enrollment is done.

--- a/docs/pages/includes/device-trust/prereqs.mdx
+++ b/docs/pages/includes/device-trust/prereqs.mdx
@@ -1,0 +1,4 @@
+- To enroll a macOS device, you need:
+  - A signed and notarized `tsh` binary for enrollment.
+    [Download the macOS tsh installer](../../installation.mdx#macos).
+  - A Teleport version newer than v12.0.0.


### PR DESCRIPTION
Backports #30821 to branch/v12

Manually backported and contents cherrypicked as `v12` is far behind in Device Trust features. 

Careful review will be appreciated. 