### PR TITLE
React to version updates faster

### DIFF
--- a/lib/web/ui/cluster.go
+++ b/lib/web/ui/cluster.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gravitational/trace"
 
+	"github.com/gravitational/teleport"
 	apidefaults "github.com/gravitational/teleport/api/defaults"
 	"github.com/gravitational/teleport/api/types"
 	"github.com/gravitational/teleport/lib/reversetunnelclient"
@@ -102,7 +103,7 @@ func GetClusterDetails(ctx context.Context, site reversetunnelclient.RemoteSite,
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
-	proxyHost, proxyVersion, err := services.GuessProxyHostAndVersion(proxies)
+	proxyHost, _, err := services.GuessProxyHostAndVersion(proxies)
 	if err != nil && !trace.IsNotFound(err) {
 		return nil, trace.Wrap(err)
 	}
@@ -112,9 +113,12 @@ func GetClusterDetails(ctx context.Context, site reversetunnelclient.RemoteSite,
 		return nil, trace.Wrap(err)
 	}
 
+	// sort auth servers newest first, so we get the most up to date version
 	authVersion := ""
+	sort.Slice(authServers, func(i, j int) bool {
+		return authServers[i].Expiry().After(authServers[j].Expiry())
+	})
 	if len(authServers) > 0 {
-		// use the first auth server
 		authVersion = authServers[0].GetTeleportVersion()
 	}
 
@@ -125,6 +129,9 @@ func GetClusterDetails(ctx context.Context, site reversetunnelclient.RemoteSite,
 		NodeCount:     len(nodes),
 		PublicURL:     proxyHost,
 		AuthVersion:   authVersion,
-		ProxyVersion:  proxyVersion,
+
+		// this code runs in the proxy service, so we can safely
+		// use the version embedded in the binary
+		ProxyVersion: teleport.Version,
 	}, nil
 }


### PR DESCRIPTION
The version shown in the UI's Help & Support page is populated by querying for all auth servers in the cluster and taking the first one. It's possible that after an upgrade the old auth server hasn't expired, so we may incorrectly report the old version for several minutes.

Fix this by:
- using the version from the newest auth server
- using the embedded version for the proxy version