### PR TITLE
fix: tsh device enroll --current-device command

### DIFF
--- a/docs/pages/access-controls/device-trust/guide.mdx
+++ b/docs/pages/access-controls/device-trust/guide.mdx
@@ -154,7 +154,7 @@ To access `(=clusterDefaults.nodeIP=)` server again, you will have to enroll you
 Enrolling your device is easy, and can be done using `tsh` client:
 
 ```code
-$ tsh enroll device --current-device
+$ tsh device enroll --current-device
 Device "(=devicetrust.asset_tag=)"/macOS registered and enrolled
 ```
 


### PR DESCRIPTION
The enroll current device command should be: `tsh device enroll --current-device` but the guide shows `tsh enroll device --current-device`


closes https://github.com/gravitational/teleport/issues/31730