### PR TITLE
Remove internal access list object members field in spec.

### DIFF
--- a/api/client/events_test.go
+++ b/api/client/events_test.go
@@ -202,22 +202,6 @@ func newAccessList(t *testing.T, name string) *accesslist.AccessList {
 					"gtrait2": {"gvalue3", "gvalue4"},
 				},
 			},
-			Members: []accesslist.Member{
-				{
-					Name:    "member1",
-					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because",
-					AddedBy: "test-user1",
-				},
-				{
-					Name:    "member2",
-					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because again",
-					AddedBy: "test-user2",
-				},
-			},
 		},
 	)
 	require.NoError(t, err)

--- a/api/types/accesslist/accesslist.go
+++ b/api/types/accesslist/accesslist.go
@@ -66,10 +66,6 @@ type Spec struct {
 
 	// Grants describes the access granted by membership to this access list.
 	Grants Grants `json:"grants" yaml:"grants"`
-
-	// Members describes the current members of the access list.
-	// TODO(mdwn): Remove this.
-	Members []Member `json:"members" yaml:"members"`
 }
 
 // Owner is an owner of an access list.
@@ -174,20 +170,6 @@ func (a *AccessList) CheckAndSetDefaults() error {
 		return trace.BadParameter("grants must specify at least one role or trait")
 	}
 
-	for _, member := range a.Spec.Members {
-		if member.Name == "" {
-			return trace.BadParameter("member name is missing")
-		}
-
-		if member.Joined.IsZero() {
-			return trace.BadParameter("member %s joined is missing", member.Name)
-		}
-
-		if member.AddedBy == "" {
-			return trace.BadParameter("member %s added by is missing", member.Name)
-		}
-	}
-
 	return nil
 }
 
@@ -214,11 +196,6 @@ func (a *AccessList) GetOwnershipRequires() Requires {
 // GetGrants returns the grants from the access list.
 func (a *AccessList) GetGrants() Grants {
 	return a.Spec.Grants
-}
-
-// GetMembers returns the members from the access list.
-func (a *AccessList) GetMembers() []Member {
-	return a.Spec.Members
 }
 
 // GetMetadata returns metadata. This is specifically for conforming to the Resource interface,

--- a/lib/services/access_list.go
+++ b/lib/services/access_list.go
@@ -168,12 +168,6 @@ func UnmarshalAccessListMember(data []byte, opts ...MarshalOption) (*accesslist.
 	return member, nil
 }
 
-// IsOwner will return true if the user is an owner for the current list.
-// TODO(mdwn): Remove this once references to this function call are removed from enterprise.
-func IsOwner(identity tlsca.Identity, accessList *accesslist.AccessList) error {
-	return IsAccessListOwner(identity, accessList)
-}
-
 // IsAccessListOwner will return true if the user is an owner for the current list.
 func IsAccessListOwner(identity tlsca.Identity, accessList *accesslist.AccessList) error {
 	isOwner := false
@@ -198,22 +192,6 @@ func IsAccessListOwner(identity tlsca.Identity, accessList *accesslist.AccessLis
 
 	// We've gotten through all the checks, so the user is an owner.
 	return nil
-}
-
-// IsMember will return true if the user is a member for the current list.
-// TODO(mdwn): Remove this once references to this function call are removed from enterprise.
-func IsMember(identity tlsca.Identity, clock clockwork.Clock, accessList *accesslist.AccessList) error {
-	username := identity.Username
-	for _, member := range accessList.Spec.Members {
-		if member.Name == username && clock.Now().Before(member.Expires) {
-			if !UserMeetsRequirements(identity, accessList.Spec.MembershipRequires) {
-				return trace.AccessDenied("user %s does not meet membership requirements", username)
-			}
-			return nil
-		}
-	}
-
-	return trace.NotFound("user %s is not a member of the access list", username)
 }
 
 // IsAccessListMember will return true if the user is a member for the current list.

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -547,17 +547,6 @@ spec:
       gtrait2:
       - gvalue3
       - gvalue4
-  members:
-  - name: member1
-    joined: 2023-01-01T00:00:00Z
-    expires: 2024-01-01T00:00:00Z
-    reason: "because"
-    added_by: "test-user1"
-  - name: member2
-    joined: 2022-01-01T00:00:00Z
-    expires: 2025-01-01T00:00:00Z
-    reason: "because again"
-    added_by: "test-user2"
 `
 
 var accessListMemberYAML = `---

--- a/lib/services/access_list_test.go
+++ b/lib/services/access_list_test.go
@@ -82,22 +82,6 @@ func TestAccessListUnmarshal(t *testing.T) {
 					"gtrait2": {"gvalue3", "gvalue4"},
 				},
 			},
-			Members: []accesslist.Member{
-				{
-					Name:    "member1",
-					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because",
-					AddedBy: "test-user1",
-				},
-				{
-					Name:    "member2",
-					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because again",
-					AddedBy: "test-user2",
-				},
-			},
 		},
 	)
 	require.NoError(t, err)
