### PR TITLE
Connect my Computer: Various fixes

### DIFF
--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerSetup/DocumentConnectMyComputerSetup.tsx
@@ -45,7 +45,7 @@ export function DocumentConnectMyComputerSetup() {
   const { rootClusterUri } = useWorkspaceContext();
 
   return (
-    <Box maxWidth="590px" mx="auto" mt="4" px="5" width="100%">
+    <Box maxWidth="680px" mx="auto" mt="4" px="5" width="100%">
       <Text typography="h3" mb="4">
         Connect My Computer
       </Text>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -24,6 +24,7 @@ import {
   Link,
   MenuItem,
   Text,
+  ButtonSecondary,
 } from 'design';
 import styled, { css } from 'styled-components';
 import { Transition } from 'react-transition-group';
@@ -40,6 +41,8 @@ import {
 } from 'teleterm/ui/ConnectMyComputer';
 import { assertUnreachable } from 'teleterm/ui/utils';
 import { codeOrSignal } from 'teleterm/ui/utils/process';
+import { connectToServer } from 'teleterm/ui/services/workspacesService';
+import { useAppContext } from 'teleterm/ui/appContextProvider';
 
 import { useAgentProperties } from '../useAgentProperties';
 import { Logs } from '../Logs';
@@ -49,6 +52,7 @@ import type { IconProps } from 'design/Icon/Icon';
 
 // TODO(gzdunek): Rename to `Status`
 export function DocumentConnectMyComputerStatus() {
+  const ctx = useAppContext();
   const {
     currentAction,
     agentNode,
@@ -65,6 +69,14 @@ export function DocumentConnectMyComputerStatus() {
     markAgentAsNotConfigured();
   }
 
+  function startSshSession(): void {
+    connectToServer(
+      ctx,
+      { uri: agentNode.uri, hostname, login: systemUsername },
+      { origin: 'resource_table' }
+    );
+  }
+
   const isRunning =
     currentAction.kind === 'observe-process' &&
     currentAction.agentProcessState.status === 'running';
@@ -78,9 +90,9 @@ export function DocumentConnectMyComputerStatus() {
     currentAction.kind === 'start' &&
     currentAction.attempt.status === 'processing';
 
-  const showDisconnectButton = isRunning || isKilling;
-  const disableDisconnectButton = isKilling;
-  const disableConnectButton = isDownloading || isStarting;
+  const showConnectAndStopAgentButtons = isRunning || isKilling;
+  const disableConnectAndStopAgentButtons = isKilling;
+  const disableStartAgentButton = isDownloading || isStarting;
 
   return (
     <Box maxWidth="590px" mx="auto" mt="4" px="5" width="100%">
@@ -146,9 +158,25 @@ export function DocumentConnectMyComputerStatus() {
           </LabelsContainer>
         )}
       </Transition>
-      <Flex mt={3} mb={2} gap={1} display="flex" alignItems="center">
+      <Flex
+        mt={3}
+        mb={2}
+        gap={1}
+        display="flex"
+        alignItems="center"
+        minHeight="32px"
+      >
         {prettyCurrentAction.Icon && <prettyCurrentAction.Icon size="medium" />}
         {prettyCurrentAction.title}
+        {showConnectAndStopAgentButtons && (
+          <ButtonSecondary
+            onClick={killAgent}
+            disabled={disableConnectAndStopAgentButtons}
+            ml={3}
+          >
+            Stop Agent
+          </ButtonSecondary>
+        )}
       </Flex>
       {prettyCurrentAction.error && (
         <Alert
@@ -165,23 +193,23 @@ export function DocumentConnectMyComputerStatus() {
         <strong>{roleName}</strong> to access it as an SSH resource with the
         user <strong>{systemUsername}</strong>.
       </Text>
-      {showDisconnectButton ? (
+      {showConnectAndStopAgentButtons ? (
         <ButtonPrimary
           block
-          disabled={disableDisconnectButton}
-          onClick={killAgent}
+          disabled={disableConnectAndStopAgentButtons}
+          onClick={startSshSession}
           size="large"
         >
-          Disconnect
+          Connect
         </ButtonPrimary>
       ) : (
         <ButtonPrimary
           block
-          disabled={disableConnectButton}
+          disabled={disableStartAgentButton}
           onClick={downloadAndStartAgent}
           size="large"
         >
-          Connect
+          Start Agent
         </ButtonPrimary>
       )}
     </Box>

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/DocumentConnectMyComputerStatus/DocumentConnectMyComputerStatus.tsx
@@ -95,7 +95,7 @@ export function DocumentConnectMyComputerStatus() {
   const disableStartAgentButton = isDownloading || isStarting;
 
   return (
-    <Box maxWidth="590px" mx="auto" mt="4" px="5" width="100%">
+    <Box maxWidth="680px" mx="auto" mt="4" px="5" width="100%">
       {isAgentConfiguredAttempt.status === 'error' && (
         <Alert
           css={`

--- a/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
+++ b/web/packages/teleterm/src/ui/ConnectMyComputer/connectMyComputerContext.tsx
@@ -108,6 +108,9 @@ export const ConnectMyComputerContextProvider: FC<{
       [connectMyComputerService, props.rootClusterUri]
     )
   );
+  const isAgentConfigured =
+    isAgentConfiguredAttempt.status === 'success' &&
+    isAgentConfiguredAttempt.data;
 
   const rootCluster = clustersService.findCluster(props.rootClusterUri);
   const canUse = useMemo(
@@ -116,8 +119,8 @@ export const ConnectMyComputerContextProvider: FC<{
         rootCluster,
         configService,
         mainProcessClient.getRuntimeSettings()
-      ),
-    [configService, mainProcessClient, rootCluster]
+      ) || isAgentConfigured,
+    [configService, isAgentConfigured, mainProcessClient, rootCluster]
   );
 
   const [currentActionKind, setCurrentActionKind] =
@@ -260,9 +263,6 @@ export const ConnectMyComputerContextProvider: FC<{
     }
   }, [checkIfAgentIsConfigured, isAgentConfiguredAttempt.status]);
 
-  const isAgentConfigured =
-    isAgentConfiguredAttempt.status === 'success' &&
-    isAgentConfiguredAttempt.data;
   const agentIsNotStarted =
     currentAction.kind === 'observe-process' &&
     currentAction.agentProcessState.status === 'not-started';

--- a/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/SideNav/SideNav.tsx
+++ b/web/packages/teleterm/src/ui/DocumentCluster/ClusterResources/SideNav/SideNav.tsx
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import React from 'react';
-import styled from 'styled-components';
 import { Flex } from 'design';
 
 import ClusterNavButton from 'teleterm/ui/DocumentCluster/ClusterNavButton';
@@ -36,7 +35,7 @@ export default function SideNav(props: Props) {
     );
   });
 
-  return <StyledNav {...props}>{$items}</StyledNav>;
+  return <Flex {...props}>{$items}</Flex>;
 }
 
 type Props = {
@@ -47,11 +46,6 @@ export type SideNavItem = {
   to: NavLocation;
   title: string;
 };
-
-const StyledNav = styled(Flex)`
-  min-width: 180px;
-  overflow: auto;
-`;
 
 function createItems(): SideNavItem[] {
   return [

--- a/web/packages/teleterm/src/ui/DocumentGateway/OfflineDocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/OfflineDocumentGateway.tsx
@@ -40,7 +40,7 @@ export function OfflineDocumentGateway(props: OfflineDocumentGatewayProps) {
 
   return (
     <Flex
-      maxWidth="590px"
+      maxWidth="680px"
       width="100%"
       flexDirection="column"
       mx="auto"

--- a/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
+++ b/web/packages/teleterm/src/ui/DocumentGateway/OnlineDocumentGateway.tsx
@@ -76,7 +76,7 @@ export function OnlineDocumentGateway(props: OnlineDocumentGatewayProps) {
   );
 
   return (
-    <Box maxWidth="590px" width="100%" mx="auto" mt="4" px="5">
+    <Box maxWidth="680px" width="100%" mx="auto" mt="4" px="5">
       <Flex justifyContent="space-between" mb="4" flexWrap="wrap" gap={2}>
         <Text typography="h3">Database Connection</Text>
         <ButtonSecondary size="small" onClick={props.disconnect}>


### PR DESCRIPTION
Contributes to https://github.com/gravitational/teleport/issues/27881

This PR fixes the following things: 
* The icon should be visible when the user has permissions to set up Connect My Computer or if the agent has been already set up.
* Kenny's proposal: Rename “Connect” / “Disconnect” options for the agent page to “Start Agent” / “Stop Agent” and put the stop option as a muted button next to the status when the agent is running. Instead of a giant “DISCONNECT” button, there is a Connect button that opens SSH session.
* After removing the CMC icon from the cluster view, the navigation items were clipped. 
* Makes the logs on the status page wider. It is not a drastic change, because I didn't want to make the CTA button too long. I also changed the width for a DB page.