### PR TITLE
[Web] Fix terminal resizing

### DIFF
--- a/lib/web/terminal.go
+++ b/lib/web/terminal.go
@@ -1109,14 +1109,20 @@ func (t *TerminalStream) handleWindowResize(ctx context.Context, envelope Envelo
 		return
 	}
 
-	var e map[string]string
+	var e map[string]interface{}
 	err := json.Unmarshal([]byte(envelope.Payload), &e)
 	if err != nil {
 		t.log.Warnf("Failed to parse resize payload: %v", err)
 		return
 	}
 
-	params, err := session.UnmarshalTerminalParams(e["size"])
+	size, ok := e["size"].(string)
+	if !ok {
+		t.log.Errorf("expected size to be of type string, got type %T instead", size)
+		return
+	}
+
+	params, err := session.UnmarshalTerminalParams(size)
 	if err != nil {
 		t.log.Warnf("Failed to retrieve terminal size: %v", err)
 		return


### PR DESCRIPTION
## Purpose

This PR resolves https://github.com/gravitational/teleport/issues/31565 

Fixes resizing not working properly in the web terminal. This was caused because we were trying to unmarshal the payload which contains number values into a `map[string]string`.

## Demo 

### Before

https://github.com/gravitational/teleport/assets/56373201/ad87defe-e9f0-4fb9-a77e-6d494bb262dc

### After

https://github.com/gravitational/teleport/assets/56373201/b06f346e-b46e-4027-9355-a98c2aff045a