@@ -150,22 +134,6 @@ func TestAccessListMarshal(t *testing.T) {
 				Traits: map[string][]string{
 					"gtrait1": {"gvalue1", "gvalue2"},
 					"gtrait2": {"gvalue3", "gvalue4"},
-				},
-			},
-			Members: []accesslist.Member{
-				{
-					Name:    "member1",
-					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because",
-					AddedBy: "test-user1",
-				},
-				{
-					Name:    "member2",
-					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because again",
-					AddedBy: "test-user2",
 				},
 			},
 		},
@@ -293,102 +261,6 @@ func TestIsAccessListOwner(t *testing.T) {
 
 			accessList := newAccessList(t)
 			test.errAssertionFunc(t, IsAccessListOwner(test.identity, accessList))
-		})
-	}
-}
-
-// TODO(mdwn): Remove this.
-func TestIsMember(t *testing.T) {
-	tests := []struct {
-		name             string
-		identity         tlsca.Identity
-		memberCtx        context.Context
-		currentTime      time.Time
-		errAssertionFunc require.ErrorAssertionFunc
-	}{
-		{
-			name: "is member",
-			identity: tlsca.Identity{
-				Username: member1,
-				Groups:   []string{"mrole1", "mrole2"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1", "mvalue2"},
-					"mtrait2": {"mvalue3", "mvalue4"},
-				},
-			},
-			currentTime:      time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: require.NoError,
-		},
-		{
-			name: "is not a member",
-			identity: tlsca.Identity{
-				Username: member3,
-				Groups:   []string{"mrole1", "mrole2"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1", "mvalue2"},
-					"mtrait2": {"mvalue3", "mvalue4"},
-				},
-			},
-			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsNotFound(err))
-			},
-		},
-		{
-			name: "is expired member",
-			identity: tlsca.Identity{
-				Username: member1,
-				Groups:   []string{"mrole1", "mrole2"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1", "mvalue2"},
-					"mtrait2": {"mvalue3", "mvalue4"},
-				},
-			},
-			currentTime: time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsNotFound(err))
-			},
-		},
-		{
-			name: "is member with missing roles",
-			identity: tlsca.Identity{
-				Username: member1,
-				Groups:   []string{"mrole1"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1", "mvalue2"},
-					"mtrait2": {"mvalue3", "mvalue4"},
-				},
-			},
-			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
-		},
-		{
-			name: "is member with missing traits",
-			identity: tlsca.Identity{
-				Username: member1,
-				Groups:   []string{"mrole1", "mrole2"},
-				Traits: map[string][]string{
-					"mtrait1": {"mvalue1"},
-					"mtrait2": {"mvalue3"},
-				},
-			},
-			currentTime: time.Date(2023, 2, 1, 0, 0, 0, 0, time.UTC),
-			errAssertionFunc: func(t require.TestingT, err error, i ...interface{}) {
-				require.True(t, trace.IsAccessDenied(err))
-			},
-		},
-	}
-
-	for _, test := range tests {
-		test := test
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
-
-			accessList := newAccessList(t)
-
-			test.errAssertionFunc(t, IsMember(test.identity, clockwork.NewFakeClockAt(test.currentTime), accessList))
 		})
 	}
 }
@@ -587,22 +459,6 @@ func newAccessList(t *testing.T) *accesslist.AccessList {
 				Traits: map[string][]string{
 					"gtrait1": {"gvalue1", "gvalue2"},
 					"gtrait2": {"gvalue3", "gvalue4"},
-				},
-			},
-			Members: []accesslist.Member{
-				{
-					Name:    member1,
-					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because",
-					AddedBy: ownerUser,
-				},
-				{
-					Name:    member2,
-					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because again",
-					AddedBy: ownerUser,
 				},
 			},
 		},

--- a/lib/services/local/access_list_test.go
+++ b/lib/services/local/access_list_test.go
@@ -411,22 +411,6 @@ func newAccessList(t *testing.T, name string) *accesslist.AccessList {
 					"gtrait2": {"gvalue3", "gvalue4"},
 				},
 			},
-			Members: []accesslist.Member{
-				{
-					Name:    "member1",
-					Joined:  time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because",
-					AddedBy: "test-user1",
-				},
-				{
-					Name:    "member2",
-					Joined:  time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC),
-					Expires: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
-					Reason:  "because again",
-					AddedBy: "test-user2",
-				},
-			},
 		},
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
The members field in the internal access list object has been removed. This has been replaced by top level AccessListMember objects, which will scale better on DynamoDB.