### PR TITLE
AWS OIDC: Set up integration with a single command

### DIFF
--- a/lib/cloud/aws/policy.go
+++ b/lib/cloud/aws/policy.go
@@ -76,6 +76,12 @@ type Statement struct {
 	Resources SliceOrString `json:"Resource,omitempty"`
 	// Principals is a list of principals.
 	Principals map[string]SliceOrString `json:"Principal,omitempty"`
+	// Conditions is a list of conditions that must be satisfied for the action to be allowed.
+	// Example:
+	// Condition:
+	//    StringEquals:
+	//        "proxy.example.com:aud": "discover.teleport"
+	Conditions map[string]map[string]SliceOrString `json:"Condition,omitempty"`
 }
 
 // ensureResource ensures that the statement contains the specified resource.

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -202,6 +202,10 @@ type CommandLineFlags struct {
 	// IntegrationConfEICEIAMArguments contains the arguments of
 	// `teleport integration configure eice-iam` command
 	IntegrationConfEICEIAMArguments IntegrationConfEICEIAM
+
+	// IntegrationConfAWSOIDCIdPArguments contains the arguments of
+	// `teleport integration configure awsoidc-idp` command
+	IntegrationConfAWSOIDCIdPArguments IntegrationConfAWSOIDCIdP
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of
@@ -226,6 +230,22 @@ type IntegrationConfEICEIAM struct {
 	Region string
 	// Role is the AWS Role associated with the Integration
 	Role string
+}
+
+// IntegrationConfAWSOIDCIdP contains the arguments of
+// `teleport integration configure awsoidc-idp` command
+type IntegrationConfAWSOIDCIdP struct {
+	// Cluster is the teleport cluster name.
+	Cluster string
+	// Name is the integration name.
+	Name string
+	// Region is the AWS Region used to set up the client.
+	Region string
+	// Role is the AWS Role to associate with the Integration
+	Role string
+	// ProxyPublicURL is the IdP Issuer URL (Teleport Proxy Public Address).
+	// Eg, https://<tenant>.teleport.sh
+	ProxyPublicURL string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -100,12 +100,12 @@ func (r *IdPIAMConfigureRequest) CheckAndSetDefaults() error {
 	return nil
 }
 
-// IdPIAMConfigureClient describes the required methods to create the AWS OpenIDConnect IdP and a Role to .
+// IdPIAMConfigureClient describes the required methods to create the AWS OIDC IdP and a Role that trusts that identity provider.
 type IdPIAMConfigureClient interface {
 	// GetCallerIdentity returns information about the caller identity.
 	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
 
-	// CreateOpenIDConnectProvider creates an IAM OpenID Connect Provider.
+	// CreateOpenIDConnectProvider creates an IAM OIDC IdP.
 	CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error)
 
 	// CreateRole creates a new IAM Role.
@@ -139,7 +139,7 @@ func NewIdPIAMConfigureClient(ctx context.Context, region string) (IdPIAMConfigu
 	}, nil
 }
 
-// ConfigureIdPIAM creates a new IAM OpenID Connect Identity Provider in AWS.
+// ConfigureIdPIAM creates a new IAM OIDC IdP in AWS.
 //
 // The Provider URL is Teleport's Public Address.
 // It also creates a new Role configured to trust the recently created IdP.

--- a/lib/integrations/awsoidc/idp_iam_config.go
+++ b/lib/integrations/awsoidc/idp_iam_config.go
@@ -1,0 +1,214 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"log"
+	"net/url"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/api/types"
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+)
+
+const (
+	descriptionOIDCIdPRole = "Used by Teleport to provide access to AWS resources."
+)
+
+// IdPIAMConfigureRequest is a request to configure the required Policies to use the EC2 Instance Connect Endpoint feature.
+type IdPIAMConfigureRequest struct {
+	// Cluster is the Teleport Cluster.
+	// Used for tagging the created Roles/IdP.
+	Cluster string
+
+	// AccountID is the AWS Account ID.
+	// Optional. sts.GetCallerIdentity is used if not provided.
+	AccountID string
+
+	// IntegrationName is the Integration Name.
+	// Used for tagging the created Roles/IdP.
+	IntegrationName string
+
+	// Region is the AWS Region.
+	// Used to set up the AWS SDK Client.
+	Region string
+
+	// ProxyPublicAddress is the URL to use as provider URL.
+	// This must be a valid URL (ie, url.Parse'able)
+	// Eg, https://<tenant>.teleport.sh, https://proxy.example.org:443, https://teleport.ec2.aws:3080
+	ProxyPublicAddress string
+
+	// issuer is the above value but only contains the host.
+	// Eg, <tenant>.teleport.sh, proxy.example.org, teleport.ec2.aws:3080
+	issuer string
+
+	// IntegrationRole is the Integration's AWS Role used to set up Teleport as an OIDC IdP.
+	IntegrationRole string
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *IdPIAMConfigureRequest) CheckAndSetDefaults() error {
+	if r.Cluster == "" {
+		return trace.BadParameter("cluster is required")
+	}
+
+	if r.IntegrationName == "" {
+		return trace.BadParameter("integration name is required")
+	}
+
+	if r.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	if r.IntegrationRole == "" {
+		return trace.BadParameter("integration role is required")
+	}
+
+	if r.ProxyPublicAddress == "" {
+		return trace.BadParameter("proxy public address is required")
+	}
+
+	issuerURL, err := url.Parse(r.ProxyPublicAddress)
+	if err != nil {
+		return trace.BadParameter("proxy public address is not a valid url: %v", err)
+	}
+	r.issuer = issuerURL.Host
+	if issuerURL.Port() == "443" {
+		r.issuer = issuerURL.Hostname()
+	}
+
+	return nil
+}
+
+// IdPIAMConfigureClient describes the required methods to create the AWS OpenIDConnect IdP and a Role to .
+type IdPIAMConfigureClient interface {
+	// GetCallerIdentity returns information about the caller identity.
+	GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+
+	// CreateOpenIDConnectProvider creates an IAM OpenID Connect Provider.
+	CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error)
+
+	// CreateRole creates a new IAM Role.
+	CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error)
+}
+
+type defaultIdPIAMConfigureClient struct {
+	*iam.Client
+	stsClient *sts.Client
+}
+
+// GetCallerIdentity returns details about the IAM user or role whose credentials are used to call the operation.
+func (d defaultIdPIAMConfigureClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return d.stsClient.GetCallerIdentity(ctx, params, optFns...)
+}
+
+// NewIdPIAMConfigureClient creates a new IdPIAMConfigureClient.
+func NewIdPIAMConfigureClient(ctx context.Context, region string) (IdPIAMConfigureClient, error) {
+	if region == "" {
+		return nil, trace.BadParameter("region is required")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultIdPIAMConfigureClient{
+		Client:    iam.NewFromConfig(cfg),
+		stsClient: sts.NewFromConfig(cfg),
+	}, nil
+}
+
+// ConfigureIdPIAM creates a new IAM OpenID Connect Identity Provider in AWS.
+//
+// The Provider URL is Teleport's Public Address.
+// It also creates a new Role configured to trust the recently created IdP.
+//
+// The following actions must be allowed by the IAM Role assigned in the Client.
+//   - iam:CreateOpenIDConnectProvider
+//   - iam:CreateRole
+func ConfigureIdPIAM(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	if req.AccountID == "" {
+		callerIdentity, err := clt.GetCallerIdentity(ctx, nil)
+		if err != nil {
+			return trace.Wrap(err)
+		}
+		req.AccountID = aws.ToString(callerIdentity.Account)
+	}
+
+	thumbprint, err := ThumbprintIdP(ctx, req.ProxyPublicAddress)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	log.Printf("Using the following thumbprint: %s", thumbprint)
+
+	createOIDCResp, err := clt.CreateOpenIDConnectProvider(ctx, &iam.CreateOpenIDConnectProviderInput{
+		ThumbprintList: []string{thumbprint},
+		Url:            &req.ProxyPublicAddress,
+		ClientIDList:   []string{types.IntegrationAWSOIDCAudience},
+		Tags:           defaultResourceCreationTags(req.Cluster, req.IntegrationName).ToIAMTags(),
+	})
+	if err != nil {
+		if trace.IsAlreadyExists(awslib.ConvertIAMv2Error(err)) {
+			return trace.AlreadyExists("identity provider for the same URL (%s) already exists, please remove it and try again", req.ProxyPublicAddress)
+		}
+		return trace.Wrap(err)
+	}
+	log.Printf("IAM OpenID Connect Provider created: url=%q arn=%q.", req.ProxyPublicAddress, aws.ToString(createOIDCResp.OpenIDConnectProviderArn))
+
+	if err := createIdPIAMRole(ctx, clt, req); err != nil {
+		return trace.Wrap(err)
+	}
+	log.Printf("IAM Role %q created.", req.IntegrationRole)
+
+	return nil
+}
+
+func createIdPIAMRole(ctx context.Context, clt IdPIAMConfigureClient, req IdPIAMConfigureRequest) error {
+	integrationRoleAssumeRoleDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForAWSOIDCRoleTrustRelationship(req.AccountID, req.issuer, []string{types.IntegrationAWSOIDCAudience}),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 &req.IntegrationRole,
+		Description:              aws.String(descriptionOIDCIdPRole),
+		AssumeRolePolicyDocument: &integrationRoleAssumeRoleDocument,
+		Tags:                     defaultResourceCreationTags(req.Cluster, req.IntegrationName).ToIAMTags(),
+	})
+	if err != nil {
+		convertedErr := awslib.ConvertIAMv2Error(err)
+		if trace.IsAlreadyExists(convertedErr) {
+			return trace.AlreadyExists("Role %q already exists, please remove it and try again.", req.IntegrationRole)
+		}
+		return trace.Wrap(convertedErr)
+	}
+
+	return nil
+}

