### PR TITLE
[v12] Validate desktop names

### DIFF
--- a/api/types/desktop.go
+++ b/api/types/desktop.go
@@ -18,6 +18,7 @@ package types
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/gravitational/trace"
 
@@ -161,6 +162,13 @@ func (d *WindowsDesktopV3) setStaticFields() {
 func (d *WindowsDesktopV3) CheckAndSetDefaults() error {
 	if d.Spec.Addr == "" {
 		return trace.BadParameter("WindowsDesktopV3.Spec missing Addr field")
+	}
+
+	// We use SNI to identify the desktop to route a connection to,
+	// and '.' will add an extra subdomain, preventing Teleport from
+	// correctly establishing TLS connections.
+	if name := d.GetName(); strings.Contains(name, ".") {
+		return trace.BadParameter("invalid name %q: desktop names cannot contain periods", name)
 	}
 
 	d.setStaticFields()

--- a/api/types/desktop_test.go
+++ b/api/types/desktop_test.go
@@ -86,3 +86,9 @@ func TestWindowsDesktopsSorter(t *testing.T) {
 	desktops := makeDesktops(testValsUnordered, "does-not-matter")
 	require.True(t, trace.IsNotImplemented(WindowsDesktops(desktops).SortByCustom(sortBy)))
 }
+
+func TestInvalidDesktopName(t *testing.T) {
+	_, err := NewWindowsDesktopV3("name-contains.period", nil,
+		WindowsDesktopSpecV3{Addr: "desktop.example.com:3389"})
+	require.True(t, trace.IsBadParameter(err), "want bad parameter error, got %v", err)
+}


### PR DESCRIPTION
Backport #31739 to branch/v12

Changelog: fail with an error if desktops are created with invalid names