### PR TITLE
docs: Rough draft of troubleshooting for apps

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -842,6 +842,10 @@
           "slug": "/application-access/controls/"
         },
         {
+          "title": "Troubleshooting Application Access",
+          "slug": "/application-access/troubleshooting-apps/",
+        },           
+        {
           "title": "Reference",
           "slug": "/application-access/reference/"
         }

--- a/docs/config.json
+++ b/docs/config.json
@@ -843,7 +843,7 @@
         },
         {
           "title": "Troubleshooting Application Access",
-          "slug": "/application-access/troubleshooting-apps/",
+          "slug": "/application-access/troubleshooting-apps/"
         },           
         {
           "title": "Reference",

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -39,7 +39,7 @@ in the Teleport configuration file for each application.
 
 To fix CSRF or CORS issues:
 
-1. Open the `/etc/teleport.yaml` file that contains the app service configuration in a text editor.
+1. Open the `/etc/teleport.yaml` file that contains the application configuration in a text editor.
 
 1. Add a `rewrite.headers` section similar to the following `grafana` example:
 
@@ -60,7 +60,8 @@ To fix CSRF or CORS issues:
 
 To fix CSRF or CORS issues if you deploy applications using Kubernetes and `teleport-kube-agent`:
 
-1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the app service configuration in a text editor.
+1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the application 
+   configuration in a text editor.
 
 1. Locate the `apps` section in the `values.yaml` file.
    

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -1,0 +1,59 @@
+---
+title: Troubleshooting Application Access
+description: Describes common issues and solutions for access to applications.
+---
+
+This section describes common issues that you might encounter in managing access to applications
+with Teleport and how to work around or resolve them.
+
+## Unable to access applications
+
+The most common issues that prevent access to applications involve Cross-Site Request Forgery (CSRF) or
+Cross-Origin Resource Sharing (CORS) errors.
+
+Cross-Site Request Forgery is a type of attack that uses an authenticated user's identity to perform operations
+without the user's knowledge. For example, a CSRF attack might transfer funds, change passwords, or make purchases
+by issuing a forged request with the user's credentials. Browsers and applications have checks to prevent these
+types of attacks. However, the checks can also block legitimate requests under certain conditions.
+
+### Symptom
+
+If your browser can't create a secure cookie or can't authorize your login from a previously-created secure 
+cookie, you might see the following error:
+
+Invalid or missing CSRF token
+
+This error can be caused by ad-blocking or script-blocking extensions or by the browser itself.
+For access to applications through Teleport, you might see this error with most often with 
+applications—like Grafana and ArgoCD—that use WebSockets extensively and in browsers where 
+cross-site scripting restrictions require traffic to be explicitly allowed.
+
+Issues with Cross-Site Request Forgery (CSRF) or Cross-Origin Resource Sharing (CORS) usually 
+result in a loss of application functionality, errors in the application itself indicating that 
+traffic isn't being permitted, or application logs that indicate CORS or CSRF errors. 
+
+### Solution
+
+In most cases, you can fix these types of issues by adding explicit `rewrite` settings for the Origin and Host headers 
+in the Teleport configuration file for each application.
+
+To fix CSRF or CORS issues:
+
+1. Open the `/etc/teleport.yaml` file in a text editor.
+
+1. Add a `rewrite.headers` section similar to the following `grafana` example:
+
+   ```code
+   app_service:
+     enabled: true
+     apps:
+     - name: grafana
+       uri: http://localhost:3000
+       public_addr: <Var name="grafana.teleport.example.com"/>
+       rewrite:
+         headers:
+           Origin: <Var name="https://grafana.teleport.example.com" /> # the Teleport application subdomain prepended with "https://"
+           Host: <Var name="grafana.teleport.example.com" /> # the Teleport application subdomain itself
+   ```
+
+1. Save your changes and restart the Teleport service.

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -126,5 +126,5 @@ command line. For example:
 sudo SSL_CERT_FILE=<Var name="path-to-rootCA-pem" /> teleport start --config=/etc/teleport.yaml
 ```
 
-You should specify the `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variable as command-line
+You should specify the `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables as command-line
 options because `sudo` doesn't inherit environment variables by default.

--- a/docs/pages/application-access/troubleshooting-apps.mdx
+++ b/docs/pages/application-access/troubleshooting-apps.mdx
@@ -1,6 +1,6 @@
 ---
 title: Troubleshooting Application Access
-description: Describes common issues and solutions for access to applications.
+description: Describes common issues and solutions for access to applications protected by Teleport.
 ---
 
 This section describes common issues that you might encounter in managing access to applications
@@ -21,7 +21,7 @@ types of attacks. However, the checks can also block legitimate requests under c
 If your browser can't create a secure cookie or can't authorize your login from a previously-created secure 
 cookie, you might see the following error:
 
-Invalid or missing CSRF token
+**Invalid or missing CSRF token**
 
 This error can be caused by ad-blocking or script-blocking extensions or by the browser itself.
 For access to applications through Teleport, you might see this error with most often with 
@@ -39,7 +39,7 @@ in the Teleport configuration file for each application.
 
 To fix CSRF or CORS issues:
 
-1. Open the `/etc/teleport.yaml` file in a text editor.
+1. Open the `/etc/teleport.yaml` file that contains the app service configuration in a text editor.
 
 1. Add a `rewrite.headers` section similar to the following `grafana` example:
 
@@ -52,8 +52,79 @@ To fix CSRF or CORS issues:
        public_addr: <Var name="grafana.teleport.example.com"/>
        rewrite:
          headers:
-           Origin: <Var name="https://grafana.teleport.example.com" /> # the Teleport application subdomain prepended with "https://"
-           Host: <Var name="grafana.teleport.example.com" /> # the Teleport application subdomain itself
+           Origin: <Var name="https://grafana.teleport.example.com" /> # Teleport application subdomain prepended with "https://"
+           Host: <Var name="grafana.teleport.example.com" /> # Teleport application subdomain itself
    ```
 
 1. Save your changes and restart the Teleport service.
+
+To fix CSRF or CORS issues if you deploy applications using Kubernetes and `teleport-kube-agent`:
+
+1. Open the `teleport/examples/chart/teleport-kube-agent/values.yaml` file that contains the app service configuration in a text editor.
+
+1. Locate the `apps` section in the `values.yaml` file.
+   
+   ```yaml
+   # Details of at least one app to be proxied. Example: 
+   # apps: 
+   #  - name: grafana 
+   #    uri: http://localhost:3000 
+   apps: []
+   ```
+
+1. Add a `rewrite.headers` section similar to the following `grafana` example:
+
+   ```yaml
+   app_service:
+     enabled: true
+     apps:
+     - name: grafana
+       uri: http://localhost:3000
+       public_addr: <Var name="grafana.teleport.example.com"/>
+       rewrite:
+         headers:
+           Origin: <Var name="https://grafana.teleport.example.com" /> # Teleport application subdomain prepended with "https://"
+           Host: <Var name="grafana.teleport.example.com" /> # Teleport application subdomain itself
+   ```
+
+## Untrusted certificate errors
+
+By default, the certificates presented by the Teleport Proxy Service must be trusted and issued by
+a recognized certificate authority. 
+
+### Symptom
+
+If you have created self-signed certificates or use certificates signed by an unrecognized 
+certificate authority, you might see an error similar to the following:
+
+```text
+ERROR: "unable to verify HTTPS certificate chain in : \x1b[31mERROR: \x1b[0mWARNING:"
+
+  The proxy you are connecting to has presented a certificate signed by a
+  unknown authority. This is most likely due to either being presented
+  with a self-signed certificate or the certificate was truly signed by an
+  authority not known to the client.
+```
+
+### Solution
+
+If you have properly created a root certificate authority and a self-signed
+certificate, you can use the `--insecure` command-line option to allow clients
+to accept the certificate. For example, you can start Teleport with a self-signed 
+certificate by running a command similar to the following:
+
+```code
+sudo teleport start --config=/etc/teleport.yaml --insecure
+```
+
+If you have your own certificate authority that you would like to use to
+validate the certificate chain presented by the Teleport Proxy Service, you can
+manually set the `SSL_CERT_FILE` or `SSL_CERT_DIR` environment variable on the 
+command line. For example:
+
+```code
+sudo SSL_CERT_FILE=<Var name="path-to-rootCA-pem" /> teleport start --config=/etc/teleport.yaml
+```
+
+You should specify the `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variable as command-line
+options because `sudo` doesn't inherit environment variables by default.


### PR DESCRIPTION
Rough draft based on info provided by @webvictim 

> Application access
> 
> The most common issue I see is CSRF/CORS or incorrect Origin/Host type issues. This comes up most often with Grafana, ArgoCD and many other modern web applications which make heavy use of websockets where cross-site scripting restrictions in browsers prevent traffic from flowing unless explicitly allowed.
> 
> This error usually manifests as lack of functionality and/or displayed errors in the application itself saying that traffic isn't being permitted. Application logs will also often mention CORS or CSRF. 
> 
> The fix is to add forced rewrites for the Origin and Host headers to each Teleport app configuration as per the example below:
> 
```
app_service:
  enabled: true
  apps:
  - name: grafana
    uri: http://localhost:3000/
    public_addr: [grafana.teleport.example.com](http://grafana.teleport.example.com/)
    rewrite:
      headers:
        Origin: "https://grafana.teleport.example.com/" # should be the Teleport application subdomain prepended with "https://"
        Host: "[grafana.teleport.example.com](http://grafana.teleport.example.com/)" # should be the Teleport application subdomain itself
```
In 99% of cases this fixes the CSRF issues and makes the applications work properly.