### PR TITLE
Deflake TestTeleportProcessAuthVersionCheck

### DIFF
--- a/lib/service/service_test.go
+++ b/lib/service/service_test.go
@@ -865,26 +865,8 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 	lib.SetInsecureDevMode(true)
 	defer lib.SetInsecureDevMode(false)
 
-	authAddr, err := getFreePort()
-	require.NoError(t, err)
-	listenAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: authAddr}
+	listenAddr := utils.NetAddr{AddrNetwork: "tcp", Addr: "127.0.0.1:0"}
 	token := "join-token"
-
-	// Create Node process.
-	nodeCfg := servicecfg.MakeDefaultConfig()
-	nodeCfg.SetAuthServerAddress(listenAddr)
-	nodeCfg.DataDir = t.TempDir()
-	nodeCfg.SetToken(token)
-	nodeCfg.Auth.Enabled = false
-	nodeCfg.Proxy.Enabled = false
-	nodeCfg.SSH.Enabled = true
-
-	// Set the Node's major version to be greater than the Auth Service's,
-	// which should make the version check fail.
-	currentVersion, err := semver.NewVersion(teleport.Version)
-	require.NoError(t, err)
-	currentVersion.Major++
-	nodeCfg.TeleportVersion = currentVersion.String()
 
 	// Create Auth Service process.
 	staticTokens, err := types.NewStaticTokens(types.StaticTokensSpecV2{
@@ -919,6 +901,23 @@ func TestTeleportProcessAuthVersionCheck(t *testing.T) {
 		authProc.Close()
 	})
 
+	// Create Node process, pointing at the auth server's local port
+	authListenAddr := authProc.Config.AuthServerAddresses()[0]
+	nodeCfg := servicecfg.MakeDefaultConfig()
+	nodeCfg.SetAuthServerAddress(authListenAddr)
+	nodeCfg.DataDir = t.TempDir()
+	nodeCfg.SetToken(token)
+	nodeCfg.Auth.Enabled = false
+	nodeCfg.Proxy.Enabled = false
+	nodeCfg.SSH.Enabled = true
+
+	// Set the Node's major version to be greater than the Auth Service's,
+	// which should make the version check fail.
+	currentVersion, err := semver.NewVersion(teleport.Version)
+	require.NoError(t, err)
+	currentVersion.Major++
+	nodeCfg.TeleportVersion = currentVersion.String()
+
 	t.Run("with version check", func(t *testing.T) {
 		testVersionCheck(t, nodeCfg, false)
 	})
@@ -946,20 +945,6 @@ func testVersionCheck(t *testing.T, nodeCfg *servicecfg.Config, skipVersionCheck
 	supervisor, ok := nodeProc.Supervisor.(*LocalSupervisor)
 	require.True(t, ok)
 	supervisor.signalExit()
-}
-
-func getFreePort() (string, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
-	if err != nil {
-		return "", err
-	}
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return "", err
-	}
-	defer l.Close()
-
-	return l.Addr().(*net.TCPAddr).String(), nil
 }
 
 func Test_readOrGenerateHostID(t *testing.T) {


### PR DESCRIPTION
This test uses a broken approach to try and allocate a local port for the auth service. It starts a listener without specifying a port, grabs the port that the OS allocates, and then closes the listener and assumes that the port that was free at the time of this check will remain free by the time the test needs to open a 2nd listener.

Instead, start the auth service first, allow the OS to allocate a free port, and *use that port* in the SSH service's config. This ensures that the port remains free since we keep the listener open the whole time.

Fixes #19752