### PR TITLE
Move `agentCleanupDaemon.js` to webpack entries

### DIFF
--- a/web/packages/teleterm/package.json
+++ b/web/packages/teleterm/package.json
@@ -42,7 +42,6 @@
     "@types/google-protobuf": "^3.10.0",
     "@types/node-forge": "^1.0.4",
     "clean-webpack-plugin": "4.0.0",
-    "copy-webpack-plugin": "^11.0.0",
     "cross-env": "5.0.5",
     "electron": "26.0.0",
     "electron-notarize": "^1.2.1",

--- a/web/packages/teleterm/webpack.main.config.js
+++ b/web/packages/teleterm/webpack.main.config.js
@@ -2,7 +2,6 @@ const path = require('path');
 const { spawn } = require('child_process');
 
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const CopyPlugin = require('copy-webpack-plugin');
 const resolvepath = require('@gravitational/build/webpack/resolvepath');
 const configFactory = require('@gravitational/build/webpack/webpack.base');
 
@@ -34,6 +33,7 @@ const cfg = {
     main: './src/main.ts',
     preload: './src/preload.ts',
     sharedProcess: './src/sharedProcess/sharedProcess.ts',
+    agentCleanupDaemon: './src/agentCleanupDaemon/agentCleanupDaemon.js',
   },
 
   output: {
@@ -66,20 +66,7 @@ const cfg = {
     'node-pty': 'commonjs2 node-pty',
   },
 
-  plugins: [
-    new CleanWebpackPlugin(),
-    // Instead of adding agentCleanupDaemon.js as a separate entry, copy it to the dist dir as is.
-    // We want the daemon in prod to be as close as possible to the daemon in tests.
-    // See agentCleanupDaemon.js for the rationale.
-    new CopyPlugin({
-      patterns: [
-        {
-          from: './src/agentCleanupDaemon/agentCleanupDaemon.js',
-          to: 'agentCleanupDaemon.js',
-        },
-      ],
-    }),
-  ],
+  plugins: [new CleanWebpackPlugin()],
 
   /**
    * Disables webpack processing of __dirname and __filename.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6207,18 +6207,6 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-copy-webpack-plugin@^11.0.0:
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-11.0.0.tgz#96d4dbdb5f73d02dd72d0528d1958721ab72e04a"
-  integrity sha512-fX2MWpamkW0hZxMEg0+mYnA40LTosOSa5TqZ9GYIBzyJa9C3QUaMPSE2xAi/buNr8u89SfD9wHSQVBzrRa/SOQ==
-  dependencies:
-    fast-glob "^3.2.11"
-    glob-parent "^6.0.1"
-    globby "^13.1.1"
-    normalize-path "^3.0.0"
-    schema-utils "^4.0.0"
-    serialize-javascript "^6.0.0"
-
 core-js-compat@^3.18.0, core-js-compat@^3.19.1, core-js-compat@^3.8.1:
   version "3.19.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.19.1.tgz#fe598f1a9bf37310d77c3813968e9f7c7bb99476"
@@ -7831,17 +7819,6 @@ fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
-fast-glob@^3.3.0:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
-  integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
 fast-json-parse@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
@@ -8351,7 +8328,7 @@ glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob-parent@^6.0.1, glob-parent@^6.0.2:
+glob-parent@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-6.0.2.tgz#6d237d99083950c79290f24c7642a3de9a28f9e3"
   integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
@@ -8484,17 +8461,6 @@ globby@^11.1.0:
     ignore "^5.2.0"
     merge2 "^1.4.1"
     slash "^3.0.0"
-
-globby@^13.1.1:
-  version "13.2.2"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-13.2.2.tgz#63b90b1bf68619c2135475cbd4e71e66aa090592"
-  integrity sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==
-  dependencies:
-    dir-glob "^3.0.1"
-    fast-glob "^3.3.0"
-    ignore "^5.2.4"
-    merge2 "^1.4.1"
-    slash "^4.0.0"
 
 globby@^13.1.3:
   version "13.1.4"
@@ -9141,11 +9107,6 @@ ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
-
-ignore@^5.2.4:
-  version "5.2.4"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.4.tgz#a291c0c6178ff1b960befe47fcdec301674a6324"
-  integrity sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==
 
 immer@^9.0.7:
   version "9.0.19"


### PR DESCRIPTION
This PR moves the `agentCleanupDaemon.js` from webpack copy plugin to webpack entries.
I remember @ravicious that you wanted to avoid any Webpack transformations, so you decided to copy the file through the webpack copy plugin. 
Unfortunately, it also means that if the script requires some other modules, like `winston`, they won't be included in the app. I noticed this while testing the packaged app - it couldn't find `winston` module because there were no `node_modules`.

I think that transforming the file via webpack isn't bad - from what I see, it look almost 1:1 as before, it is wrapped in IIFE and `winston` stuff is added at the beginning of the output file.

I'm marking the PR as draft so we can discuss it. 