### PR TITLE
AWS OIDC: command to configure IAM for listing databases

### DIFF
--- a/lib/cloud/aws/policy_statements.go
+++ b/lib/cloud/aws/policy_statements.go
@@ -147,3 +147,15 @@ func StatementForAWSOIDCRoleTrustRelationship(accountID, providerURL string, aud
 		},
 	}
 }
+
+// StatementForListRDSDatabases returns the statement that allows listing RDS DB Clusters and Instances.
+func StatementForListRDSDatabases() *Statement {
+	return &Statement{
+		Effect: EffectAllow,
+		Actions: []string{
+			"rds:DescribeDBInstances",
+			"rds:DescribeDBClusters",
+		},
+		Resources: allResources,
+	}
+}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -208,6 +208,10 @@ type CommandLineFlags struct {
 	// IntegrationConfAWSOIDCIdPArguments contains the arguments of
 	// `teleport integration configure awsoidc-idp` command
 	IntegrationConfAWSOIDCIdPArguments IntegrationConfAWSOIDCIdP
+
+	// IntegrationConfListDatabasesIAMArguments contains the arguments of
+	// `teleport integration configure listdatabases-iam` command
+	IntegrationConfListDatabasesIAMArguments IntegrationConfListDatabasesIAM
 }
 
 // IntegrationConfDeployServiceIAM contains the arguments of
@@ -248,6 +252,15 @@ type IntegrationConfAWSOIDCIdP struct {
 	// ProxyPublicURL is the IdP Issuer URL (Teleport Proxy Public Address).
 	// Eg, https://<tenant>.teleport.sh
 	ProxyPublicURL string
+}
+
+// IntegrationConfListDatabasesIAM contains the arguments of
+// `teleport integration configure listdatabases-iam` command
+type IntegrationConfListDatabasesIAM struct {
+	// Region is the AWS Region used to set up the client.
+	Region string
+	// Role is the AWS Role associated with the Integration
+	Role string
 }
 
 // ReadConfigFile reads /etc/teleport.yaml (or whatever is passed via --config flag)

