### PR TITLE
Refactor `hardware_key_touch` session MFA logic

### DIFF
--- a/api/proto/teleport/legacy/types/types.proto
+++ b/api/proto/teleport/legacy/types/types.proto
@@ -5286,9 +5286,8 @@ enum RequireMFAType {
   // and login sessions must use a private key backed by a hardware key.
   SESSION_AND_HARDWARE_KEY = 2;
   // HARDWARE_KEY_TOUCH means login sessions must use a hardware private key that
-  // requires touch to be used. This touch requirement applies to all API requests
-  // rather than only session requests. This touch is different from MFA, so to prevent
-  // requiring double touch on session requests, normal Session MFA is disabled.
+  // requires touch to be used. This touch is required for all private key operations,
+  // so the key is always treated as MFA verified for sessions.
   HARDWARE_KEY_TOUCH = 3;
 }
 

--- a/api/types/authentication.go
+++ b/api/types/authentication.go
@@ -853,7 +853,7 @@ func (d *MFADevice) UnmarshalJSON(buf []byte) error {
 
 // IsSessionMFARequired returns whether this RequireMFAType requires per-session MFA.
 func (r RequireMFAType) IsSessionMFARequired() bool {
-	return r == RequireMFAType_SESSION || r == RequireMFAType_SESSION_AND_HARDWARE_KEY
+	return r != RequireMFAType_OFF
 }
 
 // MarshalJSON marshals RequireMFAType to boolean or string.

--- a/api/types/types.pb.go
+++ b/api/types/types.pb.go
@@ -449,9 +449,8 @@ const (
 	// and login sessions must use a private key backed by a hardware key.
 	RequireMFAType_SESSION_AND_HARDWARE_KEY RequireMFAType = 2
 	// HARDWARE_KEY_TOUCH means login sessions must use a hardware private key that
-	// requires touch to be used. This touch requirement applies to all API requests
-	// rather than only session requests. This touch is different from MFA, so to prevent
-	// requiring double touch on session requests, normal Session MFA is disabled.
+	// requires touch to be used. This touch is required for all private key operations,
+	// so the key is always treated as MFA verified for sessions.
 	RequireMFAType_HARDWARE_KEY_TOUCH RequireMFAType = 3
 )
 

--- a/api/utils/keys/policy.go
+++ b/api/utils/keys/policy.go
@@ -55,6 +55,11 @@ func (p PrivateKeyPolicy) VerifyPolicy(policy PrivateKeyPolicy) error {
 	return NewPrivateKeyPolicyError(p)
 }
 
+// MFAVerified checks that meet this private key policy counts towards MFA verification.
+func (p PrivateKeyPolicy) MFAVerified() bool {
+	return p == PrivateKeyPolicyHardwareKeyTouch
+}
+
 func (p PrivateKeyPolicy) validate() error {
 	switch p {
 	case PrivateKeyPolicyNone, PrivateKeyPolicyHardwareKey, PrivateKeyPolicyHardwareKeyTouch:

--- a/lib/auth/auth_with_roles.go
+++ b/lib/auth/auth_with_roles.go
@@ -5442,6 +5442,12 @@ func (a *ServerWithRoles) IsMFARequired(ctx context.Context, req *proto.IsMFAReq
 	if !hasLocalUserRole(a.context) && !hasRemoteUserRole(a.context) {
 		return nil, trace.AccessDenied("only a user role can call IsMFARequired, got %T", a.context.Checker)
 	}
+	// Certain hardware-key based private key policies are treated as MFA verification.
+	if a.context.Identity.GetIdentity().PrivateKeyPolicy.MFAVerified() {
+		return &proto.IsMFARequiredResponse{
+			Required: false,
+		}, nil
+	}
 	return a.authServer.isMFARequired(ctx, a.context.Checker, req)
 }
 

--- a/lib/authz/permissions.go
+++ b/lib/authz/permissions.go
@@ -245,7 +245,7 @@ func (c *Context) GetAccessState(authPref types.AuthPreference) services.AccessS
 	// Builtin services (like proxy_service and kube_service) are not gated
 	// on MFA and only need to pass normal RBAC action checks.
 	_, isService := c.Identity.(BuiltinRole)
-	state.MFAVerified = isService || identity.MFAVerified != ""
+	state.MFAVerified = isService || identity.IsMFAVerified()
 
 	state.EnableDeviceVerification = !c.disableDeviceAuthorization
 	state.DeviceVerified = isService || dtauthz.IsTLSDeviceVerified(&identity.DeviceExtensions)

--- a/lib/services/role.go
+++ b/lib/services/role.go
@@ -1193,17 +1193,6 @@ func (set RoleSet) GetAccessState(authPref types.AuthPreference) AccessState {
 }
 
 func (set RoleSet) getMFARequired(clusterRequireMFAType types.RequireMFAType) MFARequired {
-	// per-session MFA is overridden by hardware key PIV touch requirement.
-	// check if the auth pref or any roles have this option.
-	if clusterRequireMFAType == types.RequireMFAType_HARDWARE_KEY_TOUCH {
-		return MFARequiredNever
-	}
-	for _, role := range set {
-		if role.GetOptions().RequireMFAType == types.RequireMFAType_HARDWARE_KEY_TOUCH {
-			return MFARequiredNever
-		}
-	}
-
 	// MFA is always required according to the cluster auth pref.
 	if clusterRequireMFAType.IsSessionMFARequired() {
 		return MFARequiredAlways

--- a/lib/srv/db/common/session.go
+++ b/lib/srv/db/common/session.go
@@ -72,7 +72,7 @@ func (c *Session) String() string {
 // [services.AccessChecker] and [tlsca.Identity].
 func (c *Session) GetAccessState(authPref types.AuthPreference) services.AccessState {
 	state := c.Checker.GetAccessState(authPref)
-	state.MFAVerified = c.Identity.MFAVerified != ""
+	state.MFAVerified = c.Identity.IsMFAVerified()
 	state.EnableDeviceVerification = true
 	state.DeviceVerified = dtauthz.IsTLSDeviceVerified(&c.Identity.DeviceExtensions)
 	return state

--- a/lib/tlsca/ca.go
+++ b/lib/tlsca/ca.go
@@ -1051,6 +1051,11 @@ func (id Identity) GetUserMetadata() events.UserMetadata {
 	}
 }
 
+// IsMFAVerified returns whether this identity is MFA verified.
+func (id *Identity) IsMFAVerified() bool {
+	return id.MFAVerified != "" || id.PrivateKeyPolicy.MFAVerified()
+}
+
 // CertificateRequest is a X.509 signing certificate request
 type CertificateRequest struct {
 	// Clock is a clock used to get current or test time


### PR DESCRIPTION
This PR updates identities with the `private_key_policy: hardware_key_touch` to count as MFA verified, instead of turning off the session-mfa requirements for the identity.

This logic is more straightforward and simplifies the implementation for upcoming additions (`private_key_policy: hardware_key_pin | hardware_key_touch_and_pin | web_session`, MFA for admin actions).

