### PR TITLE
Align auth connector tiles

### DIFF
--- a/web/packages/teleport/src/AuthConnectors/styles/LockedFeatureContainer.styles.ts
+++ b/web/packages/teleport/src/AuthConnectors/styles/LockedFeatureContainer.styles.ts
@@ -24,7 +24,6 @@ export const LockedFeatureContainer = styled(Flex)`
   flex-wrap: wrap;
   position: relative;
   justify-content: center;
-  margin-top: ${p => p.theme.space[4]}px;
   min-width: 224px;
 `;
 


### PR DESCRIPTION
This PR removes extra margin on OIDC/SAML connectors

Fixes https://github.com/gravitational/teleport/issues/31460

<img width="1142" alt="Screenshot 2023-09-06 at 8 44 48 AM" src="https://github.com/gravitational/teleport/assets/11967646/1ab111de-8fbd-419e-aa3d-0edaa6a9a727">
<img width="1182" alt="Screenshot 2023-09-06 at 8 44 57 AM" src="https://github.com/gravitational/teleport/assets/11967646/99ddfba7-af90-4cd4-9252-8e5abde8afff">