--- a/lib/integrations/awsoidc/deployservice_iam_config_test.go
+++ b/lib/integrations/awsoidc/deployservice_iam_config_test.go
@@ -235,8 +235,8 @@ func (m *mockDeployServiceIAMConfigClient) CreateRole(ctx context.Context, param
 
 // PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
 func (m *mockDeployServiceIAMConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
-	noSuchEntityMessage := fmt.Sprintf("Role %q does not exist.", *params.RoleName)
 	if !slices.Contains(m.existingRoles, *params.RoleName) {
+		noSuchEntityMessage := fmt.Sprintf("Role %q does not exist.", *params.RoleName)
 		return nil, &iamTypes.NoSuchEntityException{
 			Message: &noSuchEntityMessage,
 		}

--- a/lib/integrations/awsoidc/eice_iam_config_test.go
+++ b/lib/integrations/awsoidc/eice_iam_config_test.go
@@ -128,8 +128,8 @@ type mockEICEIAMConfigClient struct {
 
 // PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
 func (m *mockEICEIAMConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
-	noSuchEntityMessage := fmt.Sprintf("role %q does not exist.", *params.RoleName)
 	if !slices.Contains(m.existingRoles, *params.RoleName) {
+		noSuchEntityMessage := fmt.Sprintf("role %q does not exist.", *params.RoleName)
 		return nil, &iamTypes.NoSuchEntityException{
 			Message: &noSuchEntityMessage,
 		}

--- a/lib/integrations/awsoidc/listdatabases_iam_config.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"log"
+
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/gravitational/trace"
+
+	awslib "github.com/gravitational/teleport/lib/cloud/aws"
+)
+
+const (
+	// defaultPolicyNameForListDatabases is the default name for the Inline Policy added to the IntegrationRole.
+	defaultPolicyNameForListDatabases = "ListDatabases"
+)
+
+// ListDatabasesIAMConfigureRequest is a request to configure the required Policy to use the List Databases action.
+type ListDatabasesIAMConfigureRequest struct {
+	// Region is the AWS Region.
+	// Used to set up the AWS SDK Client.
+	Region string
+
+	// IntegrationRole is the Integration's AWS Role used by the integration.
+	IntegrationRole string
+
+	// ListDatabasesPolicy is the Policy Name that is created to allow access to call AWS APIs.
+	// Defaults to ListDatabases
+	ListDatabasesPolicy string
+}
+
+// CheckAndSetDefaults ensures the required fields are present.
+func (r *ListDatabasesIAMConfigureRequest) CheckAndSetDefaults() error {
+	if r.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	if r.IntegrationRole == "" {
+		return trace.BadParameter("integration role is required")
+	}
+
+	if r.ListDatabasesPolicy == "" {
+		r.ListDatabasesPolicy = defaultPolicyNameForListDatabases
+	}
+
+	return nil
+}
+
+// ListDatabasesIAMConfigureClient describes the required methods to create the IAM Policies required for Listing Databases.
+type ListDatabasesIAMConfigureClient interface {
+	// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
+}
+
+type defaultListDatabasesIAMConfigureClient struct {
+	*iam.Client
+}
+
+// NewListDatabasesIAMConfigureClient creates a new ListDatabasesIAMConfigureClient.
+func NewListDatabasesIAMConfigureClient(ctx context.Context, region string) (ListDatabasesIAMConfigureClient, error) {
+	if region == "" {
+		return nil, trace.BadParameter("region is required")
+	}
+
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
+
+	return &defaultListDatabasesIAMConfigureClient{
+		Client: iam.NewFromConfig(cfg),
+	}, nil
+}
+
+// ConfigureListDatabasesIAM set ups the policy required for accessing an RDS DB Instances and RDS DB Clusters.
+// It creates an inline policy with the following permissions:
+//   - rds:DescribeDBInstances
+//   - rds:DescribeDBClusters
+//
+// The following actions must be allowed by the IAM Role assigned in the Client.
+//   - iam:PutRolePolicy
+func ConfigureListDatabasesIAM(ctx context.Context, clt ListDatabasesIAMConfigureClient, req ListDatabasesIAMConfigureRequest) error {
+	if err := req.CheckAndSetDefaults(); err != nil {
+		return trace.Wrap(err)
+	}
+
+	listDatabasesPolicyDocument, err := awslib.NewPolicyDocument(
+		awslib.StatementForListRDSDatabases(),
+	).Marshal()
+	if err != nil {
+		return trace.Wrap(err)
+	}
+
+	_, err = clt.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		PolicyName:     &req.ListDatabasesPolicy,
+		RoleName:       &req.IntegrationRole,
+		PolicyDocument: &listDatabasesPolicyDocument,
+	})
+	if err != nil {
+		if trace.IsNotFound(awslib.ConvertIAMv2Error(err)) {
+			return trace.NotFound("role %q not found.", req.IntegrationRole)
+		}
+		return trace.Wrap(err)
+	}
+
+	log.Printf("IntegrationRole: IAM Policy %q added to Role %q\n", req.ListDatabasesPolicy, req.IntegrationRole)
+	return nil
+}

--- a/lib/integrations/awsoidc/listdatabases_iam_config.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config.go
@@ -32,8 +32,8 @@ const (
 	defaultPolicyNameForListDatabases = "ListDatabases"
 )
 
-// ListDatabasesIAMConfigureRequest is a request to configure the required Policy to use the List Databases action.
-type ListDatabasesIAMConfigureRequest struct {
+// ConfigureIAMListDatabasesRequest is a request to configure the required Policy to use the List Databases action.
+type ConfigureIAMListDatabasesRequest struct {
 	// Region is the AWS Region.
 	// Used to set up the AWS SDK Client.
 	Region string
@@ -47,7 +47,7 @@ type ListDatabasesIAMConfigureRequest struct {
 }
 
 // CheckAndSetDefaults ensures the required fields are present.
-func (r *ListDatabasesIAMConfigureRequest) CheckAndSetDefaults() error {
+func (r *ConfigureIAMListDatabasesRequest) CheckAndSetDefaults() error {
 	if r.Region == "" {
 		return trace.BadParameter("region is required")
 	}
@@ -96,7 +96,7 @@ func NewListDatabasesIAMConfigureClient(ctx context.Context, region string) (Lis
 //
 // The following actions must be allowed by the IAM Role assigned in the Client.
 //   - iam:PutRolePolicy
-func ConfigureListDatabasesIAM(ctx context.Context, clt ListDatabasesIAMConfigureClient, req ListDatabasesIAMConfigureRequest) error {
+func ConfigureListDatabasesIAM(ctx context.Context, clt ListDatabasesIAMConfigureClient, req ConfigureIAMListDatabasesRequest) error {
 	if err := req.CheckAndSetDefaults(); err != nil {
 		return trace.Wrap(err)
 	}

--- a/lib/integrations/awsoidc/listdatabases_iam_config.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config.go
@@ -69,10 +69,6 @@ type ListDatabasesIAMConfigureClient interface {
 	PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error)
 }
 
-type defaultListDatabasesIAMConfigureClient struct {
-	*iam.Client
-}
-
 // NewListDatabasesIAMConfigureClient creates a new ListDatabasesIAMConfigureClient.
 func NewListDatabasesIAMConfigureClient(ctx context.Context, region string) (ListDatabasesIAMConfigureClient, error) {
 	if region == "" {
@@ -84,9 +80,7 @@ func NewListDatabasesIAMConfigureClient(ctx context.Context, region string) (Lis
 		return nil, trace.Wrap(err)
 	}
 
-	return &defaultListDatabasesIAMConfigureClient{
-		Client: iam.NewFromConfig(cfg),
-	}, nil
+	return iam.NewFromConfig(cfg), nil
 }
 
 // ConfigureListDatabasesIAM set ups the policy required for accessing an RDS DB Instances and RDS DB Clusters.

--- a/lib/integrations/awsoidc/listdatabases_iam_config_test.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config_test.go
@@ -30,18 +30,18 @@ import (
 func TestListDatabasesIAMConfigReqDefaults(t *testing.T) {
 	for _, tt := range []struct {
 		name     string
-		req      ListDatabasesIAMConfigureRequest
+		req      ConfigureIAMListDatabasesRequest
 		errCheck require.ErrorAssertionFunc
-		expected ListDatabasesIAMConfigureRequest
+		expected ConfigureIAMListDatabasesRequest
 	}{
 		{
 			name: "set defaults",
-			req: ListDatabasesIAMConfigureRequest{
+			req: ConfigureIAMListDatabasesRequest{
 				Region:          "us-east-1",
 				IntegrationRole: "integrationrole",
 			},
 			errCheck: require.NoError,
-			expected: ListDatabasesIAMConfigureRequest{
+			expected: ConfigureIAMListDatabasesRequest{
 				Region:              "us-east-1",
 				IntegrationRole:     "integrationrole",
 				ListDatabasesPolicy: "ListDatabases",
@@ -49,14 +49,14 @@ func TestListDatabasesIAMConfigReqDefaults(t *testing.T) {
 		},
 		{
 			name: "missing region",
-			req: ListDatabasesIAMConfigureRequest{
+			req: ConfigureIAMListDatabasesRequest{
 				IntegrationRole: "integrationrole",
 			},
 			errCheck: badParameterCheck,
 		},
 		{
 			name: "missing integration role",
-			req: ListDatabasesIAMConfigureRequest{
+			req: ConfigureIAMListDatabasesRequest{
 				IntegrationRole: "integrationrole",
 			},
 			errCheck: badParameterCheck,
@@ -76,7 +76,7 @@ func TestListDatabasesIAMConfigReqDefaults(t *testing.T) {
 
 func TestListDatabasesIAMConfig(t *testing.T) {
 	ctx := context.Background()
-	baseReq := ListDatabasesIAMConfigureRequest{
+	baseReq := ConfigureIAMListDatabasesRequest{
 		Region:          "us-east-1",
 		IntegrationRole: "integrationrole",
 	}
@@ -84,7 +84,7 @@ func TestListDatabasesIAMConfig(t *testing.T) {
 	for _, tt := range []struct {
 		name              string
 		mockExistingRoles []string
-		req               ListDatabasesIAMConfigureRequest
+		req               ConfigureIAMListDatabasesRequest
 		errCheck          require.ErrorAssertionFunc
 	}{
 		{

--- a/lib/integrations/awsoidc/listdatabases_iam_config_test.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config_test.go
@@ -35,19 +35,6 @@ func TestListDatabasesIAMConfigReqDefaults(t *testing.T) {
 		expected ConfigureIAMListDatabasesRequest
 	}{
 		{
-			name: "set defaults",
-			req: ConfigureIAMListDatabasesRequest{
-				Region:          "us-east-1",
-				IntegrationRole: "integrationrole",
-			},
-			errCheck: require.NoError,
-			expected: ConfigureIAMListDatabasesRequest{
-				Region:              "us-east-1",
-				IntegrationRole:     "integrationrole",
-				listDatabasesPolicy: "ListDatabases",
-			},
-		},
-		{
 			name: "missing region",
 			req: ConfigureIAMListDatabasesRequest{
 				IntegrationRole: "integrationrole",

--- a/lib/integrations/awsoidc/listdatabases_iam_config_test.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2023 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package awsoidc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	iamTypes "github.com/aws/aws-sdk-go-v2/service/iam/types"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
+)
+
+func TestListDatabasesIAMConfigReqDefaults(t *testing.T) {
+	baseReq := func() ListDatabasesIAMConfigureRequest {
+		return ListDatabasesIAMConfigureRequest{
+			Region:          "us-east-1",
+			IntegrationRole: "integrationrole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name     string
+		req      func() ListDatabasesIAMConfigureRequest
+		errCheck require.ErrorAssertionFunc
+		expected ListDatabasesIAMConfigureRequest
+	}{
+		{
+			name:     "set defaults",
+			req:      baseReq,
+			errCheck: require.NoError,
+			expected: ListDatabasesIAMConfigureRequest{
+				Region:              "us-east-1",
+				IntegrationRole:     "integrationrole",
+				ListDatabasesPolicy: "ListDatabases",
+			},
+		},
+		{
+			name: "missing region",
+			req: func() ListDatabasesIAMConfigureRequest {
+				req := baseReq()
+				req.Region = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+		{
+			name: "missing integration role",
+			req: func() ListDatabasesIAMConfigureRequest {
+				req := baseReq()
+				req.IntegrationRole = ""
+				return req
+			},
+			errCheck: badParameterCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := tt.req()
+			err := req.CheckAndSetDefaults()
+			tt.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Equal(t, tt.expected, req)
+		})
+	}
+}
+
+func TestListDatabasesIAMConfig(t *testing.T) {
+	ctx := context.Background()
+	baseReq := func() ListDatabasesIAMConfigureRequest {
+		return ListDatabasesIAMConfigureRequest{
+			Region:          "us-east-1",
+			IntegrationRole: "integrationrole",
+		}
+	}
+
+	for _, tt := range []struct {
+		name              string
+		mockExistingRoles []string
+		req               func() ListDatabasesIAMConfigureRequest
+		errCheck          require.ErrorAssertionFunc
+	}{
+		{
+			name:              "valid",
+			req:               baseReq,
+			mockExistingRoles: []string{"integrationrole"},
+			errCheck:          require.NoError,
+		},
+		{
+			name:              "integration role does not exist",
+			mockExistingRoles: []string{},
+			req:               baseReq,
+			errCheck:          notFounCheck,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			clt := mockListDatabasesIAMConfigClient{
+				existingRoles: tt.mockExistingRoles,
+			}
+
+			err := ConfigureListDatabasesIAM(ctx, &clt, tt.req())
+			tt.errCheck(t, err)
+		})
+	}
+}
+
+type mockListDatabasesIAMConfigClient struct {
+	existingRoles []string
+}
+
+// PutRolePolicy creates or replaces a Policy by its name in a IAM Role.
+func (m *mockListDatabasesIAMConfigClient) PutRolePolicy(ctx context.Context, params *iam.PutRolePolicyInput, optFns ...func(*iam.Options)) (*iam.PutRolePolicyOutput, error) {
+	noSuchEntityMessage := fmt.Sprintf("role %q does not exist.", *params.RoleName)
+	if !slices.Contains(m.existingRoles, *params.RoleName) {
+		return nil, &iamTypes.NoSuchEntityException{
+			Message: &noSuchEntityMessage,
+		}
+	}
+	return nil, nil
+}

--- a/lib/integrations/awsoidc/listdatabases_iam_config_test.go
+++ b/lib/integrations/awsoidc/listdatabases_iam_config_test.go
@@ -44,7 +44,7 @@ func TestListDatabasesIAMConfigReqDefaults(t *testing.T) {
 			expected: ConfigureIAMListDatabasesRequest{
 				Region:              "us-east-1",
 				IntegrationRole:     "integrationrole",
-				ListDatabasesPolicy: "ListDatabases",
+				listDatabasesPolicy: "ListDatabases",
 			},
 		},
 		{

--- a/lib/web/apiserver.go
+++ b/lib/web/apiserver.go
@@ -794,6 +794,7 @@ func (h *Handler) bindDefaultEndpoints() {
 	// AWS OIDC Integration Actions
 	h.GET("/webapi/scripts/integrations/configure/awsoidc-idp.sh", h.WithLimiter(h.awsOIDCConfigureIdP))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/databases", h.WithClusterAuth(h.awsOIDCListDatabases))
+	h.GET("/webapi/scripts/integrations/configure/listdatabases-iam.sh", h.WithLimiter(h.awsOIDCConfigureListDatabasesIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/deployservice", h.WithClusterAuth(h.awsOIDCDeployService))
 	h.GET("/webapi/scripts/integrations/configure/deployservice-iam.sh", h.WithLimiter(h.awsOIDCConfigureDeployServiceIAM))
 	h.POST("/webapi/sites/:site/integrations/aws-oidc/:name/ec2", h.WithClusterAuth(h.awsOIDCListEC2))

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -243,7 +243,7 @@ func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *htt
 	}
 
 	httplib.SetScriptHeaders(w.Header())
-	fmt.Fprint(w, script)
+	_, err = fmt.Fprint(w, script)
 
 	return nil, trace.Wrap(err)
 }
@@ -279,7 +279,7 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 	}
 
 	httplib.SetScriptHeaders(w.Header())
-	fmt.Fprint(w, script)
+	_, err = fmt.Fprint(w, script)
 
 	return nil, trace.Wrap(err)
 }
@@ -494,7 +494,7 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 	}
 
 	httplib.SetScriptHeaders(w.Header())
-	fmt.Fprint(w, script)
+	_, err = fmt.Fprint(w, script)
 
 	return nil, trace.Wrap(err)
 }
@@ -529,7 +529,7 @@ func (h *Handler) awsOIDCConfigureListDatabasesIAM(w http.ResponseWriter, r *htt
 	}
 
 	httplib.SetScriptHeaders(w.Header())
-	fmt.Fprint(w, script)
+	_, err = fmt.Fprint(w, script)
 
 	return nil, trace.Wrap(err)
 }

--- a/lib/web/integrations_awsoidc.go
+++ b/lib/web/integrations_awsoidc.go
@@ -216,7 +216,7 @@ func (h *Handler) awsOIDCConfigureDeployServiceIAM(w http.ResponseWriter, r *htt
 
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
-		return nil, trace.BadParameter("invalid role")
+		return nil, trace.BadParameter("invalid role %q", role)
 	}
 
 	taskRole := queryParams.Get("taskRole")
@@ -260,7 +260,7 @@ func (h *Handler) awsOIDCConfigureEICEIAM(w http.ResponseWriter, r *http.Request
 
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
-		return nil, trace.BadParameter("invalid role")
+		return nil, trace.BadParameter("invalid role %q", role)
 	}
 
 	// The script must execute the following command:
@@ -472,7 +472,7 @@ func (h *Handler) awsOIDCConfigureIdP(w http.ResponseWriter, r *http.Request, p 
 
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
-		return nil, trace.BadParameter("invalid role")
+		return nil, trace.BadParameter("invalid role %q", role)
 	}
 
 	// The script must execute the following command:
@@ -510,7 +510,7 @@ func (h *Handler) awsOIDCConfigureListDatabasesIAM(w http.ResponseWriter, r *htt
 
 	role := queryParams.Get("role")
 	if err := aws.IsValidIAMRoleName(role); err != nil {
-		return nil, trace.BadParameter("invalid role")
+		return nil, trace.BadParameter("invalid role %q", role)
 	}
 
 	// The script must execute the following command:

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -415,7 +415,6 @@ func TestBuildListDatabasesConfigureIAMScript(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
 			tc.errCheck(t, err)

--- a/lib/web/integrations_awsoidc_test.go
+++ b/lib/web/integrations_awsoidc_test.go
@@ -341,3 +341,91 @@ func TestBuildAWSOIDCIdPConfigureScript(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildListDatabasesConfigureIAMScript(t *testing.T) {
+	isBadParamErrFn := func(tt require.TestingT, err error, i ...any) {
+		require.True(tt, trace.IsBadParameter(err), "expected bad parameter, got %v", err)
+	}
+
+	ctx := context.Background()
+	env := newWebPack(t, 1)
+
+	// Unauthenticated client for script downloading.
+	publicClt := env.proxies[0].newClient(t)
+	pathVars := []string{
+		"webapi",
+		"scripts",
+		"integrations",
+		"configure",
+		"listdatabases-iam.sh",
+	}
+	endpoint := publicClt.Endpoint(pathVars...)
+
+	tests := []struct {
+		name                 string
+		reqRelativeURL       string
+		reqQuery             url.Values
+		errCheck             require.ErrorAssertionFunc
+		expectedTeleportArgs string
+	}{
+		{
+			name: "valid",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"myRole"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure listdatabases-iam " +
+				"--aws-region=us-east-1 " +
+				"--role=myRole",
+		},
+		{
+			name: "valid with symbols in role",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+				"role":      []string{"Test+1=2,3.4@5-6_7"},
+			},
+			errCheck: require.NoError,
+			expectedTeleportArgs: "integration configure listdatabases-iam " +
+				"--aws-region=us-east-1 " +
+				"--role=Test+1=2,3.4@5-6_7",
+		},
+		{
+			name: "missing aws-region",
+			reqQuery: url.Values{
+				"role": []string{"myRole"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "missing role",
+			reqQuery: url.Values{
+				"awsRegion": []string{"us-east-1"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+		{
+			name: "trying to inject escape sequence into query params",
+			reqQuery: url.Values{
+				"awsRegion": []string{"'; rm -rf /tmp/dir; echo '"},
+				"role":      []string{"role"},
+			},
+			errCheck: isBadParamErrFn,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			resp, err := publicClt.Get(ctx, endpoint, tc.reqQuery)
+			tc.errCheck(t, err)
+			if err != nil {
+				return
+			}
+
+			require.Contains(t, string(resp.Bytes()),
+				fmt.Sprintf("teleportArgs='%s'\n", tc.expectedTeleportArgs),
+			)
+		})
+	}
+}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -466,7 +466,7 @@ func Run(options Options) (app *kingpin.Application, executedCommand string, con
 	integrationConfAWSOIDCIdPCmd.Flag("proxy-public-url", "Proxy Public URL (eg https://mytenant.teleport.sh).").Required().StringVar(&ccf.
 		IntegrationConfAWSOIDCIdPArguments.ProxyPublicURL)
 
-	integrationConfListDatabasesCmd := integrationConfigureCmd.Command("listdatabases-iam", "Adds required IAM permissions to connect to EC2 Instances using EC2 Instance Connect Endpoint")
+	integrationConfListDatabasesCmd := integrationConfigureCmd.Command("listdatabases-iam", "Adds required IAM permissions to List RDS Databases (Instances and Clusters)")
 	integrationConfListDatabasesCmd.Flag("aws-region", "AWS Region.").Required().StringVar(&ccf.IntegrationConfListDatabasesIAMArguments.Region)
 	integrationConfListDatabasesCmd.Flag("role", "The AWS Role used by the AWS OIDC Integration.").Required().StringVar(&ccf.IntegrationConfListDatabasesIAMArguments.Role)
 

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -965,6 +965,10 @@ func onIntegrationConfAWSOIDCIdP(params config.IntegrationConfAWSOIDCIdP) error 
 func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabasesIAM) error {
 	ctx := context.Background()
 
+	// Ensure we show progress to the user.
+	// LogLevel at this point is set to Error.
+	log.SetLevel(log.InfoLevel)
+
 	if params.Region == "" {
 		return trace.BadParameter("region is required")
 	}

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -968,7 +968,7 @@ func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabase
 		return trace.Wrap(err)
 	}
 
-	err = awsoidc.ConfigureListDatabasesIAM(ctx, iamClient, awsoidc.ListDatabasesIAMConfigureRequest{
+	err = awsoidc.ConfigureListDatabasesIAM(ctx, iamClient, awsoidc.ConfigureIAMListDatabasesRequest{
 		Region:          params.Region,
 		IntegrationRole: params.Role,
 	})

--- a/tool/teleport/common/teleport.go
+++ b/tool/teleport/common/teleport.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 
 	"github.com/alecthomas/kingpin/v2"
+	awsConfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/gravitational/trace"
 	log "github.com/sirupsen/logrus"
 
@@ -963,10 +965,16 @@ func onIntegrationConfAWSOIDCIdP(params config.IntegrationConfAWSOIDCIdP) error 
 func onIntegrationConfListDatabasesIAM(params config.IntegrationConfListDatabasesIAM) error {
 	ctx := context.Background()
 
-	iamClient, err := awsoidc.NewListDatabasesIAMConfigureClient(ctx, params.Region)
+	if params.Region == "" {
+		return trace.BadParameter("region is required")
+	}
+
+	cfg, err := awsConfig.LoadDefaultConfig(ctx, awsConfig.WithRegion(params.Region))
 	if err != nil {
 		return trace.Wrap(err)
 	}
+
+	iamClient := iam.NewFromConfig(cfg)
 
 	err = awsoidc.ConfigureListDatabasesIAM(ctx, iamClient, awsoidc.ConfigureIAMListDatabasesRequest{
 		Region:          params.Region,


### PR DESCRIPTION
Context: https://github.com/gravitational/teleport/issues/30447

Previously we were guiding users in a series of screens and copy/paste so that the user could configure the AWS OIDC Integration. This guide also included adding the first feature: enroll an RDS Database.

We created a new command that sets up the OIDC IdP, but decoupled from the enroll rds feature.

After updating the guide to use the new command and remove the guide, we must provide a way for users to set up the required policy for Enrolling RDS Databases.
This PR adds that command

Demo
```
$ teleport integration configure listdatabases-iam --aws-region=eu-west-2 --role=MarcoTestAWSOIDCSetup
INFO             Added Inline Policy to IAM Role policy:ListDatabases role:MarcoTestAWSOIDCSetup awsoidc/listdatabases_iam_config.go:97
```

<img width="702" alt="image" src="https://github.com/gravitational/teleport/assets/689271/1bf0983e-f73a-4bbd-8b3a-a84c25c569b9">
