### PR TITLE
Use lib/cloud/aws instead of db errors for ec2 discovery

### DIFF
--- a/lib/srv/server/ec2_watcher.go
+++ b/lib/srv/server/ec2_watcher.go
@@ -30,9 +30,9 @@ import (
 	usageeventsv1 "github.com/gravitational/teleport/api/gen/proto/go/usageevents/v1"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/cloud"
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
 	"github.com/gravitational/teleport/lib/defaults"
 	"github.com/gravitational/teleport/lib/labels"
-	"github.com/gravitational/teleport/lib/srv/db/common"
 )
 
 const (
@@ -387,7 +387,7 @@ func (f *ec2InstanceFetcher) GetInstances(ctx context.Context, rotation bool) ([
 			return true
 		})
 	if err != nil {
-		return nil, common.ConvertError(err)
+		return nil, awslib.ConvertRequestFailureError(err)
 	}
 
 	if len(instances) == 0 {


### PR DESCRIPTION
Closes https://github.com/gravitational/teleport/issues/31507