### PR TITLE
Web: Fix user signup flow and auto focus login form transition issues

### DIFF
--- a/web/packages/design/src/Onboard/OnboardCard.ts
+++ b/web/packages/design/src/Onboard/OnboardCard.ts
@@ -22,7 +22,8 @@ export const OnboardCard = styled(Card)<{ center: boolean }>`
   width: 600px;
   padding: ${props => props.theme.space[4]}px;
   text-align: ${props => (props.center ? 'center' : 'left')};
-  margin: ${props => props.theme.space[6]}px auto auto auto;
+  margin: ${props => props.theme.space[3]}px auto
+    ${props => props.theme.space[3]}px auto;
   overflow-y: auto;
 
   @media screen and (max-width: 800px) {

--- a/web/packages/design/src/Onboard/WelcomeWrapper.tsx
+++ b/web/packages/design/src/Onboard/WelcomeWrapper.tsx
@@ -28,12 +28,14 @@ export const WelcomeWrapper = ({ children }) => {
   return (
     <OnboardWrapper>
       <Flex flexDirection="column" justifyContent="space-between" height="100%">
-        <span>
+        {/* Flexing column here to prevent margin collapse
+        between WelcomeHeader and chidlren */}
+        <Flex flexDirection="column">
           <WelcomeHeader>
             <TeleportLogoII />
           </WelcomeHeader>
           {children}
-        </span>
+        </Flex>
         <OnboardFooter />
       </Flex>
     </OnboardWrapper>

--- a/web/packages/design/src/Onboard/__snapshots__/WelcomeWrapper.story.test.tsx.snap
+++ b/web/packages/design/src/Onboard/__snapshots__/WelcomeWrapper.story.test.tsx.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`wrapper 1`] = `
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c7 {
+.c8 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -23,7 +23,13 @@ exports[`wrapper 1`] = `
   flex-direction: column;
 }
 
-.c6 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c7 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -31,20 +37,20 @@ exports[`wrapper 1`] = `
   gap: 50px;
 }
 
