### PR TITLE
Simplify SSH trace support detection

### DIFF
--- a/api/observability/tracing/ssh/client.go
+++ b/api/observability/tracing/ssh/client.go
@@ -15,11 +15,10 @@
 package ssh
 
 import (
+	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"net"
-	"strings"
 	"sync"
 
 	"github.com/gravitational/trace"
@@ -35,14 +34,8 @@ import (
 // Client is a wrapper around ssh.Client that adds tracing support.
 type Client struct {
 	*ssh.Client
-	opts []tracing.Option
-
-	// mu protects capability and rejectedError which may change based
-	// on the outcome probing the server for tracing capabilities that
-	// may occur trying to establish a session
-	mu            sync.RWMutex
-	capability    tracingCapability
-	rejectedError error
+	opts       []tracing.Option
+	capability tracingCapability
 }
 
 type tracingCapability int
@@ -63,50 +56,16 @@ const (
 // of whether they should provide tracing context.
 func NewClient(c ssh.Conn, chans <-chan ssh.NewChannel, reqs <-chan *ssh.Request, opts ...tracing.Option) *Client {
 	clt := &Client{
-		Client: ssh.NewClient(c, chans, reqs),
-		opts:   opts,
+		Client:     ssh.NewClient(c, chans, reqs),
+		opts:       opts,
+		capability: tracingUnsupported,
 	}
 
-	clt.capability, clt.rejectedError = isTracingSupported(clt.Client)
+	if bytes.HasPrefix(clt.ServerVersion(), []byte("SSH-2.0-Teleport")) {
+		clt.capability = tracingSupported
+	}
 
 	return clt
-}
-
-// isTracingSupported determines whether the ssh server supports
-// tracing payloads by trying to open a TracingChannel.
-//
-// Note: a channel is used instead of a global request in order prevent blocking
-// forever in the event that the connection is rejected. In that case, the server
-// doesn't service any global requests and writes the error to the first opened
-// channel.
-func isTracingSupported(clt *ssh.Client) (tracingCapability, error) {
-	srvVer := clt.ServerVersion()
-	if !strings.HasPrefix(string(srvVer), "SSH-2.0-Teleport") {
-		// Tracing is only supported by Teleport Nodes. Skip the check for
-		// all other implementations.
-		// Note: If tracing is not implemented SSH server should return ssh.UnknownChannelType,
-		//       but OpenSSH 7.x returns ssh.Prohibited, hence the check here.
-		return tracingUnsupported, nil
-	}
-
-	ch, _, err := clt.OpenChannel(TracingChannel, nil)
-	if err != nil {
-		var openError *ssh.OpenChannelError
-		// prohibited errors due to locks and session control are expected by callers of NewSession
-		if errors.As(err, &openError) {
-			switch openError.Reason {
-			case ssh.Prohibited:
-				return tracingUnknown, err
-			case ssh.UnknownChannelType:
-				return tracingUnsupported, nil
-			}
-		}
-
-		return tracingUnknown, nil
-	}
-
-	_ = ch.Close()
-	return tracingSupported, nil
 }
 
 // DialContext initiates a connection to the addr from the remote host.
@@ -130,7 +89,6 @@ func (c *Client) DialContext(ctx context.Context, n, addr string) (net.Conn, err
 	)
 	defer span.End()
 
-	c.mu.RLock()
 	// create the wrapper while the lock is held
 	wrapper := &clientWrapper{
 		capability: c.capability,
@@ -139,7 +97,6 @@ func (c *Client) DialContext(ctx context.Context, n, addr string) (net.Conn, err
 		ctx:        ctx,
 		contexts:   make(map[string][]context.Context),
 	}
-	c.mu.RUnlock()
 
 	conn, err := wrapper.Dial(n, addr)
 	return conn, trace.Wrap(err)
@@ -168,24 +125,7 @@ func (c *Client) SendRequest(ctx context.Context, name string, wantReply bool, p
 	)
 	defer span.End()
 
-	c.mu.RLock()
-	// If the TracingChannel was rejected when the client was created,
-	// the connection was prohibited due to a lock or session control.
-	// Callers to SendRequest are expecting to receive the reason the request
-	// was rejected, so we need to propagate the rejectedError here.
-	if c.rejectedError != nil {
-		err := c.rejectedError
-		c.mu.RUnlock()
-
-		span.SetStatus(codes.Error, err.Error())
-		span.RecordError(err)
-		return false, nil, trace.Wrap(err)
-	}
-
-	capability := c.capability
-	c.mu.RUnlock()
-
-	ok, resp, err := c.Client.SendRequest(name, wantReply, wrapPayload(ctx, capability, config.TextMapPropagator, payload))
+	ok, resp, err := c.Client.SendRequest(name, wantReply, wrapPayload(ctx, c.capability, config.TextMapPropagator, payload))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
@@ -215,11 +155,7 @@ func (c *Client) OpenChannel(ctx context.Context, name string, data []byte) (*Ch
 	)
 	defer span.End()
 
-	c.mu.RLock()
-	capability := c.capability
-	c.mu.RUnlock()
-
-	ch, reqs, err := c.Client.OpenChannel(name, wrapPayload(ctx, capability, config.TextMapPropagator, data))
+	ch, reqs, err := c.Client.OpenChannel(name, wrapPayload(ctx, c.capability, config.TextMapPropagator, data))
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
 		span.RecordError(err)
@@ -251,39 +187,6 @@ func (c *Client) NewSession(ctx context.Context) (*Session, error) {
 	)
 	defer span.End()
 
-	c.mu.Lock()
-
-	// If the TracingChannel was rejected when the client was created,
-	// the connection was prohibited due to a lock or session control.
-	// Callers to NewSession are expecting to receive the reason the session
-	// was rejected, so we need to propagate the rejectedError here.
-	if c.rejectedError != nil {
-		err := c.rejectedError
-		c.rejectedError = nil
-		c.capability = tracingUnknown
-		c.mu.Unlock()
-
-		span.SetStatus(codes.Error, err.Error())
-		span.RecordError(err)
-		return nil, trace.Wrap(err)
-	}
-
-	// If the tracing capabilities of the server are unknown due to
-	// prohibited errors from previous attempts to check, we need to
-	// do another check to see if our connection will be permitted
-	// this time.
-	if c.capability == tracingUnknown {
-		capability, err := isTracingSupported(c.Client)
-		if err != nil {
-			c.mu.Unlock()
-
-			span.SetStatus(codes.Error, err.Error())
-			span.RecordError(err)
-			return nil, trace.Wrap(err)
-		}
-		c.capability = capability
-	}
-
 	// create the wrapper while the lock is still held
 	wrapper := &clientWrapper{
 		capability: c.capability,
@@ -292,8 +195,6 @@ func (c *Client) NewSession(ctx context.Context) (*Session, error) {
 		ctx:        ctx,
 		contexts:   make(map[string][]context.Context),
 	}
-
-	c.mu.Unlock()
 
 	// get a session from the wrapper
 	session, err := wrapper.NewSession()

--- a/api/observability/tracing/ssh/client_test.go
+++ b/api/observability/tracing/ssh/client_test.go
@@ -27,59 +27,20 @@ import (
 )
 
 func TestIsTracingSupported(t *testing.T) {
-	rejected := &ssh.OpenChannelError{
-		Reason:  ssh.Prohibited,
-		Message: "rejected!",
-	}
-
-	unknown := &ssh.OpenChannelError{
-		Reason:  ssh.UnknownChannelType,
-		Message: "unknown!",
-	}
-
 	cases := []struct {
 		name               string
-		channelErr         *ssh.OpenChannelError
 		srvVersion         string
 		expectedCapability tracingCapability
-		errAssertion       require.ErrorAssertionFunc
 	}{
 		{
-			name:               "rejected",
-			channelErr:         rejected,
-			expectedCapability: tracingUnknown,
-			errAssertion: func(t require.TestingT, err error, i ...interface{}) {
-				require.Error(t, err)
-				require.Equal(t, rejected.Error(), err.Error())
-			},
-		},
-		{
-			name:               "unknown",
-			channelErr:         unknown,
-			expectedCapability: tracingUnsupported,
-			errAssertion:       require.NoError,
-		},
-		{
 			name:               "supported",
-			channelErr:         nil,
 			expectedCapability: tracingSupported,
-			errAssertion:       require.NoError,
+			srvVersion:         "SSH-2.0-Teleport",
 		},
 		{
-			name:               "no backend support",
-			channelErr:         nil,
+			name:               "unsupported",
 			expectedCapability: tracingUnsupported,
 			srvVersion:         "SSH-2.0-OpenSSH_7.4", // Only Teleport supports tracing
-			errAssertion:       require.NoError,
-		},
-		{
-			name: "other error",
-			channelErr: &ssh.OpenChannelError{
-				Reason:  ssh.ConnectionFailed,
-				Message: "",
-			},
-			expectedCapability: tracingUnknown,
-			errAssertion:       require.NoError,
 		},
 	}
 
@@ -90,6 +51,8 @@ func TestIsTracingSupported(t *testing.T) {
 			errChan := make(chan error, 5)
 
 			srv := newServer(t, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
+				go ssh.DiscardRequests(requests)
+
 				for {
 					select {
 					case <-ctx.Done():
@@ -100,16 +63,8 @@ func TestIsTracingSupported(t *testing.T) {
 							return
 						}
 
-						if tt.channelErr != nil {
-							if err := ch.Reject(tt.channelErr.Reason, tt.channelErr.Message); err != nil {
-								errChan <- trace.Wrap(err, "failed to reject channel")
-							}
-							return
-						}
-
-						_, _, err := ch.Accept()
-						if err != nil {
-							errChan <- trace.Wrap(err, "failed to accept channel")
+						if err := ch.Reject(ssh.Prohibited, "no channels allowed"); err != nil {
+							errChan <- trace.Wrap(err, "rejecting channel")
 							return
 						}
 					}
@@ -123,138 +78,9 @@ func TestIsTracingSupported(t *testing.T) {
 			go srv.Run(errChan)
 
 			conn, chans, reqs := srv.GetClient(t)
-			client := ssh.NewClient(conn, chans, reqs)
+			client := NewClient(conn, chans, reqs)
 
-			capabaility, err := isTracingSupported(client)
-			require.Equal(t, tt.expectedCapability, capabaility)
-			tt.errAssertion(t, err)
-
-			select {
-			case err := <-errChan:
-				require.NoError(t, err)
-			default:
-			}
-		})
-	}
-}
-
-func TestNewSession(t *testing.T) {
-	t.Parallel()
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-	errChan := make(chan error, 5)
-
-	first := ssh.OpenChannelError{
-		Reason:  ssh.Prohibited,
-		Message: "first attempt",
-	}
-
-	second := ssh.OpenChannelError{
-		Reason:  ssh.ConnectionFailed,
-		Message: "second attempt",
-	}
-
-	srv := newServer(t, func(conn *ssh.ServerConn, channels <-chan ssh.NewChannel, requests <-chan *ssh.Request) {
-		for i := 0; ; i++ {
-			select {
-			case <-ctx.Done():
-				return
-
-			case ch := <-channels:
-				switch {
-				case ch == nil:
-					return
-				case ch.ChannelType() == "session":
-					_, _, err := ch.Accept()
-					if err != nil {
-						errChan <- trace.Wrap(err, "failed to accept session channel")
-						return
-					}
-				case i == 0:
-					if err := ch.Reject(first.Reason, first.Message); err != nil {
-						errChan <- err
-						return
-					}
-				case i == 1:
-					if err := ch.Reject(second.Reason, second.Message); err != nil {
-						errChan <- err
-						return
-					}
-				case i > 2:
-					if _, _, err := ch.Accept(); err != nil {
-						errChan <- err
-						return
-					}
-				default:
-					if err := ch.Reject(ssh.ConnectionFailed, fmt.Sprintf("unexpected channel %d", i)); err != nil {
-						errChan <- err
-						return
-					}
-				}
-			}
-		}
-	})
-
-	go srv.Run(errChan)
-
-	cases := []struct {
-		name          string
-		assertionFunc func(t *testing.T, clt *Client, session *Session, err error)
-	}{
-		{
-			name: "session prohibited",
-			assertionFunc: func(t *testing.T, clt *Client, sess *Session, err error) {
-				// creating a new session should return any errors captured when creating the client
-				// and not actually probe the server
-				require.Error(t, err)
-				require.Equal(t, trace.Unwrap(err).Error(), first.Error())
-				require.Nil(t, sess)
-				require.Nil(t, clt.rejectedError)
-				require.Equal(t, clt.capability, tracingUnknown)
-			},
-		},
-		{
-			name: "other failure to open tracing channel",
-			assertionFunc: func(t *testing.T, clt *Client, sess *Session, err error) {
-				// this time through we should probe the server without getting a prohibited error,
-				// but things still failed, so we shouldn't know the capability
-				require.NoError(t, err)
-				require.NotNil(t, sess)
-				require.NoError(t, clt.rejectedError)
-				require.Equal(t, clt.capability, tracingUnknown)
-				require.NoError(t, sess.Close())
-			},
-		},
-		{
-			name: "active session",
-			assertionFunc: func(t *testing.T, clt *Client, sess *Session, err error) {
-				// all is good now, we should have an active session
-				require.NoError(t, err)
-				require.NotNil(t, sess)
-				require.NoError(t, clt.rejectedError)
-				require.Equal(t, clt.capability, tracingSupported)
-				require.NoError(t, sess.Close())
-			},
-		},
-	}
-
-	// check tracing status after first capability probe from creating the client
-	conn, chans, reqs := srv.GetClient(t)
-	client := NewClient(conn, chans, reqs)
-	require.Error(t, client.rejectedError)
-	require.Equal(t, client.rejectedError.Error(), first.Error())
-	require.Equal(t, client.capability, tracingUnknown)
-
-	select {
-	case err := <-errChan:
-		require.NoError(t, err)
-	default:
-	}
-
-	for _, tt := range cases {
-		t.Run(tt.name, func(t *testing.T) {
-			sess, err := client.NewSession(ctx)
-			tt.assertionFunc(t, client, sess, err)
+			require.Equal(t, tt.expectedCapability, client.capability)
 
 			select {
 			case err := <-errChan:

--- a/api/observability/tracing/ssh/ssh.go
+++ b/api/observability/tracing/ssh/ssh.go
@@ -37,9 +37,11 @@ const (
 	EnvsRequest = "envs@goteleport.com"
 
 	// TracingRequest is sent by clients to server to pass along tracing context.
+	// TODO(tross): DELETE in 15.0.0
 	TracingRequest = "tracing@goteleport.com"
 
 	// TracingChannel is a SSH channel used to indicate that servers support tracing.
+	// TODO(tross): DELETE in 15.0.0
 	TracingChannel = "tracing"
 
 	// instrumentationName is the name of this instrumentation package.

--- a/lib/srv/regular/sshserver_test.go
+++ b/lib/srv/regular/sshserver_test.go
@@ -595,26 +595,12 @@ func TestLockInForce(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), lockInForceMsg)
 
-	// As long as the lock is in force, global requests are rejected.
-	newClient2, err := tracessh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
-	require.NoError(t, err)
-	t.Cleanup(func() {
-		// The client is expected to be closed by the lock monitor therefore expect
-		// an error on this second attempt.
-		require.Error(t, newClient2.Close())
-	})
-	ok, _, err := newClient2.SendRequest(ctx, teleport.ClusterDetailsReqType, true, nil)
-	require.False(t, ok)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), lockInForceMsg)
-
 	// Once the lock is lifted, new sessions should go through without error.
 	require.NoError(t, f.testSrv.Auth().DeleteLock(ctx, "test-lock"))
-	newClient3, err := tracessh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
+	newClient2, err := tracessh.Dial(ctx, "tcp", f.ssh.srvAddress, f.ssh.cltConfig)
 	require.NoError(t, err)
-
-	t.Cleanup(func() { require.NoError(t, newClient3.Close()) })
-	_, err = newClient3.NewSession(ctx)
+	t.Cleanup(func() { require.NoError(t, newClient2.Close()) })
+	_, err = newClient2.NewSession(ctx)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Since all supported versions of Teleport now support tracing we can drop opening a specific channel to evaluate if tracing is supported and just rely on the SSH server version.

Closes #13526 