### PR TITLE
charts: fix teleport-cluster port names

### DIFF
--- a/examples/chart/teleport-cluster/templates/auth/deployment.yaml
+++ b/examples/chart/teleport-cluster/templates/auth/deployment.yaml
@@ -249,10 +249,10 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 10
         ports:
-          - name: operator-http-metrics
+          - name: op-metrics
             containerPort: 8080
             protocol: TCP
-          - name: operator-http-health
+          - name: op-health
             containerPort: 8081
             protocol: TCP
   {{- if .Values.operator.resources }}

--- a/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
+++ b/examples/chart/teleport-cluster/tests/__snapshot__/auth_deployment_test.yaml.snap
@@ -11,10 +11,10 @@ should add an operator side-car when operator is enabled:
     name: operator
     ports:
     - containerPort: 8080
-      name: operator-http-metrics
+      name: op-metrics
       protocol: TCP
     - containerPort: 8081
-      name: operator-http-health
+      name: op-health
       protocol: TCP
     readinessProbe:
       httpGet:


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/gravitational/teleport/pull/31323 : I went over the max port name size (15 char).