--- a/lib/integrations/awsoidc/idp_iam_config_test.go
+++ b/lib/integrations/awsoidc/idp_iam_config_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+
+	"github.com/gravitational/teleport/lib"
+)
+
+var baseIdPIAMConfigReq = func() IdPIAMConfigureRequest {
+	return IdPIAMConfigureRequest{
+		Cluster:            "mycluster",
+		IntegrationName:    "myintegration",
+		Region:             "us-east-1",
+		IntegrationRole:    "integrationrole",
+		ProxyPublicAddress: "https://proxy.example.com",
+	}
+}
+
+func TestIdPIAMConfigReqDefaults(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		req      func() IdPIAMConfigureRequest
+		errCheck require.ErrorAssertionFunc
+		expected IdPIAMConfigureRequest
+	}{
+		{
+			name:     "set defaults",
+			req:      baseIdPIAMConfigReq,
+			errCheck: require.NoError,
+			expected: IdPIAMConfigureRequest{
+				Cluster:            "mycluster",
+				IntegrationName:    "myintegration",
+				Region:             "us-east-1",
+				IntegrationRole:    "integrationrole",
+				ProxyPublicAddress: "https://proxy.example.com",
+				issuer:             "proxy.example.com",
+			},
+		},
+		{
+			name: "missing cluster",
+			req: func() IdPIAMConfigureRequest {
+				req := baseIdPIAMConfigReq()
+				req.Cluster = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing integration name",
+			req: func() IdPIAMConfigureRequest {
+				req := baseIdPIAMConfigReq()
+				req.IntegrationName = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing region",
+			req: func() IdPIAMConfigureRequest {
+				req := baseIdPIAMConfigReq()
+				req.Region = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing integration role",
+			req: func() IdPIAMConfigureRequest {
+				req := baseIdPIAMConfigReq()
+				req.IntegrationRole = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing proxy public address",
+			req: func() IdPIAMConfigureRequest {
+				req := baseIdPIAMConfigReq()
+				req.ProxyPublicAddress = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.req()
+			err := req.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tt.expected, req)
+		})
+	}
+}
+
+func TestConfigureIdPIAM(t *testing.T) {
+	ctx := context.Background()
+
+	tlsServer := httptest.NewTLSServer(nil)
+	// TLS Server starts with self-signed certificates.
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	baseIdPIAMConfigReqWithTLServer := func() IdPIAMConfigureRequest {
+		base := baseIdPIAMConfigReq()
+		base.ProxyPublicAddress = tlsServer.URL
+		return base
+	}
+
+	for _, tt := range []struct {
+		name               string
+		mockAccountID      string
+		mockExistingRoles  []string
+		mockExistingIdPUrl []string
+		req                func() IdPIAMConfigureRequest
+		errCheck           require.ErrorAssertionFunc
+	}{
+		{
+			name:          "valid",
+			mockAccountID: "123456789012",
+			req:           baseIdPIAMConfigReqWithTLServer,
+			errCheck:      require.NoError,
+		},
+		{
+			name:               "idp url already exists",
+			mockAccountID:      "123456789012",
+			mockExistingIdPUrl: []string{tlsServer.URL},
+			req:                baseIdPIAMConfigReqWithTLServer,
+			errCheck:           alreadyExistsCheck,
+		},
+		{
+			name:              "integration role already exists",
+			mockAccountID:     "123456789012",
+			mockExistingRoles: []string{"integrationrole"},
+			req:               baseIdPIAMConfigReqWithTLServer,
+			errCheck:          alreadyExistsCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := mockIdPIAMConfigClient{
+				accountID:      tt.mockAccountID,
+				existingRoles:  tt.mockExistingRoles,
+				existingIDPUrl: tt.mockExistingIdPUrl,
+			}
+
+			err := ConfigureIdPIAM(ctx, &clt, tt.req())
+			tt.errCheck(t, err)
+		})
+	}
+}
+
+type mockIdPIAMConfigClient struct {
+	accountID      string
+	existingRoles  []string
+	existingIDPUrl []string
+}
+
+// GetCallerIdentity returns information about the caller identity.
+func (m *mockIdPIAMConfigClient) GetCallerIdentity(ctx context.Context, params *sts.GetCallerIdentityInput, optFns ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	return &sts.GetCallerIdentityOutput{
+		Account: &m.accountID,
+	}, nil
+}
+
+// CreateRole creates a new IAM Role.
+func (m *mockIdPIAMConfigClient) CreateRole(ctx context.Context, params *iam.CreateRoleInput, optFns ...func(*iam.Options)) (*iam.CreateRoleOutput, error) {
+	alreadyExistsMessage := fmt.Sprintf("Role %q already exists.", *params.RoleName)
+	if slices.Contains(m.existingRoles, *params.RoleName) {
+		return nil, &iamTypes.EntityAlreadyExistsException{
+			Message: &alreadyExistsMessage,
+		}
+	}
+	m.existingRoles = append(m.existingRoles, *params.RoleName)
+
+	return nil, nil
+}
+
+// CreateOpenIDConnectProvider creates an IAM OpenID Connect Provider.
+func (m *mockIdPIAMConfigClient) CreateOpenIDConnectProvider(ctx context.Context, params *iam.CreateOpenIDConnectProviderInput, optFns ...func(*iam.Options)) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	alreadyExistsMessage := fmt.Sprintf("IdP with URL %q already exists.", *params.Url)
+	if slices.Contains(m.existingIDPUrl, *params.Url) {
+		return nil, &iamTypes.EntityAlreadyExistsException{
+			Message: &alreadyExistsMessage,
+		}
+	}
+	m.existingIDPUrl = append(m.existingRoles, *params.Url)
+
+	return &iam.CreateOpenIDConnectProviderOutput{
+		OpenIDConnectProviderArn: aws.String("arn:something"),
+	}, nil
+}

