### PR TITLE
[v14] Wraps go-redis internal logger and logs at TRACE level.

### DIFF
--- a/lib/srv/db/redis/engine.go
+++ b/lib/srv/db/redis/engine.go
@@ -492,7 +492,7 @@ type driverLogger struct {
 	*logrus.Entry
 }
 
-func (l *driverLogger) Printf(_ context.Context, format string, v ...interface{}) {
+func (l *driverLogger) Printf(_ context.Context, format string, v ...any) {
 	l.Entry.Tracef(format, v...)
 }
 


### PR DESCRIPTION
Backport #31445 to branch/v14