### PR TITLE
Restructure the Resource Requests guide

### DIFF
--- a/docs/pages/access-controls/access-requests/resource-requests.mdx
+++ b/docs/pages/access-controls/access-requests/resource-requests.mdx
@@ -1,6 +1,7 @@
 ---
 title: Resource Access Requests
 description: Teleport allows users to request access to specific resources from the CLI or UI. Requests can be escalated via ChatOps or anywhere else via our flexible Authorization Workflow API.
+tocDepth: 3
 ---
 
 <Admonition type="tip" title="Preview">
@@ -439,115 +440,7 @@ spec:
   deny: {}
 ```
 
-##### Access Requests for Kubernetes resources
-
-Teleport users can request access to a Kubernetes resources by running the following
-command:
-
-```code
-$ tsh request create <Var name="resource-id" />
-```
-###### Namespaced-scoped resources
-
-For Kubernetes namespaced resources, the `resource-id` is in the following format:
-
-```
-/TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/NAMESPACE/RESOURCE_NAME
-```
-
-Teleport supports the following namespaced resources: `pod`, `secret`, `configmap`,
-`service`, `serviceaccount`, `persistentvolumeclaim`, `deployment`, `replicaset`,
-`statefulset`, `daemonset`, `kube_role`, `rolebinding`, `cronjob`, `job`,
-`ingress`.
-
-For example, to request access to a pod called `nginx-1` in the `development`
-namespace, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/pod/mycluster/development/nginx-1
-```
-
-For the `NAMESPACE` and `RESOURCE_NAME` values, you can match ranges of characters by
-supplying a wildcard (`*`) or regular expression. Regular expressions must begin
-with `^` and end with `$`.
-
-For example, to create a request to access all pods in all namespaces that match
-the regular expression `/^nginx-[a-z0-9-]+$/`, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/pod/mycluster/*/^nginx-[a-z0-9-]+$
-```
-
-###### Cluster-scoped resources
-
-For Kubernetes cluster-scoped resources, the `resource-id` is in the following format:
-
-```
-/TELEPORT_CLUSTER/CLUSTER_WIDE_KIND/KUBE_CLUSTER/RESOURCE_NAME
-```
-
-Teleport supports the following cluster-wide resources: `namespace`, `kube_node`,
-`clusterrole`, `clusterrolebinding`, `persistentvolume`, `certificatesigningrequest`.
-
-For example, to request access to a namespace called `prod`, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/namespace/mycluster/prod
-```
-
-For the `RESOURCE_NAME` value, you can match ranges of characters by
-supplying a wildcard (`*`) or regular expression. Regular expressions must begin
-with `^` and end with `$`.
-
-For example, to create a request to access all namespaces prefixed with `dev` match
-the regular expression `/^dev-[a-z0-9-]+$/`, run the following command:
-
-```code
-$ tsh request create --resources /teleport.example.com/namespace/mycluster/^dev-[a-z0-9-]+$
-```
-
-###### Search for Kubernetes resources
-
-If a user has no access to a Kubernetes cluster, they can search the list of resources
-in the cluster by running the following command:
-
-```code
-$ tsh request search --kind=<kind> --kube-cluster=<Var name="kube-cluster" /> \
-[--kube-namespace=<Var name="namespace" />|--all-kube-namespaces]
-Name               Namespace Labels    Resource ID
------------------  --------- --------- ----------------------------------------------------------
-nginx-deployment-0 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-0
-nginx-deployment-1 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-1
-
-To request access to these resources, run
-> tsh request create --resource /teleport.example.com/pod/local/default/nginx-deployment-0 --resource /teleport.example.com/pod/local/default/nginx-deployment-1 \
-    --reason <request reason>
-```
-
-The list returned includes the name of the resource, the namespace it is in if
-applicable, its labels, and the resource ID.
-Resources included in the list are those that match the `kubernetes_resources`
-field in the user's `search_as_roles`. The user can then:
-
-- Request access to the resources by running the command provided by the `tsh request
-search` command.
-- Edit the command to request access to a subset of the resources.
-- Use a custom request with wildcards or regular expressions.
-
-`tsh request search --kind=<kind>` works even if the user has no permissions to interact
- with the desired Kubernetes cluster, but the user's `search_as_roles` values
-must allow access to the cluster. If the user is unsure of the name of the cluster,
-they can run the following command to search it:
-
-```code
-$ tsh request search --kind=kube_cluster
-Name  Hostname Labels Resource ID
------ -------- ------ ----------------------------------------
-local                 /teleport.example.com/kube_cluster/local
-
-```
-
-##### Preventing unintended access
+##### Preventing unintended access to Kubernetes resources
 
 If you are setting up a Teleport role to enable just-in-time access to a
 specific Kubernetes resources, you should set the role's `kubernetes_groups` and
@@ -635,7 +528,116 @@ spec:
     windows_desktop_logins: ["{{internal.windows_logins}}"]
 ```
 
-### Allow reviewers to see the hostnames of SSH Nodes
+### Request access to Kubernetes resources
+
+Teleport users can request access to a Kubernetes resources by running the following
+command:
+
+```code
+$ tsh request create <Var name="resource-id" />
+```
+
+#### Namespace-scoped resources
+
+For Kubernetes namespaced resources, the `resource-id` is in the following format:
+
+```
+/TELEPORT_CLUSTER/NAMESPACED_KIND/KUBE_CLUSTER/NAMESPACE/RESOURCE_NAME
+```
+
+Teleport supports the following namespaced resources: `pod`, `secret`, `configmap`,
+`service`, `serviceaccount`, `persistentvolumeclaim`, `deployment`, `replicaset`,
+`statefulset`, `daemonset`, `kube_role`, `rolebinding`, `cronjob`, `job`,
+`ingress`.
+
+For example, to request access to a pod called `nginx-1` in the `development`
+namespace, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/pod/mycluster/development/nginx-1
+```
+
+For the `NAMESPACE` and `RESOURCE_NAME` values, you can match ranges of characters by
+supplying a wildcard (`*`) or regular expression. Regular expressions must begin
+with `^` and end with `$`.
+
+For example, to create a request to access all pods in all namespaces that match
+the regular expression `/^nginx-[a-z0-9-]+$/`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/pod/mycluster/*/^nginx-[a-z0-9-]+$
+```
+
+#### Cluster-scoped resources
+
+For Kubernetes cluster-scoped resources, the `resource-id` is in the following format:
+
+```
+/TELEPORT_CLUSTER/CLUSTER_WIDE_KIND/KUBE_CLUSTER/RESOURCE_NAME
+```
+
+Teleport supports the following cluster-wide resources: `namespace`, `kube_node`,
+`clusterrole`, `clusterrolebinding`, `persistentvolume`, `certificatesigningrequest`.
+
+For example, to request access to a namespace called `prod`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/namespace/mycluster/prod
+```
+
+For the `RESOURCE_NAME` value, you can match ranges of characters by
+supplying a wildcard (`*`) or regular expression. Regular expressions must begin
+with `^` and end with `$`.
+
+For example, to create a request to access all namespaces prefixed with `dev` match
+the regular expression `/^dev-[a-z0-9-]+$/`, run the following command:
+
+```code
+$ tsh request create --resources /teleport.example.com/namespace/mycluster/^dev-[a-z0-9-]+$
+```
+
+#### Search for Kubernetes resources
+
+If a user has no access to a Kubernetes cluster, they can search the list of resources
+in the cluster by running the following command:
+
+```code
+$ tsh request search --kind=<kind> --kube-cluster=<Var name="kube-cluster" /> \
+[--kube-namespace=<Var name="namespace" />|--all-kube-namespaces]
+Name               Namespace Labels    Resource ID
+-----------------  --------- --------- ----------------------------------------------------------
+nginx-deployment-0 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-0
+nginx-deployment-1 default   app=nginx /teleport.example.com/pod/local/default/nginx-deployment-1
+
+To request access to these resources, run
+> tsh request create --resource /teleport.example.com/pod/local/default/nginx-deployment-0 --resource /teleport.example.com/pod/local/default/nginx-deployment-1 \
+    --reason <request reason>
+```
+
+The list returned includes the name of the resource, the namespace it is in if
+applicable, its labels, and the resource ID.
+Resources included in the list are those that match the `kubernetes_resources`
+field in the user's `search_as_roles`. The user can then:
+
+- Request access to the resources by running the command provided by the `tsh request
+search` command.
+- Edit the command to request access to a subset of the resources.
+- Use a custom request with wildcards or regular expressions.
+
+`tsh request search --kind=<kind>` works even if the user has no permissions to interact
+ with the desired Kubernetes cluster, but the user's `search_as_roles` values
+must allow access to the cluster. If the user is unsure of the name of the cluster,
+they can run the following command to search it:
+
+```code
+$ tsh request search --kind=kube_cluster
+Name  Hostname Labels Resource ID
+----- -------- ------ ----------------------------------------
+local                 /teleport.example.com/kube_cluster/local
+
+```
+
+### Allow reviewers to see the hostnames of SSH nodes
 
 It is possible for a reviewer to view Resource Access Requests for SSH Nodes to
 which that reviewer does not have access.


### PR DESCRIPTION
Move the subsection on requesting access to Kubernetes resources to an H3. This way, we can avoid an unslightly H6 heading. Also, since this section relates to requesting access, not restricting access, it's more discoverable in a separate H3.