--- a/lib/integrations/awsoidc/idp_thumbprint.go
+++ b/lib/integrations/awsoidc/idp_thumbprint.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/sha1"
 	"crypto/tls"
-	"fmt"
+	"encoding/hex"
 	"net/url"
 
 	"github.com/gravitational/trace"
@@ -82,5 +82,5 @@ func ThumbprintIdP(ctx context.Context, publicAddress string) (string, error) {
 	thumbprint := sha1.Sum(cert.Raw)
 
 	// Convert the thumbprint ([]bytes) into their hex representation.
-	return fmt.Sprintf("%x", thumbprint), nil
+	return hex.EncodeToString(thumbprint[:]), nil
 }

--- a/lib/integrations/awsoidc/idp_thumbprint.go
+++ b/lib/integrations/awsoidc/idp_thumbprint.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"crypto/sha1"
+	"crypto/tls"
+	"fmt"
+	"net/url"
+
+	"github.com/gravitational/trace"
+
+	"github.com/gravitational/teleport/lib"
+)
+
+// ThumbprintIdP returns the thumbprint as required by AWS when adding an OIDC Identity Provider.
+// This is documented here:
+// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+// Returns the thumbprint of the top intermediate CA that signed the TLS cert used to serve HTTPS requests.
+// In case of a self signed certificate, then it returns the thumbprint of the TLS cert itself.
+func ThumbprintIdP(ctx context.Context, publicAddress string) (string, error) {
+	issuer, err := IssuerFromPublicAddress(publicAddress)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	addrURL, err := url.Parse(issuer)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+
+	// The port needs to be explicitly set because it uses tls.Dialer which doesn't have a default port.
+	if addrURL.Port() == "" {
+		addrURL.Host = addrURL.Host + ":443"
+	}
+
+	d := tls.Dialer{
+		Config: &tls.Config{
+			InsecureSkipVerify: lib.IsInsecureDevMode(),
+		},
+	}
+	conn, err := d.DialContext(ctx, "tcp", addrURL.Host)
+	if err != nil {
+		return "", trace.Wrap(err)
+	}
+	defer conn.Close()
+
+	tlsConn, ok := conn.(*tls.Conn)
+	if !ok {
+		return "", trace.Errorf("failed to create a tls connection")
+	}
+
+	certs := tlsConn.ConnectionState().PeerCertificates
+	if len(certs) == 0 {
+		return "", trace.Errorf("no certificates were provided")
+	}
+
+	// Get the last certificate of the chain
+	// https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html
+	// > If you see more than one certificate, find the last certificate displayed (at the end of the command output).
+	// > This contains the certificate of the top intermediate CA in the certificate authority chain.
+	//
+	// The guide above uses openssl but the expected list of certificates and their order is the same.
+
+	lastCertificateIdx := len(certs) - 1
+	cert := certs[lastCertificateIdx]
+	thumbprint := sha1.Sum(cert.Raw)
+
+	// Convert the thumbprint ([]bytes) into their hex representation.
+	return fmt.Sprintf("%x", thumbprint), nil
+}

