### PR TITLE
pgbk: derive ID from revision

### DIFF
--- a/lib/backend/pgbk/pgbk.go
+++ b/lib/backend/pgbk/pgbk.go
@@ -21,9 +21,9 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gravitational/trace"
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgtype/zeronull"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jonboulle/clockwork"
@@ -354,8 +354,8 @@ func (b *Backend) Get(ctx context.Context, key []byte) (*backend.Item, error) {
 		).QueryRow(func(row pgx.Row) error {
 			var value []byte
 			var expires zeronull.Timestamptz
-			var revision pgtype.UUID
-			if err := row.Scan(&value, &expires, &revision); err != nil {
+			var revision uuid.UUID
+			if err := row.Scan(&value, &expires, (*[16]byte)(&revision)); err != nil {
 				if errors.Is(err, pgx.ErrNoRows) {
 					return nil
 				}
@@ -366,7 +366,7 @@ func (b *Backend) Get(ctx context.Context, key []byte) (*backend.Item, error) {
 				Key:     key,
 				Value:   value,
 				Expires: time.Time(expires).UTC(),
-				// revision isn't supported in backend.Item yet
+				ID:      idFromRevision(revision),
 			}
 			return nil
 		})
@@ -411,15 +411,15 @@ func (b *Backend) GetRange(ctx context.Context, startKey []byte, endKey []byte, 
 			items, err = pgx.CollectRows(rows, func(row pgx.CollectableRow) (backend.Item, error) {
 				var key, value []byte
 				var expires zeronull.Timestamptz
-				var revision pgtype.UUID
-				if err := row.Scan(&key, &value, &expires, &revision); err != nil {
+				var revision uuid.UUID
+				if err := row.Scan(&key, &value, &expires, (*[16]byte)(&revision)); err != nil {
 					return backend.Item{}, err
 				}
 				return backend.Item{
 					Key:     key,
 					Value:   value,
 					Expires: time.Time(expires).UTC(),
-					// revision isn't supported in backend.Item yet
+					ID:      idFromRevision(revision),
 				}, nil
 			})
 			return trace.Wrap(err)

--- a/lib/backend/pgbk/utils.go
+++ b/lib/backend/pgbk/utils.go
@@ -15,6 +15,8 @@
 package pgbk
 
 import (
+	"encoding/binary"
+
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
@@ -38,6 +40,14 @@ func newRevision() pgtype.UUID {
 		Bytes: uuid.New(),
 		Valid: true,
 	}
+}
+
+// idFromRevision derives a value usable as a [backend.Item]'s ID from a
+// revision UUID.
+func idFromRevision(revision uuid.UUID) int64 {
+	u := binary.LittleEndian.Uint64(revision[:])
+	u &= 0x7fff_ffff_ffff_ffff
+	return int64(u)
 }
 
 // nonNil replaces a nil slice with an empty, non-nil one.

--- a/lib/backend/pgbk/wal2json.go
+++ b/lib/backend/pgbk/wal2json.go
@@ -139,7 +139,6 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing revision on insert")
 		}
-		_ = revision
 
 		return []backend.Event{{
 			Type: types.OpPut,
@@ -147,6 +146,7 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 				Key:     key,
 				Value:   value,
 				Expires: expires.UTC(),
+				ID:      idFromRevision(revision),
 			},
 		}}, nil
 
@@ -203,7 +203,6 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 		if err != nil {
 			return nil, trace.Wrap(err, "parsing revision on update")
 		}
-		_ = revision
 
 		if oldKey != nil {
 			return []backend.Event{{
@@ -217,6 +216,7 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 					Key:     key,
 					Value:   value,
 					Expires: expires.UTC(),
+					ID:      idFromRevision(revision),
 				},
 			}}, nil
 		}
@@ -227,6 +227,7 @@ func (w *wal2jsonMessage) Events() ([]backend.Event, error) {
 				Key:     key,
 				Value:   value,
 				Expires: expires.UTC(),
+				ID:      idFromRevision(revision),
 			},
 		}}, nil
 	}

