### PR TITLE
Allow sudoer files to be created separately from host user creation

### DIFF
--- a/integration/hostuser_test.go
+++ b/integration/hostuser_test.go
@@ -91,7 +91,7 @@ func TestRootHostUsersBackend(t *testing.T) {
 		require.True(t, trace.IsAlreadyExists(err))
 
 		require.NoFileExists(t, filepath.Join("/home", testuser))
-		err = backend.CreateHomeDirectory(testuser, tuser.Uid, tuser.Gid)
+		err = usersbk.CreateHomeDirectory(testuser, tuser.Uid, tuser.Gid)
 		require.NoError(t, err)
 		require.FileExists(t, filepath.Join("/home", testuser, ".bashrc"))
 	})
@@ -141,10 +141,10 @@ func TestRootHostUsersBackend(t *testing.T) {
 	})
 
 	t.Run("Test CreateHomeDirectory does not follow symlinks", func(t *testing.T) {
-		err := backend.CreateUser(testuser, []string{testgroup}, "", "")
+		err := usersbk.CreateUser(testuser, []string{testgroup}, "", "")
 		require.NoError(t, err)
 
-		tuser, err := backend.Lookup(testuser)
+		tuser, err := usersbk.Lookup(testuser)
 		require.NoError(t, err)
 
 		require.NoError(t, os.WriteFile("/etc/skel/testfile", []byte("test\n"), 0o700))
@@ -157,7 +157,7 @@ func TestRootHostUsersBackend(t *testing.T) {
 		require.NoError(t, os.Symlink("/tmp/ignoreme", bashrcPath))
 		require.NoFileExists(t, "/tmp/ignoreme")
 
-		err = backend.CreateHomeDirectory(testuser, tuser.Uid, tuser.Gid)
+		err = usersbk.CreateHomeDirectory(testuser, tuser.Uid, tuser.Gid)
 		t.Cleanup(func() {
 			os.RemoveAll(filepath.Join("/home", testuser))
 		})

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -851,13 +851,7 @@ func (a *accessChecker) HostUsers(s types.Server) (*HostUsersInfo, error) {
 	groups := make(map[string]struct{})
 	var mode types.CreateHostUserMode
 
-	roleSet := make([]types.Role, len(a.RoleSet))
-	copy(roleSet, a.RoleSet)
-	slices.SortStableFunc(roleSet, func(a types.Role, b types.Role) int {
-		return strings.Compare(a.GetName(), b.GetName())
-	})
-
-	for _, role := range roleSet {
+	for _, role := range a.RoleSet {
 		result, _, err := checkRoleLabelsMatch(types.Allow, role, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)
@@ -895,7 +889,7 @@ func (a *accessChecker) HostUsers(s types.Server) (*HostUsersInfo, error) {
 		}
 	}
 
-	for _, role := range roleSet {
+	for _, role := range a.RoleSet {
 		result, _, err := checkRoleLabelsMatch(types.Deny, role, a.info.Traits, s, false)
 		if err != nil {
 			return nil, trace.Wrap(err)

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -928,7 +928,7 @@ func (a *accessChecker) HostSudoers(s types.Server) ([]string, error) {
 
 	roleSet := make([]types.Role, len(a.RoleSet))
 	copy(roleSet, a.RoleSet)
-	slices.SortStableFunc(roleSet, func(a types.Role, b types.Role) int {
+	slices.SortFunc(roleSet, func(a types.Role, b types.Role) int {
 		return strings.Compare(a.GetName(), b.GetName())
 	})
 

--- a/lib/services/access_checker.go
+++ b/lib/services/access_checker.go
@@ -926,8 +926,7 @@ func (a *accessChecker) HostUsers(s types.Server) (*HostUsersInfo, error) {
 func (a *accessChecker) HostSudoers(s types.Server) ([]string, error) {
 	var sudoers []string
 
-	roleSet := make([]types.Role, len(a.RoleSet))
-	copy(roleSet, a.RoleSet)
+	roleSet := slices.Clone(a.RoleSet)
 	slices.SortFunc(roleSet, func(a types.Role, b types.Role) int {
 		return strings.Compare(a.GetName(), b.GetName())
 	})

--- a/lib/services/role_test.go
+++ b/lib/services/role_test.go
@@ -6894,9 +6894,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 			sudoers: []string{"%sudo	ALL=(ALL) ALL"},
 			roles: NewRoleSet(&types.RoleV6{
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"%sudo	ALL=(ALL) ALL"},
@@ -6920,9 +6917,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "a",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"sudoers entry 1"},
@@ -6933,9 +6927,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "b",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{types.Wildcard: []string{types.Wildcard}},
 						HostSudoers: []string{"sudoers entry 2"},
@@ -6943,9 +6934,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}, &types.RoleV6{
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{"fail": []string{"abc"}},
 						HostSudoers: []string{"not present sudoers entry"},
@@ -6966,9 +6954,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 			sudoers: nil,
 			roles: NewRoleSet(&types.RoleV6{
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"%sudo	ALL=(ALL) ALL"},
@@ -6976,9 +6961,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}, &types.RoleV6{
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Deny: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"*"},
@@ -6999,9 +6981,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 			sudoers: []string{"%sudo	ALL=(ALL) ALL"},
 			roles: NewRoleSet(&types.RoleV6{
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels: types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{
@@ -7012,9 +6991,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 				},
 			}, &types.RoleV6{
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Deny: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"removed entry"},
@@ -7038,9 +7014,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "a",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"sudoers entry 1"},
@@ -7051,9 +7024,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "c",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{types.Wildcard: []string{types.Wildcard}},
 						HostSudoers: []string{"sudoers entry 4", "sudoers entry 1"},
@@ -7064,9 +7034,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "b",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{types.Wildcard: []string{types.Wildcard}},
 						HostSudoers: []string{"sudoers entry 2", "sudoers entry 3"},
@@ -7090,9 +7057,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "a",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"sudoers entry 1"},
@@ -7103,9 +7067,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "d",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Deny: types.RoleConditions{
 						NodeLabels:  types.Labels{"success": []string{"abc"}},
 						HostSudoers: []string{"sudoers entry 1"},
@@ -7116,9 +7077,6 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 					Name: "c",
 				},
 				Spec: types.RoleSpecV6{
-					Options: types.RoleOptions{
-						CreateHostUser: types.NewBoolOption(true),
-					},
 					Allow: types.RoleConditions{
 						NodeLabels:  types.Labels{types.Wildcard: []string{types.Wildcard}},
 						HostSudoers: []string{"sudoers entry 1", "sudoers entry 2"},
@@ -7137,9 +7095,9 @@ func TestHostUsers_HostSudoers(t *testing.T) {
 	} {
 		t.Run(tc.test, func(t *testing.T) {
 			accessChecker := makeAccessCheckerWithRoleSet(tc.roles)
-			info, err := accessChecker.HostUsers(tc.server)
+			info, err := accessChecker.HostSudoers(tc.server)
 			require.NoError(t, err)
-			require.Equal(t, tc.sudoers, info.Sudoers)
+			require.Equal(t, tc.sudoers, info)
 		})
 	}
 }

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -180,6 +180,10 @@ type Server interface {
 	// host user provisioning
 	GetHostUsers() HostUsers
 
+	// GetHostSudoers returns the HostSudoers instance being used to manage
+	// sudoer file provisioning
+	GetHostSudoers() HostSudoers
+
 	// TargetMetadata returns metadata about the session target node.
 	TargetMetadata() apievents.ServerMetadata
 }

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -182,7 +182,7 @@ type Server interface {
 
 	// GetHostSudoers returns the HostSudoers instance being used to manage
 	// sudoer file provisioning
-	GetHostSudoers() HostSudoers
+	GetHostSudoers() (HostSudoers, error)
 
 	// TargetMetadata returns metadata about the session target node.
 	TargetMetadata() apievents.ServerMetadata

--- a/lib/srv/ctx.go
+++ b/lib/srv/ctx.go
@@ -182,7 +182,7 @@ type Server interface {
 
 	// GetHostSudoers returns the HostSudoers instance being used to manage
 	// sudoer file provisioning
-	GetHostSudoers() (HostSudoers, error)
+	GetHostSudoers() HostSudoers
 
 	// TargetMetadata returns metadata about the session target node.
 	TargetMetadata() apievents.ServerMetadata

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -488,8 +488,8 @@ func (s *Server) GetHostUsers() srv.HostUsers {
 
 // GetHostSudoers returns the HostSudoers instance being used to manage
 // sudoer file provisioning, unimplemented for the forwarder server.
-func (s *Server) GetHostSudoers() srv.HostSudoers {
-	return nil
+func (s *Server) GetHostSudoers() (srv.HostSudoers, error) {
+	return nil, trace.NotImplemented("not implemented for forwarding server")
 }
 
 // GetRestrictedSessionManager returns a NOP manager since for a

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -488,8 +488,8 @@ func (s *Server) GetHostUsers() srv.HostUsers {
 
 // GetHostSudoers returns the HostSudoers instance being used to manage
 // sudoer file provisioning, unimplemented for the forwarder server.
-func (s *Server) GetHostSudoers() (srv.HostSudoers, error) {
-	return nil, trace.NotImplemented("not implemented for forwarding server")
+func (s *Server) GetHostSudoers() srv.HostSudoers {
+	return &srv.HostSudoersNotImplemented{}
 }
 
 // GetRestrictedSessionManager returns a NOP manager since for a

--- a/lib/srv/forward/sshserver.go
+++ b/lib/srv/forward/sshserver.go
@@ -486,6 +486,12 @@ func (s *Server) GetHostUsers() srv.HostUsers {
 	return nil
 }
 
+// GetHostSudoers returns the HostSudoers instance being used to manage
+// sudoer file provisioning, unimplemented for the forwarder server.
+func (s *Server) GetHostSudoers() srv.HostSudoers {
+	return nil
+}
+
 // GetRestrictedSessionManager returns a NOP manager since for a
 // forwarding server it makes no sense (it has to run on the actual
 // node).

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -284,6 +284,11 @@ func (m *mockServer) GetHostUsers() HostUsers {
 	return nil
 }
 
+// GetHostSudoers
+func (m *mockServer) GetHostSudoers() HostSudoers {
+	return nil
+}
+
 // Implementation of ssh.Conn interface.
 type mockSSHConn struct {
 	remoteAddr net.Addr

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -285,8 +285,8 @@ func (m *mockServer) GetHostUsers() HostUsers {
 }
 
 // GetHostSudoers
-func (m *mockServer) GetHostSudoers() (HostSudoers, error) {
-	return nil, nil
+func (m *mockServer) GetHostSudoers() HostSudoers {
+	return &HostSudoersNotImplemented{}
 }
 
 // Implementation of ssh.Conn interface.

--- a/lib/srv/mock.go
+++ b/lib/srv/mock.go
@@ -285,8 +285,8 @@ func (m *mockServer) GetHostUsers() HostUsers {
 }
 
 // GetHostSudoers
-func (m *mockServer) GetHostSudoers() HostSudoers {
-	return nil
+func (m *mockServer) GetHostSudoers() (HostSudoers, error) {
+	return nil, nil
 }
 
 // Implementation of ssh.Conn interface.

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -316,8 +316,8 @@ func (s *Server) GetHostUsers() srv.HostUsers {
 
 // GetHostSudoers returns the HostSudoers instance being used to manage
 // sudoers file provisioning
-func (s *Server) GetHostSudoers() srv.HostSudoers {
-	return s.sudoers
+func (s *Server) GetHostSudoers() (srv.HostSudoers, error) {
+	return s.sudoers, nil
 }
 
 // ServerOption is a functional option passed to the server

--- a/lib/srv/regular/sshserver.go
+++ b/lib/srv/regular/sshserver.go
@@ -316,8 +316,11 @@ func (s *Server) GetHostUsers() srv.HostUsers {
 
 // GetHostSudoers returns the HostSudoers instance being used to manage
 // sudoers file provisioning
-func (s *Server) GetHostSudoers() (srv.HostSudoers, error) {
-	return s.sudoers, nil
+func (s *Server) GetHostSudoers() srv.HostSudoers {
+	if s.sudoers == nil {
+		return &srv.HostSudoersNotImplemented{}
+	}
+	return s.sudoers
 }
 
 // ServerOption is a functional option passed to the server

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -164,6 +164,10 @@ func NewSessionRegistry(cfg SessionRegistryConfig) (*SessionRegistry, error) {
 		return nil, trace.Wrap(err)
 	}
 
+	sudoers, err := cfg.Srv.GetHostSudoers()
+	if err != nil {
+		return nil, trace.Wrap(err)
+	}
 	return &SessionRegistry{
 		SessionRegistryConfig: cfg,
 		log: log.WithFields(log.Fields{
@@ -171,7 +175,7 @@ func NewSessionRegistry(cfg SessionRegistryConfig) (*SessionRegistry, error) {
 		}),
 		sessions: make(map[rsession.ID]*session),
 		users:    cfg.Srv.GetHostUsers(),
-		sudoers:  cfg.Srv.GetHostSudoers(),
+		sudoers:  sudoers,
 		sessionsByUser: &userSessions{
 			sessionsByUser: make(map[string]int),
 		},

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -99,6 +99,31 @@ type SessionRegistry struct {
 	// users is used for automatic user creation when new sessions are
 	// started
 	users HostUsers
+
+	// sudoers is used to create sudoers files at session start
+	sudoers        HostSudoers
+	sessionsByUser *userSessions
+}
+
+type userSessions struct {
+	sessionsByUser map[string]int
+	m              sync.Mutex
+}
+
+func (us *userSessions) add(user string) {
+	us.m.Lock()
+	defer us.m.Unlock()
+	count := us.sessionsByUser[user]
+	us.sessionsByUser[user] = count + 1
+}
+
+func (us *userSessions) del(user string) int {
+	us.m.Lock()
+	defer us.m.Unlock()
+	count := us.sessionsByUser[user]
+	count -= 1
+	us.sessionsByUser[user] = count
+	return count
 }
 
 type SessionRegistryConfig struct {
@@ -146,6 +171,10 @@ func NewSessionRegistry(cfg SessionRegistryConfig) (*SessionRegistry, error) {
 		}),
 		sessions: make(map[rsession.ID]*session),
 		users:    cfg.Srv.GetHostUsers(),
+		sudoers:  cfg.Srv.GetHostSudoers(),
+		sessionsByUser: &userSessions{
+			sessionsByUser: make(map[string]int),
+		},
 	}, nil
 }
 
@@ -185,9 +214,50 @@ func (s *SessionRegistry) Close() {
 	s.log.Debug("Closing Session Registry.")
 }
 
+type sudoersCloser struct {
+	username     string
+	userSessions *userSessions
+	cleanup      func(name string) error
+}
+
+func (sc *sudoersCloser) Close() error {
+	count := sc.userSessions.del(sc.username)
+	if count != 0 {
+		return nil
+	}
+	if err := sc.cleanup(sc.username); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
+}
+
+func (s *SessionRegistry) TryWriteSudoersFile(ctx *ServerContext) error {
+	sudoers, err := ctx.Identity.AccessChecker.HostSudoers(ctx.srv.GetInfo())
+	if err != nil {
+		return trace.Wrap(err)
+	}
+	if len(sudoers) == 0 {
+		// not an error, sudoers may not be configured.
+		return nil
+	}
+	if err := s.sudoers.WriteSudoers(ctx.Identity.Login, sudoers); err != nil {
+		return trace.Wrap(err)
+	}
+
+	s.sessionsByUser.add(ctx.Identity.Login)
+	ctx.AddCloser(&sudoersCloser{
+		username:     ctx.Identity.Login,
+		userSessions: s.sessionsByUser,
+		cleanup:      s.sudoers.RemoveSudoers,
+	})
+
+	return nil
+}
+
 func (s *SessionRegistry) TryCreateHostUser(ctx *ServerContext) error {
-	if !ctx.srv.GetCreateHostUser() || s.users == nil {
-		return nil // not an error to not be able to create a host user
+	if !ctx.srv.GetCreateHostUser() {
+		s.log.Debugf("not creating host users: node has disabled host user creation")
+		return nil // not an error to not be able to create host users
 	}
 
 	ui, err := ctx.Identity.AccessChecker.HostUsers(ctx.srv.GetInfo())

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -256,7 +256,7 @@ func (s *SessionRegistry) TryWriteSudoersFile(ctx *ServerContext) error {
 
 func (s *SessionRegistry) TryCreateHostUser(ctx *ServerContext) error {
 	if !ctx.srv.GetCreateHostUser() {
-		s.log.Debugf("not creating host users: node has disabled host user creation")
+		s.log.Debug("Not creating host user: node has disabled host user creation.")
 		return nil // not an error to not be able to create host users
 	}
 

--- a/lib/srv/sess.go
+++ b/lib/srv/sess.go
@@ -164,10 +164,7 @@ func NewSessionRegistry(cfg SessionRegistryConfig) (*SessionRegistry, error) {
 		return nil, trace.Wrap(err)
 	}
 
-	sudoers, err := cfg.Srv.GetHostSudoers()
-	if err != nil {
-		return nil, trace.Wrap(err)
-	}
+	sudoers := cfg.Srv.GetHostSudoers()
 	return &SessionRegistry{
 		SessionRegistryConfig: cfg,
 		log: log.WithFields(log.Fields{
@@ -236,6 +233,10 @@ func (sc *sudoersCloser) Close() error {
 }
 
 func (s *SessionRegistry) TryWriteSudoersFile(ctx *ServerContext) error {
+	if s.sudoers == nil {
+		return nil
+	}
+
 	sudoers, err := ctx.Identity.AccessChecker.HostSudoers(ctx.srv.GetInfo())
 	if err != nil {
 		return trace.Wrap(err)

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -124,6 +124,18 @@ type HostSudoers interface {
 	RemoveSudoers(name string) error
 }
 
+type HostSudoersNotImplemented struct{}
+
+// WriteSudoers creates a temporary Teleport user in the TeleportServiceGroup
+func (*HostSudoersNotImplemented) WriteSudoers(string, []string) error {
+	return trace.NotImplemented("host sudoers functionality not implemented on this platform")
+}
+
+// RemoveSudoers removes the users sudoer file
+func (*HostSudoersNotImplemented) RemoveSudoers(name string) error {
+	return trace.NotImplemented("host sudoers functionality not implemented on this platform")
+}
+
 type HostUsers interface {
 	// CreateUser creates a temporary Teleport user in the TeleportServiceGroup
 	CreateUser(name string, hostRoleInfo *services.HostUsersInfo) (io.Closer, error)

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -75,8 +75,6 @@ type HostSudoersBackend interface {
 	WriteSudoersFile(user string, entries []byte) error
 	// RemoveSudoersFile deletes a user's sudoers file.
 	RemoveSudoersFile(user string) error
-	// RemoveAllSudoersFiles removes all presnt teleport managed sudoers files
-	RemoveAllSudoersFiles() error
 }
 
 type HostUsersBackend interface {
@@ -124,8 +122,6 @@ type HostSudoers interface {
 	WriteSudoers(name string, sudoers []string) error
 	// RemoveSudoers removes the users sudoer file
 	RemoveSudoers(name string) error
-	// CleanupSudoers removes all sudoers in /etc/sudoers.d/teleport-$HOSTUUID-*
-	CleanupSudoers() error
 }
 
 type HostUsers interface {
@@ -194,11 +190,6 @@ func (u *HostSudoersManagement) WriteSudoers(name string, sudoers []string) erro
 	}
 	err := u.backend.WriteSudoersFile(name, []byte(sudoersOut.String()))
 	return trace.Wrap(err)
-}
-
-// CleanupSudoers will remove all sudoers files managed by teleport
-func (u *HostSudoersManagement) CleanupSudoers() error {
-	return trace.Wrap(u.backend.RemoveAllSudoersFiles())
 }
 
 func (u *HostSudoersManagement) RemoveSudoers(name string) error {

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -163,8 +163,10 @@ type HostSudoersManagement struct {
 	backend HostSudoersBackend
 }
 
-var _ HostUsers = &HostUserManagement{}
-var _ HostSudoers = &HostSudoersManagement{}
+var (
+	_ HostUsers   = &HostUserManagement{}
+	_ HostSudoers = &HostSudoersManagement{}
+)
 
 // Under the section "Including other files from within sudoers":
 //

--- a/lib/srv/usermgmt.go
+++ b/lib/srv/usermgmt.go
@@ -40,8 +40,8 @@ import (
 func NewHostUsers(ctx context.Context, storage *local.PresenceService, uuid string) HostUsers {
 	// newHostUsersBackend statically returns a valid backend or an error,
 	// resulting in a staticcheck linter error on darwin
-	backend, err := newHostUsersBackend(uuid) //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
-	if err != nil {                           //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+	backend, err := newHostUsersBackend() //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+	if err != nil {                       //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
 		log.Warnf("Error making new HostUsersBackend: %s", err)
 		return nil
 	}
@@ -53,6 +53,30 @@ func NewHostUsers(ctx context.Context, storage *local.PresenceService, uuid stri
 		storage:   storage,
 		userGrace: time.Second * 30,
 	}
+}
+
+func NewHostSudoers(uuid string) HostSudoers {
+	// newHostSudoersBackend statically returns a valid backend or an error,
+	// resulting in a staticcheck linter error on darwin
+	backend, err := newHostSudoersBackend(uuid) //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+	if err != nil {                             //nolint:staticcheck // linter fails on non-linux system as only linux implementation returns useful values.
+		log.Warnf("Error making new HostUsersBackend: %s", err)
+		return nil
+	}
+	return &HostSudoersManagement{
+		backend: backend,
+	}
+}
+
+type HostSudoersBackend interface {
+	// CheckSudoers ensures that a sudoers file to be written is valid
+	CheckSudoers(contents []byte) error
+	// WriteSudoersFile creates the user's sudoers file.
+	WriteSudoersFile(user string, entries []byte) error
+	// RemoveSudoersFile deletes a user's sudoers file.
+	RemoveSudoersFile(user string) error
+	// RemoveAllSudoersFiles removes all presnt teleport managed sudoers files
+	RemoveAllSudoersFiles() error
 }
 
 type HostUsersBackend interface {
@@ -72,12 +96,6 @@ type HostUsersBackend interface {
 	CreateUser(name string, groups []string, uid, gid string) error
 	// DeleteUser deletes a user from a host.
 	DeleteUser(name string) error
-	// CheckSudoers ensures that a sudoers file to be written is valid
-	CheckSudoers(contents []byte) error
-	// WriteSudoersFile creates the user's sudoers file.
-	WriteSudoersFile(user string, entries []byte) error
-	// RemoveSudoersFile deletes a user's sudoers file.
-	RemoveSudoersFile(user string) error
 	// CreateHomeDirectory creates the users home directory and copies in /etc/skel
 	CreateHomeDirectory(user string, uid, gid string) error
 }
@@ -100,6 +118,15 @@ func (u *userCloser) Close() error {
 }
 
 var ErrUserLoggedIn = errors.New("User logged in error")
+
+type HostSudoers interface {
+	// WriteSudoers creates a temporary Teleport user in the TeleportServiceGroup
+	WriteSudoers(name string, sudoers []string) error
+	// RemoveSudoers removes the users sudoer file
+	RemoveSudoers(name string) error
+	// CleanupSudoers removes all sudoers in /etc/sudoers.d/teleport-$HOSTUUID-*
+	CleanupSudoers() error
+}
 
 type HostUsers interface {
 	// CreateUser creates a temporary Teleport user in the TeleportServiceGroup
@@ -136,7 +163,12 @@ type HostUserManagement struct {
 	userGrace time.Duration
 }
 
+type HostSudoersManagement struct {
+	backend HostSudoersBackend
+}
+
 var _ HostUsers = &HostUserManagement{}
+var _ HostSudoers = &HostSudoersManagement{}
 
 // Under the section "Including other files from within sudoers":
 //
@@ -152,6 +184,28 @@ var sudoersSanitizationMatcher = regexp.MustCompile(`[\.~\/]`)
 // characters
 func sanitizeSudoersName(username string) string {
 	return sudoersSanitizationMatcher.ReplaceAllString(username, "_")
+}
+
+// WriteSudoers creates a sudoers file for a user from a list of entries
+func (u *HostSudoersManagement) WriteSudoers(name string, sudoers []string) error {
+	var sudoersOut strings.Builder
+	for _, entry := range sudoers {
+		sudoersOut.WriteString(fmt.Sprintf("%s %s\n", name, entry))
+	}
+	err := u.backend.WriteSudoersFile(name, []byte(sudoersOut.String()))
+	return trace.Wrap(err)
+}
+
+// CleanupSudoers will remove all sudoers files managed by teleport
+func (u *HostSudoersManagement) CleanupSudoers() error {
+	return trace.Wrap(u.backend.RemoveAllSudoersFiles())
+}
+
+func (u *HostSudoersManagement) RemoveSudoers(name string) error {
+	if err := u.backend.RemoveSudoersFile(name); err != nil {
+		return trace.Wrap(err)
+	}
+	return nil
 }
 
 // CreateUser creates a temporary Teleport user in the TeleportServiceGroup
@@ -262,14 +316,6 @@ func (u *HostUserManagement) CreateUser(name string, ui *services.HostUsersInfo)
 	})
 	if err != nil {
 		return nil, trace.Wrap(err)
-	}
-
-	if len(ui.Sudoers) != 0 {
-		var sudoers strings.Builder
-		for _, entry := range ui.Sudoers {
-			sudoers.WriteString(fmt.Sprintf("%s %s\n", name, entry))
-		}
-		err = u.backend.WriteSudoersFile(name, []byte(sudoers.String()))
 	}
 
 	if ui.Mode == types.CreateHostUserMode_HOST_USER_MODE_KEEP {
@@ -392,9 +438,6 @@ func (u *HostUserManagement) DeleteUser(username string, gid string) error {
 				return trace.Wrap(err)
 			}
 
-			if err := u.backend.RemoveSudoersFile(username); err != nil {
-				return trace.Wrap(err)
-			}
 			return nil
 		}
 	}

--- a/lib/srv/usermgmt_linux.go
+++ b/lib/srv/usermgmt_linux.go
@@ -34,16 +34,25 @@ import (
 
 // HostUsersProvisioningBackend is used to implement HostUsersBackend
 type HostUsersProvisioningBackend struct {
-	// SudoersPath is the path to write sudoers files to.
-	SudoersPath string
+}
+
+// HostSudoersProvisioningBackend is used to implement HostSudoersBackend
+type HostSudoersProvisioningBackend struct {
 	// HostUUID is the UUID of the running host
 	HostUUID string
+	// SudoersPath is the path to write sudoers files to.
+	SudoersPath string
 }
 
 // newHostUsersBackend initializes a new OS specific HostUsersBackend
-func newHostUsersBackend(uuid string) (HostUsersBackend, error) {
-	return &HostUsersProvisioningBackend{
-		SudoersPath: "/etc/sudoers.d",
+func newHostUsersBackend() (HostUsersBackend, error) {
+	return &HostUsersProvisioningBackend{}, nil
+}
+
+// newHostUsersBackend initializes a new OS specific HostUsersBackend
+func newHostSudoersBackend(uuid string) (HostSudoersBackend, error) {
+	return &HostSudoersProvisioningBackend{
+		SudoersPath: "/etc/sudoers.d/",
 		HostUUID:    uuid,
 	}, nil
 }
@@ -101,7 +110,7 @@ func (*HostUsersProvisioningBackend) DeleteUser(name string) error {
 }
 
 // CheckSudoers ensures that a sudoers file to be written is valid
-func (*HostUsersProvisioningBackend) CheckSudoers(contents []byte) error {
+func (*HostSudoersProvisioningBackend) CheckSudoers(contents []byte) error {
 	err := host.CheckSudoers(contents)
 	if err != nil {
 		return trace.Wrap(err)
@@ -128,7 +137,7 @@ func writeSudoersFile(root, name string, data []byte) (string, error) {
 }
 
 // WriteSudoersFile creates the user's sudoers file.
-func (u *HostUsersProvisioningBackend) WriteSudoersFile(username string, contents []byte) error {
+func (u *HostSudoersProvisioningBackend) WriteSudoersFile(username string, contents []byte) error {
 	if err := u.CheckSudoers(contents); err != nil {
 		return trace.Wrap(err)
 	}
@@ -148,7 +157,7 @@ func (u *HostUsersProvisioningBackend) WriteSudoersFile(username string, content
 }
 
 // RemoveSudoersFile deletes a user's sudoers file.
-func (u *HostUsersProvisioningBackend) RemoveSudoersFile(username string) error {
+func (u *HostSudoersProvisioningBackend) RemoveSudoersFile(username string) error {
 	fileUsername := sanitizeSudoersName(username)
 	sudoersFilePath := filepath.Join(u.SudoersPath, fmt.Sprintf("teleport-%s-%s", u.HostUUID, fileUsername))
 	if _, err := os.Stat(sudoersFilePath); os.IsNotExist(err) {
@@ -256,4 +265,4 @@ func (u *HostUsersProvisioningBackend) CreateHomeDirectory(user string, uidS, gi
 	}
 
 	return nil
-}
+

--- a/lib/srv/usermgmt_linux.go
+++ b/lib/srv/usermgmt_linux.go
@@ -265,4 +265,4 @@ func (u *HostUsersProvisioningBackend) CreateHomeDirectory(user string, uidS, gi
 	}
 
 	return nil
-
+}

--- a/lib/srv/usermgmt_other.go
+++ b/lib/srv/usermgmt_other.go
@@ -24,6 +24,11 @@ import (
 )
 
 //nolint:staticcheck // intended to always return an error for non-linux builds
-func newHostUsersBackend(_ string) (HostUsersBackend, error) {
+func newHostUsersBackend() (HostUsersBackend, error) {
+	return nil, trace.NotImplemented("Host user creation management is only supported on linux")
+}
+
+//nolint:staticcheck // intended to always return an error for non-linux builds
+func newHostSudoersBackend(_ string) (HostSudoersBackend, error) {
 	return nil, trace.NotImplemented("Host user creation management is only supported on linux")
 }

--- a/lib/srv/usermgmt_test.go
+++ b/lib/srv/usermgmt_test.go
@@ -149,7 +149,12 @@ func (tm *testHostUserBackend) WriteSudoersFile(user string, entries []byte) err
 	return nil
 }
 
+func (*testHostUserBackend) RemoveAllSudoersFiles() error {
+	return nil
+}
+
 var _ HostUsersBackend = &testHostUserBackend{}
+var _ HostSudoersBackend = &testHostUserBackend{}
 
 func TestUserMgmt_CreateTemporaryUser(t *testing.T) {
 	t.Parallel()
@@ -206,25 +211,24 @@ func TestUserMgmtSudoers_CreateTemporaryUser(t *testing.T) {
 		backend: backend,
 		storage: pres,
 	}
+	sudoers := HostSudoersManagement{
+		backend: backend,
+	}
 
 	closer, err := users.CreateUser("bob", &services.HostUsersInfo{
-		Groups:  []string{"hello", "sudo"},
-		Sudoers: []string{"validsudoers"},
-		Mode:    types.CreateHostUserMode_HOST_USER_MODE_DROP,
+		Groups: []string{"hello", "sudo"},
+		Mode:   types.CreateHostUserMode_HOST_USER_MODE_DROP,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, closer)
 
+	require.Empty(t, backend.sudoers)
+	sudoers.WriteSudoers("bob", []string{"validsudoers"})
 	require.Equal(t, map[string]string{"bob": "bob validsudoers"}, backend.sudoers)
+	sudoers.RemoveSudoers("bob")
 
 	require.NoError(t, closer.Close())
 	require.Empty(t, backend.sudoers)
-	_, err = users.CreateUser("bob", &services.HostUsersInfo{
-		Groups:  []string{"hello", "sudo"},
-		Sudoers: []string{"invalid"},
-		Mode:    types.CreateHostUserMode_HOST_USER_MODE_DROP,
-	})
-	require.Error(t, err)
 
 	t.Run("no teleport-service group", func(t *testing.T) {
 		backend := newTestUserMgmt()


### PR DESCRIPTION
This separates host user creation and sudoer file creation so sudoers files can be configured without the requirement that the user was a dynamically created user

#29230 