--- a/lib/integrations/awsoidc/idp_thumbprint_test.go
+++ b/lib/integrations/awsoidc/idp_thumbprint_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gravitational/teleport/lib"
+)
+
+func TestThumbprint(t *testing.T) {
+	ctx := context.Background()
+
+	tlsServer := httptest.NewTLSServer(nil)
+
+	// Proxy starts with self-signed certificates.
+	lib.SetInsecureDevMode(true)
+	defer lib.SetInsecureDevMode(false)
+
+	thumbprint, err := ThumbprintIdP(ctx, tlsServer.URL)
+	require.NoError(t, err)
+
+	// The Proxy is started using httptest.NewTLSServer, which uses a hard-coded cert
+	// located at go/src/net/http/internal/testcert/testcert.go
+	// The following value is the sha1 fingerprint of that certificate.
+	expectedThumbprint := "15dbd260c7465ecca6de2c0b2181187f66ee0d1a"
+
+	require.Equal(t, expectedThumbprint, thumbprint)
+}

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -792,6 +792,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.DELETE("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsDelete))
 
 	// AWS OIDC Integration Actions
+	h.GET("/webapi/scripts/integrations/configure/awsoidc-idp.sh", h.WithLimiter(h.awsOIDCConfigureAWSOIDCIdP))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/databases", h.WithClusterAuth(h.awsOIDCListDatabases))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -792,7 +792,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	h.DELETE("/webapi/sites/:site/integrations/:name", h.WithClusterAuth(h.integrationsDelete))
 
 	// AWS OIDC Integration Actions
-	h.GET("/webapi/scripts/integrations/configure/awsoidc-idp.sh", h.WithLimiter(h.awsOIDCConfigureAWSOIDCIdP))
+	h.GET("/webapi/scripts/integrations/configure/awsoidc-idp.sh", h.WithLimiter(h.awsOIDCConfigureIdP))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/databases", h.WithClusterAuth(h.awsOIDCListDatabases))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -441,8 +441,8 @@ func (h *Handler) awsOIDCDeployEC2ICE(w http.ResponseWriter, r *http.Request, p 
 	}, nil
 }
 
