### PR TITLE
docs: Simplify the commercial prerequisites to get rid of overstyling

### DIFF
--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -1,15 +1,7 @@
-- Access to one of the commercial editions of Teleport running in your environment:
+- Access to an Enterprise edition of Teleport running in your environment.
   
-  - Teleport Enterprise
-  - Teleport Team 
-  - Teleport Enterprise Cloud
-  
-  For information about setting up a self-hosted Teleport Enterprise cluster, see [Deploying a High 
-  Availability Teleport Cluster](../deploy-a-cluster/high-availability.mdx).
-  To begin a free trial of Teleport Team or upgrade to Teleport Enterprise Cloud, visit the cloud
-  service [sign up page](https://goteleport.com/signup/).
   For information about the differences between Teleport editions, see [Comparing 
-  editions](../choose-an-edition/introduction.mdx#comparing-editions) .
+  editions](../choose-an-edition/introduction.mdx#comparing-editions).
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=). 
   

--- a/docs/pages/includes/commercial-prereqs-tabs.mdx
+++ b/docs/pages/includes/commercial-prereqs-tabs.mdx
@@ -1,13 +1,19 @@
-<Tabs>
-<TabItem
-  scope={["enterprise"]} label="Self-Hosted Enterprise">
-
-- A running Teleport Enterprise cluster. For details on how to set this up, see the Enterprise [Getting 
-Started](../choose-an-edition/teleport-enterprise/introduction.mdx) guide.
+- Access to one of the commercial editions of Teleport running in your environment:
+  
+  - Teleport Enterprise
+  - Teleport Team 
+  - Teleport Enterprise Cloud
+  
+  For information about setting up a self-hosted Teleport Enterprise cluster, see [Deploying a High 
+  Availability Teleport Cluster](../deploy-a-cluster/high-availability.mdx).
+  To begin a free trial of Teleport Team or upgrade to Teleport Enterprise Cloud, visit the cloud
+  service [sign up page](https://goteleport.com/signup/).
+  For information about the differences between Teleport editions, see [Comparing 
+  editions](../choose-an-edition/introduction.mdx#comparing-editions) .
 
 - The Enterprise `tctl` admin tool and `tsh` client tool version >= (=teleport.version=). 
-You can download these tools by visiting your [Teleport account](https://teleport.sh).
-You can verify the tools you have installed by running the following commands:
+  
+  You can verify the tools you have installed by running the following commands:
 
   ```code
   $ tctl version
@@ -17,24 +23,5 @@ You can verify the tools you have installed by running the following commands:
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
 
-</TabItem>
-<TabItem scope={["cloud"]}
-  label="Teleport Enterprise Cloud">
-
-- A Teleport Enterprise Cloud account. If you do not have one, visit the [signup
-  page](https://goteleport.com/signup/) to begin a free trial of Teleport Team
-  and upgrade to Teleport Enterprise Cloud. 
-
-- The `tctl` admin tool and `tsh` client tool version >= (=cloud.version=).
-  To download these tools, visit the [Downloads](../choose-an-edition/teleport-cloud/downloads.mdx) page.
-
-  ```code
-  $ tctl version
-  # Teleport Enterprise v(=cloud.version=) go(=teleport.golang=)
-  
-  $ tsh version
-  # Teleport v(=cloud.version=) go(=teleport.golang=)
-  ```
-
-</TabItem>
-</Tabs>
+  You can download these tools by following the appropriate [Installation 
+  instructions](../installation.mdx#installation-instructions) for your environment and Teleport edition.


### PR DESCRIPTION
The "sign up for a free trial of Team" doesn't feel right in this context, especially if this partial is used as a prerequisite in topics for features that Team doesn't support. 