### PR TITLE
Remove non-file path links from partials

### DIFF
--- a/docs/pages/access-controls/access-lists/guide.mdx
+++ b/docs/pages/access-controls/access-lists/guide.mdx
@@ -18,8 +18,8 @@ This guide will help you:
 
 ### Step 1/4. Setting up an application service on the cluster for testing
 
-One of the easiest ways to get resources on the cluster for testing is to set up an application service
-with the debugging application enabled. To do this, add the following config to your `teleport.yaml`
+One of the easiest ways to get resources on the cluster for testing is to set up a Teleport Application Service
+instance with the debugging application enabled. To do this, add the following config to your `teleport.yaml`
 configuration:
 
 ```yaml

--- a/docs/pages/includes/cloud/cloudmanagedadvisory.mdx
+++ b/docs/pages/includes/cloud/cloudmanagedadvisory.mdx
@@ -1,9 +1,0 @@
-<Details scopeOnly={true} scope={["cloud"]} title="Teleport Cloud">
-This guide deploys the Teleport Auth Service and Proxy Service, which are fully managed in Teleport Cloud. If you are a Teleport Cloud customer, we recommend following our guides for accessing specific resources within your infrastructure:
-
-- [Servers](/docs/server-access/getting-started.mdx)
-- [Kubernetes clusters](/docs/kubernetes-access/getting-started.mdx)
-- [Databases](/docs/database-access/getting-started.mdx)
-- [Windows Desktops](/docs/desktop-access/introduction.mdx)
-- [Applications](/docs/application-access/getting-started.mdx)
-</Details>

--- a/docs/pages/includes/user-client-prereqs.mdx
+++ b/docs/pages/includes/user-client-prereqs.mdx
@@ -11,7 +11,7 @@
   # Teleport v(=teleport.version=) go(=teleport.golang=)
   ```
 
-  See [Installation](/docs/installation) for details.
+  See [Installation](../installation.mdx) for details.
 
 - A host where you will install the Teleport Auth Service and Proxy Service.
 


### PR DESCRIPTION
Fixes #12618

Ensure that all partials use relative links to MDX files for more accurate linting. Only two partials contain links to URL paths, and one of these is not included anywhere in the docs.

This change removes the unused partial and changes the remaining link to a file path.