### PR TITLE
Increase lock release timeout in RunWhileLocked

### DIFF
--- a/lib/backend/helpers.go
+++ b/lib/backend/helpers.go
@@ -178,7 +178,7 @@ func (c *RunWhileLockedConfig) CheckAndSetDefaults() error {
 		return trace.Wrap(err)
 	}
 	if c.ReleaseCtxTimeout <= 0 {
-		c.ReleaseCtxTimeout = 300 * time.Millisecond
+		c.ReleaseCtxTimeout = time.Second
 	}
 	if c.RefreshLockInterval <= 0 {
 		c.RefreshLockInterval = c.LockConfiguration.TTL / 2
@@ -220,8 +220,10 @@ func RunWhileLocked(ctx context.Context, cfg RunWhileLockedConfig, fn func(conte
 	fnErr := fn(subContext)
 	close(stopRefresh)
 
-	// lock.Release should be called with separate ctx. If someone cancels via ctx
-	// RunWhileLocked method, we want to at least try releasing lock.
+	// Release the lock with a separate context to allow the lock to be removed even
+	// if the passed in context is canceled by the user, otherwise the lock will be
+	// left around for the entire TTL even though the operation that required the
+	// lock may have completed.
 	releaseLockCtx, releaseLockCancel := context.WithTimeout(context.Background(), cfg.ReleaseCtxTimeout)
 	defer releaseLockCancel()
 	if err := lock.Release(releaseLockCtx, cfg.Backend); err != nil {

--- a/lib/backend/helpers_test.go
+++ b/lib/backend/helpers_test.go
@@ -132,7 +132,7 @@ func TestRunWhileLockedConfigCheckAndSetDefaults(t *testing.T) {
 					TTL:           ttl,
 					RetryInterval: 250 * time.Millisecond,
 				},
-				ReleaseCtxTimeout: 300 * time.Millisecond,
+				ReleaseCtxTimeout: time.Second,
 				// defaults to halft of TTL.
 				RefreshLockInterval: 30 * time.Second,
 			},


### PR DESCRIPTION
The default release timeout is now a minute to allow slow/distant connections to the backend to complete releasing the lock.

Closes #31690