### PR TITLE
Validate desktop names

### DIFF
--- a/api/types/desktop.go
+++ b/api/types/desktop.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -165,6 +166,13 @@ func (d *WindowsDesktopV3) setStaticFields() {
 func (d *WindowsDesktopV3) CheckAndSetDefaults() error {
 	if d.Spec.Addr == "" {
 		return trace.BadParameter("WindowsDesktopV3.Spec missing Addr field")
+	}
+
+	// We use SNI to identify the desktop to route a connection to,
+	// and '.' will add an extra subdomain, preventing Teleport from
+	// correctly establishing TLS connections.
+	if name := d.GetName(); strings.Contains(name, ".") {
+		return trace.BadParameter("invalid name %q: desktop names cannot contain periods", name)
 	}
 
 	d.setStaticFields()

--- a/api/types/desktop_test.go
+++ b/api/types/desktop_test.go
@@ -86,3 +86,9 @@ func TestWindowsDesktopsSorter(t *testing.T) {
 	desktops := makeDesktops(testValsUnordered, "does-not-matter")
 	require.True(t, trace.IsNotImplemented(WindowsDesktops(desktops).SortByCustom(sortBy)))
 }
+
+func TestInvalidDesktopName(t *testing.T) {
+	_, err := NewWindowsDesktopV3("name-contains.period", nil,
+		WindowsDesktopSpecV3{Addr: "desktop.example.com:3389"})
+	require.True(t, trace.IsBadParameter(err), "want bad parameter error, got %v", err)
+}


### PR DESCRIPTION
Desktops cannot contain '.' characters in their names, as we use SNI to pass the desktop name in the TLS handshake. This wasn't a problem in the past when Teleport was the only thing that created desktops, as we were sure to sanitize names. With non-AD access we encourage users to register their own desktops via API or tctl, and they often encounter a confusing TLS error when they use an invalid name.

With this change:

    ➜ tctl create -f desktop-resource.yaml
    ERROR: invalid name "this-is-a.test": desktop names cannot contain periods

Fixes #31644