-.c5 {
+.c6 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c8 {
+.c9 {
   color: white;
   text-decoration: none;
 }
 
-.c8:hover,
-.c8:active,
-.c8:focus {
+.c9:hover,
+.c9:active,
+.c9:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -76,7 +82,7 @@ exports[`wrapper 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -84,7 +90,7 @@ exports[`wrapper 1`] = `
   margin: 24px 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -92,12 +98,12 @@ exports[`wrapper 1`] = `
   width: 600px;
   padding: 24px;
   text-align: left;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c6 {
+  .c7 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -105,14 +111,14 @@ exports[`wrapper 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -124,9 +130,11 @@ exports[`wrapper 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -144,28 +152,28 @@ exports[`wrapper 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
         >
           Some content
         </div>
       </div>
-    </span>
+    </div>
     <footer
-      class="c5"
+      class="c6"
     >
       <div
-        class="c6"
+        class="c7"
       >
         <div
-          class="c4"
+          class="c5"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c7 c8"
+          class="c8 c9"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -173,7 +181,7 @@ exports[`wrapper 1`] = `
           Terms of Service
         </a>
         <a
-          class="c7 c8"
+          class="c8 c9"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"

--- a/web/packages/design/src/StepSlider/StepSlider.story.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.story.tsx
@@ -16,7 +16,7 @@
 
 import React, { useState } from 'react';
 
-import { Box, ButtonLink, ButtonPrimary, Text } from 'design';
+import { Box, ButtonLink, ButtonPrimary, Text, Card } from 'design';
 
 import { OnboardCard } from 'design/Onboard/OnboardCard';
 
@@ -27,9 +27,9 @@ export default {
 };
 
 const singleFlow = { default: [Body1, Body2] };
-export const SingleStaticFlow = () => {
+export const SingleFlowInPlaceSlider = () => {
   return (
-    <>
+    <Card my="5" mx="auto" width={464}>
       <Text typography="h3" pt={5} textAlign="center" color="text.main">
         Static Title
       </Text>
@@ -38,7 +38,7 @@ export const SingleStaticFlow = () => {
         currFlow={'default'}
         testProp="I'm that test prop"
       />
-    </>
+    </Card>
   );
 };
 
@@ -50,7 +50,7 @@ const multiflows = {
   primary: [MainStep1, MainStep2, FinalStep],
   secondary: [OtherStep1, FinalStep],
 };
-export const MultiCardFlow = () => {
+export const MultiFlowWheelSlider = () => {
   const [flow, setFlow] = useState<MultiFlow>('primary');
   const [newFlow, setNewFlow] = useState<NewFlow<MultiFlow>>();
 
@@ -233,7 +233,7 @@ function Body1({
   testProp,
 }: StepComponentProps & { testProp: string }) {
   return (
-    <OnboardCard ref={refCallback} data-testid="single-body1">
+    <Box p={6} ref={refCallback} data-testid="single-body1">
       <Text mb={3}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua.
@@ -259,7 +259,7 @@ function Body1({
           Back1
         </ButtonLink>
       </Box>
-    </OnboardCard>
+    </Box>
   );
 }
 
@@ -270,7 +270,7 @@ function Body2({
   testProp,
 }: StepComponentProps & { testProp: string }) {
   return (
-    <OnboardCard ref={refCallback} data-testid="single-body2">
+    <Box p={6} ref={refCallback} data-testid="single-body2">
       <Text mb={3}>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
@@ -302,6 +302,6 @@ function Body2({
           Next2
         </ButtonLink>
       </Box>
-    </OnboardCard>
+    </Box>
   );
 }

--- a/web/packages/design/src/StepSlider/StepSlider.test.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.test.tsx
@@ -18,10 +18,13 @@ import React from 'react';
 
 import { render, fireEvent, screen } from 'design/utils/testing';
 
-import { SingleStaticFlow, MultiCardFlow } from './StepSlider.story';
+import {
+  SingleFlowInPlaceSlider,
+  MultiFlowWheelSlider,
+} from './StepSlider.story';
 
 test('single flow', () => {
-  render(<SingleStaticFlow />);
+  render(<SingleFlowInPlaceSlider />);
 
   // Test initial render.
   expect(screen.getByTestId('single-body1')).toBeVisible();
@@ -46,7 +49,7 @@ test('single flow', () => {
 });
 
 test('switching between multi flow', () => {
-  render(<MultiCardFlow />);
+  render(<MultiFlowWheelSlider />);
 
   // Test initial primary flow.
   expect(screen.getByTestId('multi-primary1')).toBeVisible();

--- a/web/packages/design/src/StepSlider/StepSlider.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.tsx
@@ -19,6 +19,30 @@ import styled from 'styled-components';
 
 import Box from 'design/Box';
 
+/**
+ * StepSlider
+ *
+ * There are two transition style this StepSlider can
+ * take on depending on how it is used.
+ *
+ * 1) In place slider (look at FormLogin.tsx) where components
+ *    slides in the same container as parent.
+ * 2) Wheel like slider (look at Welcome.tsx) where the whole
+ *    component slides out of screen.
+ *
+ * Noted Caveats with Wheel like slider:
+ *
+ * Parent of slider must have a margin-top AND a margin-bottom
+ * (no auto, and number > 0) for the dynamic height transition
+ * to work without glitching. Transition may work fine without
+ * both top/bottom margins, but top/bottom box shadows will be
+ * cutt off and is noticeable with lighter themes.
+ *
+ * Parent of slider having a sibling where vertical margins are
+ * collapsed will also make it glitch by "uncollapsing" the
+ * margins and ending up with more space than the original.
+ *
+ */
 export function StepSlider<T>(props: Props<T>) {
   const {
     flows,
@@ -64,12 +88,6 @@ export function StepSlider<T>(props: Props<T>) {
   // our func 'setHeightOnPreMount'.
   const preMountState = useRef<{ step: number; flow: keyof T }>({} as any);
 
-  // Sets the initial height.
-  useEffect(() => {
-    const { height } = rootRef.current.getBoundingClientRect();
-    setHeight(height);
-  }, []);
-
   // Triggered as the first step to changing the current flow.
   // It preps data required for pre mounting and sets the
   // next animation direction.
@@ -97,7 +115,7 @@ export function StepSlider<T>(props: Props<T>) {
   // animations.
   const setHeightOnPreMount = (node: HTMLElement) => {
     if (node !== null) {
-      setHeight(node.getBoundingClientRect().height);
+      setHeight(node.getBoundingClientRect().height + getMarginY(node));
       setStep(preMountState.current.step);
       setPreMount(false);
 
@@ -107,11 +125,23 @@ export function StepSlider<T>(props: Props<T>) {
     }
   };
 
+  const setMarginYOnInitialMount = (node: HTMLElement) => {
+    if (node !== null) {
+      setHeight(node.getBoundingClientRect().height + getMarginY(node));
+    }
+  };
+
   function generateCurrentStep(View: StepComponent, requirePreMount = false) {
+    let refCallbackFn;
+    if (requirePreMount) {
+      refCallbackFn = setHeightOnPreMount;
+    } else if (!rootRef?.current) {
+      refCallbackFn = setMarginYOnInitialMount;
+    }
     return (
       <View
         key={step}
-        refCallback={requirePreMount ? setHeightOnPreMount : null}
+        refCallback={refCallbackFn}
         next={() => {
           preMountState.current.step = step + 1;
           setPreMount(true);
@@ -148,6 +178,14 @@ export function StepSlider<T>(props: Props<T>) {
     }
   }
 
+  let heightWithMargins = 'auto';
+  if (rootRef?.current) {
+    const currHeight = parseInt(rootRef.current.style.height);
+    if (!isNaN(currHeight)) {
+      heightWithMargins = `${currHeight}px`;
+    }
+  }
+
   const rootStyle = {
     // During the *-enter transition state, children are positioned absolutely
     // to keep views "stacked" on top of each other. Position relative is needed
@@ -156,7 +194,7 @@ export function StepSlider<T>(props: Props<T>) {
     // Height 'auto' is only ever used on the initial render to let it
     // take up as much space it needs. Afterward, it sets the starting
     // height.
-    height: rootRef?.current?.style.height || 'auto',
+    height: heightWithMargins,
     transition: `height ${tDuration}ms ease`,
   };
 
@@ -297,3 +335,15 @@ export type NewFlow<T> = {
   flow: T;
   applyNextAnimation?: boolean;
 };
+
+function getMarginY(node: HTMLElement) {
+  const style = getComputedStyle(node);
+  const marginTopNum = parseInt(style.marginTop);
+  const marginBotNum = parseInt(style.marginBottom);
+
+  if (isNaN(marginTopNum) || isNaN(marginBotNum)) {
+    return 0;
+  }
+
+  return marginTopNum + marginBotNum;
+}

--- a/web/packages/design/src/StepSlider/StepSlider.tsx
+++ b/web/packages/design/src/StepSlider/StepSlider.tsx
@@ -125,18 +125,21 @@ export function StepSlider<T>(props: Props<T>) {
     }
   };
 
-  const setMarginYOnInitialMount = (node: HTMLElement) => {
+  const setHeightOnInitialMount = (node: HTMLElement) => {
     if (node !== null) {
       setHeight(node.getBoundingClientRect().height + getMarginY(node));
     }
   };
 
   function generateCurrentStep(View: StepComponent, requirePreMount = false) {
-    let refCallbackFn;
+    // refCallbackFn is called with the DOM element ("View") that
+    // has been mounted. This way we can get the true height of
+    // the "View" container with the margins.
+    let refCallbackFn: (node: HTMLElement) => void;
     if (requirePreMount) {
       refCallbackFn = setHeightOnPreMount;
     } else if (!rootRef?.current) {
-      refCallbackFn = setMarginYOnInitialMount;
+      refCallbackFn = setHeightOnInitialMount;
     }
     return (
       <View
@@ -178,12 +181,12 @@ export function StepSlider<T>(props: Props<T>) {
     }
   }
 
+  // Sets the height of the outer container (root container).
+  // Initial render will always be 'auto' since rootRef current
+  // will be undefined.
   let heightWithMargins = 'auto';
   if (rootRef?.current) {
-    const currHeight = parseInt(rootRef.current.style.height);
-    if (!isNaN(currHeight)) {
-      heightWithMargins = `${currHeight}px`;
-    }
+    heightWithMargins = rootRef.current.style.height;
   }
 
   const rootStyle = {
@@ -191,9 +194,6 @@ export function StepSlider<T>(props: Props<T>) {
     // to keep views "stacked" on top of each other. Position relative is needed
     // so these children's position themselves relative to parent.
     position: 'relative',
-    // Height 'auto' is only ever used on the initial render to let it
-    // take up as much space it needs. Afterward, it sets the starting
-    // height.
     height: heightWithMargins,
     transition: `height ${tDuration}ms ease`,
   };

--- a/web/packages/shared/components/ButtonSso/ButtonSso.tsx
+++ b/web/packages/shared/components/ButtonSso/ButtonSso.tsx
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import styled from 'styled-components';
 import Button from 'design/Button';
 import { darken, lighten } from 'design/theme/utils/colorManipulator';
@@ -22,12 +22,12 @@ import * as Icons from 'design/Icon';
 
 import { AuthProviderType } from 'shared/services';
 
-const ButtonSso = (props: Props) => {
+const ButtonSso = forwardRef<HTMLInputElement, Props>((props: Props, ref) => {
   const { ssoType = 'unknown', title, ...rest } = props;
   const { color, Icon } = getSSOIcon(ssoType);
 
   return (
-    <StyledButton color={color} block {...rest}>
+    <StyledButton color={color} block {...rest} ref={ref}>
       {Boolean(Icon) && (
         <IconBox>
           <Icon data-testid="icon" color="white" />
@@ -36,7 +36,7 @@ const ButtonSso = (props: Props) => {
       {title}
     </StyledButton>
   );
-};
+});
 
 type Props = {
   ssoType: SSOType;

--- a/web/packages/teleport/src/Welcome/NewCredentials/__snapshots__/NewCredentials.story.test.tsx.snap
+++ b/web/packages/teleport/src/Welcome/NewCredentials/__snapshots__/NewCredentials.story.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`story.MfaDeviceError 1`] = `
-.c9 {
+.c10 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -18,11 +18,1086 @@ exports[`story.MfaDeviceError 1`] = `
   color: #000000;
 }
 
-.c9 a {
+.c10 a {
   color: #FFFFFF;
 }
 
+.c7 {
+  box-sizing: border-box;
+}
+
+.c12 {
+  box-sizing: border-box;
+  margin-bottom: 4px;
+}
+
+.c22 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  margin-right: 16px;
+  width: 50%;
+}
+
+.c25 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  width: 50%;
+}
+
+.c26 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  color: #000000;
+  background: #9F85FF;
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.c26:hover,
+.c26:focus {
+  background: #B29DFF;
+}
+
+.c26:active {
+  background: #C5B6FF;
+}
+
+.c26:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+  cursor: auto;
+}
+
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 32px;
+  margin: 0px;
+  color: #FFFFFF;
+}
+
+.c9 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  color: rgba(255,255,255,0.72);
+}
+
+.c11 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 24px;
+  text-transform: uppercase;
+  margin: 0px;
+  margin-bottom: 4px;
+  color: #FFFFFF;
+}
+
+.c19 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  margin: 0px;
+  margin-top: 8px;
+  color: rgba(255,255,255,0.72);
+  text-align: center;
+}
+
+.c29 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+}
+
 .c6 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 16px;
+}
+
+.c24 {
+  appearance: none;
+  border: 1px solid rgba(255,255,255,0.54);
+  border-radius: 4px;
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  background: #222C59;
+  color: #FFFFFF;
+  margin-top: 4px;
+}
+
+.c24:hover,
+.c24:focus,
+.c24:active {
+  border: 1px solid rgba(255,255,255,0.72);
+}
+
+.c24::-ms-clear {
+  display: none;
+}
+
+.c24::placeholder {
+  color: rgba(255,255,255,0.54);
+  opacity: 1;
+}
+
+.c24:read-only {
+  cursor: not-allowed;
+}
+
+.c24:disabled {
+  color: rgba(255,255,255,0.36);
+  border-color: rgba(255,255,255,0.36);
+}
+
+.c23 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 12px;
+  width: 100%;
+  margin-bottom: 0px;
+}
+
+.c20 {
+  color: #009EFF;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+}
+
+.c17 {
+  display: block;
+  outline: none;
+  width: 145px;
+  height: 145px;
+}
+
+.c1 {
+  box-sizing: border-box;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c5 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.c13 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+}
+
+.c16 {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: 240px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.c21 {
+  box-sizing: border-box;
+  height: 100px;
+  display: flex;
+  align-items: center;
+}
+
+.c28 {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  gap: 50px;
+}
+
+.c27 {
+  padding-bottom: 24px;
+  width: 100%;
+  color: white;
+}
+
+.c30 {
+  color: white;
+  text-decoration: none;
+}
+
+.c30:hover,
+.c30:active,
+.c30:focus {
+  color: rgba(255,255,255,0.54);
+}
+
+.c0 {
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  overflow: hidden;
+  z-index: -2;
+  background: url('file_stub');
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
+}
+
+.c0::after {
+  content: '';
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  position: absolute;
+  z-index: -1;
+  background-color: black;
+  opacity: 0.25;
+  backdrop-filter: blur(17.5px);
+}
+
+.c3 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 24px 0;
+}
+
+.c14 {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.c15 {
+  margin: 0 8px 0 0;
+  accent-color: #9F85FF;
+  cursor: inherit;
+}
+
+.c4 {
+  box-sizing: border-box;
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
+  border-radius: 8px;
+  background-color: #222C59;
+  width: 600px;
+  padding: 24px;
+  text-align: left;
+  margin: 16px auto 16px auto;
+  overflow-y: auto;
+}
+
+.c18 {
+  border: 4px solid white;
+}
+
+@media screen and (max-width:800px) {
+  .c28 {
+    flex-direction: column-reverse;
+    text-align: center;
+    gap: 10px;
+  }
+}
+
+@media screen and (max-width:800px) {
+  .c4 {
+    width: auto;
+    margin: 20px;
+  }
+}
+
+@media screen and (max-height:760px) {
+  .c4 {
+    height: calc(100vh - 250px);
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    height="100%"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <svg
+          fill="none"
+          height="32"
+          viewBox="0 0 150 32"
+          width="150"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M18.9703 0.305222C19.2104 0.332812 19.4157 0.519049 19.4922 0.739775L19.5131 0.822547L20.2959 4.81975C21.3466 5.22326 22.3382 5.76128 23.2324 6.42345L23.5629 6.67867L27.5153 5.33362C27.7727 5.22326 28.0441 5.30258 28.2354 5.52331C29.5958 7.03734 30.6987 8.86523 31.3424 10.7862C31.4433 11.007 31.3911 11.2656 31.2206 11.4312L31.151 11.4898L28.0128 14.1454C28.1241 14.7386 28.1554 15.3801 28.1554 16.0043C28.1554 16.5078 28.1346 17.0148 28.0684 17.5046L28.0093 17.8667L31.1475 20.5223C31.3702 20.6775 31.4502 20.9741 31.3389 21.2258C30.6987 23.1468 29.5958 24.9747 28.2354 26.4888C28.065 26.6819 27.8284 26.7681 27.5988 26.706L27.5118 26.675L23.5594 25.33C22.6931 26.0232 21.7224 26.5957 20.6891 27.0302L20.2959 27.1854L19.5096 31.1861C19.4609 31.4378 19.2382 31.6689 18.9634 31.7034C17.9405 31.8896 16.9141 32 15.8599 32C14.8057 32 13.7794 31.8896 12.753 31.7034C12.5129 31.6758 12.3077 31.4861 12.2311 31.2689L12.2103 31.1861L11.4274 27.1854C10.3628 26.7785 9.33295 26.2336 8.44923 25.5576L8.16046 25.3265L4.20809 26.6716C3.95063 26.7819 3.67925 26.7026 3.4879 26.4819C2.12753 24.9678 1.02462 23.1399 0.384448 21.2189C0.283551 20.9982 0.335739 20.7361 0.50622 20.574L0.575804 20.5188L3.71056 17.8632C3.59923 17.27 3.56792 16.632 3.56792 16.0043C3.56792 15.5042 3.58879 14.9938 3.6549 14.5075L3.71404 14.1454L0.579283 11.4898C0.356614 11.3311 0.273114 11.038 0.387927 10.7862C1.0281 8.86523 2.13101 7.03734 3.49137 5.52331C3.66185 5.33017 3.89844 5.2474 4.12807 5.30603L4.21505 5.33362L8.16742 6.67867C9.01635 5.9751 10.0218 5.39915 11.0795 4.96115L11.4344 4.81975L12.2172 0.822547C12.2659 0.570782 12.4886 0.336261 12.7634 0.305222C14.8127 -0.101741 16.9246 -0.101741 18.9738 0.305222H18.9703ZM103.125 11.0207C103.915 11.0207 104.646 11.1932 105.321 11.5346C105.992 11.8761 106.573 12.3727 107.06 13.0211C107.547 13.6695 107.93 14.4592 108.208 15.3973C108.487 16.3354 108.626 17.3976 108.626 18.5875C108.626 19.7015 108.466 20.7292 108.149 21.6707C107.833 22.6123 107.387 23.4331 106.817 24.1263C106.246 24.8195 105.564 25.3644 104.767 25.7542C103.974 26.1439 103.094 26.3405 102.127 26.3405C101.337 26.3405 100.672 26.2301 100.137 26.0128C99.6008 25.7955 99.1137 25.4989 98.6753 25.1265V30.8102H94.1419V11.3105H97.0888C97.3115 11.3311 97.5029 11.3932 97.6594 11.4967C97.8508 11.6208 97.983 11.8071 98.063 12.0519L98.4005 13.1383L98.6232 12.9073C98.8493 12.6831 99.0894 12.4727 99.3434 12.2796C99.6808 12.0209 100.039 11.8002 100.425 11.6174C100.812 11.4312 101.226 11.2863 101.667 11.1828C102.113 11.0794 102.596 11.0242 103.122 11.0242L103.125 11.0207ZM60.4737 11.0794C61.4792 11.0794 62.3977 11.2311 63.2292 11.5346C64.0643 11.8381 64.781 12.283 65.3794 12.8624C65.9778 13.4418 66.4475 14.1557 66.785 14.9973C67.1225 15.8388 67.2895 16.7941 67.2895 17.8598C67.2895 18.1943 67.2756 18.4633 67.2442 18.6737C67.2164 18.8841 67.1607 19.0496 67.0842 19.1738C67.0077 19.2979 66.8998 19.3842 66.7711 19.4325C66.6423 19.4807 66.4719 19.5049 66.2666 19.5049H57.5199L57.5512 19.7463C57.7182 20.8603 58.0905 21.6742 58.675 22.195C59.2977 22.7502 60.1049 23.0296 61.0895 23.0296C61.6149 23.0296 62.0707 22.9675 62.4499 22.8433C62.8291 22.7192 63.1701 22.5812 63.4658 22.4295C63.7616 22.2777 64.0364 22.1398 64.2834 22.0156C64.5305 21.8915 64.7914 21.8294 65.0663 21.8294C65.4281 21.8294 65.6995 21.957 65.8839 22.2157L67.199 23.8021L66.9972 24.0194C66.5867 24.4436 66.1518 24.7988 65.6856 25.0782C65.1428 25.4058 64.5896 25.6645 64.019 25.8507C63.4484 26.037 62.8778 26.1646 62.3073 26.237C61.7367 26.3094 61.1939 26.3439 60.6755 26.3439C59.6144 26.3439 58.6158 26.1749 57.6834 25.8369C56.751 25.499 55.9368 24.9954 55.241 24.3298C54.5452 23.6642 53.992 22.8365 53.5884 21.8466C53.1848 20.8568 52.983 19.7049 52.983 18.3909C52.983 17.4011 53.157 16.463 53.5014 15.5767C53.8458 14.6903 54.3434 13.9143 54.994 13.2487C55.6411 12.5831 56.4274 12.0554 57.3494 11.6622C58.2714 11.2725 59.3117 11.0759 60.4737 11.0759V11.0794ZM84.7237 11.0794C85.7292 11.0794 86.6477 11.2311 87.4793 11.5346C88.3143 11.8381 89.031 12.283 89.6294 12.8624C90.2278 13.4418 90.6975 14.1557 91.035 14.9973C91.3725 15.8388 91.5395 16.7941 91.5395 17.8598C91.5395 18.1943 91.5256 18.4633 91.4943 18.6737C91.4664 18.8841 91.4108 19.0496 91.3342 19.1738C91.2577 19.2979 91.1498 19.3842 91.0211 19.4325C90.8889 19.4807 90.7219 19.5049 90.5166 19.5049H81.7699L81.8012 19.7463C81.9682 20.8603 82.3405 21.6742 82.925 22.195C83.5478 22.7502 84.355 23.0296 85.3396 23.0296C85.8649 23.0296 86.3207 22.9675 86.6999 22.8433C87.0792 22.7192 87.4201 22.5812 87.7159 22.4295C88.0116 22.2777 88.2864 22.1398 88.5335 22.0156C88.7805 21.8915 89.0414 21.8294 89.3163 21.8294C89.6781 21.8294 89.9495 21.957 90.1339 22.2157L91.449 23.8021L91.2472 24.0194C90.8367 24.4436 90.4018 24.7988 89.9356 25.0782C89.3928 25.4058 88.8396 25.6645 88.2691 25.8507C87.6985 26.037 87.1279 26.1646 86.5573 26.237C85.9867 26.3094 85.4439 26.3439 84.9255 26.3439C83.8644 26.3439 82.8659 26.1749 81.9334 25.8369C81.001 25.499 80.1869 24.9954 79.491 24.3298C78.7952 23.6642 78.242 22.8365 77.8384 21.8466C77.4348 20.8568 77.233 19.7049 77.233 18.3909C77.233 17.4011 77.407 16.463 77.7514 15.5767C78.0959 14.6903 78.5934 13.9143 79.244 13.2487C79.8911 12.5831 80.6774 12.0554 81.5994 11.6622C82.5214 11.2725 83.5617 11.0759 84.7237 11.0759V11.0794ZM117.807 11.0794C118.959 11.0794 120.006 11.2553 120.953 11.607C121.899 11.9588 122.71 12.4624 123.388 13.1211C124.067 13.7764 124.592 14.5765 124.968 15.5111C125.343 16.4492 125.531 17.5011 125.531 18.6737C125.531 19.8463 125.343 20.9189 124.968 21.8639C124.592 22.8123 124.067 23.6159 123.388 24.2781C122.71 24.9402 121.899 25.4472 120.953 25.8059C120.006 26.1611 118.959 26.3405 117.807 26.3405C116.656 26.3405 115.591 26.1611 114.641 25.8059C113.692 25.4507 112.87 24.9402 112.185 24.2781C111.496 23.6159 110.967 22.8123 110.592 21.8639C110.216 20.9155 110.028 19.8532 110.028 18.6737C110.028 17.4942 110.216 16.4492 110.592 15.5111C110.967 14.573 111.5 13.7764 112.185 13.1211C112.87 12.4658 113.692 11.9588 114.641 11.607C115.591 11.2553 116.649 11.0794 117.807 11.0794ZM145.509 7.00975V11.3346H149.193V14.3627H145.509V21.7156L145.516 21.8604C145.537 22.1398 145.62 22.3743 145.766 22.5674C145.937 22.7916 146.184 22.902 146.504 22.902C146.671 22.902 146.81 22.8847 146.921 22.8537C147.033 22.8227 147.13 22.7813 147.214 22.7399C147.297 22.6985 147.374 22.6606 147.447 22.6261C147.52 22.5916 147.607 22.5778 147.704 22.5778C147.84 22.5778 147.951 22.6088 148.035 22.6709C148.118 22.733 148.202 22.8296 148.292 22.9641L149.667 25.0644L149.444 25.2196C148.915 25.5714 148.33 25.8404 147.694 26.0266C146.963 26.2404 146.208 26.3474 145.425 26.3474C144.705 26.3474 144.068 26.2439 143.515 26.0404C142.966 25.8369 142.503 25.5438 142.127 25.1679C141.751 24.7919 141.466 24.3367 141.271 23.8056C141.076 23.271 140.979 22.6778 140.979 22.0225V14.3696H139.692L139.577 14.3627C139.392 14.342 139.229 14.2695 139.09 14.1488C138.923 14.0005 138.843 13.7833 138.843 13.5005V11.7726L141.257 11.3173L142.148 7.70642L142.183 7.59606C142.322 7.21324 142.642 7.0201 143.143 7.0201H145.512L145.509 7.00975ZM55.495 5.31293V9.13768H49.4968V26.1128H44.5529V9.13768H38.5548V5.31293H55.4915H55.495ZM74.5749 4.74042V26.1128H70.0415V4.74042H74.5749ZM136.414 11.0242C137.107 11.0242 137.663 11.1863 138.081 11.5105L137.496 14.7662L137.468 14.88C137.423 15.0214 137.357 15.1249 137.263 15.1869C137.145 15.2663 136.992 15.3076 136.793 15.3076C136.626 15.3076 136.432 15.287 136.209 15.2421C135.986 15.2007 135.701 15.1766 135.36 15.1766C134.17 15.1766 133.234 15.7939 132.552 17.0321V26.1128H128.019V11.3105H130.872C131.025 11.3208 131.161 11.338 131.272 11.3691C131.422 11.407 131.55 11.4656 131.651 11.5484C131.752 11.6277 131.832 11.7381 131.884 11.8692C131.937 12.0037 131.985 12.1658 132.023 12.3554L132.27 13.7419L132.458 13.4694C132.966 12.759 133.526 12.1899 134.142 11.7588C134.835 11.2725 135.59 11.0311 136.411 11.0311L136.414 11.0242ZM15.8634 6.63728C10.6516 6.63728 6.42782 10.8276 6.42782 15.9974C6.42782 21.1672 10.6516 25.3575 15.8634 25.3575C21.0753 25.3575 25.299 21.1672 25.299 15.9974C25.299 10.8276 21.0753 6.63728 15.8634 6.63728ZM101.546 14.4075C101.215 14.4075 100.916 14.4385 100.645 14.5006C100.377 14.5627 100.126 14.6489 99.9 14.7662C99.6704 14.88 99.4582 15.0248 99.2633 15.2007C99.0685 15.3766 98.8737 15.5801 98.6788 15.8077V22.0915L98.8284 22.2432C99.1276 22.533 99.4477 22.7433 99.7922 22.8675C100.192 23.0158 100.61 23.0882 101.052 23.0882C101.493 23.0882 101.855 23.0089 102.207 22.8468C102.558 22.6847 102.861 22.426 103.122 22.0674C103.379 21.7121 103.581 21.2465 103.727 20.674C103.873 20.1015 103.946 19.4083 103.946 18.5909C103.946 17.7736 103.887 17.1528 103.772 16.6217C103.654 16.0871 103.491 15.6594 103.282 15.3283C103.073 15.0007 102.823 14.7627 102.527 14.6213C102.235 14.4799 101.908 14.4075 101.546 14.4075ZM117.811 14.3661C116.739 14.3661 115.953 14.7213 115.456 15.4353C114.958 16.1492 114.711 17.239 114.711 18.7047C114.711 20.1705 114.958 21.2638 115.456 21.9811C115.953 22.6985 116.739 23.0606 117.811 23.0606C118.883 23.0606 119.624 22.7019 120.114 21.9811C120.608 21.2638 120.852 20.1705 120.852 18.7047C120.852 17.239 120.605 16.1492 120.114 15.4353C119.62 14.7213 118.855 14.3661 117.811 14.3661ZM21.8372 11.9105V14.6972H17.2864V21.3879H14.4439V14.6972H9.8931V11.9105H21.8372ZM60.5642 14.135C59.6979 14.135 59.0194 14.3765 58.5323 14.8559C58.0452 15.3352 57.7217 16.0285 57.5686 16.932H63.2292C63.2292 16.5803 63.184 16.2388 63.0901 15.9043C62.9961 15.5698 62.8465 15.2732 62.6378 15.011C62.429 14.7489 62.1542 14.5386 61.8097 14.3765C61.4688 14.2144 61.0547 14.135 60.5677 14.135H60.5642ZM84.8142 14.135C83.9479 14.135 83.2694 14.3765 82.7824 14.8559C82.2953 15.3352 81.9717 16.0285 81.8186 16.932H87.4793C87.4793 16.5803 87.434 16.2388 87.3401 15.9043C87.2462 15.5698 87.0966 15.2732 86.8878 15.011C86.6791 14.7489 86.4042 14.5386 86.0598 14.3765C85.7188 14.2144 85.3048 14.135 84.8177 14.135H84.8142Z"
+            fill="white"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div
+        class="c4"
+      >
+        <div
+          class="c5"
+        >
+          <span
+            class="c6 icon icon-arrowback"
+            style="cursor: pointer;"
+          >
+            <svg
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M11.0303 5.78033C11.3232 5.48744 11.3232 5.01256 11.0303 4.71967C10.7374 4.42678 10.2626 4.42678 9.96967 4.71967L3.21967 11.4697C3.07322 11.6161 3 11.8081 3 12C3 12.1017 3.02024 12.1987 3.05691 12.2871C3.09268 12.3735 3.14531 12.4547 3.2148 12.5254"
+              />
+              <path
+                d="M3.22014 12.5308L9.96967 19.2803C10.2626 19.5732 10.7374 19.5732 11.0303 19.2803C11.3232 18.9874 11.3232 18.5126 11.0303 18.2197L5.56066 12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H5.56066L11.0303 5.78033"
+              />
+            </svg>
+          </span>
+          <div
+            class="c7"
+          >
+            <div
+              class="c8"
+              color="text.main"
+            >
+              Set Two-Factor Device
+            </div>
+            <div
+              class="c9"
+              color="text.slightlyMuted"
+            >
+              Step 2 of 2
+            </div>
+          </div>
+        </div>
+        <div
+          class="c10"
+          kind="danger"
+        >
+          some server error message
+        </div>
+        <div
+          class="c11"
+          color="text.main"
+        >
+          Two-Factor Method
+        </div>
+        <div
+          class="c12"
+        >
+          <div
+            class="c13"
+          >
+            <label
+              class="c14"
+            >
+              <input
+                checked=""
+                class="c15"
+                name="mfaType"
+                type="radio"
+                value="otp"
+              />
+              <span>
+                Authenticator App
+              </span>
+            </label>
+          </div>
+        </div>
+        <div
+          class="c16"
+          height="240px"
+        >
+          <img
+            class="c17 c18"
+            height="145px"
+            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAcgAAAHIEAAAAAC/Wvl1AAAJV0lEQVR4nOzdsW4jORZA0fbC///LXowVTFIWmqAefUtzTrDJeEtltS+YPDx+fn39ASL+99svAPzr85//+fj47df4ycr5ff1bXD9h/2f3vcenTf0LrTzh2tnvd9/jfZ2QECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgI+fz5P50dOz870rT/u3VH0VZ+dv+32B9mW1H41vc9e18nJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp6Mzl0rjCkV9stNjYytvG9hkOzs+F5nxO3vrL+vExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSHLo3M8nB1bOztItv9pU8N3+59W54SEEEFCiCAhRJAQIkgIESSECBJCBAkhgoQQQULIG43OvcdOs7NDZ9cKQ3L7o4n3HKhzQkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIWR5dO5uA0lT42Vnnzu1427/Hfaf0B2H+42/dSckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCnozOTQ1mTdnfLzd1UenZcbjumF3hZ691/tadkBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPkenbvbJrlrZwez9t9h39khubPvcPY763BCQoggIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5OPrq3FJ6LWpS0L3nzD1PUxdatp936l3uNZ9swcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQkYvbN3f8FW4SPPs1aErule+Fi6u7Xr2PTghIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQ8jF5geV/b1Tq7Ja8qecW9vedvVi1s4vOCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJDl0bnCoNOUs/vaCjv5pv7d9jfUrTy3MGb3qt/CCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJAnF7ZeK1zFWbgA9ezPrji7HW7F1PfQHai7Zusc3IQgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5Hvr3NTw0oqzI3nda1GvFS65feffbZ+tc/CGBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSFPRudWnL189OwQ177uOxQGFqeeULhEeP3NnJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5vrC1cLXlylDU2R13+084O1h47exut8K1viumBgvXn+CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyMfqWFdhO9yUV126+Xc/u/8OK+52Ke/KE/adHXm0dQ5uQpAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZHTu7KjU3a58LexKu3Z2QO09LnedYusc3JogIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhZHnr3A+PGdppdvYJ+wq76M5+k1MDliu6G/XWOSEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDy+eclQ1z7g0P7G+qmRqWmhu9WfuPCpr53VtiPaOsc5AgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn/+T91NZ/tP2B9buzY1QrjvbtfOrpgafPuNPXtOSAgRJIQIEkIECSGChBBBQoggIUSQECJICBEkhHyPznV2bv3dz147O+g0NV5WGFub+nvY36jX/Xu4tv4bOyEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZOvcvpUxpf2RpsJY1bWpa2f3P23f2VG/qUtup76z9Sc4ISFEkBAiSAgRJIQIEkIECSGChBBBQoggIUSQELI8Ojc1KlXYZjd1mefUtbN3GzecGt87+/3uf9o1W+cgR5AQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyPTp3dlyrMII19Q5TQ1wr9sfA7vZvPLXVb2pI7hknJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp5snfuNnVt/94SzV5IWLnfdf0JhoG7f2b/JFa96ByckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn4e+Tm7I2xFYbdbYYPa1BNWFEbRrp39Hl71Dk5ICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSELF/YOmV/09nUvraz9rfDXetu6iu8w9Snrf9uTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ82Tr3w//hZteBvvM+vLtt1Fv5tMLw3bWpa4gfP+uEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLWucKOsKnhu6kxu8IVqiufdnbccF/3r2SdExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGfr3nM1GWpZwe+zm4v23d2f9/+O+x/v1NPKFwl++CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLoXGEo6m5jdlNb3N5jb92KwuWus+/ghIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjH11fjQtF93QG199gD173q9D2+3wcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQj7udknpn8Ehrv19Yt1Pu3Z2i9vZ8b2zI4+v+h6ckBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPm+sPXs1q4V1wNJ++NlZ6282f4w28oTCpfcFnYe7n8Pr/rWnZAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5/Pk/nd1Hd3a8rKCw7+/sHrizQ3LXpj7tVc91QkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIeTJ6Ny1qctSu87+xvvby1Z20Z21/y/f/Y1fNRbohIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FzX1IjbynOnriQtvMOK7vewb2rn4eMJTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIS80ejc1IWtZy+CvdtOvmtTg3pTY3b772DrHLwhQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FxhtGvlHaY2yV1beW7hCtV93d1uUz879WkPTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ8GZ3rjnbtD76d3X92ber60v0xsClnB9/OsnUO3pAgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5KMwdgQ8OCEhRJAQ8v8AAAD//1QuL6EmJFBiAAAAAElFTkSuQmCC"
+            width="145px"
+          />
+          <div
+            class="c19"
+            color="text.slightlyMuted"
+            font-size="1"
+          >
+            Scan the QR Code with any authenticator app and enter the generated code. We recommend
+             
+            <a
+              class="c20"
+              href="https://authy.com/download/"
+              rel="noreferrer"
+              target="_blank"
+            >
+              Authy
+            </a>
+            .
+          </div>
+        </div>
+        <div
+          class="c21"
+          height="100"
+        >
+          <div
+            class="c22"
+            width="50%"
+          >
+            <label
+              class="c23"
+              font-size="0"
+            >
+              Device Name
+              <input
+                autocomplete="off"
+                class="c24"
+                inputmode="text"
+                placeholder="Name"
+                type="text"
+                value="otp-device"
+              />
+            </label>
+          </div>
+          <div
+            class="c25"
+            width="50%"
+          >
+            <label
+              class="c23"
+              font-size="0"
+            >
+              Authenticator Code
+              <input
+                autocomplete="one-time-code"
+                class="c24"
+                inputmode="numeric"
+                placeholder="123 456"
+                type="text"
+                value=""
+              />
+            </label>
+          </div>
+        </div>
+        <button
+          class="c26"
+          kind="primary"
+          width="100%"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+    <footer
+      class="c27"
+    >
+      <div
+        class="c28"
+      >
+        <div
+          class="c29"
+        >
+          © Gravitational, Inc. All Rights Reserved
+        </div>
+        <a
+          class="c20 c30"
+          href="https://goteleport.com/legal/tos/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Terms of Service
+        </a>
+        <a
+          class="c20 c30"
+          href="https://goteleport.com/legal/privacy/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Privacy Policy
+        </a>
+      </div>
+    </footer>
+  </div>
+</div>
+`;
+
+exports[`story.MfaDeviceOn 1`] = `
+.c7 {
+  box-sizing: border-box;
+}
+
+.c11 {
+  box-sizing: border-box;
+  margin-bottom: 4px;
+}
+
+.c19 {
+  box-sizing: border-box;
+  margin-bottom: 24px;
+  margin-right: 0px;
+  width: 100%;
+}
+
+.c22 {
+  line-height: 1.5;
+  margin: 0;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  box-sizing: border-box;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-family: inherit;
+  font-weight: 600;
+  outline: none;
+  position: relative;
+  text-align: center;
+  text-decoration: none;
+  text-transform: uppercase;
+  transition: all 0.3s;
+  -webkit-font-smoothing: antialiased;
+  color: #000000;
+  background: #9F85FF;
+  min-height: 40px;
+  font-size: 12px;
+  padding: 0px 40px;
+  margin-top: 8px;
+  width: 100%;
+}
+
+.c22:hover,
+.c22:focus {
+  background: #B29DFF;
+}
+
+.c22:active {
+  background: #C5B6FF;
+}
+
+.c22:disabled {
+  background: rgba(255,255,255,0.12);
+  color: rgba(255,255,255,0.3);
+  cursor: auto;
+}
+
+.c8 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 32px;
+  margin: 0px;
+  color: #FFFFFF;
+}
+
+.c9 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+  color: rgba(255,255,255,0.72);
+}
+
+.c10 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 24px;
+  text-transform: uppercase;
+  margin: 0px;
+  margin-bottom: 4px;
+  color: #FFFFFF;
+}
+
+.c17 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  margin: 0px;
+  color: rgba(255,255,255,0.72);
+  text-align: center;
+}
+
+.c25 {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin: 0px;
+}
+
+.c6 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 16px;
+}
+
+.c21 {
+  appearance: none;
+  border: 1px solid rgba(255,255,255,0.54);
+  border-radius: 4px;
+  box-sizing: border-box;
+  display: block;
+  height: 40px;
+  font-size: 16px;
+  padding: 0 16px;
+  outline: none;
+  width: 100%;
+  background: #222C59;
+  color: #FFFFFF;
+  margin-top: 4px;
+}
+
+.c21:hover,
+.c21:focus,
+.c21:active {
+  border: 1px solid rgba(255,255,255,0.72);
+}
+
+.c21::-ms-clear {
+  display: none;
+}
+
+.c21::placeholder {
+  color: rgba(255,255,255,0.54);
+  opacity: 1;
+}
+
+.c21:read-only {
+  cursor: not-allowed;
+}
+
+.c21:disabled {
+  color: rgba(255,255,255,0.36);
+  border-color: rgba(255,255,255,0.36);
+}
+
+.c20 {
+  color: #FFFFFF;
+  display: block;
+  font-size: 12px;
+  width: 100%;
+  margin-bottom: 0px;
+}
+
+.c26 {
+  color: #009EFF;
+  font-weight: normal;
+  background: none;
+  text-decoration: underline;
+  text-transform: none;
+}
+
+.c16 {
+  display: block;
+  outline: none;
+  width: 220px;
+  height: 154px;
+}
+
+.c1 {
+  box-sizing: border-box;
+  height: 100%;
+  display: flex;
+  justify-content: space-between;
+  flex-direction: column;
+}
+
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c5 {
+  box-sizing: border-box;
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+}
+
+.c12 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+}
+
+.c15 {
+  box-sizing: border-box;
+  padding-left: 16px;
+  padding-right: 16px;
+  height: 240px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+}
+
+.c18 {
+  box-sizing: border-box;
+  height: 100px;
+  display: flex;
+  align-items: center;
+}
+
+.c24 {
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  gap: 50px;
+}
+
+.c23 {
+  padding-bottom: 24px;
+  width: 100%;
+  color: white;
+}
+
+.c27 {
+  color: white;
+  text-decoration: none;
+}
+
+.c27:hover,
+.c27:active,
+.c27:focus {
+  color: rgba(255,255,255,0.54);
+}
+
+.c0 {
+  position: absolute;
+  width: 100vw;
+  height: 100vh;
+  top: 0;
+  left: 0;
+  overflow: hidden;
+  z-index: -2;
+  background: url('file_stub');
+  -webkit-background-size: cover;
+  -moz-background-size: cover;
+  -o-background-size: cover;
+  background-size: cover;
+}
+
+.c0::after {
+  content: '';
+  top: 0;
+  left: 0;
+  bottom: 0;
+  right: 0;
+  position: absolute;
+  z-index: -1;
+  background-color: black;
+  opacity: 0.25;
+  backdrop-filter: blur(17.5px);
+}
+
+.c3 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: 24px 0;
+}
+
+.c13 {
+  display: flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.c14 {
+  margin: 0 8px 0 0;
+  accent-color: #9F85FF;
+  cursor: inherit;
+}
+
+.c4 {
+  box-sizing: border-box;
+  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
+  border-radius: 8px;
+  background-color: #222C59;
+  width: 600px;
+  padding: 24px;
+  text-align: left;
+  margin: 16px auto 16px auto;
+  overflow-y: auto;
+}
+
+@media screen and (max-width:800px) {
+  .c24 {
+    flex-direction: column-reverse;
+    text-align: center;
+    gap: 10px;
+  }
+}
+
+@media screen and (max-width:800px) {
+  .c4 {
+    width: auto;
+    margin: 20px;
+  }
+}
+
+@media screen and (max-height:760px) {
+  .c4 {
+    height: calc(100vh - 250px);
+  }
+}
+
+<div
+  class="c0"
+>
+  <div
+    class="c1"
+    height="100%"
+  >
+    <div
+      class="c2"
+    >
+      <div
+        class="c3"
+      >
+        <svg
+          fill="none"
+          height="32"
+          viewBox="0 0 150 32"
+          width="150"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            clip-rule="evenodd"
+            d="M18.9703 0.305222C19.2104 0.332812 19.4157 0.519049 19.4922 0.739775L19.5131 0.822547L20.2959 4.81975C21.3466 5.22326 22.3382 5.76128 23.2324 6.42345L23.5629 6.67867L27.5153 5.33362C27.7727 5.22326 28.0441 5.30258 28.2354 5.52331C29.5958 7.03734 30.6987 8.86523 31.3424 10.7862C31.4433 11.007 31.3911 11.2656 31.2206 11.4312L31.151 11.4898L28.0128 14.1454C28.1241 14.7386 28.1554 15.3801 28.1554 16.0043C28.1554 16.5078 28.1346 17.0148 28.0684 17.5046L28.0093 17.8667L31.1475 20.5223C31.3702 20.6775 31.4502 20.9741 31.3389 21.2258C30.6987 23.1468 29.5958 24.9747 28.2354 26.4888C28.065 26.6819 27.8284 26.7681 27.5988 26.706L27.5118 26.675L23.5594 25.33C22.6931 26.0232 21.7224 26.5957 20.6891 27.0302L20.2959 27.1854L19.5096 31.1861C19.4609 31.4378 19.2382 31.6689 18.9634 31.7034C17.9405 31.8896 16.9141 32 15.8599 32C14.8057 32 13.7794 31.8896 12.753 31.7034C12.5129 31.6758 12.3077 31.4861 12.2311 31.2689L12.2103 31.1861L11.4274 27.1854C10.3628 26.7785 9.33295 26.2336 8.44923 25.5576L8.16046 25.3265L4.20809 26.6716C3.95063 26.7819 3.67925 26.7026 3.4879 26.4819C2.12753 24.9678 1.02462 23.1399 0.384448 21.2189C0.283551 20.9982 0.335739 20.7361 0.50622 20.574L0.575804 20.5188L3.71056 17.8632C3.59923 17.27 3.56792 16.632 3.56792 16.0043C3.56792 15.5042 3.58879 14.9938 3.6549 14.5075L3.71404 14.1454L0.579283 11.4898C0.356614 11.3311 0.273114 11.038 0.387927 10.7862C1.0281 8.86523 2.13101 7.03734 3.49137 5.52331C3.66185 5.33017 3.89844 5.2474 4.12807 5.30603L4.21505 5.33362L8.16742 6.67867C9.01635 5.9751 10.0218 5.39915 11.0795 4.96115L11.4344 4.81975L12.2172 0.822547C12.2659 0.570782 12.4886 0.336261 12.7634 0.305222C14.8127 -0.101741 16.9246 -0.101741 18.9738 0.305222H18.9703ZM103.125 11.0207C103.915 11.0207 104.646 11.1932 105.321 11.5346C105.992 11.8761 106.573 12.3727 107.06 13.0211C107.547 13.6695 107.93 14.4592 108.208 15.3973C108.487 16.3354 108.626 17.3976 108.626 18.5875C108.626 19.7015 108.466 20.7292 108.149 21.6707C107.833 22.6123 107.387 23.4331 106.817 24.1263C106.246 24.8195 105.564 25.3644 104.767 25.7542C103.974 26.1439 103.094 26.3405 102.127 26.3405C101.337 26.3405 100.672 26.2301 100.137 26.0128C99.6008 25.7955 99.1137 25.4989 98.6753 25.1265V30.8102H94.1419V11.3105H97.0888C97.3115 11.3311 97.5029 11.3932 97.6594 11.4967C97.8508 11.6208 97.983 11.8071 98.063 12.0519L98.4005 13.1383L98.6232 12.9073C98.8493 12.6831 99.0894 12.4727 99.3434 12.2796C99.6808 12.0209 100.039 11.8002 100.425 11.6174C100.812 11.4312 101.226 11.2863 101.667 11.1828C102.113 11.0794 102.596 11.0242 103.122 11.0242L103.125 11.0207ZM60.4737 11.0794C61.4792 11.0794 62.3977 11.2311 63.2292 11.5346C64.0643 11.8381 64.781 12.283 65.3794 12.8624C65.9778 13.4418 66.4475 14.1557 66.785 14.9973C67.1225 15.8388 67.2895 16.7941 67.2895 17.8598C67.2895 18.1943 67.2756 18.4633 67.2442 18.6737C67.2164 18.8841 67.1607 19.0496 67.0842 19.1738C67.0077 19.2979 66.8998 19.3842 66.7711 19.4325C66.6423 19.4807 66.4719 19.5049 66.2666 19.5049H57.5199L57.5512 19.7463C57.7182 20.8603 58.0905 21.6742 58.675 22.195C59.2977 22.7502 60.1049 23.0296 61.0895 23.0296C61.6149 23.0296 62.0707 22.9675 62.4499 22.8433C62.8291 22.7192 63.1701 22.5812 63.4658 22.4295C63.7616 22.2777 64.0364 22.1398 64.2834 22.0156C64.5305 21.8915 64.7914 21.8294 65.0663 21.8294C65.4281 21.8294 65.6995 21.957 65.8839 22.2157L67.199 23.8021L66.9972 24.0194C66.5867 24.4436 66.1518 24.7988 65.6856 25.0782C65.1428 25.4058 64.5896 25.6645 64.019 25.8507C63.4484 26.037 62.8778 26.1646 62.3073 26.237C61.7367 26.3094 61.1939 26.3439 60.6755 26.3439C59.6144 26.3439 58.6158 26.1749 57.6834 25.8369C56.751 25.499 55.9368 24.9954 55.241 24.3298C54.5452 23.6642 53.992 22.8365 53.5884 21.8466C53.1848 20.8568 52.983 19.7049 52.983 18.3909C52.983 17.4011 53.157 16.463 53.5014 15.5767C53.8458 14.6903 54.3434 13.9143 54.994 13.2487C55.6411 12.5831 56.4274 12.0554 57.3494 11.6622C58.2714 11.2725 59.3117 11.0759 60.4737 11.0759V11.0794ZM84.7237 11.0794C85.7292 11.0794 86.6477 11.2311 87.4793 11.5346C88.3143 11.8381 89.031 12.283 89.6294 12.8624C90.2278 13.4418 90.6975 14.1557 91.035 14.9973C91.3725 15.8388 91.5395 16.7941 91.5395 17.8598C91.5395 18.1943 91.5256 18.4633 91.4943 18.6737C91.4664 18.8841 91.4108 19.0496 91.3342 19.1738C91.2577 19.2979 91.1498 19.3842 91.0211 19.4325C90.8889 19.4807 90.7219 19.5049 90.5166 19.5049H81.7699L81.8012 19.7463C81.9682 20.8603 82.3405 21.6742 82.925 22.195C83.5478 22.7502 84.355 23.0296 85.3396 23.0296C85.8649 23.0296 86.3207 22.9675 86.6999 22.8433C87.0792 22.7192 87.4201 22.5812 87.7159 22.4295C88.0116 22.2777 88.2864 22.1398 88.5335 22.0156C88.7805 21.8915 89.0414 21.8294 89.3163 21.8294C89.6781 21.8294 89.9495 21.957 90.1339 22.2157L91.449 23.8021L91.2472 24.0194C90.8367 24.4436 90.4018 24.7988 89.9356 25.0782C89.3928 25.4058 88.8396 25.6645 88.2691 25.8507C87.6985 26.037 87.1279 26.1646 86.5573 26.237C85.9867 26.3094 85.4439 26.3439 84.9255 26.3439C83.8644 26.3439 82.8659 26.1749 81.9334 25.8369C81.001 25.499 80.1869 24.9954 79.491 24.3298C78.7952 23.6642 78.242 22.8365 77.8384 21.8466C77.4348 20.8568 77.233 19.7049 77.233 18.3909C77.233 17.4011 77.407 16.463 77.7514 15.5767C78.0959 14.6903 78.5934 13.9143 79.244 13.2487C79.8911 12.5831 80.6774 12.0554 81.5994 11.6622C82.5214 11.2725 83.5617 11.0759 84.7237 11.0759V11.0794ZM117.807 11.0794C118.959 11.0794 120.006 11.2553 120.953 11.607C121.899 11.9588 122.71 12.4624 123.388 13.1211C124.067 13.7764 124.592 14.5765 124.968 15.5111C125.343 16.4492 125.531 17.5011 125.531 18.6737C125.531 19.8463 125.343 20.9189 124.968 21.8639C124.592 22.8123 124.067 23.6159 123.388 24.2781C122.71 24.9402 121.899 25.4472 120.953 25.8059C120.006 26.1611 118.959 26.3405 117.807 26.3405C116.656 26.3405 115.591 26.1611 114.641 25.8059C113.692 25.4507 112.87 24.9402 112.185 24.2781C111.496 23.6159 110.967 22.8123 110.592 21.8639C110.216 20.9155 110.028 19.8532 110.028 18.6737C110.028 17.4942 110.216 16.4492 110.592 15.5111C110.967 14.573 111.5 13.7764 112.185 13.1211C112.87 12.4658 113.692 11.9588 114.641 11.607C115.591 11.2553 116.649 11.0794 117.807 11.0794ZM145.509 7.00975V11.3346H149.193V14.3627H145.509V21.7156L145.516 21.8604C145.537 22.1398 145.62 22.3743 145.766 22.5674C145.937 22.7916 146.184 22.902 146.504 22.902C146.671 22.902 146.81 22.8847 146.921 22.8537C147.033 22.8227 147.13 22.7813 147.214 22.7399C147.297 22.6985 147.374 22.6606 147.447 22.6261C147.52 22.5916 147.607 22.5778 147.704 22.5778C147.84 22.5778 147.951 22.6088 148.035 22.6709C148.118 22.733 148.202 22.8296 148.292 22.9641L149.667 25.0644L149.444 25.2196C148.915 25.5714 148.33 25.8404 147.694 26.0266C146.963 26.2404 146.208 26.3474 145.425 26.3474C144.705 26.3474 144.068 26.2439 143.515 26.0404C142.966 25.8369 142.503 25.5438 142.127 25.1679C141.751 24.7919 141.466 24.3367 141.271 23.8056C141.076 23.271 140.979 22.6778 140.979 22.0225V14.3696H139.692L139.577 14.3627C139.392 14.342 139.229 14.2695 139.09 14.1488C138.923 14.0005 138.843 13.7833 138.843 13.5005V11.7726L141.257 11.3173L142.148 7.70642L142.183 7.59606C142.322 7.21324 142.642 7.0201 143.143 7.0201H145.512L145.509 7.00975ZM55.495 5.31293V9.13768H49.4968V26.1128H44.5529V9.13768H38.5548V5.31293H55.4915H55.495ZM74.5749 4.74042V26.1128H70.0415V4.74042H74.5749ZM136.414 11.0242C137.107 11.0242 137.663 11.1863 138.081 11.5105L137.496 14.7662L137.468 14.88C137.423 15.0214 137.357 15.1249 137.263 15.1869C137.145 15.2663 136.992 15.3076 136.793 15.3076C136.626 15.3076 136.432 15.287 136.209 15.2421C135.986 15.2007 135.701 15.1766 135.36 15.1766C134.17 15.1766 133.234 15.7939 132.552 17.0321V26.1128H128.019V11.3105H130.872C131.025 11.3208 131.161 11.338 131.272 11.3691C131.422 11.407 131.55 11.4656 131.651 11.5484C131.752 11.6277 131.832 11.7381 131.884 11.8692C131.937 12.0037 131.985 12.1658 132.023 12.3554L132.27 13.7419L132.458 13.4694C132.966 12.759 133.526 12.1899 134.142 11.7588C134.835 11.2725 135.59 11.0311 136.411 11.0311L136.414 11.0242ZM15.8634 6.63728C10.6516 6.63728 6.42782 10.8276 6.42782 15.9974C6.42782 21.1672 10.6516 25.3575 15.8634 25.3575C21.0753 25.3575 25.299 21.1672 25.299 15.9974C25.299 10.8276 21.0753 6.63728 15.8634 6.63728ZM101.546 14.4075C101.215 14.4075 100.916 14.4385 100.645 14.5006C100.377 14.5627 100.126 14.6489 99.9 14.7662C99.6704 14.88 99.4582 15.0248 99.2633 15.2007C99.0685 15.3766 98.8737 15.5801 98.6788 15.8077V22.0915L98.8284 22.2432C99.1276 22.533 99.4477 22.7433 99.7922 22.8675C100.192 23.0158 100.61 23.0882 101.052 23.0882C101.493 23.0882 101.855 23.0089 102.207 22.8468C102.558 22.6847 102.861 22.426 103.122 22.0674C103.379 21.7121 103.581 21.2465 103.727 20.674C103.873 20.1015 103.946 19.4083 103.946 18.5909C103.946 17.7736 103.887 17.1528 103.772 16.6217C103.654 16.0871 103.491 15.6594 103.282 15.3283C103.073 15.0007 102.823 14.7627 102.527 14.6213C102.235 14.4799 101.908 14.4075 101.546 14.4075ZM117.811 14.3661C116.739 14.3661 115.953 14.7213 115.456 15.4353C114.958 16.1492 114.711 17.239 114.711 18.7047C114.711 20.1705 114.958 21.2638 115.456 21.9811C115.953 22.6985 116.739 23.0606 117.811 23.0606C118.883 23.0606 119.624 22.7019 120.114 21.9811C120.608 21.2638 120.852 20.1705 120.852 18.7047C120.852 17.239 120.605 16.1492 120.114 15.4353C119.62 14.7213 118.855 14.3661 117.811 14.3661ZM21.8372 11.9105V14.6972H17.2864V21.3879H14.4439V14.6972H9.8931V11.9105H21.8372ZM60.5642 14.135C59.6979 14.135 59.0194 14.3765 58.5323 14.8559C58.0452 15.3352 57.7217 16.0285 57.5686 16.932H63.2292C63.2292 16.5803 63.184 16.2388 63.0901 15.9043C62.9961 15.5698 62.8465 15.2732 62.6378 15.011C62.429 14.7489 62.1542 14.5386 61.8097 14.3765C61.4688 14.2144 61.0547 14.135 60.5677 14.135H60.5642ZM84.8142 14.135C83.9479 14.135 83.2694 14.3765 82.7824 14.8559C82.2953 15.3352 81.9717 16.0285 81.8186 16.932H87.4793C87.4793 16.5803 87.434 16.2388 87.3401 15.9043C87.2462 15.5698 87.0966 15.2732 86.8878 15.011C86.6791 14.7489 86.4042 14.5386 86.0598 14.3765C85.7188 14.2144 85.3048 14.135 84.8177 14.135H84.8142Z"
+            fill="white"
+            fill-rule="evenodd"
+          />
+        </svg>
+      </div>
+      <div
+        class="c4"
+      >
+        <div
+          class="c5"
+        >
+          <span
+            class="c6 icon icon-arrowback"
+            style="cursor: pointer;"
+          >
+            <svg
+              fill="currentColor"
+              height="24"
+              viewBox="0 0 24 24"
+              width="24"
+            >
+              <path
+                d="M11.0303 5.78033C11.3232 5.48744 11.3232 5.01256 11.0303 4.71967C10.7374 4.42678 10.2626 4.42678 9.96967 4.71967L3.21967 11.4697C3.07322 11.6161 3 11.8081 3 12C3 12.1017 3.02024 12.1987 3.05691 12.2871C3.09268 12.3735 3.14531 12.4547 3.2148 12.5254"
+              />
+              <path
+                d="M3.22014 12.5308L9.96967 19.2803C10.2626 19.5732 10.7374 19.5732 11.0303 19.2803C11.3232 18.9874 11.3232 18.5126 11.0303 18.2197L5.56066 12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H5.56066L11.0303 5.78033"
+              />
+            </svg>
+          </span>
+          <div
+            class="c7"
+          >
+            <div
+              class="c8"
+              color="text.main"
+            >
+              Set Two-Factor Device
+            </div>
+            <div
+              class="c9"
+              color="text.slightlyMuted"
+            >
+              Step 2 of 2
+            </div>
+          </div>
+        </div>
+        <div
+          class="c10"
+          color="text.main"
+        >
+          Two-Factor Method
+        </div>
+        <div
+          class="c11"
+        >
+          <div
+            class="c12"
+          >
+            <label
+              class="c13"
+            >
+              <input
+                checked=""
+                class="c14"
+                name="mfaType"
+                type="radio"
+                value="webauthn"
+              />
+              <span>
+                Hardware Key
+              </span>
+            </label>
+            <label
+              class="c13"
+            >
+              <input
+                class="c14"
+                name="mfaType"
+                type="radio"
+                value="otp"
+              />
+              <span>
+                Authenticator App
+              </span>
+            </label>
+          </div>
+        </div>
+        <div
+          class="c15"
+          height="240px"
+        >
+          <img
+            class="c16"
+            height="154px"
+            src="file_stub"
+            width="220px"
+          />
+          <div
+            class="c17"
+            color="text.slightlyMuted"
+            font-size="1"
+          >
+            We support a wide range of hardware devices including YubiKeys, Touch ID, watches, and more.
+          </div>
+        </div>
+        <div
+          class="c18"
+          height="100"
+        >
+          <div
+            class="c19"
+            width="100%"
+          >
+            <label
+              class="c20"
+              font-size="0"
+            >
+              Device Name
+              <input
+                autocomplete="off"
+                class="c21"
+                inputmode="text"
+                placeholder="Name"
+                type="text"
+                value="webauthn-device"
+              />
+            </label>
+          </div>
+        </div>
+        <button
+          class="c22"
+          kind="primary"
+          width="100%"
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+    <footer
+      class="c23"
+    >
+      <div
+        class="c24"
+      >
+        <div
+          class="c25"
+        >
+          © Gravitational, Inc. All Rights Reserved
+        </div>
+        <a
+          class="c26 c27"
+          href="https://goteleport.com/legal/tos/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Terms of Service
+        </a>
+        <a
+          class="c26 c27"
+          href="https://goteleport.com/legal/privacy/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          Privacy Policy
+        </a>
+      </div>
+    </footer>
+  </div>
+</div>
+`;
+
+exports[`story.MfaDeviceOtp 1`] = `
+.c7 {
   box-sizing: border-box;
 }
 
@@ -87,7 +1162,7 @@ exports[`story.MfaDeviceError 1`] = `
   cursor: auto;
 }
 
-.c7 {
+.c8 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
@@ -97,7 +1172,7 @@ exports[`story.MfaDeviceError 1`] = `
   color: #FFFFFF;
 }
 
-.c8 {
+.c9 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
@@ -132,7 +1207,7 @@ exports[`story.MfaDeviceError 1`] = `
   margin: 0px;
 }
 
-.c5 {
+.c6 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -210,7 +1285,13 @@ exports[`story.MfaDeviceError 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c5 {
   box-sizing: border-box;
   margin-bottom: 16px;
   display: flex;
@@ -296,7 +1377,7 @@ exports[`story.MfaDeviceError 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -316,7 +1397,7 @@ exports[`story.MfaDeviceError 1`] = `
   cursor: inherit;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -324,7 +1405,7 @@ exports[`story.MfaDeviceError 1`] = `
   width: 600px;
   padding: 24px;
   text-align: left;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
@@ -341,14 +1422,14 @@ exports[`story.MfaDeviceError 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -360,9 +1441,11 @@ exports[`story.MfaDeviceError 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -380,13 +1463,13 @@ exports[`story.MfaDeviceError 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
         >
           <span
-            class="c5 icon icon-arrowback"
+            class="c6 icon icon-arrowback"
             style="cursor: pointer;"
           >
             <svg
@@ -404,27 +1487,21 @@ exports[`story.MfaDeviceError 1`] = `
             </svg>
           </span>
           <div
-            class="c6"
+            class="c7"
           >
             <div
-              class="c7"
+              class="c8"
               color="text.main"
             >
               Set Two-Factor Device
             </div>
             <div
-              class="c8"
+              class="c9"
               color="text.slightlyMuted"
             >
               Step 2 of 2
             </div>
           </div>
-        </div>
-        <div
-          class="c9"
-          kind="danger"
-        >
-          some server error message
         </div>
         <div
           class="c10"
@@ -533,7 +1610,7 @@ exports[`story.MfaDeviceError 1`] = `
           Submit
         </button>
       </div>
-    </span>
+    </div>
     <footer
       class="c26"
     >
@@ -567,24 +1644,24 @@ exports[`story.MfaDeviceError 1`] = `
 </div>
 `;
 
-exports[`story.MfaDeviceOn 1`] = `
-.c6 {
+exports[`story.MfaDeviceWebauthn 1`] = `
+.c7 {
   box-sizing: border-box;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   margin-bottom: 4px;
 }
 
-.c18 {
+.c19 {
   box-sizing: border-box;
   margin-bottom: 24px;
   margin-right: 0px;
   width: 100%;
 }
 
-.c21 {
+.c22 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -612,22 +1689,22 @@ exports[`story.MfaDeviceOn 1`] = `
   width: 100%;
 }
 
-.c21:hover,
-.c21:focus {
+.c22:hover,
+.c22:focus {
   background: #B29DFF;
 }
 
-.c21:active {
+.c22:active {
   background: #C5B6FF;
 }
 
-.c21:disabled {
+.c22:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c7 {
+.c8 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
@@ -637,14 +1714,14 @@ exports[`story.MfaDeviceOn 1`] = `
   color: #FFFFFF;
 }
 
-.c8 {
+.c9 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
   color: rgba(255,255,255,0.72);
 }
 
-.c9 {
+.c10 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -656,7 +1733,7 @@ exports[`story.MfaDeviceOn 1`] = `
   color: #FFFFFF;
 }
 
-.c16 {
+.c17 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 12px;
@@ -665,20 +1742,20 @@ exports[`story.MfaDeviceOn 1`] = `
   text-align: center;
 }
 
-.c24 {
+.c25 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c5 {
+.c6 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
   margin-right: 16px;
 }
 
-.c20 {
+.c21 {
   appearance: none;
   border: 1px solid rgba(255,255,255,0.54);
   border-radius: 4px;
@@ -694,31 +1771,31 @@ exports[`story.MfaDeviceOn 1`] = `
   margin-top: 4px;
 }
 
-.c20:hover,
-.c20:focus,
-.c20:active {
+.c21:hover,
+.c21:focus,
+.c21:active {
   border: 1px solid rgba(255,255,255,0.72);
 }
 
-.c20::-ms-clear {
+.c21::-ms-clear {
   display: none;
 }
 
-.c20::placeholder {
+.c21::placeholder {
   color: rgba(255,255,255,0.54);
   opacity: 1;
 }
 
-.c20:read-only {
+.c21:read-only {
   cursor: not-allowed;
 }
 
-.c20:disabled {
+.c21:disabled {
   color: rgba(255,255,255,0.36);
   border-color: rgba(255,255,255,0.36);
 }
 
-.c19 {
+.c20 {
   color: #FFFFFF;
   display: block;
   font-size: 12px;
@@ -726,7 +1803,7 @@ exports[`story.MfaDeviceOn 1`] = `
   margin-bottom: 0px;
 }
 
-.c25 {
+.c26 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -734,7 +1811,7 @@ exports[`story.MfaDeviceOn 1`] = `
   text-transform: none;
 }
 
-.c15 {
+.c16 {
   display: block;
   outline: none;
   width: 220px;
@@ -749,21 +1826,27 @@ exports[`story.MfaDeviceOn 1`] = `
   flex-direction: column;
 }
 
-.c4 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c5 {
   box-sizing: border-box;
   margin-bottom: 16px;
   display: flex;
   align-items: center;
 }
 
-.c11 {
+.c12 {
   box-sizing: border-box;
   display: flex;
   flex-direction: row;
   gap: 16px;
 }
 
-.c14 {
+.c15 {
   box-sizing: border-box;
   padding-left: 16px;
   padding-right: 16px;
@@ -775,14 +1858,14 @@ exports[`story.MfaDeviceOn 1`] = `
   flex-direction: column;
 }
 
-.c17 {
+.c18 {
   box-sizing: border-box;
   height: 100px;
   display: flex;
   align-items: center;
 }
 
-.c23 {
+.c24 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -790,20 +1873,20 @@ exports[`story.MfaDeviceOn 1`] = `
   gap: 50px;
 }
 
-.c22 {
+.c23 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c26 {
+.c27 {
   color: white;
   text-decoration: none;
 }
 
-.c26:hover,
-.c26:active,
-.c26:focus {
+.c27:hover,
+.c27:active,
+.c27:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -835,7 +1918,7 @@ exports[`story.MfaDeviceOn 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -843,19 +1926,19 @@ exports[`story.MfaDeviceOn 1`] = `
   margin: 24px 0;
 }
 
-.c12 {
+.c13 {
   display: flex;
   align-items: center;
   cursor: pointer;
 }
 
-.c13 {
+.c14 {
   margin: 0 8px 0 0;
   accent-color: #9F85FF;
   cursor: inherit;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -863,12 +1946,12 @@ exports[`story.MfaDeviceOn 1`] = `
   width: 600px;
   padding: 24px;
   text-align: left;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c23 {
+  .c24 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -876,14 +1959,14 @@ exports[`story.MfaDeviceOn 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -895,9 +1978,11 @@ exports[`story.MfaDeviceOn 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -915,13 +2000,13 @@ exports[`story.MfaDeviceOn 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
         >
           <span
-            class="c5 icon icon-arrowback"
+            class="c6 icon icon-arrowback"
             style="cursor: pointer;"
           >
             <svg
@@ -939,16 +2024,16 @@ exports[`story.MfaDeviceOn 1`] = `
             </svg>
           </span>
           <div
-            class="c6"
+            class="c7"
           >
             <div
-              class="c7"
+              class="c8"
               color="text.main"
             >
               Set Two-Factor Device
             </div>
             <div
-              class="c8"
+              class="c9"
               color="text.slightlyMuted"
             >
               Step 2 of 2
@@ -956,23 +2041,23 @@ exports[`story.MfaDeviceOn 1`] = `
           </div>
         </div>
         <div
-          class="c9"
+          class="c10"
           color="text.main"
         >
           Two-Factor Method
         </div>
         <div
-          class="c10"
+          class="c11"
         >
           <div
-            class="c11"
+            class="c12"
           >
             <label
-              class="c12"
+              class="c13"
             >
               <input
                 checked=""
-                class="c13"
+                class="c14"
                 name="mfaType"
                 type="radio"
                 value="webauthn"
@@ -981,1095 +2066,42 @@ exports[`story.MfaDeviceOn 1`] = `
                 Hardware Key
               </span>
             </label>
-            <label
-              class="c12"
-            >
-              <input
-                class="c13"
-                name="mfaType"
-                type="radio"
-                value="otp"
-              />
-              <span>
-                Authenticator App
-              </span>
-            </label>
           </div>
         </div>
         <div
-          class="c14"
+          class="c15"
           height="240px"
         >
           <img
-            class="c15"
+            class="c16"
             height="154px"
             src="file_stub"
             width="220px"
-          />
-          <div
-            class="c16"
-            color="text.slightlyMuted"
-            font-size="1"
-          >
-            We support a wide range of hardware devices including YubiKeys, Touch ID, watches, and more.
-          </div>
-        </div>
-        <div
-          class="c17"
-          height="100"
-        >
-          <div
-            class="c18"
-            width="100%"
-          >
-            <label
-              class="c19"
-              font-size="0"
-            >
-              Device Name
-              <input
-                autocomplete="off"
-                class="c20"
-                inputmode="text"
-                placeholder="Name"
-                type="text"
-                value="webauthn-device"
-              />
-            </label>
-          </div>
-        </div>
-        <button
-          class="c21"
-          kind="primary"
-          width="100%"
-        >
-          Submit
-        </button>
-      </div>
-    </span>
-    <footer
-      class="c22"
-    >
-      <div
-        class="c23"
-      >
-        <div
-          class="c24"
-        >
-          © Gravitational, Inc. All Rights Reserved
-        </div>
-        <a
-          class="c25 c26"
-          href="https://goteleport.com/legal/tos/"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Terms of Service
-        </a>
-        <a
-          class="c25 c26"
-          href="https://goteleport.com/legal/privacy/"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Privacy Policy
-        </a>
-      </div>
-    </footer>
-  </div>
-</div>
-`;
-
-exports[`story.MfaDeviceOtp 1`] = `
-.c6 {
-  box-sizing: border-box;
-}
-
-.c10 {
-  box-sizing: border-box;
-  margin-bottom: 4px;
-}
-
-.c20 {
-  box-sizing: border-box;
-  margin-bottom: 24px;
-  margin-right: 16px;
-  width: 50%;
-}
-
-.c23 {
-  box-sizing: border-box;
-  margin-bottom: 24px;
-  width: 50%;
-}
-
-.c24 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  color: #000000;
-  background: #9F85FF;
-  min-height: 40px;
-  font-size: 12px;
-  padding: 0px 40px;
-  margin-top: 8px;
-  width: 100%;
-}
-
-.c24:hover,
-.c24:focus {
-  background: #B29DFF;
-}
-
-.c24:active {
-  background: #C5B6FF;
-}
-
-.c24:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-  cursor: auto;
-}
-
-.c7 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  font-size: 18px;
-  line-height: 32px;
-  margin: 0px;
-  color: #FFFFFF;
-}
-
-.c8 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-  color: rgba(255,255,255,0.72);
-}
-
-.c9 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 24px;
-  text-transform: uppercase;
-  margin: 0px;
-  margin-bottom: 4px;
-  color: #FFFFFF;
-}
-
-.c17 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 12px;
-  margin: 0px;
-  margin-top: 8px;
-  color: rgba(255,255,255,0.72);
-  text-align: center;
-}
-
-.c27 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-}
-
-.c5 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-right: 16px;
-}
-
-.c22 {
-  appearance: none;
-  border: 1px solid rgba(255,255,255,0.54);
-  border-radius: 4px;
-  box-sizing: border-box;
-  display: block;
-  height: 40px;
-  font-size: 16px;
-  padding: 0 16px;
-  outline: none;
-  width: 100%;
-  background: #222C59;
-  color: #FFFFFF;
-  margin-top: 4px;
-}
-
-.c22:hover,
-.c22:focus,
-.c22:active {
-  border: 1px solid rgba(255,255,255,0.72);
-}
-
-.c22::-ms-clear {
-  display: none;
-}
-
-.c22::placeholder {
-  color: rgba(255,255,255,0.54);
-  opacity: 1;
-}
-
-.c22:read-only {
-  cursor: not-allowed;
-}
-
-.c22:disabled {
-  color: rgba(255,255,255,0.36);
-  border-color: rgba(255,255,255,0.36);
-}
-
-.c21 {
-  color: #FFFFFF;
-  display: block;
-  font-size: 12px;
-  width: 100%;
-  margin-bottom: 0px;
-}
-
-.c18 {
-  color: #009EFF;
-  font-weight: normal;
-  background: none;
-  text-decoration: underline;
-  text-transform: none;
-}
-
-.c15 {
-  display: block;
-  outline: none;
-  width: 145px;
-  height: 145px;
-}
-
-.c1 {
-  box-sizing: border-box;
-  height: 100%;
-  display: flex;
-  justify-content: space-between;
-  flex-direction: column;
-}
-
-.c4 {
-  box-sizing: border-box;
-  margin-bottom: 16px;
-  display: flex;
-  align-items: center;
-}
-
-.c11 {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: row;
-  gap: 16px;
-}
-
-.c14 {
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  height: 240px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-}
-
-.c19 {
-  box-sizing: border-box;
-  height: 100px;
-  display: flex;
-  align-items: center;
-}
-
-.c26 {
-  box-sizing: border-box;
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  gap: 50px;
-}
-
-.c25 {
-  padding-bottom: 24px;
-  width: 100%;
-  color: white;
-}
-
-.c28 {
-  color: white;
-  text-decoration: none;
-}
-
-.c28:hover,
-.c28:active,
-.c28:focus {
-  color: rgba(255,255,255,0.54);
-}
-
-.c0 {
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  top: 0;
-  left: 0;
-  overflow: hidden;
-  z-index: -2;
-  background: url('file_stub');
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-}
-
-.c0::after {
-  content: '';
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  position: absolute;
-  z-index: -1;
-  background-color: black;
-  opacity: 0.25;
-  backdrop-filter: blur(17.5px);
-}
-
-.c2 {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 24px 0;
-}
-
-.c12 {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-
-.c13 {
-  margin: 0 8px 0 0;
-  accent-color: #9F85FF;
-  cursor: inherit;
-}
-
-.c3 {
-  box-sizing: border-box;
-  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
-  border-radius: 8px;
-  background-color: #222C59;
-  width: 600px;
-  padding: 24px;
-  text-align: left;
-  margin: 40px auto auto auto;
-  overflow-y: auto;
-}
-
-.c16 {
-  border: 4px solid white;
-}
-
-@media screen and (max-width:800px) {
-  .c26 {
-    flex-direction: column-reverse;
-    text-align: center;
-    gap: 10px;
-  }
-}
-
-@media screen and (max-width:800px) {
-  .c3 {
-    width: auto;
-    margin: 20px;
-  }
-}
-
-@media screen and (max-height:760px) {
-  .c3 {
-    height: calc(100vh - 250px);
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    height="100%"
-  >
-    <span>
-      <div
-        class="c2"
-      >
-        <svg
-          fill="none"
-          height="32"
-          viewBox="0 0 150 32"
-          width="150"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M18.9703 0.305222C19.2104 0.332812 19.4157 0.519049 19.4922 0.739775L19.5131 0.822547L20.2959 4.81975C21.3466 5.22326 22.3382 5.76128 23.2324 6.42345L23.5629 6.67867L27.5153 5.33362C27.7727 5.22326 28.0441 5.30258 28.2354 5.52331C29.5958 7.03734 30.6987 8.86523 31.3424 10.7862C31.4433 11.007 31.3911 11.2656 31.2206 11.4312L31.151 11.4898L28.0128 14.1454C28.1241 14.7386 28.1554 15.3801 28.1554 16.0043C28.1554 16.5078 28.1346 17.0148 28.0684 17.5046L28.0093 17.8667L31.1475 20.5223C31.3702 20.6775 31.4502 20.9741 31.3389 21.2258C30.6987 23.1468 29.5958 24.9747 28.2354 26.4888C28.065 26.6819 27.8284 26.7681 27.5988 26.706L27.5118 26.675L23.5594 25.33C22.6931 26.0232 21.7224 26.5957 20.6891 27.0302L20.2959 27.1854L19.5096 31.1861C19.4609 31.4378 19.2382 31.6689 18.9634 31.7034C17.9405 31.8896 16.9141 32 15.8599 32C14.8057 32 13.7794 31.8896 12.753 31.7034C12.5129 31.6758 12.3077 31.4861 12.2311 31.2689L12.2103 31.1861L11.4274 27.1854C10.3628 26.7785 9.33295 26.2336 8.44923 25.5576L8.16046 25.3265L4.20809 26.6716C3.95063 26.7819 3.67925 26.7026 3.4879 26.4819C2.12753 24.9678 1.02462 23.1399 0.384448 21.2189C0.283551 20.9982 0.335739 20.7361 0.50622 20.574L0.575804 20.5188L3.71056 17.8632C3.59923 17.27 3.56792 16.632 3.56792 16.0043C3.56792 15.5042 3.58879 14.9938 3.6549 14.5075L3.71404 14.1454L0.579283 11.4898C0.356614 11.3311 0.273114 11.038 0.387927 10.7862C1.0281 8.86523 2.13101 7.03734 3.49137 5.52331C3.66185 5.33017 3.89844 5.2474 4.12807 5.30603L4.21505 5.33362L8.16742 6.67867C9.01635 5.9751 10.0218 5.39915 11.0795 4.96115L11.4344 4.81975L12.2172 0.822547C12.2659 0.570782 12.4886 0.336261 12.7634 0.305222C14.8127 -0.101741 16.9246 -0.101741 18.9738 0.305222H18.9703ZM103.125 11.0207C103.915 11.0207 104.646 11.1932 105.321 11.5346C105.992 11.8761 106.573 12.3727 107.06 13.0211C107.547 13.6695 107.93 14.4592 108.208 15.3973C108.487 16.3354 108.626 17.3976 108.626 18.5875C108.626 19.7015 108.466 20.7292 108.149 21.6707C107.833 22.6123 107.387 23.4331 106.817 24.1263C106.246 24.8195 105.564 25.3644 104.767 25.7542C103.974 26.1439 103.094 26.3405 102.127 26.3405C101.337 26.3405 100.672 26.2301 100.137 26.0128C99.6008 25.7955 99.1137 25.4989 98.6753 25.1265V30.8102H94.1419V11.3105H97.0888C97.3115 11.3311 97.5029 11.3932 97.6594 11.4967C97.8508 11.6208 97.983 11.8071 98.063 12.0519L98.4005 13.1383L98.6232 12.9073C98.8493 12.6831 99.0894 12.4727 99.3434 12.2796C99.6808 12.0209 100.039 11.8002 100.425 11.6174C100.812 11.4312 101.226 11.2863 101.667 11.1828C102.113 11.0794 102.596 11.0242 103.122 11.0242L103.125 11.0207ZM60.4737 11.0794C61.4792 11.0794 62.3977 11.2311 63.2292 11.5346C64.0643 11.8381 64.781 12.283 65.3794 12.8624C65.9778 13.4418 66.4475 14.1557 66.785 14.9973C67.1225 15.8388 67.2895 16.7941 67.2895 17.8598C67.2895 18.1943 67.2756 18.4633 67.2442 18.6737C67.2164 18.8841 67.1607 19.0496 67.0842 19.1738C67.0077 19.2979 66.8998 19.3842 66.7711 19.4325C66.6423 19.4807 66.4719 19.5049 66.2666 19.5049H57.5199L57.5512 19.7463C57.7182 20.8603 58.0905 21.6742 58.675 22.195C59.2977 22.7502 60.1049 23.0296 61.0895 23.0296C61.6149 23.0296 62.0707 22.9675 62.4499 22.8433C62.8291 22.7192 63.1701 22.5812 63.4658 22.4295C63.7616 22.2777 64.0364 22.1398 64.2834 22.0156C64.5305 21.8915 64.7914 21.8294 65.0663 21.8294C65.4281 21.8294 65.6995 21.957 65.8839 22.2157L67.199 23.8021L66.9972 24.0194C66.5867 24.4436 66.1518 24.7988 65.6856 25.0782C65.1428 25.4058 64.5896 25.6645 64.019 25.8507C63.4484 26.037 62.8778 26.1646 62.3073 26.237C61.7367 26.3094 61.1939 26.3439 60.6755 26.3439C59.6144 26.3439 58.6158 26.1749 57.6834 25.8369C56.751 25.499 55.9368 24.9954 55.241 24.3298C54.5452 23.6642 53.992 22.8365 53.5884 21.8466C53.1848 20.8568 52.983 19.7049 52.983 18.3909C52.983 17.4011 53.157 16.463 53.5014 15.5767C53.8458 14.6903 54.3434 13.9143 54.994 13.2487C55.6411 12.5831 56.4274 12.0554 57.3494 11.6622C58.2714 11.2725 59.3117 11.0759 60.4737 11.0759V11.0794ZM84.7237 11.0794C85.7292 11.0794 86.6477 11.2311 87.4793 11.5346C88.3143 11.8381 89.031 12.283 89.6294 12.8624C90.2278 13.4418 90.6975 14.1557 91.035 14.9973C91.3725 15.8388 91.5395 16.7941 91.5395 17.8598C91.5395 18.1943 91.5256 18.4633 91.4943 18.6737C91.4664 18.8841 91.4108 19.0496 91.3342 19.1738C91.2577 19.2979 91.1498 19.3842 91.0211 19.4325C90.8889 19.4807 90.7219 19.5049 90.5166 19.5049H81.7699L81.8012 19.7463C81.9682 20.8603 82.3405 21.6742 82.925 22.195C83.5478 22.7502 84.355 23.0296 85.3396 23.0296C85.8649 23.0296 86.3207 22.9675 86.6999 22.8433C87.0792 22.7192 87.4201 22.5812 87.7159 22.4295C88.0116 22.2777 88.2864 22.1398 88.5335 22.0156C88.7805 21.8915 89.0414 21.8294 89.3163 21.8294C89.6781 21.8294 89.9495 21.957 90.1339 22.2157L91.449 23.8021L91.2472 24.0194C90.8367 24.4436 90.4018 24.7988 89.9356 25.0782C89.3928 25.4058 88.8396 25.6645 88.2691 25.8507C87.6985 26.037 87.1279 26.1646 86.5573 26.237C85.9867 26.3094 85.4439 26.3439 84.9255 26.3439C83.8644 26.3439 82.8659 26.1749 81.9334 25.8369C81.001 25.499 80.1869 24.9954 79.491 24.3298C78.7952 23.6642 78.242 22.8365 77.8384 21.8466C77.4348 20.8568 77.233 19.7049 77.233 18.3909C77.233 17.4011 77.407 16.463 77.7514 15.5767C78.0959 14.6903 78.5934 13.9143 79.244 13.2487C79.8911 12.5831 80.6774 12.0554 81.5994 11.6622C82.5214 11.2725 83.5617 11.0759 84.7237 11.0759V11.0794ZM117.807 11.0794C118.959 11.0794 120.006 11.2553 120.953 11.607C121.899 11.9588 122.71 12.4624 123.388 13.1211C124.067 13.7764 124.592 14.5765 124.968 15.5111C125.343 16.4492 125.531 17.5011 125.531 18.6737C125.531 19.8463 125.343 20.9189 124.968 21.8639C124.592 22.8123 124.067 23.6159 123.388 24.2781C122.71 24.9402 121.899 25.4472 120.953 25.8059C120.006 26.1611 118.959 26.3405 117.807 26.3405C116.656 26.3405 115.591 26.1611 114.641 25.8059C113.692 25.4507 112.87 24.9402 112.185 24.2781C111.496 23.6159 110.967 22.8123 110.592 21.8639C110.216 20.9155 110.028 19.8532 110.028 18.6737C110.028 17.4942 110.216 16.4492 110.592 15.5111C110.967 14.573 111.5 13.7764 112.185 13.1211C112.87 12.4658 113.692 11.9588 114.641 11.607C115.591 11.2553 116.649 11.0794 117.807 11.0794ZM145.509 7.00975V11.3346H149.193V14.3627H145.509V21.7156L145.516 21.8604C145.537 22.1398 145.62 22.3743 145.766 22.5674C145.937 22.7916 146.184 22.902 146.504 22.902C146.671 22.902 146.81 22.8847 146.921 22.8537C147.033 22.8227 147.13 22.7813 147.214 22.7399C147.297 22.6985 147.374 22.6606 147.447 22.6261C147.52 22.5916 147.607 22.5778 147.704 22.5778C147.84 22.5778 147.951 22.6088 148.035 22.6709C148.118 22.733 148.202 22.8296 148.292 22.9641L149.667 25.0644L149.444 25.2196C148.915 25.5714 148.33 25.8404 147.694 26.0266C146.963 26.2404 146.208 26.3474 145.425 26.3474C144.705 26.3474 144.068 26.2439 143.515 26.0404C142.966 25.8369 142.503 25.5438 142.127 25.1679C141.751 24.7919 141.466 24.3367 141.271 23.8056C141.076 23.271 140.979 22.6778 140.979 22.0225V14.3696H139.692L139.577 14.3627C139.392 14.342 139.229 14.2695 139.09 14.1488C138.923 14.0005 138.843 13.7833 138.843 13.5005V11.7726L141.257 11.3173L142.148 7.70642L142.183 7.59606C142.322 7.21324 142.642 7.0201 143.143 7.0201H145.512L145.509 7.00975ZM55.495 5.31293V9.13768H49.4968V26.1128H44.5529V9.13768H38.5548V5.31293H55.4915H55.495ZM74.5749 4.74042V26.1128H70.0415V4.74042H74.5749ZM136.414 11.0242C137.107 11.0242 137.663 11.1863 138.081 11.5105L137.496 14.7662L137.468 14.88C137.423 15.0214 137.357 15.1249 137.263 15.1869C137.145 15.2663 136.992 15.3076 136.793 15.3076C136.626 15.3076 136.432 15.287 136.209 15.2421C135.986 15.2007 135.701 15.1766 135.36 15.1766C134.17 15.1766 133.234 15.7939 132.552 17.0321V26.1128H128.019V11.3105H130.872C131.025 11.3208 131.161 11.338 131.272 11.3691C131.422 11.407 131.55 11.4656 131.651 11.5484C131.752 11.6277 131.832 11.7381 131.884 11.8692C131.937 12.0037 131.985 12.1658 132.023 12.3554L132.27 13.7419L132.458 13.4694C132.966 12.759 133.526 12.1899 134.142 11.7588C134.835 11.2725 135.59 11.0311 136.411 11.0311L136.414 11.0242ZM15.8634 6.63728C10.6516 6.63728 6.42782 10.8276 6.42782 15.9974C6.42782 21.1672 10.6516 25.3575 15.8634 25.3575C21.0753 25.3575 25.299 21.1672 25.299 15.9974C25.299 10.8276 21.0753 6.63728 15.8634 6.63728ZM101.546 14.4075C101.215 14.4075 100.916 14.4385 100.645 14.5006C100.377 14.5627 100.126 14.6489 99.9 14.7662C99.6704 14.88 99.4582 15.0248 99.2633 15.2007C99.0685 15.3766 98.8737 15.5801 98.6788 15.8077V22.0915L98.8284 22.2432C99.1276 22.533 99.4477 22.7433 99.7922 22.8675C100.192 23.0158 100.61 23.0882 101.052 23.0882C101.493 23.0882 101.855 23.0089 102.207 22.8468C102.558 22.6847 102.861 22.426 103.122 22.0674C103.379 21.7121 103.581 21.2465 103.727 20.674C103.873 20.1015 103.946 19.4083 103.946 18.5909C103.946 17.7736 103.887 17.1528 103.772 16.6217C103.654 16.0871 103.491 15.6594 103.282 15.3283C103.073 15.0007 102.823 14.7627 102.527 14.6213C102.235 14.4799 101.908 14.4075 101.546 14.4075ZM117.811 14.3661C116.739 14.3661 115.953 14.7213 115.456 15.4353C114.958 16.1492 114.711 17.239 114.711 18.7047C114.711 20.1705 114.958 21.2638 115.456 21.9811C115.953 22.6985 116.739 23.0606 117.811 23.0606C118.883 23.0606 119.624 22.7019 120.114 21.9811C120.608 21.2638 120.852 20.1705 120.852 18.7047C120.852 17.239 120.605 16.1492 120.114 15.4353C119.62 14.7213 118.855 14.3661 117.811 14.3661ZM21.8372 11.9105V14.6972H17.2864V21.3879H14.4439V14.6972H9.8931V11.9105H21.8372ZM60.5642 14.135C59.6979 14.135 59.0194 14.3765 58.5323 14.8559C58.0452 15.3352 57.7217 16.0285 57.5686 16.932H63.2292C63.2292 16.5803 63.184 16.2388 63.0901 15.9043C62.9961 15.5698 62.8465 15.2732 62.6378 15.011C62.429 14.7489 62.1542 14.5386 61.8097 14.3765C61.4688 14.2144 61.0547 14.135 60.5677 14.135H60.5642ZM84.8142 14.135C83.9479 14.135 83.2694 14.3765 82.7824 14.8559C82.2953 15.3352 81.9717 16.0285 81.8186 16.932H87.4793C87.4793 16.5803 87.434 16.2388 87.3401 15.9043C87.2462 15.5698 87.0966 15.2732 86.8878 15.011C86.6791 14.7489 86.4042 14.5386 86.0598 14.3765C85.7188 14.2144 85.3048 14.135 84.8177 14.135H84.8142Z"
-            fill="white"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </div>
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          <span
-            class="c5 icon icon-arrowback"
-            style="cursor: pointer;"
-          >
-            <svg
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M11.0303 5.78033C11.3232 5.48744 11.3232 5.01256 11.0303 4.71967C10.7374 4.42678 10.2626 4.42678 9.96967 4.71967L3.21967 11.4697C3.07322 11.6161 3 11.8081 3 12C3 12.1017 3.02024 12.1987 3.05691 12.2871C3.09268 12.3735 3.14531 12.4547 3.2148 12.5254"
-              />
-              <path
-                d="M3.22014 12.5308L9.96967 19.2803C10.2626 19.5732 10.7374 19.5732 11.0303 19.2803C11.3232 18.9874 11.3232 18.5126 11.0303 18.2197L5.56066 12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H5.56066L11.0303 5.78033"
-              />
-            </svg>
-          </span>
-          <div
-            class="c6"
-          >
-            <div
-              class="c7"
-              color="text.main"
-            >
-              Set Two-Factor Device
-            </div>
-            <div
-              class="c8"
-              color="text.slightlyMuted"
-            >
-              Step 2 of 2
-            </div>
-          </div>
-        </div>
-        <div
-          class="c9"
-          color="text.main"
-        >
-          Two-Factor Method
-        </div>
-        <div
-          class="c10"
-        >
-          <div
-            class="c11"
-          >
-            <label
-              class="c12"
-            >
-              <input
-                checked=""
-                class="c13"
-                name="mfaType"
-                type="radio"
-                value="otp"
-              />
-              <span>
-                Authenticator App
-              </span>
-            </label>
-          </div>
-        </div>
-        <div
-          class="c14"
-          height="240px"
-        >
-          <img
-            class="c15 c16"
-            height="145px"
-            src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAcgAAAHIEAAAAAC/Wvl1AAAJV0lEQVR4nOzdsW4jORZA0fbC///LXowVTFIWmqAefUtzTrDJeEtltS+YPDx+fn39ASL+99svAPzr85//+fj47df4ycr5ff1bXD9h/2f3vcenTf0LrTzh2tnvd9/jfZ2QECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgI+fz5P50dOz870rT/u3VH0VZ+dv+32B9mW1H41vc9e18nJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp6Mzl0rjCkV9stNjYytvG9hkOzs+F5nxO3vrL+vExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSHLo3M8nB1bOztItv9pU8N3+59W54SEEEFCiCAhRJAQIkgIESSECBJCBAkhgoQQQULIG43OvcdOs7NDZ9cKQ3L7o4n3HKhzQkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIWR5dO5uA0lT42Vnnzu1427/Hfaf0B2H+42/dSckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCnozOTQ1mTdnfLzd1UenZcbjumF3hZ691/tadkBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPkenbvbJrlrZwez9t9h39khubPvcPY763BCQoggIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5OPrq3FJ6LWpS0L3nzD1PUxdatp936l3uNZ9swcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQkYvbN3f8FW4SPPs1aErule+Fi6u7Xr2PTghIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhRJAQ8jF5geV/b1Tq7Ja8qecW9vedvVi1s4vOCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJDl0bnCoNOUs/vaCjv5pv7d9jfUrTy3MGb3qt/CCQkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGChJAnF7ZeK1zFWbgA9ezPrji7HW7F1PfQHai7Zusc3IQgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5Hvr3NTw0oqzI3nda1GvFS65feffbZ+tc/CGBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSFPRudWnL189OwQ177uOxQGFqeeULhEeP3NnJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5vrC1cLXlylDU2R13+084O1h47exut8K1viumBgvXn+CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyMfqWFdhO9yUV126+Xc/u/8OK+52Ke/KE/adHXm0dQ5uQpAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZHTu7KjU3a58LexKu3Z2QO09LnedYusc3JogIUSQECJICBEkhAgSQgQJIYKEEEFCiCAhZHnr3A+PGdppdvYJ+wq76M5+k1MDliu6G/XWOSEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDy+eclQ1z7g0P7G+qmRqWmhu9WfuPCpr53VtiPaOsc5AgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn/+T91NZ/tP2B9buzY1QrjvbtfOrpgafPuNPXtOSAgRJIQIEkIECSGChBBBQoggIUSQECJICBEkhHyPznV2bv3dz147O+g0NV5WGFub+nvY36jX/Xu4tv4bOyEhRJAQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyZOvcvpUxpf2RpsJY1bWpa2f3P23f2VG/qUtup76z9Sc4ISFEkBAiSAgRJIQIEkIECSGChBBBQoggIUSQELI8Ojc1KlXYZjd1mefUtbN3GzecGt87+/3uf9o1W+cgR5AQIkgIESSECBJCBAkhgoQQQUKIICFEkBDyPTp3dlyrMII19Q5TQ1wr9sfA7vZvPLXVb2pI7hknJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQp5snfuNnVt/94SzV5IWLnfdf0JhoG7f2b/JFa96ByckhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSECBJCPn4e+Tm7I2xFYbdbYYPa1BNWFEbRrp39Hl71Dk5ICBEkhAgSQgQJIYKEEEFCiCAhRJAQIkgIESSELF/YOmV/09nUvraz9rfDXetu6iu8w9Snrf9uTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ82Tr3w//hZteBvvM+vLtt1Fv5tMLw3bWpa4gfP+uEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLWucKOsKnhu6kxu8IVqiufdnbccF/3r2SdExJCBAkhgoQQQUKIICFEkBAiSAgRJIQIEkIECSGfr3nM1GWpZwe+zm4v23d2f9/+O+x/v1NPKFwl++CEhBBBQoggIUSQECJICBEkhAgSQgQJIYKEEEFCyPLoXGEo6m5jdlNb3N5jb92KwuWus+/ghIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjH11fjQtF93QG199gD173q9D2+3wcnJIQIEkIECSGChBBBQoggIUSQECJICBEkhAgSQj7udknpn8Ehrv19Yt1Pu3Z2i9vZ8b2zI4+v+h6ckBAiSAgRJIQIEkIECSGChBBBQoggIUSQECJICPm+sPXs1q4V1wNJ++NlZ6282f4w28oTCpfcFnYe7n8Pr/rWnZAQIkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAj5/Pk/nd1Hd3a8rKCw7+/sHrizQ3LXpj7tVc91QkKIICFEkBAiSAgRJIQIEkIECSGChBBBQoggIeTJ6Ny1qctSu87+xvvby1Z20Z21/y/f/Y1fNRbohIQQQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FzX1IjbynOnriQtvMOK7vewb2rn4eMJTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIS80ejc1IWtZy+CvdtOvmtTg3pTY3b772DrHLwhQUKIICFEkBAiSAgRJIQIEkIECSGChBBBQsjy6FxhtGvlHaY2yV1beW7hCtV93d1uUz879WkPTkgIESSECBJCBAkhgoQQQUKIICFEkBAiSAgRJIQ8GZ3rjnbtD76d3X92ber60v0xsClnB9/OsnUO3pAgIUSQECJICBEkhAgSQgQJIYKEEEFCiCAh5KMwdgQ8OCEhRJAQ8v8AAAD//1QuL6EmJFBiAAAAAElFTkSuQmCC"
-            width="145px"
           />
           <div
             class="c17"
             color="text.slightlyMuted"
             font-size="1"
           >
-            Scan the QR Code with any authenticator app and enter the generated code. We recommend
-             
-            <a
-              class="c18"
-              href="https://authy.com/download/"
-              rel="noreferrer"
-              target="_blank"
-            >
-              Authy
-            </a>
-            .
-          </div>
-        </div>
-        <div
-          class="c19"
-          height="100"
-        >
-          <div
-            class="c20"
-            width="50%"
-          >
-            <label
-              class="c21"
-              font-size="0"
-            >
-              Device Name
-              <input
-                autocomplete="off"
-                class="c22"
-                inputmode="text"
-                placeholder="Name"
-                type="text"
-                value="otp-device"
-              />
-            </label>
-          </div>
-          <div
-            class="c23"
-            width="50%"
-          >
-            <label
-              class="c21"
-              font-size="0"
-            >
-              Authenticator Code
-              <input
-                autocomplete="one-time-code"
-                class="c22"
-                inputmode="numeric"
-                placeholder="123 456"
-                type="text"
-                value=""
-              />
-            </label>
-          </div>
-        </div>
-        <button
-          class="c24"
-          kind="primary"
-          width="100%"
-        >
-          Submit
-        </button>
-      </div>
-    </span>
-    <footer
-      class="c25"
-    >
-      <div
-        class="c26"
-      >
-        <div
-          class="c27"
-        >
-          © Gravitational, Inc. All Rights Reserved
-        </div>
-        <a
-          class="c18 c28"
-          href="https://goteleport.com/legal/tos/"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Terms of Service
-        </a>
-        <a
-          class="c18 c28"
-          href="https://goteleport.com/legal/privacy/"
-          rel="noreferrer"
-          target="_blank"
-        >
-          Privacy Policy
-        </a>
-      </div>
-    </footer>
-  </div>
-</div>
-`;
-
-exports[`story.MfaDeviceWebauthn 1`] = `
-.c6 {
-  box-sizing: border-box;
-}
-
-.c10 {
-  box-sizing: border-box;
-  margin-bottom: 4px;
-}
-
-.c18 {
-  box-sizing: border-box;
-  margin-bottom: 24px;
-  margin-right: 0px;
-  width: 100%;
-}
-
-.c21 {
-  line-height: 1.5;
-  margin: 0;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  box-sizing: border-box;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-family: inherit;
-  font-weight: 600;
-  outline: none;
-  position: relative;
-  text-align: center;
-  text-decoration: none;
-  text-transform: uppercase;
-  transition: all 0.3s;
-  -webkit-font-smoothing: antialiased;
-  color: #000000;
-  background: #9F85FF;
-  min-height: 40px;
-  font-size: 12px;
-  padding: 0px 40px;
-  margin-top: 8px;
-  width: 100%;
-}
-
-.c21:hover,
-.c21:focus {
-  background: #B29DFF;
-}
-
-.c21:active {
-  background: #C5B6FF;
-}
-
-.c21:disabled {
-  background: rgba(255,255,255,0.12);
-  color: rgba(255,255,255,0.3);
-  cursor: auto;
-}
-
-.c7 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 600;
-  font-size: 18px;
-  line-height: 32px;
-  margin: 0px;
-  color: #FFFFFF;
-}
-
-.c8 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-  color: rgba(255,255,255,0.72);
-}
-
-.c9 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-weight: 400;
-  font-size: 14px;
-  line-height: 24px;
-  text-transform: uppercase;
-  margin: 0px;
-  margin-bottom: 4px;
-  color: #FFFFFF;
-}
-
-.c16 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  font-size: 12px;
-  margin: 0px;
-  color: rgba(255,255,255,0.72);
-  text-align: center;
-}
-
-.c24 {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  margin: 0px;
-}
-
-.c5 {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-right: 16px;
-}
-
-.c20 {
-  appearance: none;
-  border: 1px solid rgba(255,255,255,0.54);
-  border-radius: 4px;
-  box-sizing: border-box;
-  display: block;
-  height: 40px;
-  font-size: 16px;
-  padding: 0 16px;
-  outline: none;
-  width: 100%;
-  background: #222C59;
-  color: #FFFFFF;
-  margin-top: 4px;
-}
-
-.c20:hover,
-.c20:focus,
-.c20:active {
-  border: 1px solid rgba(255,255,255,0.72);
-}
-
-.c20::-ms-clear {
-  display: none;
-}
-
-.c20::placeholder {
-  color: rgba(255,255,255,0.54);
-  opacity: 1;
-}
-
-.c20:read-only {
-  cursor: not-allowed;
-}
-
-.c20:disabled {
-  color: rgba(255,255,255,0.36);
-  border-color: rgba(255,255,255,0.36);
-}
-
-.c19 {
-  color: #FFFFFF;
-  display: block;
-  font-size: 12px;
-  width: 100%;
-  margin-bottom: 0px;
-}
-
-.c25 {
-  color: #009EFF;
-  font-weight: normal;
-  background: none;
-  text-decoration: underline;
-  text-transform: none;
-}
-
-.c15 {
-  display: block;
-  outline: none;
-  width: 220px;
-  height: 154px;
-}
-
-.c1 {
-  box-sizing: border-box;
-  height: 100%;
-  display: flex;
-  justify-content: space-between;
-  flex-direction: column;
-}
-
-.c4 {
-  box-sizing: border-box;
-  margin-bottom: 16px;
-  display: flex;
-  align-items: center;
-}
-
-.c11 {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: row;
-  gap: 16px;
-}
-
-.c14 {
-  box-sizing: border-box;
-  padding-left: 16px;
-  padding-right: 16px;
-  height: 240px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-direction: column;
-}
-
-.c17 {
-  box-sizing: border-box;
-  height: 100px;
-  display: flex;
-  align-items: center;
-}
-
-.c23 {
-  box-sizing: border-box;
-  display: flex;
-  justify-content: center;
-  width: 100%;
-  gap: 50px;
-}
-
-.c22 {
-  padding-bottom: 24px;
-  width: 100%;
-  color: white;
-}
-
-.c26 {
-  color: white;
-  text-decoration: none;
-}
-
-.c26:hover,
-.c26:active,
-.c26:focus {
-  color: rgba(255,255,255,0.54);
-}
-
-.c0 {
-  position: absolute;
-  width: 100vw;
-  height: 100vh;
-  top: 0;
-  left: 0;
-  overflow: hidden;
-  z-index: -2;
-  background: url('file_stub');
-  -webkit-background-size: cover;
-  -moz-background-size: cover;
-  -o-background-size: cover;
-  background-size: cover;
-}
-
-.c0::after {
-  content: '';
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  position: absolute;
-  z-index: -1;
-  background-color: black;
-  opacity: 0.25;
-  backdrop-filter: blur(17.5px);
-}
-
-.c2 {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  margin: 24px 0;
-}
-
-.c12 {
-  display: flex;
-  align-items: center;
-  cursor: pointer;
-}
-
-.c13 {
-  margin: 0 8px 0 0;
-  accent-color: #9F85FF;
-  cursor: inherit;
-}
-
-.c3 {
-  box-sizing: border-box;
-  box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
-  border-radius: 8px;
-  background-color: #222C59;
-  width: 600px;
-  padding: 24px;
-  text-align: left;
-  margin: 40px auto auto auto;
-  overflow-y: auto;
-}
-
-@media screen and (max-width:800px) {
-  .c23 {
-    flex-direction: column-reverse;
-    text-align: center;
-    gap: 10px;
-  }
-}
-
-@media screen and (max-width:800px) {
-  .c3 {
-    width: auto;
-    margin: 20px;
-  }
-}
-
-@media screen and (max-height:760px) {
-  .c3 {
-    height: calc(100vh - 250px);
-  }
-}
-
-<div
-  class="c0"
->
-  <div
-    class="c1"
-    height="100%"
-  >
-    <span>
-      <div
-        class="c2"
-      >
-        <svg
-          fill="none"
-          height="32"
-          viewBox="0 0 150 32"
-          width="150"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            clip-rule="evenodd"
-            d="M18.9703 0.305222C19.2104 0.332812 19.4157 0.519049 19.4922 0.739775L19.5131 0.822547L20.2959 4.81975C21.3466 5.22326 22.3382 5.76128 23.2324 6.42345L23.5629 6.67867L27.5153 5.33362C27.7727 5.22326 28.0441 5.30258 28.2354 5.52331C29.5958 7.03734 30.6987 8.86523 31.3424 10.7862C31.4433 11.007 31.3911 11.2656 31.2206 11.4312L31.151 11.4898L28.0128 14.1454C28.1241 14.7386 28.1554 15.3801 28.1554 16.0043C28.1554 16.5078 28.1346 17.0148 28.0684 17.5046L28.0093 17.8667L31.1475 20.5223C31.3702 20.6775 31.4502 20.9741 31.3389 21.2258C30.6987 23.1468 29.5958 24.9747 28.2354 26.4888C28.065 26.6819 27.8284 26.7681 27.5988 26.706L27.5118 26.675L23.5594 25.33C22.6931 26.0232 21.7224 26.5957 20.6891 27.0302L20.2959 27.1854L19.5096 31.1861C19.4609 31.4378 19.2382 31.6689 18.9634 31.7034C17.9405 31.8896 16.9141 32 15.8599 32C14.8057 32 13.7794 31.8896 12.753 31.7034C12.5129 31.6758 12.3077 31.4861 12.2311 31.2689L12.2103 31.1861L11.4274 27.1854C10.3628 26.7785 9.33295 26.2336 8.44923 25.5576L8.16046 25.3265L4.20809 26.6716C3.95063 26.7819 3.67925 26.7026 3.4879 26.4819C2.12753 24.9678 1.02462 23.1399 0.384448 21.2189C0.283551 20.9982 0.335739 20.7361 0.50622 20.574L0.575804 20.5188L3.71056 17.8632C3.59923 17.27 3.56792 16.632 3.56792 16.0043C3.56792 15.5042 3.58879 14.9938 3.6549 14.5075L3.71404 14.1454L0.579283 11.4898C0.356614 11.3311 0.273114 11.038 0.387927 10.7862C1.0281 8.86523 2.13101 7.03734 3.49137 5.52331C3.66185 5.33017 3.89844 5.2474 4.12807 5.30603L4.21505 5.33362L8.16742 6.67867C9.01635 5.9751 10.0218 5.39915 11.0795 4.96115L11.4344 4.81975L12.2172 0.822547C12.2659 0.570782 12.4886 0.336261 12.7634 0.305222C14.8127 -0.101741 16.9246 -0.101741 18.9738 0.305222H18.9703ZM103.125 11.0207C103.915 11.0207 104.646 11.1932 105.321 11.5346C105.992 11.8761 106.573 12.3727 107.06 13.0211C107.547 13.6695 107.93 14.4592 108.208 15.3973C108.487 16.3354 108.626 17.3976 108.626 18.5875C108.626 19.7015 108.466 20.7292 108.149 21.6707C107.833 22.6123 107.387 23.4331 106.817 24.1263C106.246 24.8195 105.564 25.3644 104.767 25.7542C103.974 26.1439 103.094 26.3405 102.127 26.3405C101.337 26.3405 100.672 26.2301 100.137 26.0128C99.6008 25.7955 99.1137 25.4989 98.6753 25.1265V30.8102H94.1419V11.3105H97.0888C97.3115 11.3311 97.5029 11.3932 97.6594 11.4967C97.8508 11.6208 97.983 11.8071 98.063 12.0519L98.4005 13.1383L98.6232 12.9073C98.8493 12.6831 99.0894 12.4727 99.3434 12.2796C99.6808 12.0209 100.039 11.8002 100.425 11.6174C100.812 11.4312 101.226 11.2863 101.667 11.1828C102.113 11.0794 102.596 11.0242 103.122 11.0242L103.125 11.0207ZM60.4737 11.0794C61.4792 11.0794 62.3977 11.2311 63.2292 11.5346C64.0643 11.8381 64.781 12.283 65.3794 12.8624C65.9778 13.4418 66.4475 14.1557 66.785 14.9973C67.1225 15.8388 67.2895 16.7941 67.2895 17.8598C67.2895 18.1943 67.2756 18.4633 67.2442 18.6737C67.2164 18.8841 67.1607 19.0496 67.0842 19.1738C67.0077 19.2979 66.8998 19.3842 66.7711 19.4325C66.6423 19.4807 66.4719 19.5049 66.2666 19.5049H57.5199L57.5512 19.7463C57.7182 20.8603 58.0905 21.6742 58.675 22.195C59.2977 22.7502 60.1049 23.0296 61.0895 23.0296C61.6149 23.0296 62.0707 22.9675 62.4499 22.8433C62.8291 22.7192 63.1701 22.5812 63.4658 22.4295C63.7616 22.2777 64.0364 22.1398 64.2834 22.0156C64.5305 21.8915 64.7914 21.8294 65.0663 21.8294C65.4281 21.8294 65.6995 21.957 65.8839 22.2157L67.199 23.8021L66.9972 24.0194C66.5867 24.4436 66.1518 24.7988 65.6856 25.0782C65.1428 25.4058 64.5896 25.6645 64.019 25.8507C63.4484 26.037 62.8778 26.1646 62.3073 26.237C61.7367 26.3094 61.1939 26.3439 60.6755 26.3439C59.6144 26.3439 58.6158 26.1749 57.6834 25.8369C56.751 25.499 55.9368 24.9954 55.241 24.3298C54.5452 23.6642 53.992 22.8365 53.5884 21.8466C53.1848 20.8568 52.983 19.7049 52.983 18.3909C52.983 17.4011 53.157 16.463 53.5014 15.5767C53.8458 14.6903 54.3434 13.9143 54.994 13.2487C55.6411 12.5831 56.4274 12.0554 57.3494 11.6622C58.2714 11.2725 59.3117 11.0759 60.4737 11.0759V11.0794ZM84.7237 11.0794C85.7292 11.0794 86.6477 11.2311 87.4793 11.5346C88.3143 11.8381 89.031 12.283 89.6294 12.8624C90.2278 13.4418 90.6975 14.1557 91.035 14.9973C91.3725 15.8388 91.5395 16.7941 91.5395 17.8598C91.5395 18.1943 91.5256 18.4633 91.4943 18.6737C91.4664 18.8841 91.4108 19.0496 91.3342 19.1738C91.2577 19.2979 91.1498 19.3842 91.0211 19.4325C90.8889 19.4807 90.7219 19.5049 90.5166 19.5049H81.7699L81.8012 19.7463C81.9682 20.8603 82.3405 21.6742 82.925 22.195C83.5478 22.7502 84.355 23.0296 85.3396 23.0296C85.8649 23.0296 86.3207 22.9675 86.6999 22.8433C87.0792 22.7192 87.4201 22.5812 87.7159 22.4295C88.0116 22.2777 88.2864 22.1398 88.5335 22.0156C88.7805 21.8915 89.0414 21.8294 89.3163 21.8294C89.6781 21.8294 89.9495 21.957 90.1339 22.2157L91.449 23.8021L91.2472 24.0194C90.8367 24.4436 90.4018 24.7988 89.9356 25.0782C89.3928 25.4058 88.8396 25.6645 88.2691 25.8507C87.6985 26.037 87.1279 26.1646 86.5573 26.237C85.9867 26.3094 85.4439 26.3439 84.9255 26.3439C83.8644 26.3439 82.8659 26.1749 81.9334 25.8369C81.001 25.499 80.1869 24.9954 79.491 24.3298C78.7952 23.6642 78.242 22.8365 77.8384 21.8466C77.4348 20.8568 77.233 19.7049 77.233 18.3909C77.233 17.4011 77.407 16.463 77.7514 15.5767C78.0959 14.6903 78.5934 13.9143 79.244 13.2487C79.8911 12.5831 80.6774 12.0554 81.5994 11.6622C82.5214 11.2725 83.5617 11.0759 84.7237 11.0759V11.0794ZM117.807 11.0794C118.959 11.0794 120.006 11.2553 120.953 11.607C121.899 11.9588 122.71 12.4624 123.388 13.1211C124.067 13.7764 124.592 14.5765 124.968 15.5111C125.343 16.4492 125.531 17.5011 125.531 18.6737C125.531 19.8463 125.343 20.9189 124.968 21.8639C124.592 22.8123 124.067 23.6159 123.388 24.2781C122.71 24.9402 121.899 25.4472 120.953 25.8059C120.006 26.1611 118.959 26.3405 117.807 26.3405C116.656 26.3405 115.591 26.1611 114.641 25.8059C113.692 25.4507 112.87 24.9402 112.185 24.2781C111.496 23.6159 110.967 22.8123 110.592 21.8639C110.216 20.9155 110.028 19.8532 110.028 18.6737C110.028 17.4942 110.216 16.4492 110.592 15.5111C110.967 14.573 111.5 13.7764 112.185 13.1211C112.87 12.4658 113.692 11.9588 114.641 11.607C115.591 11.2553 116.649 11.0794 117.807 11.0794ZM145.509 7.00975V11.3346H149.193V14.3627H145.509V21.7156L145.516 21.8604C145.537 22.1398 145.62 22.3743 145.766 22.5674C145.937 22.7916 146.184 22.902 146.504 22.902C146.671 22.902 146.81 22.8847 146.921 22.8537C147.033 22.8227 147.13 22.7813 147.214 22.7399C147.297 22.6985 147.374 22.6606 147.447 22.6261C147.52 22.5916 147.607 22.5778 147.704 22.5778C147.84 22.5778 147.951 22.6088 148.035 22.6709C148.118 22.733 148.202 22.8296 148.292 22.9641L149.667 25.0644L149.444 25.2196C148.915 25.5714 148.33 25.8404 147.694 26.0266C146.963 26.2404 146.208 26.3474 145.425 26.3474C144.705 26.3474 144.068 26.2439 143.515 26.0404C142.966 25.8369 142.503 25.5438 142.127 25.1679C141.751 24.7919 141.466 24.3367 141.271 23.8056C141.076 23.271 140.979 22.6778 140.979 22.0225V14.3696H139.692L139.577 14.3627C139.392 14.342 139.229 14.2695 139.09 14.1488C138.923 14.0005 138.843 13.7833 138.843 13.5005V11.7726L141.257 11.3173L142.148 7.70642L142.183 7.59606C142.322 7.21324 142.642 7.0201 143.143 7.0201H145.512L145.509 7.00975ZM55.495 5.31293V9.13768H49.4968V26.1128H44.5529V9.13768H38.5548V5.31293H55.4915H55.495ZM74.5749 4.74042V26.1128H70.0415V4.74042H74.5749ZM136.414 11.0242C137.107 11.0242 137.663 11.1863 138.081 11.5105L137.496 14.7662L137.468 14.88C137.423 15.0214 137.357 15.1249 137.263 15.1869C137.145 15.2663 136.992 15.3076 136.793 15.3076C136.626 15.3076 136.432 15.287 136.209 15.2421C135.986 15.2007 135.701 15.1766 135.36 15.1766C134.17 15.1766 133.234 15.7939 132.552 17.0321V26.1128H128.019V11.3105H130.872C131.025 11.3208 131.161 11.338 131.272 11.3691C131.422 11.407 131.55 11.4656 131.651 11.5484C131.752 11.6277 131.832 11.7381 131.884 11.8692C131.937 12.0037 131.985 12.1658 132.023 12.3554L132.27 13.7419L132.458 13.4694C132.966 12.759 133.526 12.1899 134.142 11.7588C134.835 11.2725 135.59 11.0311 136.411 11.0311L136.414 11.0242ZM15.8634 6.63728C10.6516 6.63728 6.42782 10.8276 6.42782 15.9974C6.42782 21.1672 10.6516 25.3575 15.8634 25.3575C21.0753 25.3575 25.299 21.1672 25.299 15.9974C25.299 10.8276 21.0753 6.63728 15.8634 6.63728ZM101.546 14.4075C101.215 14.4075 100.916 14.4385 100.645 14.5006C100.377 14.5627 100.126 14.6489 99.9 14.7662C99.6704 14.88 99.4582 15.0248 99.2633 15.2007C99.0685 15.3766 98.8737 15.5801 98.6788 15.8077V22.0915L98.8284 22.2432C99.1276 22.533 99.4477 22.7433 99.7922 22.8675C100.192 23.0158 100.61 23.0882 101.052 23.0882C101.493 23.0882 101.855 23.0089 102.207 22.8468C102.558 22.6847 102.861 22.426 103.122 22.0674C103.379 21.7121 103.581 21.2465 103.727 20.674C103.873 20.1015 103.946 19.4083 103.946 18.5909C103.946 17.7736 103.887 17.1528 103.772 16.6217C103.654 16.0871 103.491 15.6594 103.282 15.3283C103.073 15.0007 102.823 14.7627 102.527 14.6213C102.235 14.4799 101.908 14.4075 101.546 14.4075ZM117.811 14.3661C116.739 14.3661 115.953 14.7213 115.456 15.4353C114.958 16.1492 114.711 17.239 114.711 18.7047C114.711 20.1705 114.958 21.2638 115.456 21.9811C115.953 22.6985 116.739 23.0606 117.811 23.0606C118.883 23.0606 119.624 22.7019 120.114 21.9811C120.608 21.2638 120.852 20.1705 120.852 18.7047C120.852 17.239 120.605 16.1492 120.114 15.4353C119.62 14.7213 118.855 14.3661 117.811 14.3661ZM21.8372 11.9105V14.6972H17.2864V21.3879H14.4439V14.6972H9.8931V11.9105H21.8372ZM60.5642 14.135C59.6979 14.135 59.0194 14.3765 58.5323 14.8559C58.0452 15.3352 57.7217 16.0285 57.5686 16.932H63.2292C63.2292 16.5803 63.184 16.2388 63.0901 15.9043C62.9961 15.5698 62.8465 15.2732 62.6378 15.011C62.429 14.7489 62.1542 14.5386 61.8097 14.3765C61.4688 14.2144 61.0547 14.135 60.5677 14.135H60.5642ZM84.8142 14.135C83.9479 14.135 83.2694 14.3765 82.7824 14.8559C82.2953 15.3352 81.9717 16.0285 81.8186 16.932H87.4793C87.4793 16.5803 87.434 16.2388 87.3401 15.9043C87.2462 15.5698 87.0966 15.2732 86.8878 15.011C86.6791 14.7489 86.4042 14.5386 86.0598 14.3765C85.7188 14.2144 85.3048 14.135 84.8177 14.135H84.8142Z"
-            fill="white"
-            fill-rule="evenodd"
-          />
-        </svg>
-      </div>
-      <div
-        class="c3"
-      >
-        <div
-          class="c4"
-        >
-          <span
-            class="c5 icon icon-arrowback"
-            style="cursor: pointer;"
-          >
-            <svg
-              fill="currentColor"
-              height="24"
-              viewBox="0 0 24 24"
-              width="24"
-            >
-              <path
-                d="M11.0303 5.78033C11.3232 5.48744 11.3232 5.01256 11.0303 4.71967C10.7374 4.42678 10.2626 4.42678 9.96967 4.71967L3.21967 11.4697C3.07322 11.6161 3 11.8081 3 12C3 12.1017 3.02024 12.1987 3.05691 12.2871C3.09268 12.3735 3.14531 12.4547 3.2148 12.5254"
-              />
-              <path
-                d="M3.22014 12.5308L9.96967 19.2803C10.2626 19.5732 10.7374 19.5732 11.0303 19.2803C11.3232 18.9874 11.3232 18.5126 11.0303 18.2197L5.56066 12.75H20.25C20.6642 12.75 21 12.4142 21 12C21 11.5858 20.6642 11.25 20.25 11.25H5.56066L11.0303 5.78033"
-              />
-            </svg>
-          </span>
-          <div
-            class="c6"
-          >
-            <div
-              class="c7"
-              color="text.main"
-            >
-              Set Two-Factor Device
-            </div>
-            <div
-              class="c8"
-              color="text.slightlyMuted"
-            >
-              Step 2 of 2
-            </div>
-          </div>
-        </div>
-        <div
-          class="c9"
-          color="text.main"
-        >
-          Two-Factor Method
-        </div>
-        <div
-          class="c10"
-        >
-          <div
-            class="c11"
-          >
-            <label
-              class="c12"
-            >
-              <input
-                checked=""
-                class="c13"
-                name="mfaType"
-                type="radio"
-                value="webauthn"
-              />
-              <span>
-                Hardware Key
-              </span>
-            </label>
-          </div>
-        </div>
-        <div
-          class="c14"
-          height="240px"
-        >
-          <img
-            class="c15"
-            height="154px"
-            src="file_stub"
-            width="220px"
-          />
-          <div
-            class="c16"
-            color="text.slightlyMuted"
-            font-size="1"
-          >
             We support a wide range of hardware devices including YubiKeys, Touch ID, watches, and more.
           </div>
         </div>
         <div
-          class="c17"
+          class="c18"
           height="100"
         >
           <div
-            class="c18"
+            class="c19"
             width="100%"
           >
             <label
-              class="c19"
+              class="c20"
               font-size="0"
             >
               Device Name
               <input
                 autocomplete="off"
-                class="c20"
+                class="c21"
                 inputmode="text"
                 placeholder="Name"
                 type="text"
@@ -2079,27 +2111,27 @@ exports[`story.MfaDeviceWebauthn 1`] = `
           </div>
         </div>
         <button
-          class="c21"
+          class="c22"
           kind="primary"
           width="100%"
         >
           Submit
         </button>
       </div>
-    </span>
+    </div>
     <footer
-      class="c22"
+      class="c23"
     >
       <div
-        class="c23"
+        class="c24"
       >
         <div
-          class="c24"
+          class="c25"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c25 c26"
+          class="c26 c27"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -2107,7 +2139,7 @@ exports[`story.MfaDeviceWebauthn 1`] = `
           Terms of Service
         </a>
         <a
-          class="c25 c26"
+          class="c26 c27"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -2121,7 +2153,7 @@ exports[`story.MfaDeviceWebauthn 1`] = `
 `;
 
 exports[`story.PasswordOnlyError 1`] = `
-.c7 {
+.c8 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2138,20 +2170,20 @@ exports[`story.PasswordOnlyError 1`] = `
   color: #000000;
 }
 
-.c7 a {
+.c8 a {
   color: #FFFFFF;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   box-sizing: border-box;
   margin-bottom: 24px;
 }
 
-.c11 {
+.c12 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -2179,22 +2211,22 @@ exports[`story.PasswordOnlyError 1`] = `
   width: 100%;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   background: #B29DFF;
 }
 
-.c11:active {
+.c12:active {
   background: #C5B6FF;
 }
 
-.c11:disabled {
+.c12:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c6 {
+.c7 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
@@ -2204,13 +2236,13 @@ exports[`story.PasswordOnlyError 1`] = `
   color: #FFFFFF;
 }
 
-.c14 {
+.c15 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c10 {
+.c11 {
   appearance: none;
   border: 1px solid rgba(255,255,255,0.54);
   border-radius: 4px;
@@ -2226,31 +2258,31 @@ exports[`story.PasswordOnlyError 1`] = `
   margin-top: 4px;
 }
 
-.c10:hover,
-.c10:focus,
-.c10:active {
+.c11:hover,
+.c11:focus,
+.c11:active {
   border: 1px solid rgba(255,255,255,0.72);
 }
 
-.c10::-ms-clear {
+.c11::-ms-clear {
   display: none;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: rgba(255,255,255,0.54);
   opacity: 1;
 }
 
-.c10:read-only {
+.c11:read-only {
   cursor: not-allowed;
 }
 
-.c10:disabled {
+.c11:disabled {
   color: rgba(255,255,255,0.36);
   border-color: rgba(255,255,255,0.36);
 }
 
-.c9 {
+.c10 {
   color: #FFFFFF;
   display: block;
   font-size: 12px;
@@ -2258,7 +2290,7 @@ exports[`story.PasswordOnlyError 1`] = `
   margin-bottom: 0px;
 }
 
-.c15 {
+.c16 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -2274,7 +2306,13 @@ exports[`story.PasswordOnlyError 1`] = `
   flex-direction: column;
 }
 
-.c4 .prev-slide-enter {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c5 .prev-slide-enter {
   transform: translateX(-100%);
   opacity: 0;
   position: absolute;
@@ -2284,19 +2322,19 @@ exports[`story.PasswordOnlyError 1`] = `
   bottom: 0;
 }
 
-.c4 .prev-slide-enter-active {
+.c5 .prev-slide-enter-active {
   transform: translateX(0);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c4 .prev-slide-exit {
+.c5 .prev-slide-exit {
   transform: translateX(100%);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c4 .next-slide-enter {
+.c5 .next-slide-enter {
   transform: translateX(100%);
   opacity: 0;
   position: absolute;
@@ -2306,19 +2344,19 @@ exports[`story.PasswordOnlyError 1`] = `
   bottom: 0;
 }
 
-.c4 .next-slide-enter-active {
+.c5 .next-slide-enter-active {
   transform: translateX(0);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c4 .next-slide-exit {
+.c5 .next-slide-exit {
   transform: translateX(-100%);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c13 {
+.c14 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -2326,20 +2364,20 @@ exports[`story.PasswordOnlyError 1`] = `
   gap: 50px;
 }
 
-.c12 {
+.c13 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c16 {
+.c17 {
   color: white;
   text-decoration: none;
 }
 
-.c16:hover,
-.c16:active,
-.c16:focus {
+.c17:hover,
+.c17:active,
+.c17:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -2371,7 +2409,7 @@ exports[`story.PasswordOnlyError 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -2379,7 +2417,7 @@ exports[`story.PasswordOnlyError 1`] = `
   margin: 24px 0;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -2387,12 +2425,12 @@ exports[`story.PasswordOnlyError 1`] = `
   width: 600px;
   padding: 24px;
   text-align: left;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c13 {
+  .c14 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -2400,14 +2438,14 @@ exports[`story.PasswordOnlyError 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c5 {
+  .c6 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c5 {
+  .c6 {
     height: calc(100vh - 250px);
   }
 }
@@ -2419,9 +2457,11 @@ exports[`story.PasswordOnlyError 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -2439,45 +2479,45 @@ exports[`story.PasswordOnlyError 1`] = `
         </svg>
       </div>
       <form
-        class="c3"
+        class="c4"
       >
         <div
-          class="c3"
+          class="c4"
           style="position: relative; height: auto; transition: height 500ms ease;"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c3"
+              class="c4"
             >
               <div
-                class="c5"
+                class="c6"
                 data-testid="password"
               >
                 <div
-                  class="c6"
+                  class="c7"
                   color="text.main"
                 >
                   Set A Password
                 </div>
                 <div
-                  class="c7"
+                  class="c8"
                   kind="danger"
                 >
                   some server error message
                 </div>
                 <div
-                  class="c8"
+                  class="c9"
                 >
                   <label
-                    class="c9"
+                    class="c10"
                     font-size="0"
                   >
                     Username
                     <input
                       autocomplete="off"
-                      class="c10"
+                      class="c11"
                       inputmode="text"
                       readonly=""
                       type="text"
@@ -2486,16 +2526,16 @@ exports[`story.PasswordOnlyError 1`] = `
                   </label>
                 </div>
                 <div
-                  class="c8"
+                  class="c9"
                 >
                   <label
-                    class="c9"
+                    class="c10"
                     font-size="0"
                   >
                     Password
                     <input
                       autocomplete="off"
-                      class="c10"
+                      class="c11"
                       inputmode="text"
                       placeholder="Password"
                       type="password"
@@ -2504,16 +2544,16 @@ exports[`story.PasswordOnlyError 1`] = `
                   </label>
                 </div>
                 <div
-                  class="c8"
+                  class="c9"
                 >
                   <label
-                    class="c9"
+                    class="c10"
                     font-size="0"
                   >
                     Confirm Password
                     <input
                       autocomplete="off"
-                      class="c10"
+                      class="c11"
                       inputmode="text"
                       placeholder="Confirm Password"
                       type="password"
@@ -2522,7 +2562,7 @@ exports[`story.PasswordOnlyError 1`] = `
                   </label>
                 </div>
                 <button
-                  class="c11"
+                  class="c12"
                   kind="primary"
                   width="100%"
                 >
@@ -2533,20 +2573,20 @@ exports[`story.PasswordOnlyError 1`] = `
           </div>
         </div>
       </form>
-    </span>
+    </div>
     <footer
-      class="c12"
+      class="c13"
     >
       <div
-        class="c13"
+        class="c14"
       >
         <div
-          class="c14"
+          class="c15"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c15 c16"
+          class="c16 c17"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -2554,7 +2594,7 @@ exports[`story.PasswordOnlyError 1`] = `
           Terms of Service
         </a>
         <a
-          class="c15 c16"
+          class="c16 c17"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -2568,7 +2608,7 @@ exports[`story.PasswordOnlyError 1`] = `
 `;
 
 exports[`story.PrimaryPasswordlessError 1`] = `
-.c7 {
+.c8 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2585,27 +2625,27 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   color: #000000;
 }
 
-.c7 a {
+.c8 a {
   color: #FFFFFF;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
 }
 
-.c8 {
+.c9 {
   box-sizing: border-box;
   margin-bottom: 24px;
   width: 100%;
 }
 
-.c12 {
+.c13 {
   box-sizing: border-box;
   margin-top: 16px;
   text-align: center;
 }
 
-.c11 {
+.c12 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -2633,22 +2673,22 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   width: 100%;
 }
 
-.c11:hover,
-.c11:focus {
+.c12:hover,
+.c12:focus {
   background: #B29DFF;
 }
 
-.c11:active {
+.c12:active {
   background: #C5B6FF;
 }
 
-.c11:disabled {
+.c12:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c13 {
+.c14 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -2675,19 +2715,19 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   padding: 0px 24px;
 }
 
-.c13:hover,
-.c13:focus {
+.c14:hover,
+.c14:focus {
   background: none;
   text-decoration: underline;
 }
 
-.c13:disabled {
+.c14:disabled {
   background: none;
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c6 {
+.c7 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 600;
@@ -2698,13 +2738,13 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   color: #FFFFFF;
 }
 
-.c16 {
+.c17 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c10 {
+.c11 {
   appearance: none;
   border: 1px solid rgba(255,255,255,0.54);
   border-radius: 4px;
@@ -2720,31 +2760,31 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   margin-top: 4px;
 }
 
-.c10:hover,
-.c10:focus,
-.c10:active {
+.c11:hover,
+.c11:focus,
+.c11:active {
   border: 1px solid rgba(255,255,255,0.72);
 }
 
-.c10::-ms-clear {
+.c11::-ms-clear {
   display: none;
 }
 
-.c10::placeholder {
+.c11::placeholder {
   color: rgba(255,255,255,0.54);
   opacity: 1;
 }
 
-.c10:read-only {
+.c11:read-only {
   cursor: not-allowed;
 }
 
-.c10:disabled {
+.c11:disabled {
   color: rgba(255,255,255,0.36);
   border-color: rgba(255,255,255,0.36);
 }
 
-.c9 {
+.c10 {
   color: #FFFFFF;
   display: block;
   font-size: 12px;
@@ -2752,7 +2792,7 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   margin-bottom: 0px;
 }
 
-.c17 {
+.c18 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -2768,7 +2808,13 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   flex-direction: column;
 }
 
-.c4 .prev-slide-enter {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c5 .prev-slide-enter {
   transform: translateX(-100%);
   opacity: 0;
   position: absolute;
@@ -2778,19 +2824,19 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   bottom: 0;
 }
 
-.c4 .prev-slide-enter-active {
+.c5 .prev-slide-enter-active {
   transform: translateX(0);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c4 .prev-slide-exit {
+.c5 .prev-slide-exit {
   transform: translateX(100%);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c4 .next-slide-enter {
+.c5 .next-slide-enter {
   transform: translateX(100%);
   opacity: 0;
   position: absolute;
@@ -2800,19 +2846,19 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   bottom: 0;
 }
 
-.c4 .next-slide-enter-active {
+.c5 .next-slide-enter-active {
   transform: translateX(0);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c4 .next-slide-exit {
+.c5 .next-slide-exit {
   transform: translateX(-100%);
   opacity: 1;
   transition: transform 500ms ease;
 }
 
-.c15 {
+.c16 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -2820,20 +2866,20 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   gap: 50px;
 }
 
-.c14 {
+.c15 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c18 {
+.c19 {
   color: white;
   text-decoration: none;
 }
 
-.c18:hover,
-.c18:active,
-.c18:focus {
+.c19:hover,
+.c19:active,
+.c19:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -2865,7 +2911,7 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -2873,7 +2919,7 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   margin: 24px 0;
 }
 
-.c5 {
+.c6 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -2881,12 +2927,12 @@ exports[`story.PrimaryPasswordlessError 1`] = `
   width: 600px;
   padding: 24px;
   text-align: left;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c15 {
+  .c16 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -2894,14 +2940,14 @@ exports[`story.PrimaryPasswordlessError 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c5 {
+  .c6 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c5 {
+  .c6 {
     height: calc(100vh - 250px);
   }
 }
@@ -2913,9 +2959,11 @@ exports[`story.PrimaryPasswordlessError 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -2933,46 +2981,46 @@ exports[`story.PrimaryPasswordlessError 1`] = `
         </svg>
       </div>
       <form
-        class="c3"
+        class="c4"
       >
         <div
-          class="c3"
+          class="c4"
           style="position: relative; height: auto; transition: height 500ms ease;"
         >
           <div
-            class="c4"
+            class="c5"
           >
             <div
-              class="c3"
+              class="c4"
             >
               <div
-                class="c5"
+                class="c6"
                 data-testid="passwordless"
               >
                 <div
-                  class="c6"
+                  class="c7"
                   color="text.main"
                 >
                   Set A Passwordless Device
                 </div>
                 <div
-                  class="c7"
+                  class="c8"
                   kind="danger"
                 >
                   some server error message
                 </div>
                 <div
-                  class="c8"
+                  class="c9"
                   width="100%"
                 >
                   <label
-                    class="c9"
+                    class="c10"
                     font-size="0"
                   >
                     Device Name
                     <input
                       autocomplete="off"
-                      class="c10"
+                      class="c11"
                       inputmode="text"
                       placeholder="Name"
                       type="text"
@@ -2981,17 +3029,17 @@ exports[`story.PrimaryPasswordlessError 1`] = `
                   </label>
                 </div>
                 <button
-                  class="c11"
+                  class="c12"
                   kind="primary"
                   width="100%"
                 >
                   Submit
                 </button>
                 <div
-                  class="c12"
+                  class="c13"
                 >
                   <button
-                    class="c13"
+                    class="c14"
                     kind="text"
                   >
                     Use password
@@ -3002,20 +3050,20 @@ exports[`story.PrimaryPasswordlessError 1`] = `
           </div>
         </div>
       </form>
-    </span>
+    </div>
     <footer
-      class="c14"
+      class="c15"
     >
       <div
-        class="c15"
+        class="c16"
       >
         <div
-          class="c16"
+          class="c17"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c17 c18"
+          class="c18 c19"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -3023,7 +3071,7 @@ exports[`story.PrimaryPasswordlessError 1`] = `
           Terms of Service
         </a>
         <a
-          class="c17 c18"
+          class="c18 c19"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -3037,7 +3085,7 @@ exports[`story.PrimaryPasswordlessError 1`] = `
 `;
 
 exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
-.c5 {
+.c6 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3056,11 +3104,11 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   color: #000000;
 }
 
-.c5 a {
+.c6 a {
   color: #FFFFFF;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -3072,7 +3120,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   text-align: center;
 }
 
-.c6 {
+.c7 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -3082,13 +3130,13 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   margin-bottom: 8px;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c7 {
+.c8 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -3097,7 +3145,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   color: #FFFFFF;
 }
 
-.c11 {
+.c12 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -3113,7 +3161,13 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   flex-direction: column;
 }
 
-.c9 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c10 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -3121,20 +3175,20 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   gap: 50px;
 }
 
-.c8 {
+.c9 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c12 {
+.c13 {
   color: white;
   text-decoration: none;
 }
 
-.c12:hover,
-.c12:active,
-.c12:focus {
+.c13:hover,
+.c13:active,
+.c13:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -3166,7 +3220,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -3174,7 +3228,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   margin: 24px 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -3182,12 +3236,12 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
   width: 600px;
   padding: 24px;
   text-align: left;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c9 {
+  .c10 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -3195,14 +3249,14 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -3214,9 +3268,11 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -3234,27 +3290,27 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
           color="text.main"
         >
           Registration Complete
         </div>
         <div
-          class="c5"
+          class="c6"
           kind="danger"
         >
           Web UI Login Disabled
         </div>
         <div
-          class="c6"
+          class="c7"
         >
           This Teleport Cluster requires that user
            
           <a
-            class="c7"
+            class="c8"
             color="text.main"
             href="https://goteleport.com/docs/access-controls/guides/hardware-key-support/"
             rel="noreferrer"
@@ -3266,7 +3322,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
           be stored on hardware authentication devices. Since these keys are not accessible by web browsers, Web UI login has been disabled. Please use
            
           <a
-            class="c7"
+            class="c8"
             color="text.main"
             href="https://goteleport.com/docs/connect-your-client/teleport-connect/"
             rel="noreferrer"
@@ -3278,7 +3334,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
           or
            
           <a
-            class="c7"
+            class="c8"
             color="text.main"
             href="https://goteleport.com/docs/connect-your-client/tsh/#installing-tsh"
             rel="noreferrer"
@@ -3290,20 +3346,20 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
           to log in.
         </div>
       </div>
-    </span>
+    </div>
     <footer
-      class="c8"
+      class="c9"
     >
       <div
-        class="c9"
+        class="c10"
       >
         <div
-          class="c10"
+          class="c11"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c11 c12"
+          class="c12 c13"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -3311,7 +3367,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
           Terms of Service
         </a>
         <a
-          class="c11 c12"
+          class="c12 c13"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -3325,7 +3381,7 @@ exports[`story.SuccessAndPrivateKeyEnabledRegister 1`] = `
 `;
 
 exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
-.c5 {
+.c6 {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -3344,11 +3400,11 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   color: #000000;
 }
 
-.c5 a {
+.c6 a {
   color: #FFFFFF;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -3360,7 +3416,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   text-align: center;
 }
 
-.c6 {
+.c7 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 300;
@@ -3370,13 +3426,13 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   margin-bottom: 8px;
 }
 
-.c10 {
+.c11 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c7 {
+.c8 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -3385,7 +3441,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   color: #FFFFFF;
 }
 
-.c11 {
+.c12 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -3401,7 +3457,13 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   flex-direction: column;
 }
 
-.c9 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c10 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -3409,20 +3471,20 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   gap: 50px;
 }
 
-.c8 {
+.c9 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c12 {
+.c13 {
   color: white;
   text-decoration: none;
 }
 
-.c12:hover,
-.c12:active,
-.c12:focus {
+.c13:hover,
+.c13:active,
+.c13:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -3454,7 +3516,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -3462,7 +3524,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   margin: 24px 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -3470,12 +3532,12 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
   width: 600px;
   padding: 24px;
   text-align: left;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c9 {
+  .c10 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -3483,14 +3545,14 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -3502,9 +3564,11 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -3522,27 +3586,27 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
           color="text.main"
         >
           Reset Complete
         </div>
         <div
-          class="c5"
+          class="c6"
           kind="danger"
         >
           Web UI Login Disabled
         </div>
         <div
-          class="c6"
+          class="c7"
         >
           This Teleport Cluster requires that user
            
           <a
-            class="c7"
+            class="c8"
             color="text.main"
             href="https://goteleport.com/docs/access-controls/guides/hardware-key-support/"
             rel="noreferrer"
@@ -3554,7 +3618,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
           be stored on hardware authentication devices. Since these keys are not accessible by web browsers, Web UI login has been disabled. Please use
            
           <a
-            class="c7"
+            class="c8"
             color="text.main"
             href="https://goteleport.com/docs/connect-your-client/teleport-connect/"
             rel="noreferrer"
@@ -3566,7 +3630,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
           or
            
           <a
-            class="c7"
+            class="c8"
             color="text.main"
             href="https://goteleport.com/docs/connect-your-client/tsh/#installing-tsh"
             rel="noreferrer"
@@ -3578,20 +3642,20 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
           to log in.
         </div>
       </div>
-    </span>
+    </div>
     <footer
-      class="c8"
+      class="c9"
     >
       <div
-        class="c9"
+        class="c10"
       >
         <div
-          class="c10"
+          class="c11"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c11 c12"
+          class="c12 c13"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -3599,7 +3663,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
           Terms of Service
         </a>
         <a
-          class="c11 c12"
+          class="c12 c13"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -3613,7 +3677,7 @@ exports[`story.SuccessAndPrivateKeyEnabledReset 1`] = `
 `;
 
 exports[`story.SuccessRegister 1`] = `
-.c8 {
+.c9 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -3640,22 +3704,22 @@ exports[`story.SuccessRegister 1`] = `
   width: 100%;
 }
 
-.c8:hover,
-.c8:focus {
+.c9:hover,
+.c9:focus {
   background: #B29DFF;
 }
 
-.c8:active {
+.c9:active {
   background: #C5B6FF;
 }
 
-.c8:disabled {
+.c9:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -3665,7 +3729,7 @@ exports[`story.SuccessRegister 1`] = `
   margin-bottom: 16px;
 }
 
-.c4 color {
+.c5 color {
   main: #FFFFFF;
   slightly-muted: rgba(255,255,255,0.72);
   muted: rgba(255,255,255,0.54);
@@ -3673,7 +3737,7 @@ exports[`story.SuccessRegister 1`] = `
   primary-inverse: #000000;
 }
 
-.c7 {
+.c8 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 14px;
@@ -3682,13 +3746,13 @@ exports[`story.SuccessRegister 1`] = `
   color: rgba(255,255,255,0.72);
 }
 
-.c11 {
+.c12 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c12 {
+.c13 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -3696,7 +3760,7 @@ exports[`story.SuccessRegister 1`] = `
   text-transform: none;
 }
 
-.c6 {
+.c7 {
   display: block;
   outline: none;
   width: 200px;
@@ -3711,14 +3775,20 @@ exports[`story.SuccessRegister 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c6 {
   box-sizing: border-box;
   margin-bottom: 16px;
   display: flex;
   justify-content: center;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -3726,20 +3796,20 @@ exports[`story.SuccessRegister 1`] = `
   gap: 50px;
 }
 
-.c9 {
+.c10 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c13 {
+.c14 {
   color: white;
   text-decoration: none;
 }
 
-.c13:hover,
-.c13:active,
-.c13:focus {
+.c14:hover,
+.c14:active,
+.c14:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -3771,7 +3841,7 @@ exports[`story.SuccessRegister 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -3779,7 +3849,7 @@ exports[`story.SuccessRegister 1`] = `
   margin: 24px 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -3787,12 +3857,12 @@ exports[`story.SuccessRegister 1`] = `
   width: 600px;
   padding: 24px;
   text-align: center;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c10 {
+  .c11 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -3800,14 +3870,14 @@ exports[`story.SuccessRegister 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -3819,9 +3889,11 @@ exports[`story.SuccessRegister 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -3839,10 +3911,10 @@ exports[`story.SuccessRegister 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
           color="text"
           style="text-transform: capitalize;"
         >
@@ -3850,17 +3922,17 @@ exports[`story.SuccessRegister 1`] = `
            successful
         </div>
         <div
-          class="c5"
+          class="c6"
         >
           <img
-            class="c6"
+            class="c7"
             height="143px"
             src="file_stub"
             width="200px"
           />
         </div>
         <div
-          class="c7"
+          class="c8"
           color="text.slightlyMuted"
           font-size="2"
         >
@@ -3871,7 +3943,7 @@ exports[`story.SuccessRegister 1`] = `
           Proceed to access your account.
         </div>
         <button
-          class="c8"
+          class="c9"
           kind="primary"
           width="100%"
         >
@@ -3879,20 +3951,20 @@ exports[`story.SuccessRegister 1`] = `
           Cluster
         </button>
       </div>
-    </span>
+    </div>
     <footer
-      class="c9"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -3900,7 +3972,7 @@ exports[`story.SuccessRegister 1`] = `
           Terms of Service
         </a>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -3914,7 +3986,7 @@ exports[`story.SuccessRegister 1`] = `
 `;
 
 exports[`story.SuccessRegisterDashboard 1`] = `
-.c8 {
+.c9 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -3941,22 +4013,22 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   width: 100%;
 }
 
-.c8:hover,
-.c8:focus {
+.c9:hover,
+.c9:focus {
   background: #B29DFF;
 }
 
-.c8:active {
+.c9:active {
   background: #C5B6FF;
 }
 
-.c8:disabled {
+.c9:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -3966,7 +4038,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   margin-bottom: 16px;
 }
 
-.c4 color {
+.c5 color {
   main: #FFFFFF;
   slightly-muted: rgba(255,255,255,0.72);
   muted: rgba(255,255,255,0.54);
@@ -3974,7 +4046,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   primary-inverse: #000000;
 }
 
-.c7 {
+.c8 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 14px;
@@ -3983,13 +4055,13 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   color: rgba(255,255,255,0.72);
 }
 
-.c11 {
+.c12 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c12 {
+.c13 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -3997,7 +4069,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   text-transform: none;
 }
 
-.c6 {
+.c7 {
   display: block;
   outline: none;
   width: 200px;
@@ -4012,14 +4084,20 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c6 {
   box-sizing: border-box;
   margin-bottom: 16px;
   display: flex;
   justify-content: center;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -4027,20 +4105,20 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   gap: 50px;
 }
 
-.c9 {
+.c10 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c13 {
+.c14 {
   color: white;
   text-decoration: none;
 }
 
-.c13:hover,
-.c13:active,
-.c13:focus {
+.c14:hover,
+.c14:active,
+.c14:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -4072,7 +4150,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -4080,7 +4158,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   margin: 24px 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -4088,12 +4166,12 @@ exports[`story.SuccessRegisterDashboard 1`] = `
   width: 600px;
   padding: 24px;
   text-align: center;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c10 {
+  .c11 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -4101,14 +4179,14 @@ exports[`story.SuccessRegisterDashboard 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -4120,9 +4198,11 @@ exports[`story.SuccessRegisterDashboard 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -4140,10 +4220,10 @@ exports[`story.SuccessRegisterDashboard 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
           color="text"
           style="text-transform: capitalize;"
         >
@@ -4151,17 +4231,17 @@ exports[`story.SuccessRegisterDashboard 1`] = `
            successful
         </div>
         <div
-          class="c5"
+          class="c6"
         >
           <img
-            class="c6"
+            class="c7"
             height="143px"
             src="file_stub"
             width="200px"
           />
         </div>
         <div
-          class="c7"
+          class="c8"
           color="text.slightlyMuted"
           font-size="2"
         >
@@ -4172,7 +4252,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
           Proceed to access your account.
         </div>
         <button
-          class="c8"
+          class="c9"
           kind="primary"
           width="100%"
         >
@@ -4180,20 +4260,20 @@ exports[`story.SuccessRegisterDashboard 1`] = `
           Dashboard
         </button>
       </div>
-    </span>
+    </div>
     <footer
-      class="c9"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -4201,7 +4281,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
           Terms of Service
         </a>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -4215,7 +4295,7 @@ exports[`story.SuccessRegisterDashboard 1`] = `
 `;
 
 exports[`story.SuccessReset 1`] = `
-.c8 {
+.c9 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -4242,22 +4322,22 @@ exports[`story.SuccessReset 1`] = `
   width: 100%;
 }
 
-.c8:hover,
-.c8:focus {
+.c9:hover,
+.c9:focus {
   background: #B29DFF;
 }
 
-.c8:active {
+.c9:active {
   background: #C5B6FF;
 }
 
-.c8:disabled {
+.c9:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -4267,7 +4347,7 @@ exports[`story.SuccessReset 1`] = `
   margin-bottom: 16px;
 }
 
-.c4 color {
+.c5 color {
   main: #FFFFFF;
   slightly-muted: rgba(255,255,255,0.72);
   muted: rgba(255,255,255,0.54);
@@ -4275,7 +4355,7 @@ exports[`story.SuccessReset 1`] = `
   primary-inverse: #000000;
 }
 
-.c7 {
+.c8 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 14px;
@@ -4284,13 +4364,13 @@ exports[`story.SuccessReset 1`] = `
   color: rgba(255,255,255,0.72);
 }
 
-.c11 {
+.c12 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c12 {
+.c13 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -4298,7 +4378,7 @@ exports[`story.SuccessReset 1`] = `
   text-transform: none;
 }
 
-.c6 {
+.c7 {
   display: block;
   outline: none;
   width: 200px;
@@ -4313,14 +4393,20 @@ exports[`story.SuccessReset 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c6 {
   box-sizing: border-box;
   margin-bottom: 16px;
   display: flex;
   justify-content: center;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -4328,20 +4414,20 @@ exports[`story.SuccessReset 1`] = `
   gap: 50px;
 }
 
-.c9 {
+.c10 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c13 {
+.c14 {
   color: white;
   text-decoration: none;
 }
 
-.c13:hover,
-.c13:active,
-.c13:focus {
+.c14:hover,
+.c14:active,
+.c14:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -4373,7 +4459,7 @@ exports[`story.SuccessReset 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -4381,7 +4467,7 @@ exports[`story.SuccessReset 1`] = `
   margin: 24px 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -4389,12 +4475,12 @@ exports[`story.SuccessReset 1`] = `
   width: 600px;
   padding: 24px;
   text-align: center;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c10 {
+  .c11 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -4402,14 +4488,14 @@ exports[`story.SuccessReset 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -4421,9 +4507,11 @@ exports[`story.SuccessReset 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -4441,10 +4529,10 @@ exports[`story.SuccessReset 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
           color="text"
           style="text-transform: capitalize;"
         >
@@ -4452,17 +4540,17 @@ exports[`story.SuccessReset 1`] = `
            successful
         </div>
         <div
-          class="c5"
+          class="c6"
         >
           <img
-            class="c6"
+            class="c7"
             height="143px"
             src="file_stub"
             width="200px"
           />
         </div>
         <div
-          class="c7"
+          class="c8"
           color="text.slightlyMuted"
           font-size="2"
         >
@@ -4473,7 +4561,7 @@ exports[`story.SuccessReset 1`] = `
           Proceed to access your account.
         </div>
         <button
-          class="c8"
+          class="c9"
           kind="primary"
           width="100%"
         >
@@ -4481,20 +4569,20 @@ exports[`story.SuccessReset 1`] = `
           Cluster
         </button>
       </div>
-    </span>
+    </div>
     <footer
-      class="c9"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -4502,7 +4590,7 @@ exports[`story.SuccessReset 1`] = `
           Terms of Service
         </a>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"
@@ -4516,7 +4604,7 @@ exports[`story.SuccessReset 1`] = `
 `;
 
 exports[`story.SuccessResetDashboard 1`] = `
-.c8 {
+.c9 {
   line-height: 1.5;
   margin: 0;
   display: inline-flex;
@@ -4543,22 +4631,22 @@ exports[`story.SuccessResetDashboard 1`] = `
   width: 100%;
 }
 
-.c8:hover,
-.c8:focus {
+.c9:hover,
+.c9:focus {
   background: #B29DFF;
 }
 
-.c8:active {
+.c9:active {
   background: #C5B6FF;
 }
 
-.c8:disabled {
+.c9:disabled {
   background: rgba(255,255,255,0.12);
   color: rgba(255,255,255,0.3);
   cursor: auto;
 }
 
-.c4 {
+.c5 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-weight: 400;
@@ -4568,7 +4656,7 @@ exports[`story.SuccessResetDashboard 1`] = `
   margin-bottom: 16px;
 }
 
-.c4 color {
+.c5 color {
   main: #FFFFFF;
   slightly-muted: rgba(255,255,255,0.72);
   muted: rgba(255,255,255,0.54);
@@ -4576,7 +4664,7 @@ exports[`story.SuccessResetDashboard 1`] = `
   primary-inverse: #000000;
 }
 
-.c7 {
+.c8 {
   overflow: hidden;
   text-overflow: ellipsis;
   font-size: 14px;
@@ -4585,13 +4673,13 @@ exports[`story.SuccessResetDashboard 1`] = `
   color: rgba(255,255,255,0.72);
 }
 
-.c11 {
+.c12 {
   overflow: hidden;
   text-overflow: ellipsis;
   margin: 0px;
 }
 
-.c12 {
+.c13 {
   color: #009EFF;
   font-weight: normal;
   background: none;
@@ -4599,7 +4687,7 @@ exports[`story.SuccessResetDashboard 1`] = `
   text-transform: none;
 }
 
-.c6 {
+.c7 {
   display: block;
   outline: none;
   width: 200px;
@@ -4614,14 +4702,20 @@ exports[`story.SuccessResetDashboard 1`] = `
   flex-direction: column;
 }
 
-.c5 {
+.c2 {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+}
+
+.c6 {
   box-sizing: border-box;
   margin-bottom: 16px;
   display: flex;
   justify-content: center;
 }
 
-.c10 {
+.c11 {
   box-sizing: border-box;
   display: flex;
   justify-content: center;
@@ -4629,20 +4723,20 @@ exports[`story.SuccessResetDashboard 1`] = `
   gap: 50px;
 }
 
-.c9 {
+.c10 {
   padding-bottom: 24px;
   width: 100%;
   color: white;
 }
 
-.c13 {
+.c14 {
   color: white;
   text-decoration: none;
 }
 
-.c13:hover,
-.c13:active,
-.c13:focus {
+.c14:hover,
+.c14:active,
+.c14:focus {
   color: rgba(255,255,255,0.54);
 }
 
@@ -4674,7 +4768,7 @@ exports[`story.SuccessResetDashboard 1`] = `
   backdrop-filter: blur(17.5px);
 }
 
-.c2 {
+.c3 {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
@@ -4682,7 +4776,7 @@ exports[`story.SuccessResetDashboard 1`] = `
   margin: 24px 0;
 }
 
-.c3 {
+.c4 {
   box-sizing: border-box;
   box-shadow: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px rgba(0,0,0,0.14),0px 1px 18px rgba(0,0,0,0.12);
   border-radius: 8px;
@@ -4690,12 +4784,12 @@ exports[`story.SuccessResetDashboard 1`] = `
   width: 600px;
   padding: 24px;
   text-align: center;
-  margin: 40px auto auto auto;
+  margin: 16px auto 16px auto;
   overflow-y: auto;
 }
 
 @media screen and (max-width:800px) {
-  .c10 {
+  .c11 {
     flex-direction: column-reverse;
     text-align: center;
     gap: 10px;
@@ -4703,14 +4797,14 @@ exports[`story.SuccessResetDashboard 1`] = `
 }
 
 @media screen and (max-width:800px) {
-  .c3 {
+  .c4 {
     width: auto;
     margin: 20px;
   }
 }
 
 @media screen and (max-height:760px) {
-  .c3 {
+  .c4 {
     height: calc(100vh - 250px);
   }
 }
@@ -4722,9 +4816,11 @@ exports[`story.SuccessResetDashboard 1`] = `
     class="c1"
     height="100%"
   >
-    <span>
+    <div
+      class="c2"
+    >
       <div
-        class="c2"
+        class="c3"
       >
         <svg
           fill="none"
@@ -4742,10 +4838,10 @@ exports[`story.SuccessResetDashboard 1`] = `
         </svg>
       </div>
       <div
-        class="c3"
+        class="c4"
       >
         <div
-          class="c4"
+          class="c5"
           color="text"
           style="text-transform: capitalize;"
         >
@@ -4753,17 +4849,17 @@ exports[`story.SuccessResetDashboard 1`] = `
            successful
         </div>
         <div
-          class="c5"
+          class="c6"
         >
           <img
-            class="c6"
+            class="c7"
             height="143px"
             src="file_stub"
             width="200px"
           />
         </div>
         <div
-          class="c7"
+          class="c8"
           color="text.slightlyMuted"
           font-size="2"
         >
@@ -4774,7 +4870,7 @@ exports[`story.SuccessResetDashboard 1`] = `
           Proceed to access your account.
         </div>
         <button
-          class="c8"
+          class="c9"
           kind="primary"
           width="100%"
         >
@@ -4782,20 +4878,20 @@ exports[`story.SuccessResetDashboard 1`] = `
           Dashboard
         </button>
       </div>
-    </span>
+    </div>
     <footer
-      class="c9"
+      class="c10"
     >
       <div
-        class="c10"
+        class="c11"
       >
         <div
-          class="c11"
+          class="c12"
         >
           © Gravitational, Inc. All Rights Reserved
         </div>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/tos/"
           rel="noreferrer"
           target="_blank"
@@ -4803,7 +4899,7 @@ exports[`story.SuccessResetDashboard 1`] = `
           Terms of Service
         </a>
         <a
-          class="c12 c13"
+          class="c13 c14"
           href="https://goteleport.com/legal/privacy/"
           rel="noreferrer"
           target="_blank"

--- a/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
+++ b/web/packages/teleport/src/components/FormLogin/FormLogin.tsx
@@ -83,7 +83,7 @@ export default function LoginForm(props: Props) {
             {attempt.message}
           </Alerts.Danger>
         )}
-        <SsoList {...props} />
+        <SsoList {...props} autoFocus={true} hasTransitionEnded={true} />
       </Card>
     );
   }
@@ -128,7 +128,11 @@ const SsoList = ({
   authProviders,
   onLoginWithSso,
   autoFocus = false,
-}: Props) => {
+  hasTransitionEnded,
+}: Props & { hasTransitionEnded?: boolean }) => {
+  const ref = useRefAutoFocus<HTMLInputElement>({
+    shouldFocus: hasTransitionEnded && autoFocus,
+  });
   const { isProcessing } = attempt;
   return (
     <SSOButtonList
@@ -136,7 +140,7 @@ const SsoList = ({
       isDisabled={isProcessing}
       providers={authProviders}
       onClick={onLoginWithSso}
-      autoFocus={autoFocus}
+      ref={ref}
     />
   );
 };
@@ -145,7 +149,11 @@ const Passwordless = ({
   onLoginWithWebauthn,
   attempt,
   autoFocus = false,
-}: Props) => {
+  hasTransitionEnded,
+}: Props & { hasTransitionEnded: boolean }) => {
+  const ref = useRefAutoFocus<HTMLInputElement>({
+    shouldFocus: hasTransitionEnded && autoFocus,
+  });
   // Firefox currently does not support passwordless and when
   // logging in, it will return an ambigugous error.
   // We display a soft warning because firefox may provide
@@ -162,13 +170,13 @@ const Passwordless = ({
         </Alerts.Info>
       )}
       <StyledPaswordlessBtn
+        setRef={ref}
         mt={3}
         py={2}
         px={3}
         width="100%"
         onClick={() => onLoginWithWebauthn()}
         disabled={attempt.isProcessing}
-        autoFocus={autoFocus}
       >
         <Flex alignItems="center" justifyContent="space-between">
           <Flex alignItems="center">
@@ -361,10 +369,22 @@ const Primary = ({
 
   switch (otherProps.primaryAuthType) {
     case 'passwordless':
-      $primary = <Passwordless {...otherProps} autoFocus={true} />;
+      $primary = (
+        <Passwordless
+          {...otherProps}
+          autoFocus={true}
+          hasTransitionEnded={hasTransitionEnded}
+        />
+      );
       break;
     case 'sso':
-      $primary = <SsoList {...otherProps} autoFocus={true} />;
+      $primary = (
+        <SsoList
+          {...otherProps}
+          autoFocus={true}
+          hasTransitionEnded={hasTransitionEnded}
+        />
+      );
       break;
     case 'local':
       otherOptionsAvailable = otherProps.isPasswordlessEnabled || ssoEnabled;

--- a/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
+++ b/web/packages/teleport/src/components/FormLogin/SsoButtons.tsx
@@ -14,54 +14,51 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import React from 'react';
+import React, { forwardRef } from 'react';
 import { Box, Text } from 'design';
 import ButtonSso, { guessProviderType } from 'shared/components/ButtonSso';
 import { AuthProvider } from 'shared/services';
 
-const SSOBtnList = ({
-  providers,
-  prefixText,
-  isDisabled,
-  onClick,
-  autoFocus = false,
-}: Props) => {
-  const $btns = providers.map((item, index) => {
-    let { name, type, displayName } = item;
-    const title = displayName || `${prefixText} ${name}`;
-    const ssoType = guessProviderType(title, type);
-    const len = providers.length - 1;
-    return (
-      <ButtonSso
-        key={index}
-        title={title}
-        ssoType={ssoType}
-        disabled={isDisabled}
-        mt={3}
-        mb={index < len ? 3 : 0}
-        autoFocus={index === 0 && autoFocus}
-        onClick={e => {
-          e.preventDefault();
-          onClick(item);
-        }}
-      />
-    );
-  });
+const SSOBtnList = forwardRef<HTMLInputElement, Props>(
+  ({ providers, prefixText, isDisabled, onClick, autoFocus = false }, ref) => {
+    const $btns = providers.map((item, index) => {
+      let { name, type, displayName } = item;
+      const title = displayName || `${prefixText} ${name}`;
+      const ssoType = guessProviderType(title, type);
+      const len = providers.length - 1;
+      return (
+        <ButtonSso
+          setRef={index === 0 ? ref : null}
+          key={index}
+          title={title}
+          ssoType={ssoType}
+          disabled={isDisabled}
+          mt={3}
+          mb={index < len ? 3 : 0}
+          autoFocus={index === 0 && autoFocus}
+          onClick={e => {
+            e.preventDefault();
+            onClick(item);
+          }}
+        />
+      );
+    });
 
-  if ($btns.length === 0) {
+    if ($btns.length === 0) {
+      return (
+        <Text textAlign="center" bold pt={3}>
+          You have no SSO providers configured
+        </Text>
+      );
+    }
+
     return (
-      <Text textAlign="center" bold pt={3}>
-        You have no SSO providers configured
-      </Text>
+      <Box px={6} pt={2} pb={2} data-testid="sso-list">
+        {$btns}
+      </Box>
     );
   }
-
-  return (
-    <Box px={6} pt={2} pb={2} data-testid="sso-list">
-      {$btns}
-    </Box>
-  );
-};
+);
 
 type Props = {
   prefixText: string;


### PR DESCRIPTION
- step slider glitch: step slider can also be used as a wheel slider and there were glitches with this use in the newly designed user signup flow where when sliding, the bottom of component will quickly resize up and down (it was because of margins not being taken into height calculations)
- with login forms (going from local -> sso for eg), transition ended prematurely in safari from trying to auto focus too early (should be done after transition ended)


there is also another glitch with step slider when used as `in place slider` that's been present from beginning but left it out for another day (it's not as bad as the wheel glitch). still can't figure out why because it sometimes does it and some forms don't (eg: LoginForm doesn't glitch for some reason)... it's the same glitch where the bottom can resize up and down 🤷‍♀️ 

TODO:
 - [ ] requires a one file snapshot update in `enterprise`, will do after this gets reviewed

This is before (the glitch)

https://github.com/gravitational/teleport/assets/43280172/eb96da47-6653-42c8-ba78-cc08fa109c47



