### PR TITLE
Use container queries for unified layout

### DIFF
--- a/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
+++ b/web/packages/teleport/src/UnifiedResources/ResourceCard.tsx
@@ -391,8 +391,10 @@ const CardContainer = styled(Box)`
  * outer container.
  */
 const CardInnerContainer = styled(Flex)`
-  border-top: 2px solid ${props => props.theme.colors.spotBackground[0]};
   background-color: transparent;
+  border: ${props => props.theme.borders[2]}
+    ${props => props.theme.colors.spotBackground[0]};
+  border-radius: ${props => props.theme.radii[3]}px;
 
   ${props =>
     props.showAllLabels
@@ -405,12 +407,6 @@ const CardInnerContainer = styled(Flex)`
     background-color: ${props => props.theme.colors.levels.elevated};
     border-color: ${props => props.theme.colors.levels.elevated};
     box-shadow: ${props => props.theme.boxShadow[1]};
-  }
-
-  @media (min-width: ${props => props.theme.breakpoints.tablet}px) {
-    border: ${props => props.theme.borders[2]}
-      ${props => props.theme.colors.spotBackground[0]};
-    border-radius: ${props => props.theme.radii[3]}px;
   }
 `;
 

--- a/web/packages/teleport/src/UnifiedResources/Resources.tsx
+++ b/web/packages/teleport/src/UnifiedResources/Resources.tsx
@@ -41,6 +41,7 @@ import { useUrlFiltering } from 'teleport/components/hooks';
 import { ResourceCard, LoadingCard } from './ResourceCard';
 import SearchPanel from './SearchPanel';
 import { FilterPanel } from './FilterPanel';
+import './unifiedStyles.css';
 
 const RESOURCES_MAX_WIDTH = '1800px';
 // get 48 resources to start
@@ -124,6 +125,8 @@ export function Resources() {
 
   return (
     <FeatureBox
+      className="ContainerContext"
+      px={4}
       css={`
         max-width: ${RESOURCES_MAX_WIDTH};
         margin: auto;
@@ -163,7 +166,7 @@ export function Resources() {
       {attempt.status === 'failed' && (
         <ErrorMessage message={attempt.statusText} />
       )}
-      <ResourcesContainer gap={2}>
+      <ResourcesContainer className="ResourcesContainer" gap={2}>
         {fetchedData.agents.map((agent, i) => (
           <ResourceCard key={i} onLabelClick={onLabelClick} resource={agent} />
         ))}
@@ -229,9 +232,6 @@ function NoResults({ query }: { query: string }) {
 const ResourcesContainer = styled(Flex)`
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(400px, 1fr));
-  @media (min-width: ${RESOURCES_MAX_WIDTH}) {
-    grid-template-columns: repeat(4, minmax(400px, 1fr));
-  }
 `;
 
 const emptyStateInfo: EmptyStateInfo = {

--- a/web/packages/teleport/src/UnifiedResources/SearchPanel.tsx
+++ b/web/packages/teleport/src/UnifiedResources/SearchPanel.tsx
@@ -47,7 +47,7 @@ export function SearchPanel({
   }
 
   return (
-    <Flex as="form" style={{ width: '70%' }} onSubmit={onSubmitSearch} mb={2}>
+    <Flex as="form" className="SearchPanel" onSubmit={onSubmitSearch} mb={2}>
       <SearchInput searchValue={searchString} setSearchValue={setSearchString}>
         <ToggleWrapper>
           <Toggle isToggled={isAdvancedSearch} onToggle={onToggle} />

--- a/web/packages/teleport/src/UnifiedResources/unifiedStyles.css
+++ b/web/packages/teleport/src/UnifiedResources/unifiedStyles.css
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2023 Gravitational, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* 
+    the styled-components@5 doesn't support container queries so
+    we have to create and set the classes manually
+    TODO (avatus): DELETE if we ever upgrade to v6
+*/
+.ContainerContext {
+  min-width: 800px;
+  container-type: inline-size;
+}
+
+.ResourcesContainer {
+  @container (min-width: 1600px) {
+    grid-template-columns: repeat(4, minmax(400px, 1fr));
+  }
+}
+
+.SearchPanel {
+  width: 100%;
+  @container (min-width: 800px) {
+    width: 70%;
+  }
+}


### PR DESCRIPTION
This fixes the layout to better match the breakpoints. We were doing a bit of guesswork before with the sidebar (the bane of our layout) and so I opted in to using [container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_container_queries)

Using a container query makes our development experience match what we are "thinking about" when we talk about breakpoints in our content containers. the downside is that `styled-components` v5 doesn't support it. it's in v6 but that introduced a bunch of breaking changes to our codebase so rather than doing ALL OF THAT for this one page, i just opted to importing some basic css.

When the sidebar goes away we can move back to media queries very easily. 


https://github.com/gravitational/teleport/assets/5201977/5d92da5e-7bc1-454b-a778-73481431ccef

