### PR TITLE
Restrict triggers for the Vercel preview workflow

### DIFF
--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -7,9 +7,9 @@ env:
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
 on:
-  pull_request: 
-    paths: [ 'docs/**' ]
-    types: [ opened, reopened, edited, synchronize ]
+  pull_request:
+    paths: ['docs/**']
+    types: [opened, reopened, ready_for_review, review_requested]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -9,7 +9,7 @@ env:
 on:
   pull_request:
     paths: ['docs/**']
-    types: [opened, reopened, ready_for_review, review_requested]
+    types: [opened, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:
@@ -49,5 +49,6 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '🤖 Vercel preview here: ${{ steps.deploy.outputs.PREVIEW_URL }}/docs/ver/14.x'
+              body: '🤖 Vercel preview here: ${{ steps.deploy.outputs.PREVIEW_URL }}/docs/ver/14.x\n'+
+                'To trigger another preview, put this pull request in "Draft" mode and take it out again.'
             })


### PR DESCRIPTION
This workflow currently runs any time an author pushes changes to a docs PR via the `sychronize` trigger type. This causes rate limiting on the Vercel API, since authors may push commits to a PR throughout the day.

This change limits the workflow triggers to moments where an author would typically solicit a PR review, which is when a Vercel preview would be useful:

- Opening a PR
- Reopening a PR
- Indicating that a draft PR is ready for review
- Requesting a review (i.e., after responding to review feedback)