--- a/lib/backend/pgbk/wal2json_test.go
+++ b/lib/backend/pgbk/wal2json_test.go
@@ -109,6 +109,7 @@ func TestMessage(t *testing.T) {
 	t.Parallel()
 
 	s := func(s string) *string { return &s }
+	rev := uuid.New()
 
 	m := &wal2jsonMessage{
 		Action: "I",
@@ -153,7 +154,7 @@ func TestMessage(t *testing.T) {
 			{Name: "key", Type: "bytea", Value: s("666f6f")},
 			{Name: "value", Type: "bytea", Value: s("")},
 			{Name: "expires", Type: "timestamp with time zone", Value: nil},
-			{Name: "revision", Type: "uuid", Value: s(uuid.NewString())},
+			{Name: "revision", Type: "uuid", Value: s(rev.String())},
 		},
 		Identity: []wal2jsonColumn{},
 	}
@@ -165,6 +166,7 @@ func TestMessage(t *testing.T) {
 		Item: backend.Item{
 			Key:   []byte("foo"),
 			Value: []byte(""),
+			ID:    idFromRevision(rev),
 		},
 	}))
 
@@ -184,7 +186,7 @@ func TestMessage(t *testing.T) {
 		Identity: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f")},
 			{Name: "value", Type: "bytea", Value: s("")},
-			{Name: "revision", Type: "uuid", Value: s(uuid.NewString())},
+			{Name: "revision", Type: "uuid", Value: s(rev.String())},
 		},
 	}
 	evs, err = m.Events()
@@ -195,6 +197,7 @@ func TestMessage(t *testing.T) {
 		Item: backend.Item{
 			Key:   []byte("foo"),
 			Value: []byte("foo2"),
+			ID:    idFromRevision(rev),
 		},
 	}))
 
@@ -213,7 +216,7 @@ func TestMessage(t *testing.T) {
 		Identity: []wal2jsonColumn{
 			{Name: "key", Type: "bytea", Value: s("666f6f")},
 			{Name: "value", Type: "bytea", Value: s("")},
-			{Name: "revision", Type: "uuid", Value: s(uuid.NewString())},
+			{Name: "revision", Type: "uuid", Value: s(rev.String())},
 		},
 	}
 	evs, err = m.Events()
@@ -231,6 +234,7 @@ func TestMessage(t *testing.T) {
 			Key:     []byte("foo2"),
 			Value:   []byte("foo2"),
 			Expires: time.Date(2023, 9, 5, 15, 57, 1, 340426000, time.UTC),
+			ID:      idFromRevision(rev),
 		},
 	}))
 

--- a/lib/service/connect.go
+++ b/lib/service/connect.go
@@ -763,10 +763,6 @@ func (process *TeleportProcess) syncRotationStateCycle() error {
 				process.log.Debugf("Skipping event for %v %v", ca.GetType(), ca.GetClusterName())
 				continue
 			}
-			if status.ca.GetResourceID() > ca.GetResourceID() {
-				process.log.Debugf("Skipping stale event %v, latest object version is %v.", ca.GetResourceID(), status.ca.GetResourceID())
-				continue
-			}
 			status, err := process.syncRotationStateAndBroadcast(conn)
 			if err != nil {
 				return trace.Wrap(err)

--- a/lib/services/suite/suite.go
+++ b/lib/services/suite/suite.go
@@ -1884,10 +1884,6 @@ waitLoop:
 				log.Debugf("Skipping event %+v", event)
 				continue
 			}
-			if resource.GetResourceID() > event.Resource.GetResourceID() {
-				log.Debugf("Skipping stale event %v %v %v %v, latest object version is %v", event.Type, event.Resource.GetKind(), event.Resource.GetName(), event.Resource.GetResourceID(), resource.GetResourceID())
-				continue waitLoop
-			}
 			if resource.GetName() != event.Resource.GetName() || resource.GetKind() != event.Resource.GetKind() || resource.GetSubKind() != event.Resource.GetSubKind() {
 				log.Debugf("Skipping event %v resource %v, expecting %v", event.Type, event.Resource.GetMetadata(), event.Resource.GetMetadata())
 				continue waitLoop


### PR DESCRIPTION
The `backend.Item.ID` field has been recently deprecated, but it's still relied upon by the Terraform provider to detect when a new version of a resource has been successfully written to, which is currently broken on clusters using pgbk.

This PR derives a numerical ID from the UUID revision, and removes the last couple of places in which we assumed that the ID field was monotonically increasing for a given key.