### PR TITLE
Fix incorrect autofill in safari

### DIFF
--- a/web/packages/shared/components/MenuLogin/MenuLogin.tsx
+++ b/web/packages/shared/components/MenuLogin/MenuLogin.tsx
@@ -127,6 +127,13 @@ const LoginItemList = ({
       <Input
         p="2"
         m="2"
+        // this prevents safari from adding the autofill options which would cover the available logins and make it
+        // impossible to select. "But why would it do that? this isn't a username or password field?".
+        // Safari includes parsed words in the placeholder as well to determine if that autofill should show.
+        // Since our placeholder has the word "login" in it, it thinks its a login form.
+        // https://github.com/gravitational/teleport/pull/31600
+        // https://stackoverflow.com/questions/22661977/disabling-safari-autofill-on-usernames-and-passwords
+        name="notsearch_password"
         onKeyPress={onKeyPress}
         type="text"
         autoFocus


### PR DESCRIPTION
Fixes: https://github.com/gravitational/teleport/issues/31592

Took me a bit to debug why this was happening. Apparently, `autocomplete` is ignored by almost every browser now. The only reason this showed up in safari specifically is, our input wasn't named or typed like "password" so the browsers think "cool, just an input". but safari actually also checks the PLACEHOLDER text, and since our placeholder text included the word "login", it would ignore the autocomplete and add the widget. You can test this out yourself by changing the placeholder text in this input field with something like "hi". Blew my mind.

The added name prop and value are what safari prescribes to ignore autofill. 

Some info [here](https://stackoverflow.com/questions/22661977/disabling-safari-autofill-on-usernames-and-passwords) with the answer found below the accepted answer (although its all good info)