### PR TITLE
Fix non-interactive kube benchmark

### DIFF
--- a/lib/benchmark/benchmark.go
+++ b/lib/benchmark/benchmark.go
@@ -172,14 +172,14 @@ func (c *Config) Benchmark(ctx context.Context, tc *client.TeleportClient, suite
 		return Result{}, trace.BadParameter("missing benchmark suite")
 	}
 
+	tc.Stdout = io.Discard
+	tc.Stderr = io.Discard
+	tc.Stdin = &bytes.Buffer{}
+
 	workload, err := suite.BenchBuilder(ctx, tc)
 	if err != nil {
 		return Result{}, trace.Wrap(err)
 	}
-
-	tc.Stdout = io.Discard
-	tc.Stderr = io.Discard
-	tc.Stdin = &bytes.Buffer{}
 
 	var delay time.Duration
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
This PR fixes the non-interactive Kube benchmark because `tc.StdIn` changes its value from the benchmark build call till the benchmark cases are actually called.
This cases SPDY protocol to flip out because it expects more streams to be created by the server.