### PR TITLE
Careful handling when loading files

### DIFF
--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -172,7 +172,7 @@ func (s *Service) Place(sessionID string, pid int) error {
 // readPids returns a slice of PIDs from a file. Used to get list of all PIDs
 // within a cgroup.
 func readPids(path string) ([]string, error) {
-	f, err := utils.OpenFileNoSymlinks(path)
+	f, err := utils.OpenFileNoUnsafeLinks(path)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/gravitational/teleport"
 	"github.com/gravitational/teleport/lib/defaults"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 var log = logrus.WithFields(logrus.Fields{
@@ -171,7 +172,7 @@ func (s *Service) Place(sessionID string, pid int) error {
 // readPids returns a slice of PIDs from a file. Used to get list of all PIDs
 // within a cgroup.
 func readPids(path string) ([]string, error) {
-	f, err := os.Open(path)
+	f, err := utils.OpenFile(path, false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/cgroup/cgroup.go
+++ b/lib/cgroup/cgroup.go
@@ -172,7 +172,7 @@ func (s *Service) Place(sessionID string, pid int) error {
 // readPids returns a slice of PIDs from a file. Used to get list of all PIDs
 // within a cgroup.
 func readPids(path string) ([]string, error) {
-	f, err := utils.OpenFile(path, false)
+	f, err := utils.OpenFileNoSymlinks(path)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -271,7 +271,7 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 
 // ReadResources loads a set of resources from a file.
 func ReadResources(filePath string) ([]types.Resource, error) {
-	reader, err := utils.OpenFile(filePath)
+	reader, err := utils.OpenFile(filePath, true)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -271,7 +271,7 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 
 // ReadResources loads a set of resources from a file.
 func ReadResources(filePath string) ([]types.Resource, error) {
-	reader, err := utils.OpenFile(filePath, true)
+	reader, err := utils.OpenFileAllowingSymlinks(filePath)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/config/configuration.go
+++ b/lib/config/configuration.go
@@ -271,7 +271,7 @@ func ReadConfigFile(cliConfigPath string) (*FileConfig, error) {
 
 // ReadResources loads a set of resources from a file.
 func ReadResources(filePath string) ([]types.Resource, error) {
-	reader, err := utils.OpenFileAllowingSymlinks(filePath)
+	reader, err := utils.OpenFileAllowingUnsafeLinks(filePath)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -104,7 +104,7 @@ type FileConfig struct {
 // ReadFromFile reads Teleport configuration from a file. Currently only YAML
 // format is supported
 func ReadFromFile(filePath string) (*FileConfig, error) {
-	f, err := os.Open(filePath)
+	f, err := utils.OpenFile(filePath, true)
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
 			return nil, trace.Wrap(err, "failed to open file for Teleport configuration: %v. Ensure that you are running as a user with appropriate permissions.", filePath)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -104,7 +104,7 @@ type FileConfig struct {
 // ReadFromFile reads Teleport configuration from a file. Currently only YAML
 // format is supported
 func ReadFromFile(filePath string) (*FileConfig, error) {
-	f, err := utils.OpenFileAllowingSymlinks(filePath)
+	f, err := utils.OpenFileAllowingUnsafeLinks(filePath)
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
 			return nil, trace.Wrap(err, "failed to open file for Teleport configuration: %v. Ensure that you are running as a user with appropriate permissions.", filePath)

--- a/lib/config/fileconf.go
+++ b/lib/config/fileconf.go
@@ -104,7 +104,7 @@ type FileConfig struct {
 // ReadFromFile reads Teleport configuration from a file. Currently only YAML
 // format is supported
 func ReadFromFile(filePath string) (*FileConfig, error) {
-	f, err := utils.OpenFile(filePath, true)
+	f, err := utils.OpenFileAllowingSymlinks(filePath)
 	if err != nil {
 		if errors.Is(err, fs.ErrPermission) {
 			return nil, trace.Wrap(err, "failed to open file for Teleport configuration: %v. Ensure that you are running as a user with appropriate permissions.", filePath)

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -527,7 +527,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	envRootPath := defaultEnvRootPath
 
 	// open file, if it doesn't exist return a default path and move on
-	f, err := utils.OpenFile(loginDefsPath, true)
+	f, err := utils.OpenFileAllowingSymlinks(loginDefsPath)
 	if err != nil {
 		if uid == "0" {
 			log.Infof("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvRootPath)

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -41,6 +41,7 @@ import (
 	apievents "github.com/gravitational/teleport/api/types/events"
 	"github.com/gravitational/teleport/lib/events"
 	"github.com/gravitational/teleport/lib/services"
+	"github.com/gravitational/teleport/lib/utils"
 )
 
 const (
@@ -526,7 +527,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	envRootPath := defaultEnvRootPath
 
 	// open file, if it doesn't exist return a default path and move on
-	f, err := os.Open(loginDefsPath)
+	f, err := utils.OpenFile(loginDefsPath, true)
 	if err != nil {
 		if uid == "0" {
 			log.Infof("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvRootPath)

--- a/lib/srv/exec.go
+++ b/lib/srv/exec.go
@@ -527,7 +527,7 @@ func getDefaultEnvPath(uid string, loginDefsPath string) string {
 	envRootPath := defaultEnvRootPath
 
 	// open file, if it doesn't exist return a default path and move on
-	f, err := utils.OpenFileAllowingSymlinks(loginDefsPath)
+	f, err := utils.OpenFileAllowingUnsafeLinks(loginDefsPath)
 	if err != nil {
 		if uid == "0" {
 			log.Infof("Unable to open %q: %v: returning default su path: %q", loginDefsPath, err, defaultEnvRootPath)

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -662,7 +662,7 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 
 // ReadConfigFromFile reads and parses a YAML config from a file.
 func ReadConfigFromFile(filePath string, manualMigration bool) (*BotConfig, error) {
-	f, err := utils.OpenFile(filePath, true)
+	f, err := utils.OpenFileAllowingSymlinks(filePath)
 	if err != nil {
 		return nil, trace.Wrap(err, fmt.Sprintf("failed to open file: %v", filePath))
 	}

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -663,7 +662,7 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 
 // ReadConfigFromFile reads and parses a YAML config from a file.
 func ReadConfigFromFile(filePath string, manualMigration bool) (*BotConfig, error) {
-	f, err := os.Open(filePath)
+	f, err := utils.OpenFile(filePath, true)
 	if err != nil {
 		return nil, trace.Wrap(err, fmt.Sprintf("failed to open file: %v", filePath))
 	}

--- a/lib/tbot/config/config.go
+++ b/lib/tbot/config/config.go
@@ -662,7 +662,7 @@ func FromCLIConf(cf *CLIConf) (*BotConfig, error) {
 
 // ReadConfigFromFile reads and parses a YAML config from a file.
 func ReadConfigFromFile(filePath string, manualMigration bool) (*BotConfig, error) {
-	f, err := utils.OpenFileAllowingSymlinks(filePath)
+	f, err := utils.OpenFileAllowingUnsafeLinks(filePath)
 	if err != nil {
 		return nil, trace.Wrap(err, fmt.Sprintf("failed to open file: %v", filePath))
 	}

--- a/lib/utils/environment.go
+++ b/lib/utils/environment.go
@@ -29,7 +29,7 @@ import (
 func ReadEnvironmentFile(filename string) ([]string, error) {
 	// open the users environment file. if we don't find a file, move on as
 	// having this file for the user is optional.
-	file, err := OpenFileNoSymlinks(filename)
+	file, err := OpenFileNoUnsafeLinks(filename)
 	if err != nil {
 		log.Warnf("Unable to open environment file %v: %v, skipping", filename, err)
 		return []string{}, nil

--- a/lib/utils/environment.go
+++ b/lib/utils/environment.go
@@ -29,7 +29,7 @@ import (
 func ReadEnvironmentFile(filename string) ([]string, error) {
 	// open the users environment file. if we don't find a file, move on as
 	// having this file for the user is optional.
-	file, err := OpenFile(filename, false)
+	file, err := OpenFileNoSymlinks(filename)
 	if err != nil {
 		log.Warnf("Unable to open environment file %v: %v, skipping", filename, err)
 		return []string{}, nil

--- a/lib/utils/environment.go
+++ b/lib/utils/environment.go
@@ -16,7 +16,6 @@ package utils
 
 import (
 	"bufio"
-	"os"
 	"strings"
 
 	log "github.com/sirupsen/logrus"
@@ -30,7 +29,7 @@ import (
 func ReadEnvironmentFile(filename string) ([]string, error) {
 	// open the users environment file. if we don't find a file, move on as
 	// having this file for the user is optional.
-	file, err := os.Open(filename)
+	file, err := OpenFile(filename, false)
 	if err != nil {
 		log.Warnf("Unable to open environment file %v: %v, skipping", filename, err)
 		return []string{}, nil

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -104,14 +104,14 @@ func NormalizePath(path string, evaluateSymlinks bool) (string, error) {
 // OpenFileAllowingUnsafeLinks opens a file, if the path includes a symlink, the returned os.File will be resolved to
 // the actual file.  This will return an error if the file is not found or is a directory.
 func OpenFileAllowingUnsafeLinks(path string) (*os.File, error) {
-	return openFile(path, true, true)
+	return openFile(path, true /* allowSymlink */, true /* allowMultipleHardlinks */)
 }
 
 // OpenFileNoUnsafeLinks opens a file, ensuring it's an actual file and not a directory or symlink.  Depending on
 // the os, it may also prevent hardlinks.  This is important because MacOS allows hardlinks without validating write
 // permissions (similar to a symlink in that regard).
 func OpenFileNoUnsafeLinks(path string) (*os.File, error) {
-	return openFile(path, false, runtime.GOOS != "darwin")
+	return openFile(path, false /* allowSymlink */, runtime.GOOS != "darwin" /* allowMultipleHardlinks */)
 }
 
 func openFile(path string, allowSymlink, allowMultipleHardlinks bool) (*os.File, error) {

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -126,13 +126,14 @@ func openFile(path string, allowSymlink, allowMultipleHardlinks bool) (*os.File,
 			return nil, trace.ConvertSystemError(err)
 		}
 	} else {
-		isAbs := filepath.IsAbs(newPath)
 		components := strings.Split(newPath, string(os.PathSeparator))
-		for i := 1; i <= len(components); i++ {
-			subPath := filepath.Join(components[:i]...)
-			if isAbs {
-				subPath = string(os.PathSeparator) + subPath
+		var subPath string
+		for _, p := range components {
+			subPath = filepath.Join(subPath, p)
+			if subPath == "" {
+				subPath = string(os.PathSeparator)
 			}
+
 			fi, err = os.Lstat(subPath)
 			if err != nil {
 				return nil, trace.ConvertSystemError(err)

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -96,9 +96,20 @@ func NormalizePath(path string) (string, error) {
 	return abs, nil
 }
 
-// OpenFile opens a file and returns file handle. In general symlinks should not be allowed to reduce the risk of
+// OpenFileAllowingSymlinks will open a file, if it's a symlink the file referenced by the link will be associated to
+// the returned os.File.  This will return an error if the file is not found or is a directory.
+func OpenFileAllowingSymlinks(path string) (*os.File, error) {
+	return openFile(path, true)
+}
+
+// OpenFileNoSymlinks will open a file, ensuring it's an actual file and not a directory or symlink.
+func OpenFileNoSymlinks(path string) (*os.File, error) {
+	return openFile(path, false)
+}
+
+// openFile opens a file and returns file handle. In general symlinks should not be allowed to reduce the risk of
 // privilege escalation from Teleports elevated privileges to potentially less privileged users accidentally.
-func OpenFile(path string, allowSymlink bool) (*os.File, error) {
+func openFile(path string, allowSymlink bool) (*os.File, error) {
 	newPath, err := NormalizePath(path)
 	if err != nil {
 		return nil, trace.Wrap(err)

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -25,7 +25,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/gofrs/flock"
@@ -144,7 +143,7 @@ func openFile(path string, allowSymlink, allowMultipleHardlinks bool) (*os.File,
 	}
 	if !allowMultipleHardlinks {
 		// hardlinks can only exist at the end file, not for directories within the path
-		if statT, ok := fi.Sys().(*syscall.Stat_t); ok && statT.Nlink > 1 {
+		if ok, linkCount := getHardLinkCount(fi); ok && linkCount > 1 {
 			return nil, trace.BadParameter("file has hardlink count greater than 1: %s", path)
 		}
 	}

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -143,7 +143,7 @@ func openFile(path string, allowSymlink, allowMultipleHardlinks bool) (*os.File,
 	}
 	if !allowMultipleHardlinks {
 		// hardlinks can only exist at the end file, not for directories within the path
-		if ok, linkCount := getHardLinkCount(fi); ok && linkCount > 1 {
+		if linkCount, ok := getHardLinkCount(fi); ok && linkCount > 1 {
 			return nil, trace.BadParameter("file has hardlink count greater than 1: %s", path)
 		}
 	}

--- a/lib/utils/fs.go
+++ b/lib/utils/fs.go
@@ -135,7 +135,7 @@ func openFile(path string, allowSymlink bool) (*os.File, error) {
 			if err != nil {
 				return nil, trace.ConvertSystemError(err)
 			} else if fi.Mode().Type()&os.ModeSymlink != 0 {
-				return nil, trace.BadParameter("symlink not allowed in path: %v", subPath)
+				return nil, trace.BadParameter("failed to open file %v, symlink not allowed in path: %v", path, subPath)
 			}
 		}
 	}

--- a/lib/utils/fs_test.go
+++ b/lib/utils/fs_test.go
@@ -154,9 +154,11 @@ func TestOpenFileLinks(t *testing.T) {
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
 			f, err := openFile(tt.filePath, tt.allowSymln, tt.allowHardln)
+			if f != nil {
+				f.Close()
+			}
 			if tt.expectErr == "" {
 				require.NoError(t, err)
-				f.Close()
 			} else {
 				require.ErrorContains(t, err, tt.expectErr)
 			}

--- a/lib/utils/fs_test.go
+++ b/lib/utils/fs_test.go
@@ -38,7 +38,7 @@ func TestOpenFileSymlinks(t *testing.T) {
 	rootDir := t.TempDir()
 
 	dirPath := filepath.Join(rootDir, "dir")
-	err = os.Mkdir(dirPath, 0755)
+	err := os.Mkdir(dirPath, 0755)
 	require.NoError(t, err)
 
 	filePath := filepath.Join(dirPath, "file")

--- a/lib/utils/fs_test.go
+++ b/lib/utils/fs_test.go
@@ -35,9 +35,7 @@ func TestOpenFileSymlinks(t *testing.T) {
 	// dir/file-s -> dir/file
 	// circular-s -> circular-s
 	// broken-s -> nonexistent
-	rootDir, err := os.MkdirTemp("", "symlink-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(rootDir)
+	rootDir := t.TempDir()
 
 	dirPath := filepath.Join(rootDir, "dir")
 	err = os.Mkdir(dirPath, 0755)
@@ -69,6 +67,8 @@ func TestOpenFileSymlinks(t *testing.T) {
 
 	// Tests below can not be done with t.Parallel due to the need for directory cleanup in defer
 	t.Run("directFileOpenAllowed", func(t *testing.T) {
+		filePath, err = filepath.EvalSymlinks(filePath)
+		require.NoError(t, err)
 		f, err := openFile(filePath, false)
 		require.NoError(t, err)
 		defer f.Close()

--- a/lib/utils/fs_unix.go
+++ b/lib/utils/fs_unix.go
@@ -31,7 +31,8 @@ func getPlatformLockFilePath(path string) string {
 
 func getHardLinkCount(fi os.FileInfo) (uint64, bool) {
 	if statT, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return statT.Nlink, true
+		// we must do a cast here because this will be uint16 on OSX
+		return uint64(statT.Nlink), true
 	} else {
 		return 0, false
 	}

--- a/lib/utils/fs_unix.go
+++ b/lib/utils/fs_unix.go
@@ -32,6 +32,7 @@ func getPlatformLockFilePath(path string) string {
 func getHardLinkCount(fi os.FileInfo) (uint64, bool) {
 	if statT, ok := fi.Sys().(*syscall.Stat_t); ok {
 		// we must do a cast here because this will be uint16 on OSX
+		//nolint:unconvert // the cast is only necessary for macOS
 		return uint64(statT.Nlink), true
 	} else {
 		return 0, false

--- a/lib/utils/fs_unix.go
+++ b/lib/utils/fs_unix.go
@@ -29,10 +29,10 @@ func getPlatformLockFilePath(path string) string {
 	return path
 }
 
-func getHardLinkCount(fi os.FileInfo) (bool, uint64) {
+func getHardLinkCount(fi os.FileInfo) (uint64, bool) {
 	if statT, ok := fi.Sys().(*syscall.Stat_t); ok {
-		return true, statT.Nlink
+		return statT.Nlink, true
 	} else {
-		return false, 0
+		return 0, false
 	}
 }

--- a/lib/utils/fs_unix.go
+++ b/lib/utils/fs_unix.go
@@ -19,7 +19,20 @@ limitations under the License.
 
 package utils
 
+import (
+	"os"
+	"syscall"
+)
+
 // On non-windows we just lock the target file itself.
 func getPlatformLockFilePath(path string) string {
 	return path
+}
+
+func getHardLinkCount(fi os.FileInfo) (bool, uint64) {
+	if statT, ok := fi.Sys().(*syscall.Stat_t); ok {
+		return true, statT.Nlink
+	} else {
+		return false, 0
+	}
 }

--- a/lib/utils/fs_windows.go
+++ b/lib/utils/fs_windows.go
@@ -19,14 +19,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// On Windows we use auxiliary .lock.tmp files to acquire locks, so we can still read/write target
-// files themselves.
-//
-// .lock.tmp files are deliberately not cleaned up. Their presence doesn't matter to the actual
-// locking. Repeatedly removing them on unlock when acquiring dozens of locks in a short timespan
-// was causing flock.Flock.TryRLock to return either "access denied" or "The process cannot access
-// the file because it is being used by another process".
-
 import (
 	"os"
 	"strings"
@@ -34,6 +26,13 @@ import (
 
 const lockPostfix = ".lock.tmp"
 
+// On Windows we use auxiliary .lock.tmp files to acquire locks, so we can still read/write target
+// files themselves.
+//
+// .lock.tmp files are deliberately not cleaned up. Their presence doesn't matter to the actual
+// locking. Repeatedly removing them on unlock when acquiring dozens of locks in a short timespan
+// was causing flock.Flock.TryRLock to return either "access denied" or "The process cannot access
+// the file because it is being used by another process".
 func getPlatformLockFilePath(path string) string {
 	// If target file is itself dedicated lockfile, we don't create another lockfile, since
 	// we don't intend to read/write the target file itself.
@@ -44,5 +43,6 @@ func getPlatformLockFilePath(path string) string {
 }
 
 func getHardLinkCount(fi os.FileInfo) (uint64, bool) {
+	// Although hardlinks on Windows are possible, Go does not currently expose the hardlinks associated to a file on windows
 	return 0, false
 }

--- a/lib/utils/fs_windows.go
+++ b/lib/utils/fs_windows.go
@@ -43,6 +43,6 @@ func getPlatformLockFilePath(path string) string {
 	return path + lockPostfix
 }
 
-func getHardLinkCount(fi os.FileInfo) (bool, uint64) {
-	return false, 0
+func getHardLinkCount(fi os.FileInfo) (uint64, bool) {
+	return 0, false
 }

--- a/lib/utils/fs_windows.go
+++ b/lib/utils/fs_windows.go
@@ -27,7 +27,10 @@ limitations under the License.
 // was causing flock.Flock.TryRLock to return either "access denied" or "The process cannot access
 // the file because it is being used by another process".
 
-import "strings"
+import (
+	"os"
+	"strings"
+)
 
 const lockPostfix = ".lock.tmp"
 
@@ -38,4 +41,8 @@ func getPlatformLockFilePath(path string) string {
 		return path
 	}
 	return path + lockPostfix
+}
+
+func getHardLinkCount(fi os.FileInfo) (bool, uint64) {
+	return false, 0
 }

--- a/lib/utils/kernel.go
+++ b/lib/utils/kernel.go
@@ -36,7 +36,7 @@ func KernelVersion() (*semver.Version, error) {
 		return nil, trace.BadParameter("requested kernel version on non-Linux host")
 	}
 
-	file, err := OpenFileNoSymlinks("/proc/sys/kernel/osrelease")
+	file, err := OpenFileNoUnsafeLinks("/proc/sys/kernel/osrelease")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -89,7 +89,7 @@ func HasBTF() error {
 		return trace.BadParameter("requested kernel version on non-Linux host")
 	}
 
-	file, err := OpenFileNoSymlinks(btfFile)
+	file, err := OpenFileNoUnsafeLinks(btfFile)
 	if err == nil {
 		file.Close()
 		return nil

--- a/lib/utils/kernel.go
+++ b/lib/utils/kernel.go
@@ -36,7 +36,7 @@ func KernelVersion() (*semver.Version, error) {
 		return nil, trace.BadParameter("requested kernel version on non-Linux host")
 	}
 
-	file, err := os.Open("/proc/sys/kernel/osrelease")
+	file, err := OpenFile("/proc/sys/kernel/osrelease", false)
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -89,7 +89,7 @@ func HasBTF() error {
 		return trace.BadParameter("requested kernel version on non-Linux host")
 	}
 
-	file, err := os.Open(btfFile)
+	file, err := OpenFile(btfFile, false)
 	if err == nil {
 		file.Close()
 		return nil

--- a/lib/utils/kernel.go
+++ b/lib/utils/kernel.go
@@ -36,7 +36,7 @@ func KernelVersion() (*semver.Version, error) {
 		return nil, trace.BadParameter("requested kernel version on non-Linux host")
 	}
 
-	file, err := OpenFile("/proc/sys/kernel/osrelease", false)
+	file, err := OpenFileNoSymlinks("/proc/sys/kernel/osrelease")
 	if err != nil {
 		return nil, trace.Wrap(err)
 	}
@@ -89,7 +89,7 @@ func HasBTF() error {
 		return trace.BadParameter("requested kernel version on non-Linux host")
 	}
 
-	file, err := OpenFile(btfFile, false)
+	file, err := OpenFileNoSymlinks(btfFile)
 	if err == nil {
 		file.Close()
 		return nil

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -153,7 +153,7 @@ func editor() string {
 }
 
 func checksum(filename string) (string, error) {
-	f, err := utils.OpenFile(filename)
+	f, err := utils.OpenFile(filename, true)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -168,7 +168,7 @@ func checksum(filename string) (string, error) {
 }
 
 func resourceName(filename string) (string, error) {
-	f, err := utils.OpenFile(filename)
+	f, err := utils.OpenFile(filename, true)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -153,7 +153,7 @@ func editor() string {
 }
 
 func checksum(filename string) (string, error) {
-	f, err := utils.OpenFile(filename, true)
+	f, err := utils.OpenFileAllowingSymlinks(filename)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -168,7 +168,7 @@ func checksum(filename string) (string, error) {
 }
 
 func resourceName(filename string) (string, error) {
-	f, err := utils.OpenFile(filename, true)
+	f, err := utils.OpenFileAllowingSymlinks(filename)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/tool/tctl/common/edit_command.go
+++ b/tool/tctl/common/edit_command.go
@@ -153,7 +153,7 @@ func editor() string {
 }
 
 func checksum(filename string) (string, error) {
-	f, err := utils.OpenFileAllowingSymlinks(filename)
+	f, err := utils.OpenFileAllowingUnsafeLinks(filename)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}
@@ -168,7 +168,7 @@ func checksum(filename string) (string, error) {
 }
 
 func resourceName(filename string) (string, error) {
-	f, err := utils.OpenFileAllowingSymlinks(filename)
+	f, err := utils.OpenFileAllowingUnsafeLinks(filename)
 	if err != nil {
 		return "", trace.Wrap(err)
 	}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -270,7 +270,7 @@ func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err
 	if rc.filename == "" {
 		reader = os.Stdin
 	} else {
-		f, err := utils.OpenFile(rc.filename)
+		f, err := utils.OpenFile(rc.filename, true)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -270,7 +270,7 @@ func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err
 	if rc.filename == "" {
 		reader = os.Stdin
 	} else {
-		f, err := utils.OpenFile(rc.filename, true)
+		f, err := utils.OpenFileAllowingSymlinks(rc.filename)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/common/resource_command.go
+++ b/tool/tctl/common/resource_command.go
@@ -270,7 +270,7 @@ func (rc *ResourceCommand) Create(ctx context.Context, client auth.ClientI) (err
 	if rc.filename == "" {
 		reader = os.Stdin
 	} else {
-		f, err := utils.OpenFileAllowingSymlinks(rc.filename)
+		f, err := utils.OpenFileAllowingUnsafeLinks(rc.filename)
 		if err != nil {
 			return trace.Wrap(err)
 		}

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -98,7 +98,7 @@ func (cmd *SSOTestCommand) getSupportedKinds() []string {
 func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c auth.ClientI) error {
 	reader := os.Stdin
 	if cmd.connectorFileName != "" {
-		f, err := utils.OpenFile(cmd.connectorFileName, true)
+		f, err := utils.OpenFileAllowingSymlinks(cmd.connectorFileName)
 		if err != nil {
 			return trace.Wrap(err, "could not open connector spec file %v", cmd.connectorFileName)
 		}

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -98,7 +98,7 @@ func (cmd *SSOTestCommand) getSupportedKinds() []string {
 func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c auth.ClientI) error {
 	reader := os.Stdin
 	if cmd.connectorFileName != "" {
-		f, err := utils.OpenFileAllowingSymlinks(cmd.connectorFileName)
+		f, err := utils.OpenFileAllowingUnsafeLinks(cmd.connectorFileName)
 		if err != nil {
 			return trace.Wrap(err, "could not open connector spec file %v", cmd.connectorFileName)
 		}

--- a/tool/tctl/sso/tester/command.go
+++ b/tool/tctl/sso/tester/command.go
@@ -98,7 +98,7 @@ func (cmd *SSOTestCommand) getSupportedKinds() []string {
 func (cmd *SSOTestCommand) ssoTestCommand(ctx context.Context, c auth.ClientI) error {
 	reader := os.Stdin
 	if cmd.connectorFileName != "" {
-		f, err := utils.OpenFile(cmd.connectorFileName)
+		f, err := utils.OpenFile(cmd.connectorFileName, true)
 		if err != nil {
 			return trace.Wrap(err, "could not open connector spec file %v", cmd.connectorFileName)
 		}


### PR DESCRIPTION
This PR attempts to provide a common API so that the decision of when to follow symlinks is a conscious decision. Because Teleport (particularly the agent) runs in a privileged context, there is risk that following symlinks may allow information disclosure.

After review of the cases covered in this commit (and some additional cases where this API was not a natural fit), this does not appear to be a broad problem.  This PR however does fix the one known flaw described in the issue https://github.com/gravitational/teleport-private/issues/1009

In many cases where this API is being adopted, symlinks are still being allowed.  This is only after verifying there is no information disclosure when symlinks are followed.  Although symlinks are not likely useful in many of these cases, this choice to still allow symlinks is to maintain compatibility with potentially unknown use cases.  Future use of this API will almost certainly always specify a `false` for allowing symlinks.