### PR TITLE
Add docs to Kubernetes per-Resource RBAC

### DIFF
--- a/docs/cspell.json
+++ b/docs/cspell.json
@@ -824,7 +824,12 @@
     "yubishm",
     "znmqk",
     "zxvf",
-    "zztop"
+    "zztop",
+    "persistentvolume",
+    "persistentvolumeclaim",
+    "daemonset",
+    "certificatesigningrequest",
+    "deletecollection"
   ],
   "flagWords": [
     "hte"

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -147,8 +147,8 @@ Teleport supports searching and requesting access to the following Kubernetes re
 >
 
 Requesting access to a Kubernetes namespace allows you to access all resources
-in that namespace, including the supported resources listed above. However, it
-prevents you from access any resources belonging to another namespace.
+in that namespace, including the supported Kubernetes resources listed below.
+However, it prevents you from access any resources belonging to another namespace.
 
 </Admonition>
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -137,7 +137,7 @@ You can search for resources of kind `node`, `kube_cluster`, `db`, `app`, and
 `windows_desktop`. Teleport also supports searching and requesting access to
 resources within Kubernetes clusters.
 
-<Details title="List of Supported Kubernetes resources">
+<Details title="List of supported Kubernetes resources">
 
 Teleport supports searching and requesting access to the following Kubernetes resources:
 
@@ -146,8 +146,8 @@ Teleport supports searching and requesting access to the following Kubernetes re
   title="Resource Access Requests to Kubernetes Namespaces"
 >
 
-Requesting access to a Kubernetes Namespace allows you to access all resources
-in that namespace including the supported resources listed above. However, it
+Requesting access to a Kubernetes namespace allows you to access all resources
+in that namespace, including the supported resources listed above. However, it
 prevents you from access any resources belonging to another namespace.
 
 </Admonition>
@@ -447,7 +447,7 @@ command:
 ```code
 $ tsh request create <Var name="resource-id" />
 ```
-###### Namespaced-scoped Resources
+###### Namespaced-scoped resources
 
 For Kubernetes namespaced resources, the `resource-id` is in the following format:
 
@@ -478,7 +478,7 @@ the regular expression `/^nginx-[a-z0-9-]+$/`, run the following command:
 $ tsh request create --resources /teleport.example.com/pod/mycluster/*/^nginx-[a-z0-9-]+$
 ```
 
-###### Cluster-scoped Resources
+###### Cluster-scoped resources
 
 For Kubernetes cluster-scoped resources, the `resource-id` is in the following format:
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -135,29 +135,47 @@ To request access to these resources, run
 
 You can search for resources of kind `node`, `kube_cluster`, `db`, `app`, and
 `windows_desktop`. Teleport also supports searching and requesting access to
-resources within Kubernetes clusters, such as:
+resources within Kubernetes clusters.
 
-- `pod`: Grant acess to individual pods.
-- `secret`: Grant access to individual secrets.
-- `configmap`: CoGrantntrol access to individual configmaps.
-- `namespace`: Grant access to all resources in a namespace.
-- `service`: Grant access to individual services.
-- `serviceaccount`: Grant access to individual service accounts.
-- `kube_node`: Grant access to individual Kubernetes nodes.
-- `persistentvolume`: Grant access to individual persistent volumes.
-- `persistentvolumeclaim`: Grant access to individual persistent volume claims.
-- `deployment`: Grant access to individual deployments.
-- `replicaset`: Grant access to individual replica sets.
-- `statefulset`: Grant access to individual stateful sets.
-- `daemonset`: Grant access to individual daemon sets.
-- `clusterrole`: Grant access to individual cluster roles.
-- `kube_role`: Grant access to individual Kubernetes roles.
-- `clusterrolebinding`: Grant access to individual cluster role bindings.
-- `rolebinding`: Grant access to individual role bindings.
-- `cronjob`: Grant access to individual cron jobs.
-- `job`: Grant access to individual jobs.
-- `certificatesigningrequest`: Grant access to individual certificate signing requests.
-- `ingress`: Grant access to individual ingresses.
+<Details title="List of Supported Kubernetes resources">
+
+Teleport supports searching and requesting access to the following Kubernetes resources:
+
+<Admonition
+  type="tip"
+  title="Resource Access Requests to Kubernetes Namespaces"
+>
+
+Requesting access to a Kubernetes Namespace allows you to access all resources
+in that namespace including the supported resources listed above. However, it
+prevents you from access any resources belonging to another namespace.
+
+</Admonition>
+
+- `pod`
+- `secret`
+- `configmap`
+- `namespace`
+- `service`
+- `serviceaccount`
+- `kube_node`
+- `persistentvolume`
+- `persistentvolumeclaim`
+- `deployment`
+- `replicaset`
+- `statefulset`
+- `daemonset`
+- `clusterrole`
+- `kube_role`
+- `clusterrolebinding`
+- `rolebinding`
+- `cronjob`
+- `job`
+- `certificatesigningrequest`
+- `ingress`
+
+
+</Details>
 
 Advanced filters and queries are supported. See our
 [filtering reference](../../reference/cli.mdx#resource-filtering) for more information.
@@ -392,7 +410,7 @@ spec:
   deny: {}
 ```
 
-#### Kubernetes Resources
+#### Kubernetes resources
 
 You can restrict access to Kubernetes resources by assigning values to the
 `kubernetes_resources` field in the `spec.allow` or `spec.deny` fields.
@@ -437,7 +455,7 @@ For Kubernetes namespaced resources, the `resource-id` is in the following forma
 /TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/NAMESPACE/RESOURCE_NAME
 ```
 
-Teleport suports the following namespaced resources: `pod`, `secret`, `configmap`,
+Teleport supports the following namespaced resources: `pod`, `secret`, `configmap`,
 `service`, `serviceaccount`, `persistentvolumeclaim`, `deployment`, `replicaset`,
 `statefulset`, `daemonset`, `kube_role`, `rolebinding`, `cronjob`, `job`,
 `ingress`.
@@ -465,10 +483,10 @@ $ tsh request create --resources /teleport.example.com/pod/mycluster/*/^nginx-[a
 For Kubernetes cluster-scoped resources, the `resource-id` is in the following format:
 
 ```
-/TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/RESOURCE_NAME
+/TELEPORT_CLUSTER/CLUSTER_WIDE_KIND/KUBE_CLUSTER/RESOURCE_NAME
 ```
 
-Teleport suports the following namespaced resources: `namespace`, `kube_node`,
+Teleport supports the following cluster-wide resources: `namespace`, `kube_node`,
 `clusterrole`, `clusterrolebinding`, `persistentvolume`, `certificatesigningrequest`.
 
 For example, to request access to a namespace called `prod`, run the following command:

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -133,8 +133,33 @@ To request access to these resources, run
     --reason <request reason>
 ```
 
-You can search for resources of kind `node`, `kube_cluster`, `pod`, `db`, `app`, and
-`windows_desktop`. Advanced filters and queries are supported. See our
+You can search for resources of kind `node`, `kube_cluster`, `db`, `app`, and
+`windows_desktop`. Teleport also supports searching and requesting access to
+resources within Kubernetes clusters, such as:
+
+- `pod`: Grant acess to individual pods.
+- `secret`: Grant access to individual secrets.
+- `configmap`: CoGrantntrol access to individual configmaps.
+- `namespace`: Grant access to all resources in a namespace.
+- `service`: Grant access to individual services.
+- `serviceaccount`: Grant access to individual service accounts.
+- `kube_node`: Grant access to individual Kubernetes nodes.
+- `persistentvolume`: Grant access to individual persistent volumes.
+- `persistentvolumeclaim`: Grant access to individual persistent volume claims.
+- `deployment`: Grant access to individual deployments.
+- `replicaset`: Grant access to individual replica sets.
+- `statefulset`: Grant access to individual stateful sets.
+- `daemonset`: Grant access to individual daemon sets.
+- `clusterrole`: Grant access to individual cluster roles.
+- `kube_role`: Grant access to individual Kubernetes roles.
+- `clusterrolebinding`: Grant access to individual cluster role bindings.
+- `rolebinding`: Grant access to individual role bindings.
+- `cronjob`: Grant access to individual cron jobs.
+- `job`: Grant access to individual jobs.
+- `certificatesigningrequest`: Grant access to individual certificate signing requests.
+- `ingress`: Grant access to individual ingresses.
+
+Advanced filters and queries are supported. See our
 [filtering reference](../../reference/cli.mdx#resource-filtering) for more information.
 
 Try narrowing your search to a specific resource you want to access.
@@ -355,21 +380,21 @@ label:
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
       'env': 'staging'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
   deny: {}
 ```
 
-#### `pod`
+#### Kubernetes Resources
 
-You can restrict access to `pod` resources by assigning values to the
+You can restrict access to Kubernetes resources by assigning values to the
 `kubernetes_resources` field in the `spec.allow` or `spec.deny` fields.
 
 The following role allows access to Kubernetes pods with the name `nginx` in any
@@ -379,7 +404,7 @@ namespace, and all pods in the `dev` namespace:
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -396,20 +421,26 @@ spec:
   deny: {}
 ```
 
-##### Access Requests for pods
+##### Access Requests for Kubernetes resources
 
-Teleport users can request access to a Kubernetes pod by running the following
+Teleport users can request access to a Kubernetes resources by running the following
 command:
 
 ```code
-$ tsh request create <Var name="pod-id" />
+$ tsh request create <Var name="resource-id" />
+```
+###### Namespaced-scoped Resources
+
+For Kubernetes namespaced resources, the `resource-id` is in the following format:
+
+```
+/TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/NAMESPACE/RESOURCE_NAME
 ```
 
-Replace `pod-id` with the name of a pod in the following format:
-
-```
-/TELEPORT_CLUSTER/pod/KUBE_CLUSTER/NAMESPACE/POD_NAME
-```
+Teleport suports the following namespaced resources: `pod`, `secret`, `configmap`,
+`service`, `serviceaccount`, `persistentvolumeclaim`, `deployment`, `replicaset`,
+`statefulset`, `daemonset`, `kube_role`, `rolebinding`, `cronjob`, `job`,
+`ingress`.
 
 For example, to request access to a pod called `nginx-1` in the `development`
 namespace, run the following command:
@@ -418,7 +449,7 @@ namespace, run the following command:
 $ tsh request create --resources /teleport.example.com/pod/mycluster/development/nginx-1
 ```
 
-For the `NAMESPACE` and `POD_NAME` values, you can match ranges of characters by
+For the `NAMESPACE` and `RESOURCE_NAME` values, you can match ranges of characters by
 supplying a wildcard (`*`) or regular expression. Regular expressions must begin
 with `^` and end with `$`.
 
@@ -429,11 +460,41 @@ the regular expression `/^nginx-[a-z0-9-]+$/`, run the following command:
 $ tsh request create --resources /teleport.example.com/pod/mycluster/*/^nginx-[a-z0-9-]+$
 ```
 
-If a user has no access to a Kubernetes cluster, they can search the list of pods
+###### Cluster-scoped Resources
+
+For Kubernetes cluster-scoped resources, the `resource-id` is in the following format:
+
+```
+/TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/RESOURCE_NAME
+```
+
+Teleport suports the following namespaced resources: `namespace`, `kube_node`,
+`clusterrole`, `clusterrolebinding`, `persistentvolume`, `certificatesigningrequest`.
+
+For example, to request access to a namespace called `prod`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/namespace/mycluster/prod
+```
+
+For the `RESOURCE_NAME` value, you can match ranges of characters by
+supplying a wildcard (`*`) or regular expression. Regular expressions must begin
+with `^` and end with `$`.
+
+For example, to create a request to access all namespaces prefixed with `dev` match
+the regular expression `/^dev-[a-z0-9-]+$/`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/namespace/mycluster/^dev-[a-z0-9-]+$
+```
+
+###### Search for Kubernetes resources
+
+If a user has no access to a Kubernetes cluster, they can search the list of resources
 in the cluster by running the following command:
 
 ```code
-$ tsh request search --kind=pod --kube-cluster=<Var name="kube-cluster" /> \
+$ tsh request search --kind=<kind> --kube-cluster=<Var name="kube-cluster" /> \
 [--kube-namespace=<Var name="namespace" />|--all-kube-namespaces]
 Name               Namespace Labels    Resource ID
 -----------------  --------- --------- ----------------------------------------------------------
@@ -445,16 +506,17 @@ To request access to these resources, run
     --reason <request reason>
 ```
 
-The list returned includes the name of the pod, the namespace it is in, its labels,
-and the resource ID. Pods included in the list are those that match the
-`kubernetes_resources` field in the user's `search_as_roles`. The user can then:
+The list returned includes the name of the resource, the namespace it is in if
+applicable, its labels, and the resource ID.
+Resources included in the list are those that match the `kubernetes_resources`
+field in the user's `search_as_roles`. The user can then:
 
-- Request access to the pods by running the command provided by the `tsh request
+- Request access to the resources by running the command provided by the `tsh request
 search` command.
-- Edit the command to request access to a subset of the pods.
+- Edit the command to request access to a subset of the resources.
 - Use a custom request with wildcards or regular expressions.
 
-`tsh request search --kind=pod` works even if the user has no permissions to interact
+`tsh request search --kind=<kind>` works even if the user has no permissions to interact
  with the desired Kubernetes cluster, but the user's `search_as_roles` values
 must allow access to the cluster. If the user is unsure of the name of the cluster,
 they can run the following command to search it:
@@ -470,19 +532,23 @@ local                 /teleport.example.com/kube_cluster/local
 ##### Preventing unintended access
 
 If you are setting up a Teleport role to enable just-in-time access to a
-specific Kubernetes pod, you should set the role's `kubernetes_groups` and
+specific Kubernetes resources, you should set the role's `kubernetes_groups` and
 `kubernetes_users` to a role that has no access to Kubernetes resource beside
-the target pod.
+the Kubernetes resources that Teleport is able to restrict access for.
 
 This is because, if a user requests access to a Kubernetes pod, and the request
 is approved, the Teleport Kubernetes Service will use the `kubernetes_groups`
 and `kubernetes_users` fields in the role to add impersonation headers to the user's
-requests to a Kubernetes API server.
+requests to a Kubernetes API server. Under these conditions, Teleport will be able
+to restrict access to all Kubernetes resources kinds mentioned above except for
+the desired `pod`. Teleport is also able to restrict access to namespaced-scoped
+custom resources but not cluster-scoped custom resources - CRDs resources that
+are cluster-scoped will be accessible to the user if the principals in the
+`kubernetes_users` and `kubernetes_groups` fields have access to them.
 
-If the values of `kubernetes_users` and `kubernetes_groups` map to Kubernetes
-users and groups with access to additional resources, the user will be able to
-send requests that interact with those resources, e.g., `Secret`s and
-`ConfigMap`s, depending on the privileges of the Kubernetes users and groups.
+Requesting access to a Kubernetes Namespace allows you to access all resources
+in that namespace but you won't be able to access any other supported resources
+in the cluster.
 
 #### `db`
 

--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -1,6 +1,7 @@
 ---
 title: Resource Access Requests
 description: Teleport allows users to request access to specific resources from the CLI or UI. Requests can be escalated via ChatOps or anywhere else via our flexible Authorization Workflow API.
+tocDepth: 3
 ---
 
 <Admonition type="tip" title="Preview">
@@ -439,115 +440,7 @@ spec:
   deny: {}
 ```
 
-##### Access Requests for Kubernetes resources
-
-Teleport users can request access to a Kubernetes resources by running the following
-command:
-
-```code
-$ tsh request create <Var name="resource-id" />
-```
-###### Namespaced-scoped resources
-
-For Kubernetes namespaced resources, the `resource-id` is in the following format:
-
-```
-/TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/NAMESPACE/RESOURCE_NAME
-```
-
-Teleport supports the following namespaced resources: `pod`, `secret`, `configmap`,
-`service`, `serviceaccount`, `persistentvolumeclaim`, `deployment`, `replicaset`,
-`statefulset`, `daemonset`, `kube_role`, `rolebinding`, `cronjob`, `job`,
-`ingress`.
-
-For example, to request access to a pod called `nginx-1` in the `development`
-namespace, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/pod/mycluster/development/nginx-1
-```
-
-For the `NAMESPACE` and `RESOURCE_NAME` values, you can match ranges of characters by
-supplying a wildcard (`*`) or regular expression. Regular expressions must begin
-with `^` and end with `$`.
-
-For example, to create a request to access all pods in all namespaces that match
-the regular expression `/^nginx-[a-z0-9-]+$/`, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/pod/mycluster/*/^nginx-[a-z0-9-]+$
-```
-
-###### Cluster-scoped resources
-
-For Kubernetes cluster-scoped resources, the `resource-id` is in the following format:
-
-```
-/TELEPORT_CLUSTER/CLUSTER_WIDE_KIND/KUBE_CLUSTER/RESOURCE_NAME
-```
-
-Teleport supports the following cluster-wide resources: `namespace`, `kube_node`,
-`clusterrole`, `clusterrolebinding`, `persistentvolume`, `certificatesigningrequest`.
-
-For example, to request access to a namespace called `prod`, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/namespace/mycluster/prod
-```
-
-For the `RESOURCE_NAME` value, you can match ranges of characters by
-supplying a wildcard (`*`) or regular expression. Regular expressions must begin
-with `^` and end with `$`.
-
-For example, to create a request to access all namespaces prefixed with `dev` match
-the regular expression `/^dev-[a-z0-9-]+$/`, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/namespace/mycluster/^dev-[a-z0-9-]+$
-```
-
-###### Search for Kubernetes resources
-
-If a user has no access to a Kubernetes cluster, they can search the list of resources
-in the cluster by running the following command:
-
-```code
-$ tsh request search --kind=<kind> --kube-cluster=<Var name="kube-cluster" /> \
-[--kube-namespace=<Var name="namespace" />|--all-kube-namespaces]
-Name               Namespace Labels    Resource ID
------------------  --------- --------- ----------------------------------------------------------
-nginx-deployment-0 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-0
-nginx-deployment-1 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-1
-
-To request access to these resources, run
-> tsh request create --resource /teleport.example.com/pod/local/default/nginx-deployment-0 --resource /teleport.example.com/pod/local/default/nginx-deployment-1 \
-    --reason <request reason>
-```
-
-The list returned includes the name of the resource, the namespace it is in if
-applicable, its labels, and the resource ID.
-Resources included in the list are those that match the `kubernetes_resources`
-field in the user's `search_as_roles`. The user can then:
-
-- Request access to the resources by running the command provided by the `tsh request
-search` command.
-- Edit the command to request access to a subset of the resources.
-- Use a custom request with wildcards or regular expressions.
-
-`tsh request search --kind=<kind>` works even if the user has no permissions to interact
- with the desired Kubernetes cluster, but the user's `search_as_roles` values
-must allow access to the cluster. If the user is unsure of the name of the cluster,
-they can run the following command to search it:
-
-```code
-$ tsh request search --kind=kube_cluster
-Name  Hostname Labels Resource ID
------ -------- ------ ----------------------------------------
-local                 /teleport.example.com/kube_cluster/local
-
-```
-
-##### Preventing unintended access
+##### Preventing unintended access to Kubernetes resources
 
 If you are setting up a Teleport role to enable just-in-time access to a
 specific Kubernetes resources, you should set the role's `kubernetes_groups` and
@@ -635,7 +528,116 @@ spec:
     windows_desktop_logins: ["{{internal.windows_logins}}"]
 ```
 
-### Allow reviewers to see the hostnames of SSH Nodes
+### Request access to Kubernetes resources
+
+Teleport users can request access to a Kubernetes resources by running the following
+command:
+
+```code
+$ tsh request create <Var name="resource-id" />
+```
+
+#### Namespace-scoped resources
+
+For Kubernetes namespaced resources, the `resource-id` is in the following format:
+
+```
+/TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/NAMESPACE/RESOURCE_NAME
+```
+
+Teleport supports the following namespaced resources: `pod`, `secret`, `configmap`,
+`service`, `serviceaccount`, `persistentvolumeclaim`, `deployment`, `replicaset`,
+`statefulset`, `daemonset`, `kube_role`, `rolebinding`, `cronjob`, `job`,
+`ingress`.
+
+For example, to request access to a pod called `nginx-1` in the `development`
+namespace, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/pod/mycluster/development/nginx-1
+```
+
+For the `NAMESPACE` and `RESOURCE_NAME` values, you can match ranges of characters by
+supplying a wildcard (`*`) or regular expression. Regular expressions must begin
+with `^` and end with `$`.
+
+For example, to create a request to access all pods in all namespaces that match
+the regular expression `/^nginx-[a-z0-9-]+$/`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/pod/mycluster/*/^nginx-[a-z0-9-]+$
+```
+
+#### Cluster-scoped resources
+
+For Kubernetes cluster-scoped resources, the `resource-id` is in the following format:
+
+```
+/TELEPORT_CLUSTER/CLUSTER_WIDE_KIND/KUBE_CLUSTER/RESOURCE_NAME
+```
+
+Teleport supports the following cluster-wide resources: `namespace`, `kube_node`,
+`clusterrole`, `clusterrolebinding`, `persistentvolume`, `certificatesigningrequest`.
+
+For example, to request access to a namespace called `prod`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/namespace/mycluster/prod
+```
+
+For the `RESOURCE_NAME` value, you can match ranges of characters by
+supplying a wildcard (`*`) or regular expression. Regular expressions must begin
+with `^` and end with `$`.
+
+For example, to create a request to access all namespaces prefixed with `dev` match
+the regular expression `/^dev-[a-z0-9-]+$/`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/namespace/mycluster/^dev-[a-z0-9-]+$
+```
+
+#### Search for Kubernetes resources
+
+If a user has no access to a Kubernetes cluster, they can search the list of resources
+in the cluster by running the following command:
+
+```code
+$ tsh request search --kind=<kind> --kube-cluster=<Var name="kube-cluster" /> \
+[--kube-namespace=<Var name="namespace" />|--all-kube-namespaces]
+Name               Namespace Labels    Resource ID
+-----------------  --------- --------- ----------------------------------------------------------
+nginx-deployment-0 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-0
+nginx-deployment-1 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-1
+
+To request access to these resources, run
+> tsh request create --resource /teleport.example.com/pod/local/default/nginx-deployment-0 --resource /teleport.example.com/pod/local/default/nginx-deployment-1 \
+    --reason <request reason>
+```
+
+The list returned includes the name of the resource, the namespace it is in if
+applicable, its labels, and the resource ID.
+Resources included in the list are those that match the `kubernetes_resources`
+field in the user's `search_as_roles`. The user can then:
+
+- Request access to the resources by running the command provided by the `tsh request
+search` command.
+- Edit the command to request access to a subset of the resources.
+- Use a custom request with wildcards or regular expressions.
+
+`tsh request search --kind=<kind>` works even if the user has no permissions to interact
+ with the desired Kubernetes cluster, but the user's `search_as_roles` values
+must allow access to the cluster. If the user is unsure of the name of the cluster,
+they can run the following command to search it:
+
+```code
+$ tsh request search --kind=kube_cluster
+Name  Hostname Labels Resource ID
+----- -------- ------ ----------------------------------------
+local                 /teleport.example.com/kube_cluster/local
+
+```
+
+### Allow reviewers to see the hostnames of SSH nodes
 
 It is possible for a reviewer to view Resource Access Requests for SSH Nodes to
 which that reviewer does not have access.

--- a/docs/pages/access-controls/device-trust/device-management.mdx
+++ b/docs/pages/access-controls/device-trust/device-management.mdx
@@ -270,7 +270,7 @@ the inventory. Save the yaml below as `device-admin.yaml` and create it in your
 cluster:
 
 ```yaml
-version: v6
+version: v7
 kind: role
 metadata:
   name: device-admin

--- a/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
+++ b/docs/pages/access-controls/device-trust/enforcing-device-trust.mdx
@@ -47,7 +47,7 @@ the following:
 
 ```diff
 kind: role
-version: v6
+version: v7
 metadata:
   name: require-trusted-device
 spec:

--- a/docs/pages/access-controls/getting-started.mdx
+++ b/docs/pages/access-controls/getting-started.mdx
@@ -212,7 +212,7 @@ Save this role as `interns.yaml`:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: interns
 spec:
@@ -228,9 +228,10 @@ spec:
     kubernetes_labels:
       'env': 'dev'
     kubernetes_resources:
-      - kind: pod
+      - kind: *
         namespace: "*"
         name: "*"
+        verbs: ["*"]
     app_labels:
       'type': ['monitoring']
   # The deny rules always override allow rules.
@@ -242,9 +243,8 @@ spec:
     kubernetes_labels:
       'env': 'prod'
     kubernetes_resources:
-      - kind: pod
-        namespace: "prod"
-        name: "*"
+      - kind: "namespace"
+        name: "prod"
     db_labels:
       'env': 'prod'
     app_labels:

--- a/docs/pages/access-controls/guides/ip-pinning.mdx
+++ b/docs/pages/access-controls/guides/ip-pinning.mdx
@@ -9,8 +9,8 @@ IP Pinning is currently in Preview mode.
 IP Pinning requires Teleport Enterprise.
 </Admonition>
 
-IP Pinning is a security feature that helps protect against unauthorized access by ensuring that 
-Teleport users can only access resources from the IP address they used during the login process. 
+IP Pinning is a security feature that helps protect against unauthorized access by ensuring that
+Teleport users can only access resources from the IP address they used during the login process.
 This helps minimize the risk of compromised credentials being used from different locations.
 
 ## How it works
@@ -23,7 +23,7 @@ This helps minimize the risk of compromised credentials being used from differen
 </Admonition>
 
 When IP pinning is enabled for at least one of a user's roles, the IP address observed by Teleport during the login process will
- be embedded into the user's certificates. Later, whenever the user attempts to access Teleport resources, the system will compare 
+ be embedded into the user's certificates. Later, whenever the user attempts to access Teleport resources, the system will compare
  the observed IP address with the pinned IP address stored in the certificate. If the IP addresses do not match, access will be denied.
 
 If the user's role requires IP pinning, but the user's certificate that is presented to a Teleport service doesn't have pinned IP information embedded,
@@ -32,7 +32,7 @@ order to regenerate their certificates. A client's observed IP will be propagate
  if needed, so Teleport performs the IP pinning check against the correct IP.
 
 IP pinning can work across Trusted Clusters, but be aware that if a user tries to access a leaf cluster's resources through the root cluster, and their
-mapped role on the leaf cluster has IP pinning enabled, they should also have IP pinning enabled on their root cluster roles. Otherwise, their 
+mapped role on the leaf cluster has IP pinning enabled, they should also have IP pinning enabled on their root cluster roles. Otherwise, their
 certificates will not contain pinned IP information.
 
 ## Configure IP Pinning
@@ -41,7 +41,7 @@ To enable IP pinning, update the role to contain `pin_source_ip` option:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: example-role-with-ip-pinning
 spec:
@@ -63,7 +63,7 @@ A Teleport admin adds the following role, which enforces IP pinning for users:
 ```yaml
 # pinned-ip.yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: pinned-ip
 spec:
@@ -71,7 +71,7 @@ spec:
     pin_source_ip: true
 ```
 
-The admin assigns this role to the user Alice, who then logs into Teleport using the 'tsh' command and tries 
+The admin assigns this role to the user Alice, who then logs into Teleport using the 'tsh' command and tries
 to access a node from the same IP address she logged in with:
 
 ```code

--- a/docs/pages/access-controls/guides/moderated-sessions.mdx
+++ b/docs/pages/access-controls/guides/moderated-sessions.mdx
@@ -33,7 +33,7 @@ Moderated Sessions are useful in the following scenarios:
 Moderated Sessions makes use of RBAC policies to allow for fine grained control
 over who can join a session and who is required to be present to start one.
 
-The system is based around **require policies** and **allow policies**. 
+The system is based around **require policies** and **allow policies**.
 
 Require policies define a set of conditions that must be a met for a session to
 start or run. A minimum of one policy from each relevant role the user has must
@@ -79,7 +79,7 @@ until the policy is fulfilled.
 kind: role
 metadata:
   name: prod-access
-version: v6
+version: v7
 spec:
   allow:
     require_session_join:
@@ -100,9 +100,10 @@ spec:
     kubernetes_users:
     - USER
     kubernetes_resources:
-    - kind: pod
+    - kind: '*'
       name: '*'
       namespace: '*'
+      verbs: ['*']
 ```
 
 #### Combining Policies
@@ -137,7 +138,7 @@ as a moderator or observer.
 kind: role
 metadata:
   name: auditor
-version: v6
+version: v7
 spec:
   allow:
     join_sessions:
@@ -165,7 +166,7 @@ Teleport > Waiting for required participants...
 Jeff's session is paused, waiting for the required observers.
 
 Now Alice with the `auditor` role joins as a moderator and
-the session can begin. 
+the session can begin.
 
 ```code
 $ tsh join --mode=moderator 46e2af03-62d6-4e07-a886-43fe741ca044
@@ -178,7 +179,7 @@ Teleport > Waiting for required participants...
 Teleport > User alice joined the session.
 Teleport > Connecting to prod.teleport.example.com over SSH
 
-ubuntu@prod.teleport.example.com % 
+ubuntu@prod.teleport.example.com %
 ```
 
 Here is an example of joining from the UI that is available for server sessions.

--- a/docs/pages/access-controls/guides/per-session-mfa.mdx
+++ b/docs/pages/access-controls/guides/per-session-mfa.mdx
@@ -157,7 +157,7 @@ To enforce MFA checks for a specific role, update the role to contain:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: example-role-with-mfa
 spec:
@@ -187,7 +187,7 @@ Olga defines two Teleport roles: `access-dev` and `access-prod`:
 ```yaml
 # access-dev.yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: access-dev
 spec:
@@ -199,7 +199,7 @@ spec:
 ---
 # access-prod.yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: access-prod
 spec:

--- a/docs/pages/access-controls/guides/role-templates.mdx
+++ b/docs/pages/access-controls/guides/role-templates.mdx
@@ -34,7 +34,7 @@ We can create two roles, one for each user in file `roles.yaml`:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: alice
 spec:
@@ -46,12 +46,13 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ---
 kind: role
-version: v6
+version: v7
 metadata:
   name: bob
 spec:
@@ -63,9 +64,10 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 You can create roles and invite Alice and Bob as local users:
@@ -84,7 +86,7 @@ Let's create a role template called `devs.yaml`:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: devs
 spec:
@@ -96,9 +98,10 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 Any role becomes a template once it starts using template variables.
@@ -212,7 +215,7 @@ Let's create a role template called `sso-users` that expects external attribute
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: sso-users
 spec:
@@ -223,9 +226,10 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 A GitHub connector called `github.yaml` maps every member of team `cyber` in
@@ -322,7 +326,7 @@ Let's see how these variables are used with role template `interpolation`:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: interpolation
 spec:
@@ -349,9 +353,10 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 After interpolation with Alice's SSO user attributes, the role template will
@@ -359,7 +364,7 @@ behave as the following role:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: interpolation
 spec:
@@ -390,9 +395,10 @@ spec:
       '*': '*'
 
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 Available interpolation functions include:

--- a/docs/pages/access-controls/idps/saml-grafana.mdx
+++ b/docs/pages/access-controls/idps/saml-grafana.mdx
@@ -28,7 +28,7 @@ create a role called `sp-manager.yaml` with the following contents:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: sp-manager
 spec:
@@ -41,7 +41,7 @@ spec:
 Create it with `tctl`:
 
 ```code
-$ tctl create sp-manager.yaml 
+$ tctl create sp-manager.yaml
 role 'saml-idp-service-provider-manager' has been created
 ```
 

--- a/docs/pages/access-controls/idps/saml-guide.mdx
+++ b/docs/pages/access-controls/idps/saml-guide.mdx
@@ -44,13 +44,13 @@ spec:
       - read
       - update
       - delete
-version: v6
+version: v7
 ```
 
 Create the role with `tctl`:
 
 ```code
-$ tctl create sp-manager.yaml 
+$ tctl create sp-manager.yaml
 role 'saml-idp-service-provider-manager' has been created
 ```
 

--- a/docs/pages/access-controls/login-rules/guide.mdx
+++ b/docs/pages/access-controls/login-rules/guide.mdx
@@ -39,13 +39,13 @@ spec:
     rules:
       - resources: [login_rule]
         verbs: [list, create, read, update, delete]
-version: v6
+version: v7
 ```
 
 Create the role with `tctl`:
 
 ```code
-$ tctl create loginrule-manager.yaml 
+$ tctl create loginrule-manager.yaml
 role 'loginrule-manager' has been created
 ```
 

--- a/docs/pages/access-controls/login-rules/terraform.mdx
+++ b/docs/pages/access-controls/login-rules/terraform.mdx
@@ -59,7 +59,7 @@ spec:
     rules:
       - resources: [login_rule]
         verbs: [list, read, create, update, delete]
-version: v6
+version: v7
 ```
 
 Create the role with `tctl`:

--- a/docs/pages/access-controls/reference.mdx
+++ b/docs/pages/access-controls/reference.mdx
@@ -135,7 +135,7 @@ Teleport provides several pre-defined roles out-of-the-box:
 
 ### Role versions
 
-There are currently four supported role versions: `v3`, `v4`, `v5` and `v6`. `v4`, `v5` and `v6` roles are
+There are currently four supported role versions: `v3`, `v4`, `v5`, `v6` and `v7`. `v4`, `v5` and `v6` roles are
 completely backwards-compatible with `v3`, the only difference lies in the
 default values which will be applied to the role if they are not
 explicitly set. Additionally, roles `v5` or `v6` are required to use [Moderated Sessions](./guides/moderated-sessions.mdx).
@@ -150,9 +150,11 @@ Label              | `v3` Default   | `v4`, `v5` and `v6` Default
 Role `v6` introduced a new field `kubernetes_resources` that allows
 fine-grained control over Kubernetes resources. See [Kubernetes RBAC](../kubernetes-access/manage-access/rbac.mdx) for more details.
 
-Label              | `v3`, `v4` and `v5` Default   | `v6` Default
------------------- | -------------- | ---------------
-`kubernetes_resources` | `[{"kind":"pod", "name":"*", "namespace":"*"}]` | `[]`
+Version              |  `kubernetes_resources`
+------------------ | --------------
+`v3`, `v4` and `v5` Default | `[{"kind":"pod", "name":"*", "namespace":"*", "verbs": ["*"]}]`
+`v6` Default |  `[]`
+`v7` Default |  `[{"kind":"*", "name":"*", "namespace":"*", "verbs": ["*"]}]`
 
 ## RBAC for resources
 
@@ -258,7 +260,7 @@ or labeled `team=<team>`, where `<team>` is one of the values of the user's
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: example-role
 spec:

--- a/docs/pages/ai-assist.mdx
+++ b/docs/pages/ai-assist.mdx
@@ -90,7 +90,7 @@ Proxy and Auth Service host, perform the following actions:
 1. Add your OpenAI API key to the `assist` section:
 
    If the host is running the Auth Service, add the following section:
-   
+
    ```yaml
    auth_service:
      assist:
@@ -99,7 +99,7 @@ Proxy and Auth Service host, perform the following actions:
    ```
 
    If the host is running the Proxy Service, add the following section:
-   
+
    ```yaml
    proxy_service:
      assist:
@@ -117,7 +117,7 @@ add it to a custom role. Here is an example:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: assist
 spec:

--- a/docs/pages/api/rbac.mdx
+++ b/docs/pages/api/rbac.mdx
@@ -94,7 +94,7 @@ In Kubernetes, you can divide a cluster into logically isolated **namespaces**.
 A **role** defines a set of permissions for manipulating resources in a specific
 namespace. A **cluster role** is a role that applies to all namespaces in a
 cluster. You can use a **role binding** or **cluster role binding** to attach a
-role or cluster role to Kubernetes users and groups. 
+role or cluster role to Kubernetes users and groups.
 
 Define a Kubernetes role and role binding that allows users in the
 `app-developer` group to read and list pods in the `app` namespace. Add the
@@ -122,14 +122,14 @@ metadata:
   name: read-pods
   namespace: app
   annotations:
-    'create-teleport-role': 'true' 
+    'create-teleport-role': 'true'
 subjects:
 - kind: Group
   name: app-developer
   apiGroup: rbac.authorization.k8s.io
 roleRef:
-  kind: Role 
-  name: pod-reader 
+  kind: Role
+  name: pod-reader
   apiGroup: rbac.authorization.k8s.io
 ```
 
@@ -161,7 +161,7 @@ kind: ClusterRoleBinding
 metadata:
   name: pod-ops
   annotations:
-    'create-teleport-role': 'true' 
+    'create-teleport-role': 'true'
 subjects:
 - kind: Group
   name: ops
@@ -220,7 +220,7 @@ clusterrole.rbac.authorization.k8s.io/rbac-sync created
 clusterrolebinding.rbac.authorization.k8s.io/rbac-sync created
 ```
 
-## Step 2/4. Set up Teleport 
+## Step 2/4. Set up Teleport
 
 In this step, you will configure Teleport to enable your API client application
 to interact with your Kubernetes cluster.
@@ -235,7 +235,7 @@ Create a file called `sync-kubernetes-rbac.yaml` with the following content:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: sync-kubernetes-rbac
 spec:
@@ -299,7 +299,7 @@ spec:
       - sync-kubernetes-rbac
 ```
 
-Create the `sync-kubernetes-rbac-impersonator` role: 
+Create the `sync-kubernetes-rbac-impersonator` role:
 
 ```code
 $ tctl create -f sync-kubernetes-rbac-impersonator.yaml
@@ -330,7 +330,7 @@ $ tctl tokens add --type=kube,app,discovery --ttl=10000h --format=json
 Copy this token so you can use it when running the Teleport Kubernetes Service.
 
 Ensure that you are connected to the right Kubernetes cluster (logging into
-Teleport earlier will have changed your Kubernetes context): 
+Teleport earlier will have changed your Kubernetes context):
 
 ```code
 $ kubectl config use-context minikube
@@ -351,7 +351,7 @@ $ helm install teleport-agent teleport/teleport-kube-agent \
   --create-namespace \
   --namespace=teleport \
   --set labels.environment=demo \
-  --version (=teleport.version=) 
+  --version (=teleport.version=)
 ```
 
 After a few seconds, verify that you have deployed the Teleport Kubernetes
@@ -531,7 +531,7 @@ func getRBACClient() (v1.RbacV1Interface, error) {
 `getRBACClient` opens and reads the Kubernetes credentials file at
 `kubeconfigPath`, then uses the file to set up a Kubernetes API client
 configuration (`clientcmd.RESTConfigFromKubeConfig(kc)`) and, with that, an HTTP
-client (`kubernetes.NewForConfig(n)`). 
+client (`kubernetes.NewForConfig(n)`).
 
 Finally, it returns an interface to the Kubernetes API dedicated to role-based
 access controls, which the rest of the program uses to interact with your
@@ -601,7 +601,7 @@ key, `roleAnnotationKey`, and ignores any resource where this key is not set to
 
 We also want a quick way to identify roles we created with this program. To do
 so, this function names all roles it generates based on cluster role bindings
-according to the following attributes: 
+according to the following attributes:
 
 - Kubernetes cluster name
 - Kubernetes role name
@@ -733,7 +733,7 @@ Teleport-registered Kubernetes cluster. It calls the `getRBACClient` function we
 defined earlier to set up a client for the Kubernetes cluster. It then:
 
 - Lists Kubernetes cluster role bindings and creates a Teleport role for each one.
-- Lists Kubernetes role bindings and creates a Teleport role for each one. 
+- Lists Kubernetes role bindings and creates a Teleport role for each one.
 
 ### Initializing clients and start the application
 
@@ -785,7 +785,7 @@ initializes a Teleport client by calling `client.LoadIdentityFile` to obtain a
 <Admonition type="warning">
 
 This program does not validate your credentials or Teleport cluster address.
-Make sure that: 
+Make sure that:
 
 - The identity file you exported earlier does not have an expired TTL
 - The value you supplied to the `Addrs` field in `teleport.Config` includes both
@@ -796,7 +796,7 @@ Make sure that:
 
 After initializing a Teleport client, the `main` function fetches all Kubernetes
 servers registered with Teleport (`teleport.GetKubernetesServers`) and checks if
-there is a registered Kubernetes cluster that matches the one you specified. 
+there is a registered Kubernetes cluster that matches the one you specified.
 
 If a matching Kubernetes cluster exists, the code calls the
 `createTeleportRolesForKubeClusters` function we defined earlier. If not, the
@@ -864,7 +864,7 @@ spec:
       default: best_effort
       desktop: true
     ssh_file_copy: true
-version: v6
+version: v7
 ```
 
 Compare this with the `minikube-pod-reader-app` role, which you can retrieve
@@ -911,7 +911,7 @@ spec:
       default: best_effort
       desktop: true
     ssh_file_copy: true
-version: v6
+version: v7
 ```
 
 Since role bindings are namespaced, this role only allows access to pods in the

--- a/docs/pages/application-access/cloud-apis/google-cloud.mdx
+++ b/docs/pages/application-access/cloud-apis/google-cloud.mdx
@@ -321,7 +321,7 @@ Create a file called `google-cloud-cli-access.yaml` with the following content:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: google-cloud-cli-access
 spec:
@@ -379,7 +379,7 @@ Create a file called `google-cloud-cli-access.yaml` with the following content:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: google-cloud-cli-access
 spec:
@@ -414,7 +414,7 @@ replacing `my-project` with the ID of your Google Cloud project in the value of
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: google-cloud-cli-access
 spec:
@@ -448,7 +448,7 @@ For example, this role denies the user access to all Google Cloud service accoun
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: "no-google-cloud"
 spec:

--- a/docs/pages/architecture/authorization.mdx
+++ b/docs/pages/architecture/authorization.mdx
@@ -75,7 +75,7 @@ of non-interactive users:
   bordered="true"
   caption="Machine-ID certs"
   >
-  
+
 ![Certificates for services](../../img/architecture/certs-machine-id@1.8x.svg)
 </Figure>
 
@@ -169,12 +169,13 @@ spec:
        'environment': ['test', 'stage']
     kubernetes_labels:
        'environment': ['test', 'stage']
-    # Allow access to any Kubernetes pod in a cluster with the labels specified
+    # Allow access to any Kubernetes resources in a cluster with the labels specified
     # above.
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 Prod role allows SSH access as `ubuntu` and `view` access to kubernetes for
@@ -192,9 +193,10 @@ spec:
     kubernetes_labels:
        'environment': ['prod']
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 Here is how Teleport will evaluate Alice's access:

--- a/docs/pages/database-access/guides/aws-dynamodb.mdx
+++ b/docs/pages/database-access/guides/aws-dynamodb.mdx
@@ -68,7 +68,7 @@ Click **Next**. Find the AWS-managed policy `AmazonDynamoDBFullAccess` and then 
 <Admonition type="note" title="Apply least-privilege permissions">
 The `AmazonDynamoDBFullAccess` policy may grant more permissions than desired.
 If you want to use a different IAM policy to reduce permissions, refer to
-[Managing access permissions to your Amazon DynamoDB 
+[Managing access permissions to your Amazon DynamoDB
 Resources](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/access-control-overview.html)
 for more information.
 </Admonition>
@@ -110,7 +110,7 @@ listing the IAM role ARN created in the previous step. Create a file called
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: aws-dynamodb-access
 spec:
@@ -226,7 +226,7 @@ Type "help", "copyright", "credits" or "license" for more information.
 >>> res = clt.list_tables()
 >>> print(res)
 {'TableNames': *snip output*}
->>> 
+>>>
 ```
 
 ## Next Steps

--- a/docs/pages/database-access/guides/aws-opensearch.mdx
+++ b/docs/pages/database-access/guides/aws-opensearch.mdx
@@ -128,7 +128,7 @@ listing the IAM role ARN created in the previous step. Create a file called
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: aws-opensearch-access
 spec:

--- a/docs/pages/database-access/guides/azure-postgres-mysql.mdx
+++ b/docs/pages/database-access/guides/azure-postgres-mysql.mdx
@@ -125,7 +125,7 @@ On your workstation logged in to your Teleport cluster with `tsh`, define a new
 role to provide access to your Azure database. Create a file called `azure-database-role.yaml` with the following content:
 
 ```yaml
-version: v6
+version: v7
 kind: role
 metadata:
   name: azure-database-access
@@ -197,7 +197,7 @@ Create a role with assignable scope(s) that include all databases that Teleport 
 }
 ```
 
-This role definition allows Teleport to discover MySQL and PostgreSQL databases, but Teleport only needs 
+This role definition allows Teleport to discover MySQL and PostgreSQL databases, but Teleport only needs
 permissions for the database types you have. The assignable scopes include a subscription, so
 the role can be assigned at any resource scope within that subscription, or assigned using the
 subscription scope itself.
@@ -207,7 +207,7 @@ Custom roles, unlike
 [Azure built-in roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/built-in-roles),
 can not have a root assignable scope. The highest assignable scope that
 can be used in a custom role is subscription scope. Using a management group scope is currently an Azure
-preview feature, and only allows for a single management group in the "assignableScopes" of a role 
+preview feature, and only allows for a single management group in the "assignableScopes" of a role
 definition.
 See [Azure RBAC custom roles](https://docs.microsoft.com/en-us/azure/role-based-access-control/custom-roles) for
 more information.

--- a/docs/pages/database-access/rbac/configuring-auto-user-provisioning.mdx
+++ b/docs/pages/database-access/rbac/configuring-auto-user-provisioning.mdx
@@ -125,7 +125,7 @@ use the `db_roles` role option:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: auto-db-users
 spec:

--- a/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
+++ b/docs/pages/deploy-a-cluster/helm-deployments/kubernetes-cluster.mdx
@@ -286,7 +286,7 @@ Save this role as `member.yaml`:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: member
 spec:
@@ -295,9 +295,10 @@ spec:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
 ```
 
 Create the role:

--- a/docs/pages/desktop-access/getting-started.mdx
+++ b/docs/pages/desktop-access/getting-started.mdx
@@ -158,7 +158,7 @@ Create the file `windows-desktop-admins.yaml`:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: windows-desktop-admins
 spec:

--- a/docs/pages/desktop-access/rbac.mdx
+++ b/docs/pages/desktop-access/rbac.mdx
@@ -210,7 +210,7 @@ This feature is disabled by default, and can be enabled by setting the
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: allow-user-provisioning
 spec:
@@ -241,7 +241,7 @@ To add the user to additional groups, specify the `desktop_groups` role option:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: allow-user-provisioning
 spec:

--- a/docs/pages/includes/kubernetes-access/rbac.mdx
+++ b/docs/pages/includes/kubernetes-access/rbac.mdx
@@ -18,15 +18,16 @@ Create a file called `kube-access.yaml` with the following content, replacing
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
       '*': '*'
     kubernetes_resources:
-      - kind: pod
-        namespace: "*"
-        name: "*"
+      - kind: '*'
+        namespace: '*'
+        name: '*'
+        verbs: ['*']
     kubernetes_groups:
     - viewers
     kubernetes_users:

--- a/docs/pages/includes/role-spec.mdx
+++ b/docs/pages/includes/role-spec.mdx
@@ -1,6 +1,6 @@
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: example
 spec:
@@ -163,8 +163,30 @@ spec:
     # kubernetes_resources indicates the Kubernetes resources that a user with
     # this role is allowed to access.
     kubernetes_resources:
-        # The resource kind. Teleport currently only supports "pod".
-      - kind: pod
+        # The resource kind. Teleport currently supports:
+        # - * (all resources)
+        # - pod
+        # - secret
+        # - configmap
+        # - namespace
+        # - service
+        # - serviceaccount
+        # - kube_node
+        # - persistentvolume
+        # - persistentvolumeclaim
+        # - deployment
+        # - replicaset
+        # - statefulset
+        # - daemonset
+        # - clusterrole
+        # - kube_role
+        # - clusterrolebinding
+        # - rolebinding
+        # - cronjob
+        # - job
+        # - certificatesigningrequest
+        # - ingress
+      - kind: '*'
         # The name of the Kubernetes namespace in which to allow access the
         # resources you specify with "name" and "kind".
         # The wildcard character "*" matches any sequence of characters.
@@ -176,6 +198,20 @@ spec:
         # If the value begins with "^" and ends with "$", the Kubernetes
         # Service will treat it as a regular expression.
         name: "^nginx-[a-z0-9-]+$"
+        # The verbs that the user is allowed to perform on the resource.
+        # Teleport currently supports:
+        # - * (all verbs)
+        # - get
+        # - list
+        # - watch
+        # - create
+        # - update
+        # - patch
+        # - delete
+        # - deletecollection
+        # - exec - allows users to execute commands in a pod
+        # - portforward - allows users to forward ports from a pod
+        verbs: ['*']
 
     # Functions transform variables.
     db_users: ['{{email.local(external.email)}}']

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -521,11 +521,14 @@ the following kinds:
   | `job` | Jobs |
   | `certificatesigningrequest` | CertificateSigningRequests |
   | `ingress` | Ingresses |
+
 - `namespace`: The Kubernetes namespace in which to allow access to a resource.
   In the `kube-access` role, we are allowing access to a pod in the
   `production` namespace.
+
 - `name`: The name of the pod to allow access to. In `kube-access`, this is
   the `webapp` pod.
+
 - `verbs`: The operations to allow on the resource. Currently, Teleport supports:
 
   | Verb | Grants access to |

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -36,7 +36,7 @@ clusters:
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -66,7 +66,7 @@ using a role's  `kubernetes_labels` field.
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -212,7 +212,7 @@ server:
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_groups:
@@ -281,7 +281,7 @@ An example of a role that impersonates a Service Account can be found below.
 kind: role
 metadata:
   name: kube-access-impersonate-sa
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_users:
@@ -401,7 +401,7 @@ The Teleport Auth Service will substitute any template variable in the format
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: group-member
 spec:
@@ -418,7 +418,7 @@ evaluate to the following:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: group-member
 spec:
@@ -439,7 +439,7 @@ internal traits:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: group-member
 spec:
@@ -478,7 +478,7 @@ specific resources in a Kubernetes cluster:
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -487,19 +487,75 @@ spec:
       - kind: pod
         namespace: "production"
         name: "webapp"
+        verbs: ['*']
     # ...
 ```
 
-The value of this field is a list of mappings, where each mapping has three
+The value of this field is a list of mappings, where each mapping has four
 fields:
 
-- `kind`: The kind of resource to enable access to. Currently, Teleport only
-  supports the value `pod`.
+- `kind`: The kind of resource to enable access to. Currently, Teleport supports
+the following kinds:
+  - `*`: Allow access to all resources.
+  - `pod`: Controls access to pods. The `name` and `namespace` fields of a `pod` resource
+    corresponds to the name and namespace of a pod.
+  - `secret`: Controls access to secrets. The `name` and `namespace` fields of a `secret`
+    resource corresponds to the name and namespace of a secret.
+  - `configmap`: Controls access to configmaps. The `name` and `namespace` fields of a `configmap`
+    resource corresponds to the name and namespace of a configmap.
+  - `namespace`: Controls access to namespaces and all resources within. The `name` field of a `namespace`
+    resource corresponds to the name of a namespace.
+  - `service`: Controls access to services. The `name` and `namespace` fields of a `service`
+    resource corresponds to the name and namespace of a service.
+  - `serviceaccount`: Controls access to service accounts. The `name` and `namespace` fields of a `serviceaccount`
+    resource corresponds to the name and namespace of a service account.
+  - `kube_node`: Controls access to nodes. The `name` field of a `kube_node`
+    resource corresponds to the name of a node.
+  - `persistentvolume`: Controls access to persistent volumes. The `name` field of a `persistentvolume`
+    resource corresponds to the name of a persistent volume.
+  - `persistentvolumeclaim`: Controls access to persistent volume claims. The `name` and `namespace` fields of a `persistentvolumeclaim`
+    resource corresponds to the name and namespace of a persistent volume claim.
+  - `deployment`: Controls access to deployments. The `name` and `namespace` fields of a `deployment`
+    resource corresponds to the name and namespace of a deployment.
+  - `replicaset`: Controls access to replica sets. The `name` and `namespace` fields of a `replicaset`
+    resource corresponds to the name and namespace of a replica set.
+  - `statefulset`: Controls access to stateful sets. The `name` and `namespace` fields of a `statefulset`
+    resource corresponds to the name and namespace of a stateful set.
+  - `daemonset`: Controls access to daemon sets. The `name` and `namespace` fields of a `daemonset`
+    resource corresponds to the name and namespace of a daemon set.
+  - `clusterrole`: Controls access to cluster roles. The `name` field of a `clusterrole`
+    resource corresponds to the name of a cluster role.
+  - `kube_role`: Controls access to roles. The `name` and `namespace` fields of a `kube_role`
+    resource corresponds to the name and namespace of a role.
+  - `clusterrolebinding`: Controls access to cluster role bindings. The `name` field of a `clusterrolebinding`
+    resource corresponds to the name of a cluster role binding.
+  - `rolebinding`: Controls access to role bindings. The `name` and `namespace` fields of a `rolebinding`
+    resource corresponds to the name and namespace of a role binding.
+  - `cronjob`: Controls access to cron jobs. The `name` and `namespace` fields of a `cronjob`
+    resource corresponds to the name and namespace of a cron job.
+  - `job`: Controls access to jobs. The `name` and `namespace` fields of a `job`
+    resource corresponds to the name and namespace of a job.
+  - `certificatesigningrequest`: Controls access to certificate signing requests. The `name` field of a `certificatesigningrequest`
+    resource corresponds to the name of a certificate signing request.
+  - `ingress`: Controls access to ingresses. The `name` and `namespace` fields of a `ingress`
+    resource corresponds to the name and namespace of a ingress.
 - `namespace`: The Kubernetes namespace in which to allow access to a resource.
   In the `kube-access` role, we are allowing access to a pod in the
   `production` namespace.
 - `name`: The name of the pod to allow access to. In `kube-access`, this is
   the `webapp` pod.
+- `verbs`: The operations to allow on the resource. Currently, Teleport supports:
+  - `*`: Allow all operations.
+  - `read`: Controls access to read a resource of a given kind.
+  - `list`: Controls access to list resources of a given kind.
+  - `create`: Controls access to create a resource of a given kind.
+  - `update`: Controls access to update a resource of a given kind.
+  - `patch`: Controls access to patch a resource of a given kind.
+  - `delete`:  Controls access to delete a resource of a given kind.
+  - `deletecollection`: Controls access to delete a collection of resources of a given kind.
+  - `watch`: Controls access to watch a resource of a given kind.
+  - `portforward`: Controls access to create portforward requests for Pods.
+  - `exec`: Controls access to execute commands in Pods.
 
 For both the `namespace` and `name` fields, you can add a wildcard character
 (`*`) to replace any sequence of characters. For example, `name: "pod-*-*"`
@@ -607,7 +663,7 @@ Let's say you have assigned the following three roles to a user:
 kind: role
 metadata:
   name: allow-dev-us-east-2
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -625,7 +681,7 @@ spec:
 kind: role
 metadata:
   name: allow-exec
-  version: v6
+  version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -640,7 +696,7 @@ spec:
 kind: role
 metadata:
   name: deny-redis-exec
-  version: v6
+  version: v7
 spec:
   deny:
     kubernetes_resources:
@@ -692,7 +748,7 @@ registered Kubernetes clusters, but only run `kubectl exec` or `kubectl logs` on
 kind: role
 metadata:
   name: kube-viewer
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -707,7 +763,7 @@ spec:
 kind: role
 metadata:
   name: nginx-exec
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -729,7 +785,7 @@ In this setup, you could also combine the `kube-viewer` role with other roles
 that grant elevated access to subsets of pods, depending on the requirements of
 your Teleport users.
 
-### Security consideration: pod namespace restrictions
+### Security consideration: Resource namespace restrictions
 
 When a Teleport user sends a request to list pods, e.g., with `kubectl get
 pods`, the Teleport Kubernetes Service does the following:
@@ -741,7 +797,7 @@ pods`, the Teleport Kubernetes Service does the following:
   authorized to access via `kubernetes_resources`.
 - Returns the list of pods to the user.
 
-To avoid leaking pods unintentionally, you should ensure that namespace
+To avoid leaking resources unintentionally, you should ensure that namespace
 restrictions in your Kubernetes RBAC line up with those you have set up in
 Teleport.
 
@@ -753,7 +809,7 @@ group. This group can only view pods in the `default` namespace:
 kind: role
 metadata:
   name: kube-access-1
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_groups:
@@ -772,7 +828,7 @@ only to the `webapp` pod in the `default` namespace:
 ```yaml
 metadata:
   name: kube-access-2
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_groups:
@@ -808,7 +864,7 @@ permissions, restricting the user to pods in the `default` namespace:
 kind: role
 metadata:
   name: kube-access-1
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_groups:

--- a/docs/pages/kubernetes-access/controls.mdx
+++ b/docs/pages/kubernetes-access/controls.mdx
@@ -496,66 +496,51 @@ fields:
 
 - `kind`: The kind of resource to enable access to. Currently, Teleport supports
 the following kinds:
-  - `*`: Allow access to all resources.
-  - `pod`: Controls access to pods. The `name` and `namespace` fields of a `pod` resource
-    corresponds to the name and namespace of a pod.
-  - `secret`: Controls access to secrets. The `name` and `namespace` fields of a `secret`
-    resource corresponds to the name and namespace of a secret.
-  - `configmap`: Controls access to configmaps. The `name` and `namespace` fields of a `configmap`
-    resource corresponds to the name and namespace of a configmap.
-  - `namespace`: Controls access to namespaces and all resources within. The `name` field of a `namespace`
-    resource corresponds to the name of a namespace.
-  - `service`: Controls access to services. The `name` and `namespace` fields of a `service`
-    resource corresponds to the name and namespace of a service.
-  - `serviceaccount`: Controls access to service accounts. The `name` and `namespace` fields of a `serviceaccount`
-    resource corresponds to the name and namespace of a service account.
-  - `kube_node`: Controls access to nodes. The `name` field of a `kube_node`
-    resource corresponds to the name of a node.
-  - `persistentvolume`: Controls access to persistent volumes. The `name` field of a `persistentvolume`
-    resource corresponds to the name of a persistent volume.
-  - `persistentvolumeclaim`: Controls access to persistent volume claims. The `name` and `namespace` fields of a `persistentvolumeclaim`
-    resource corresponds to the name and namespace of a persistent volume claim.
-  - `deployment`: Controls access to deployments. The `name` and `namespace` fields of a `deployment`
-    resource corresponds to the name and namespace of a deployment.
-  - `replicaset`: Controls access to replica sets. The `name` and `namespace` fields of a `replicaset`
-    resource corresponds to the name and namespace of a replica set.
-  - `statefulset`: Controls access to stateful sets. The `name` and `namespace` fields of a `statefulset`
-    resource corresponds to the name and namespace of a stateful set.
-  - `daemonset`: Controls access to daemon sets. The `name` and `namespace` fields of a `daemonset`
-    resource corresponds to the name and namespace of a daemon set.
-  - `clusterrole`: Controls access to cluster roles. The `name` field of a `clusterrole`
-    resource corresponds to the name of a cluster role.
-  - `kube_role`: Controls access to roles. The `name` and `namespace` fields of a `kube_role`
-    resource corresponds to the name and namespace of a role.
-  - `clusterrolebinding`: Controls access to cluster role bindings. The `name` field of a `clusterrolebinding`
-    resource corresponds to the name of a cluster role binding.
-  - `rolebinding`: Controls access to role bindings. The `name` and `namespace` fields of a `rolebinding`
-    resource corresponds to the name and namespace of a role binding.
-  - `cronjob`: Controls access to cron jobs. The `name` and `namespace` fields of a `cronjob`
-    resource corresponds to the name and namespace of a cron job.
-  - `job`: Controls access to jobs. The `name` and `namespace` fields of a `job`
-    resource corresponds to the name and namespace of a job.
-  - `certificatesigningrequest`: Controls access to certificate signing requests. The `name` field of a `certificatesigningrequest`
-    resource corresponds to the name of a certificate signing request.
-  - `ingress`: Controls access to ingresses. The `name` and `namespace` fields of a `ingress`
-    resource corresponds to the name and namespace of a ingress.
+
+  | Kind | Grants access to |
+  | ---- | ----------- |
+  | `*` | All resources |
+  | `pod` | Pods |
+  | `secret` | Secrets |
+  | `configmap` | ConfigMaps |
+  | `namespace` | Namespaces and all resources within |
+  | `service` | Services |
+  | `serviceaccount` | ServiceAccounts |
+  | `kube_node` | Nodes |
+  | `persistentvolume` | PersistentVolumes |
+  | `persistentvolumeclaim` | PersistentVolumeClaims |
+  | `deployment` | Deployments |
+  | `replicaset` | ReplicaSets |
+  | `statefulset` | StatefulSets |
+  | `daemonset` | DaemonSets |
+  | `clusterrole` | ClusterRoles |
+  | `kube_role` | Roles |
+  | `clusterrolebinding` | ClusterRoleBindings |
+  | `rolebinding` | RoleBindings |
+  | `cronjob` | CronJobs |
+  | `job` | Jobs |
+  | `certificatesigningrequest` | CertificateSigningRequests |
+  | `ingress` | Ingresses |
 - `namespace`: The Kubernetes namespace in which to allow access to a resource.
   In the `kube-access` role, we are allowing access to a pod in the
   `production` namespace.
 - `name`: The name of the pod to allow access to. In `kube-access`, this is
   the `webapp` pod.
 - `verbs`: The operations to allow on the resource. Currently, Teleport supports:
-  - `*`: Allow all operations.
-  - `read`: Controls access to read a resource of a given kind.
-  - `list`: Controls access to list resources of a given kind.
-  - `create`: Controls access to create a resource of a given kind.
-  - `update`: Controls access to update a resource of a given kind.
-  - `patch`: Controls access to patch a resource of a given kind.
-  - `delete`:  Controls access to delete a resource of a given kind.
-  - `deletecollection`: Controls access to delete a collection of resources of a given kind.
-  - `watch`: Controls access to watch a resource of a given kind.
-  - `portforward`: Controls access to create portforward requests for Pods.
-  - `exec`: Controls access to execute commands in Pods.
+
+  | Verb | Grants access to |
+  | ---- | ----------- |
+  | `*` | All operations |
+  | `read` | Read a resource |
+  | `list` | List resources |
+  | `create` | Create a resource |
+  | `update` | Update a resource |
+  | `patch` | Patch a resource |
+  | `delete` | Delete a resource |
+  | `deletecollection` | Delete a collection of resources |
+  | `watch` | Watch resources |
+  | `portforward` | Create portforward requests for Pods |
+  | `exec` | Execute commands in Pods |
 
 For both the `namespace` and `name` fields, you can add a wildcard character
 (`*`) to replace any sequence of characters. For example, `name: "pod-*-*"`

--- a/docs/pages/kubernetes-access/introduction.mdx
+++ b/docs/pages/kubernetes-access/introduction.mdx
@@ -8,8 +8,8 @@ Teleport provides secure access to Kubernetes clusters:
 - Users can access Kubernetes clusters with Single Sign-On (SSO) providers like
   Okta and switch between clusters without logging in twice.
 - Operators can implement granular role-based access controls, including
-  limiting access to specific Kubernetes clusters or even specific pods within a
-  namespace.
+  limiting access to specific Kubernetes clusters or even specific resources within a
+  cluster.
 - Organizations can achieve compliance by recording `kubectl` sessions.
 
 Here is an example of using Teleport to access a Kubernetes cluster, execute

--- a/docs/pages/kubernetes-access/manage-access/rbac.mdx
+++ b/docs/pages/kubernetes-access/manage-access/rbac.mdx
@@ -314,7 +314,7 @@ Create a file called `kube-access.yaml` with the following content:
 kind: role
 metadata:
   name: kube-access
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:

--- a/docs/pages/machine-id/guides/kubernetes.mdx
+++ b/docs/pages/machine-id/guides/kubernetes.mdx
@@ -46,7 +46,7 @@ First, create a file named `role.yaml` with the following content:
 kind: role
 metadata:
   name: machine-id-kube-role
-version: v6
+version: v7
 spec:
   allow:
     kubernetes_labels:
@@ -249,7 +249,7 @@ $ kubectl --kubeconfig /opt/machine-id/kubeconfig.yaml get pods -n demo
 ```
 
 This `kubeconfig.yaml` can also be passed to any other Kubernetes API clients
-that support credential provider plugins, including those built with 
+that support credential provider plugins, including those built with
 [`kubernetes/client-go`](https://github.com/kubernetes/client-go) and most other
 language libraries.
 

--- a/docs/pages/management/dynamic-resources.mdx
+++ b/docs/pages/management/dynamic-resources.mdx
@@ -16,28 +16,28 @@ There are two ways to configure a Teleport cluster:
   configuration file from the local filesystem (the default path is
   `/etc/teleport.yaml`). Static configuration settings control aspects of a
   cluster that are not expected to change frequently, like the ports that
-  services listen on. 
+  services listen on.
 - **Dynamic resources:** Dynamic resources control aspects of your cluster that
   are likely to change over time, such as roles, local users, and registered
   infrastructure resources.
 
 This approach makes it possible to incrementally adjust your Teleport
-configuration without restarting Teleport instances. 
+configuration without restarting Teleport instances.
 
 ```mermaid
 flowchart LR
 subgraph backend["Cluster state backend"]
   direction LR
   resources["Dynamic resources"]
-end 
+end
 
 subgraph cluster[Teleport cluster]
   subgraph auth[Auth Service]
     conf1["Static config"]
-  end 
+  end
   subgraph proxy[Proxy Service]
     conf2["Static config"]
-  end 
+  end
 end
 
 auth-->backend
@@ -91,7 +91,7 @@ servers with the label `env:test`:
 
 ```yaml
 kind: role
-version: v6
+version: v7
 metadata:
   name: developer
 spec:
@@ -151,7 +151,7 @@ spec:
       'env': 'test'
 ```
 
-[Get started with the Kubernetes Operator](dynamic-resources/teleport-operator.mdx). 
+[Get started with the Kubernetes Operator](dynamic-resources/teleport-operator.mdx).
 
 ## Reconciling the configuration file with dynamic resources
 
@@ -233,7 +233,7 @@ Here are possible values of the `teleport.dev/origin` label:
 When the Auth Service starts up, it looks up the values of static configuration
 fields that correspond to fields in dynamic configuration resources. If any of
 these have values, it creates the corresponding dynamic configuration resources
-and stores them in its backend. 
+and stores them in its backend.
 
 For any static configuration fields without a value, the Auth Service checks
 whether the backend contains the corresponding dynamic configuration resource.

--- a/docs/pages/management/dynamic-resources/terraform-provider.mdx
+++ b/docs/pages/management/dynamic-resources/terraform-provider.mdx
@@ -26,12 +26,12 @@ This guide demonstrates how to:
 
 Terraform needs a signed identity file from the Teleport cluster certificate
 authority to manage resources in the cluster.
-You can create a local Teleport user for this purpose or you can use the machine identity agent 
+You can create a local Teleport user for this purpose or you can use the machine identity agent
 [(Machine ID)](../../machine-id/introduction.mdx) to generate credentials.
 
-If you intend to run Terraform from a CI/CD platform, Machine ID is often a better 
-option for generating credentials. Machine ID can provision ephemeral short-lived 
-certificates that are appropriate for CI/CD workflows instead of using manually-generated 
+If you intend to run Terraform from a CI/CD platform, Machine ID is often a better
+option for generating credentials. Machine ID can provision ephemeral short-lived
+certificates that are appropriate for CI/CD workflows instead of using manually-generated
 credentials that have a longer time-to-live (TTL) period. For more information about
 using Machine ID, see the [Machine ID Getting Started Guide](../../machine-id/getting-started.mdx).
 
@@ -47,7 +47,7 @@ To prepare credentials for a local Teleport user:
 1. Create a new file called `terraform.yaml` and open it in an editor.
 
 1. Configure settings for a local Teleport user and role by pasting the following content into the `terraform.yaml` file:
-   
+
    ```yaml
    kind: role
    metadata:
@@ -76,7 +76,7 @@ To prepare credentials for a local Teleport user:
            - trusted_cluster
            - user
            verbs: ['list','create','read','update','delete']
-   version: v6
+   version: v7
    ---
    kind: user
    metadata:
@@ -85,8 +85,8 @@ To prepare credentials for a local Teleport user:
      roles: ['terraform']
    version: v2
    ```
-   
-   These settings configure a user and role named `terraform` with the permissions 
+
+   These settings configure a user and role named `terraform` with the permissions
    required to manage resources in your Teleport cluster.
 
 1. Create the `terraform` user and role by running the following command:
@@ -94,18 +94,18 @@ To prepare credentials for a local Teleport user:
    ```code
    $ tctl create terraform.yaml
    ```
-   
+
    The `terraform` user can't sign in to get credentials, so you must have another user
    **impersonate** the `terraform` account to request a certificate.
 
 1. Create a new file called `terraform-impersonator.yaml` and open it in an editor.
 
-1. Configure a role that enables your user to impersonate the Terraform user by pasting 
+1. Configure a role that enables your user to impersonate the Terraform user by pasting
 the following content into the `terraform-impersonator.yaml` file:
-   
+
    ```yaml
    kind: role
-   version: v6
+   version: v7
    metadata:
      name: terraform-impersonator
    spec:
@@ -119,7 +119,7 @@ the following content into the `terraform-impersonator.yaml` file:
    ```
 
 1. Create the `terraform-impersonator` role by running the following command:
-   
+
    ```code
    $ tctl create terraform-impersonator.yaml
    ```
@@ -131,7 +131,7 @@ the following content into the `terraform-impersonator.yaml` file:
    ```code
    $ tctl auth sign --user=terraform --out=terraform-identity
    ```
-   
+
    After running this command, you have a `terraform-identity` file with credentials for the Terraform user.
 
 ## Step 2/3. Prepare a Terraform configuration file
@@ -141,7 +141,7 @@ To prepare a Terraform configuration file:
 1. Create a new file called `main.tf` and open it in an editor.
 
 1. Define an example user and role using Terraform by pasting the following content into the `main.tf` file:
-   
+
    <Tabs>
    <TabItem scope={["cloud","team"]} label="Cloud-Hosted">
    ```hcl
@@ -166,16 +166,16 @@ To apply the configuration:
    # main.tf  terraform-identity  terraform-impersonator.yaml  terraform.yaml
    ```
 
-1. Initialize the working directory that contains Terraform configuration files by running the 
+1. Initialize the working directory that contains Terraform configuration files by running the
 following command:
-   
+
    ```code
    $ terraform init
    ```
 
-1. Execute the Terraform plan defined in the configuration file by running the 
+1. Execute the Terraform plan defined in the configuration file by running the
 following command:
-   
+
    ```code
    $ terraform apply
    ```


### PR DESCRIPTION
This PR adds documentation for the Kubernetes per-Resource RBAC and supported verbs introduced in Teleport 14.