### PR TITLE
[v14] Ensures the canvas stays at a fixed size

### DIFF
--- a/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
+++ b/web/packages/teleport/src/DesktopSession/DesktopSession.tsx
@@ -291,7 +291,6 @@ function Session({
       <TdpClientCanvas
         style={{
           display: displayCanvas ? 'flex' : 'none',
-          flex: 1, // ensures the canvas fills available screen space
         }}
         tdpCli={tdpClient}
         tdpCliInit={initTdpCli}

--- a/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
+++ b/web/packages/teleport/src/DesktopSession/__snapshots__/DesktopSession.story.test.tsx.snap
@@ -511,7 +511,7 @@ exports[`connected settings false 1`] = `
       </div>
     </nav>
     <canvas
-      style="display: flex; flex: 1;"
+      style="display: flex;"
     />
   </div>
 </div>
@@ -812,7 +812,7 @@ exports[`connected settings true 1`] = `
       </div>
     </nav>
     <canvas
-      style="display: flex; flex: 1;"
+      style="display: flex;"
     />
   </div>
 </div>
@@ -1331,7 +1331,7 @@ exports[`disconnected 1`] = `
       </div>
     </div>
     <canvas
-      style="display: none; flex: 1;"
+      style="display: none;"
     />
   </div>
 </div>
@@ -2035,7 +2035,7 @@ exports[`processing 1`] = `
       class="c12"
     />
     <canvas
-      style="display: none; flex: 1;"
+      style="display: none;"
     />
   </div>
 </div>
@@ -2345,7 +2345,7 @@ exports[`tdp processing 1`] = `
       class="c12"
     />
     <canvas
-      style="display: none; flex: 1;"
+      style="display: none;"
     />
   </div>
 </div>

--- a/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
+++ b/web/packages/teleport/src/DesktopSession/useTdpClientCanvas.tsx
@@ -66,18 +66,26 @@ export default function useTdpClientCanvas(props: Props) {
     setTdpClient(new TdpClient(addr));
   }, [clusterId, username, desktopName]);
 
-  const syncCanvasSizeToDisplaySize = (canvas: HTMLCanvasElement) => {
+  const syncCanvasResolutionAndSize = (canvas: HTMLCanvasElement) => {
     const { width, height } = getDisplaySize();
 
+    // Set a fixed canvas resolution and display size. This ensures
+    // that neither of these change when the user resizes the browser
+    // window. Instead, the canvas will remain the same size and the
+    // browser will add scrollbars if necessary. This is the behavior
+    // we want until https://github.com/gravitational/teleport/issues/9702
+    // is resolved.
     canvas.width = width;
     canvas.height = height;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
   };
 
   // Default TdpClientEvent.TDP_PNG_FRAME handler (buffered)
   const onPngFrame = (ctx: CanvasRenderingContext2D, pngFrame: PngFrame) => {
     // The first image fragment we see signals a successful tdp connection.
     if (!initialTdpConnectionSucceeded.current) {
-      syncCanvasSizeToDisplaySize(ctx.canvas);
+      syncCanvasResolutionAndSize(ctx.canvas);
       setTdpConnection({ status: 'success' });
       initialTdpConnectionSucceeded.current = true;
     }


### PR DESCRIPTION
Backport #31475 to branch/v14

Changelog: Fixes desktop sessions' viewport size to the size of browser window at session start