### PR TITLE
Use localstorage package instead of default

### DIFF
--- a/web/packages/teleport/src/Desktops/Desktops.tsx
+++ b/web/packages/teleport/src/Desktops/Desktops.tsx
@@ -27,6 +27,7 @@ import Empty, { EmptyStateInfo } from 'teleport/components/Empty';
 import ErrorMessage from 'teleport/components/AgentErrorMessage';
 import cfg from 'teleport/config';
 import history from 'teleport/services/history/history';
+import localStorage from 'teleport/services/localStorage';
 
 import AgentButtonAdd from 'teleport/components/AgentButtonAdd';
 


### PR DESCRIPTION
Desktops page was broke because it was using the window's localstorage instead of our package (should probably rename this eventually or something)