-// awsOIDCConfigureIdP returns a script that configures the AWS OIDC Integration in AWS.
-// This creates an OIDC Identity Provider that trusts this Teleport instance.
+// awsOIDCConfigureIdP returns a script that configures AWS OIDC Integration
+// by creating an OIDC Identity Provider that trusts Teleport instance.
 func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 	ctx := r.Context()
 

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -441,9 +441,9 @@ func (h *Handler) awsOIDCDeployEC2ICE(w http.ResponseWriter, r *http.Request, p 
 	}, nil
 }
 
-// awsOIDCConfigureAWSOIDCIdP returns a script that configures the AWS OIDC Integration in AWS.
+// awsOIDCConfigureIdP returns a script that configures the AWS OIDC Integration in AWS.
 // This creates an OIDC Identity Provider that trusts this Teleport instance.
-func (h *Handler) awsOIDCConfigureAWSOIDCIdP(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
+func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p httprouter.Params) (any, error) {
 	ctx := r.Context()
 
 	queryParams := r.URL.Query()

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -232,3 +232,112 @@ func TestBuildEICEConfigureIAMScript(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
+	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+
+	// Unauthenticated client for script downloading.
+	publicClt := env.proxies[0].newClient(t)
+	pathVars := []string{
+		"webapi",
+		"scripts",
+		"integrations",
+		"configure",
+		"awsoidc-idp.sh",
+	}
+	endpoint := publicClt.Endpoint(pathVars...)
+
+	proxyPublicURL := env.proxies[0].webURL
+
+	tests := []struct {
+		name                 string
+		reqRelativeURL       string
+		reqQuery             url.Values
+		errCheck             require.ErrorAssertionFunc
+		expectedTeleportArgs string
+	}{
+		{
+			name: "valid",
+			reqQuery: url.Values{
+				"awsRegion":       []string{"us-east-1"},
+				"role":            []string{"myRole"},
+				"integrationName": []string{"myintegration"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure awsoidc-idp " +
+				"--cluster=localhost " +
+				"--name=myintegration " +
+				"--aws-region=us-east-1 " +
+				"--role=myRole " +
+				"--proxy-public-url=" + proxyPublicURL.String(),
+		},
+		{
+			name: "valid with symbols in role",
+			reqQuery: url.Values{
+				"awsRegion":       []string{"us-east-1"},
+				"role":            []string{"Test+1=2,3.4@5-6_7"},
+				"integrationName": []string{"myintegration"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure awsoidc-idp " +
+				"--cluster=localhost " +
+				"--name=myintegration " +
+				"--aws-region=us-east-1 " +
+				"--role=Test+1=2,3.4@5-6_7 " +
+				"--proxy-public-url=" + proxyPublicURL.String(),
+		},
+		{
+			name: "missing aws-region",
+			reqQuery: url.Values{
+				"role":            []string{"myRole"},
+				"integrationName": []string{"myintegration"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing role",
+			reqQuery: url.Values{
+				"awsRegion":       []string{"us-east-1"},
+				"integrationName": []string{"myintegration"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing integration name",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"role"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "trying to inject escape sequence into query params",
+			reqQuery: url.Values{
+				"awsRegion":       []string{"us-east-1"},
+				"role":            []string{"role"},
+				"integrationName": []string{"'; rm -rf /tmp/dir; echo '"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
+			tc.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Contains(t, string(resp.Bytes()),
+				fmt.Sprintf("teleportArgs='%s'\n", tc.expectedTeleportArgs),
+			)
+		})
+	}
+}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -454,6 +454,18 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEICECmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Region)
 	integrationConfEICECmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Role)
 
+	integrationConfAWSOIDCIdPCmd := integrationConfigureCmd.Command("awsoidc-idp", "Creates an IAM IdP (OIDC) in your AWS account to allow the AWS OIDC Integration to access AWS APIs.")
+	integrationConfAWSOIDCIdPCmd.Flag("cluster", "Teleport Cluster's name.").Required().StringVar(&ccf.
+		IntegrationConfAWSOIDCIdPArguments.Cluster)
+	integrationConfAWSOIDCIdPCmd.Flag("name", "Integration name.").Required().StringVar(&ccf.
+		IntegrationConfAWSOIDCIdPArguments.Name)
+	integrationConfAWSOIDCIdPCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.
+		IntegrationConfAWSOIDCIdPArguments.Region)
+	integrationConfAWSOIDCIdPCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.
+		IntegrationConfAWSOIDCIdPArguments.Role)
+	integrationConfAWSOIDCIdPCmd.Flag("proxy-public-url", "Proxy Public URL (eg https://mytenant.teleport.sh).").Required().StringVar(&ccf.
+		IntegrationConfAWSOIDCIdPArguments.ProxyPublicURL)
+
 	// parse CLI commands+flags:
 	utils.UpdateAppUsageTemplate(app, options.Args)
 	command, err := app.Parse(options.Args)
@@ -543,6 +555,8 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 		err = onIntegrationConfDeployService(ccf.IntegrationConfDeployServiceIAMArguments)
 	case integrationConfEICECmd.FullCommand():
 		err = onIntegrationConfEICEIAM(ccf.IntegrationConfEICEIAMArguments)
+	case integrationConfAWSOIDCIdPCmd.FullCommand():
+		err = onIntegrationConfAWSOIDCIdP(ccf.IntegrationConfAWSOIDCIdPArguments)
 	}
 	if err != nil {
 		utils.FatalError(err)
@@ -910,6 +924,28 @@ func onIntegrationConfEICEIAM(params config.IntegrationConfEICEIAM) error {
 	err = awsoidc.ConfigureEICEIAM(ctx, iamClient, awsoidc.EICEIAMConfigureRequest{
 		Region:          params.Region,
 		IntegrationRole: params.Role,
+	})
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	return nil
+}
+
+func onIntegrationConfAWSOIDCIdP(params config.IntegrationConfAWSOIDCIdP) error {
+	ctx := context.Background()
+
+	iamClient, err := awsoidc.NewIdPIAMConfigureClient(ctx, params.Region)
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	err = awsoidc.ConfigureIdPIAM(ctx, iamClient, awsoidc.IdPIAMConfigureRequest{
+		Cluster:            params.Cluster,
+		IntegrationName:    params.Name,
+		Region:             params.Region,
+		IntegrationRole:    params.Role,
+		ProxyPublicAddress: params.ProxyPublicURL,
 	})
 	if err != nil {
 		return trace.Wrap(err)

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -455,7 +455,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfEICECmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfEICEIAMArguments.Role)
 
 	integrationConfAWSOIDCIdPCmd := integrationConfigureCmd.Command("awsoidc-idp", "Creates an IAM IdP (OIDC) in your AWS account to allow the AWS OIDC Integration to access AWS APIs.")
-	integrationConfAWSOIDCIdPCmd.Flag("cluster", "Teleport Cluster's name.").Required().StringVar(&ccf.
+	integrationConfAWSOIDCIdPCmd.Flag("cluster", "Teleport Cluster name.").Required().StringVar(&ccf.
 		IntegrationConfAWSOIDCIdPArguments.Cluster)
 	integrationConfAWSOIDCIdPCmd.Flag("name", "Integration name.").Required().StringVar(&ccf.
 		IntegrationConfAWSOIDCIdPArguments.Name)


### PR DESCRIPTION
Creating an AWS OIDC Integration requires a lot of clicks, copy/paste, navigation between tabs.

This PR adds a single teleport command that creates all the required resources in AWS:
- AWS OIDC Identity Provider that uses Teleport as source
- AWS IAM Role that can be used by this Identity Provider

After running this command, the integration must be created in Teleport as well.
The UI will be updated to consider this command, as an alternative you can also create the following resource in your cluster
`tctl create -f integration.yaml`:
```yaml
kind: integration
sub_kind: aws-oidc
version: v1
metadata:
  name: teleport-dev
spec:
  aws_oidc:
    role_arn: "arn:aws:iam::278576220453:role/MarcoTestAWSOIDCSetup"
```


This role, will then have inline policies allowing multiple features in Teleport.
Example: a policy must be added to this role that has `rds:DescribeInstances` and `rds:DescribeClusters` so that the user can use the integration to enroll RDS Databases.

Demo
```
$ teleport integration configure awsoidc-idp --cluster=lenix --name=teleportdev --aws-region=eu-west-2 --role=MarcoTestAWSOIDCSetup --proxy-public-url=https://teleport-local.marcoandredinis.com
2023/09/06 19:04:48 Using the following thumbprint: b3dd7606d2b5a8b4a13771dbecc9ee1cecafa38a
2023/09/06 19:04:52 IAM OpenID Connect Provider created: url="https://teleport-local.marcoandredinis.com" arn="arn:aws:iam::278576220453:oidc-provider/teleport-local.marcoandredinis.com".
2023/09/06 19:04:52 IAM Role "MarcoTestAWSOIDCSetup" created.
```
![image](https://github.com/gravitational/teleport/assets/689271/df6a0f5b-798c-424f-841c-570066bcb29d)
![image](https://github.com/gravitational/teleport/assets/689271/cf90fe40-c948-4094-8fff-9b8270b6f3e2)


The script download was manually tested but it fails because the downloaded teleport binary doesn't yet have the new command:
```
bash script.sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  280M  100  280M    0     0  1192k      0  0:04:01  0:04:01 --:--:-- 1099k
Extracting teleport to /var/folders/r5/g7bry4g95blfvprpmxm6bqyh0000gn/T/tmp.hJ5ZXOQ8 ...
> ./bin/teleport integration configure awsoidc-idp --cluster=lenix --name=teleportdev --aws-region=eu-west-1 --role=MarcoCloudStageAWSOIDC --proxy-public-url=127.0.0.1.nip.io:3080
teleport: error: expected command but got "awsoidc-idp"
```

