### PR TITLE
AWS OIDC - List RDS: add Subnet and VPC for aurora clusters

### DIFF
--- a/lib/integrations/awsoidc/listdatabases.go
+++ b/lib/integrations/awsoidc/listdatabases.go
@@ -195,6 +195,7 @@ func listDBClusters(ctx context.Context, clt ListDatabasesClient, req ListDataba
 		// RDS Clusters do not return VPC and Subnets.
 		// To get this value, a member of the cluster is fetched and its Network Information is used to
 		// populate the RDS Cluster information.
+		// All the members have the same network information, so picking one at random should not matter.
 		clusterInstance, err := fetchSingleRDSDBInstance(ctx, clt, req, aws.ToString(db.DBClusterIdentifier))
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/integrations/awsoidc/listdatabases.go
+++ b/lib/integrations/awsoidc/listdatabases.go
@@ -19,6 +19,7 @@ package awsoidc
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	rdsTypes "github.com/aws/aws-sdk-go-v2/service/rds/types"
 	"github.com/gravitational/trace"
@@ -30,6 +31,9 @@ import (
 var (
 	// filterEngine is the filter name for filtering Databses based on their engine.
 	filterEngine = "engine"
+
+	// filterDBClusterID is the filter name for filtering RDS Instances for a given RDS Cluster.
+	filterDBClusterID = "db-cluster-id"
 )
 
 const (
@@ -188,7 +192,15 @@ func listDBClusters(ctx context.Context, clt ListDatabasesClient, req ListDataba
 			continue
 		}
 
-		awsDB, err := services.NewDatabaseFromRDSV2Cluster(&db)
+		// RDS Clusters do not return VPC and Subnets.
+		// To get this value, a member of the cluster is fetched and its Network Information is used to
+		// populate the RDS Cluster information.
+		clusterInstance, err := fetchSingleRDSDBInstance(ctx, clt, req, aws.ToString(db.DBClusterIdentifier))
+		if err != nil {
+			return nil, trace.Wrap(err)
+		}
+
+		awsDB, err := services.NewDatabaseFromRDSV2Cluster(&db, clusterInstance)
 		if err != nil {
 			return nil, trace.Wrap(err)
 		}
@@ -197,4 +209,23 @@ func listDBClusters(ctx context.Context, clt ListDatabasesClient, req ListDataba
 	}
 
 	return ret, nil
+}
+
+func fetchSingleRDSDBInstance(ctx context.Context, clt ListDatabasesClient, req ListDatabasesRequest, clusterID string) (*rdsTypes.DBInstance, error) {
+	describeDBInstanceInput := &rds.DescribeDBInstancesInput{
+		Filters: []rdsTypes.Filter{
+			{Name: &filterDBClusterID, Values: []string{clusterID}},
+		},
+	}
+
+	rdsDBs, err := clt.DescribeDBInstances(ctx, describeDBInstanceInput)
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	if len(rdsDBs.DBInstances) == 0 {
+		return nil, trace.BadParameter("DB Cluster %s has no DB Instance", clusterID)
+	}
+
+	return &rdsDBs.DBInstances[0], nil
 }

--- a/lib/integrations/awsoidc/listdatabases.go
+++ b/lib/integrations/awsoidc/listdatabases.go
@@ -224,7 +224,7 @@ func fetchSingleRDSDBInstance(ctx context.Context, clt ListDatabasesClient, req 
 	}
 
 	if len(rdsDBs.DBInstances) == 0 {
-		return nil, trace.BadParameter("DB Cluster %s has no DB Instance", clusterID)
+		return nil, trace.BadParameter("database cluster %s has no instance", clusterID)
 	}
 
 	return &rdsDBs.DBInstances[0], nil

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -676,21 +676,25 @@ func NewDatabaseFromRDSV2Cluster(cluster *rdsTypesV2.DBCluster, firstInstance *r
 }
 
 func rdsSubnetGroupToNetworkInfo(subnetGroup *rdsTypesV2.DBSubnetGroup) (vpcID string, subnets []string) {
-	if subnetGroup != nil {
-		vpcID = aws.StringValue(subnetGroup.VpcId)
-		subnets = make([]string, 0, len(subnetGroup.Subnets))
-		for _, s := range subnetGroup.Subnets {
-			subnetID := aws.StringValue(s.SubnetIdentifier)
-			if subnetID != "" {
-				subnets = append(subnets, subnetID)
-			}
+	if subnetGroup == nil {
+		return
+	}
+
+	vpcID = aws.StringValue(subnetGroup.VpcId)
+	subnets = make([]string, 0, len(subnetGroup.Subnets))
+	for _, s := range subnetGroup.Subnets {
+		subnetID := aws.StringValue(s.SubnetIdentifier)
+		if subnetID != "" {
+			subnets = append(subnets, subnetID)
 		}
 	}
+
 	return
 }
 
 // MetadataFromRDSV2Cluster creates AWS metadata from the provided RDS cluster.
 // It uses aws sdk v2.
+// An optional [rdsTypesV2.DBInstance] can be passed to fill the network configuration of the Cluster.
 func MetadataFromRDSV2Cluster(rdsCluster *rdsTypesV2.DBCluster, rdsInstance *rdsTypesV2.DBInstance) (*types.AWS, error) {
 	parsedARN, err := arn.Parse(aws.StringValue(rdsCluster.DBClusterArn))
 	if err != nil {

--- a/lib/services/database.go
+++ b/lib/services/database.go
@@ -620,18 +620,7 @@ func MetadataFromRDSV2Instance(rdsInstance *rdsTypesV2.DBInstance) (*types.AWS, 
 		return nil, trace.Wrap(err)
 	}
 
-	var vpcID string
-	var subnets []string
-	if rdsInstance.DBSubnetGroup != nil {
-		vpcID = aws.StringValue(rdsInstance.DBSubnetGroup.VpcId)
-		subnets = make([]string, 0, len(rdsInstance.DBSubnetGroup.Subnets))
-		for _, s := range rdsInstance.DBSubnetGroup.Subnets {
-			if s.SubnetIdentifier == nil || *s.SubnetIdentifier == "" {
-				continue
-			}
-			subnets = append(subnets, *s.SubnetIdentifier)
-		}
-	}
+	vpcID, subnets := rdsSubnetGroupToNetworkInfo(rdsInstance.DBSubnetGroup)
 
 	return &types.AWS{
 		Region:    parsedARN.Region,
@@ -660,8 +649,8 @@ func labelsFromRDSV2Instance(rdsInstance *rdsTypesV2.DBInstance, meta *types.AWS
 
 // NewDatabaseFromRDSV2Cluster creates a database resource from an RDS cluster (Aurora).
 // It uses aws sdk v2.
-func NewDatabaseFromRDSV2Cluster(cluster *rdsTypesV2.DBCluster) (types.Database, error) {
-	metadata, err := MetadataFromRDSV2Cluster(cluster)
+func NewDatabaseFromRDSV2Cluster(cluster *rdsTypesV2.DBCluster, firstInstance *rdsTypesV2.DBInstance) (types.Database, error) {
+	metadata, err := MetadataFromRDSV2Cluster(cluster, firstInstance)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -686,13 +675,35 @@ func NewDatabaseFromRDSV2Cluster(cluster *rdsTypesV2.DBCluster) (types.Database,
 		})
 }
 
+func rdsSubnetGroupToNetworkInfo(subnetGroup *rdsTypesV2.DBSubnetGroup) (vpcID string, subnets []string) {
+	if subnetGroup != nil {
+		vpcID = aws.StringValue(subnetGroup.VpcId)
+		subnets = make([]string, 0, len(subnetGroup.Subnets))
+		for _, s := range subnetGroup.Subnets {
+			subnetID := aws.StringValue(s.SubnetIdentifier)
+			if subnetID != "" {
+				subnets = append(subnets, subnetID)
+			}
+		}
+	}
+	return
+}
+
 // MetadataFromRDSV2Cluster creates AWS metadata from the provided RDS cluster.
 // It uses aws sdk v2.
-func MetadataFromRDSV2Cluster(rdsCluster *rdsTypesV2.DBCluster) (*types.AWS, error) {
+func MetadataFromRDSV2Cluster(rdsCluster *rdsTypesV2.DBCluster, rdsInstance *rdsTypesV2.DBInstance) (*types.AWS, error) {
 	parsedARN, err := arn.Parse(aws.StringValue(rdsCluster.DBClusterArn))
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
+
+	var vpcID string
+	var subnets []string
+
+	if rdsInstance != nil {
+		vpcID, subnets = rdsSubnetGroupToNetworkInfo(rdsInstance.DBSubnetGroup)
+	}
+
 	return &types.AWS{
 		Region:    parsedARN.Region,
 		AccountID: parsedARN.AccountID,
@@ -700,6 +711,8 @@ func MetadataFromRDSV2Cluster(rdsCluster *rdsTypesV2.DBCluster) (*types.AWS, err
 			ClusterID:  aws.StringValue(rdsCluster.DBClusterIdentifier),
 			ResourceID: aws.StringValue(rdsCluster.DbClusterResourceId),
 			IAMAuth:    aws.BoolValue(rdsCluster.IAMDatabaseAuthenticationEnabled),
+			Subnets:    subnets,
+			VPCID:      vpcID,
 		},
 	}, nil
 }

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -1125,7 +1125,7 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 		require.NoError(t, err)
 		actual, err := NewDatabaseFromRDSV2Cluster(cluster, instance)
 		require.NoError(t, err)
-		require.Empty(t, cmp.Diff(expected, actual))
+		require.Empty(t, cmp.Diff(expected, actual), "NewDatabaseFromRDSV2Cluster diff (-want +got)")
 	})
 }
 

--- a/lib/services/database_test.go
+++ b/lib/services/database_test.go
@@ -1058,7 +1058,7 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 			AWS:      expectedAWS,
 		})
 		require.NoError(t, err)
-		actual, err := NewDatabaseFromRDSV2Cluster(cluster)
+		actual, err := NewDatabaseFromRDSV2Cluster(cluster, nil)
 		require.NoError(t, err)
 		require.Empty(t, cmp.Diff(expected, actual))
 
@@ -1074,11 +1074,58 @@ func TestDatabaseFromRDSV2Cluster(t *testing.T) {
 				)
 				expected.Metadata.Name = newName
 
-				actual, err := NewDatabaseFromRDSV2Cluster(cluster)
+				actual, err := NewDatabaseFromRDSV2Cluster(cluster, nil)
 				require.NoError(t, err)
 				require.Equal(t, actual.GetName(), newName)
 			})
 		}
+	})
+
+	t.Run("DB Cluster uses network information from DB Instance when available", func(t *testing.T) {
+		instance := &rdsTypesV2.DBInstance{
+			DBSubnetGroup: &rdsTypesV2.DBSubnetGroup{
+				VpcId: aws.String("vpc-123"),
+				Subnets: []rdsTypesV2.Subnet{
+					{SubnetIdentifier: aws.String("subnet-123")},
+					{SubnetIdentifier: aws.String("subnet-456")},
+				},
+			},
+		}
+
+		expected, err := types.NewDatabaseV3(types.Metadata{
+			Name:        "override-1",
+			Description: "Aurora cluster in us-east-1",
+			Labels: map[string]string{
+				"TeleportDatabaseName":            "override-1",
+				"teleport.dev/database_name":      "override-1",
+				types.DiscoveryLabelAccountID:     "123456789012",
+				types.CloudLabel:                  types.CloudAWS,
+				types.DiscoveryLabelRegion:        "us-east-1",
+				types.DiscoveryLabelEngine:        RDSEngineAuroraMySQL,
+				types.DiscoveryLabelEngineVersion: "8.0.0",
+				types.DiscoveryLabelEndpointType:  "primary",
+				types.DiscoveryLabelStatus:        "available",
+				"key":                             "val",
+			},
+		}, types.DatabaseSpecV3{
+			Protocol: defaults.ProtocolMySQL,
+			URI:      "localhost:3306",
+			AWS: types.AWS{
+				AccountID: "123456789012",
+				Region:    "us-east-1",
+				RDS: types.RDS{
+					ClusterID:  "cluster-1",
+					ResourceID: "resource-1",
+					IAMAuth:    true,
+					Subnets:    []string{"subnet-123", "subnet-456"},
+					VPCID:      "vpc-123",
+				},
+			},
+		})
+		require.NoError(t, err)
+		actual, err := NewDatabaseFromRDSV2Cluster(cluster, instance)
+		require.NoError(t, err)
+		require.Empty(t, cmp.Diff(expected, actual))
 	})
 }
 


### PR DESCRIPTION
When converting from an Aurora Cluster to a Teleport Database we were not populating the VPC and Subnets.

This PR adds those fields using one of the instances for the cluster.

Demo
Before
![image](https://github.com/gravitational/teleport/assets/689271/20ce6a90-b2cd-41d1-a7d5-8f78e5fc84c8)
After
![image](https://github.com/gravitational/teleport/assets/689271/fb143616-261a-4e1d-b373-b94c12365c55)
